### PR TITLE
Cleanup SSL test.

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -340,7 +340,7 @@ public class ParameterizedSslHandlerTest {
                                 public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                     if (cause.getCause() instanceof SSLException) {
                                         // We received the alert and so produce an SSLException.
-                                        promise.setSuccess(null);
+                                        promise.trySuccess(null);
                                     }
                                 }
                             });


### PR DESCRIPTION
Motivation:

I noticed that we had some errors showing up in a test (which did not fail it tho) because we tried to full-fill the promise multiples times.

Modifications:

Use trySuccess(...) as we may produce multiple exceptions.

Result:

Less errors during test-run.