### PR TITLE
Cleanup: deprecate ConcurrentSet for removal

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ConcurrentSet.java
+++ b/common/src/main/java/io/netty/util/internal/ConcurrentSet.java
@@ -20,6 +20,10 @@ import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * @deprecated For removal in Netty 4.2. Please use {@link ConcurrentHashMap#newKeySet()} instead
+ */
+@Deprecated
 public final class ConcurrentSet<E> extends AbstractSet<E> implements Serializable {
 
     private static final long serialVersionUID = -6761513279741915432L;


### PR DESCRIPTION
Motivation:

Java since version 6 has the wrapper for the `ConcurrentHashMap` that could be created via  `Collections.newSetFromMap(map)`. So no need to create own `ConcurrentSet` class. Also, since netty plans to switch to Java 8 soon there is another method for that - `ConcurrentHashMap.newKeySet()`.
For now, marking this class @deprecated would be enough, just to warn users who use netty's `ConcurrentSet`. After switching to Java 8 `ConcurrentSet` should be removed and replaced with `ConcurrentHashMap.newKeySet()`.

Modification:

`ConcurrentSet` deprecated.
