### PR TITLE
Increase test timeout

### DIFF
--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -136,7 +136,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
         }
     }
 
-    @Test(timeout = 1000)
+    @Test(timeout = 3000)
     public void testSelectableChannel() throws Exception {
         NioEventLoopGroup group = new NioEventLoopGroup(1);
         NioEventLoop loop = (NioEventLoop) group.next();


### PR DESCRIPTION
Motivation:

It has shown that the used test timeout may be too low when the CI is busy.

Modifications:

Increase timeout to 3 seconds.

Result:

Less false-positives.