### PR TITLE
Avoid allocations when wrapping byte[] and ByteBuffer arrays as ByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -15,15 +15,14 @@
  */
 package io.netty.buffer;
 
+import io.netty.buffer.CompositeByteBuf.ByteWrapper;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 
 /**
@@ -262,38 +261,37 @@ public final class Unpooled {
         return wrappedBuffer(buffers.length, buffers);
     }
 
+    static <T> ByteBuf wrappedBuffer(int maxNumComponents, ByteWrapper<T> wrapper, T[] array) {
+        switch (array.length) {
+        case 0:
+            break;
+        case 1:
+            if (!wrapper.isEmpty(array[0])) {
+                return wrapper.wrap(array[0]);
+            }
+            break;
+        default:
+            for (int i = 0, len = array.length; i < len; i++) {
+                T bytes = array[i];
+                if (bytes == null) {
+                    return EMPTY_BUFFER;
+                }
+                if (!wrapper.isEmpty(bytes)) {
+                    return new CompositeByteBuf(ALLOC, false, maxNumComponents, wrapper, array, i);
+                }
+            }
+        }
+
+        return EMPTY_BUFFER;
+    }
+
     /**
      * Creates a new big-endian composite buffer which wraps the specified
      * arrays without copying them.  A modification on the specified arrays'
      * content will be visible to the returned buffer.
      */
     public static ByteBuf wrappedBuffer(int maxNumComponents, byte[]... arrays) {
-        switch (arrays.length) {
-        case 0:
-            break;
-        case 1:
-            if (arrays[0].length != 0) {
-                return wrappedBuffer(arrays[0]);
-            }
-            break;
-        default:
-            // Get the list of the component, while guessing the byte order.
-            final List<ByteBuf> components = new ArrayList<ByteBuf>(arrays.length);
-            for (byte[] a: arrays) {
-                if (a == null) {
-                    break;
-                }
-                if (a.length > 0) {
-                    components.add(wrappedBuffer(a));
-                }
-            }
-
-            if (!components.isEmpty()) {
-                return new CompositeByteBuf(ALLOC, false, maxNumComponents, components);
-            }
-        }
-
-        return EMPTY_BUFFER;
+        return wrappedBuffer(maxNumComponents, CompositeByteBuf.BYTE_ARRAY_WRAPPER, arrays);
     }
 
     /**
@@ -336,32 +334,7 @@ public final class Unpooled {
      * specified buffers will be visible to the returned buffer.
      */
     public static ByteBuf wrappedBuffer(int maxNumComponents, ByteBuffer... buffers) {
-        switch (buffers.length) {
-        case 0:
-            break;
-        case 1:
-            if (buffers[0].hasRemaining()) {
-                return wrappedBuffer(buffers[0].order(BIG_ENDIAN));
-            }
-            break;
-        default:
-            // Get the list of the component, while guessing the byte order.
-            final List<ByteBuf> components = new ArrayList<ByteBuf>(buffers.length);
-            for (ByteBuffer b: buffers) {
-                if (b == null) {
-                    break;
-                }
-                if (b.remaining() > 0) {
-                    components.add(wrappedBuffer(b.order(BIG_ENDIAN)));
-                }
-            }
-
-            if (!components.isEmpty()) {
-                return new CompositeByteBuf(ALLOC, false, maxNumComponents, components);
-            }
-        }
-
-        return EMPTY_BUFFER;
+        return wrappedBuffer(maxNumComponents, CompositeByteBuf.BYTE_BUFFER_WRAPPER, buffers);
     }
 
     /**


### PR DESCRIPTION
Motivation:

`Unpooled.wrap(byte[]...)` and `Unpooled.wrap(ByteBuffer...)` currently allocate/copy an intermediate `ByteBuf` `ArrayList` and array, which can be avoided.

Modifications:

- Define new internal `ByteWrapper` interface and add a `CompositeByteBuf` constructor which takes a `ByteWrapper` with an array of the type that it wraps; modify the appropriate `Unpooled.wrap(...)` methods to take advantage of it
- Tidy up other constructors in `CompositeByteBuf` to remove duplication and misleading `len` arg (which is really an end offset into provided array)

Result:

Less allocation/copying when wrapping `byte[]` and `ByteBuffer` arrays, tidier code.
