### PR TITLE
Cleanup: deprecate IntegerHolder for removal

### DIFF
--- a/common/src/main/java/io/netty/util/internal/IntegerHolder.java
+++ b/common/src/main/java/io/netty/util/internal/IntegerHolder.java
@@ -16,6 +16,10 @@
 
 package io.netty.util.internal;
 
+/**
+ * @deprecated For removal in netty 4.2
+ */
+@Deprecated
 public final class IntegerHolder {
     public int value;
 }

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -257,10 +257,12 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
         return cache;
     }
 
+    @Deprecated
     public IntegerHolder counterHashCode() {
         return counterHashCode;
     }
 
+    @Deprecated
     public void setCounterHashCode(IntegerHolder counterHashCode) {
         this.counterHashCode = counterHashCode;
     }


### PR DESCRIPTION
Motivation:

Seems like `IntegerHolder counterHashCode` field is the very old legacy field that is no longer used. Should be marked as deprecated and removed in the future versions.

Modification:

`IntegerHolder` class, `InternalThreadLocalMap.counterHashCode()` and `InternalThreadLocalMap.setCounterHashCode(IntegerHolder counterHashCode)`  are now deprecated.
