### PR TITLE
Remove workaround in tests for TLSv1.3 bug in Java11 as it was fixed …

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
@@ -15,12 +15,6 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.PlatformDependent;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import static io.netty.handler.ssl.SslUtils.PROTOCOL_TLS_V1_2;
 import static org.junit.Assume.assumeTrue;
 
 final class OpenSslTestUtils {
@@ -33,18 +27,5 @@ final class OpenSslTestUtils {
 
     static boolean isBoringSSL() {
         return "BoringSSL".equals(OpenSsl.versionString());
-    }
-
-    static SslContextBuilder configureProtocolForMutualAuth(
-            SslContextBuilder ctx, SslProvider sslClientProvider, SslProvider sslServerProvider) {
-        if (PlatformDependent.javaVersion() >= 11
-            && sslClientProvider == SslProvider.JDK && sslServerProvider != SslProvider.JDK) {
-            // Make sure we do not use TLSv1.3 as there seems to be a bug currently in the JDK TLSv1.3 implementation.
-            // See:
-            //  - http://mail.openjdk.java.net/pipermail/security-dev/2018-September/018191.html
-            //  - https://bugs.openjdk.java.net/projects/JDK/issues/JDK-8210846
-            ctx.protocols(PROTOCOL_TLS_V1_2).ciphers(Collections.singleton("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"));
-        }
-        return ctx;
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -36,7 +36,6 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
@@ -46,7 +45,6 @@ import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,9 +59,7 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
-import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.security.Provider;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -655,16 +651,12 @@ public abstract class SSLEngineTest {
     protected void mySetupMutualAuthServerInitSslHandler(SslHandler handler) {
     }
 
-    private SslContextBuilder configureProtocolForMutualAuth(SslContextBuilder ctx) {
-        return OpenSslTestUtils.configureProtocolForMutualAuth(ctx, sslClientProvider(), sslServerProvider());
-    }
-
     private void mySetupMutualAuth(KeyManagerFactory serverKMF, final File serverTrustManager,
                                    KeyManagerFactory clientKMF, File clientTrustManager,
                                    ClientAuth clientAuth, final boolean failureExpected,
                                    final boolean serverInitEngine)
             throws SSLException, InterruptedException {
-        serverSslCtx = configureProtocolForMutualAuth(
+        serverSslCtx =
                 SslContextBuilder.forServer(serverKMF)
                                  .protocols(protocols())
                                  .ciphers(ciphers())
@@ -674,9 +666,9 @@ public abstract class SSLEngineTest {
                                  .clientAuth(clientAuth)
                                  .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
                                  .sessionCacheSize(0)
-                                 .sessionTimeout(0)).build();
+                                 .sessionTimeout(0).build();
 
-        clientSslCtx =  configureProtocolForMutualAuth(
+        clientSslCtx =
                 SslContextBuilder.forClient()
                                  .protocols(protocols())
                                  .ciphers(ciphers())
@@ -686,7 +678,7 @@ public abstract class SSLEngineTest {
                                  .keyManager(clientKMF)
                                  .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
                                  .sessionCacheSize(0)
-                                 .sessionTimeout(0)).build();
+                                 .sessionTimeout(0).build();
 
         serverConnectedChannel = null;
         sb = new ServerBootstrap();
@@ -941,7 +933,7 @@ public abstract class SSLEngineTest {
             File servertTrustCrtFile, File serverKeyFile, final File serverCrtFile, String serverKeyPassword,
             File clientTrustCrtFile, File clientKeyFile, File clientCrtFile, String clientKeyPassword)
             throws InterruptedException, SSLException {
-        serverSslCtx = configureProtocolForMutualAuth(
+        serverSslCtx =
                 SslContextBuilder.forServer(serverCrtFile, serverKeyFile, serverKeyPassword)
                                  .sslProvider(sslServerProvider())
                                  .sslContextProvider(serverSslContextProvider())
@@ -950,8 +942,8 @@ public abstract class SSLEngineTest {
                                  .trustManager(servertTrustCrtFile)
                                  .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
                                  .sessionCacheSize(0)
-                                 .sessionTimeout(0)).build();
-        clientSslCtx = configureProtocolForMutualAuth(
+                                 .sessionTimeout(0).build();
+        clientSslCtx =
                 SslContextBuilder.forClient()
                                  .sslProvider(sslClientProvider())
                                  .sslContextProvider(clientSslContextProvider())
@@ -961,7 +953,7 @@ public abstract class SSLEngineTest {
                                  .keyManager(clientCrtFile, clientKeyFile, clientKeyPassword)
                                  .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
                                  .sessionCacheSize(0)
-                                 .sessionTimeout(0)).build();
+                                 .sessionTimeout(0).build();
 
         serverConnectedChannel = null;
         sb = new ServerBootstrap();
@@ -1611,7 +1603,7 @@ public abstract class SSLEngineTest {
 
     @Test(timeout = 30000)
     public void testMutualAuthSameCertChain() throws Exception {
-        serverSslCtx = configureProtocolForMutualAuth(
+        serverSslCtx =
                 SslContextBuilder.forServer(
                         new ByteArrayInputStream(X509_CERT_PEM.getBytes(CharsetUtil.UTF_8)),
                         new ByteArrayInputStream(PRIVATE_KEY_PEM.getBytes(CharsetUtil.UTF_8)))
@@ -1619,7 +1611,7 @@ public abstract class SSLEngineTest {
                                  .clientAuth(ClientAuth.REQUIRE).sslProvider(sslServerProvider())
                                  .sslContextProvider(serverSslContextProvider())
                                  .protocols(protocols())
-                                 .ciphers(ciphers())).build();
+                                 .ciphers(ciphers()).build();
 
         sb = new ServerBootstrap();
         sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
@@ -1670,14 +1662,14 @@ public abstract class SSLEngineTest {
             }
         }).bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
 
-        clientSslCtx = configureProtocolForMutualAuth(
+        clientSslCtx =
                 SslContextBuilder.forClient().keyManager(
                         new ByteArrayInputStream(CLIENT_X509_CERT_CHAIN_PEM.getBytes(CharsetUtil.UTF_8)),
                         new ByteArrayInputStream(CLIENT_PRIVATE_KEY_PEM.getBytes(CharsetUtil.UTF_8)))
                 .trustManager(new ByteArrayInputStream(X509_CERT_PEM.getBytes(CharsetUtil.UTF_8)))
                 .sslProvider(sslClientProvider())
                 .sslContextProvider(clientSslContextProvider())
-                .protocols(protocols()).ciphers(ciphers())).build();
+                .protocols(protocols()).ciphers(ciphers()).build();
         cb = new Bootstrap();
         cb.group(new NioEventLoopGroup());
         cb.channel(NioSocketChannel.class);

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -124,7 +124,7 @@ public class SslErrorTest {
         Assume.assumeTrue(OpenSsl.isAvailable());
 
         SelfSignedCertificate ssc = new SelfSignedCertificate();
-        final SslContext sslServerCtx = OpenSslTestUtils.configureProtocolForMutualAuth(
+        final SslContext sslServerCtx =
                 SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                                  .sslProvider(serverProvider)
                                  .trustManager(new SimpleTrustManagerFactory() {
@@ -155,13 +155,13 @@ public class SslErrorTest {
                     }
                 } };
             }
-        }).clientAuth(ClientAuth.REQUIRE), clientProvider, serverProvider).build();
+        }).clientAuth(ClientAuth.REQUIRE).build();
 
-        final SslContext sslClientCtx = OpenSslTestUtils.configureProtocolForMutualAuth(SslContextBuilder.forClient()
+        final SslContext sslClientCtx = SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .keyManager(new File(getClass().getResource("test.crt").getFile()),
                         new File(getClass().getResource("test_unencrypted.pem").getFile()))
-                .sslProvider(clientProvider), clientProvider, serverProvider).build();
+                .sslProvider(clientProvider).build();
 
         Channel serverChannel = null;
         Channel clientChannel = null;


### PR DESCRIPTION
…in 11.0.1

Motivation:

We had put some workaround in our tests due a bug in the Java11 implementation of TLSv1.3. This was now fixes as part of 11.0.1.

See https://bugs.openjdk.java.net/browse/JDK-8211067.

Modifications:

Remove workaround in SSL tests.

Result:

Run all tests with supported TLS version.