### PR TITLE
Make FixedChannelPool#close() wait for all idle channels to be closed

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -444,7 +444,6 @@ public class FixedChannelPool extends SimpleChannelPool {
     public void close() {
         if (executor.inEventLoop()) {
             failPendingAcquireOperations();
-            super.closeIdleChannels();
         } else {
             executor.submit(new Runnable() {
                 @Override
@@ -452,8 +451,8 @@ public class FixedChannelPool extends SimpleChannelPool {
                     failPendingAcquireOperations();
                 }
             }).awaitUninterruptibly();
-            super.closeIdleChannels().awaitUninterruptibly();
         }
+        super.closeIdleChannels(executor);
     }
 
     private void failPendingAcquireOperations() {

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -419,7 +419,8 @@ public class SimpleChannelPool implements ChannelPool {
                     channelsToClose.remove(channel);
                     if (channelsToClose.isEmpty()) {
                         // last channel was closed - can complete the result promise
-                        result.setSuccess(null);
+                        // it might already be completed by a concurrently executing listener so use trySuccess
+                        result.trySuccess(null);
                     }
                 }
             });

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -415,7 +415,7 @@ public class SimpleChannelPool implements ChannelPool {
         }
         if (channelsToClose.isEmpty()) {
             // no idle channels in the pool - nothing to close
-            result.setSuccess(null);
+            result.trySuccess(null);
         }
 
         for (final Channel channel : channelsToClose) {

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -400,7 +400,7 @@ public class SimpleChannelPool implements ChannelPool {
         Promise<Void> result = executor.newPromise();
         closeIdleChannels(result);
         if (!executor.inEventLoop()) {
-            result.awaitUninterruptibly();
+            result.syncUninterruptibly();
         }
     }
 


### PR DESCRIPTION
Motivation:

`FixedChannelPool#close()` is a blocking call when executed by non event loop thread. It offloaded closing of the idle channels to `GlobalEventExecutor` and could return before all channels were actually closed.

Modifications:

Introduced an async method to close all idle channels in the parent class `SimpleChannelPool`. `FixedChannelPool.close()` uses it in a blocking fashion when invoked by a non event loop thread.

Result:

`FixedChannelPool.close()` returns to the caller only after all idle channels are closed.

Fixes #8398.