### PR TITLE
Update to final Java11 release

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.11.0-28"
+        java_version : "1.11.0"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.11.0-28"
+        java_version : "1.11.0"
 
   test:
     image: netty:centos-7-1.11


### PR DESCRIPTION
Motivation:

We should use final Java11 release during builds.

Modifications:

Update to final Java11 release

Result:

Use latest release.