### PR TITLE
Improve CompositeByteBuf sequential access performance

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1289,7 +1289,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
-    private int forEachByteAsc0(int start, int end, ByteProcessor processor) throws Exception {
+    protected int forEachByteAsc0(int start, int end, ByteProcessor processor) throws Exception {
         for (; start < end; ++start) {
             if (!processor.process(_getByte(start))) {
                 return start;
@@ -1321,7 +1321,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
-    private int forEachByteDesc0(int rStart, final int rEnd, ByteProcessor processor) throws Exception {
+    protected int forEachByteDesc0(int rStart, final int rEnd, ByteProcessor processor) throws Exception {
         for (; rStart >= rEnd; --rStart) {
             if (!processor.process(_getByte(rStart))) {
                 return rStart;

--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1289,7 +1289,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
-    protected int forEachByteAsc0(int start, int end, ByteProcessor processor) throws Exception {
+    int forEachByteAsc0(int start, int end, ByteProcessor processor) throws Exception {
         for (; start < end; ++start) {
             if (!processor.process(_getByte(start))) {
                 return start;
@@ -1321,7 +1321,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
-    protected int forEachByteDesc0(int rStart, final int rEnd, ByteProcessor processor) throws Exception {
+    int forEachByteDesc0(int rStart, final int rEnd, ByteProcessor processor) throws Exception {
         for (; rStart >= rEnd; --rStart) {
             if (!processor.process(_getByte(rStart))) {
                 return rStart;

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1427,7 +1427,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     private Component findComponent(int offset) {
         Component la = lastAccessed;
         if (la != null && offset >= la.offset && offset < la.endOffset) {
-           return lastAccessed;
+           return la;
         }
         checkIndex(offset);
 

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -550,16 +550,14 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
                 continue; // empty
             }
             ByteBuf s = c.buf;
-            int localRStart = 1 + rStart - c.offset;
+            int localRStart = length + rEnd - c.offset;
             int localLength = Math.min(length, localRStart), localIndex = localRStart - localLength;
             // avoid additional checks in AbstractByteBuf case
-            int result = s instanceof AbstractByteBuf
-                    ? ((AbstractByteBuf) s).forEachByteDesc0(localRStart - 1, localIndex, processor)
-                    : s.forEachByteDesc(localIndex, localLength, processor);
+            int result = !(s instanceof AbstractByteBuf) ? s.forEachByteDesc(localIndex, localLength, processor)
+                    : ((AbstractByteBuf) s).forEachByteDesc0(localRStart - 1, localIndex, processor);
             if (result != -1) {
                 return c.offset + result;
             }
-            rStart -= localLength;
             length -= localLength;
         }
         return -1;

--- a/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
@@ -52,19 +52,13 @@ public class CompositeByteBufSequentialBenchmark extends AbstractMicrobenchmark 
         abstract ByteBuf newBuffer(int length);
     }
 
-    @Param({ "8", "64", "1024", "10240", "102400", "1024000" }) //"1073741824" })
+    @Param({ "8", "64", "1024", "10240", "102400", "1024000" })
     public int size;
 
     @Param
     public ByteBufType bufferType;
 
     private ByteBuf buffer;
-
-    @Override
-    protected String[] jvmArgs() {
-        // Ensure we minimize the GC overhead by sizing the heap big enough.
-        return new String[] { "-Xmx8g", "-Xms8g", "-Xmn6g" };
-    }
 
     @Setup
     public void setup() {
@@ -92,7 +86,7 @@ public class CompositeByteBufSequentialBenchmark extends AbstractMicrobenchmark 
 
     @Benchmark
     public int sequentialWriteAndRead() {
-        buffer.readerIndex(0).writerIndex(0);
+        buffer.clear();
         for (int i = 0, l = buffer.writableBytes(); i < l; i++) {
             buffer.writeByte('a');
         }
@@ -106,26 +100,12 @@ public class CompositeByteBufSequentialBenchmark extends AbstractMicrobenchmark 
 
     private static ByteBuf newBufferSmallChunks(int length) {
 
-        List<ByteBuf> buffers = new ArrayList<ByteBuf>();
+        List<ByteBuf> buffers = new ArrayList<ByteBuf>(((length + 1) / 45) * 19);
         for (int i = 0; i < length + 45; i += 45) {
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[1]));
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[2]));
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[3]));
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[4]));
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[5]));
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[6]));
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[7]));
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[8]));
-            buffers.add(EMPTY_BUFFER);
-            buffers.add(wrappedBuffer(new byte[9]));
+            for (int j = 1; j <= 9; j++) {
+                buffers.add(EMPTY_BUFFER);
+                buffers.add(wrappedBuffer(new byte[j]));
+            }
             buffers.add(EMPTY_BUFFER);
         }
 
@@ -137,7 +117,7 @@ public class CompositeByteBufSequentialBenchmark extends AbstractMicrobenchmark 
 
     private static ByteBuf newBufferLargeChunks(int length) {
 
-        List<ByteBuf> buffers = new ArrayList<ByteBuf>();
+        List<ByteBuf> buffers = new ArrayList<ByteBuf>((length + 1) / 512);
         for (int i = 0; i < length + 1536; i += 1536) {
             buffers.add(wrappedBuffer(new byte[512]));
             buffers.add(EMPTY_BUFFER);

--- a/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
@@ -79,7 +79,7 @@ public class CompositeByteBufSequentialBenchmark extends AbstractMicrobenchmark 
 
     @Benchmark
     public int forEachByte() {
-        buffer.writerIndex(buffer.capacity()).readerIndex(0);
+        buffer.setIndex(0, buffer.capacity());
         buffer.forEachByte(TEST_PROCESSOR);
         return buffer.forEachByteDesc(TEST_PROCESSOR);
     }

--- a/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.ByteProcessor;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
+public class CompositeByteBufSequentialBenchmark extends AbstractMicrobenchmark {
+    
+    public enum ByteBufType {
+        SMALL_CHUNKS {
+            @Override
+            ByteBuf newBuffer(int length) {
+                return newBufferSmallChunks(length);
+            }
+        },
+        LARGE_CHUNKS {
+            @Override
+            ByteBuf newBuffer(int length) {
+                return newBufferLargeChunks(length);
+            }
+        };
+        abstract ByteBuf newBuffer(int length);
+    }
+
+    @Param({ "8", "64", "1024", "10240", "102400", "1024000" }) //"1073741824" })
+    public int size;
+
+    @Param
+    public ByteBufType bufferType;
+
+    private ByteBuf buffer;
+
+    @Override
+    protected String[] jvmArgs() {
+        // Ensure we minimize the GC overhead by sizing the heap big enough.
+        return new String[] { "-Xmx8g", "-Xms8g", "-Xmn6g" };
+    }
+
+    @Setup
+    public void setup() {
+        buffer = bufferType.newBuffer(size);
+    }
+
+    @TearDown
+    public void teardown() {
+        buffer.release();
+    }
+
+    @Benchmark
+    public int forEachByte() {
+        buffer.writerIndex(buffer.capacity()).readerIndex(0);
+        ByteProcessor processor = new ByteProcessor() {
+            @Override
+            public boolean process(byte value) throws Exception {
+                return value == 'b'; // false
+            }
+        };
+        buffer.forEachByte(processor);
+        return buffer.forEachByteDesc(processor);
+    }
+
+    @Benchmark
+    public int sequentialWriteAndRead() {
+        buffer.readerIndex(0).writerIndex(0);
+        for (int i = 0, l = buffer.writableBytes(); i < l; i++) {
+            buffer.writeByte('a');
+        }
+        for (int i = 0, l = buffer.readableBytes(); i < l; i++) {
+            if (buffer.readByte() == 'b') {
+                return -1;
+            }
+        }
+        return 1;
+    }
+
+    protected static ByteBuf newBufferSmallChunks(int length) {
+
+        List<ByteBuf> buffers = new ArrayList<ByteBuf>();
+        for (int i = 0; i < length + 45; i += 45) {
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[1]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[2]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[3]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[4]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[5]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[6]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[7]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[8]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[9]));
+            buffers.add(EMPTY_BUFFER);
+        }
+
+        ByteBuf buffer = wrappedBuffer(Integer.MAX_VALUE, buffers.toArray(new ByteBuf[0]));
+
+        // Truncate to the requested capacity.
+        buffer.capacity(length);
+
+        buffer.writerIndex(0);
+        return buffer;
+    }
+
+    protected static ByteBuf newBufferLargeChunks(int length) {
+
+        List<ByteBuf> buffers = new ArrayList<ByteBuf>();
+        for (int i = 0; i < length + 1536; i += 1536) {
+            buffers.add(wrappedBuffer(new byte[512]));
+            buffers.add(EMPTY_BUFFER);
+            buffers.add(wrappedBuffer(new byte[1024]));
+        }
+
+        ByteBuf buffer = wrappedBuffer(Integer.MAX_VALUE, buffers.toArray(new ByteBuf[0]));
+
+        // Truncate to the requested capacity.
+        buffer.capacity(length);
+
+        buffer.writerIndex(0);
+        return buffer;
+    }
+}


### PR DESCRIPTION
Motivation:

While running some other benchmarks I noticed that sequential access of `CompositeByteBuf`s is very slow, particularly if they are large.
 
Modifications:

- Override `forEachByte(...)` methods
- Remove redundant `Component.length` field and standardize component offset modifications via `setOffset()`
- Simplify the general pattern used where a sub-range is iterated over
- Add racy cache of last-accessed Component to `findComponent(int)` method
- Add benchmark to demonstrate improvement

The cache is based on the fact that a call to `findComponent` precededs every individual read/write access, and the assumption that very often the same component will be needed between successive accesses.
 
Result:

I will paste benchmark results below. Also some anecdotal observations:
- There is a "cache hit" rate of 75% when running the existing buffer package unit tests
- The complete buffer package unit tests appear to take 30% less time to run if `AbstractByteBufTest.CAPACITY` is increased by a factor of 10

In addition to the raw speed there should also be a minor mem/garbage benefit due to removal of `Component.length`.
