### PR TITLE
Add support for TLSv1.3

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -17,6 +17,7 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -26,6 +27,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 import java.security.Security;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
@@ -34,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -58,11 +61,13 @@ public class JdkSslContext extends SslContext {
     static final String PROTOCOL = "TLS";
     private static final String[] DEFAULT_PROTOCOLS;
     private static final List<String> DEFAULT_CIPHERS;
+    private static final List<String> DEFAULT_CIPHERS_NON_TLSV13;
     private static final Set<String> SUPPORTED_CIPHERS;
+    private static final Set<String> SUPPORTED_CIPHERS_NON_TLSV13;
+    private static final Provider DEFAULT_PROVIDER;
 
     static {
         SSLContext context;
-        int i;
         try {
             context = SSLContext.getInstance(PROTOCOL);
             context.init(null, null, null);
@@ -70,31 +75,54 @@ public class JdkSslContext extends SslContext {
             throw new Error("failed to initialize the default SSL context", e);
         }
 
-        SSLEngine engine = context.createSSLEngine();
+        DEFAULT_PROVIDER = context.getProvider();
 
+        SSLEngine engine = context.createSSLEngine();
+        DEFAULT_PROTOCOLS = defaultProtocols(engine);
+
+        SUPPORTED_CIPHERS = Collections.unmodifiableSet(supportedCiphers(engine));
+        DEFAULT_CIPHERS = Collections.unmodifiableList(defaultCiphers(engine, SUPPORTED_CIPHERS));
+
+        List<String> ciphersNonTLSv13 = new ArrayList<String>(DEFAULT_CIPHERS);
+        ciphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
+        DEFAULT_CIPHERS_NON_TLSV13 = Collections.unmodifiableList(ciphersNonTLSv13);
+
+        Set<String> suppertedCiphersNonTLSv13 = new LinkedHashSet<String>(SUPPORTED_CIPHERS);
+        suppertedCiphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
+        SUPPORTED_CIPHERS_NON_TLSV13 = Collections.unmodifiableSet(suppertedCiphersNonTLSv13);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Default protocols (JDK): {} ", Arrays.asList(DEFAULT_PROTOCOLS));
+            logger.debug("Default cipher suites (JDK): {}", DEFAULT_CIPHERS);
+        }
+    }
+
+    private static String[] defaultProtocols(SSLEngine engine) {
         // Choose the sensible default list of protocols.
         final String[] supportedProtocols = engine.getSupportedProtocols();
         Set<String> supportedProtocolsSet = new HashSet<String>(supportedProtocols.length);
-        for (i = 0; i < supportedProtocols.length; ++i) {
+        for (int i = 0; i < supportedProtocols.length; ++i) {
             supportedProtocolsSet.add(supportedProtocols[i]);
         }
         List<String> protocols = new ArrayList<String>();
         addIfSupported(
                 supportedProtocolsSet, protocols,
-                "TLSv1.2", "TLSv1.1", "TLSv1");
+                // Do not include TLSv1.3 for now by default.
+                SslUtils.PROTOCOL_TLS_V1_2, SslUtils.PROTOCOL_TLS_V1_1, SslUtils.PROTOCOL_TLS_V1);
 
         if (!protocols.isEmpty()) {
-            DEFAULT_PROTOCOLS = protocols.toArray(new String[0]);
-        } else {
-            DEFAULT_PROTOCOLS = engine.getEnabledProtocols();
+            return protocols.toArray(new String[0]);
         }
+        return engine.getEnabledProtocols();
+    }
 
+    private static Set<String> supportedCiphers(SSLEngine engine) {
         // Choose the sensible default list of cipher suites.
         final String[] supportedCiphers = engine.getSupportedCipherSuites();
-        SUPPORTED_CIPHERS = new HashSet<String>(supportedCiphers.length);
-        for (i = 0; i < supportedCiphers.length; ++i) {
+        Set<String> supportedCiphersSet = new LinkedHashSet<String>(supportedCiphers.length);
+        for (int i = 0; i < supportedCiphers.length; ++i) {
             String supportedCipher = supportedCiphers[i];
-            SUPPORTED_CIPHERS.add(supportedCipher);
+            supportedCiphersSet.add(supportedCipher);
             // IBM's J9 JVM utilizes a custom naming scheme for ciphers and only returns ciphers with the "SSL_"
             // prefix instead of the "TLS_" prefix (as defined in the JSSE cipher suite names [1]). According to IBM's
             // documentation [2] the "SSL_" prefix is "interchangeable" with the "TLS_" prefix.
@@ -108,21 +136,29 @@ public class JdkSslContext extends SslContext {
                 final String tlsPrefixedCipherName = "TLS_" + supportedCipher.substring("SSL_".length());
                 try {
                     engine.setEnabledCipherSuites(new String[]{tlsPrefixedCipherName});
-                    SUPPORTED_CIPHERS.add(tlsPrefixedCipherName);
+                    supportedCiphersSet.add(tlsPrefixedCipherName);
                 } catch (IllegalArgumentException ignored) {
                     // The cipher is not supported ... move on to the next cipher.
                 }
             }
         }
-        List<String> ciphers = new ArrayList<String>();
-        addIfSupported(SUPPORTED_CIPHERS, ciphers, DEFAULT_CIPHER_SUITES);
-        useFallbackCiphersIfDefaultIsEmpty(ciphers, engine.getEnabledCipherSuites());
-        DEFAULT_CIPHERS = Collections.unmodifiableList(ciphers);
+        return supportedCiphersSet;
+    }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Default protocols (JDK): {} ", Arrays.asList(DEFAULT_PROTOCOLS));
-            logger.debug("Default cipher suites (JDK): {}", DEFAULT_CIPHERS);
+    private static List<String> defaultCiphers(SSLEngine engine, Set<String> supportedCiphers) {
+        List<String> ciphers = new ArrayList<String>();
+        addIfSupported(supportedCiphers, ciphers, DEFAULT_CIPHER_SUITES);
+        useFallbackCiphersIfDefaultIsEmpty(ciphers, engine.getEnabledCipherSuites());
+        return ciphers;
+    }
+
+    private static boolean isTlsV13Supported(String[] protocols) {
+        for (String protocol: protocols) {
+            if (SslUtils.PROTOCOL_TLS_V1_3.equals(protocol)) {
+                return true;
+            }
         }
+        return false;
     }
 
     private final String[] protocols;
@@ -169,11 +205,49 @@ public class JdkSslContext extends SslContext {
         super(startTls);
         this.apn = checkNotNull(apn, "apn");
         this.clientAuth = checkNotNull(clientAuth, "clientAuth");
-        cipherSuites = checkNotNull(cipherFilter, "cipherFilter").filterCipherSuites(
-                ciphers, DEFAULT_CIPHERS, SUPPORTED_CIPHERS);
-        this.protocols = protocols == null ? DEFAULT_PROTOCOLS : protocols;
-        unmodifiableCipherSuites = Collections.unmodifiableList(Arrays.asList(cipherSuites));
         this.sslContext = checkNotNull(sslContext, "sslContext");
+
+        final List<String> defaultCiphers;
+        final Set<String> supportedCiphers;
+        if (DEFAULT_PROVIDER.equals(sslContext.getProvider())) {
+            this.protocols = protocols == null? DEFAULT_PROTOCOLS : protocols;
+            if (isTlsV13Supported(this.protocols)) {
+                supportedCiphers = SUPPORTED_CIPHERS;
+                defaultCiphers = DEFAULT_CIPHERS;
+            } else {
+                // TLSv1.3 is not supported, ensure we do not include any TLSv1.3 ciphersuite.
+                supportedCiphers = SUPPORTED_CIPHERS_NON_TLSV13;
+                defaultCiphers = DEFAULT_CIPHERS_NON_TLSV13;
+            }
+        } else {
+            // This is a different Provider then the one used by the JDK by default so we can not just assume
+            // the same protocols and ciphers are supported. For example even if Java11+ is used Conscrypt will
+            // not support TLSv1.3 and the TLSv1.3 ciphersuites.
+            SSLEngine engine = sslContext.createSSLEngine();
+            try {
+                if (protocols == null) {
+                    this.protocols = defaultProtocols(engine);
+                } else {
+                    this.protocols = protocols;
+                }
+                supportedCiphers = supportedCiphers(engine);
+                defaultCiphers = defaultCiphers(engine, supportedCiphers);
+                if (!isTlsV13Supported(this.protocols)) {
+                    // TLSv1.3 is not supported, ensure we do not include any TLSv1.3 ciphersuite.
+                    for (String cipher: SslUtils.DEFAULT_TLSV13_CIPHER_SUITES) {
+                        supportedCiphers.remove(cipher);
+                        defaultCiphers.remove(cipher);
+                    }
+                }
+            } finally {
+                ReferenceCountUtil.release(engine);
+            }
+        }
+
+        cipherSuites = checkNotNull(cipherFilter, "cipherFilter").filterCipherSuites(
+                ciphers, defaultCiphers, supportedCiphers);
+
+        unmodifiableCipherSuites = Collections.unmodifiableList(Arrays.asList(cipherSuites));
         this.isClient = isClient;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -24,8 +24,11 @@ import io.netty.internal.tcnative.SSLContext;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -47,6 +50,12 @@ import javax.security.auth.x500.X500Principal;
 public final class ReferenceCountedOpenSslClientContext extends ReferenceCountedOpenSslContext {
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(ReferenceCountedOpenSslClientContext.class);
+    private static final Set<String> SUPPORTED_KEY_TYPES = Collections.unmodifiableSet(new LinkedHashSet<String>(
+            Arrays.asList(OpenSslKeyMaterialManager.KEY_TYPE_RSA,
+                          OpenSslKeyMaterialManager.KEY_TYPE_DH_RSA,
+                          OpenSslKeyMaterialManager.KEY_TYPE_EC,
+                          OpenSslKeyMaterialManager.KEY_TYPE_EC_RSA,
+                          OpenSslKeyMaterialManager.KEY_TYPE_EC_EC)));
     private final OpenSslSessionContext sessionContext;
 
     ReferenceCountedOpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
@@ -277,7 +286,8 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
          */
         private static Set<String> supportedClientKeyTypes(byte[] clientCertificateTypes) {
             if (clientCertificateTypes == null) {
-                return Collections.emptySet();
+                // Try all of the supported key types.
+                return SUPPORTED_KEY_TYPES;
             }
             Set<String> result = new HashSet<String>(clientCertificateTypes.length);
             for (byte keyTypeCode : clientCertificateTypes) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -22,9 +22,14 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.base64.Base64;
 import io.netty.handler.codec.base64.Base64Dialect;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -36,7 +41,11 @@ import static java.util.Arrays.asList;
  * Constants for SSL packets.
  */
 final class SslUtils {
-
+    // See https://tools.ietf.org/html/rfc8446#appendix-B.4
+    private static final Set<String> TLSV13_CIPHERS = Collections.unmodifiableSet(new HashSet<String>(
+            asList("TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
+                          "TLS_AES_128_GCM_SHA256", "TLS_AES_128_CCM_8_SHA256",
+                          "TLS_AES_128_CCM_SHA256")));
     // Protocols
     static final String PROTOCOL_SSL_V2_HELLO = "SSLv2Hello";
     static final String PROTOCOL_SSL_V2 = "SSLv2";
@@ -44,6 +53,7 @@ final class SslUtils {
     static final String PROTOCOL_TLS_V1 = "TLSv1";
     static final String PROTOCOL_TLS_V1_1 = "TLSv1.1";
     static final String PROTOCOL_TLS_V1_2 = "TLSv1.2";
+    static final String PROTOCOL_TLS_V1_3 = "TLSv1.3";
 
     /**
      * change cipher spec
@@ -85,20 +95,36 @@ final class SslUtils {
      */
     static final int NOT_ENCRYPTED = -2;
 
-    static final String[] DEFAULT_CIPHER_SUITES = {
+    static final String[] DEFAULT_CIPHER_SUITES;
+    static final String[] DEFAULT_TLSV13_CIPHER_SUITES;
+
+    static {
+        if (PlatformDependent.javaVersion() >= 11) {
+            DEFAULT_TLSV13_CIPHER_SUITES = new String[] { "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384" };
+        } else {
+            DEFAULT_TLSV13_CIPHER_SUITES = EmptyArrays.EMPTY_STRINGS;
+        }
+
+        List<String> defaultCiphers = new ArrayList<String>();
         // GCM (Galois/Counter Mode) requires JDK 8.
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        defaultCiphers.add("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384");
+        defaultCiphers.add("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
+        defaultCiphers.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        defaultCiphers.add("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA");
         // AES256 requires JCE unlimited strength jurisdiction policy files.
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        defaultCiphers.add("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
         // GCM (Galois/Counter Mode) requires JDK 8.
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
+        defaultCiphers.add("TLS_RSA_WITH_AES_128_GCM_SHA256");
+        defaultCiphers.add("TLS_RSA_WITH_AES_128_CBC_SHA");
         // AES256 requires JCE unlimited strength jurisdiction policy files.
-        "TLS_RSA_WITH_AES_256_CBC_SHA"
-    };
+        defaultCiphers.add("TLS_RSA_WITH_AES_256_CBC_SHA");
+
+        for (String tlsv13Cipher: DEFAULT_TLSV13_CIPHER_SUITES) {
+            defaultCiphers.add(tlsv13Cipher);
+        }
+
+        DEFAULT_CIPHER_SUITES = defaultCiphers.toArray(new String[0]);
+    }
 
     /**
      * Add elements from {@code names} into {@code enabled} if they are in {@code supported}.
@@ -359,6 +385,14 @@ final class SslUtils {
                !hostname.endsWith(".") &&
                !NetUtil.isValidIpV4Address(hostname) &&
                !NetUtil.isValidIpV6Address(hostname);
+    }
+
+    /**
+     * Returns {@code true} if the the given cipher (in openssl format) is for TLSv1.3, {@code false} otherwise.
+     */
+    static boolean isTLSv13Cipher(String cipher) {
+        // See https://tools.ietf.org/html/rfc8446#appendix-B.4
+        return TLSV13_CIPHERS.contains(cipher);
     }
 
     private SslUtils() {

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteCanaryTest.java
@@ -125,12 +125,16 @@ public class CipherSuiteCanaryTest {
         final SslContext sslServerContext = SslContextBuilder.forServer(CERT.certificate(), CERT.privateKey())
                 .sslProvider(serverSslProvider)
                 .ciphers(ciphers)
+                // As this is not a TLSv1.3 cipher we should ensure we talk something else.
+                .protocols(SslUtils.PROTOCOL_TLS_V1_2)
                 .build();
 
         try {
             final SslContext sslClientContext = SslContextBuilder.forClient()
                     .sslProvider(clientSslProvider)
                     .ciphers(ciphers)
+                    // As this is not a TLSv1.3 cipher we should ensure we talk something else.
+                    .protocols(SslUtils.PROTOCOL_TLS_V1_2)
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
                     .build();
 

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
@@ -22,8 +22,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class CipherSuiteConverterTest {
 

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -31,17 +31,17 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}")
-    public static Collection<Object> data() {
-        List<Object> params = new ArrayList<Object>();
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(type);
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
         }
         return params;
     }
 
-    public ConscryptJdkSslEngineInteropTest(BufferType type) {
-        super(type);
+    public ConscryptJdkSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo) {
+        super(type, combo);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
@@ -30,17 +30,17 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class ConscryptSslEngineTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}")
-    public static Collection<Object> data() {
-        List<Object> params = new ArrayList<Object>();
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(type);
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
         }
         return params;
     }
 
-    public ConscryptSslEngineTest(BufferType type) {
-        super(type);
+    public ConscryptSslEngineTest(BufferType type, ProtocolCipherCombo combo) {
+        super(type, combo);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import java.security.Provider;
+
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -31,17 +32,17 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}")
-    public static Collection<Object> data() {
-        List<Object> params = new ArrayList<Object>();
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(type);
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
         }
         return params;
     }
 
-    public JdkConscryptSslEngineInteropTest(BufferType type) {
-        super(type);
+    public JdkConscryptSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo) {
+        super(type, combo);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.PlatformDependent;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,17 +33,21 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}")
-    public static Collection<Object> data() {
-        List<Object> params = new ArrayList<Object>();
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(type);
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+
+            if (PlatformDependent.javaVersion() >= 11 && OpenSsl.isTlsv13Supported()) {
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13() });
+            }
         }
         return params;
     }
 
-    public JdkOpenSslEngineInteroptTest(BufferType type) {
-        super(type);
+    public JdkOpenSslEngineInteroptTest(BufferType type, ProtocolCipherCombo protocolCipherCombo) {
+        super(type, protocolCipherCombo);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -67,17 +67,21 @@ public class OpenSslEngineTest extends SSLEngineTest {
     private static final String PREFERRED_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http2";
     private static final String FALLBACK_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http1_1";
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}")
-    public static Collection<Object> data() {
-        List<Object> params = new ArrayList<Object>();
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(type);
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+
+            if (PlatformDependent.javaVersion() >= 11 && OpenSsl.isTlsv13Supported()) {
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13() });
+            }
         }
         return params;
     }
 
-    public OpenSslEngineTest(BufferType type) {
-        super(type);
+    public OpenSslEngineTest(BufferType type, ProtocolCipherCombo cipherCombo) {
+        super(type, cipherCombo);
     }
 
     @BeforeClass
@@ -206,13 +210,17 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testWrapBuffersNoWritePendingError() throws Exception {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SSLEngine clientEngine = null;
         SSLEngine serverEngine = null;
         try {
@@ -240,13 +248,17 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testOnlySmallBufferNeededForWrap() throws Exception {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SSLEngine clientEngine = null;
         SSLEngine serverEngine = null;
         try {
@@ -291,13 +303,17 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testNeededDstCapacityIsCorrectlyCalculated() throws Exception {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SSLEngine clientEngine = null;
         SSLEngine serverEngine = null;
         try {
@@ -327,13 +343,17 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testSrcsLenOverFlowCorrectlyHandled() throws Exception {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SSLEngine clientEngine = null;
         SSLEngine serverEngine = null;
         try {
@@ -374,9 +394,11 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testCalculateOutNetBufSizeOverflow() throws SSLException {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SSLEngine clientEngine = null;
         try {
             clientEngine = clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
@@ -390,9 +412,11 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testCalculateOutNetBufSize0() throws SSLException {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SSLEngine clientEngine = null;
         try {
             clientEngine = clientSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
@@ -415,13 +439,17 @@ public class OpenSslEngineTest extends SSLEngineTest {
     private void testCorrectlyCalculateSpaceForAlert(boolean jdkCompatabilityMode) throws Exception {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
 
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
         SSLEngine clientEngine = null;
         SSLEngine serverEngine = null;
         try {
@@ -473,13 +501,13 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testWrapWithDifferentSizesTLSv1() throws Exception {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .build();
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .build();
 
         testWrapWithDifferentSizes(PROTOCOL_TLS_V1, "AES128-SHA");
         testWrapWithDifferentSizes(PROTOCOL_TLS_V1, "ECDHE-RSA-AES128-SHA");
@@ -504,13 +532,13 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testWrapWithDifferentSizesTLSv1_1() throws Exception {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .build();
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .build();
 
         testWrapWithDifferentSizes(PROTOCOL_TLS_V1_1, "ECDHE-RSA-AES256-SHA");
         testWrapWithDifferentSizes(PROTOCOL_TLS_V1_1, "AES256-SHA");
@@ -613,12 +641,16 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .forClient()
                 .trustManager(cert.cert())
                 .sslProvider(sslClientProvider())
+                .protocols(protocols())
+                .ciphers(ciphers())
                 .build();
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
         serverSslCtx = SslContextBuilder
                 .forServer(cert.certificate(), cert.privateKey())
                 .sslProvider(sslServerProvider())
+                .protocols(protocols())
+                .ciphers(ciphers())
                 .build();
         SSLEngine server = wrapEngine(serverSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
@@ -690,12 +722,16 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .forClient()
                 .trustManager(cert.cert())
                 .sslProvider(sslClientProvider())
+                .protocols(protocols())
+                .ciphers(ciphers())
                 .build();
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
         serverSslCtx = SslContextBuilder
                 .forServer(cert.certificate(), cert.privateKey())
                 .sslProvider(sslServerProvider())
+                .protocols(protocols())
+                .ciphers(ciphers())
                 .build();
         SSLEngine server = wrapEngine(serverSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
@@ -774,12 +810,16 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .forClient()
                 .trustManager(cert.cert())
                 .sslProvider(sslClientProvider())
+                .protocols(protocols())
+                .ciphers(ciphers())
                 .build();
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
         serverSslCtx = SslContextBuilder
                 .forServer(cert.certificate(), cert.privateKey())
                 .sslProvider(sslServerProvider())
+                .protocols(protocols())
+                .ciphers(ciphers())
                 .build();
         SSLEngine server = wrapEngine(serverSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
@@ -849,12 +889,16 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .forClient()
                 .trustManager(cert.cert())
                 .sslProvider(sslClientProvider())
+                .protocols(protocols())
+                .ciphers(ciphers())
                 .build();
         SSLEngine client = wrapEngine(clientSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
         serverSslCtx = SslContextBuilder
                 .forServer(cert.certificate(), cert.privateKey())
                 .sslProvider(sslServerProvider())
+                .protocols(protocols())
+                .ciphers(ciphers())
                 .build();
         SSLEngine server = wrapEngine(serverSslCtx.newHandler(UnpooledByteBufAllocator.DEFAULT).engine());
 
@@ -982,8 +1026,10 @@ public class OpenSslEngineTest extends SSLEngineTest {
         assumeTrue(PlatformDependent.javaVersion() >= 8);
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
 
         SSLEngine engine = wrapEngine(serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
         try {
@@ -1002,8 +1048,10 @@ public class OpenSslEngineTest extends SSLEngineTest {
         byte[] name = "rb8hx3pww30y3tvw0mwy.v1_1".getBytes(CharsetUtil.UTF_8);
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
 
         SSLEngine engine = wrapEngine(serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
         try {
@@ -1022,8 +1070,10 @@ public class OpenSslEngineTest extends SSLEngineTest {
     public void testAlgorithmConstraintsThrows() throws Exception {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(sslServerProvider())
-                .build();
+                                        .sslProvider(sslServerProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
 
         SSLEngine engine = wrapEngine(serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
         try {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.PlatformDependent;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -34,17 +35,21 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}")
-    public static Collection<Object> data() {
-        List<Object> params = new ArrayList<Object>();
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(type);
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+
+            if (PlatformDependent.javaVersion() >= 11 && OpenSsl.isTlsv13Supported()) {
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13() });
+            }
         }
         return params;
     }
 
-    public OpenSslJdkSslEngineInteroptTest(BufferType type) {
-        super(type);
+    public OpenSslJdkSslEngineInteroptTest(BufferType type, ProtocolCipherCombo combo) {
+        super(type, combo);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
@@ -15,6 +15,12 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.PlatformDependent;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static io.netty.handler.ssl.SslUtils.PROTOCOL_TLS_V1_2;
 import static org.junit.Assume.assumeTrue;
 
 final class OpenSslTestUtils {
@@ -27,5 +33,18 @@ final class OpenSslTestUtils {
 
     static boolean isBoringSSL() {
         return "BoringSSL".equals(OpenSsl.versionString());
+    }
+
+    static SslContextBuilder configureProtocolForMutualAuth(
+            SslContextBuilder ctx, SslProvider sslClientProvider, SslProvider sslServerProvider) {
+        if (PlatformDependent.javaVersion() >= 11
+            && sslClientProvider == SslProvider.JDK && sslServerProvider != SslProvider.JDK) {
+            // Make sure we do not use TLSv1.3 as there seems to be a bug currently in the JDK TLSv1.3 implementation.
+            // See:
+            //  - http://mail.openjdk.java.net/pipermail/security-dev/2018-September/018191.html
+            //  - https://bugs.openjdk.java.net/projects/JDK/issues/JDK-8210846
+            ctx.protocols(PROTOCOL_TLS_V1_2).ciphers(Collections.singleton("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"));
+        }
+        return ctx;
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -381,12 +381,21 @@ public class ParameterizedSslHandlerTest {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
 
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(serverProvider)
-                .build();
+                                                         .sslProvider(serverProvider)
+                                                         // Use TLSv1.2 as we depend on the fact that the handshake
+                                                         // is done in an extra round trip in the test which
+                                                         // is not true in TLSv1.3
+                                                         .protocols(SslUtils.PROTOCOL_TLS_V1_2)
+                                                         .build();
 
         final SslContext sslClientCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(clientProvider).build();
+                                                         .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                                         .sslProvider(clientProvider)
+                                                         // Use TLSv1.2 as we depend on the fact that the handshake
+                                                         // is done in an extra round trip in the test which
+                                                         // is not true in TLSv1.3
+                                                         .protocols(SslUtils.PROTOCOL_TLS_V1_2)
+                                                         .build();
 
         EventLoopGroup group = new NioEventLoopGroup();
         Channel sc = null;

--- a/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
@@ -23,8 +23,8 @@ import javax.net.ssl.SSLEngine;
 
 public class ReferenceCountedOpenSslEngineTest extends OpenSslEngineTest {
 
-    public ReferenceCountedOpenSslEngineTest(BufferType type) {
-        super(type);
+    public ReferenceCountedOpenSslEngineTest(BufferType type, ProtocolCipherCombo combo) {
+        super(type, combo);
     }
 
     @Override
@@ -60,9 +60,11 @@ public class ReferenceCountedOpenSslEngineTest extends OpenSslEngineTest {
     @Test(expected = NullPointerException.class)
     public void testNotLeakOnException() throws Exception {
         clientSslCtx = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .sslProvider(sslClientProvider())
-                .build();
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                                        .sslProvider(sslClientProvider())
+                                        .protocols(protocols())
+                                        .ciphers(ciphers())
+                                        .build();
 
         clientSslCtx.newEngine(null);
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
@@ -15,17 +15,18 @@
  */
 package io.netty.handler.ssl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import java.util.Collections;
+
+import static org.junit.Assert.*;
 
 public class SslContextBuilderTest {
 
@@ -79,10 +80,19 @@ public class SslContextBuilderTest {
         testInvalidCipher(SslProvider.JDK);
     }
 
-    @Test(expected = SSLException.class)
+    @Test
     public void testInvalidCipherOpenSSL() throws Exception {
         Assume.assumeTrue(OpenSsl.isAvailable());
-        testInvalidCipher(SslProvider.OPENSSL);
+        try {
+            // This may fail or not depending on the OpenSSL version used
+            // See https://github.com/openssl/openssl/issues/7196
+            testInvalidCipher(SslProvider.OPENSSL);
+            if (!OpenSsl.versionString().contains("1.1.1")) {
+                fail();
+            }
+        } catch (SSLException expected) {
+            // ok
+        }
     }
 
     private static void testInvalidCipher(SslProvider provider) throws Exception {

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -124,9 +124,10 @@ public class SslErrorTest {
         Assume.assumeTrue(OpenSsl.isAvailable());
 
         SelfSignedCertificate ssc = new SelfSignedCertificate();
-        final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .sslProvider(serverProvider)
-                .trustManager(new SimpleTrustManagerFactory() {
+        final SslContext sslServerCtx = OpenSslTestUtils.configureProtocolForMutualAuth(
+                SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                                 .sslProvider(serverProvider)
+                                 .trustManager(new SimpleTrustManagerFactory() {
             @Override
             protected void engineInit(KeyStore keyStore) { }
             @Override
@@ -154,13 +155,13 @@ public class SslErrorTest {
                     }
                 } };
             }
-        }).clientAuth(ClientAuth.REQUIRE).build();
+        }).clientAuth(ClientAuth.REQUIRE), clientProvider, serverProvider).build();
 
-        final SslContext sslClientCtx = SslContextBuilder.forClient()
+        final SslContext sslClientCtx = OpenSslTestUtils.configureProtocolForMutualAuth(SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .keyManager(new File(getClass().getResource("test.crt").getFile()),
                         new File(getClass().getResource("test_unencrypted.pem").getFile()))
-                .sslProvider(clientProvider).build();
+                .sslProvider(clientProvider), clientProvider, serverProvider).build();
 
         Channel serverChannel = null;
         Channel clientChannel = null;

--- a/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
@@ -28,6 +28,7 @@ import java.security.NoSuchAlgorithmException;
 
 import static io.netty.handler.ssl.SslUtils.getEncryptedPacketLength;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SslUtilsTest {
@@ -63,4 +64,15 @@ public class SslUtilsTest {
         engine.beginHandshake();
         return engine;
     }
+
+    @Test
+    public void testIsTLSv13Cipher() {
+        assertTrue(SslUtils.isTLSv13Cipher("TLS_AES_128_GCM_SHA256"));
+        assertTrue(SslUtils.isTLSv13Cipher("TLS_AES_256_GCM_SHA384"));
+        assertTrue(SslUtils.isTLSv13Cipher("TLS_CHACHA20_POLY1305_SHA256"));
+        assertTrue(SslUtils.isTLSv13Cipher("TLS_AES_128_CCM_SHA256"));
+        assertTrue(SslUtils.isTLSv13Cipher("TLS_AES_128_CCM_8_SHA256"));
+        assertFalse(SslUtils.isTLSv13Cipher("TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"));
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.17.Final</tcnative.version>
+    <tcnative.version>2.0.18.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -138,7 +138,8 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
             public void initChannel(Channel sch) throws Exception {
                 serverChannel = sch;
                 serverSslHandler = serverCtx.newHandler(sch.alloc());
-
+                // As we test renegotiation we should use a protocol that support it.
+                serverSslHandler.engine().setEnabledProtocols(new String[] { "TLSv1.2" });
                 sch.pipeline().addLast("ssl", serverSslHandler);
                 sch.pipeline().addLast("handler", serverHandler);
             }
@@ -150,7 +151,8 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
             public void initChannel(Channel sch) throws Exception {
                 clientChannel = sch;
                 clientSslHandler = clientCtx.newHandler(sch.alloc());
-
+                // As we test renegotiation we should use a protocol that support it.
+                clientSslHandler.engine().setEnabledProtocols(new String[] { "TLSv1.2" });
                 sch.pipeline().addLast("ssl", clientSslHandler);
                 sch.pipeline().addLast("handler", clientHandler);
             }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -123,17 +123,33 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             "autoRead = {5}, useChunkedWriteHandler = {6}, useCompositeByteBuf = {7}")
     public static Collection<Object[]> data() throws Exception {
         List<SslContext> serverContexts = new ArrayList<SslContext>();
-        serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
+        serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
+                                            .sslProvider(SslProvider.JDK)
+                                            // As we test renegotiation we should use a protocol that support it.
+                                            .protocols("TLSv1.2")
+                                            .build());
 
         List<SslContext> clientContexts = new ArrayList<SslContext>();
-        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE).build());
+        clientContexts.add(SslContextBuilder.forClient()
+                                            .sslProvider(SslProvider.JDK)
+                                            .trustManager(CERT_FILE)
+                                            // As we test renegotiation we should use a protocol that support it.
+                                            .protocols("TLSv1.2")
+                                            .build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
             serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
-                                                .sslProvider(SslProvider.OPENSSL).build());
-            clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL)
-                                                .trustManager(CERT_FILE).build());
+                                                .sslProvider(SslProvider.OPENSSL)
+                                                // As we test renegotiation we should use a protocol that support it.
+                                                .protocols("TLSv1.2")
+                                                .build());
+            clientContexts.add(SslContextBuilder.forClient()
+                                                .sslProvider(SslProvider.OPENSSL)
+                                                .trustManager(CERT_FILE)
+                                                // As we test renegotiation we should use a protocol that support it.
+                                                .protocols("TLSv1.2")
+                                                .build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -98,7 +98,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
     public void testSslSessionReuse(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         final ReadAndDiscardHandler sh = new ReadAndDiscardHandler(true, true);
         final ReadAndDiscardHandler ch = new ReadAndDiscardHandler(false, true);
-        final String[] protocols = new String[]{ "TLSv1", "TLSv1.1", "TLSv1.2" };
+        final String[] protocols = { "TLSv1", "TLSv1.1", "TLSv1.2" };
 
         sb.childHandler(new ChannelInitializer<SocketChannel>() {
             @Override


### PR DESCRIPTION
Motivation:

TLSv1.3 support is included in java11 and is also supported by OpenSSL 1.1.1, so we should support when possible.

Modifications:
- Add support for TLSv1.3 using either the JDK implementation or the native implementation provided by netty-tcnative when compiled against openssl 1.1.1
- Adjust unit tests for semantics provided by TLSv1.3
- Correctly handle custom Provider implementations that not support TLSv1.3

Result:

Be able to use TLSv1.3 with netty.