### PR TITLE
Correctly parse /etc/resolv.conf when contain multiple entries for se…

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
@@ -140,6 +140,22 @@ public class UnixResolverDnsServerAddressStreamProviderTest {
     }
 
     @Test
+    public void searchDomainsWithMultipleSearchSeperatedByWhitespace() throws IOException {
+        File f = buildFile("search linecorp.local squarecorp.local\n" +
+                           "nameserver 127.0.0.2\n");
+        List<String> domains = UnixResolverDnsServerAddressStreamProvider.parseEtcResolverSearchDomains(f);
+        assertEquals(Arrays.asList("linecorp.local", "squarecorp.local"), domains);
+    }
+
+    @Test
+    public void searchDomainsWithMultipleSearchSeperatedByTab() throws IOException {
+        File f = buildFile("search linecorp.local\tsquarecorp.local\n" +
+                "nameserver 127.0.0.2\n");
+        List<String> domains = UnixResolverDnsServerAddressStreamProvider.parseEtcResolverSearchDomains(f);
+        assertEquals(Arrays.asList("linecorp.local", "squarecorp.local"), domains);
+    }
+
+    @Test
     public void searchDomainsPrecedence() throws IOException {
         File f = buildFile("domain linecorp.local\n" +
                            "search squarecorp.local\n" +


### PR DESCRIPTION
…archdomain.

Motivation:

ba594bcf4a62c47810f85c6d28e87367c6903ed4 added a utility to parse searchdomains defined in /etc/resolv.conf but did not correctly handle the case when multiple are defined that are seperated by either whitespace or tab.

Modifications:

- Correctly parse multiple entries
- Add unit test.

Result:

Correctly parse multiple searchdomain entries.