### PR TITLE
Add testing ByteBufAllocator for leak unit testing

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
@@ -208,7 +208,7 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
 
     @Override
     public CompositeByteBuf compositeHeapBuffer(int maxNumComponents) {
-        return toLeakAwareBuffer(new CompositeByteBuf(this, false, maxNumComponents));
+        return toLeakAwareBufferInternal(new CompositeByteBuf(this, false, maxNumComponents));
     }
 
     @Override
@@ -218,7 +218,15 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
 
     @Override
     public CompositeByteBuf compositeDirectBuffer(int maxNumComponents) {
-        return toLeakAwareBuffer(new CompositeByteBuf(this, true, maxNumComponents));
+        return toLeakAwareBufferInternal(new CompositeByteBuf(this, true, maxNumComponents));
+    }
+
+    ByteBuf toLeakAwareBufferInternal(ByteBuf buf) {
+        return toLeakAwareBuffer(buf);
+    }
+
+    CompositeByteBuf toLeakAwareBufferInternal(CompositeByteBuf buf) {
+        return toLeakAwareBuffer(buf);
     }
 
     private static void validate(int initialCapacity, int maxCapacity) {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -311,7 +311,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                     new UnpooledHeapByteBuf(this, initialCapacity, maxCapacity);
         }
 
-        return toLeakAwareBuffer(buf);
+        return toLeakAwareBufferInternal(buf);
     }
 
     @Override
@@ -328,7 +328,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                     new UnpooledDirectByteBuf(this, initialCapacity, maxCapacity);
         }
 
-        return toLeakAwareBuffer(buf);
+        return toLeakAwareBufferInternal(buf);
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/TestingPooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/TestingPooledByteBufAllocator.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakTracker;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static io.netty.util.internal.StringUtil.NEWLINE;
+
+/**
+ * A {@link ByteBufAllocator} for unit testing.  This allocator performs leak tracking
+ * on all allocated buffers.  At the end the test, call {@link #close} to assert
+ * that all buffers have been freed.
+ */
+public class TestingPooledByteBufAllocator extends PooledByteBufAllocator implements Closeable {
+
+    private final TestingResourceLeakDetector leakDetector = new TestingResourceLeakDetector();
+
+    public TestingPooledByteBufAllocator() {
+    }
+
+    public TestingPooledByteBufAllocator(boolean preferDirect) {
+        super(preferDirect);
+    }
+
+    @Override
+    ByteBuf toLeakAwareBufferInternal(ByteBuf buf) {
+        ResourceLeakTracker<ByteBuf> leak = leakDetector.track(buf);
+        if (leak != null) {
+            buf = new AdvancedLeakAwareByteBuf(buf, leak);
+        }
+        return buf;
+    }
+
+    @Override
+    CompositeByteBuf toLeakAwareBufferInternal(CompositeByteBuf buf) {
+        ResourceLeakTracker<ByteBuf> leak = leakDetector.track(buf);
+        if (leak != null) {
+            buf = new AdvancedLeakAwareCompositeByteBuf(buf, leak);
+        }
+        return buf;
+    }
+
+    /**
+     * Throws an exception if all allocated buffers have been not freed.
+     * @throws AssertionError if buffers have been leaked.
+     */
+    @Override
+    public void close() {
+        List<String> allLeaks = leakDetector.getAllLeaks();
+        if (!allLeaks.isEmpty()) {
+            throwLeakDetected(allLeaks);
+        }
+    }
+
+    private static void throwLeakDetected(List<String> allLeaks) {
+        int expectedBufferSize = 1024;
+        for (String leak : allLeaks) {
+            expectedBufferSize += leak.length();
+        }
+
+        StringBuilder buf = new StringBuilder(expectedBufferSize)
+                .append("LEAK: ")
+                .append(allLeaks.size())
+                .append(" leak(s) detected. ")
+                .append("ByteBuf.release() was not called before it's garbage-collected. ")
+                .append("See http://netty.io/wiki/reference-counted-objects.html for more information.");
+        for (int i = 0; i < allLeaks.size(); i++) {
+            String leak = allLeaks.get(i);
+            buf.append(NEWLINE)
+                    .append("== ByteBuf ")
+                    .append(i + 1)
+                    .append(": ")
+                    .append(leak);
+        }
+        buf.append(NEWLINE)
+                .append("== Leak detection:");
+        throw new AssertionError(buf.toString());
+    }
+
+    private static class TestingResourceLeakDetector extends ResourceLeakDetector<ByteBuf> {
+
+        private final List<String> leaks = new ArrayList<String>(0);
+
+        public TestingResourceLeakDetector() {
+            super(ByteBuf.class);
+        }
+
+        @Override
+        protected boolean shouldTrack(ByteBuf obj) {
+            return true;
+        }
+
+        @Override
+        protected boolean isLeakReportingEnabled() {
+            return true;
+        }
+
+        @Override
+        protected synchronized void reportTracedLeak(String resourceType, String records) {
+            leaks.add(records);
+        }
+
+        @Override
+        protected synchronized void reportUntracedLeak(String resourceType) {
+            leaks.add("Untracked ByteBuf without created at information");
+        }
+
+        synchronized List<String> getAllLeaks() {
+            disposeAllReferences();
+            return Collections.unmodifiableList(new ArrayList<String>(leaks));
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/TestingPooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/TestingPooledByteBufAllocatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class TestingPooledByteBufAllocatorTest {
+
+    @Test
+    public void testNoLeakByteBuffer() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator();
+        try {
+            allocator.buffer(100).release();
+        } finally {
+            allocator.close();
+        }
+    }
+
+    @Test
+    public void testLeakByteBuffer() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator();
+        try {
+            allocator.buffer(100).getByte(0);
+            allocator.buffer(100).getByte(0);
+        } finally {
+            assertLeaked(allocator);
+        }
+    }
+
+    @Test
+    public void testNoLeakByteBufferDirect() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator(true);
+        try {
+            allocator.buffer(100).release();
+        } finally {
+            allocator.close();
+        }
+    }
+
+    @Test
+    public void testLeakByteBufferDirect() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator(true);
+        try {
+            allocator.buffer(100).getByte(0);
+            allocator.buffer(100).getByte(0);
+        } finally {
+            assertLeaked(allocator);
+        }
+    }
+
+    @Test
+    public void testNoLeakCompositeBuffer() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator();
+        try {
+            allocator.compositeBuffer().release();
+        } finally {
+            allocator.close();
+        }
+    }
+
+    @Test
+    public void testLeakCompositeBuffer() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator();
+        try {
+            allocator.compositeBuffer();
+            allocator.compositeBuffer();
+        } finally {
+            assertLeaked(allocator);
+        }
+    }
+
+    private static void assertLeaked(TestingPooledByteBufAllocator allocator) {
+        try {
+            allocator.close();
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("LEAK"));
+            assertThat(e.getMessage(), containsString("2 leak(s) detected."));
+            assertThat(e.getMessage(), containsString("ByteBuf 1:"));
+            assertThat(e.getMessage(), containsString("ByteBuf 2:"));
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Currently the only way to detect leaks during testing is log scanning which is
difficult to automate.  As an alternative it would be nice to fail unit tests
that leak buffers.

Modifications:

Added try with resources friendly TestingPooledByteBufAllocator which throws
an AssertionError in close if all buffers have not been freed.  To implement
this, I modified modified ResourceLeakDetector to allow sub clases to force
tracking and error reporting regardless of the global static tracking level,
or the configuration of the logging system.  I also added a method to allow
sub classes to dispose of all tracked references, which triggers reporting
if the referant was not freed. Then I modified, AbstractByteBufAllocator and
PooledByteBufAllocator to allow package local sub classes to hook the call to
the global static toLeakAwareBuffer methods.  Finally, I added
TestingPooledByteBufAllocator which is a subclass of PooledByteBufAllocator
containing a private ResourceLeakDetector that always tracks and warns on
leaks.

Result:

Developers using Netty can now easily verify that all buffers have been
released in unit tests.
