### PR TITLE
Do the same extended checks as the JDK when a X509TrustManager is use…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -404,6 +404,10 @@ public final class PlatformDependent {
                 "sun.misc.Unsafe or java.nio.DirectByteBuffer.<init>(long, int) not available");
     }
 
+    public static Object getObject(Object object, long fieldOffset) {
+        return PlatformDependent0.getObject(object, fieldOffset);
+    }
+
     public static int getInt(Object object, long fieldOffset) {
         return PlatformDependent0.getInt(object, fieldOffset);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509TrustManagerWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509TrustManagerWrapper.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivilegedAction;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ * Utility which allows to wrap {@link X509TrustManager} implementations with the internal implementation used by
+ * {@code SSLContextImpl} that provides extended verification.
+ *
+ * This is really a "hack" until there is an official API as requested on the in
+ * <a href="https://bugs.openjdk.java.net/projects/JDK/issues/JDK-8210843">JDK-8210843</a>.
+ */
+final class OpenSslX509TrustManagerWrapper {
+    private static final InternalLogger LOGGER = InternalLoggerFactory
+            .getInstance(OpenSslX509TrustManagerWrapper.class);
+    private static final TrustManagerWrapper WRAPPER;
+
+    static {
+        // By default we will not do any wrapping but just return the passed in manager.
+        TrustManagerWrapper wrapper = new TrustManagerWrapper() {
+            @Override
+            public X509TrustManager wrapIfNeeded(X509TrustManager manager) {
+                return manager;
+            }
+        };
+
+        Throwable cause = null;
+        Throwable unsafeCause = PlatformDependent.getUnsafeUnavailabilityCause();
+        if (unsafeCause == null) {
+            SSLContext context;
+            try {
+                context = newSSLContext();
+                // Now init with an array that only holds a X509TrustManager. This should be wrapped into an
+                // AbstractTrustManagerWrapper which will delegate the TrustManager itself but also do extra
+                // validations.
+                //
+                // See:
+                // - http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/
+                //          cadea780bc76/src/share/classes/sun/security/ssl/SSLContextImpl.java#l127
+                context.init(null, new TrustManager[] {
+                        new X509TrustManager() {
+                            @Override
+                            public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
+                                    throws CertificateException {
+                            }
+
+                            @Override
+                            public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
+                                    throws CertificateException {
+                            }
+
+                            @Override
+                            public X509Certificate[] getAcceptedIssuers() {
+                                return EmptyArrays.EMPTY_X509_CERTIFICATES;
+                            }
+                        }
+                }, null);
+            } catch (Throwable error) {
+                context = null;
+                cause = error;
+            }
+            if (cause != null) {
+                LOGGER.debug("Unable to access wrapped TrustManager", cause);
+            } else {
+                final SSLContext finalContext = context;
+                Object maybeWrapper = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                    @Override
+                    public Object run() {
+                        try {
+                            Field contextSpiField = SSLContext.class.getDeclaredField("contextSpi");
+                            final long spiOffset = PlatformDependent.objectFieldOffset(contextSpiField);
+                            Object spi = PlatformDependent.getObject(finalContext, spiOffset);
+                            if (spi != null) {
+                                Class<?> clazz = spi.getClass();
+
+                                // Let's cycle through the whole hierarchy until we find what we are looking for or
+                                // there is nothing left in which case we will not wrap at all.
+                                do {
+                                    try {
+                                        Field trustManagerField = clazz.getDeclaredField("trustManager");
+                                        final long tmOffset = PlatformDependent.objectFieldOffset(trustManagerField);
+                                        Object trustManager = PlatformDependent.getObject(spi, tmOffset);
+                                        if (trustManager instanceof X509ExtendedTrustManager) {
+                                            return new UnsafeTrustManagerWrapper(spiOffset, tmOffset);
+                                        }
+                                    } catch (NoSuchFieldException ignore) {
+                                        // try next
+                                    }
+                                    clazz = clazz.getSuperclass();
+                                } while (clazz != null);
+                            }
+                            throw new NoSuchFieldException();
+                        } catch (NoSuchFieldException e) {
+                            return e;
+                        } catch (SecurityException e) {
+                            return e;
+                        }
+                    }
+                });
+                if (maybeWrapper instanceof Throwable) {
+                    LOGGER.debug("Unable to access wrapped TrustManager", (Throwable) maybeWrapper);
+                } else {
+                    wrapper = (TrustManagerWrapper) maybeWrapper;
+                }
+            }
+        } else {
+            LOGGER.debug("Unable to access wrapped TrustManager", cause);
+        }
+        WRAPPER = wrapper;
+    }
+
+    private OpenSslX509TrustManagerWrapper() { }
+
+    static X509TrustManager wrapIfNeeded(X509TrustManager trustManager) {
+        return WRAPPER.wrapIfNeeded(trustManager);
+    }
+
+    private interface TrustManagerWrapper {
+        X509TrustManager wrapIfNeeded(X509TrustManager manager);
+    }
+
+    private static SSLContext newSSLContext() throws NoSuchAlgorithmException {
+        return SSLContext.getInstance("TLS");
+    }
+
+    private static final class UnsafeTrustManagerWrapper implements TrustManagerWrapper {
+        private final long spiOffset;
+        private final long tmOffset;
+
+        UnsafeTrustManagerWrapper(long spiOffset, long tmOffset) {
+            this.spiOffset = spiOffset;
+            this.tmOffset = tmOffset;
+        }
+
+        @Override
+        public X509TrustManager wrapIfNeeded(X509TrustManager manager) {
+            if (!(manager instanceof X509ExtendedTrustManager)) {
+                try {
+                    SSLContext ctx = newSSLContext();
+                    ctx.init(null, new TrustManager[] { manager }, null);
+                    Object spi = PlatformDependent.getObject(ctx, spiOffset);
+                    if (spi != null) {
+                        Object tm = PlatformDependent.getObject(spi, tmOffset);
+                        if (tm instanceof X509ExtendedTrustManager) {
+                            return (X509TrustManager) tm;
+                        }
+                    }
+                } catch (NoSuchAlgorithmException e) {
+                    // This should never happen as we did the same in the static
+                    // before.
+                    PlatformDependent.throwException(e);
+                } catch (KeyManagementException e) {
+                    // This should never happen as we did the same in the static
+                    // before.
+                    PlatformDependent.throwException(e);
+                }
+            }
+            return manager;
+        }
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -508,7 +508,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     protected static X509TrustManager chooseTrustManager(TrustManager[] managers) {
         for (TrustManager m : managers) {
             if (m instanceof X509TrustManager) {
-                return (X509TrustManager) m;
+                return OpenSslX509TrustManagerWrapper.wrapIfNeeded((X509TrustManager) m);
             }
         }
         throw new IllegalStateException("no X509TrustManager found");


### PR DESCRIPTION
…d with the OpenSSL provider.

Motivation:

When a X509TrustManager is used while configure the SslContext the JDK automatically does some extra checks during validation of provided certs by the remote peer. We should do the same when our native implementation is used.

Modification:

- Automatically wrap a X509TrustManager and so do the same validations as the JDK does.
- Add unit tests.

Result:

More consistent behaviour. Fixes https://github.com/netty/netty/issues/6664.