### PR TITLE
Make it clear that HashedWheelTimer only support millis.

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -84,6 +84,7 @@ public class HashedWheelTimer implements Timer {
     private static final AtomicInteger INSTANCE_COUNTER = new AtomicInteger();
     private static final AtomicBoolean WARNED_TOO_MANY_INSTANCES = new AtomicBoolean();
     private static final int INSTANCE_COUNT_LIMIT = 64;
+    private static final long MILLISECOND_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
     private static final ResourceLeakDetector<HashedWheelTimer> leakDetector = ResourceLeakDetectorFactory.instance()
             .newResourceLeakDetector(HashedWheelTimer.class, 1);
 
@@ -259,14 +260,25 @@ public class HashedWheelTimer implements Timer {
         mask = wheel.length - 1;
 
         // Convert tickDuration to nanos.
-        this.tickDuration = unit.toNanos(tickDuration);
+        long duration = unit.toNanos(tickDuration);
 
         // Prevent overflow.
-        if (this.tickDuration >= Long.MAX_VALUE / wheel.length) {
+        if (duration >= Long.MAX_VALUE / wheel.length) {
             throw new IllegalArgumentException(String.format(
                     "tickDuration: %d (expected: 0 < tickDuration in nanos < %d",
                     tickDuration, Long.MAX_VALUE / wheel.length));
         }
+
+        if (duration < MILLISECOND_NANOS) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Configured tickDuration %d smaller then %d, using 1ms.",
+                            tickDuration, MILLISECOND_NANOS);
+            }
+            this.tickDuration = MILLISECOND_NANOS;
+        } else {
+            this.tickDuration = duration;
+        }
+
         workerThread = threadFactory.newThread(worker);
 
         leak = leakDetection || !workerThread.isDaemon() ? leakDetector.track(this) : null;


### PR DESCRIPTION
    Motivation:

    HWT does not support anything smaller then 1ms so we should make it clear that this is the case.

    Modifications:

    Log a warning if < 1ms is used.

    Result:

    Less suprising behaviour.