### PR TITLE
When running our testsuite with netty-tcnative-boringssl-static we sh…

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
 
   test-boringssl-static:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.artifactId=netty-tcnative-boringssl-static"
+    command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.artifactId=netty-tcnative-boringssl-static -Dtcnative.classifier="
 
   shell:
     <<: *common


### PR DESCRIPTION
…ould use an empty classifier.

Motivation:

We publish an "uber-jar" for netty-tcnative-boringssl-static so we should use it when testing against boringssl.

Modifications:

Ensure we use empty classifier.

Result:

Use uber-jar when testing