### PR TITLE
Fix incorrectly encoded empty SOCKS5 address

### DIFF
--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressEncoder.java
@@ -44,7 +44,6 @@ public interface Socks5AddressEncoder {
                     out.writeByte(addrValue.length());
                     out.writeCharSequence(addrValue, CharsetUtil.US_ASCII);
                 } else {
-                    out.writeByte(1);
                     out.writeByte(0);
                 }
             } else if (typeVal == Socks5AddressType.IPv6.byteValue()) {

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
@@ -51,8 +51,7 @@ public class DefaultSocks5CommandResponseTest {
                 0x00, // success reply
                 0x00, // reserved
                 0x03, // address type domain
-                0x01, // length of domain
-                0x00, // domain value
+                0x00, // length of domain
                 0x00, // port value
                 0x00
         };


### PR DESCRIPTION
Motivation:

If you encode a SOCKS5 message like `new DefaultSocks5CommandResponse(FAILURE, DOMAIN, "", 0)`
you correctly get a result of `05010003000000`.
But if the `bndAddr` is `null`, for example like `new DefaultSocks5CommandResponse(FAILURE, DOMAIN)`
the encoded result is `0501000301000000` which means the domain name has a length of one and consists of a 0-byte.

Modification:

With this commit it is also correctly encoded as a string of 0 length.