### PR TITLE
Update to Conscrypt 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
-    <conscrypt.version>1.1.3</conscrypt.version>
+    <conscrypt.version>1.3.0</conscrypt.version>
     <conscrypt.classifier />
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

Conscrypt 1.3.0 was just released and adds support for TLSv1.3

Modifications:

Update to 1.3.0

Result:

Use latest conscrypt during build / test.