### PR TITLE
Allow to run tests with leak detection enabled.

### DIFF
--- a/docker/docker-compose.centos-6.110.yaml
+++ b/docker/docker-compose.centos-6.110.yaml
@@ -11,6 +11,8 @@ services:
 
   test:
     image: netty:centos-6-1.10
+  test-leak:
+    image: netty:centos-6-1.10
 
   test-boringssl-static:
     image: netty:centos-6-1.10

--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -12,6 +12,9 @@ services:
   test:
     image: netty:centos-6-1.11
 
+  test-leak:
+    image: netty:centos-6-1.11
+
   test-boringssl-static:
     image: netty:centos-6-1.11
 

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -12,6 +12,9 @@ services:
   test:
     image: netty:centos-6-1.8
 
+  test-leak:
+    image: netty:centos-6-1.8
+
   test-boringssl-static:
     image: netty:centos-6-1.8
 

--- a/docker/docker-compose.centos-6.19.yaml
+++ b/docker/docker-compose.centos-6.19.yaml
@@ -12,6 +12,9 @@ services:
   test:
     image: netty:centos-6-1.9
 
+  test-leak:
+    image: netty:centos-6-1.9
+
   test-boringssl-static:
     image: netty:centos-6-1.9
 

--- a/docker/docker-compose.centos-7.110.yaml
+++ b/docker/docker-compose.centos-7.110.yaml
@@ -12,6 +12,9 @@ services:
   test:
     image: netty:centos-7-1.10
 
+  test-leak:
+    image: netty:centos-7-1.10
+
   test-boringssl-static:
     image: netty:centos-7-1.10
 

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -12,6 +12,9 @@ services:
   test:
     image: netty:centos-7-1.11
 
+  test-leak:
+    image: netty:centos-7-1.11
+
   test-boringssl-static:
     image: netty:centos-7-1.11
 

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -12,6 +12,9 @@ services:
   test:
     image: netty:centos-7-1.8
 
+  test-leak:
+    image: netty:centos-7-1.8
+
   test-boringssl-static:
     image: netty:centos-7-1.8
 

--- a/docker/docker-compose.centos-7.19.yaml
+++ b/docker/docker-compose.centos-7.19.yaml
@@ -12,6 +12,9 @@ services:
   test:
     image: netty:centos-7-1.9
 
+  test-leak:
+    image: netty:centos-7-1.9
+
   test-boringssl-static:
     image: netty:centos-7-1.9
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -17,6 +17,10 @@ services:
       - ..:/code
     working_dir: /code
 
+  test-leak:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -Pleak clean install -Dio.netty.testsuite.badHost=netty.io"
+
   test:
     <<: *common
     command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io"


### PR DESCRIPTION
Motivation:

We should add some command to be able to run all tests with leak detection enabled. This will then be used on the CI during PR builds.

Modifications:

Add new docker-compose config to run with leak-detection enabled.

Result:

Easy way to enable leak detection while running tests via docker.
