### PR TITLE
Correctly implement ExtendedSSLSession.getStatusResponses() for Refer…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -251,6 +251,20 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 public List getRequestedServerNames() {
                     return Java8SslUtils.getSniHostNames(sniHostNames);
                 }
+
+                @Override
+                public List<byte[]> getStatusResponses() {
+                    byte[] ocspResponse = null;
+                    if (enableOcsp && clientMode) {
+                        synchronized (ReferenceCountedOpenSslEngine.this) {
+                            if (!isDestroyed()) {
+                                ocspResponse = SSL.getOcspResponse(ssl);
+                            }
+                        }
+                    }
+                    return ocspResponse == null ?
+                            Collections.<byte[]>emptyList() : Collections.singletonList(ocspResponse);
+                }
             };
         } else {
             session = new DefaultOpenSslSession(context.sessionContext());


### PR DESCRIPTION
…enceCountedOpenSslEngine

Motivation:

Java9 added getStatusResponses() to ExtendedSSLSession which we should correctly support when possible.

Modifications:

Implement the method correctly.

Result:

More complete and correct implementation.