### PR TITLE
Include the whole initial line in the exception message when failing …

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.ByteProcessor;
 import io.netty.util.internal.AppendableCharSequence;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -216,7 +217,13 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 return;
             }
 
-            message = createMessage(initialLine);
+            try {
+                message = createMessage(initialLine);
+            } catch (IllegalArgumentException e) {
+                // Include the whole initial line to easier debug.
+                throw new IllegalArgumentException(
+                        "Unable to parse initial line: '" + Arrays.toString(initialLine) + '\'', e);
+            }
             currentState = State.READ_HEADER;
             // fall-through
         } catch (Exception e) {


### PR DESCRIPTION
…to create a message from it.

Motivation:

Sometimes we may fail to parse the initial line because some garbage was received. To make it easier to debug we should include the whole initial line in this case in the exception message.

Modifications:

Wrap thrown IllegalArgumentException in another IllegalArgumentException and include the full intial line in the message.

Result:

Easier to debug HTTP decoders.
