### PR TITLE
Explicit specify java version to use to ensure we rebuild image when …

### DIFF
--- a/docker/docker-compose.centos-6.110.yaml
+++ b/docker/docker-compose.centos-6.110.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.10-0"
+        java_version : "openjdk@1.10.0-2"
 
   test:
     image: netty:centos-6-1.10

--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.11.0"
+        java_version : "openjdk@1.11.0-1"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.112.yaml
+++ b/docker/docker-compose.centos-6.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.12.0"
+        java_version : "openjdk@1.12.0-15"
 
   test:
     image: netty:centos-6-1.12

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.8"
+        java_version : "1.8.192"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.19.yaml
+++ b/docker/docker-compose.centos-6.19.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "zulu@1.9.0"
+        java_version : "openjdk@1.9.0-4"
 
   test:
     image: netty:centos-6-1.9

--- a/docker/docker-compose.centos-7.110.yaml
+++ b/docker/docker-compose.centos-7.110.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.10-0"
+        java_version : "openjdk@1.10.0-2"
 
   test:
     image: netty:centos-7-1.10

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.11.0"
+        java_version : "openjdk@1.11.0-1"
 
   test:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.112.yaml
+++ b/docker/docker-compose.centos-7.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.12.0"
+        java_version : "openjdk@1.12.0-15"
 
   test:
     image: netty:centos-7-1.12

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.8"
+        java_version : "1.8.192"
 
   test:
     image: netty:centos-7-1.8

--- a/docker/docker-compose.centos-7.19.yaml
+++ b/docker/docker-compose.centos-7.19.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "zulu@1.9.0"
+        java_version : "openjdk@1.9.0-4"
 
   test:
     image: netty:centos-7-1.9


### PR DESCRIPTION
…java version changes.

Motivation:

We should explicit specify the java version to use to ensure docker will rebuild the image once a new java version was released and we specify it. Also we should use openjdk for testing when possible.

Modifications:

- Explicit specify the java versions to use
- Use openjdk when possible.

Result:

Ensure latest java versions are used during testing
