### PR TITLE
Cleanup: remove unnecessary vararg argument in PooledByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -580,7 +580,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         return usedMemory(directArenas);
     }
 
-    private static long usedMemory(PoolArena<?>... arenas) {
+    private static long usedMemory(PoolArena<?>[] arenas) {
         if (arenas == null) {
             return -1;
         }


### PR DESCRIPTION
Motivation:

No need in varargs, the method always accepts array.

Modification:

`...` replaced with `[]`