### PR TITLE
Update jetty-alpn-agent version to support latest JDK 8 release and s…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>22</netty.build.version>
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
-    <jetty.alpnAgent.version>2.0.8</jetty.alpnAgent.version>
+    <jetty.alpnAgent.version>2.0.9</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.common>
       -server


### PR DESCRIPTION
…till work on Java7.

Motivation:

jetty-alpn-agent was not compatible with Java7 anymore. This version fixes this.

See https://github.com/jetty-project/jetty-alpn-agent/issues/10.

Modifications:

Update to 2.0.9

Result:

Be able to run tests with latest JDK 8 release and also Java 7