### PR TITLE
Upgrade h2spec-maven-plugin

### DIFF
--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -61,17 +61,15 @@
       <plugin>
         <groupId>com.github.madgnome</groupId>
         <artifactId>h2spec-maven-plugin</artifactId>
-        <version>0.3</version>
+        <version>0.6</version>
         <configuration>
           <mainClass>io.netty.testsuite.http2.Http2Server</mainClass>
           <excludeSpecs>
-            <excludeSpec>3.8 - Sends a GOAWAY frame</excludeSpec>
             <excludeSpec>4.2 - Sends a dynamic table size update at the end of header block</excludeSpec>
             <excludeSpec>5.1 - idle: Sends a DATA frame</excludeSpec>
-            <excludeSpec>5.1 - closed: Sends a DATA frame</excludeSpec>
+            <excludeSpec>5.1 - half closed (remote): Sends a HEADERS frame</excludeSpec>
             <excludeSpec>5.1 - closed: Sends a HEADERS frame</excludeSpec>
             <excludeSpec>5.1.1 - Sends stream identifier that is numerically smaller than previous</excludeSpec>
-            <excludeSpec>7 - Sends a GOAWAY frame with unknown error code</excludeSpec>
             <excludeSpec>8.1.2.2 - Sends a HEADERS frame that contains the connection-specific header field</excludeSpec>
             <excludeSpec>8.1.2.2 - Sends a HEADERS frame that contains the TE header field with any value other than "trailers"</excludeSpec>
             <excludeSpec>8.1.2.3 - Sends a HEADERS frame with empty ":path" pseudo-header field</excludeSpec>


### PR DESCRIPTION
Motivation:
- Version 0.3 would sometimes fail to report failing tests
- New version contains upgraded version of h2spec

Modifications:
- Bump h2spec-maven-plugin to 0.6
- Remove excluded specs that are no passing
- Add failing spec "half closed (remote): Sends a HEADERS frame" to
exclude list

Result:
Build will fail when non excluded specs fails.
