### PR TITLE
Upgrade commons-compress to 2.0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -559,7 +559,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.12</version>
+        <version>1.18</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Motivation:

Commons-compress < 2.0.18 has a security flaw so we should upgrade (even if we only use it in tests anyway).

Modifications:

Update to 2.0.18

Result:

Use latest version.