### PR TITLE
Add support for boringssl and TLSv1.3

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
@@ -24,8 +24,4 @@ final class OpenSslTestUtils {
     static void checkShouldUseKeyManagerFactory() {
         assumeTrue(OpenSsl.supportsKeyManagerFactory() && OpenSsl.useKeyManagerFactory());
     }
-
-    static boolean isBoringSSL() {
-        return "BoringSSL".equals(OpenSsl.versionString());
-    }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1087,7 +1087,7 @@ public abstract class SSLEngineTest {
                                                MessageReceiver receiver) throws Exception {
         List<ByteBuf> dataCapture = null;
         try {
-            sendChannel.writeAndFlush(message);
+            assertTrue(sendChannel.writeAndFlush(message).await(5, TimeUnit.SECONDS));
             receiverLatch.await(5, TimeUnit.SECONDS);
             message.resetReaderIndex();
             ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -182,7 +182,7 @@ final class SniClientJava8TestUtil {
             if (clientSide) {
                 Assert.assertEquals(0, extendedSSLSession.getPeerSupportedSignatureAlgorithms().length);
             } else {
-                if (session instanceof OpenSslSession && OpenSslTestUtils.isBoringSSL()) {
+                if (session instanceof OpenSslSession && OpenSsl.isBoringSSL()) {
                     // BoringSSL does not support SSL_get_sigalgs(...)
                     // https://boringssl.googlesource.com/boringssl/+/ba16a1e405c617f4179bd780ad15522fb25b0a65%5E%21/
                     Assert.assertEquals(0, extendedSSLSession.getPeerSupportedSignatureAlgorithms().length);

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -205,7 +205,7 @@ public class SslErrorTest {
                                                 verifyException(unwrappedCause, "expired", promise);
                                             } else if (reason == CertPathValidatorException.BasicReason.NOT_YET_VALID) {
                                                 // BoringSSL uses "expired" in this case while others use "bad"
-                                                if (OpenSslTestUtils.isBoringSSL()) {
+                                                if (OpenSsl.isBoringSSL()) {
                                                     verifyException(unwrappedCause, "expired", promise);
                                                 } else {
                                                     verifyException(unwrappedCause, "bad", promise);
@@ -217,7 +217,7 @@ public class SslErrorTest {
                                             verifyException(unwrappedCause, "expired", promise);
                                         } else if (exception instanceof CertificateNotYetValidException) {
                                             // BoringSSL uses "expired" in this case while others use "bad"
-                                            if (OpenSslTestUtils.isBoringSSL()) {
+                                            if (OpenSsl.isBoringSSL()) {
                                                 verifyException(unwrappedCause, "expired", promise);
                                             } else {
                                                 verifyException(unwrappedCause, "bad", promise);

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.18.Final</tcnative.version>
+    <tcnative.version>2.0.19.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

    0ddc62cec0b4715ae37cef0e6a9f8c79d42d74e9 added support for TLSv1.3 when using openssl 1.1.1. Now that BoringSSL chromium-stable branch supports it as well we can also support it with netty-tcnative-boringssl-static.
    During this some unit tests failed with BoringSSL which was caused by not correctly handling flush() while the handshake is still in progress.

    Modification:

    - Upgrade netty-tcnative version which also supports TLSv1.3 when using BoringSSL
    - Correctly handle flush() when done while the handshake is still in progress in all cases.

    Result:

    Easier for people to enable TLSv1.3 when using native SSL impl.
    Ensure flush() while handshake is in progress will always be honored.