### PR TITLE
Use AuthoritativeDnsServerCache for creating the new redirect stream.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -414,8 +414,14 @@ public class DnsNameResolver extends InetNameResolver {
      */
     protected DnsServerAddressStream newRedirectDnsServerStream(
             @SuppressWarnings("unused") String hostname, List<InetSocketAddress> nameservers) {
-        Collections.sort(nameservers, nameServerComparator);
-        return new SequentialDnsServerAddressStream(nameservers, 0);
+        DnsServerAddressStream cached = authoritativeDnsServerCache().get(hostname);
+        if (cached == null || cached.size() == 0) {
+            // If there is not cache hit (which may be the case for example when a NoopAuthoritativeDnsServerCache
+            // is used we will just directly use the provided nameservers.
+            Collections.sort(nameservers, nameServerComparator);
+            return new SequentialDnsServerAddressStream(nameservers, 0);
+        }
+        return cached;
     }
 
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -416,8 +416,8 @@ public class DnsNameResolver extends InetNameResolver {
             @SuppressWarnings("unused") String hostname, List<InetSocketAddress> nameservers) {
         DnsServerAddressStream cached = authoritativeDnsServerCache().get(hostname);
         if (cached == null || cached.size() == 0) {
-            // If there is not cache hit (which may be the case for example when a NoopAuthoritativeDnsServerCache
-            // is used we will just directly use the provided nameservers.
+            // If there is no cache hit (which may be the case for example when a NoopAuthoritativeDnsServerCache
+            // is used), we will just directly use the provided nameservers.
             Collections.sort(nameservers, nameServerComparator);
             return new SequentialDnsServerAddressStream(nameservers, 0);
         }


### PR DESCRIPTION
Motivation:

At the moment if a user wants to provide custom sorting of the nameservers used for redirects it needs to be implemented in two places. This is more complicated as it needs to be.

Modifications:

- Just delegate to the AuthoritativeDnsServerCache always as we fill it before we call newRedirectDnsServerStream anyway.

Result:

Easier way for the user to implement custom sorting.