### PR TITLE
HashedWheelTimer should support sub-ms tickDurations

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -561,7 +561,8 @@ public class HashedWheelTimer implements Timer {
                 //
                 // See https://github.com/netty/netty/issues/356
                 if (PlatformDependent.isWindows()) {
-                    sleepTimeNanos = sleepTimeNanos / 10 * 10;
+                    sleepTimeNanos = TimeUnit.MILLISECONDS.toNanos(
+                            Math.max(1, TimeUnit.NANOSECONDS.toMillis(sleepTimeNanos) / 10 * 10));
                 }
 
                 LockSupport.parkNanos(sleepTimeNanos);

--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
 
 import static io.netty.util.internal.StringUtil.simpleClassName;
 
@@ -544,9 +545,9 @@ public class HashedWheelTimer implements Timer {
 
             for (;;) {
                 final long currentTime = System.nanoTime() - startTime;
-                long sleepTimeMs = (deadline - currentTime + 999999) / 1000000;
+                long sleepTimeNanos = deadline - currentTime + 999999;
 
-                if (sleepTimeMs <= 0) {
+                if (sleepTimeNanos <= 0) {
                     if (currentTime == Long.MIN_VALUE) {
                         return -Long.MAX_VALUE;
                     } else {
@@ -560,12 +561,11 @@ public class HashedWheelTimer implements Timer {
                 //
                 // See https://github.com/netty/netty/issues/356
                 if (PlatformDependent.isWindows()) {
-                    sleepTimeMs = sleepTimeMs / 10 * 10;
+                    sleepTimeNanos = sleepTimeNanos / 10 * 10;
                 }
 
-                try {
-                    Thread.sleep(sleepTimeMs);
-                } catch (InterruptedException ignored) {
+                LockSupport.parkNanos(sleepTimeNanos);
+                if (Thread.interrupted()) {
                     if (WORKER_STATE_UPDATER.get(HashedWheelTimer.this) == WORKER_STATE_SHUTDOWN) {
                         return Long.MIN_VALUE;
                     }


### PR DESCRIPTION
Motivation:

waitForNextTick converts the sleep time to ms, so when the HWT constructor is passed a tickDuration shorter than 1 ms, waitForNextTick doesn't sleep. This is misleading since HWT's tickDuration seems to have nanosecond granularity.

Modifications:

Replace Thread.sleep(...) with LockSupport.parkNanos(...) and so be able to use tick durations < 1ms.

Result:

Fixes https://github.com/netty/netty/issues/8277.