### PR TITLE
Fix minor bug in DefaultResourceLeak.toString()

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -501,7 +501,7 @@ public class ResourceLeakDetector<T> {
 
             if (duped > 0) {
                 buf.append(": ")
-                        .append(dropped)
+                        .append(duped)
                         .append(" leak records were discarded because they were duplicates")
                         .append(NEWLINE);
             }


### PR DESCRIPTION
As you can see, we were printing `dropped` instead of `duped`. Looks like nobody ever noticed.