### PR TITLE
Update to JDK 12 EA16 when running CI jobs against JDK 12.

### DIFF
--- a/docker/docker-compose.centos-6.112.yaml
+++ b/docker/docker-compose.centos-6.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.12.0-15"
+        java_version : "openjdk@1.12.0-16"
 
   test:
     image: netty:centos-6-1.12

--- a/docker/docker-compose.centos-7.112.yaml
+++ b/docker/docker-compose.centos-7.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.12.0-15"
+        java_version : "openjdk@1.12.0-16"
 
   test:
     image: netty:centos-7-1.12


### PR DESCRIPTION
Motivation:

A new EA release was done, we should always run against the latest.

Modifications:

Update to EA 16.

Result:

CI runs with latest EA release for JDK12.