### PR TITLE
Return an ExtendSSLSession whenever possible to allow more strict che…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.util.internal.EmptyArrays;
+
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSessionContext;
+import javax.security.cert.X509Certificate;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.util.List;
+
+/**
+ * Delegates all operations to a wrapped {@link OpenSslSession} except the methods defined by {@link ExtendedSSLSession}
+ * itself.
+ */
+abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements OpenSslSession {
+
+    // TODO: use OpenSSL API to actually fetch the real data but for now just do what Conscrypt does:
+    // https://github.com/google/conscrypt/blob/1.2.0/common/
+    // src/main/java/org/conscrypt/Java7ExtendedSSLSession.java#L32
+    private static final String[] LOCAL_SUPPORTED_SIGNATURE_ALGORITHMS = {
+            "SHA512withRSA", "SHA512withECDSA", "SHA384withRSA", "SHA384withECDSA", "SHA256withRSA",
+            "SHA256withECDSA", "SHA224withRSA", "SHA224withECDSA", "SHA1withRSA", "SHA1withECDSA",
+    };
+
+    private final OpenSslSession wrapped;
+
+    ExtendedOpenSslSession(OpenSslSession wrapped) {
+        assert !(wrapped instanceof ExtendedSSLSession);
+        this.wrapped = wrapped;
+    }
+
+    // Use rawtypes an unchecked override to be able to also work on java7.
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public abstract List getRequestedServerNames();
+
+    @Override
+    public void handshakeFinished() throws SSLException {
+        wrapped.handshakeFinished();
+    }
+
+    @Override
+    public void tryExpandApplicationBufferSize(int packetLengthDataOnly) {
+        wrapped.tryExpandApplicationBufferSize(packetLengthDataOnly);
+    }
+
+    @Override
+    public String[] getLocalSupportedSignatureAlgorithms() {
+        return LOCAL_SUPPORTED_SIGNATURE_ALGORITHMS.clone();
+    }
+
+    @Override
+    public String[] getPeerSupportedSignatureAlgorithms() {
+        // Always return empty for now.
+        return EmptyArrays.EMPTY_STRINGS;
+    }
+
+    @Override
+    public byte[] getId() {
+        return wrapped.getId();
+    }
+
+    @Override
+    public SSLSessionContext getSessionContext() {
+        return wrapped.getSessionContext();
+    }
+
+    @Override
+    public long getCreationTime() {
+        return wrapped.getCreationTime();
+    }
+
+    @Override
+    public long getLastAccessedTime() {
+        return wrapped.getLastAccessedTime();
+    }
+
+    @Override
+    public void invalidate() {
+        wrapped.invalidate();
+    }
+
+    @Override
+    public boolean isValid() {
+        return wrapped.isValid();
+    }
+
+    @Override
+    public void putValue(String s, Object o) {
+        wrapped.putValue(s, o);
+    }
+
+    @Override
+    public Object getValue(String s) {
+        return wrapped.getValue(s);
+    }
+
+    @Override
+    public void removeValue(String s) {
+        wrapped.removeValue(s);
+    }
+
+    @Override
+    public String[] getValueNames() {
+        return wrapped.getValueNames();
+    }
+
+    @Override
+    public Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
+        return wrapped.getPeerCertificates();
+    }
+
+    @Override
+    public Certificate[] getLocalCertificates() {
+        return wrapped.getLocalCertificates();
+    }
+
+    @Override
+    public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
+        return wrapped.getPeerCertificateChain();
+    }
+
+    @Override
+    public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
+        return wrapped.getPeerPrincipal();
+    }
+
+    @Override
+    public Principal getLocalPrincipal() {
+        return wrapped.getLocalPrincipal();
+    }
+
+    @Override
+    public String getCipherSuite() {
+        return wrapped.getCipherSuite();
+    }
+
+    @Override
+    public String getProtocol() {
+        return wrapped.getProtocol();
+    }
+
+    @Override
+    public String getPeerHost() {
+        return wrapped.getPeerHost();
+    }
+
+    @Override
+    public int getPeerPort() {
+        return wrapped.getPeerPort();
+    }
+
+    @Override
+    public int getPacketBufferSize() {
+        return wrapped.getPacketBufferSize();
+    }
+
+    @Override
+    public int getApplicationBufferSize() {
+        return wrapped.getApplicationBufferSize();
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -48,11 +48,18 @@ final class Java8SslUtils {
     }
 
     static void setSniHostNames(SSLParameters sslParameters, List<String> names) {
+        sslParameters.setServerNames(getSniHostNames(names));
+    }
+
+    static List getSniHostNames(List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Collections.emptyList();
+        }
         List<SNIServerName> sniServerNames = new ArrayList<SNIServerName>(names.size());
         for (String name: names) {
             sniServerNames.add(new SNIHostName(name));
         }
-        sslParameters.setServerNames(sniServerNames);
+        return sniServerNames;
     }
 
     static boolean getUseCipherSuitesOrder(SSLParameters sslParameters) {

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+
+interface OpenSslSession extends SSLSession {
+
+    /**
+     * Finish the handshake and so init everything in the {@link OpenSslSession} that should be accessible by
+     * the user.
+     */
+    void handshakeFinished() throws SSLException;
+
+    /**
+     * Expand (or increase) the value returned by {@link #getApplicationBufferSize()} if necessary.
+     * <p>
+     * This is only called in a synchronized block, so no need to use atomic operations.
+     * @param packetLengthDataOnly The packet size which exceeds the current {@link #getApplicationBufferSize()}.
+     */
+    void tryExpandApplicationBufferSize(int packetLengthDataOnly);
+}

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -29,14 +29,42 @@ import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ThrowableUtil;
+import org.junit.Assert;
 
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.KeyManagerFactorySpi;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.io.IOException;
+import java.net.Socket;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * In extra class to be able to run tests with java7 without trying to load classes that not exists in java7.
@@ -123,6 +151,178 @@ final class SniClientJava8TestUtil {
                 sc.close().syncUninterruptibly();
             }
             group.shutdownGracefully();
+        }
+    }
+
+    static void assertSSLSession(SSLSession session, String name) {
+        assertSSLSession(session, new SNIHostName(name));
+    }
+
+    private static void assertSSLSession(SSLSession session, SNIServerName name) {
+        Assert.assertNotNull(session);
+        if (session instanceof ExtendedSSLSession) {
+            ExtendedSSLSession extendedSSLSession = (ExtendedSSLSession) session;
+            List<SNIServerName> names = extendedSSLSession.getRequestedServerNames();
+            Assert.assertEquals(1, names.size());
+            Assert.assertEquals(name, names.get(0));
+            Assert.assertTrue(extendedSSLSession.getLocalSupportedSignatureAlgorithms().length > 0);
+        }
+    }
+
+    static TrustManagerFactory newSniX509TrustmanagerFactory(String name) {
+        return new SniX509TrustmanagerFactory(new SNIHostName(name));
+    }
+
+    private static final class SniX509TrustmanagerFactory extends SimpleTrustManagerFactory {
+
+        private final SNIServerName name;
+
+        SniX509TrustmanagerFactory(SNIServerName name) {
+            this.name = name;
+        }
+
+        @Override
+        protected void engineInit(KeyStore keyStore) throws Exception {
+            // NOOP
+        }
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters managerFactoryParameters) throws Exception {
+            // NOOP
+        }
+
+        @Override
+        protected TrustManager[] engineGetTrustManagers() {
+            return new TrustManager[] { new X509ExtendedTrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket)
+                        throws CertificateException {
+                    Assert.fail();
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket)
+                        throws CertificateException {
+                    Assert.fail();
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine)
+                        throws CertificateException {
+                    Assert.fail();
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine)
+                        throws CertificateException {
+                    assertSSLSession(sslEngine.getHandshakeSession(), name);
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
+                        throws CertificateException {
+                    Assert.fail();
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
+                        throws CertificateException {
+                    Assert.fail();
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return EmptyArrays.EMPTY_X509_CERTIFICATES;
+                }
+            } };
+        }
+    }
+
+    static KeyManagerFactory newSniX509KeyManagerFactory(SelfSignedCertificate cert, String hostname)
+            throws NoSuchAlgorithmException, KeyStoreException, UnrecoverableKeyException,
+                   IOException, CertificateException {
+        return new SniX509KeyManagerFactory(
+                new SNIHostName(hostname), SslContext.buildKeyManagerFactory(
+                new X509Certificate[] { cert.cert() }, cert.key(), null, null));
+    }
+
+    private static final class SniX509KeyManagerFactory extends KeyManagerFactory {
+
+        SniX509KeyManagerFactory(final SNIServerName name, final KeyManagerFactory factory) {
+            super(new KeyManagerFactorySpi() {
+                @Override
+                protected void engineInit(KeyStore keyStore, char[] chars)
+                        throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+                    factory.init(keyStore, chars);
+                }
+
+                @Override
+                protected void engineInit(ManagerFactoryParameters managerFactoryParameters)
+                        throws InvalidAlgorithmParameterException {
+                    factory.init(managerFactoryParameters);
+                }
+
+                @Override
+                protected KeyManager[] engineGetKeyManagers() {
+                    List<KeyManager> managers = new ArrayList<KeyManager>();
+                    for (final KeyManager km: factory.getKeyManagers()) {
+                        if (km instanceof X509ExtendedKeyManager) {
+                            managers.add(new X509ExtendedKeyManager() {
+                                @Override
+                                public String[] getClientAliases(String s, Principal[] principals) {
+                                    return ((X509ExtendedKeyManager) km).getClientAliases(s, principals);
+                                }
+
+                                @Override
+                                public String chooseClientAlias(String[] strings, Principal[] principals,
+                                                                Socket socket) {
+                                    return ((X509ExtendedKeyManager) km).chooseClientAlias(strings, principals, socket);
+                                }
+
+                                @Override
+                                public String[] getServerAliases(String s, Principal[] principals) {
+                                    return ((X509ExtendedKeyManager) km).getServerAliases(s, principals);
+                                }
+
+                                @Override
+                                public String chooseServerAlias(String s, Principal[] principals, Socket socket) {
+                                    return ((X509ExtendedKeyManager) km).chooseServerAlias(s, principals, socket);
+                                }
+
+                                @Override
+                                public X509Certificate[] getCertificateChain(String s) {
+                                    return ((X509ExtendedKeyManager) km).getCertificateChain(s);
+                                }
+
+                                @Override
+                                public PrivateKey getPrivateKey(String s) {
+                                    return ((X509ExtendedKeyManager) km).getPrivateKey(s);
+                                }
+
+                                @Override
+                                public String chooseEngineClientAlias(String[] strings, Principal[] principals,
+                                                                      SSLEngine sslEngine) {
+                                    return ((X509ExtendedKeyManager) km)
+                                            .chooseEngineClientAlias(strings, principals, sslEngine);
+                                }
+
+                                @Override
+                                public String chooseEngineServerAlias(String s, Principal[] principals,
+                                                                      SSLEngine sslEngine) {
+
+                                    SSLSession session = sslEngine.getHandshakeSession();
+                                    assertSSLSession(session, name);
+                                    return ((X509ExtendedKeyManager) km)
+                                            .chooseEngineServerAlias(s, principals, sslEngine);
+                                }
+                            });
+                        } else {
+                            managers.add(km);
+                        }
+                    }
+                    return managers.toArray(new KeyManager[0]);
+                }
+            }, factory.getProvider(), factory.getAlgorithm());
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -721,6 +721,7 @@
 
             <!-- SSLSession implementation -->
             <ignore>javax.net.ssl.SSLEngine</ignore>
+            <ignore>javax.net.ssl.ExtendedSSLSession</ignore>
             <ignore>javax.net.ssl.X509ExtendedTrustManager</ignore>
             <ignore>javax.net.ssl.SSLParameters</ignore>
             <ignore>javax.net.ssl.SNIServerName</ignore>


### PR DESCRIPTION
…cking when using OpenSSL

Motivation:

When an ExtendedSSLSession is used its possible to do more strict checking of the keys during handshake. We should do this whenever possible.

Modification:

- Return an ExtendedSSLSession when using client-mode and Java7+
- Add unit test
- Simplify unit tests

Result:

More consistent behaviour.