### PR TITLE
Avoid repeating the same field and hiding it

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -29,12 +29,10 @@ import java.util.Map;
 import static io.netty.channel.unix.Limits.SSIZE_MAX;
 
 public class EpollChannelConfig extends DefaultChannelConfig {
-    final AbstractEpollChannel channel;
     private volatile long maxBytesPerGatheringWrite = SSIZE_MAX;
 
     EpollChannelConfig(AbstractEpollChannel channel) {
         super(channel);
-        this.channel = channel;
     }
 
     @Override
@@ -136,7 +134,7 @@ public class EpollChannelConfig extends DefaultChannelConfig {
      * {@link EpollMode#LEVEL_TRIGGERED}.
      */
     public EpollMode getEpollMode() {
-        return channel.isFlagSet(Native.EPOLLET)
+        return ((AbstractEpollChannel) channel).isFlagSet(Native.EPOLLET)
                 ? EpollMode.EDGE_TRIGGERED : EpollMode.LEVEL_TRIGGERED;
     }
 
@@ -156,11 +154,11 @@ public class EpollChannelConfig extends DefaultChannelConfig {
             switch (mode) {
             case EDGE_TRIGGERED:
                 checkChannelNotRegistered();
-                channel.setFlag(Native.EPOLLET);
+                ((AbstractEpollChannel) channel).setFlag(Native.EPOLLET);
                 break;
             case LEVEL_TRIGGERED:
                 checkChannelNotRegistered();
-                channel.clearFlag(Native.EPOLLET);
+                ((AbstractEpollChannel) channel).clearFlag(Native.EPOLLET);
                 break;
             default:
                 throw new Error();
@@ -179,7 +177,7 @@ public class EpollChannelConfig extends DefaultChannelConfig {
 
     @Override
     protected final void autoReadCleared() {
-        channel.clearEpollIn();
+        ((AbstractEpollChannel) channel).clearEpollIn();
     }
 
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -31,12 +31,10 @@ import java.util.Map;
 
 public final class EpollDatagramChannelConfig extends EpollChannelConfig implements DatagramChannelConfig {
     private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
-    private final EpollDatagramChannel datagramChannel;
     private boolean activeOnOpen;
 
     EpollDatagramChannelConfig(EpollDatagramChannel channel) {
         super(channel);
-        datagramChannel = channel;
         setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
     }
 
@@ -219,7 +217,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public int getSendBufferSize() {
         try {
-            return datagramChannel.socket.getSendBufferSize();
+            return ((EpollDatagramChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -228,7 +226,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public EpollDatagramChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
-            datagramChannel.socket.setSendBufferSize(sendBufferSize);
+            ((EpollDatagramChannel) channel).socket.setSendBufferSize(sendBufferSize);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -238,7 +236,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public int getReceiveBufferSize() {
         try {
-            return datagramChannel.socket.getReceiveBufferSize();
+            return ((EpollDatagramChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -247,7 +245,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public EpollDatagramChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
-            datagramChannel.socket.setReceiveBufferSize(receiveBufferSize);
+            ((EpollDatagramChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -257,7 +255,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public int getTrafficClass() {
         try {
-            return datagramChannel.socket.getTrafficClass();
+            return ((EpollDatagramChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -266,7 +264,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public EpollDatagramChannelConfig setTrafficClass(int trafficClass) {
         try {
-            datagramChannel.socket.setTrafficClass(trafficClass);
+            ((EpollDatagramChannel) channel).socket.setTrafficClass(trafficClass);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -276,7 +274,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public boolean isReuseAddress() {
         try {
-            return datagramChannel.socket.isReuseAddress();
+            return ((EpollDatagramChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -285,7 +283,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public EpollDatagramChannelConfig setReuseAddress(boolean reuseAddress) {
         try {
-            datagramChannel.socket.setReuseAddress(reuseAddress);
+            ((EpollDatagramChannel) channel).socket.setReuseAddress(reuseAddress);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -295,7 +293,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public boolean isBroadcast() {
         try {
-            return datagramChannel.socket.isBroadcast();
+            return ((EpollDatagramChannel) channel).socket.isBroadcast();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -304,7 +302,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     @Override
     public EpollDatagramChannelConfig setBroadcast(boolean broadcast) {
         try {
-            datagramChannel.socket.setBroadcast(broadcast);
+            ((EpollDatagramChannel) channel).socket.setBroadcast(broadcast);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -362,7 +360,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
      */
     public boolean isReusePort() {
         try {
-            return datagramChannel.socket.isReusePort();
+            return ((EpollDatagramChannel) channel).socket.isReusePort();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -377,7 +375,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
      */
     public EpollDatagramChannelConfig setReusePort(boolean reusePort) {
         try {
-            datagramChannel.socket.setReusePort(reusePort);
+            ((EpollDatagramChannel) channel).socket.setReusePort(reusePort);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -390,7 +388,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
      */
     public boolean isIpTransparent() {
         try {
-            return datagramChannel.socket.isIpTransparent();
+            return ((EpollDatagramChannel) channel).socket.isIpTransparent();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -402,7 +400,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
      */
     public EpollDatagramChannelConfig setIpTransparent(boolean ipTransparent) {
         try {
-            datagramChannel.socket.setIpTransparent(ipTransparent);
+            ((EpollDatagramChannel) channel).socket.setIpTransparent(ipTransparent);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -415,7 +413,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
      */
     public boolean isIpRecvOrigDestAddr() {
         try {
-            return datagramChannel.socket.isIpRecvOrigDestAddr();
+            return ((EpollDatagramChannel) channel).socket.isIpRecvOrigDestAddr();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -427,7 +425,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
      */
     public EpollDatagramChannelConfig setIpRecvOrigDestAddr(boolean ipTransparent) {
         try {
-            datagramChannel.socket.setIpRecvOrigDestAddr(ipTransparent);
+            ((EpollDatagramChannel) channel).socket.setIpRecvOrigDestAddr(ipTransparent);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
@@ -32,13 +32,11 @@ import static io.netty.channel.ChannelOption.SO_RCVBUF;
 import static io.netty.channel.ChannelOption.SO_REUSEADDR;
 
 public class EpollServerChannelConfig extends EpollChannelConfig implements ServerSocketChannelConfig {
-    protected final AbstractEpollChannel channel;
     private volatile int backlog = NetUtil.SOMAXCONN;
     private volatile int pendingFastOpenRequestsThreshold;
 
     EpollServerChannelConfig(AbstractEpollChannel channel) {
         super(channel);
-        this.channel = channel;
     }
 
     @Override
@@ -85,7 +83,7 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
 
     public boolean isReuseAddress() {
         try {
-            return channel.socket.isReuseAddress();
+            return ((AbstractEpollChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -93,7 +91,7 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
 
     public EpollServerChannelConfig setReuseAddress(boolean reuseAddress) {
         try {
-            channel.socket.setReuseAddress(reuseAddress);
+            ((AbstractEpollChannel) channel).socket.setReuseAddress(reuseAddress);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -102,7 +100,7 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
 
     public int getReceiveBufferSize() {
         try {
-            return channel.socket.getReceiveBufferSize();
+            return ((AbstractEpollChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -110,7 +108,7 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
 
     public EpollServerChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
-            channel.socket.setReceiveBufferSize(receiveBufferSize);
+            ((AbstractEpollChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannelConfig.java
@@ -191,7 +191,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      */
     public boolean isReusePort() {
         try {
-            return channel.socket.isReusePort();
+            return ((EpollServerSocketChannel) channel).socket.isReusePort();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -206,7 +206,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      */
     public EpollServerSocketChannelConfig setReusePort(boolean reusePort) {
         try {
-            channel.socket.setReusePort(reusePort);
+            ((EpollServerSocketChannel) channel).socket.setReusePort(reusePort);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -219,7 +219,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      */
     public boolean isFreeBind() {
         try {
-            return channel.socket.isIpFreeBind();
+            return ((EpollServerSocketChannel) channel).socket.isIpFreeBind();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -231,7 +231,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      */
     public EpollServerSocketChannelConfig setFreeBind(boolean freeBind) {
         try {
-            channel.socket.setIpFreeBind(freeBind);
+            ((EpollServerSocketChannel) channel).socket.setIpFreeBind(freeBind);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -244,7 +244,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      */
     public boolean isIpTransparent() {
         try {
-            return channel.socket.isIpTransparent();
+            return ((EpollServerSocketChannel) channel).socket.isIpTransparent();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -256,7 +256,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      */
     public EpollServerSocketChannelConfig setIpTransparent(boolean transparent) {
         try {
-            channel.socket.setIpTransparent(transparent);
+            ((EpollServerSocketChannel) channel).socket.setIpTransparent(transparent);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -268,7 +268,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      */
     public EpollServerSocketChannelConfig setTcpDeferAccept(int deferAccept) {
         try {
-            channel.socket.setTcpDeferAccept(deferAccept);
+            ((EpollServerSocketChannel) channel).socket.setTcpDeferAccept(deferAccept);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -280,7 +280,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      */
     public int getTcpDeferAccept() {
         try {
-            return channel.socket.getTcpDeferAccept();
+            return ((EpollServerSocketChannel) channel).socket.getTcpDeferAccept();
         } catch (IOException e) {
             throw new ChannelException(e);
         }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
@@ -38,7 +38,6 @@ import static io.netty.channel.ChannelOption.SO_SNDBUF;
 import static io.netty.channel.ChannelOption.TCP_NODELAY;
 
 public final class EpollSocketChannelConfig extends EpollChannelConfig implements SocketChannelConfig {
-    private final EpollSocketChannel channel;
     private volatile boolean allowHalfClosure;
 
     /**
@@ -47,7 +46,6 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     EpollSocketChannelConfig(EpollSocketChannel channel) {
         super(channel);
 
-        this.channel = channel;
         if (PlatformDependent.canEnableTcpNoDelayByDefault()) {
             setTcpNoDelay(true);
         }
@@ -179,7 +177,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public int getReceiveBufferSize() {
         try {
-            return channel.socket.getReceiveBufferSize();
+            return ((EpollSocketChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -188,7 +186,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public int getSendBufferSize() {
         try {
-            return channel.socket.getSendBufferSize();
+            return ((EpollSocketChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -197,7 +195,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public int getSoLinger() {
         try {
-            return channel.socket.getSoLinger();
+            return ((EpollSocketChannel) channel).socket.getSoLinger();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -206,7 +204,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public int getTrafficClass() {
         try {
-            return channel.socket.getTrafficClass();
+            return ((EpollSocketChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -215,7 +213,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public boolean isKeepAlive() {
         try {
-            return channel.socket.isKeepAlive();
+            return ((EpollSocketChannel) channel).socket.isKeepAlive();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -224,7 +222,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public boolean isReuseAddress() {
         try {
-            return channel.socket.isReuseAddress();
+            return ((EpollSocketChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -233,7 +231,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public boolean isTcpNoDelay() {
         try {
-            return channel.socket.isTcpNoDelay();
+            return ((EpollSocketChannel) channel).socket.isTcpNoDelay();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -244,7 +242,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public boolean isTcpCork() {
         try {
-            return channel.socket.isTcpCork();
+            return ((EpollSocketChannel) channel).socket.isTcpCork();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -255,7 +253,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public int getSoBusyPoll() {
         try {
-            return channel.socket.getSoBusyPoll();
+            return ((EpollSocketChannel) channel).socket.getSoBusyPoll();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -267,7 +265,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public long getTcpNotSentLowAt() {
         try {
-            return channel.socket.getTcpNotSentLowAt();
+            return ((EpollSocketChannel) channel).socket.getTcpNotSentLowAt();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -278,7 +276,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public int getTcpKeepIdle() {
         try {
-            return channel.socket.getTcpKeepIdle();
+            return ((EpollSocketChannel) channel).socket.getTcpKeepIdle();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -289,7 +287,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public int getTcpKeepIntvl() {
         try {
-            return channel.socket.getTcpKeepIntvl();
+            return ((EpollSocketChannel) channel).socket.getTcpKeepIntvl();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -300,7 +298,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public int getTcpKeepCnt() {
         try {
-            return channel.socket.getTcpKeepCnt();
+            return ((EpollSocketChannel) channel).socket.getTcpKeepCnt();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -311,7 +309,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public int getTcpUserTimeout() {
         try {
-            return channel.socket.getTcpUserTimeout();
+            return ((EpollSocketChannel) channel).socket.getTcpUserTimeout();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -320,7 +318,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public EpollSocketChannelConfig setKeepAlive(boolean keepAlive) {
         try {
-            channel.socket.setKeepAlive(keepAlive);
+            ((EpollSocketChannel) channel).socket.setKeepAlive(keepAlive);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -336,7 +334,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public EpollSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
-            channel.socket.setReceiveBufferSize(receiveBufferSize);
+            ((EpollSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -346,7 +344,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public EpollSocketChannelConfig setReuseAddress(boolean reuseAddress) {
         try {
-            channel.socket.setReuseAddress(reuseAddress);
+            ((EpollSocketChannel) channel).socket.setReuseAddress(reuseAddress);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -356,7 +354,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public EpollSocketChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
-            channel.socket.setSendBufferSize(sendBufferSize);
+            ((EpollSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
             calculateMaxBytesPerGatheringWrite();
             return this;
         } catch (IOException e) {
@@ -367,7 +365,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public EpollSocketChannelConfig setSoLinger(int soLinger) {
         try {
-            channel.socket.setSoLinger(soLinger);
+            ((EpollSocketChannel) channel).socket.setSoLinger(soLinger);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -377,7 +375,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public EpollSocketChannelConfig setTcpNoDelay(boolean tcpNoDelay) {
         try {
-            channel.socket.setTcpNoDelay(tcpNoDelay);
+            ((EpollSocketChannel) channel).socket.setTcpNoDelay(tcpNoDelay);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -389,7 +387,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpCork(boolean tcpCork) {
         try {
-            channel.socket.setTcpCork(tcpCork);
+            ((EpollSocketChannel) channel).socket.setTcpCork(tcpCork);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -401,7 +399,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setSoBusyPoll(int loopMicros) {
         try {
-            channel.socket.setSoBusyPoll(loopMicros);
+            ((EpollSocketChannel) channel).socket.setSoBusyPoll(loopMicros);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -414,7 +412,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpNotSentLowAt(long tcpNotSentLowAt) {
         try {
-            channel.socket.setTcpNotSentLowAt(tcpNotSentLowAt);
+            ((EpollSocketChannel) channel).socket.setTcpNotSentLowAt(tcpNotSentLowAt);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -424,7 +422,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     @Override
     public EpollSocketChannelConfig setTrafficClass(int trafficClass) {
         try {
-            channel.socket.setTrafficClass(trafficClass);
+            ((EpollSocketChannel) channel).socket.setTrafficClass(trafficClass);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -436,7 +434,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpKeepIdle(int seconds) {
         try {
-            channel.socket.setTcpKeepIdle(seconds);
+            ((EpollSocketChannel) channel).socket.setTcpKeepIdle(seconds);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -448,7 +446,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpKeepIntvl(int seconds) {
         try {
-            channel.socket.setTcpKeepIntvl(seconds);
+            ((EpollSocketChannel) channel).socket.setTcpKeepIntvl(seconds);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -468,7 +466,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpKeepCnt(int probes) {
         try {
-            channel.socket.setTcpKeepCnt(probes);
+            ((EpollSocketChannel) channel).socket.setTcpKeepCnt(probes);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -480,7 +478,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpUserTimeout(int milliseconds) {
         try {
-            channel.socket.setTcpUserTimeout(milliseconds);
+            ((EpollSocketChannel) channel).socket.setTcpUserTimeout(milliseconds);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -493,7 +491,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public boolean isIpTransparent() {
         try {
-            return channel.socket.isIpTransparent();
+            return ((EpollSocketChannel) channel).socket.isIpTransparent();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -505,7 +503,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setIpTransparent(boolean transparent) {
         try {
-            channel.socket.setIpTransparent(transparent);
+            ((EpollSocketChannel) channel).socket.setIpTransparent(transparent);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -519,7 +517,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpMd5Sig(Map<InetAddress, byte[]> keys) {
         try {
-            channel.setTcpMd5Sig(keys);
+            ((EpollSocketChannel) channel).setTcpMd5Sig(keys);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -532,7 +530,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpQuickAck(boolean quickAck) {
         try {
-            channel.socket.setTcpQuickAck(quickAck);
+            ((EpollSocketChannel) channel).socket.setTcpQuickAck(quickAck);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -545,7 +543,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public boolean isTcpQuickAck() {
         try {
-            return channel.socket.isTcpQuickAck();
+            return ((EpollSocketChannel) channel).socket.isTcpQuickAck();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -559,7 +557,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public EpollSocketChannelConfig setTcpFastOpenConnect(boolean fastOpenConnect) {
         try {
-            channel.socket.setTcpFastOpenConnect(fastOpenConnect);
+            ((EpollSocketChannel) channel).socket.setTcpFastOpenConnect(fastOpenConnect);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -571,7 +569,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
      */
     public boolean isTcpFastOpenConnect() {
         try {
-            return channel.socket.isTcpFastOpenConnect();
+            return ((EpollSocketChannel) channel).socket.isTcpFastOpenConnect();
         } catch (IOException e) {
             throw new ChannelException(e);
         }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
@@ -31,13 +31,11 @@ import static java.lang.Math.min;
 
 @UnstableApi
 public class KQueueChannelConfig extends DefaultChannelConfig {
-    final AbstractKQueueChannel channel;
     private volatile boolean transportProvidesGuess;
     private volatile long maxBytesPerGatheringWrite = SSIZE_MAX;
 
     KQueueChannelConfig(AbstractKQueueChannel channel) {
         super(channel);
-        this.channel = channel;
     }
 
     @Override
@@ -154,7 +152,7 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
 
     @Override
     protected final void autoReadCleared() {
-        channel.clearReadFilter();
+        ((AbstractKQueueChannel) channel).clearReadFilter();
     }
 
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
@@ -45,12 +45,10 @@ import static io.netty.channel.unix.UnixChannelOption.SO_REUSEPORT;
 @UnstableApi
 public final class KQueueDatagramChannelConfig extends KQueueChannelConfig implements DatagramChannelConfig {
     private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
-    private final KQueueDatagramChannel datagramChannel;
     private boolean activeOnOpen;
 
     KQueueDatagramChannelConfig(KQueueDatagramChannel channel) {
         super(channel);
-        this.datagramChannel = channel;
         setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
     }
 
@@ -153,7 +151,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
      */
     public boolean isReusePort() {
         try {
-            return datagramChannel.socket.isReusePort();
+            return ((KQueueDatagramChannel) channel).socket.isReusePort();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -168,7 +166,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
      */
     public KQueueDatagramChannelConfig setReusePort(boolean reusePort) {
         try {
-            datagramChannel.socket.setReusePort(reusePort);
+            ((KQueueDatagramChannel) channel).socket.setReusePort(reusePort);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -253,7 +251,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public int getSendBufferSize() {
         try {
-            return datagramChannel.socket.getSendBufferSize();
+            return ((KQueueDatagramChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -262,7 +260,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public KQueueDatagramChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
-            datagramChannel.socket.setSendBufferSize(sendBufferSize);
+            ((KQueueDatagramChannel) channel).socket.setSendBufferSize(sendBufferSize);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -272,7 +270,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public int getReceiveBufferSize() {
         try {
-            return datagramChannel.socket.getReceiveBufferSize();
+            return ((KQueueDatagramChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -281,7 +279,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public KQueueDatagramChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
-            datagramChannel.socket.setReceiveBufferSize(receiveBufferSize);
+            ((KQueueDatagramChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -291,7 +289,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public int getTrafficClass() {
         try {
-            return datagramChannel.socket.getTrafficClass();
+            return ((KQueueDatagramChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -300,7 +298,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public KQueueDatagramChannelConfig setTrafficClass(int trafficClass) {
         try {
-            datagramChannel.socket.setTrafficClass(trafficClass);
+            ((KQueueDatagramChannel) channel).socket.setTrafficClass(trafficClass);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -310,7 +308,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public boolean isReuseAddress() {
         try {
-            return datagramChannel.socket.isReuseAddress();
+            return ((KQueueDatagramChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -319,7 +317,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public KQueueDatagramChannelConfig setReuseAddress(boolean reuseAddress) {
         try {
-            datagramChannel.socket.setReuseAddress(reuseAddress);
+            ((KQueueDatagramChannel) channel).socket.setReuseAddress(reuseAddress);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -329,7 +327,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public boolean isBroadcast() {
         try {
-            return datagramChannel.socket.isBroadcast();
+            return ((KQueueDatagramChannel) channel).socket.isBroadcast();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -338,7 +336,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     @Override
     public KQueueDatagramChannelConfig setBroadcast(boolean broadcast) {
         try {
-            datagramChannel.socket.setBroadcast(broadcast);
+            ((KQueueDatagramChannel) channel).socket.setBroadcast(broadcast);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerChannelConfig.java
@@ -34,12 +34,10 @@ import static io.netty.channel.ChannelOption.SO_REUSEADDR;
 
 @UnstableApi
 public class KQueueServerChannelConfig extends KQueueChannelConfig implements ServerSocketChannelConfig {
-    protected final AbstractKQueueChannel channel;
     private volatile int backlog = NetUtil.SOMAXCONN;
 
     KQueueServerChannelConfig(AbstractKQueueChannel channel) {
         super(channel);
-        this.channel = channel;
     }
 
     @Override
@@ -81,7 +79,7 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
 
     public boolean isReuseAddress() {
         try {
-            return channel.socket.isReuseAddress();
+            return ((AbstractKQueueChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -89,7 +87,7 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
 
     public KQueueServerChannelConfig setReuseAddress(boolean reuseAddress) {
         try {
-            channel.socket.setReuseAddress(reuseAddress);
+            ((AbstractKQueueChannel) channel).socket.setReuseAddress(reuseAddress);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -98,7 +96,7 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
 
     public int getReceiveBufferSize() {
         try {
-            return channel.socket.getReceiveBufferSize();
+            return ((AbstractKQueueChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -106,7 +104,7 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
 
     public KQueueServerChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
-            channel.socket.setReceiveBufferSize(receiveBufferSize);
+            ((AbstractKQueueChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
@@ -75,7 +75,7 @@ public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig i
 
     public KQueueServerSocketChannelConfig setReusePort(boolean reusePort) {
         try {
-            channel.socket.setReusePort(reusePort);
+            ((KQueueServerSocketChannel) channel).socket.setReusePort(reusePort);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -84,7 +84,7 @@ public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig i
 
     public boolean isReusePort() {
         try {
-            return channel.socket.isReusePort();
+            return ((KQueueServerSocketChannel) channel).socket.isReusePort();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -92,7 +92,7 @@ public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig i
 
     public KQueueServerSocketChannelConfig setAcceptFilter(AcceptFilter acceptFilter) {
         try {
-            channel.socket.setAcceptFilter(acceptFilter);
+            ((KQueueServerSocketChannel) channel).socket.setAcceptFilter(acceptFilter);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -101,7 +101,7 @@ public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig i
 
     public AcceptFilter getAcceptFilter() {
         try {
-            return channel.socket.getAcceptFilter();
+            return ((KQueueServerSocketChannel) channel).socket.getAcceptFilter();
         } catch (IOException e) {
             throw new ChannelException(e);
         }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
@@ -41,12 +41,10 @@ import static io.netty.channel.kqueue.KQueueChannelOption.TCP_NOPUSH;
 
 @UnstableApi
 public final class KQueueSocketChannelConfig extends KQueueChannelConfig implements SocketChannelConfig {
-    private final KQueueSocketChannel channel;
     private volatile boolean allowHalfClosure;
 
     KQueueSocketChannelConfig(KQueueSocketChannel channel) {
         super(channel);
-        this.channel = channel;
         if (PlatformDependent.canEnableTcpNoDelayByDefault()) {
             setTcpNoDelay(true);
         }
@@ -131,7 +129,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public int getReceiveBufferSize() {
         try {
-            return channel.socket.getReceiveBufferSize();
+            return ((KQueueSocketChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -140,7 +138,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public int getSendBufferSize() {
         try {
-            return channel.socket.getSendBufferSize();
+            return ((KQueueSocketChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -149,7 +147,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public int getSoLinger() {
         try {
-            return channel.socket.getSoLinger();
+            return ((KQueueSocketChannel) channel).socket.getSoLinger();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -158,7 +156,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public int getTrafficClass() {
         try {
-            return channel.socket.getTrafficClass();
+            return ((KQueueSocketChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -167,7 +165,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public boolean isKeepAlive() {
         try {
-            return channel.socket.isKeepAlive();
+            return ((KQueueSocketChannel) channel).socket.isKeepAlive();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -176,7 +174,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public boolean isReuseAddress() {
         try {
-            return channel.socket.isReuseAddress();
+            return ((KQueueSocketChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -185,7 +183,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public boolean isTcpNoDelay() {
         try {
-            return channel.socket.isTcpNoDelay();
+            return ((KQueueSocketChannel) channel).socket.isTcpNoDelay();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -193,7 +191,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
 
     public int getSndLowAt() {
         try {
-            return channel.socket.getSndLowAt();
+            return ((KQueueSocketChannel) channel).socket.getSndLowAt();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -201,7 +199,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
 
     public void setSndLowAt(int sndLowAt)  {
         try {
-            channel.socket.setSndLowAt(sndLowAt);
+            ((KQueueSocketChannel) channel).socket.setSndLowAt(sndLowAt);
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -209,7 +207,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
 
     public boolean isTcpNoPush() {
         try {
-            return channel.socket.isTcpNoPush();
+            return ((KQueueSocketChannel) channel).socket.isTcpNoPush();
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -217,7 +215,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
 
     public void setTcpNoPush(boolean tcpNoPush)  {
         try {
-            channel.socket.setTcpNoPush(tcpNoPush);
+            ((KQueueSocketChannel) channel).socket.setTcpNoPush(tcpNoPush);
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -226,7 +224,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public KQueueSocketChannelConfig setKeepAlive(boolean keepAlive) {
         try {
-            channel.socket.setKeepAlive(keepAlive);
+            ((KQueueSocketChannel) channel).socket.setKeepAlive(keepAlive);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -236,7 +234,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public KQueueSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
-            channel.socket.setReceiveBufferSize(receiveBufferSize);
+            ((KQueueSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -246,7 +244,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public KQueueSocketChannelConfig setReuseAddress(boolean reuseAddress) {
         try {
-            channel.socket.setReuseAddress(reuseAddress);
+            ((KQueueSocketChannel) channel).socket.setReuseAddress(reuseAddress);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -256,7 +254,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public KQueueSocketChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
-            channel.socket.setSendBufferSize(sendBufferSize);
+            ((KQueueSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
             calculateMaxBytesPerGatheringWrite();
             return this;
         } catch (IOException e) {
@@ -267,7 +265,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public KQueueSocketChannelConfig setSoLinger(int soLinger) {
         try {
-            channel.socket.setSoLinger(soLinger);
+            ((KQueueSocketChannel) channel).socket.setSoLinger(soLinger);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -277,7 +275,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public KQueueSocketChannelConfig setTcpNoDelay(boolean tcpNoDelay) {
         try {
-            channel.socket.setTcpNoDelay(tcpNoDelay);
+            ((KQueueSocketChannel) channel).socket.setTcpNoDelay(tcpNoDelay);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);
@@ -287,7 +285,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public KQueueSocketChannelConfig setTrafficClass(int trafficClass) {
         try {
-            channel.socket.setTrafficClass(trafficClass);
+            ((KQueueSocketChannel) channel).socket.setTrafficClass(trafficClass);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);


### PR DESCRIPTION
Motivation

The EpollChannelConfig (same for KQueues) and its subclasses repeatetly declare their own channel field which leads to a 3x repetition for each config instance. Given the fields are protected or package-private it's exposing the code code to "field hiding" bugs.

Modifications

Use the the existing protected channel field from the DefaultChannelConfig class and simply cast it when needed.

Result

Fixes #8331