### PR TITLE
Ensure we always encode all data in JdkZlibEncoder.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -225,8 +225,18 @@ public class JdkZlibEncoder extends ZlibEncoder {
         }
 
         deflater.setInput(inAry, offset, len);
-        while (!deflater.needsInput()) {
+        for (;;) {
             deflate(out);
+            if (deflater.needsInput()) {
+                // Consumed everything
+                break;
+            } else {
+                if (!out.isWritable()) {
+                    // We did not consume everything but the buffer is not writable anymore. Increase the capacity to
+                    // make more room.
+                    out.ensureWritable(out.writerIndex());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

In theory our estimation of the needed buffer could be off and so we need to ensure we grow it if there is no space left.

Modifications:

Ensure we grow the buffer if there is no space left in there but we still have data to deflate.

Result:

Correctly deflate data in all cases.