### PR TITLE
Allow to specify a RedirectDnsServerAddressStreamProvider when buildi…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultRedirectDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultRedirectDnsServerAddressStreamProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Default implementation of a {@link RedirectDnsServerAddressStreamProvider} which just uses a {@link Comparator}
+ * to sorty the {@link List} of servers and returns a sequential {@link DnsServerAddressStream} out of it.
+ */
+@UnstableApi
+public final class DefaultRedirectDnsServerAddressStreamProvider implements RedirectDnsServerAddressStreamProvider {
+
+    private final Comparator<InetSocketAddress> nameServerComparator;
+
+    public DefaultRedirectDnsServerAddressStreamProvider(Comparator<InetSocketAddress> nameServerComparator) {
+        this.nameServerComparator = ObjectUtil.checkNotNull(nameServerComparator, "nameServerComparator");
+    }
+
+    @Override
+    public DnsServerAddressStream nameServerAddressStream(String hostname, List<InetSocketAddress> nameservers) {
+        Collections.sort(nameservers, nameServerComparator);
+        return new SequentialDnsServerAddressStream(nameservers, 0);
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/RedirectDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/RedirectDnsServerAddressStreamProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * Provides an opportunity to override which {@link DnsServerAddressStream} is used when follow redirects for
+ * hostname.
+ */
+@UnstableApi
+public interface RedirectDnsServerAddressStreamProvider {
+    /**
+     * Ask this provider for the name servers to query for {@code hostname}.
+     * @param hostname The hostname for which we want to to follow a redirect.
+     * @param nameservers The nameservers returned by the nameserver that should be use to follow.
+     * @return The {@link DnsServerAddressStream} which should be used to resolve {@code hostname}.
+     */
+    DnsServerAddressStream nameServerAddressStream(String hostname,  List<InetSocketAddress> nameservers);
+}


### PR DESCRIPTION
…ng a DnsNameResolver.

Motivation:

Sometimes users need to adjust the logic on how we should follow dns redirects (for example adjust the order of the tried nameservers). This is currently possible by extending DnsNameResolver and overriding a method. This is really a bit "odd" as constructing this class directly involves a constructor with a lot of different arguments. We should allow the user to do this via the builder.

Modifications:

- Add a RedirectDnsServerAddressStreamProvider interface and a default implementation
- Add the extra methods to DnsNameResolverBuilder to configure such a provider
- Deprecate the public constructors of DnsNameResolver, as users should just us the builder.

Result:

Easier and cleaner way of adjusting the DnsNameResolver