### PR TITLE
Add docker-compose config to run with Java12

### DIFF
--- a/docker/docker-compose.centos-6.112.yaml
+++ b/docker/docker-compose.centos-6.112.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-1.12
+    build:
+      args:
+        centos_version : "6"
+        java_version : "openjdk@1.12.0"
+
+  test:
+    image: netty:centos-6-1.12
+
+  test-leak:
+    image: netty:centos-6-1.12
+
+  test-boringssl-static:
+    image: netty:centos-6-1.12
+
+  shell:
+    image: netty:centos-6-1.12

--- a/docker/docker-compose.centos-7.112.yaml
+++ b/docker/docker-compose.centos-7.112.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-7-1.12
+    build:
+      args:
+        centos_version : "7"
+        java_version : "openjdk@1.12.0"
+
+  test:
+    image: netty:centos-7-1.12
+
+  test-leak:
+    image: netty:centos-7-1.12
+
+  test-boringssl-static:
+    image: netty:centos-7-1.12
+
+  shell:
+    image: netty:centos-7-1.12


### PR DESCRIPTION
Motivation:

The first EA builds for Java12 are released so we should allow to run with these in our docker-compose setup.

Modifications:

Add docker-compose configs for Java12.

Result:

Be able to run easily with Java12 as well.