### PR TITLE
Proof of concept for #2646 http cache

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -208,6 +208,10 @@ public final class HttpHeaderValues {
      * {@code "websocket"}
      */
     public static final AsciiString WEBSOCKET = AsciiString.cached("websocket");
+    /**
+     * {@code "immutable"}
+     */
+    public static final AsciiString IMMUTABLE = AsciiString.cached("immutable");
 
     private HttpHeaderValues() { }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/AggregatedCacheFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/AggregatedCacheFullHttpResponse.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+final class AggregatedCacheFullHttpResponse implements FullHttpResponse {
+
+    private final HttpMessage message;
+    private final CompositeByteBuf content;
+    private HttpHeaders trailingHeaders;
+
+    AggregatedCacheFullHttpResponse(HttpMessage message, CompositeByteBuf content, HttpHeaders trailingHeaders) {
+        this.message = message;
+        this.content = content;
+        this.trailingHeaders = trailingHeaders;
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        HttpHeaders trailingHeaders = this.trailingHeaders;
+        if (trailingHeaders == null) {
+            return EmptyHttpHeaders.INSTANCE;
+        } else {
+            return trailingHeaders;
+        }
+    }
+
+    void setTrailingHeaders(HttpHeaders trailingHeaders) {
+        this.trailingHeaders = trailingHeaders;
+    }
+
+    @Override
+    public HttpVersion getProtocolVersion() {
+        return message.protocolVersion();
+    }
+
+    @Override
+    public HttpVersion protocolVersion() {
+        return message.protocolVersion();
+    }
+
+    @Override
+    public FullHttpResponse setProtocolVersion(HttpVersion version) {
+        message.setProtocolVersion(version);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return message.headers();
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return message.decoderResult();
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return message.decoderResult();
+    }
+
+    @Override
+    public void setDecoderResult(DecoderResult result) {
+        message.setDecoderResult(result);
+    }
+
+    @Override
+    public CompositeByteBuf content() {
+        return content;
+    }
+
+    @Override
+    public int refCnt() {
+        return content.refCnt();
+    }
+
+    @Override
+    public FullHttpResponse retain() {
+        content.retain();
+        return this;
+    }
+
+    @Override
+    public FullHttpResponse retain(int increment) {
+        content.retain(increment);
+        return this;
+    }
+
+    @Override
+    public FullHttpResponse touch(Object hint) {
+        content.touch(hint);
+        return this;
+    }
+
+    @Override
+    public FullHttpResponse touch() {
+        content.touch();
+        return this;
+    }
+
+    @Override
+    public boolean release() {
+        return content.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return content.release(decrement);
+    }
+
+    @Override
+    public FullHttpResponse copy() {
+        return replace(content().copy());
+    }
+
+    @Override
+    public FullHttpResponse duplicate() {
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public FullHttpResponse retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public FullHttpResponse replace(ByteBuf content) {
+        DefaultFullHttpResponse dup = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(), content,
+                                                                  headers().copy(), trailingHeaders().copy());
+        dup.setDecoderResult(decoderResult());
+        return dup;
+    }
+
+    @Override
+    public FullHttpResponse setStatus(HttpResponseStatus status) {
+        ((HttpResponse) message).setStatus(status);
+        return this;
+    }
+
+    @Override
+    public HttpResponseStatus getStatus() {
+        return ((HttpResponse) message).status();
+    }
+
+    @Override
+    public HttpResponseStatus status() {
+        return getStatus();
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheConfig.java
@@ -24,14 +24,18 @@ public class CacheConfig {
     private static final int DEFAULT_MAX_OBJECT_SIZE_IN_BYTES = 8192;
     private static final int DEFAULT_MAX_CACHE_ENTRIES = 1000;
     private static final boolean DEFAULT_SHARED_CACHED = true;
+    private static final boolean DEFAULT_CHECK_FRESHNESS = true;
+
     private final long maxObjectSize;
     private final int maxCacheEntries;
     private final boolean sharedCache;
+    private final boolean checkFreshness;
 
-    CacheConfig(long maxObjectSize, int maxCacheEntries, boolean sharedCache) {
+    CacheConfig(long maxObjectSize, int maxCacheEntries, boolean sharedCache, boolean checkFreshness) {
         this.maxObjectSize = maxObjectSize;
         this.maxCacheEntries = maxCacheEntries;
         this.sharedCache = sharedCache;
+        this.checkFreshness = checkFreshness;
     }
 
     public static Builder custom() {
@@ -59,15 +63,21 @@ public class CacheConfig {
         return sharedCache;
     }
 
+    public boolean shoulCheckFreshness() {
+        return checkFreshness;
+    }
+
     public static class Builder {
         private long maxObjectSize;
         private int maxCacheEntries;
         private boolean sharedCache;
+        private boolean checkFreshness;
 
         Builder() {
             maxObjectSize = DEFAULT_MAX_OBJECT_SIZE_IN_BYTES;
             maxCacheEntries = DEFAULT_MAX_CACHE_ENTRIES;
             sharedCache = DEFAULT_SHARED_CACHED;
+            checkFreshness = DEFAULT_CHECK_FRESHNESS;
         }
 
         /**
@@ -94,8 +104,16 @@ public class CacheConfig {
             return this;
         }
 
+        /**
+         * Set whether the cache should check entry freshness before returning response, true by default.
+         */
+        public Builder shouldCheckFreshness(final boolean checkFreshness) {
+            this.checkFreshness = checkFreshness;
+            return this;
+        }
+
         public CacheConfig build() {
-            return new CacheConfig(maxObjectSize, maxCacheEntries, sharedCache);
+            return new CacheConfig(maxObjectSize, maxCacheEntries, sharedCache, checkFreshness);
         }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public class CacheConfig {
+    public static final CacheConfig DEFAULT = new Builder().build();
+
+    private static final int DEFAULT_MAX_OBJECT_SIZE_IN_BYTES = 8192;
+    private static final int DEFAULT_MAX_CACHE_ENTRIES = 1000;
+    private static final boolean DEFAULT_SHARED_CACHED = true;
+    private final long maxObjectSize;
+    private final int maxCacheEntries;
+    private final boolean sharedCache;
+
+    CacheConfig(long maxObjectSize, int maxCacheEntries, boolean sharedCache) {
+        this.maxObjectSize = maxObjectSize;
+        this.maxCacheEntries = maxCacheEntries;
+        this.sharedCache = sharedCache;
+    }
+
+    public static Builder custom() {
+        return new Builder();
+    }
+
+    /**
+     * Maximum response body size in bytes that will be cached.
+     */
+    public long getMaxObjectSize() {
+        return maxObjectSize;
+    }
+
+    /**
+     * Maximum number of entries in the cache
+     */
+    public int getMaxCacheEntries() {
+        return maxCacheEntries;
+    }
+
+    /**
+     * Should the cache behave as a shared cache?
+     */
+    public boolean isSharedCache() {
+        return sharedCache;
+    }
+
+    public static class Builder {
+        private long maxObjectSize;
+        private int maxCacheEntries;
+        private boolean sharedCache;
+
+        Builder() {
+            maxObjectSize = DEFAULT_MAX_OBJECT_SIZE_IN_BYTES;
+            maxCacheEntries = DEFAULT_MAX_CACHE_ENTRIES;
+            sharedCache = DEFAULT_SHARED_CACHED;
+        }
+
+        /**
+         * Set maximum response body size in bytes that will be cached.
+         */
+        public Builder setMaxObjectSize(final long maxObjectSize) {
+            this.maxObjectSize = maxObjectSize;
+            return this;
+        }
+
+        /**
+         * Set maximum number of entries in the cache
+         */
+        public Builder setMaxCacheEntries(final int maxCacheEntries) {
+            this.maxCacheEntries = maxCacheEntries;
+            return this;
+        }
+
+        /**
+         * Set whether the cache should behave as a shared cache or not, true by default.
+         */
+        public Builder isSharedCache(final boolean sharedCache) {
+            this.sharedCache = sharedCache;
+            return this;
+        }
+
+        public CacheConfig build() {
+            return new CacheConfig(maxObjectSize, maxCacheEntries, sharedCache);
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDecoder.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+
+import java.util.EnumSet;
+
+import static io.netty.handler.codec.http.HttpHeaderValues.*;
+
+public final class CacheControlDecoder {
+    // https://blogs.msdn.microsoft.com/ie/2010/07/14/caching-improvements-in-internet-explorer-9
+    public static final int MAXIMUM_AGE = Integer.MAX_VALUE;
+
+    private CacheControlDecoder() {
+    }
+
+    public static CacheControlDirectives decode(HttpHeaders headers) {
+        int maxAgeSeconds = -1;
+        int sMaxAgeSeconds = -1;
+        int maxStaleSeconds = -1;
+        int minFreshSeconds = -1;
+        int staleWhileRevalidate = -1;
+        int staleIfError = -1;
+        EnumSet<CacheControlDirectives.CacheControlFlags> flags =
+                EnumSet.noneOf(CacheControlDirectives.CacheControlFlags.class);
+
+        for (String value : headers.getAll(HttpHeaderNames.CACHE_CONTROL)) {
+            int pos = 0;
+            while (pos < value.length()) {
+                int tokenStart = pos;
+                pos = skipUntil(value, pos, "=,;");
+                String directive = value.substring(tokenStart, pos).trim();
+                String parameter;
+
+                if (pos == value.length() || value.charAt(pos) == ',' || value.charAt(pos) == ';') {
+                    pos++; // consume ',' or ';' (if necessary)
+                    parameter = null;
+                } else {
+                    pos++; // consume '='
+                    pos = skipWhitespace(value, pos);
+
+                    // quoted string
+                    if (pos < value.length() && value.charAt(pos) == '\"') {
+                        pos++; // consume '"' open quote
+                        int parameterStart = pos;
+                        pos = skipUntil(value, pos, "\"");
+                        parameter = value.substring(parameterStart, pos);
+                        pos++; // consume '"' close quote (if necessary)
+
+                        // unquoted string
+                    } else {
+                        int parameterStart = pos;
+                        pos = skipUntil(value, pos, ",;");
+                        parameter = value.substring(parameterStart, pos).trim();
+                    }
+                }
+
+                if (NO_CACHE.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.NO_CACHE);
+                } else if (NO_STORE.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.NO_STORE);
+                } else if (MAX_AGE.contentEqualsIgnoreCase(directive)) {
+                    maxAgeSeconds = parseSeconds(parameter, -1);
+                } else if (S_MAXAGE.contentEqualsIgnoreCase(directive)) {
+                    sMaxAgeSeconds = parseSeconds(parameter, -1);
+                } else if (PRIVATE.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.PRIVATE);
+                } else if (PUBLIC.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.PUBLIC);
+                } else if (PROXY_REVALIDATE.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.PROXY_REVALIDATE);
+                } else if (MUST_REVALIDATE.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.MUST_REVALIDATE);
+                } else if (MAX_STALE.contentEqualsIgnoreCase(directive)) {
+                    maxStaleSeconds = parseSeconds(parameter, MAXIMUM_AGE);
+                } else if (MIN_FRESH.contentEqualsIgnoreCase(directive)) {
+                    minFreshSeconds = parseSeconds(parameter, -1);
+                } else if (ONLY_IF_CACHED.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.ONLY_IF_CACHED);
+                } else if (NO_TRANSFORM.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.NO_TRANSFORM);
+                } else if (IMMUTABLE.contentEqualsIgnoreCase(directive)) {
+                    flags.add(CacheControlDirectives.CacheControlFlags.IMMUTABLE);
+                } else if ("stale-while-revalidate".equalsIgnoreCase(directive)) {
+                    staleWhileRevalidate = parseSeconds(parameter, -1);
+                } else if ("stale-if-error".equalsIgnoreCase(directive)) {
+                    staleIfError = parseSeconds(parameter, -1);
+                }
+            }
+        }
+
+        return new CacheControlDirectives(flags, maxAgeSeconds, sMaxAgeSeconds, maxStaleSeconds,
+                                          minFreshSeconds, staleWhileRevalidate, staleIfError);
+    }
+
+    private static int skipUntil(String input, int pos, String characters) {
+        for (; pos < input.length(); pos++) {
+            if (characters.indexOf(input.charAt(pos)) != -1) {
+                break;
+            }
+        }
+        return pos;
+    }
+
+    private static int skipWhitespace(String input, int pos) {
+        for (; pos < input.length(); pos++) {
+            char c = input.charAt(pos);
+            if (c != ' ' && c != '\t') {
+                break;
+            }
+        }
+        return pos;
+    }
+
+    private static int parseSeconds(String value, int defaultValue) {
+        try {
+            long seconds = Long.parseLong(value);
+            if (seconds > MAXIMUM_AGE) {
+                return MAXIMUM_AGE;
+            } else if (seconds < 0) {
+                return 0;
+            } else {
+                return (int) seconds;
+            }
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDecoder.java
@@ -22,7 +22,7 @@ import java.util.EnumSet;
 
 import static io.netty.handler.codec.http.HttpHeaderValues.*;
 
-public final class CacheControlDecoder {
+final class CacheControlDecoder {
     // https://blogs.msdn.microsoft.com/ie/2010/07/14/caching-improvements-in-internet-explorer-9
     public static final int MAXIMUM_AGE = Integer.MAX_VALUE;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectives.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectives.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import java.util.EnumSet;
+
+public class CacheControlDirectives {
+    public static final CacheControlDirectives EMPTY = builder().build();
+
+    private final EnumSet<CacheControlFlags> flags;
+    private final int maxAge;
+    private final int sMaxAge;
+    private final int maxStale;
+    private final int minFresh;
+    private final int staleWhileRevalidate;
+    private final int staleIfError;
+
+    public static CacheControlDirectivesBuilder builder() {
+        return new CacheControlDirectivesBuilder();
+    }
+
+    public CacheControlDirectives(final EnumSet<CacheControlFlags> flags, final int maxAge, final int sMaxAge,
+                                  final int maxStale, final int minFresh, final int staleWhileRevalidate,
+                                  final int staleIfError) {
+        this.flags = flags;
+        this.maxAge = maxAge;
+        this.sMaxAge = sMaxAge;
+        this.maxStale = maxStale;
+        this.minFresh = minFresh;
+        this.staleWhileRevalidate = staleWhileRevalidate;
+        this.staleIfError = staleIfError;
+    }
+
+    public boolean noCache() {
+        return flags.contains(CacheControlFlags.NO_CACHE);
+    }
+
+    public boolean noStore() {
+        return flags.contains(CacheControlFlags.NO_STORE);
+    }
+
+    public boolean noTransform() {
+        return flags.contains(CacheControlFlags.NO_TRANSFORM);
+    }
+
+    public boolean mustRevalidate() {
+        return flags.contains(CacheControlFlags.MUST_REVALIDATE);
+    }
+
+    public boolean proxyRevalidate() {
+        return flags.contains(CacheControlFlags.PROXY_REVALIDATE);
+    }
+
+    public boolean onlyIfCached() {
+        return flags.contains(CacheControlFlags.ONLY_IF_CACHED);
+    }
+
+    public boolean immutable() {
+        return flags.contains(CacheControlFlags.IMMUTABLE);
+    }
+
+    public boolean isPrivate() {
+        return flags.contains(CacheControlFlags.PRIVATE);
+    }
+
+    public boolean isPublic() {
+        return flags.contains(CacheControlFlags.PUBLIC);
+    }
+
+    public int getMaxAge() {
+        return maxAge;
+    }
+
+    public int getSMaxAge() {
+        return sMaxAge;
+    }
+
+    public int getMaxStale() {
+        return maxStale;
+    }
+
+    public int getMinFresh() {
+        return minFresh;
+    }
+
+    public int getStaleWhileRevalidate() {
+        return staleWhileRevalidate;
+    }
+
+    public int getStaleIfError() {
+        return staleIfError;
+    }
+
+    enum CacheControlFlags {
+        PUBLIC,
+        PRIVATE,
+        NO_CACHE,
+        NO_STORE,
+        NO_TRANSFORM,
+        MUST_REVALIDATE,
+        PROXY_REVALIDATE,
+        ONLY_IF_CACHED,
+        IMMUTABLE
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectives.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectives.java
@@ -17,7 +17,7 @@ package io.netty.handler.codec.http.cache;
 
 import java.util.EnumSet;
 
-public class CacheControlDirectives {
+class CacheControlDirectives {
     public static final CacheControlDirectives EMPTY = builder().build();
 
     private final EnumSet<CacheControlFlags> flags;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectives.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectives.java
@@ -35,7 +35,7 @@ class CacheControlDirectives {
     public CacheControlDirectives(final EnumSet<CacheControlFlags> flags, final int maxAge, final int sMaxAge,
                                   final int maxStale, final int minFresh, final int staleWhileRevalidate,
                                   final int staleIfError) {
-        this.flags = flags;
+        this.flags = EnumSet.copyOf(flags);
         this.maxAge = maxAge;
         this.sMaxAge = sMaxAge;
         this.maxStale = maxStale;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectivesBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectivesBuilder.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import java.util.EnumSet;
+
+public class CacheControlDirectivesBuilder {
+    private EnumSet<CacheControlDirectives.CacheControlFlags> flags =
+            EnumSet.noneOf(CacheControlDirectives.CacheControlFlags.class);
+    private int maxAge = -1;
+    private int sMaxAge = -1;
+    private int maxStale = -1;
+    private int minFresh = -1;
+    private int staleWhileRevalidate = -1;
+    private int staleIfError = -1;
+
+    public CacheControlDirectivesBuilder publicCache() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.PUBLIC);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder privateCache() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.PRIVATE);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder noCache() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.NO_CACHE);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder noStore() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.NO_STORE);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder noTransform() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.NO_TRANSFORM);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder mustRevalidate() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.MUST_REVALIDATE);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder proxyRevalidate() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.PROXY_REVALIDATE);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder onlyIfCached() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.ONLY_IF_CACHED);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder immutable() {
+        this.flags.add(CacheControlDirectives.CacheControlFlags.IMMUTABLE);
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder flags(final EnumSet<CacheControlDirectives.CacheControlFlags> flags) {
+        this.flags = flags;
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder maxAge(final int maxAge) {
+        this.maxAge = maxAge;
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder sMaxAge(final int sMaxAge) {
+        this.sMaxAge = sMaxAge;
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder maxStale(final int maxStale) {
+        this.maxStale = maxStale;
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder minFresh(final int minFresh) {
+        this.minFresh = minFresh;
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder staleWhileRevalidate(final int staleWhileRevalidate) {
+        this.staleWhileRevalidate = staleWhileRevalidate;
+        return this;
+    }
+
+    public CacheControlDirectivesBuilder staleIfError(final int staleIfError) {
+        this.staleIfError = staleIfError;
+        return this;
+    }
+
+    public CacheControlDirectives build() {
+        return new CacheControlDirectives(flags, maxAge, sMaxAge, maxStale, minFresh, staleWhileRevalidate,
+                                          staleIfError);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectivesBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheControlDirectivesBuilder.java
@@ -28,52 +28,52 @@ public class CacheControlDirectivesBuilder {
     private int staleIfError = -1;
 
     public CacheControlDirectivesBuilder publicCache() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.PUBLIC);
+        flags.add(CacheControlDirectives.CacheControlFlags.PUBLIC);
         return this;
     }
 
     public CacheControlDirectivesBuilder privateCache() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.PRIVATE);
+        flags.add(CacheControlDirectives.CacheControlFlags.PRIVATE);
         return this;
     }
 
     public CacheControlDirectivesBuilder noCache() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.NO_CACHE);
+        flags.add(CacheControlDirectives.CacheControlFlags.NO_CACHE);
         return this;
     }
 
     public CacheControlDirectivesBuilder noStore() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.NO_STORE);
+        flags.add(CacheControlDirectives.CacheControlFlags.NO_STORE);
         return this;
     }
 
     public CacheControlDirectivesBuilder noTransform() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.NO_TRANSFORM);
+        flags.add(CacheControlDirectives.CacheControlFlags.NO_TRANSFORM);
         return this;
     }
 
     public CacheControlDirectivesBuilder mustRevalidate() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.MUST_REVALIDATE);
+        flags.add(CacheControlDirectives.CacheControlFlags.MUST_REVALIDATE);
         return this;
     }
 
     public CacheControlDirectivesBuilder proxyRevalidate() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.PROXY_REVALIDATE);
+        flags.add(CacheControlDirectives.CacheControlFlags.PROXY_REVALIDATE);
         return this;
     }
 
     public CacheControlDirectivesBuilder onlyIfCached() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.ONLY_IF_CACHED);
+        flags.add(CacheControlDirectives.CacheControlFlags.ONLY_IF_CACHED);
         return this;
     }
 
     public CacheControlDirectivesBuilder immutable() {
-        this.flags.add(CacheControlDirectives.CacheControlFlags.IMMUTABLE);
+        flags.add(CacheControlDirectives.CacheControlFlags.IMMUTABLE);
         return this;
     }
 
     public CacheControlDirectivesBuilder flags(final EnumSet<CacheControlDirectives.CacheControlFlags> flags) {
-        this.flags = flags;
+        this.flags = EnumSet.copyOf(flags);
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheKeyGenerator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheKeyGenerator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
+
+public class CacheKeyGenerator {
+    public String generateKey(HttpRequest request) {
+        final String host = request.headers().get(HttpHeaderNames.HOST);
+        if (host == null) {
+            return null;
+        }
+
+        final StringBuilder stringBuilder = new StringBuilder(host);
+        stringBuilder.append(request.uri());
+
+        return stringBuilder.toString();
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheKeyGenerator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/CacheKeyGenerator.java
@@ -17,11 +17,17 @@ package io.netty.handler.codec.http.cache;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 public class CacheKeyGenerator {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(CacheKeyGenerator.class);
+
     public String generateKey(HttpRequest request) {
         final String host = request.headers().get(HttpHeaderNames.HOST);
-        if (host == null) {
+        if (StringUtil.isNullOrEmpty(host)) {
+            logger.debug("Can't generate cache key, the request has no meaningful HOST header.");
             return null;
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/ConditionalRequestBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/ConditionalRequestBuilder.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public class ConditionalRequestBuilder {
+
+    private static final Set<CharSequence> UNCONDITIONAL_EXCLUDED_HEADERS;
+
+    static {
+        UNCONDITIONAL_EXCLUDED_HEADERS = new HashSet<CharSequence>();
+        UNCONDITIONAL_EXCLUDED_HEADERS.add(HttpHeaderNames.IF_RANGE);
+        UNCONDITIONAL_EXCLUDED_HEADERS.add(HttpHeaderNames.IF_MATCH);
+        UNCONDITIONAL_EXCLUDED_HEADERS.add(HttpHeaderNames.IF_NONE_MATCH);
+        UNCONDITIONAL_EXCLUDED_HEADERS.add(HttpHeaderNames.IF_UNMODIFIED_SINCE);
+        UNCONDITIONAL_EXCLUDED_HEADERS.add(HttpHeaderNames.IF_MODIFIED_SINCE);
+    }
+
+    HttpRequest conditionalRequest(HttpRequest request, HttpCacheEntry cacheEntry) {
+        final DefaultHttpHeaders copiedHeaders = new DefaultHttpHeaders();
+        for (Entry<String, String> header : request.headers()) {
+            copiedHeaders.add(header.getKey(), header.getValue());
+        }
+
+        final HttpRequest newRequest =
+                new DefaultHttpRequest(request.protocolVersion(), request.method(), request.uri(), copiedHeaders);
+
+        final String etag = cacheEntry.getResponseHeaders().get(HttpHeaderNames.ETAG);
+        if (etag != null) {
+            copiedHeaders.set(HttpHeaderNames.IF_NONE_MATCH, etag);
+        }
+
+        final String lastModified = cacheEntry.getResponseHeaders().get(HttpHeaderNames.LAST_MODIFIED);
+        if (lastModified != null) {
+            copiedHeaders.set(HttpHeaderNames.IF_MODIFIED_SINCE, lastModified);
+        }
+
+        final CacheControlDirectives cacheEntryCacheControlDirectives =
+                CacheControlDecoder.decode(cacheEntry.getResponseHeaders());
+        boolean mustRevalidate = cacheEntryCacheControlDirectives.mustRevalidate() ||
+                                 cacheEntryCacheControlDirectives.proxyRevalidate();
+
+        if (mustRevalidate) {
+            copiedHeaders.add(HttpHeaderNames.CACHE_CONTROL, HttpHeaderValues.MAX_AGE + "=0");
+        }
+
+        return newRequest;
+    }
+
+    /**
+     * Request with all caching disabled. Sometimes we can receive a response older than the current cache entry, when
+     * this happens the recommendation is to retry the validation and force syncup.
+     *
+     * @param request request we are trying to satisfy
+     *
+     * @return
+     */
+    HttpRequest unconditionalRequest(HttpRequest request) {
+        final DefaultHttpHeaders copiedHeaders = new DefaultHttpHeaders();
+        for (Entry<String, String> header : request.headers()) {
+            if (!UNCONDITIONAL_EXCLUDED_HEADERS.contains(header.getKey())) {
+                copiedHeaders.add(header.getKey(), header.getValue());
+            }
+        }
+
+        copiedHeaders.add(HttpHeaderNames.CACHE_CONTROL, HttpHeaderValues.NO_CACHE);
+        copiedHeaders.add(HttpHeaderNames.PRAGMA, HttpHeaderValues.NO_CACHE);
+
+        // TODO: Copy full request including body
+        return new DefaultHttpRequest(request.protocolVersion(), request.method(), request.uri(), copiedHeaders);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCache.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCache.java
@@ -53,6 +53,10 @@ class HttpCache {
         this.executor = checkNotNull(executor, "executor");
     }
 
+    private static boolean isHttpMethodSafe(HttpMethod method) {
+        return method == HttpMethod.GET || method == HttpMethod.HEAD || method == HttpMethod.TRACE;
+    }
+
     public Future<HttpCacheEntry> cache(final HttpRequest request,
                                         final FullHttpResponse response,
                                         final Date requestSent,
@@ -111,11 +115,11 @@ class HttpCache {
      * @see <a href="https://tools.ietf.org/html/rfc7234#section-4.4">RFC 7234 - Invalidation</a>
      */
     public Future<Void> flushCacheEntriesInvalidatedByExchange(final HttpRequest request,
-                                                                      final HttpResponse response,
-                                                                      Promise<Void> promise) {
+                                                               final HttpResponse response,
+                                                               Promise<Void> promise) {
         if (logger.isDebugEnabled()) {
-            logger.debug("Flush cache entries invalidated by exchange: " + request.headers().get(HttpHeaderNames.HOST) + "; " +
-                         request.method() + ' ' + request.uri() + request.protocolVersion() + " -> " +
+            logger.debug("Flush cache entries invalidated by exchange: " + request.headers().get(HttpHeaderNames.HOST) +
+                         "; " + request.method() + ' ' + request.uri() + request.protocolVersion() + " -> " +
                          response.protocolVersion() + ' ' + response.status());
         }
 
@@ -131,7 +135,6 @@ class HttpCache {
             // TODO: flush content location uri if present
 
             // TODO: flush location uri if present
-
         }
 
         return promise;
@@ -151,9 +154,9 @@ class HttpCache {
     }
 
     public Future<HttpCacheEntry> updateCacheEntry(final HttpRequest request,
-                                         final HttpResponse response,
-                                         final Date requestSent,
-                                         final Date responseReceived) {
+                                                   final HttpResponse response,
+                                                   final Date requestSent,
+                                                   final Date responseReceived) {
         if (logger.isDebugEnabled()) {
             logger.debug("Update cache entry: " + request.headers().get(HttpHeaderNames.HOST));
         }
@@ -162,9 +165,5 @@ class HttpCache {
 
         // TODO cacheUpdateHandler.updateCacheEntry
         return getCacheEntry(request, executor.<HttpCacheEntry>newPromise());
-    }
-
-    private static boolean isHttpMethodSafe(HttpMethod method) {
-        return method == HttpMethod.GET || method == HttpMethod.HEAD || method == HttpMethod.TRACE;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCache.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCache.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.Date;
+
+import static io.netty.util.internal.ObjectUtil.*;
+
+public class HttpCache {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(HttpCache.class);
+
+    private final HttpCacheStorage storage;
+    private final CacheKeyGenerator keyGenerator;
+
+    public HttpCache(final HttpCacheStorage storage) {
+        this(storage, new CacheKeyGenerator());
+    }
+
+    public HttpCache(final HttpCacheStorage storage, final CacheKeyGenerator keyGenerator) {
+        this.storage = checkNotNull(storage, "storage");
+        this.keyGenerator = checkNotNull(keyGenerator, "keyGenerator");
+    }
+
+    public HttpCacheEntry cache(final HttpRequest request,
+                                final FullHttpResponse response,
+                                final Date requestSent,
+                                final Date responseReceived) {
+        final String cacheKey = keyGenerator.generateKey(request);
+
+        final HttpCacheEntry entry = new HttpCacheEntry(response.copy(), requestSent, responseReceived,
+                                                        response.status(), response.headers());
+
+        storage.put(cacheKey, entry);
+        return entry;
+    }
+
+    public HttpCacheEntry getCacheEntry(HttpRequest request) {
+        final HttpCacheEntry cacheEntry;
+        try {
+            final String cacheKey = keyGenerator.generateKey(request);
+            cacheEntry = storage.get(cacheKey);
+        } catch (Exception e) {
+            logger.error("Error while retrieving cache entry.", e);
+            return null;
+        }
+
+        return cacheEntry;
+    }
+
+    public void invalidate(final HttpRequest request) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Invalid cache entries");
+        }
+
+        final String cacheKey = keyGenerator.generateKey(request);
+        final HttpCacheEntry cacheEntry = getCacheEntry(request);
+        if (cacheEntry != null) {
+
+            // TODO: remove variants
+
+            storage.remove(cacheKey);
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntry.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntry.java
@@ -172,4 +172,16 @@ public class HttpCacheEntry implements Serializable {
         long responseDelayInSeconds = (responseDate.getTime() - requestDate.getTime()) / 1000L;
         return getAgeInSeconds() + responseDelayInSeconds;
     }
+
+    boolean mustRevalidate() {
+        return responseCacheControlDirectives.mustRevalidate();
+    }
+
+    boolean proxyRevalidate() {
+        return responseCacheControlDirectives.proxyRevalidate();
+    }
+
+    CacheControlDirectives getCacheControlDirectives() {
+        return responseCacheControlDirectives;
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntry.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntry.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.buffer.ByteBufHolder;
+import io.netty.handler.codec.DateFormatter;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+public class HttpCacheEntry implements Serializable {
+    private static final long serialVersionUID = -7024260271684161731L;
+
+    private final ByteBufHolder content;
+
+    private final Date requestDate;
+    private final Date responseDate;
+    private final HttpResponseStatus status;
+    private final HttpHeaders responseHeaders;
+    private final Date date;
+    private final CacheControlDirectives responseCacheControlDirectives;
+
+    public HttpCacheEntry(final ByteBufHolder content,
+                          final Date requestDate,
+                          final Date responseDate,
+                          final HttpResponseStatus status, final HttpHeaders responseHeaders) {
+        this.content = content;
+        this.requestDate = requestDate;
+        this.responseDate = checkNotNull(responseDate, "responseDate");
+        this.status = checkNotNull(status, "status");
+        this.responseHeaders = responseHeaders;
+        this.responseCacheControlDirectives = CacheControlDecoder.decode(responseHeaders);
+
+        final String dateString = responseHeaders.get(HttpHeaderNames.DATE);
+        this.date = dateString != null ? DateFormatter.parseHttpDate(dateString) : null;
+    }
+
+    public ByteBufHolder getContent() {
+        return content;
+    }
+
+    public HttpHeaders getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    public HttpResponseStatus getStatus() {
+        return status;
+    }
+
+    public Date getRequestDate() {
+        return requestDate;
+    }
+
+    public Date getResponseDate() {
+        return responseDate;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public long getAgeInSeconds() {
+        final String age = responseHeaders.get(HttpHeaderNames.AGE);
+        if (age != null) {
+            try {
+                return Long.parseLong(age);
+            } catch (NumberFormatException e) {
+                return 0L;
+            }
+        }
+        return 0L;
+    }
+
+    public long getSMaxAge() {
+        return responseCacheControlDirectives.getSMaxAge();
+    }
+
+    public long getMaxAge() {
+        return responseCacheControlDirectives.getMaxAge();
+    }
+
+    public long getStalenessInSeconds(final boolean shared, final Date now) {
+        final long age = getCurrentAgeInSeconds(now);
+        final long freshness = getFreshnessLifetimeInSeconds(shared);
+        return Math.max(0L, age - freshness);
+    }
+
+    /**
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-4.2">rfc7234#section-4.2</a>
+     */
+    boolean isFresh(final boolean sharedCache, final Date now) {
+        return getFreshnessLifetimeInSeconds(sharedCache) > getCurrentAgeInSeconds(now);
+    }
+
+    /**
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-4.2.1">rfc7234#section-4.2.1</a>
+     */
+    long getFreshnessLifetimeInSeconds(final boolean sharedCache) {
+        final long sMaxAge = getSMaxAge();
+        if (sharedCache && sMaxAge != -1L) {
+            return sMaxAge;
+        }
+
+        final long maxAge = responseCacheControlDirectives.getMaxAge();
+        if (maxAge != -1L) {
+            return maxAge;
+        }
+
+        final Date date = getDate();
+        if (date == null) {
+            return 0L;
+        }
+
+        final long expires = responseHeaders.getTimeMillis(HttpHeaderNames.EXPIRES, -1L);
+        if (expires != -1L) {
+            return (expires - date.getTime()) / 1000L;
+        }
+
+        return 0L;
+    }
+
+    /**
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-4.2.3">rfc7234#section-4.2.3</a>
+     */
+    long getCurrentAgeInSeconds(final Date now) {
+        return getCorrectedInitialAgeInSeconds() + getResidentTimeInSeconds(now);
+    }
+
+    /**
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-4.2.3">rfc7234#section-4.2.3</a>
+     */
+    long getCorrectedInitialAgeInSeconds() {
+        return Math.max(getApparentAgeInSeconds(), getCorrectedAgeInSeconds());
+    }
+
+    /**
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-4.2.3">rfc7234#section-4.2.3</a>
+     */
+    long getResidentTimeInSeconds(final Date now) {
+        return (now.getTime() - responseDate.getTime()) / 1000L;
+    }
+
+    long getApparentAgeInSeconds() {
+        if (date == null) {
+            return 0L;
+        }
+
+        return Math.max(0L, (responseDate.getTime() - date.getTime()) / 1000L);
+    }
+
+    long getCorrectedAgeInSeconds() {
+        long responseDelayInSeconds = (responseDate.getTime() - requestDate.getTime()) / 1000L;
+        return getAgeInSeconds() + responseDelayInSeconds;
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntry.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntry.java
@@ -20,12 +20,14 @@ import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.internal.UnstableApi;
 
 import java.io.Serializable;
 import java.util.Date;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
+@UnstableApi
 public class HttpCacheEntry implements Serializable {
     private static final long serialVersionUID = -7024260271684161731L;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntryChecker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntryChecker.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.Date;
+
+public class HttpCacheEntryChecker {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(HttpCacheEntryChecker.class);
+
+    private final boolean sharedCache;
+
+    public HttpCacheEntryChecker(final boolean sharedCache) {
+        this.sharedCache = sharedCache;
+    }
+
+    public boolean canUseCachedResponse(final CacheControlDirectives requestCacheControlDirectives,
+                                        final HttpCacheEntry cacheEntry, final Date now) {
+        if (!isFreshEnough(requestCacheControlDirectives, cacheEntry, now)) {
+            logger.debug("Cache entry is not fresh");
+            return false;
+        }
+
+        if (requestCacheControlDirectives.noCache()) {
+            logger.debug("Request has no-cache directive, cache entry is not suitable.");
+            return false;
+        }
+
+        // TODO: Shouldn't happen since we check that before
+        if (requestCacheControlDirectives.noStore()) {
+            logger.debug("Request has no-store directive, cache entry is not suitable.");
+            return false;
+        }
+
+        // https://tools.ietf.org/html/rfc7234#section-5.2.1.1
+        final int requestMaxAge = requestCacheControlDirectives.getMaxAge();
+        final int requestMaxStale = requestCacheControlDirectives.getMaxStale();
+        if (requestMaxAge != -1) {
+            final int maxAgePlusStale = requestMaxAge + (requestMaxStale != -1 ? requestMaxStale : 0);
+            if (cacheEntry.getCurrentAgeInSeconds(now) > maxAgePlusStale) {
+                logger.debug("Cache entry was not suitable due to max age.");
+                return false;
+            }
+        }
+
+        if (requestMaxStale != -1) {
+            if (cacheEntry.getFreshnessLifetimeInSeconds(sharedCache) > requestMaxStale) {
+                logger.debug("Cache entry was not suitable due to max stale freshness.");
+                return false;
+            }
+        }
+
+        final int requestMinFresh = requestCacheControlDirectives.getMinFresh();
+        if (requestMinFresh != -1) {
+            final long ageInSeconds = cacheEntry.getCurrentAgeInSeconds(now);
+            final long freshnessInSeconds = cacheEntry.getFreshnessLifetimeInSeconds(sharedCache);
+            if ((freshnessInSeconds - ageInSeconds) < requestMinFresh) {
+                logger.debug("Cache entry was not suitable due to min fresh freshness requirement.");
+                return false;
+            }
+        }
+
+        logger.debug("Response from cache can be used.");
+        return true;
+    }
+
+    private boolean isFreshEnough(final CacheControlDirectives requestCacheControlDirectives,
+                                  final HttpCacheEntry cacheEntry, final Date now) {
+        if (cacheEntry.isFresh(sharedCache, now)) {
+            return true;
+        }
+
+        // heuristicaly fresh?
+
+        // stale
+        final long maxStale = requestCacheControlDirectives.getMaxStale();
+        if (maxStale == -1) {
+            return false;
+        }
+
+        return maxStale > cacheEntry.getStalenessInSeconds(sharedCache, now);
+    }
+
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntryChecker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntryChecker.java
@@ -15,6 +15,11 @@
  */
 package io.netty.handler.codec.http.cache;
 
+import io.netty.handler.codec.DateFormatter;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -29,10 +34,92 @@ class HttpCacheEntryChecker {
         this.sharedCache = sharedCache;
     }
 
-    public boolean canUseCachedResponse(final CacheControlDirectives requestCacheControlDirectives,
+    public static boolean isConditional(HttpRequest request) {
+        final HttpHeaders headers = request.headers();
+        return headers.contains(HttpHeaderNames.IF_NONE_MATCH) ||
+               headers.getTimeMillis(HttpHeaderNames.IF_MODIFIED_SINCE) != null;
+    }
+
+    public static boolean allConditionsMatch(final HttpRequest request, final HttpCacheEntry cacheEntry,
+                                             final Date now) {
+        final HttpHeaders headers = request.headers();
+        final boolean hasIfNoneMatchHeader = headers.contains(HttpHeaderNames.IF_NONE_MATCH);
+        final boolean hasIfModifiedSinceHeader = headers.getTimeMillis(HttpHeaderNames.IF_MODIFIED_SINCE) != null;
+
+        final boolean etagMatches = hasIfNoneMatchHeader && etagMatches(request, cacheEntry);
+        final boolean lastModifiedMatches = hasIfModifiedSinceHeader && ifModifiedMatches(request, cacheEntry, now);
+
+        if (hasIfNoneMatchHeader && hasIfModifiedSinceHeader &&
+            !(etagMatches && lastModifiedMatches)) {
+            return false;
+        }
+
+        if (hasIfNoneMatchHeader && !etagMatches) {
+            return false;
+        }
+
+        return !hasIfModifiedSinceHeader || lastModifiedMatches;
+    }
+
+    private static boolean etagMatches(final HttpRequest request, final HttpCacheEntry cacheEntry) {
+        final String cachedEtag = cacheEntry.getResponseHeaders().get(HttpHeaderNames.ETAG);
+        for (String ifNoneMatchHeader : request.headers().getAll(HttpHeaderNames.IF_NONE_MATCH)) {
+            if ("*".equals(ifNoneMatchHeader) && cachedEtag != null ||
+                ifNoneMatchHeader.equals(cachedEtag)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean ifModifiedMatches(final HttpRequest request, final HttpCacheEntry cacheEntry,
+                                             final Date now) {
+        final Date lastModified =
+                DateFormatter.parseHttpDate(cacheEntry.getResponseHeaders().get(HttpHeaderNames.LAST_MODIFIED));
+        if (lastModified == null) {
+            return false;
+        }
+
+        for (String ifModified : request.headers().getAll(HttpHeaderNames.IF_MODIFIED_SINCE)) {
+            final Date ifModifiedSince = DateFormatter.parseHttpDate(ifModified);
+            if (ifModifiedSince != null) {
+                if (ifModifiedSince.after(now) || lastModified.after(ifModifiedSince)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean requestHasUnsupportedHeaders(final HttpRequest request) {
+        final HttpHeaders headers = request.headers();
+        return headers.contains(HttpHeaderNames.IF_RANGE) ||
+               headers.contains(HttpHeaderNames.IF_MATCH) ||
+               headers.contains(HttpHeaderNames.IF_UNMODIFIED_SINCE);
+    }
+
+    public boolean canUseCachedResponse(final HttpRequest request,
+                                        final CacheControlDirectives requestCacheControlDirectives,
                                         final HttpCacheEntry cacheEntry, final Date now) {
         if (!isFreshEnough(requestCacheControlDirectives, cacheEntry, now)) {
             logger.debug("Cache entry is not fresh");
+            return false;
+        }
+
+        if (requestHasUnsupportedHeaders(request)) {
+            logger.debug("Request contains unsupported headers.");
+            return false;
+        }
+
+        if (!isConditional(request) && cacheEntry.getStatus() == HttpResponseStatus.NOT_MODIFIED) {
+            logger.debug("Non-modified cached response can only match conditional request.");
+            return false;
+        }
+
+        if (isConditional(request) && !allConditionsMatch(request, cacheEntry, now)) {
+            logger.debug("Conditional request with non matching conditions, cache entry is not suitable.");
             return false;
         }
 
@@ -41,7 +128,6 @@ class HttpCacheEntryChecker {
             return false;
         }
 
-        // TODO: Shouldn't happen since we check that before
         if (requestCacheControlDirectives.noStore()) {
             logger.debug("Request has no-store directive, cache entry is not suitable.");
             return false;
@@ -51,7 +137,7 @@ class HttpCacheEntryChecker {
         final int requestMaxAge = requestCacheControlDirectives.getMaxAge();
         final int requestMaxStale = requestCacheControlDirectives.getMaxStale();
         if (requestMaxAge != -1) {
-            final int maxAgePlusStale = requestMaxAge + (requestMaxStale != -1 ? requestMaxStale : 0);
+            final int maxAgePlusStale = requestMaxAge + (requestMaxStale != -1? requestMaxStale : 0);
             if (cacheEntry.getCurrentAgeInSeconds(now) > maxAgePlusStale) {
                 logger.debug("Cache entry was not suitable due to max age.");
                 return false;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntryChecker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheEntryChecker.java
@@ -20,12 +20,12 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.Date;
 
-public class HttpCacheEntryChecker {
+class HttpCacheEntryChecker {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(HttpCacheEntryChecker.class);
 
     private final boolean sharedCache;
 
-    public HttpCacheEntryChecker(final boolean sharedCache) {
+    HttpCacheEntryChecker(final boolean sharedCache) {
         this.sharedCache = sharedCache;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheMemoryStorage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheMemoryStorage.java
@@ -21,10 +21,13 @@ import io.netty.util.concurrent.Promise;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-class HttpCacheMemoryStorage implements HttpCacheStorage {
+/**
+ * TODO: Enforce config like maxCacheEntries
+ */
+public class HttpCacheMemoryStorage implements HttpCacheStorage {
     private final ConcurrentMap<String, HttpCacheEntry> cache;
 
-    HttpCacheMemoryStorage() {
+    public HttpCacheMemoryStorage() {
         cache = new ConcurrentHashMap<String, HttpCacheEntry>();
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheMemoryStorage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheMemoryStorage.java
@@ -15,28 +15,35 @@
  */
 package io.netty.handler.codec.http.cache;
 
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-public class HttpCacheMemoryStorage implements HttpCacheStorage {
+class HttpCacheMemoryStorage implements HttpCacheStorage {
     private final ConcurrentMap<String, HttpCacheEntry> cache;
 
-    public HttpCacheMemoryStorage() {
+    HttpCacheMemoryStorage() {
         cache = new ConcurrentHashMap<String, HttpCacheEntry>();
     }
 
     @Override
-    public void put(final String key, final HttpCacheEntry entry) {
+    public Future<Void> put(final String key, final HttpCacheEntry entry, final Promise<Void> promise) {
         cache.put(key, entry);
+        return promise.setSuccess(null);
     }
 
     @Override
-    public HttpCacheEntry get(final String key) {
-        return cache.get(key);
+    public Future<HttpCacheEntry> get(final String key, final Promise<HttpCacheEntry> promise) {
+        return promise.setSuccess(cache.get(key));
     }
 
     @Override
-    public void remove(final String key) {
-        cache.remove(key);
+    public Future<Void> remove(final String key, Promise<Void> promise) {
+        final HttpCacheEntry cacheEntry = cache.remove(key);
+        cacheEntry.getContent().release();
+        promise.setSuccess(null);
+        return promise;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheMemoryStorage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheMemoryStorage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class HttpCacheMemoryStorage implements HttpCacheStorage {
+    private final ConcurrentMap<String, HttpCacheEntry> cache;
+
+    public HttpCacheMemoryStorage() {
+        cache = new ConcurrentHashMap<String, HttpCacheEntry>();
+    }
+
+    @Override
+    public void put(final String key, final HttpCacheEntry entry) {
+        cache.put(key, entry);
+    }
+
+    @Override
+    public HttpCacheEntry get(final String key) {
+        return cache.get(key);
+    }
+
+    @Override
+    public void remove(final String key) {
+        cache.remove(key);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheStorage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheStorage.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+public interface HttpCacheStorage {
+
+    void put(String key, HttpCacheEntry entry);
+
+    HttpCacheEntry get(String key);
+
+    void remove(String key);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheStorage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpCacheStorage.java
@@ -15,11 +15,16 @@
  */
 package io.netty.handler.codec.http.cache;
 
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
 public interface HttpCacheStorage {
 
-    void put(String key, HttpCacheEntry entry);
+    Future<Void> put(String key, HttpCacheEntry entry, Promise<Void> promise);
 
-    HttpCacheEntry get(String key);
+    Future<HttpCacheEntry> get(String key, Promise<HttpCacheEntry> promise);
 
-    void remove(String key);
+    Future<Void> remove(String key, Promise<Void> promise);
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpClientCacheHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpClientCacheHandler.java
@@ -15,13 +15,30 @@
  */
 package io.netty.handler.codec.http.cache;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -31,39 +48,70 @@ import static io.netty.util.ReferenceCountUtil.*;
 import static io.netty.util.internal.ObjectUtil.*;
 
 /**
- *
+ * A {@link ChannelDuplexHandler} that provides http client caching capabilities.
  */
+@UnstableApi
 public class HttpClientCacheHandler extends ChannelDuplexHandler {
+    public static final int MAX_COMPOSITEBUFFER_COMPONENTS = 1024;
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(HttpClientCacheHandler.class);
-
     private final RequestCachingPolicy requestCachingPolicy;
     private final HttpCache httpCache;
     private final ResponseCachingPolicy responseCachingPolicy;
     private final HttpCacheEntryChecker httpCacheEntryChecker;
     private final HttpResponseFromCacheGenerator httpResponseFromCacheGenerator;
+    private final CacheConfig cacheConfig;
 
     private HttpRequest request;
+    private AggregatedFullHttpResponse inFlightResponse;
     private Date requestSent;
 
-    public HttpClientCacheHandler(final HttpCacheStorage cacheStorage, final boolean sharedCache) {
-        this.httpCache = new HttpCache(cacheStorage, new CacheKeyGenerator());
+    public HttpClientCacheHandler(final HttpCacheStorage cacheStorage,
+                                  final CacheConfig cacheConfig,
+                                  final EventLoop eventLoop) {
+        this.httpCache = new HttpCache(cacheStorage, new CacheKeyGenerator(), eventLoop);
         this.requestCachingPolicy = new RequestCachingPolicy();
-        this.responseCachingPolicy = new ResponseCachingPolicy(sharedCache);
-        this.httpCacheEntryChecker = new HttpCacheEntryChecker(sharedCache);
+        this.responseCachingPolicy = new ResponseCachingPolicy(cacheConfig.isSharedCache());
+        this.httpCacheEntryChecker = new HttpCacheEntryChecker(cacheConfig.isSharedCache());
         this.httpResponseFromCacheGenerator = new HttpResponseFromCacheGenerator();
+        this.cacheConfig = cacheConfig;
     }
 
-    public HttpClientCacheHandler(final RequestCachingPolicy requestCachingPolicy,
-                                  final HttpCache httpCache,
-                                  final ResponseCachingPolicy responseCachingPolicy,
-                                  final HttpCacheEntryChecker httpCacheEntryChecker,
-                                  final HttpResponseFromCacheGenerator httpResponseFromCacheGenerator) {
+    HttpClientCacheHandler(final RequestCachingPolicy requestCachingPolicy,
+                           final HttpCache httpCache,
+                           final ResponseCachingPolicy responseCachingPolicy,
+                           final HttpCacheEntryChecker httpCacheEntryChecker,
+                           final HttpResponseFromCacheGenerator httpResponseFromCacheGenerator,
+                           final CacheConfig cacheConfig) {
         this.httpCache = checkNotNull(httpCache, "httpCache");
         this.requestCachingPolicy = checkNotNull(requestCachingPolicy, "requestCachingPolicy");
         this.responseCachingPolicy = checkNotNull(responseCachingPolicy, "responseCachingPolicy");
         this.httpCacheEntryChecker = checkNotNull(httpCacheEntryChecker, "httpCacheEntryChecker");
         this.httpResponseFromCacheGenerator =
                 checkNotNull(httpResponseFromCacheGenerator, "httpResponseFromCacheGenerator");
+        this.cacheConfig = checkNotNull(cacheConfig, "cacheConfig");
+    }
+
+    private static void appendPartialContent(CompositeByteBuf content, ByteBuf partialContent) {
+        if (partialContent.isReadable()) {
+            content.addComponent(true, partialContent.retain());
+        }
+    }
+
+    private static void sendGatewayTimeout(final ChannelHandlerContext ctx, final HttpRequest request) {
+        ctx.fireChannelRead(new DefaultFullHttpResponse(request.protocolVersion(), HttpResponseStatus.GATEWAY_TIMEOUT));
+        release(request);
+    }
+
+    /**
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.2.1.7">rfc7234#section-5.2.1.7</a>
+     */
+    private static boolean mayCallBackend(final CacheControlDirectives requestCacheControlDirectives) {
+        if (requestCacheControlDirectives.onlyIfCached()) {
+            logger.debug("Backend will not be call because request is using 'only-if-cached' header.");
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -79,12 +127,94 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
-        if (!(msg instanceof FullHttpResponse)) {
-            super.channelRead(ctx, msg);
-            return;
+
+        if (msg instanceof HttpResponse) {
+            final HttpResponse httpResponse = (HttpResponse) msg;
+            if (responseCachingPolicy.canBeCached(request, httpResponse)) {
+                logger.debug("Start caching response...");
+                if (httpResponse instanceof FullHttpResponse) {
+                    // Already have a full response, no need to wait for the other elements
+                    cacheResponse((FullHttpResponse) httpResponse);
+                } else {
+                    // A streamed message - initialize the cumulative buffer, and wait for incoming chunks.
+                    CompositeByteBuf content = ctx.alloc().compositeBuffer(MAX_COMPOSITEBUFFER_COMPONENTS);
+                    if (msg instanceof ByteBufHolder) {
+                        appendPartialContent(content, ((ByteBufHolder) httpResponse).content());
+                    }
+
+                    inFlightResponse = new AggregatedFullHttpResponse(httpResponse, content.retain(), null);
+                }
+            }
+        } else if (msg instanceof HttpContent) {
+
+            final HttpContent httpContent = (HttpContent) msg;
+            if (inFlightResponse != null) {
+                CompositeByteBuf content = inFlightResponse.content();
+                appendPartialContent(content, httpContent.content());
+
+                aggregate(inFlightResponse, httpContent);
+
+                if (msg instanceof LastHttpContent) {
+                    cacheResponse(inFlightResponse);
+                }
+            }
         }
 
-        channelRead(ctx, (FullHttpResponse) msg);
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        try {
+            // release current message if it is not null as it may be a left-over
+            super.channelInactive(ctx);
+        } finally {
+            releaseCurrentResponse();
+        }
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        try {
+            super.handlerRemoved(ctx);
+        } finally {
+            // release current message if it is not null as it may be a left-over as there is not much more we can do in
+            // this case
+            releaseCurrentResponse();
+        }
+    }
+
+    private void cacheResponse(FullHttpResponse response) {
+        ByteBuf content = response.content();
+        if (content.readableBytes() > cacheConfig.getMaxObjectSize()) {
+            logger.info("HTTP response too big to be cached.");
+        } else {
+            httpCache.cache(request, response, requestSent, new Date())
+                     .addListener(new GenericFutureListener<Future<? super HttpCacheEntry>>() {
+                         @Override
+                         public void operationComplete(Future<? super HttpCacheEntry> future) throws Exception {
+                             if (future.isSuccess()) {
+                                 logger.debug("Response has been cached");
+                             }
+
+                             releaseCurrentResponse();
+                         }
+                     });
+        }
+    }
+
+    private void releaseCurrentResponse() {
+        if (inFlightResponse != null) {
+            inFlightResponse.release();
+            inFlightResponse = null;
+        }
+    }
+
+    protected void aggregate(FullHttpMessage aggregated, HttpContent content) throws Exception {
+        if (content instanceof LastHttpContent) {
+            // Merge trailing headers into the message.
+            ((AggregatedFullHttpResponse) aggregated).setTrailingHeaders(((LastHttpContent) content).trailingHeaders());
+        }
     }
 
     private void write(final ChannelHandlerContext ctx, final HttpRequest request, final ChannelPromise promise)
@@ -93,19 +223,25 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
 
         if (!requestCachingPolicy.canBeServedFromCache(request)) {
             logger.debug("Request can not be served from cache.");
-            httpCache.invalidate(request);
+            httpCache.invalidate(request, ctx.executor().<Void>newPromise());
 
             callBackend(ctx, request, promise);
             return;
         }
 
         final CacheControlDirectives requestCacheControlDirectives = CacheControlDecoder.decode(request.headers());
-        final HttpCacheEntry cacheEntry = httpCache.getCacheEntry(request);
-        if (cacheEntry == null) {
-            handleCacheMiss(ctx, request, requestCacheControlDirectives, promise);
-        } else {
-            handleCacheHit(ctx, request, requestCacheControlDirectives, cacheEntry, promise);
-        }
+        httpCache.getCacheEntry(request, ctx.executor().<HttpCacheEntry>newPromise())
+                 .addListener(new FutureListener<HttpCacheEntry>() {
+                     @Override
+                     public void operationComplete(Future<HttpCacheEntry> cacheEntryFuture) throws Exception {
+                         if (cacheEntryFuture.isSuccess() && cacheEntryFuture.getNow() != null) {
+                             handleCacheHit(ctx, request, requestCacheControlDirectives, cacheEntryFuture.getNow(),
+                                            promise);
+                         } else {
+                             handleCacheMiss(ctx, request, requestCacheControlDirectives, promise);
+                         }
+                     }
+                 });
     }
 
     private void handleCacheHit(final ChannelHandlerContext ctx, final HttpRequest request,
@@ -127,11 +263,6 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
         }
     }
 
-    private void sendGatewayTimeout(final ChannelHandlerContext ctx, final HttpRequest request) {
-        ctx.fireChannelRead(new DefaultFullHttpResponse(request.protocolVersion(), HttpResponseStatus.GATEWAY_TIMEOUT));
-        release(request);
-    }
-
     private void handleCacheMiss(final ChannelHandlerContext ctx, final HttpRequest request,
                                  final CacheControlDirectives requestCacheControlDirectives,
                                  final ChannelPromise promise) throws Exception {
@@ -144,31 +275,155 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
         callBackend(ctx, request, promise);
     }
 
-    /**
-     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.2.1.7">rfc7234#section-5.2.1.7</a>
-     */
-    private boolean mayCallBackend(final CacheControlDirectives requestCacheControlDirectives) {
-        if (requestCacheControlDirectives.onlyIfCached()) {
-            logger.debug("Backend will not be call because request is using 'only-if-cached' header.");
-            return false;
-        }
-
-        return true;
-    }
-
     private void callBackend(final ChannelHandlerContext ctx, final HttpRequest request, final ChannelPromise promise)
             throws Exception {
         requestSent = new Date();
         super.write(ctx, request, promise);
     }
 
-    private void channelRead(final ChannelHandlerContext ctx, final FullHttpResponse response) throws Exception {
-        if (responseCachingPolicy.canBeCached(request, response)) {
-            logger.debug("Caching response");
-            HttpCacheEntry cacheEntry = httpCache.cache(request, response, requestSent, new Date());
+    private static final class AggregatedFullHttpResponse implements FullHttpResponse {
+
+        private final HttpMessage message;
+        private final CompositeByteBuf content;
+        private HttpHeaders trailingHeaders;
+
+        AggregatedFullHttpResponse(HttpMessage message, CompositeByteBuf content, HttpHeaders trailingHeaders) {
+            this.message = message;
+            this.content = content;
+            this.trailingHeaders = trailingHeaders;
         }
 
-        super.channelRead(ctx, response);
-    }
+        @Override
+        public HttpHeaders trailingHeaders() {
+            HttpHeaders trailingHeaders = this.trailingHeaders;
+            if (trailingHeaders == null) {
+                return EmptyHttpHeaders.INSTANCE;
+            } else {
+                return trailingHeaders;
+            }
+        }
 
+        void setTrailingHeaders(HttpHeaders trailingHeaders) {
+            this.trailingHeaders = trailingHeaders;
+        }
+
+        @Override
+        public HttpVersion getProtocolVersion() {
+            return message.protocolVersion();
+        }
+
+        @Override
+        public HttpVersion protocolVersion() {
+            return message.protocolVersion();
+        }
+
+        @Override
+        public FullHttpResponse setProtocolVersion(HttpVersion version) {
+            message.setProtocolVersion(version);
+            return this;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return message.headers();
+        }
+
+        @Override
+        public DecoderResult decoderResult() {
+            return message.decoderResult();
+        }
+
+        @Override
+        public DecoderResult getDecoderResult() {
+            return message.decoderResult();
+        }
+
+        @Override
+        public void setDecoderResult(DecoderResult result) {
+            message.setDecoderResult(result);
+        }
+
+        @Override
+        public CompositeByteBuf content() {
+            return content;
+        }
+
+        @Override
+        public int refCnt() {
+            return content.refCnt();
+        }
+
+        @Override
+        public FullHttpResponse retain() {
+            content.retain();
+            return this;
+        }
+
+        @Override
+        public FullHttpResponse retain(int increment) {
+            content.retain(increment);
+            return this;
+        }
+
+        @Override
+        public FullHttpResponse touch(Object hint) {
+            content.touch(hint);
+            return this;
+        }
+
+        @Override
+        public FullHttpResponse touch() {
+            content.touch();
+            return this;
+        }
+
+        @Override
+        public boolean release() {
+            return content.release();
+        }
+
+        @Override
+        public boolean release(int decrement) {
+            return content.release(decrement);
+        }
+
+        @Override
+        public FullHttpResponse copy() {
+            return replace(content().copy());
+        }
+
+        @Override
+        public FullHttpResponse duplicate() {
+            return replace(content().duplicate());
+        }
+
+        @Override
+        public FullHttpResponse retainedDuplicate() {
+            return replace(content().retainedDuplicate());
+        }
+
+        @Override
+        public FullHttpResponse replace(ByteBuf content) {
+            DefaultFullHttpResponse dup = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(), content,
+                                                                      headers().copy(), trailingHeaders().copy());
+            dup.setDecoderResult(decoderResult());
+            return dup;
+        }
+
+        @Override
+        public FullHttpResponse setStatus(HttpResponseStatus status) {
+            ((HttpResponse) message).setStatus(status);
+            return this;
+        }
+
+        @Override
+        public HttpResponseStatus getStatus() {
+            return ((HttpResponse) message).status();
+        }
+
+        @Override
+        public HttpResponseStatus status() {
+            return getStatus();
+        }
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpClientCacheHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpClientCacheHandler.java
@@ -22,12 +22,17 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
+import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
@@ -43,6 +48,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.Date;
+import java.util.Map.Entry;
 
 import static io.netty.util.ReferenceCountUtil.*;
 import static io.netty.util.internal.ObjectUtil.*;
@@ -64,6 +70,8 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
     private HttpRequest request;
     private AggregatedFullHttpResponse inFlightResponse;
     private Date requestSent;
+
+    private boolean waitingOnConditionalResponse;
 
     public HttpClientCacheHandler(final HttpCacheStorage cacheStorage,
                                   final CacheConfig cacheConfig,
@@ -117,7 +125,7 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
     @Override
     public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
             throws Exception {
-        if (!(msg instanceof HttpRequest)) {
+        if (!(msg instanceof HttpRequest) || waitingOnConditionalResponse) {
             super.write(ctx, msg, promise);
             return;
         }
@@ -128,13 +136,66 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
     @Override
     public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
 
+        if (waitingOnConditionalResponse) {
+            handleConditionalRequestResponse(ctx, msg);
+        } else {
+            handleBackendResponse(ctx, msg);
+        }
+    }
+
+    private void handleConditionalRequestResponse(final ChannelHandlerContext ctx, final Object msg) {
         if (msg instanceof HttpResponse) {
             final HttpResponse httpResponse = (HttpResponse) msg;
+
+            // TODO revalidationResponseIsTooOld
+
+            final HttpResponseStatus status = httpResponse.status();
+            if (status == HttpResponseStatus.NOT_MODIFIED || status == HttpResponseStatus.OK) {
+                // TODO: record cache update
+            }
+
+            if (status == HttpResponseStatus.NOT_MODIFIED) {
+                httpCache.updateCacheEntry(request, httpResponse, null, null)
+                         .addListener(new GenericFutureListener<Future<HttpCacheEntry>>() {
+                             @Override
+                             public void operationComplete(Future<HttpCacheEntry> future) throws Exception {
+                                 if (future.isSuccess()) {
+                                     final HttpCacheEntry cacheEntry = future.getNow();
+
+                                     HttpResponse httpResponse;
+                                     if (isConditional(request) && allConditionsMatch(request, cacheEntry)) {
+                                         httpResponse = httpResponseFromCacheGenerator.generateNotModifiedResponse(cacheEntry);
+                                     } else {
+                                         httpResponse = httpResponseFromCacheGenerator.generate(request, cacheEntry);
+                                     }
+
+                                     ctx.fireChannelRead(httpResponse);
+                                 }
+                             }
+                         });
+            } else if (true) {
+                // TODO staleIfErrorAppliesTo
+            } else {
+                // TODO handleBackendResponse
+            }
+
+
+        }
+    }
+
+    private void handleBackendResponse(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof HttpResponse) {
+            final HttpResponse httpResponse = (HttpResponse) msg;
+
+            httpCache.flushCacheEntriesInvalidatedByExchange(request, httpResponse, ctx.newPromise());
             if (responseCachingPolicy.canBeCached(request, httpResponse)) {
                 logger.debug("Start caching response...");
+
+                // TODO: storeRequestIfModifiedSinceFor304Response
+
                 if (httpResponse instanceof FullHttpResponse) {
                     // Already have a full response, no need to wait for the other elements
-                    cacheResponse((FullHttpResponse) httpResponse);
+                    tryCacheResponse((FullHttpResponse) httpResponse, ctx);
                 } else {
                     // A streamed message - initialize the cumulative buffer, and wait for incoming chunks.
                     CompositeByteBuf content = ctx.alloc().compositeBuffer(MAX_COMPOSITEBUFFER_COMPONENTS);
@@ -144,6 +205,9 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
 
                     inFlightResponse = new AggregatedFullHttpResponse(httpResponse, content.retain(), null);
                 }
+            } else {
+                logger.debug("Response is not cacheable.");
+                httpCache.flushCacheEntriesFor(request, ctx.newPromise());
             }
         } else if (msg instanceof HttpContent) {
 
@@ -155,7 +219,7 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
                 aggregate(inFlightResponse, httpContent);
 
                 if (msg instanceof LastHttpContent) {
-                    cacheResponse(inFlightResponse);
+                    tryCacheResponse(inFlightResponse, ctx);
                 }
             }
         }
@@ -169,7 +233,7 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
             // release current message if it is not null as it may be a left-over
             super.channelInactive(ctx);
         } finally {
-            releaseCurrentResponse();
+            releaseInFlightResponse();
         }
     }
 
@@ -180,30 +244,63 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
         } finally {
             // release current message if it is not null as it may be a left-over as there is not much more we can do in
             // this case
-            releaseCurrentResponse();
+            releaseInFlightResponse();
         }
     }
 
-    private void cacheResponse(FullHttpResponse response) {
+    private void tryCacheResponse(final FullHttpResponse response, ChannelHandlerContext ctx) {
         ByteBuf content = response.content();
         if (content.readableBytes() > cacheConfig.getMaxObjectSize()) {
             logger.info("HTTP response too big to be cached.");
-        } else {
-            httpCache.cache(request, response, requestSent, new Date())
-                     .addListener(new GenericFutureListener<Future<? super HttpCacheEntry>>() {
-                         @Override
-                         public void operationComplete(Future<? super HttpCacheEntry> future) throws Exception {
-                             if (future.isSuccess()) {
-                                 logger.debug("Response has been cached");
-                             }
+            return;
+        }
 
-                             releaseCurrentResponse();
-                         }
-                     });
+        if (cacheConfig.shoulCheckFreshness()) {
+            cacheIfFresh(response, ctx);
+        } else {
+            cache(response);
         }
     }
 
-    private void releaseCurrentResponse() {
+    private void cacheIfFresh(final FullHttpResponse response, ChannelHandlerContext ctx) {
+        httpCache.getCacheEntry(request, ctx.executor().<HttpCacheEntry>newPromise())
+                 .addListener(new GenericFutureListener<Future<HttpCacheEntry>>() {
+                     @Override
+                     public void operationComplete(Future<HttpCacheEntry> future) throws Exception {
+                         if (future.isSuccess()) {
+
+                             HttpCacheEntry existingCacheEntry = future.getNow();
+                             if (existingCacheEntry != null) {
+                                 final Long responseTimestamp = response.headers().getTimeMillis(HttpHeaderNames.DATE);
+                                 final long cacheTimestamp  = existingCacheEntry.getResponseDate().getTime();
+                                 if (cacheTimestamp > responseTimestamp) {
+                                     logger.debug("Cache already contains fresher cache entry");
+                                     releaseInFlightResponse();
+                                     return;
+                                 }
+                             }
+                         }
+
+                         cache(response);
+                     }
+                 });
+    }
+
+    private Future<HttpCacheEntry> cache(FullHttpResponse response) {
+        return httpCache.cache(request, response, requestSent, new Date())
+                 .addListener(new GenericFutureListener<Future<? super HttpCacheEntry>>() {
+                     @Override
+                     public void operationComplete(Future<? super HttpCacheEntry> future) throws Exception {
+                         if (future.isSuccess()) {
+                             logger.debug("Response has been cached");
+                         }
+
+                         releaseInFlightResponse();
+                     }
+                 });
+    }
+
+    private void releaseInFlightResponse() {
         if (inFlightResponse != null) {
             inFlightResponse.release();
             inFlightResponse = null;
@@ -248,6 +345,8 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
                                 final CacheControlDirectives requestCacheControlDirectives,
                                 final HttpCacheEntry cacheEntry, final ChannelPromise promise) throws Exception {
 
+        // TODO record cache hit
+
         final Date now = new Date();
         if (httpCacheEntryChecker.canUseCachedResponse(requestCacheControlDirectives, cacheEntry, now)) {
             logger.debug("Cache hit");
@@ -258,9 +357,126 @@ public class HttpClientCacheHandler extends ChannelDuplexHandler {
         } else if (!mayCallBackend(requestCacheControlDirectives)) {
             logger.debug("Cache entry not suitable but only-if-cached requested");
             sendGatewayTimeout(ctx, request);
+        } else if (cacheEntry.getStatus() != HttpResponseStatus.NOT_MODIFIED || isConditional(request))  {
+            logger.debug("Revalidating cache entry");
+
+            revalidateCacheEntry(ctx, request, cacheEntry, promise);
         } else {
+            logger.debug("Cache entry non existent or not usable, calling backend.");
             callBackend(ctx, request, promise);
         }
+    }
+
+    /**
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-4.3">RFC 7234 - Validation</a>
+     */
+    private void revalidateCacheEntry(final ChannelHandlerContext ctx,
+                                      final HttpRequest request,
+                                      final HttpCacheEntry cacheEntry,
+                                      final ChannelPromise promise) throws Exception {
+
+        final HttpRequest conditionalRequest = buildConditionalRequest(request, cacheEntry);
+        waitingOnConditionalResponse = true;
+
+        ctx.pipeline().write(conditionalRequest, promise);
+    }
+
+    private HttpRequest buildConditionalRequest(HttpRequest request, HttpCacheEntry cacheEntry) {
+        final DefaultHttpHeaders copiedHeaders = new DefaultHttpHeaders();
+        for (Entry<String, String> header : request.headers()) {
+            copiedHeaders.add(header.getKey(), header.getValue());
+        }
+
+        final HttpRequest newRequest =
+                new DefaultHttpRequest(request.protocolVersion(), request.method(), request.uri(), copiedHeaders);
+
+        final String etag = cacheEntry.getResponseHeaders().get(HttpHeaderNames.ETAG);
+        if (etag != null) {
+            copiedHeaders.set(HttpHeaderNames.IF_NONE_MATCH, etag);
+        }
+
+        final String lastModified = cacheEntry.getResponseHeaders().get(HttpHeaderNames.LAST_MODIFIED);
+        if (lastModified != null) {
+            copiedHeaders.set(HttpHeaderNames.IF_MODIFIED_SINCE, lastModified);
+        }
+
+        final CacheControlDirectives cacheEntryCacheControlDirectives = CacheControlDecoder.decode(cacheEntry.getResponseHeaders());
+        boolean mustRevalidate = cacheEntryCacheControlDirectives.mustRevalidate() ||
+                                 cacheEntryCacheControlDirectives.proxyRevalidate();
+
+        if (mustRevalidate) {
+            copiedHeaders.add(HttpHeaderNames.CACHE_CONTROL, HttpHeaderValues.MAX_AGE + "=0");
+        }
+
+        return newRequest;
+    }
+
+    private static boolean isConditional(HttpRequest request) {
+        if (request.headers().contains(HttpHeaderNames.IF_NONE_MATCH)) {
+            return true;
+        }
+
+        final String ifModifiedHeader = request.headers().get(HttpHeaderNames.IF_MODIFIED_SINCE);
+        if (ifModifiedHeader == null) {
+            return false;
+        }
+
+        return DateFormatter.parseHttpDate(ifModifiedHeader) != null;
+    }
+
+    private static boolean allConditionsMatch(final HttpRequest request, final HttpCacheEntry cacheEntry) {
+        final boolean hasIfNoneMatchHeader = request.headers().contains(HttpHeaderNames.IF_NONE_MATCH);
+        final String ifModifiedHeader = request.headers().get(HttpHeaderNames.IF_MODIFIED_SINCE);
+        final boolean hasIfModifiedSinceHeader = ifModifiedHeader != null && DateFormatter.parseHttpDate(ifModifiedHeader) != null;
+
+        final boolean etagMatches = hasIfNoneMatchHeader && etagMatches(request, cacheEntry);
+        final boolean lastModifiedMatches = hasIfModifiedSinceHeader && ifModifiedMatches(request, cacheEntry, new Date());
+
+        if (hasIfNoneMatchHeader && hasIfModifiedSinceHeader &&
+            !(etagMatches && lastModifiedMatches)) {
+            return false;
+        }
+
+        if (hasIfNoneMatchHeader && !etagMatches) {
+            return false;
+        }
+
+        if (hasIfModifiedSinceHeader && !lastModifiedMatches) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean etagMatches(final HttpRequest request, final HttpCacheEntry cacheEntry) {
+        final String cachedEtag = cacheEntry.getResponseHeaders().get(HttpHeaderNames.ETAG);
+        for (String ifNoneMatchHeader : request.headers().getAll(HttpHeaderNames.IF_NONE_MATCH)) {
+            if ("*".equals(ifNoneMatchHeader) && cachedEtag != null ||
+                ifNoneMatchHeader.equals(cachedEtag)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean ifModifiedMatches(final HttpRequest request, final HttpCacheEntry cacheEntry, final Date now) {
+        final Date lastModified =
+                DateFormatter.parseHttpDate(cacheEntry.getResponseHeaders().get(HttpHeaderNames.LAST_MODIFIED));
+        if (lastModified == null) {
+            return false;
+        }
+
+        for (String ifModified : request.headers().getAll(HttpHeaderNames.IF_MODIFIED_SINCE)) {
+            final Date ifModifiedSince = DateFormatter.parseHttpDate(ifModified);
+            if (ifModifiedSince != null) {
+                if (ifModifiedSince.after(now) || lastModified.after(ifModifiedSince)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private void handleCacheMiss(final ChannelHandlerContext ctx, final HttpRequest request,

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpClientCacheHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpClientCacheHandler.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.Date;
+
+import static io.netty.util.ReferenceCountUtil.*;
+import static io.netty.util.internal.ObjectUtil.*;
+
+/**
+ *
+ */
+public class HttpClientCacheHandler extends ChannelDuplexHandler {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(HttpClientCacheHandler.class);
+
+    private final RequestCachingPolicy requestCachingPolicy;
+    private final HttpCache httpCache;
+    private final ResponseCachingPolicy responseCachingPolicy;
+    private final HttpCacheEntryChecker httpCacheEntryChecker;
+    private final HttpResponseFromCacheGenerator httpResponseFromCacheGenerator;
+
+    private HttpRequest request;
+    private Date requestSent;
+
+    public HttpClientCacheHandler(final HttpCacheStorage cacheStorage, final boolean sharedCache) {
+        this.httpCache = new HttpCache(cacheStorage, new CacheKeyGenerator());
+        this.requestCachingPolicy = new RequestCachingPolicy();
+        this.responseCachingPolicy = new ResponseCachingPolicy(sharedCache);
+        this.httpCacheEntryChecker = new HttpCacheEntryChecker(sharedCache);
+        this.httpResponseFromCacheGenerator = new HttpResponseFromCacheGenerator();
+    }
+
+    public HttpClientCacheHandler(final RequestCachingPolicy requestCachingPolicy,
+                                  final HttpCache httpCache,
+                                  final ResponseCachingPolicy responseCachingPolicy,
+                                  final HttpCacheEntryChecker httpCacheEntryChecker,
+                                  final HttpResponseFromCacheGenerator httpResponseFromCacheGenerator) {
+        this.httpCache = checkNotNull(httpCache, "httpCache");
+        this.requestCachingPolicy = checkNotNull(requestCachingPolicy, "requestCachingPolicy");
+        this.responseCachingPolicy = checkNotNull(responseCachingPolicy, "responseCachingPolicy");
+        this.httpCacheEntryChecker = checkNotNull(httpCacheEntryChecker, "httpCacheEntryChecker");
+        this.httpResponseFromCacheGenerator =
+                checkNotNull(httpResponseFromCacheGenerator, "httpResponseFromCacheGenerator");
+    }
+
+    @Override
+    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
+            throws Exception {
+        if (!(msg instanceof HttpRequest)) {
+            super.write(ctx, msg, promise);
+            return;
+        }
+
+        write(ctx, (HttpRequest) msg, promise);
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
+        if (!(msg instanceof FullHttpResponse)) {
+            super.channelRead(ctx, msg);
+            return;
+        }
+
+        channelRead(ctx, (FullHttpResponse) msg);
+    }
+
+    private void write(final ChannelHandlerContext ctx, final HttpRequest request, final ChannelPromise promise)
+            throws Exception {
+        this.request = request;
+
+        if (!requestCachingPolicy.canBeServedFromCache(request)) {
+            logger.debug("Request can not be served from cache.");
+            httpCache.invalidate(request);
+
+            callBackend(ctx, request, promise);
+            return;
+        }
+
+        final CacheControlDirectives requestCacheControlDirectives = CacheControlDecoder.decode(request.headers());
+        final HttpCacheEntry cacheEntry = httpCache.getCacheEntry(request);
+        if (cacheEntry == null) {
+            handleCacheMiss(ctx, request, requestCacheControlDirectives, promise);
+        } else {
+            handleCacheHit(ctx, request, requestCacheControlDirectives, cacheEntry, promise);
+        }
+    }
+
+    private void handleCacheHit(final ChannelHandlerContext ctx, final HttpRequest request,
+                                final CacheControlDirectives requestCacheControlDirectives,
+                                final HttpCacheEntry cacheEntry, final ChannelPromise promise) throws Exception {
+
+        final Date now = new Date();
+        if (httpCacheEntryChecker.canUseCachedResponse(requestCacheControlDirectives, cacheEntry, now)) {
+            logger.debug("Cache hit");
+
+            final FullHttpResponse httpResponse = httpResponseFromCacheGenerator.generate(request, cacheEntry);
+            release(request);
+            ctx.fireChannelRead(httpResponse);
+        } else if (!mayCallBackend(requestCacheControlDirectives)) {
+            logger.debug("Cache entry not suitable but only-if-cached requested");
+            sendGatewayTimeout(ctx, request);
+        } else {
+            callBackend(ctx, request, promise);
+        }
+    }
+
+    private void sendGatewayTimeout(final ChannelHandlerContext ctx, final HttpRequest request) {
+        ctx.fireChannelRead(new DefaultFullHttpResponse(request.protocolVersion(), HttpResponseStatus.GATEWAY_TIMEOUT));
+        release(request);
+    }
+
+    private void handleCacheMiss(final ChannelHandlerContext ctx, final HttpRequest request,
+                                 final CacheControlDirectives requestCacheControlDirectives,
+                                 final ChannelPromise promise) throws Exception {
+        logger.debug("Cache miss");
+        if (!mayCallBackend(requestCacheControlDirectives)) {
+            sendGatewayTimeout(ctx, request);
+            return;
+        }
+
+        callBackend(ctx, request, promise);
+    }
+
+    /**
+     * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.2.1.7">rfc7234#section-5.2.1.7</a>
+     */
+    private boolean mayCallBackend(final CacheControlDirectives requestCacheControlDirectives) {
+        if (requestCacheControlDirectives.onlyIfCached()) {
+            logger.debug("Backend will not be call because request is using 'only-if-cached' header.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void callBackend(final ChannelHandlerContext ctx, final HttpRequest request, final ChannelPromise promise)
+            throws Exception {
+        requestSent = new Date();
+        super.write(ctx, request, promise);
+    }
+
+    private void channelRead(final ChannelHandlerContext ctx, final FullHttpResponse response) throws Exception {
+        if (responseCachingPolicy.canBeCached(request, response)) {
+            logger.debug("Caching response");
+            HttpCacheEntry cacheEntry = httpCache.cache(request, response, requestSent, new Date());
+        }
+
+        super.channelRead(ctx, response);
+    }
+
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGenerator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+
+import java.util.Date;
+
+import static io.netty.buffer.Unpooled.*;
+import static io.netty.handler.codec.http.cache.CacheControlDecoder.*;
+
+public class HttpResponseFromCacheGenerator {
+
+    FullHttpResponse generate(final HttpRequest request, final HttpCacheEntry cacheEntry) {
+        final Date now = new Date();
+
+        final DefaultHttpHeaders headers = new DefaultHttpHeaders(false);
+        headers.set(cacheEntry.getResponseHeaders());
+
+        ByteBuf content = EMPTY_BUFFER;
+        final ByteBufHolder contentHolder = cacheEntry.getContent();
+        if (request.method().equals(HttpMethod.GET) && content != null) {
+            content = contentHolder.content();
+
+            if (headers.get(HttpHeaderNames.TRANSFER_ENCODING) == null &&
+                headers.get(HttpHeaderNames.CONTENT_LENGTH) == null) {
+                headers.setInt(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
+            }
+        }
+
+        final long age = cacheEntry.getCurrentAgeInSeconds(now);
+        if (age > 0) {
+            if (age >= MAXIMUM_AGE) {
+                headers.add(HttpHeaderNames.AGE, Integer.toString(MAXIMUM_AGE));
+            } else {
+                headers.add(HttpHeaderNames.AGE, Long.toString(age));
+            }
+        }
+
+        return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, cacheEntry.getStatus(), content, headers,
+                                           new ReadOnlyHttpHeaders(false));
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGenerator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGenerator.java
@@ -19,14 +19,22 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import io.netty.util.AsciiString;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 import static io.netty.buffer.Unpooled.*;
 import static io.netty.handler.codec.http.cache.CacheControlDecoder.*;
@@ -61,5 +69,21 @@ class HttpResponseFromCacheGenerator {
 
         return new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, cacheEntry.getStatus(), content, headers,
                                            new ReadOnlyHttpHeaders(false));
+    }
+
+    HttpResponse generateNotModifiedResponse(final HttpCacheEntry entry) {
+
+        HttpHeaders headers = new DefaultHttpHeaders();
+        Set<AsciiString> headerNames = new HashSet<AsciiString>(Arrays.asList(
+                HttpHeaderNames.DATE, HttpHeaderNames.ETAG, HttpHeaderNames.CONTENT_LOCATION, HttpHeaderNames.EXPIRES,
+                HttpHeaderNames.CACHE_CONTROL, HttpHeaderNames.VARY));
+        for (AsciiString headerName : headerNames) {
+            final String headerValue = entry.getResponseHeaders().get(headerName);
+            if (headerValue != null) {
+                headers.add(headerName, headerValue);
+            }
+        }
+
+        return new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_MODIFIED, headers);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGenerator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGenerator.java
@@ -31,7 +31,7 @@ import java.util.Date;
 import static io.netty.buffer.Unpooled.*;
 import static io.netty.handler.codec.http.cache.CacheControlDecoder.*;
 
-public class HttpResponseFromCacheGenerator {
+class HttpResponseFromCacheGenerator {
 
     FullHttpResponse generate(final HttpRequest request, final HttpCacheEntry cacheEntry) {
         final Date now = new Date();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/RequestCachingPolicy.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/RequestCachingPolicy.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+public class RequestCachingPolicy {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(RequestCachingPolicy.class);
+
+    public boolean canBeServedFromCache(HttpRequest request) {
+        if (request.protocolVersion().compareTo(HttpVersion.HTTP_1_1) < 0) {
+            logger.debug("Non HTTP/1.1 request can not be served from cache.");
+            return false;
+        }
+
+        final HttpMethod method = request.method();
+        if (!method.equals(HttpMethod.GET) && !method.equals(HttpMethod.HEAD)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(method + " request can not be served from cache.");
+            }
+            return false;
+        }
+
+        final CacheControlDirectives cacheControlDirectives = CacheControlDecoder.decode(request.headers());
+        if (cacheControlDirectives.noStore()) {
+            logger.debug("Request with 'cache-control: no-store' header can not be served from cache.");
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/RequestCachingPolicy.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/RequestCachingPolicy.java
@@ -15,13 +15,14 @@
  */
 package io.netty.handler.codec.http.cache;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-public class RequestCachingPolicy {
+class RequestCachingPolicy {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(RequestCachingPolicy.class);
 
@@ -36,6 +37,12 @@ public class RequestCachingPolicy {
             if (logger.isDebugEnabled()) {
                 logger.debug(method + " request can not be served from cache.");
             }
+            return false;
+        }
+
+        if (request.headers().contains(HttpHeaderNames.VARY)) {
+            // TODO: handle Vary
+            logger.debug("Vary header is not yet supported, request can not be served from cache.");
             return false;
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/ResponseCachingPolicy.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/ResponseCachingPolicy.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ResponseCachingPolicy {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(RequestCachingPolicy.class);
+
+    private final Set<HttpResponseStatus> uncacheableStatusCodes = new HashSet<HttpResponseStatus>(Arrays.asList(
+            HttpResponseStatus.PARTIAL_CONTENT
+    ));
+
+    private final boolean sharedCache;
+
+    public ResponseCachingPolicy(final boolean sharedCache) {
+        this.sharedCache = sharedCache;
+    }
+
+    public boolean canBeCached(final HttpRequest request, final HttpResponse response) {
+        if (request.protocolVersion().compareTo(HttpVersion.HTTP_1_1) < 0) {
+            logger.debug("HTTP/1.0 request can not be cached.");
+            return false;
+        }
+
+        final HttpMethod httpMethod = request.method();
+        if (httpMethod != HttpMethod.GET && httpMethod != HttpMethod.HEAD) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(httpMethod + " method response is not cacheable.");
+            }
+
+            return false;
+        }
+
+        final HttpResponseStatus status = response.status();
+        if (uncacheableStatusCodes.contains(status)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(status + " response is not cacheable.");
+            }
+
+            return false;
+        } else if (unknownStatusCode(status)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(status + " response status is unknown.");
+            }
+
+            return false;
+        }
+
+        final HttpHeaders headers = response.headers();
+        final CacheControlDirectives cacheControlDirectives = CacheControlDecoder.decode(headers);
+        final List<String> dateHeader = headers.getAll(HttpHeaderNames.DATE);
+        if (dateHeader.size() > 1) {
+            logger.debug("Multiple Date headers.");
+            return false;
+        }
+
+        final Long dateHeaderInMilliseconds = headers.getTimeMillis(HttpHeaderNames.DATE);
+        if (dateHeaderInMilliseconds == null) {
+            logger.debug("Invalid Date header.");
+            return false;
+        }
+
+        if (isForbiddenByCacheControl(cacheControlDirectives)) {
+            logger.debug("Response can not be cached because of Cache-Control header.");
+            return false;
+        }
+
+        if (sharedCache) {
+            if (headers.contains(HttpHeaderNames.AUTHORIZATION) &&
+                    !isCacheableAuthorizedResponse(cacheControlDirectives)) {
+                logger.debug("Shared cache can not cache request with credentials.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean isForbiddenByCacheControl(final CacheControlDirectives cacheControlDirectives) {
+        return cacheControlDirectives.noStore() || cacheControlDirectives.noCache();
+    }
+
+    private static boolean isCacheableAuthorizedResponse(final CacheControlDirectives cacheControlDirectives) {
+        return cacheControlDirectives.isPublic() ||
+                cacheControlDirectives.mustRevalidate() ||
+                cacheControlDirectives.getSMaxAge() != -1;
+    }
+
+    private static boolean unknownStatusCode(final HttpResponseStatus status) {
+        final int code = status.code();
+        return (code < 100 || code > 101) &&
+                (code < 200 || code > 206) &&
+                (code < 300 || code > 307) &&
+                (code < 400 || code > 417) &&
+                (code < 500 || code > 505);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/ResponseCachingPolicy.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/ResponseCachingPolicy.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class ResponseCachingPolicy {
+class ResponseCachingPolicy {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(RequestCachingPolicy.class);
 
@@ -40,7 +40,7 @@ public class ResponseCachingPolicy {
 
     private final boolean sharedCache;
 
-    public ResponseCachingPolicy(final boolean sharedCache) {
+    ResponseCachingPolicy(final boolean sharedCache) {
         this.sharedCache = sharedCache;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/ResponseCachingPolicy.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/ResponseCachingPolicy.java
@@ -25,7 +25,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -34,9 +34,10 @@ class ResponseCachingPolicy {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(RequestCachingPolicy.class);
 
-    private final Set<HttpResponseStatus> uncacheableStatusCodes = new HashSet<HttpResponseStatus>(Arrays.asList(
-            HttpResponseStatus.PARTIAL_CONTENT
-    ));
+    private final Set<HttpResponseStatus> uncacheableStatusCodes = new HashSet<HttpResponseStatus>(
+            Collections.singletonList(
+                    HttpResponseStatus.PARTIAL_CONTENT
+            ));
 
     private final boolean sharedCache;
 
@@ -66,7 +67,9 @@ class ResponseCachingPolicy {
             }
 
             return false;
-        } else if (unknownStatusCode(status)) {
+        }
+
+        if (unknownStatusCode(status)) {
             if (logger.isDebugEnabled()) {
                 logger.debug(status + " response status is unknown.");
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cache/package-info.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cache/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This package contains http client cache related classes.
+ */
+package io.netty.handler.codec.http.cache;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
@@ -59,7 +59,9 @@ public abstract class AbstractHttpData extends AbstractReferenceCounted implemen
     }
 
     @Override
-    public long getMaxSize() { return maxSize; }
+    public long getMaxSize() {
+        return maxSize;
+    }
 
     @Override
     public void setMaxSize(long maxSize) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheControlDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheControlDecoderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http.cache;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -129,13 +144,14 @@ public class CacheControlDecoderTest {
 
     @Test
     public void shouldLimitValueToMaximumAge() {
-        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "max-age=" + Long.toString(MAXIMUM_AGE + 100L));
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "max-age=" + (MAXIMUM_AGE + 100L));
         assertThat(decode(headers).getMaxAge(), is(MAXIMUM_AGE));
     }
 
     @Test
     public void shouldMergeFromMultipleCacheControlHeaders() {
-        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "private", CACHE_CONTROL, "min-fresh=10");
+        final HttpHeaders headers =
+                new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "private", CACHE_CONTROL, "min-fresh=10");
         assertThat(decode(headers).isPrivate(), is(true));
         assertThat(decode(headers).getMinFresh(), is(10));
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheControlDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheControlDecoderTest.java
@@ -1,0 +1,142 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import org.junit.Test;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
+import static io.netty.handler.codec.http.cache.CacheControlDecoder.MAXIMUM_AGE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class CacheControlDecoderTest {
+    @Test
+    public void shouldParsePublicDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.PUBLIC);
+        assertThat(CacheControlDecoder.decode(headers).isPublic(), is(true));
+    }
+
+    @Test
+    public void shouldParsePrivateDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.PRIVATE);
+        assertThat(CacheControlDecoder.decode(headers).isPrivate(), is(true));
+    }
+
+    @Test
+    public void shouldParseNoCacheDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.NO_CACHE);
+        assertThat(CacheControlDecoder.decode(headers).noCache(), is(true));
+    }
+
+    @Test
+    public void shouldParseNoStoreDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.NO_STORE);
+        assertThat(CacheControlDecoder.decode(headers).noStore(), is(true));
+    }
+
+    @Test
+    public void shouldParseNoTransformDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.NO_TRANSFORM);
+        assertThat(CacheControlDecoder.decode(headers).noTransform(), is(true));
+    }
+
+    @Test
+    public void shouldParseMustRevalidateDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.MUST_REVALIDATE);
+        assertThat(CacheControlDecoder.decode(headers).mustRevalidate(), is(true));
+    }
+
+    @Test
+    public void shouldParseProxyRevalidateDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.PROXY_REVALIDATE);
+        assertThat(CacheControlDecoder.decode(headers).proxyRevalidate(), is(true));
+    }
+
+    @Test
+    public void shouldParseOnlyIfCachedDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.ONLY_IF_CACHED);
+        assertThat(CacheControlDecoder.decode(headers).onlyIfCached(), is(true));
+    }
+
+    @Test
+    public void shouldParseImmutableDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.IMMUTABLE);
+        assertThat(CacheControlDecoder.decode(headers).immutable(), is(true));
+    }
+
+    @Test
+    public void shouldParseMaxAgeDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "max-age=10");
+        assertThat(CacheControlDecoder.decode(headers).getMaxAge(), is(10));
+    }
+
+    @Test
+    public void shouldParseSMaxAgeDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "s-maxage=10");
+        assertThat(CacheControlDecoder.decode(headers).getSMaxAge(), is(10));
+    }
+
+    @Test
+    public void shouldParseMaxStaleDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "max-stale=10");
+        assertThat(CacheControlDecoder.decode(headers).getMaxStale(), is(10));
+    }
+
+    @Test
+    public void shouldParseMinFreshDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "min-fresh=10");
+        assertThat(CacheControlDecoder.decode(headers).getMinFresh(), is(10));
+    }
+
+    @Test
+    public void shouldParseStaleWhileRevalidateDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "stale-while-revalidate=10");
+        assertThat(CacheControlDecoder.decode(headers).getStaleWhileRevalidate(), is(10));
+    }
+
+    @Test
+    public void shouldParseStaleIfErrorDirective() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "stale-if-error=10");
+        assertThat(CacheControlDecoder.decode(headers).getStaleIfError(), is(10));
+    }
+
+    @Test
+    public void shouldBeCaseInsensitive() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "PUBLIC, Max-Age=5");
+        assertThat(CacheControlDecoder.decode(headers).isPublic(), is(true));
+        assertThat(CacheControlDecoder.decode(headers).getMaxAge(), is(5));
+    }
+
+    @Test
+    public void shouldDecodeMultipleDirectives() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "public, max-age=5");
+        assertThat(CacheControlDecoder.decode(headers).isPublic(), is(true));
+        assertThat(CacheControlDecoder.decode(headers).getMaxAge(), is(5));
+    }
+
+    @Test
+    public void shouldIgnoreFieldNameForNoCache() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "no-cache=test");
+        assertThat(CacheControlDecoder.decode(headers).noCache(), is(true));
+    }
+
+    @Test
+    public void shouldIgnoreFieldNameForPrivate() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "private=test");
+        assertThat(CacheControlDecoder.decode(headers).isPrivate(), is(true));
+    }
+
+    @Test
+    public void shouldLimitValueToMaximumAge() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "max-age=" + Long.toString(MAXIMUM_AGE + 100L));
+        assertThat(CacheControlDecoder.decode(headers).getMaxAge(), is(MAXIMUM_AGE));
+    }
+
+    @Test
+    public void shouldMergeFromMultipleCacheControlHeaders() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "private", CACHE_CONTROL, "min-fresh=10");
+        assertThat(CacheControlDecoder.decode(headers).isPrivate(), is(true));
+        assertThat(CacheControlDecoder.decode(headers).getMinFresh(), is(10));
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheControlDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheControlDecoderTest.java
@@ -5,138 +5,144 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
 import org.junit.Test;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
-import static io.netty.handler.codec.http.cache.CacheControlDecoder.MAXIMUM_AGE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
+import static io.netty.handler.codec.http.cache.CacheControlDecoder.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class CacheControlDecoderTest {
     @Test
     public void shouldParsePublicDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.PUBLIC);
-        assertThat(CacheControlDecoder.decode(headers).isPublic(), is(true));
+        assertThat(decode(headers).isPublic(), is(true));
     }
 
     @Test
     public void shouldParsePrivateDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.PRIVATE);
-        assertThat(CacheControlDecoder.decode(headers).isPrivate(), is(true));
+        assertThat(decode(headers).isPrivate(), is(true));
     }
 
     @Test
     public void shouldParseNoCacheDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.NO_CACHE);
-        assertThat(CacheControlDecoder.decode(headers).noCache(), is(true));
+        assertThat(decode(headers).noCache(), is(true));
     }
 
     @Test
     public void shouldParseNoStoreDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.NO_STORE);
-        assertThat(CacheControlDecoder.decode(headers).noStore(), is(true));
+        assertThat(decode(headers).noStore(), is(true));
     }
 
     @Test
     public void shouldParseNoTransformDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.NO_TRANSFORM);
-        assertThat(CacheControlDecoder.decode(headers).noTransform(), is(true));
+        assertThat(decode(headers).noTransform(), is(true));
     }
 
     @Test
     public void shouldParseMustRevalidateDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.MUST_REVALIDATE);
-        assertThat(CacheControlDecoder.decode(headers).mustRevalidate(), is(true));
+        assertThat(decode(headers).mustRevalidate(), is(true));
     }
 
     @Test
     public void shouldParseProxyRevalidateDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.PROXY_REVALIDATE);
-        assertThat(CacheControlDecoder.decode(headers).proxyRevalidate(), is(true));
+        assertThat(decode(headers).proxyRevalidate(), is(true));
     }
 
     @Test
     public void shouldParseOnlyIfCachedDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.ONLY_IF_CACHED);
-        assertThat(CacheControlDecoder.decode(headers).onlyIfCached(), is(true));
+        assertThat(decode(headers).onlyIfCached(), is(true));
     }
 
     @Test
     public void shouldParseImmutableDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, HttpHeaderValues.IMMUTABLE);
-        assertThat(CacheControlDecoder.decode(headers).immutable(), is(true));
+        assertThat(decode(headers).immutable(), is(true));
     }
 
     @Test
     public void shouldParseMaxAgeDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "max-age=10");
-        assertThat(CacheControlDecoder.decode(headers).getMaxAge(), is(10));
+        assertThat(decode(headers).getMaxAge(), is(10));
     }
 
     @Test
     public void shouldParseSMaxAgeDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "s-maxage=10");
-        assertThat(CacheControlDecoder.decode(headers).getSMaxAge(), is(10));
+        assertThat(decode(headers).getSMaxAge(), is(10));
     }
 
     @Test
     public void shouldParseMaxStaleDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "max-stale=10");
-        assertThat(CacheControlDecoder.decode(headers).getMaxStale(), is(10));
+        assertThat(decode(headers).getMaxStale(), is(10));
     }
 
     @Test
     public void shouldParseMinFreshDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "min-fresh=10");
-        assertThat(CacheControlDecoder.decode(headers).getMinFresh(), is(10));
+        assertThat(decode(headers).getMinFresh(), is(10));
     }
 
     @Test
     public void shouldParseStaleWhileRevalidateDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "stale-while-revalidate=10");
-        assertThat(CacheControlDecoder.decode(headers).getStaleWhileRevalidate(), is(10));
+        assertThat(decode(headers).getStaleWhileRevalidate(), is(10));
     }
 
     @Test
     public void shouldParseStaleIfErrorDirective() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "stale-if-error=10");
-        assertThat(CacheControlDecoder.decode(headers).getStaleIfError(), is(10));
+        assertThat(decode(headers).getStaleIfError(), is(10));
     }
 
     @Test
     public void shouldBeCaseInsensitive() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "PUBLIC, Max-Age=5");
-        assertThat(CacheControlDecoder.decode(headers).isPublic(), is(true));
-        assertThat(CacheControlDecoder.decode(headers).getMaxAge(), is(5));
+        assertThat(decode(headers).isPublic(), is(true));
+        assertThat(decode(headers).getMaxAge(), is(5));
     }
 
     @Test
     public void shouldDecodeMultipleDirectives() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "public, max-age=5");
-        assertThat(CacheControlDecoder.decode(headers).isPublic(), is(true));
-        assertThat(CacheControlDecoder.decode(headers).getMaxAge(), is(5));
+        assertThat(decode(headers).isPublic(), is(true));
+        assertThat(decode(headers).getMaxAge(), is(5));
     }
 
     @Test
     public void shouldIgnoreFieldNameForNoCache() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "no-cache=test");
-        assertThat(CacheControlDecoder.decode(headers).noCache(), is(true));
+        assertThat(decode(headers).noCache(), is(true));
     }
 
     @Test
     public void shouldIgnoreFieldNameForPrivate() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "private=test");
-        assertThat(CacheControlDecoder.decode(headers).isPrivate(), is(true));
+        assertThat(decode(headers).isPrivate(), is(true));
     }
 
     @Test
     public void shouldLimitValueToMaximumAge() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "max-age=" + Long.toString(MAXIMUM_AGE + 100L));
-        assertThat(CacheControlDecoder.decode(headers).getMaxAge(), is(MAXIMUM_AGE));
+        assertThat(decode(headers).getMaxAge(), is(MAXIMUM_AGE));
     }
 
     @Test
     public void shouldMergeFromMultipleCacheControlHeaders() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "private", CACHE_CONTROL, "min-fresh=10");
-        assertThat(CacheControlDecoder.decode(headers).isPrivate(), is(true));
-        assertThat(CacheControlDecoder.decode(headers).getMinFresh(), is(10));
+        assertThat(decode(headers).isPrivate(), is(true));
+        assertThat(decode(headers).getMinFresh(), is(10));
+    }
+
+    @Test
+    public void shouldHandleStupidValue() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false, CACHE_CONTROL, "aaa=dsadad;bbb=a,b,c;");
+        assertThat(decode(headers), is(notNullValue()));
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheKeyGeneratorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheKeyGeneratorTest.java
@@ -1,0 +1,69 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class CacheKeyGeneratorTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private CacheKeyGenerator keyGenerator;
+
+    @Before
+    public void setUp() {
+        keyGenerator = new CacheKeyGenerator();
+    }
+
+    @Test
+    public void shouldGenerateSameKeyForSameRequest() {
+        assertThat(keyGenerator.generateKey(request("example.com", "/test")),
+                is(keyGenerator.generateKey(request("example.com", "/test"))));
+    }
+
+    @Ignore
+    @Test
+    public void shouldGenerateSameKeyForEquivalentRequest() {
+        assertThat(keyGenerator.generateKey(request("example.com", "/test")),
+                is(keyGenerator.generateKey(request("example.com:80", "/test"))));
+    }
+
+    @Test
+    public void shouldGenerateDifferentKeyForDifferentHost() {
+        assertThat(keyGenerator.generateKey(request("example.com", "/test")),
+            is(not(keyGenerator.generateKey(request("example2.com", "/test")))));
+    }
+
+    @Test
+    public void shouldGenerateDifferentKeyForDifferentPath() {
+        assertThat(keyGenerator.generateKey(request("example.com", "/test")),
+            is(not(keyGenerator.generateKey(request("example.com", "/test2")))));
+    }
+
+    @Ignore
+    @Test
+    public void shouldGenerateSameKeyForSameQueryParamInDifferentOrder() {
+        assertThat(keyGenerator.generateKey(request("example.com", "/test?param1=1&param2=2")),
+                is(keyGenerator.generateKey(request("example.com", "test?param2=2&param1=1"))));
+    }
+
+    private HttpRequest request(String host, String uri) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri, EMPTY_BUFFER, new ReadOnlyHttpHeaders(false, HOST, host), new ReadOnlyHttpHeaders(false));
+    }
+
+
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheKeyGeneratorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheKeyGeneratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http.cache;
 
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -65,6 +80,4 @@ public class CacheKeyGeneratorTest {
         assertThat(keyGenerator.generateKey(request("example.com", "/test?param1=1&param2=2")),
                    is(keyGenerator.generateKey(request("example.com", "test?param2=2&param1=1"))));
     }
-
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheKeyGeneratorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/CacheKeyGeneratorTest.java
@@ -12,17 +12,22 @@ import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
-import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static io.netty.buffer.Unpooled.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class CacheKeyGeneratorTest {
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
     private CacheKeyGenerator keyGenerator;
+
+    private static HttpRequest request(String host, String uri) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri, EMPTY_BUFFER,
+                                          new ReadOnlyHttpHeaders(false, HOST, host), new ReadOnlyHttpHeaders(false));
+    }
 
     @Before
     public void setUp() {
@@ -32,37 +37,33 @@ public class CacheKeyGeneratorTest {
     @Test
     public void shouldGenerateSameKeyForSameRequest() {
         assertThat(keyGenerator.generateKey(request("example.com", "/test")),
-                is(keyGenerator.generateKey(request("example.com", "/test"))));
+                   is(keyGenerator.generateKey(request("example.com", "/test"))));
     }
 
     @Ignore
     @Test
     public void shouldGenerateSameKeyForEquivalentRequest() {
         assertThat(keyGenerator.generateKey(request("example.com", "/test")),
-                is(keyGenerator.generateKey(request("example.com:80", "/test"))));
+                   is(keyGenerator.generateKey(request("example.com:80", "/test"))));
     }
 
     @Test
     public void shouldGenerateDifferentKeyForDifferentHost() {
         assertThat(keyGenerator.generateKey(request("example.com", "/test")),
-            is(not(keyGenerator.generateKey(request("example2.com", "/test")))));
+                   is(not(keyGenerator.generateKey(request("example2.com", "/test")))));
     }
 
     @Test
     public void shouldGenerateDifferentKeyForDifferentPath() {
         assertThat(keyGenerator.generateKey(request("example.com", "/test")),
-            is(not(keyGenerator.generateKey(request("example.com", "/test2")))));
+                   is(not(keyGenerator.generateKey(request("example.com", "/test2")))));
     }
 
     @Ignore
     @Test
     public void shouldGenerateSameKeyForSameQueryParamInDifferentOrder() {
         assertThat(keyGenerator.generateKey(request("example.com", "/test?param1=1&param2=2")),
-                is(keyGenerator.generateKey(request("example.com", "test?param2=2&param1=1"))));
-    }
-
-    private HttpRequest request(String host, String uri) {
-        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri, EMPTY_BUFFER, new ReadOnlyHttpHeaders(false, HOST, host), new ReadOnlyHttpHeaders(false));
+                   is(keyGenerator.generateKey(request("example.com", "test?param2=2&param1=1"))));
     }
 
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheEntryCheckerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheEntryCheckerTest.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http.cache;
 
 import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -17,9 +31,9 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Date;
 
-import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static io.netty.buffer.Unpooled.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class HttpCacheEntryCheckerTest {
     @Rule
@@ -45,84 +59,141 @@ public class HttpCacheEntryCheckerTest {
     @Test
     public void freshCacheEntryCanBeUsed() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
-                HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
-                HttpHeaderNames.CONTENT_LENGTH, "0"
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                                                            HttpHeaderNames.CONTENT_LENGTH, "0"
         );
-        assertThat(checker.canUseCachedResponse(CacheControlDirectives.EMPTY, new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                HttpResponseStatus.OK, headers), now), is(true));
+        assertThat(checker.canUseCachedResponse(request(), CacheControlDirectives.EMPTY,
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(true));
     }
 
     @Test
     public void notFreshCacheEntryCanNotBeUsed() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
-                HttpHeaderNames.CACHE_CONTROL, "max-age=5",
-                HttpHeaderNames.CONTENT_LENGTH, "0"
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=5",
+                                                            HttpHeaderNames.CONTENT_LENGTH, "0"
         );
-        assertThat(checker.canUseCachedResponse(CacheControlDirectives.EMPTY, new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                HttpResponseStatus.OK, headers), now), is(false));
+        assertThat(checker.canUseCachedResponse(request(), CacheControlDirectives.EMPTY,
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
     }
 
     @Test
     public void requestWithNoCacheDirectiveCanNotUsedCacheEntry() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
-                HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
-                HttpHeaderNames.CONTENT_LENGTH, "0"
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                                                            HttpHeaderNames.CONTENT_LENGTH, "0"
         );
-        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().noCache().build(),
-                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                HttpResponseStatus.OK, headers), now), is(false));
+        assertThat(checker.canUseCachedResponse(request(), CacheControlDirectives.builder().noCache().build(),
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
     }
 
     @Test
     public void requestWithNoStoreDirectiveCanNotUsedCacheEntry() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
-                HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
-                HttpHeaderNames.CONTENT_LENGTH, "0"
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                                                            HttpHeaderNames.CONTENT_LENGTH, "0"
         );
-        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().noStore().build(),
-                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                HttpResponseStatus.OK, headers), now), is(false));
+        assertThat(checker.canUseCachedResponse(request(), CacheControlDirectives.builder().noStore().build(),
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
     }
 
     @Test
     public void cacheEntryExceedingMaxAgeCanNotUsedCacheEntry() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
-                HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
-                HttpHeaderNames.CONTENT_LENGTH, "0"
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                                                            HttpHeaderNames.CONTENT_LENGTH, "0"
         );
-        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().maxAge(5).build(),
-                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, HttpResponseStatus.OK, headers), now), is(false));
+        assertThat(checker.canUseCachedResponse(request(), CacheControlDirectives.builder().maxAge(5).build(),
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
     }
 
     @Test
     public void cacheEntryExceedingMaxStaleCanNotUsedCacheEntry() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
-                HttpHeaderNames.CACHE_CONTROL, "max-age=15",
-                HttpHeaderNames.CONTENT_LENGTH, "0"
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=15",
+                                                            HttpHeaderNames.CONTENT_LENGTH, "0"
         );
-        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().maxStale(6).build(),
-                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, HttpResponseStatus.OK, headers), now), is(false));
+        assertThat(checker.canUseCachedResponse(request(), CacheControlDirectives.builder().maxStale(6).build(),
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
     }
 
     @Test
     public void cacheEntryNotMeetingMinFreshRequirementCanNotUsedCacheEntry() {
         final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
-                HttpHeaderNames.CACHE_CONTROL, "max-age=15",
-                HttpHeaderNames.CONTENT_LENGTH, "0"
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=15",
+                                                            HttpHeaderNames.CONTENT_LENGTH, "0"
         );
-        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().minFresh(20).build(),
-                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, HttpResponseStatus.OK, headers), now), is(false));
+        assertThat(checker.canUseCachedResponse(request(), CacheControlDirectives.builder().minFresh(20).build(),
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    @Test
+    public void conditionalRequestCanNotUsedMismatchedCacheEntryEtag() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                                                            HttpHeaderNames.ETAG, "etagValue"
+        );
+        assertThat(checker.canUseCachedResponse(request(HttpHeaderNames.IF_NONE_MATCH, "oldEtagValue"),
+                                                CacheControlDirectives.builder().build(),
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    @Test
+    public void conditionalRequestCanNotUsedMismatchedCacheEntryIfModified() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                                                            HttpHeaderNames.LAST_MODIFIED,
+                                                            DateFormatter.format(tenSecondsAgo)
+        );
+        assertThat(checker.canUseCachedResponse(
+                request(HttpHeaderNames.IF_MODIFIED_SINCE, DateFormatter.format(twentySecondsAgo)),
+                CacheControlDirectives.builder().build(),
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                   HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    @Test
+    public void requestWithUnsupportedHeaderCanNotBeUsed() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                                                            HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                                                            HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                                                            HttpHeaderNames.CONTENT_LENGTH, "0"
+        );
+        assertThat(checker.canUseCachedResponse(request(HttpHeaderNames.IF_RANGE, "rangeValue"),
+                                                CacheControlDirectives.EMPTY,
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
+
+        assertThat(checker.canUseCachedResponse(request(HttpHeaderNames.IF_MATCH, "etag"), CacheControlDirectives.EMPTY,
+                                                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                                                   HttpResponseStatus.OK, headers), now), is(false));
+
+        assertThat(checker.canUseCachedResponse(
+                request(HttpHeaderNames.IF_UNMODIFIED_SINCE, DateFormatter.format(tenSecondsAgo)),
+                CacheControlDirectives.EMPTY,
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                   HttpResponseStatus.OK, headers), now), is(false));
     }
 
     private DefaultFullHttpRequest request(CharSequence... headerNameValuePairs) {
         return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test", EMPTY_BUFFER,
-                new ReadOnlyHttpHeaders(false, headerNameValuePairs), new ReadOnlyHttpHeaders(false));
+                                          new ReadOnlyHttpHeaders(false, headerNameValuePairs),
+                                          new ReadOnlyHttpHeaders(false));
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheEntryCheckerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheEntryCheckerTest.java
@@ -1,0 +1,128 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.DateFormatter;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Date;
+
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HttpCacheEntryCheckerTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private Date now;
+    private Date tenSecondsAgo;
+    private Date fifteenSecondsAgo;
+    private Date twentySecondsAgo;
+
+    private HttpCacheEntryChecker checker;
+
+    @Before
+    public void setUp() {
+        now = new Date();
+        tenSecondsAgo = new Date(now.getTime() - 10 * 1000L);
+        fifteenSecondsAgo = new Date(now.getTime() - 15 * 1000L);
+        twentySecondsAgo = new Date(now.getTime() - 20 * 1000L);
+
+        checker = new HttpCacheEntryChecker(false);
+    }
+
+    @Test
+    public void freshCacheEntryCanBeUsed() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                HttpHeaderNames.CONTENT_LENGTH, "0"
+        );
+        assertThat(checker.canUseCachedResponse(CacheControlDirectives.EMPTY, new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                HttpResponseStatus.OK, headers), now), is(true));
+    }
+
+    @Test
+    public void notFreshCacheEntryCanNotBeUsed() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                HttpHeaderNames.CACHE_CONTROL, "max-age=5",
+                HttpHeaderNames.CONTENT_LENGTH, "0"
+        );
+        assertThat(checker.canUseCachedResponse(CacheControlDirectives.EMPTY, new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    @Test
+    public void requestWithNoCacheDirectiveCanNotUsedCacheEntry() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                HttpHeaderNames.CONTENT_LENGTH, "0"
+        );
+        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().noCache().build(),
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    @Test
+    public void requestWithNoStoreDirectiveCanNotUsedCacheEntry() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                HttpHeaderNames.CONTENT_LENGTH, "0"
+        );
+        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().noStore().build(),
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    @Test
+    public void cacheEntryExceedingMaxAgeCanNotUsedCacheEntry() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                HttpHeaderNames.CACHE_CONTROL, "max-age=3600",
+                HttpHeaderNames.CONTENT_LENGTH, "0"
+        );
+        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().maxAge(5).build(),
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    @Test
+    public void cacheEntryExceedingMaxStaleCanNotUsedCacheEntry() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                HttpHeaderNames.CACHE_CONTROL, "max-age=15",
+                HttpHeaderNames.CONTENT_LENGTH, "0"
+        );
+        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().maxStale(6).build(),
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    @Test
+    public void cacheEntryNotMeetingMinFreshRequirementCanNotUsedCacheEntry() {
+        final HttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                HttpHeaderNames.DATE, DateFormatter.format(tenSecondsAgo),
+                HttpHeaderNames.CACHE_CONTROL, "max-age=15",
+                HttpHeaderNames.CONTENT_LENGTH, "0"
+        );
+        assertThat(checker.canUseCachedResponse(CacheControlDirectives.builder().minFresh(20).build(),
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, HttpResponseStatus.OK, headers), now), is(false));
+    }
+
+    private DefaultFullHttpRequest request(CharSequence... headerNameValuePairs) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test", EMPTY_BUFFER,
+                new ReadOnlyHttpHeaders(false, headerNameValuePairs), new ReadOnlyHttpHeaders(false));
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheEntryTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheEntryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http.cache;
 
 import io.netty.handler.codec.DateFormatter;
@@ -10,8 +25,8 @@ import org.junit.Test;
 
 import java.util.Date;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class HttpCacheEntryTest {
     private Date now;
@@ -43,142 +58,160 @@ public class HttpCacheEntryTest {
     @Test
     public void shouldBeFreshIfFreshnessLifetimeGreaterThanCurrentAge() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                status, headers(HttpHeaderNames.CACHE_CONTROL, "max-age=20"));
+                                                             status,
+                                                             headers(HttpHeaderNames.CACHE_CONTROL, "max-age=20"));
         assertThat(cacheEntry.isFresh(false, now), is(true));
     }
 
     @Test
     public void getFreshnessLifetimeShouldUseSMaxAgeIfDefinedAndCacheIsShared() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                status, headers(HttpHeaderNames.CACHE_CONTROL, "s-maxage=5"));
+                                                             status,
+                                                             headers(HttpHeaderNames.CACHE_CONTROL, "s-maxage=5"));
         assertThat(cacheEntry.getFreshnessLifetimeInSeconds(true), is(5L));
     }
 
     @Test
     public void getFreshnessLifetimeShouldNotUseSMaxAgeIfDefinedButCacheIsNotShared() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                status, headers(HttpHeaderNames.CACHE_CONTROL, "s-maxage=5"));
+                                                             status,
+                                                             headers(HttpHeaderNames.CACHE_CONTROL, "s-maxage=5"));
         assertThat(cacheEntry.getFreshnessLifetimeInSeconds(false), is(0L));
     }
 
     @Test
     public void getFreshnessLifetimeShouldUseMaxAgeIfDefined() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                status, headers(HttpHeaderNames.CACHE_CONTROL, "max-age=5"));
+                                                             status,
+                                                             headers(HttpHeaderNames.CACHE_CONTROL, "max-age=5"));
         assertThat(cacheEntry.getFreshnessLifetimeInSeconds(false), is(5L));
     }
 
     @Test
     public void getFreshnessLifetimeShouldUseExpireIfDefined() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo,
-                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo),
-                        HttpHeaderNames.EXPIRES, DateFormatter.format(tenSecondsAgo)));
+                                                             status, headers(HttpHeaderNames.DATE,
+                                                                             DateFormatter.format(twentySecondsAgo),
+                                                                             HttpHeaderNames.EXPIRES,
+                                                                             DateFormatter.format(tenSecondsAgo)));
         assertThat(cacheEntry.getFreshnessLifetimeInSeconds(false), is(10L));
     }
 
     @Test
     public void getFreshnessLifetimeShouldReturnZeroHasDefault() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo,
-                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo)));
+                                                             status, headers(HttpHeaderNames.DATE,
+                                                                             DateFormatter.format(twentySecondsAgo)));
         assertThat(cacheEntry.getFreshnessLifetimeInSeconds(false), is(0L));
     }
 
     @Test
     public void getCurrentAgeShouldBeSumOfCorrectedInitialAgeAndResidentTime() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo)));
+                                                             status, headers(HttpHeaderNames.DATE,
+                                                                             DateFormatter.format(twentySecondsAgo)));
         assertThat(cacheEntry.getCurrentAgeInSeconds(now), is(cacheEntry.getResidentTimeInSeconds(now) +
-                cacheEntry.getCorrectedInitialAgeInSeconds()));
+                                                              cacheEntry.getCorrectedInitialAgeInSeconds()));
     }
 
     @Test
     public void getAgeShouldReturnAgeDefinedInHeader() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                status, headers(HttpHeaderNames.AGE, "5"));
+                                                             status, headers(HttpHeaderNames.AGE, "5"));
         assertThat(cacheEntry.getAgeInSeconds(), is(5L));
     }
 
     @Test
     public void getAgeShouldReturnZeroIfAgeNotDefinedInHeader() {
-        final HttpCacheEntry biggerApparentAgeCacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, status, headers());
+        final HttpCacheEntry biggerApparentAgeCacheEntry =
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, status, headers());
         assertThat(biggerApparentAgeCacheEntry.getAgeInSeconds(), is(0L));
     }
 
     @Test
     public void getAgeShouldReturnZeroIfAgeCantBeParsed() {
-        final HttpCacheEntry biggerApparentAgeCacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, status,
-                headers(HttpHeaderNames.AGE, "hello"));
+        final HttpCacheEntry biggerApparentAgeCacheEntry =
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, status,
+                                   headers(HttpHeaderNames.AGE, "hello"));
         assertThat(biggerApparentAgeCacheEntry.getAgeInSeconds(), is(0L));
     }
 
     @Test
     public void getCorrectedInitialAgeInSecondsShouldBeMaxBetweenApparentAndCorrectedAge() {
-        final HttpCacheEntry biggerApparentAgeCacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo)));
+        final HttpCacheEntry biggerApparentAgeCacheEntry =
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                   status, headers(HttpHeaderNames.DATE,
+                                                   DateFormatter
+                                                           .format(twentySecondsAgo)));
         assertThat(biggerApparentAgeCacheEntry.getCorrectedInitialAgeInSeconds(), is(10L));
 
-        final HttpCacheEntry biggerCorrectedAge = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
-                status, headers(HttpHeaderNames.AGE, "20"));
+        final HttpCacheEntry biggerCorrectedAge =
+                new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                                   status, headers(HttpHeaderNames.AGE, "20"));
         assertThat(biggerCorrectedAge.getCorrectedInitialAgeInSeconds(), is(20L));
     }
 
     @Test
     public void getResidentTimeInSecondsShouldBeDifferenceBetweenResponseTimeAndNow() {
-        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo, status, headers());
+        final HttpCacheEntry cacheEntry =
+                new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo, status, headers());
         assertThat(cacheEntry.getResidentTimeInSeconds(now), is(20L));
     }
 
     @Test
     public void getApparentAgeShouldBeZeroIfDateHeaderNotProvided() {
-        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo, status, headers());
+        final HttpCacheEntry cacheEntry =
+                new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo, status, headers());
         assertThat(cacheEntry.getApparentAgeInSeconds(), is(0L));
     }
 
     @Test
     public void getApparentAgeShouldNotBeNegative() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo,
-                status, headers(HttpHeaderNames.DATE, DateFormatter.format(fifteenSecondsAgo)));
+                                                             status, headers(HttpHeaderNames.DATE,
+                                                                             DateFormatter.format(fifteenSecondsAgo)));
         assertThat(cacheEntry.getApparentAgeInSeconds(), is(0L));
     }
 
     @Test
     public void getApparentAgeShouldBeDifferenceBetweenResponseTimeAndDateHeader() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, fifteenSecondsAgo,
-                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo)));
+                                                             status, headers(HttpHeaderNames.DATE,
+                                                                             DateFormatter.format(twentySecondsAgo)));
         assertThat(cacheEntry.getApparentAgeInSeconds(), is(5L));
     }
 
     @Test
     public void getCorrectedAgeInSecondsShouldIncludeResponseTime() {
-        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, fifteenSecondsAgo, status, headers());
+        final HttpCacheEntry cacheEntry =
+                new HttpCacheEntry(null, twentySecondsAgo, fifteenSecondsAgo, status, headers());
         assertThat(cacheEntry.getCorrectedAgeInSeconds(), is(5L));
     }
 
     @Test
     public void getCorrectedAgeInSecondsShouldAddResponseTimeToExistingAgeHeader() {
-        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, fifteenSecondsAgo, status, headers(HttpHeaderNames.AGE, "5"));
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, fifteenSecondsAgo, status,
+                                                             headers(HttpHeaderNames.AGE, "5"));
         assertThat(cacheEntry.getCorrectedAgeInSeconds(), is(10L));
     }
 
     @Test
     public void getStalenessInSecondsShouldNotBeNegative() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, now, now, status,
-                headers(HttpHeaderNames.AGE, "5",
-                        HttpHeaderNames.CACHE_CONTROL, "max-age=6"));
+                                                             headers(HttpHeaderNames.AGE, "5",
+                                                                     HttpHeaderNames.CACHE_CONTROL, "max-age=6"));
         assertThat(cacheEntry.getStalenessInSeconds(false, now), is(0L));
     }
 
     @Test
     public void getStalenessInSecondsShouldAgeMinusFreshness() {
         final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, now, now, status,
-                headers(HttpHeaderNames.AGE, "5",
-                        HttpHeaderNames.CACHE_CONTROL, "max-age=3"));
+                                                             headers(HttpHeaderNames.AGE, "5",
+                                                                     HttpHeaderNames.CACHE_CONTROL, "max-age=3"));
         assertThat(cacheEntry.getStalenessInSeconds(false, now), is(2L));
     }
 
     private HttpHeaders headers(CharSequence... headerNameValuePairs) {
         return new ReadOnlyHttpHeaders(false, headerNameValuePairs);
     }
-
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheEntryTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheEntryTest.java
@@ -1,0 +1,184 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.DateFormatter;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HttpCacheEntryTest {
+    private Date now;
+    private Date tenSecondsAgo;
+    private Date fifteenSecondsAgo;
+    private Date twentySecondsAgo;
+
+    private HttpResponseStatus status = HttpResponseStatus.OK;
+
+    @Before
+    public void setUp() {
+        now = new Date();
+        tenSecondsAgo = new Date(now.getTime() - 10 * 1000L);
+        fifteenSecondsAgo = new Date(now.getTime() - 15 * 1000L);
+        twentySecondsAgo = new Date(now.getTime() - 20 * 1000L);
+    }
+
+    @Test
+    public void shouldReturnSMaxAgeIfDefined() {
+        final HttpHeaders headers = headers(
+                HttpHeaderNames.DATE, DateFormatter.format(new Date()),
+                HttpHeaderNames.CACHE_CONTROL, "s-maxage=1234567"
+        );
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, fifteenSecondsAgo, new Date(), status, headers);
+
+        assertThat(cacheEntry.getSMaxAge(), is(1234567L));
+    }
+
+    @Test
+    public void shouldBeFreshIfFreshnessLifetimeGreaterThanCurrentAge() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                status, headers(HttpHeaderNames.CACHE_CONTROL, "max-age=20"));
+        assertThat(cacheEntry.isFresh(false, now), is(true));
+    }
+
+    @Test
+    public void getFreshnessLifetimeShouldUseSMaxAgeIfDefinedAndCacheIsShared() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                status, headers(HttpHeaderNames.CACHE_CONTROL, "s-maxage=5"));
+        assertThat(cacheEntry.getFreshnessLifetimeInSeconds(true), is(5L));
+    }
+
+    @Test
+    public void getFreshnessLifetimeShouldNotUseSMaxAgeIfDefinedButCacheIsNotShared() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                status, headers(HttpHeaderNames.CACHE_CONTROL, "s-maxage=5"));
+        assertThat(cacheEntry.getFreshnessLifetimeInSeconds(false), is(0L));
+    }
+
+    @Test
+    public void getFreshnessLifetimeShouldUseMaxAgeIfDefined() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                status, headers(HttpHeaderNames.CACHE_CONTROL, "max-age=5"));
+        assertThat(cacheEntry.getFreshnessLifetimeInSeconds(false), is(5L));
+    }
+
+    @Test
+    public void getFreshnessLifetimeShouldUseExpireIfDefined() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo,
+                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo),
+                        HttpHeaderNames.EXPIRES, DateFormatter.format(tenSecondsAgo)));
+        assertThat(cacheEntry.getFreshnessLifetimeInSeconds(false), is(10L));
+    }
+
+    @Test
+    public void getFreshnessLifetimeShouldReturnZeroHasDefault() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo,
+                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo)));
+        assertThat(cacheEntry.getFreshnessLifetimeInSeconds(false), is(0L));
+    }
+
+    @Test
+    public void getCurrentAgeShouldBeSumOfCorrectedInitialAgeAndResidentTime() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo)));
+        assertThat(cacheEntry.getCurrentAgeInSeconds(now), is(cacheEntry.getResidentTimeInSeconds(now) +
+                cacheEntry.getCorrectedInitialAgeInSeconds()));
+    }
+
+    @Test
+    public void getAgeShouldReturnAgeDefinedInHeader() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                status, headers(HttpHeaderNames.AGE, "5"));
+        assertThat(cacheEntry.getAgeInSeconds(), is(5L));
+    }
+
+    @Test
+    public void getAgeShouldReturnZeroIfAgeNotDefinedInHeader() {
+        final HttpCacheEntry biggerApparentAgeCacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, status, headers());
+        assertThat(biggerApparentAgeCacheEntry.getAgeInSeconds(), is(0L));
+    }
+
+    @Test
+    public void getAgeShouldReturnZeroIfAgeCantBeParsed() {
+        final HttpCacheEntry biggerApparentAgeCacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo, status,
+                headers(HttpHeaderNames.AGE, "hello"));
+        assertThat(biggerApparentAgeCacheEntry.getAgeInSeconds(), is(0L));
+    }
+
+    @Test
+    public void getCorrectedInitialAgeInSecondsShouldBeMaxBetweenApparentAndCorrectedAge() {
+        final HttpCacheEntry biggerApparentAgeCacheEntry = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo)));
+        assertThat(biggerApparentAgeCacheEntry.getCorrectedInitialAgeInSeconds(), is(10L));
+
+        final HttpCacheEntry biggerCorrectedAge = new HttpCacheEntry(null, tenSecondsAgo, tenSecondsAgo,
+                status, headers(HttpHeaderNames.AGE, "20"));
+        assertThat(biggerCorrectedAge.getCorrectedInitialAgeInSeconds(), is(20L));
+    }
+
+    @Test
+    public void getResidentTimeInSecondsShouldBeDifferenceBetweenResponseTimeAndNow() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo, status, headers());
+        assertThat(cacheEntry.getResidentTimeInSeconds(now), is(20L));
+    }
+
+    @Test
+    public void getApparentAgeShouldBeZeroIfDateHeaderNotProvided() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo, status, headers());
+        assertThat(cacheEntry.getApparentAgeInSeconds(), is(0L));
+    }
+
+    @Test
+    public void getApparentAgeShouldNotBeNegative() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, twentySecondsAgo,
+                status, headers(HttpHeaderNames.DATE, DateFormatter.format(fifteenSecondsAgo)));
+        assertThat(cacheEntry.getApparentAgeInSeconds(), is(0L));
+    }
+
+    @Test
+    public void getApparentAgeShouldBeDifferenceBetweenResponseTimeAndDateHeader() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, fifteenSecondsAgo,
+                status, headers(HttpHeaderNames.DATE, DateFormatter.format(twentySecondsAgo)));
+        assertThat(cacheEntry.getApparentAgeInSeconds(), is(5L));
+    }
+
+    @Test
+    public void getCorrectedAgeInSecondsShouldIncludeResponseTime() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, fifteenSecondsAgo, status, headers());
+        assertThat(cacheEntry.getCorrectedAgeInSeconds(), is(5L));
+    }
+
+    @Test
+    public void getCorrectedAgeInSecondsShouldAddResponseTimeToExistingAgeHeader() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, twentySecondsAgo, fifteenSecondsAgo, status, headers(HttpHeaderNames.AGE, "5"));
+        assertThat(cacheEntry.getCorrectedAgeInSeconds(), is(10L));
+    }
+
+    @Test
+    public void getStalenessInSecondsShouldNotBeNegative() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, now, now, status,
+                headers(HttpHeaderNames.AGE, "5",
+                        HttpHeaderNames.CACHE_CONTROL, "max-age=6"));
+        assertThat(cacheEntry.getStalenessInSeconds(false, now), is(0L));
+    }
+
+    @Test
+    public void getStalenessInSecondsShouldAgeMinusFreshness() {
+        final HttpCacheEntry cacheEntry = new HttpCacheEntry(null, now, now, status,
+                headers(HttpHeaderNames.AGE, "5",
+                        HttpHeaderNames.CACHE_CONTROL, "max-age=3"));
+        assertThat(cacheEntry.getStalenessInSeconds(false, now), is(2L));
+    }
+
+    private HttpHeaders headers(CharSequence... headerNameValuePairs) {
+        return new ReadOnlyHttpHeaders(false, headerNameValuePairs);
+    }
+
+
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpCacheTest.java
@@ -1,0 +1,126 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.DateFormatter;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.FailedFuture;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.SucceededFuture;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Date;
+
+import static io.netty.buffer.Unpooled.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+public class HttpCacheTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private HttpCacheStorage storage;
+
+    @Mock
+    private CacheKeyGenerator cacheKeyGenerator;
+
+    private EventExecutor eventExecutor;
+
+    private HttpCache cache;
+
+    @Before
+    public void setUp() throws Exception {
+        eventExecutor = ImmediateEventExecutor.INSTANCE;
+        cache = new HttpCache(storage, cacheKeyGenerator, eventExecutor);
+    }
+
+    @Test
+    public void cacheShouldCallStoragePutWithCacheKey() {
+        when(cacheKeyGenerator.generateKey(any(HttpRequest.class))).thenReturn("key");
+        when(storage.put(anyString(), any(HttpCacheEntry.class), any(Promise.class)))
+                .thenReturn(new SucceededFuture(eventExecutor, null));
+
+        cache.cache(request(HttpMethod.GET), response(HttpResponseStatus.OK), new Date(), new Date());
+
+        verify(storage).put(eq("key"), any(HttpCacheEntry.class), any(Promise.class));
+    }
+
+    @Test
+    public void cacheShouldReturnNullIfPuttingEntryInCacheFails() throws Exception {
+        when(cacheKeyGenerator.generateKey(any(HttpRequest.class))).thenReturn("key");
+
+        when(storage.put(anyString(), any(HttpCacheEntry.class), any(Promise.class)))
+                .thenReturn(new FailedFuture(eventExecutor, new RuntimeException()));
+
+        final Future<HttpCacheEntry> cacheEntry =
+                cache.cache(request(HttpMethod.GET), response(HttpResponseStatus.OK), new Date(), new Date());
+
+        assertThat(cacheEntry.isSuccess(), is(false));
+        assertThat(cacheEntry.cause(), instanceOf(RuntimeException.class));
+    }
+
+    @Test
+    public void getCacheEntryShouldReturnNullIfNotInCache() {
+        when(storage.get(anyString(), any(Promise.class))).thenReturn(null);
+
+        assertThat(cache.getCacheEntry(request(HttpMethod.GET),
+                                       ImmediateEventExecutor.INSTANCE.<HttpCacheEntry>newPromise()), is(nullValue()));
+    }
+
+    @Test
+    public void getCacheEntryShouldReturnEntryIfInCache() throws Exception {
+        final HttpCacheEntry cacheEntry = mock(HttpCacheEntry.class);
+        when(cacheKeyGenerator.generateKey(any(HttpRequest.class))).thenReturn("key");
+        when(storage.get(anyString(), any(Promise.class)))
+                .thenReturn(new SucceededFuture<HttpCacheEntry>(ImmediateEventExecutor.INSTANCE, cacheEntry));
+
+        final Future<HttpCacheEntry> cacheEntryFuture = cache.getCacheEntry(request(HttpMethod.GET),
+                                                                            ImmediateEventExecutor.INSTANCE.<HttpCacheEntry>newPromise());
+        assertThat(cacheEntryFuture.get(), is(cacheEntry));
+    }
+
+    private static DefaultFullHttpRequest request(final HttpMethod httpMethod) {
+        return request(HttpVersion.HTTP_1_1, httpMethod);
+    }
+
+    private static DefaultFullHttpRequest request(final HttpVersion httpVersion, final HttpMethod httpMethod) {
+        return new DefaultFullHttpRequest(httpVersion, httpMethod, "/test", EMPTY_BUFFER);
+    }
+
+    private static DefaultFullHttpResponse response(final HttpResponseStatus partialContent,
+                                                    CharSequence... headerNameValuePairs) {
+        final DefaultFullHttpResponse response =
+                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, partialContent, EMPTY_BUFFER,
+                                            new DefaultHttpHeaders(false), new ReadOnlyHttpHeaders(false));
+        response.headers().add(HttpHeaderNames.DATE, DateFormatter.format(new Date()));
+
+        for (int i = 0; i < headerNameValuePairs.length; i += 2) {
+            response.headers().add(headerNameValuePairs[i], headerNameValuePairs[i + 1]);
+        }
+
+        return response;
+    }
+
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheHandlerTest.java
@@ -1,0 +1,220 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import io.netty.util.CharsetUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.buffer.Unpooled.copiedBuffer;
+import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * - return cached entry can be served by cache / cache non expired
+ * - cacheable but not cached
+ * -
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpClientCacheHandlerTest {
+
+    @Rule
+    public MockitoRule mockitoRule;
+
+    @Mock
+    private RequestCachingPolicy requestCachingPolicy;
+
+    @Mock
+    private HttpCache cache;
+
+    @Mock
+    private ResponseCachingPolicy responseCachingPolicy;
+
+    @Mock
+    private HttpCacheEntryChecker httpCacheEntryChecker;
+
+    @Mock
+    private HttpResponseFromCacheGenerator httpResponseFromCacheGenerator;
+
+    private static DefaultFullHttpResponse response() {
+        return new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK, copiedBuffer("Hello World", CharsetUtil.UTF_8));
+    }
+
+    /**
+     * Outbound: HttpRequest
+     */
+
+    @Test
+    public void shouldReturnCachedEntry() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCacheHandler(requestCachingPolicy, cache, responseCachingPolicy, httpCacheEntryChecker, httpResponseFromCacheGenerator));
+
+        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/info");
+
+        final DefaultFullHttpResponse cachedResponse = response();
+        final HttpCacheEntry httpCacheEntry = new HttpCacheEntry(cachedResponse, new Date(), new Date(),
+                HttpResponseStatus.OK, EmptyHttpHeaders.INSTANCE);
+        when(requestCachingPolicy.canBeServedFromCache(request)).thenReturn(true);
+        when(cache.getCacheEntry(request)).thenReturn(httpCacheEntry);
+        when(httpCacheEntryChecker.canUseCachedResponse(any(CacheControlDirectives.class), eq(httpCacheEntry), any(Date.class)))
+                .thenReturn(true);
+        when(httpResponseFromCacheGenerator.generate(eq(request), eq(httpCacheEntry))).thenReturn(cachedResponse);
+
+        channel.writeOutbound(request);
+
+        final FullHttpResponse response = channel.readInbound();
+
+        verify(cache).getCacheEntry(request);
+        assertThat(response.content().toString(CharsetUtil.UTF_8), is("Hello World"));
+    }
+
+    @Test
+    public void shouldIgnoreNonHttpRequest() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCacheHandler(requestCachingPolicy, cache, responseCachingPolicy, httpCacheEntryChecker, httpResponseFromCacheGenerator));
+
+        final Object msg = new Object();
+        channel.writeOutbound(msg);
+
+        assertThat(channel.readOutbound(), is(msg));
+    }
+
+    @Test
+    public void shouldPassNonCacheableRequestThrough() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCacheHandler(requestCachingPolicy, cache, responseCachingPolicy, httpCacheEntryChecker, httpResponseFromCacheGenerator));
+
+        final HttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/info");
+
+        when(requestCachingPolicy.canBeServedFromCache(request)).thenReturn(false);
+
+        channel.writeOutbound(request);
+
+        verify(cache, never()).getCacheEntry(request);
+        assertThat((HttpRequest) channel.readOutbound(), is(request));
+    }
+
+    @Test
+    public void shouldPassNonCachedRequestThrough() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCacheHandler(requestCachingPolicy, cache, responseCachingPolicy, httpCacheEntryChecker, httpResponseFromCacheGenerator));
+
+        final HttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/info");
+
+        when(requestCachingPolicy.canBeServedFromCache(request)).thenReturn(true);
+        when(cache.getCacheEntry(request)).thenReturn(null);
+
+        channel.writeOutbound(request);
+
+        assertThat((HttpRequest) channel.readOutbound(), is(request));
+    }
+
+    @Test
+    public void shouldRespondWith504IfNonCachedRequestAndCacheControlOnlyIfCachedUsed() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCacheHandler(requestCachingPolicy, cache, responseCachingPolicy, httpCacheEntryChecker, httpResponseFromCacheGenerator));
+
+        final HttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/info", EMPTY_BUFFER, new ReadOnlyHttpHeaders(false, HttpHeaderNames.CACHE_CONTROL, HttpHeaderValues.ONLY_IF_CACHED), new ReadOnlyHttpHeaders(false));
+
+        when(requestCachingPolicy.canBeServedFromCache(request)).thenReturn(true);
+        when(cache.getCacheEntry(request)).thenReturn(null);
+
+        channel.writeOutbound(request);
+
+        final FullHttpResponse response = channel.readInbound();
+
+        assertThat(response.status(), is(HttpResponseStatus.GATEWAY_TIMEOUT));
+    }
+
+    /**
+     * Inbound: HttpResponse
+     */
+
+    @Test
+    public void shouldCacheResponseIfCacheable() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCacheHandler(requestCachingPolicy, cache, responseCachingPolicy, httpCacheEntryChecker, httpResponseFromCacheGenerator));
+
+        final DefaultFullHttpResponse response = response();
+
+        when(responseCachingPolicy.canBeCached((HttpRequest) any(), eq(response))).thenReturn(true);
+
+        channel.writeInbound(response);
+
+        verify(cache).cache((HttpRequest) any(), eq(response), (Date) any(), (Date) any());
+    }
+
+    @Test
+    public void shouldIgnoreNonHttpResponse() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCacheHandler(requestCachingPolicy, cache, responseCachingPolicy, httpCacheEntryChecker, httpResponseFromCacheGenerator));
+
+        final Object msg = new Object();
+        channel.writeInbound(msg);
+
+        assertThat(channel.readInbound(), is(msg));
+    }
+
+    /**
+     * Outbound + Inbound
+     */
+
+    @Test
+    public void shouldUseCachedResponseForNextRequest() {
+        final EchoHandler echoHandler = new EchoHandler();
+        final EmbeddedChannel channel = new EmbeddedChannel(echoHandler, new HttpClientCacheHandler(requestCachingPolicy, new HttpCache(new HttpCacheMemoryStorage()), responseCachingPolicy, httpCacheEntryChecker, httpResponseFromCacheGenerator));
+
+        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/info");
+        request.headers().add(HOST, "example.com");
+
+        when(requestCachingPolicy.canBeServedFromCache(request)).thenReturn(true);
+        when(responseCachingPolicy.canBeCached(any(HttpRequest.class), any(HttpResponse.class))).thenReturn(true);
+        when(httpCacheEntryChecker.canUseCachedResponse(any(CacheControlDirectives.class), any(HttpCacheEntry.class), any(Date.class))).thenReturn(true);
+        when(httpResponseFromCacheGenerator.generate(any(HttpRequest.class), any(HttpCacheEntry.class))).thenReturn(response());
+
+        channel.writeOutbound(request);
+        channel.writeOutbound(request);
+
+        assertThat(echoHandler.getCallCount(), is(1));
+    }
+
+    private static class EchoHandler extends ChannelOutboundHandlerAdapter {
+
+        private final AtomicInteger callCount = new AtomicInteger();
+
+        @Override
+        public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
+            final DefaultFullHttpResponse response = response();
+            response.headers().add(CACHE_CONTROL, "max-age=3600");
+
+            ctx.fireChannelRead(response);
+            callCount.incrementAndGet();
+        }
+
+        public int getCallCount() {
+            return callCount.get();
+        }
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheIntegrationTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheIntegrationTest.java
@@ -17,13 +17,14 @@ import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
@@ -34,6 +35,7 @@ import java.util.Date;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BinaryOperator;
 
 import static io.netty.buffer.Unpooled.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
@@ -42,64 +44,102 @@ import static org.junit.Assert.*;
 
 public class HttpClientCacheIntegrationTest {
 
-    @Test
-    public void loadFromCache() throws InterruptedException {
+    private static ServerBootstrap getLocalServerBootstrap(final AtomicInteger serverRequestCount,
+                                                           final CountDownLatch serverChannelLatch) {
         ServerBootstrap sb = new ServerBootstrap();
-        Bootstrap cb = new Bootstrap();
-        final CountDownLatch serverChannelLatch = new CountDownLatch(1);
-        final AtomicReference<CountDownLatch> responseReceivedLatch = new AtomicReference<CountDownLatch>(new CountDownLatch(1));
-        final AtomicInteger serverRequestCount = new AtomicInteger(0);
-        try {
-            sb.group(new NioEventLoopGroup(2));
-            sb.channel(NioServerSocketChannel.class);
-            sb.childHandler(new ChannelInitializer<Channel>() {
-                @Override
-                protected void initChannel(Channel ch) {
-                    // Don't use the HttpServerCodec, because we don't want to have content-length or anything added.
-                    ch.pipeline().addLast(new HttpServerCodec(4096, 8192, 8192, true));
-                    ch.pipeline().addLast(new HttpObjectAggregator(4096));
-                    ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpRequest>() {
-                        @Override
-                        protected void channelRead0(final ChannelHandlerContext ctx, final FullHttpRequest msg) {
-                            serverRequestCount.incrementAndGet();
-                            assertTrue(ctx.channel() instanceof SocketChannel);
-                            final SocketChannel sChannel = (SocketChannel) ctx.channel();
-                            final ReadOnlyHttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                                    HttpHeaderNames.DATE, DateFormatter.format(new Date()),
-                                    HttpHeaderNames.CACHE_CONTROL, "max-age=5");
-                            sChannel.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK,
-                                    copiedBuffer("Hello World", CharsetUtil.UTF_8), headers, new ReadOnlyHttpHeaders(false)))
-                                    .addListener(new ChannelFutureListener() {
-                                        @Override
-                                        public void operationComplete(final ChannelFuture future) {
-                                            sChannel.shutdownOutput();
-                                        }
-                                    });
-                        }
-                    });
-                    serverChannelLatch.countDown();
-                }
-            });
+        sb.group(new NioEventLoopGroup(2));
+        sb.channel(NioServerSocketChannel.class);
+        sb.childHandler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) {
+                ch.pipeline().addLast(new HttpServerCodec(4096, 8192, 8192, true));
+                ch.pipeline().addLast(new HttpObjectAggregator(4096));
+                ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpRequest>() {
+                    @Override
+                    protected void channelRead0(final ChannelHandlerContext ctx, final FullHttpRequest msg) {
+                        serverRequestCount.incrementAndGet();
+                        assertTrue(ctx.channel() instanceof SocketChannel);
+                        final SocketChannel sChannel = (SocketChannel) ctx.channel();
+                        final ReadOnlyHttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                                                                                    HttpHeaderNames.DATE,
+                                                                                    DateFormatter.format(new Date()),
+                                                                                    HttpHeaderNames.CACHE_CONTROL,
+                                                                                    "max-age=5");
+                        sChannel.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK,
+                                                                           copiedBuffer("Hello World",
+                                                                                        CharsetUtil.UTF_8), headers,
+                                                                           new ReadOnlyHttpHeaders(false)))
+                                .addListener(new ChannelFutureListener() {
+                                    @Override
+                                    public void operationComplete(final ChannelFuture future) {
+                                        sChannel.shutdownOutput();
+                                    }
+                                });
+                    }
+                });
+                serverChannelLatch.countDown();
+            }
+        });
 
-            final HttpCacheMemoryStorage cacheStorage = new HttpCacheMemoryStorage();
-            cb.group(new NioEventLoopGroup(1));
-            cb.channel(NioSocketChannel.class);
-            cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true);
-            cb.handler(new ChannelInitializer<Channel>() {
-                @Override
-                protected void initChannel(Channel ch) {
-                    ch.pipeline().addLast(new HttpClientCodec(4096, 8192, 8192, true, true));
-                    ch.pipeline().addLast(new HttpObjectAggregator(4096));
-                    ch.pipeline().addLast(new HttpClientCacheHandler(cacheStorage, false));
-                    ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpResponse>() {
-                        @Override
-                        protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) {
+        return sb;
+    }
+
+    private static Bootstrap getLocalClientBootstrap(final AtomicReference<CountDownLatch> responseReceivedLatch,
+                                                     final AtomicReference<String> responseContent) {
+        final Bootstrap cb = new Bootstrap();
+        final NioEventLoopGroup clientGroup = new NioEventLoopGroup(1);
+        final HttpCacheMemoryStorage cacheStorage = new HttpCacheMemoryStorage();
+        cb.group(clientGroup);
+        cb.channel(NioSocketChannel.class);
+        cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true);
+        cb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) {
+                ch.pipeline().addLast(new HttpClientCodec(4096, 8192, 8192, true, true));
+                ch.pipeline()
+                  .addLast(new HttpClientCacheHandler(cacheStorage, CacheConfig.DEFAULT, clientGroup.next()));
+                ch.pipeline().addLast(new SimpleChannelInboundHandler<HttpContent>() {
+                    @Override
+                    protected void channelRead0(ChannelHandlerContext ctx, HttpContent msg) throws Exception {
+                        responseContent.getAndAccumulate(msg.content().toString(CharsetUtil.UTF_8),
+                                                         new BinaryOperator<String>() {
+                                                             @Override
+                                                             public String apply(String s, String s2) {
+                                                                 if (s == null) {
+                                                                     return s2;
+                                                                 }
+
+                                                                 if (s2 == null) {
+                                                                     return s;
+                                                                 }
+
+                                                                 return s + s2;
+                                                             }
+                                                         });
+
+                        if (msg instanceof LastHttpContent) {
                             responseReceivedLatch.get().countDown();
                         }
-                    });
-                }
-            });
+                    }
+                });
+            }
+        });
 
+        return cb;
+    }
+
+    @Test
+    public void shouldLoadFromCache() throws InterruptedException {
+        final CountDownLatch serverChannelLatch = new CountDownLatch(1);
+        final AtomicReference<CountDownLatch> responseReceivedLatch =
+                new AtomicReference<CountDownLatch>(new CountDownLatch(1));
+        final AtomicReference<String> responseContent = new AtomicReference<String>();
+        final AtomicInteger serverRequestCount = new AtomicInteger(0);
+
+        final ServerBootstrap sb = getLocalServerBootstrap(serverRequestCount, serverChannelLatch);
+        final Bootstrap cb = getLocalClientBootstrap(responseReceivedLatch, responseContent);
+
+        try {
             Channel serverChannel = sb.bind(new InetSocketAddress(0)).sync().channel();
             int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
@@ -107,19 +147,68 @@ public class HttpClientCacheIntegrationTest {
             assertTrue(ccf.awaitUninterruptibly().isSuccess());
             Channel clientChannel = ccf.channel();
             assertTrue(serverChannelLatch.await(5, SECONDS));
-            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/", new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST, "localhost")));
+            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/",
+                                                               new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST,
+                                                                                       "localhost")));
             assertTrue(responseReceivedLatch.get().await(5, SECONDS));
             assertTrue(clientChannel.close().awaitUninterruptibly().isSuccess());
 
             responseReceivedLatch.set(new CountDownLatch(1));
+            assertEquals("Server should have been called.", 1, serverRequestCount.getAndSet(0));
+            assertEquals("Hello World", responseContent.getAndSet(null));
 
             ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
             assertTrue(ccf.awaitUninterruptibly().isSuccess());
             clientChannel = ccf.channel();
-            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/", new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST, "localhost")));
+            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/",
+                                                               new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST,
+                                                                                       "localhost")));
             assertTrue(responseReceivedLatch.get().await(5, SECONDS));
 
-            assertEquals(1, serverRequestCount.get());
+            assertEquals("Server should not have been called.", 0, serverRequestCount.get());
+            assertEquals("Hello World", responseContent.getAndSet(null));
+        } finally {
+            sb.config().group().shutdownGracefully();
+            sb.config().childGroup().shutdownGracefully();
+            cb.config().group().shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void shouldNotLoadFromCache() throws InterruptedException {
+        final CountDownLatch serverChannelLatch = new CountDownLatch(1);
+        final AtomicReference<CountDownLatch> responseReceivedLatch =
+                new AtomicReference<CountDownLatch>(new CountDownLatch(1));
+        final AtomicInteger serverRequestCount = new AtomicInteger(0);
+
+        final ServerBootstrap sb = getLocalServerBootstrap(serverRequestCount, serverChannelLatch);
+        final Bootstrap cb = getLocalClientBootstrap(responseReceivedLatch, new AtomicReference<String>());
+        try {
+            Channel serverChannel = sb.bind(new InetSocketAddress(0)).sync().channel();
+            int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+            ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
+            assertTrue(ccf.awaitUninterruptibly().isSuccess());
+            Channel clientChannel = ccf.channel();
+            assertTrue(serverChannelLatch.await(5, SECONDS));
+            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.POST, "/",
+                                                               new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST,
+                                                                                       "localhost")));
+            assertTrue(responseReceivedLatch.get().await(5, SECONDS));
+            assertTrue(clientChannel.close().awaitUninterruptibly().isSuccess());
+
+            responseReceivedLatch.set(new CountDownLatch(1));
+            assertEquals("Server should have been called.", 1, serverRequestCount.get());
+
+            ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
+            assertTrue(ccf.awaitUninterruptibly().isSuccess());
+            clientChannel = ccf.channel();
+            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.POST, "/",
+                                                               new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST,
+                                                                                       "localhost")));
+            assertTrue(responseReceivedLatch.get().await(5, SECONDS));
+
+            assertEquals("Server should have been called.", 2, serverRequestCount.get());
         } finally {
             sb.config().group().shutdownGracefully();
             sb.config().childGroup().shutdownGracefully();
@@ -127,4 +216,5 @@ public class HttpClientCacheIntegrationTest {
         }
 
     }
+
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheIntegrationTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http.cache;
 
 import io.netty.bootstrap.Bootstrap;
@@ -19,7 +34,6 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -28,24 +42,38 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
 import java.util.Date;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BinaryOperator;
 
 import static io.netty.buffer.Unpooled.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
 import static java.util.concurrent.TimeUnit.*;
 import static org.junit.Assert.*;
 
 public class HttpClientCacheIntegrationTest {
 
-    private static ServerBootstrap getLocalServerBootstrap(final AtomicInteger serverRequestCount,
-                                                           final CountDownLatch serverChannelLatch) {
+    private CountDownLatch serverChannelLatch;
+    private AtomicReference<CountDownLatch> responseReceivedLatch;
+    private AtomicReference<String> responseContent;
+    //    private AtomicInteger serverRequestCount;
+    private ConcurrentHashMap<HttpResponseStatus, Integer> serverResponseCountPerStatus;
+    private int port;
+
+    private ServerBootstrap serverBootstrap;
+    private Bootstrap clientBootstrap;
+
+    private static ServerBootstrap getLocalServerBootstrap(
+            final ConcurrentHashMap<HttpResponseStatus, Integer> countPerStatus,
+            final CountDownLatch serverChannelLatch) {
         ServerBootstrap sb = new ServerBootstrap();
         sb.group(new NioEventLoopGroup(2));
         sb.channel(NioServerSocketChannel.class);
@@ -55,15 +83,38 @@ public class HttpClientCacheIntegrationTest {
                 ch.pipeline().addLast(new HttpServerCodec(4096, 8192, 8192, true));
                 ch.pipeline().addLast(new HttpObjectAggregator(4096));
                 ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpRequest>() {
+                    private void incrementRequestCountForStatus(HttpResponseStatus status) {
+                        countPerStatus.putIfAbsent(status, 0);
+                        Integer count = countPerStatus.get(status);
+                        while (!countPerStatus.replace(status, count != null? count + 1 : 0).equals(count)) {
+                            count = countPerStatus.get(status);
+                        }
+                    }
+
                     @Override
-                    protected void channelRead0(final ChannelHandlerContext ctx, final FullHttpRequest msg) {
-                        serverRequestCount.incrementAndGet();
+                    protected void channelRead0(final ChannelHandlerContext ctx, final FullHttpRequest request) {
                         assertTrue(ctx.channel() instanceof SocketChannel);
                         final SocketChannel sChannel = (SocketChannel) ctx.channel();
+
+                        if (request.headers().contains(IF_NONE_MATCH)) {
+                            final ReadOnlyHttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                                                                                        DATE,
+                                                                                        DateFormatter
+                                                                                                .format(new Date()));
+                            ctx.writeAndFlush(
+                                    new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.NOT_MODIFIED, EMPTY_BUFFER,
+                                                                headers, new ReadOnlyHttpHeaders(false)))
+                               .addListener(ChannelFutureListener.CLOSE);
+
+                            incrementRequestCountForStatus(HttpResponseStatus.NOT_MODIFIED);
+                            return;
+                        }
+
+                        incrementRequestCountForStatus(HttpResponseStatus.OK);
                         final ReadOnlyHttpHeaders headers = new ReadOnlyHttpHeaders(false,
-                                                                                    HttpHeaderNames.DATE,
+                                                                                    DATE,
                                                                                     DateFormatter.format(new Date()),
-                                                                                    HttpHeaderNames.CACHE_CONTROL,
+                                                                                    CACHE_CONTROL,
                                                                                     "max-age=5");
                         sChannel.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK,
                                                                            copiedBuffer("Hello World",
@@ -123,96 +174,108 @@ public class HttpClientCacheIntegrationTest {
         return cb;
     }
 
+    private Channel connect(Bootstrap cb, int port) throws InterruptedException {
+        ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
+        assertTrue(ccf.awaitUninterruptibly().isSuccess());
+        assertTrue(serverChannelLatch.await(5, SECONDS));
+        return ccf.channel();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        serverChannelLatch = new CountDownLatch(1);
+        responseReceivedLatch = new AtomicReference<CountDownLatch>(new CountDownLatch(1));
+        responseContent = new AtomicReference<String>();
+//        serverRequestCount = new AtomicInteger(0);
+        serverResponseCountPerStatus = new ConcurrentHashMap<HttpResponseStatus, Integer>();
+
+        serverBootstrap = getLocalServerBootstrap(serverResponseCountPerStatus, serverChannelLatch);
+
+        Channel serverChannel = serverBootstrap.bind(new InetSocketAddress(0)).sync().channel();
+        port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+        clientBootstrap = getLocalClientBootstrap(responseReceivedLatch, responseContent);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        serverBootstrap.config().group().shutdownGracefully();
+        serverBootstrap.config().childGroup().shutdownGracefully();
+        clientBootstrap.config().group().shutdownGracefully();
+    }
+
     @Test
     public void shouldLoadFromCache() throws InterruptedException {
-        final CountDownLatch serverChannelLatch = new CountDownLatch(1);
-        final AtomicReference<CountDownLatch> responseReceivedLatch =
-                new AtomicReference<CountDownLatch>(new CountDownLatch(1));
-        final AtomicReference<String> responseContent = new AtomicReference<String>();
-        final AtomicInteger serverRequestCount = new AtomicInteger(0);
+        Channel clientChannel = connect(clientBootstrap, port);
+        clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/",
+                                                           new ReadOnlyHttpHeaders(false, HOST,
+                                                                                   "localhost")));
+        assertTrue(responseReceivedLatch.get().await(5, SECONDS));
+        assertTrue(clientChannel.close().awaitUninterruptibly().isSuccess());
 
-        final ServerBootstrap sb = getLocalServerBootstrap(serverRequestCount, serverChannelLatch);
-        final Bootstrap cb = getLocalClientBootstrap(responseReceivedLatch, responseContent);
+        responseReceivedLatch.set(new CountDownLatch(1));
+        assertEquals("Server should have been called.", 1,
+                     serverResponseCountPerStatus.get(HttpResponseStatus.OK).intValue());
+        assertEquals("Hello World", responseContent.getAndSet(null));
 
-        try {
-            Channel serverChannel = sb.bind(new InetSocketAddress(0)).sync().channel();
-            int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+        clientChannel = connect(clientBootstrap, port);
+        clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/",
+                                                           new ReadOnlyHttpHeaders(false, HOST,
+                                                                                   "localhost")));
+        assertTrue(responseReceivedLatch.get().await(5, SECONDS));
 
-            ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-            assertTrue(ccf.awaitUninterruptibly().isSuccess());
-            Channel clientChannel = ccf.channel();
-            assertTrue(serverChannelLatch.await(5, SECONDS));
-            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/",
-                                                               new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST,
-                                                                                       "localhost")));
-            assertTrue(responseReceivedLatch.get().await(5, SECONDS));
-            assertTrue(clientChannel.close().awaitUninterruptibly().isSuccess());
-
-            responseReceivedLatch.set(new CountDownLatch(1));
-            assertEquals("Server should have been called.", 1, serverRequestCount.getAndSet(0));
-            assertEquals("Hello World", responseContent.getAndSet(null));
-
-            ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-            assertTrue(ccf.awaitUninterruptibly().isSuccess());
-            clientChannel = ccf.channel();
-            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/",
-                                                               new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST,
-                                                                                       "localhost")));
-            assertTrue(responseReceivedLatch.get().await(5, SECONDS));
-
-            assertEquals("Server should not have been called.", 0, serverRequestCount.get());
-            assertEquals("Hello World", responseContent.getAndSet(null));
-        } finally {
-            sb.config().group().shutdownGracefully();
-            sb.config().childGroup().shutdownGracefully();
-            cb.config().group().shutdownGracefully();
-        }
+        assertEquals("Server should not have been called.", 1,
+                     serverResponseCountPerStatus.get(HttpResponseStatus.OK).intValue());
+        assertEquals("Hello World", responseContent.getAndSet(null));
     }
 
     @Test
     public void shouldNotLoadFromCache() throws InterruptedException {
-        final CountDownLatch serverChannelLatch = new CountDownLatch(1);
-        final AtomicReference<CountDownLatch> responseReceivedLatch =
-                new AtomicReference<CountDownLatch>(new CountDownLatch(1));
-        final AtomicInteger serverRequestCount = new AtomicInteger(0);
+        Channel clientChannel = connect(clientBootstrap, port);
+        clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.POST, "/",
+                                                           new ReadOnlyHttpHeaders(false, HOST,
+                                                                                   "localhost")));
+        assertTrue(responseReceivedLatch.get().await(5, SECONDS));
+        assertTrue(clientChannel.close().awaitUninterruptibly().isSuccess());
 
-        final ServerBootstrap sb = getLocalServerBootstrap(serverRequestCount, serverChannelLatch);
-        final Bootstrap cb = getLocalClientBootstrap(responseReceivedLatch, new AtomicReference<String>());
-        try {
-            Channel serverChannel = sb.bind(new InetSocketAddress(0)).sync().channel();
-            int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+        responseReceivedLatch.set(new CountDownLatch(1));
+        assertEquals("Server should have been called.", 1,
+                     serverResponseCountPerStatus.get(HttpResponseStatus.OK).intValue());
 
-            ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-            assertTrue(ccf.awaitUninterruptibly().isSuccess());
-            Channel clientChannel = ccf.channel();
-            assertTrue(serverChannelLatch.await(5, SECONDS));
-            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.POST, "/",
-                                                               new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST,
-                                                                                       "localhost")));
-            assertTrue(responseReceivedLatch.get().await(5, SECONDS));
-            assertTrue(clientChannel.close().awaitUninterruptibly().isSuccess());
+        clientChannel = connect(clientBootstrap, port);
+        clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.POST, "/",
+                                                           new ReadOnlyHttpHeaders(false, HOST,
+                                                                                   "localhost")));
+        assertTrue(responseReceivedLatch.get().await(5, SECONDS));
 
-            responseReceivedLatch.set(new CountDownLatch(1));
-            assertEquals("Server should have been called.", 1, serverRequestCount.get());
-
-            ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-            assertTrue(ccf.awaitUninterruptibly().isSuccess());
-            clientChannel = ccf.channel();
-            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.POST, "/",
-                                                               new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST,
-                                                                                       "localhost")));
-            assertTrue(responseReceivedLatch.get().await(5, SECONDS));
-
-            assertEquals("Server should have been called.", 2, serverRequestCount.get());
-        } finally {
-            sb.config().group().shutdownGracefully();
-            sb.config().childGroup().shutdownGracefully();
-            cb.config().group().shutdownGracefully();
-        }
+        assertEquals("Server should have been called.", 2,
+                     serverResponseCountPerStatus.get(HttpResponseStatus.OK).intValue());
     }
 
     @Test
-    public void shouldRevalidateCacheEntry() {
+    public void shouldRevalidateCacheEntry() throws InterruptedException {
+        Channel clientChannel = connect(clientBootstrap, port);
+        clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/",
+                                                           new ReadOnlyHttpHeaders(false, HOST,
+                                                                                   "localhost")));
+        assertTrue(responseReceivedLatch.get().await(5, SECONDS));
+        assertTrue(clientChannel.close().awaitUninterruptibly().isSuccess());
 
+        responseReceivedLatch.set(new CountDownLatch(1));
+        assertEquals("Server should have been called.", 1,
+                     serverResponseCountPerStatus.get(HttpResponseStatus.OK).intValue());
+        assertEquals("Hello World", responseContent.getAndSet(null));
+
+        clientChannel = connect(clientBootstrap, port);
+        clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/",
+                                                           new ReadOnlyHttpHeaders(false, HOST,
+                                                                                   "localhost",
+                                                                                   IF_NONE_MATCH,
+                                                                                   "etagValue")));
+        assertTrue(responseReceivedLatch.get().await(5, SECONDS));
+
+        assertEquals("Server should have been called for revalidation.", 1,
+                     serverResponseCountPerStatus.get(HttpResponseStatus.NOT_MODIFIED).intValue());
+        assertEquals("Hello World", responseContent.getAndSet(null));
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheIntegrationTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheIntegrationTest.java
@@ -1,0 +1,130 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.DateFormatter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.netty.buffer.Unpooled.*;
+import static io.netty.handler.codec.http.HttpVersion.*;
+import static java.util.concurrent.TimeUnit.*;
+import static org.junit.Assert.*;
+
+public class HttpClientCacheIntegrationTest {
+
+    @Test
+    public void loadFromCache() throws InterruptedException {
+        ServerBootstrap sb = new ServerBootstrap();
+        Bootstrap cb = new Bootstrap();
+        final CountDownLatch serverChannelLatch = new CountDownLatch(1);
+        final AtomicReference<CountDownLatch> responseReceivedLatch = new AtomicReference<CountDownLatch>(new CountDownLatch(1));
+        final AtomicInteger serverRequestCount = new AtomicInteger(0);
+        try {
+            sb.group(new NioEventLoopGroup(2));
+            sb.channel(NioServerSocketChannel.class);
+            sb.childHandler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) {
+                    // Don't use the HttpServerCodec, because we don't want to have content-length or anything added.
+                    ch.pipeline().addLast(new HttpServerCodec(4096, 8192, 8192, true));
+                    ch.pipeline().addLast(new HttpObjectAggregator(4096));
+                    ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpRequest>() {
+                        @Override
+                        protected void channelRead0(final ChannelHandlerContext ctx, final FullHttpRequest msg) {
+                            serverRequestCount.incrementAndGet();
+                            assertTrue(ctx.channel() instanceof SocketChannel);
+                            final SocketChannel sChannel = (SocketChannel) ctx.channel();
+                            final ReadOnlyHttpHeaders headers = new ReadOnlyHttpHeaders(false,
+                                    HttpHeaderNames.DATE, DateFormatter.format(new Date()),
+                                    HttpHeaderNames.CACHE_CONTROL, "max-age=5");
+                            sChannel.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK,
+                                    copiedBuffer("Hello World", CharsetUtil.UTF_8), headers, new ReadOnlyHttpHeaders(false)))
+                                    .addListener(new ChannelFutureListener() {
+                                        @Override
+                                        public void operationComplete(final ChannelFuture future) {
+                                            sChannel.shutdownOutput();
+                                        }
+                                    });
+                        }
+                    });
+                    serverChannelLatch.countDown();
+                }
+            });
+
+            final HttpCacheMemoryStorage cacheStorage = new HttpCacheMemoryStorage();
+            cb.group(new NioEventLoopGroup(1));
+            cb.channel(NioSocketChannel.class);
+            cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true);
+            cb.handler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) {
+                    ch.pipeline().addLast(new HttpClientCodec(4096, 8192, 8192, true, true));
+                    ch.pipeline().addLast(new HttpObjectAggregator(4096));
+                    ch.pipeline().addLast(new HttpClientCacheHandler(cacheStorage, false));
+                    ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpResponse>() {
+                        @Override
+                        protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) {
+                            responseReceivedLatch.get().countDown();
+                        }
+                    });
+                }
+            });
+
+            Channel serverChannel = sb.bind(new InetSocketAddress(0)).sync().channel();
+            int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+            ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
+            assertTrue(ccf.awaitUninterruptibly().isSuccess());
+            Channel clientChannel = ccf.channel();
+            assertTrue(serverChannelLatch.await(5, SECONDS));
+            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/", new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST, "localhost")));
+            assertTrue(responseReceivedLatch.get().await(5, SECONDS));
+            assertTrue(clientChannel.close().awaitUninterruptibly().isSuccess());
+
+            responseReceivedLatch.set(new CountDownLatch(1));
+
+            ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
+            assertTrue(ccf.awaitUninterruptibly().isSuccess());
+            clientChannel = ccf.channel();
+            clientChannel.writeAndFlush(new DefaultHttpRequest(HTTP_1_1, HttpMethod.GET, "/", new ReadOnlyHttpHeaders(false, HttpHeaderNames.HOST, "localhost")));
+            assertTrue(responseReceivedLatch.get().await(5, SECONDS));
+
+            assertEquals(1, serverRequestCount.get());
+        } finally {
+            sb.config().group().shutdownGracefully();
+            sb.config().childGroup().shutdownGracefully();
+            cb.config().group().shutdownGracefully();
+        }
+
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheIntegrationTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpClientCacheIntegrationTest.java
@@ -69,12 +69,7 @@ public class HttpClientCacheIntegrationTest {
                                                                            copiedBuffer("Hello World",
                                                                                         CharsetUtil.UTF_8), headers,
                                                                            new ReadOnlyHttpHeaders(false)))
-                                .addListener(new ChannelFutureListener() {
-                                    @Override
-                                    public void operationComplete(final ChannelFuture future) {
-                                        sChannel.shutdownOutput();
-                                    }
-                                });
+                                .addListener(ChannelFutureListener.CLOSE);
                     }
                 });
                 serverChannelLatch.countDown();
@@ -214,7 +209,10 @@ public class HttpClientCacheIntegrationTest {
             sb.config().childGroup().shutdownGracefully();
             cb.config().group().shutdownGracefully();
         }
-
     }
 
+    @Test
+    public void shouldRevalidateCacheEntry() {
+
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGeneratorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGeneratorTest.java
@@ -1,0 +1,118 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Date;
+
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.handler.codec.http.cache.CacheControlDecoder.MAXIMUM_AGE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HttpResponseFromCacheGeneratorTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private HttpResponseFromCacheGenerator responseGenerator;
+
+    @Before
+    public void setUp() throws Exception {
+        responseGenerator = new HttpResponseFromCacheGenerator();
+    }
+
+    @Test
+    public void contentLengthHeaderIsPopulated() {
+        final byte[] content = {1, 2, 3, 4, 5};
+        final HttpCacheEntry cacheEntry = cacheEntry(HttpResponseStatus.NO_CONTENT, 0L, Unpooled.wrappedBuffer(content));
+
+        final FullHttpResponse response = responseGenerator.generate(request(), cacheEntry);
+
+        assertThat(response.headers().getInt(HttpHeaderNames.CONTENT_LENGTH), is(content.length));
+    }
+
+    @Test
+    public void contentLengthHeaderIsNotPopulatedWhenTransferEncodingHeaderIsPresent() {
+        final byte[] content = {1, 2, 3, 4, 5};
+        final HttpCacheEntry cacheEntry = cacheEntry(HttpResponseStatus.NO_CONTENT, 0L,
+                Unpooled.wrappedBuffer(content), HttpHeaderNames.TRANSFER_ENCODING, "gzip");
+
+        final FullHttpResponse response = responseGenerator.generate(request(), cacheEntry);
+
+        assertThat(response.headers().getInt(HttpHeaderNames.CONTENT_LENGTH), nullValue());
+    }
+
+    @Test
+    public void responseStatusMatchesCacheEntryStatus() {
+        final HttpCacheEntry cacheEntry = cacheEntry(HttpResponseStatus.NO_CONTENT, 0L);
+
+        final FullHttpResponse response = responseGenerator.generate(request(), cacheEntry);
+
+        assertThat(response.status(), is(HttpResponseStatus.NO_CONTENT));
+    }
+
+    @Test
+    public void ageHeaderIsPopulatedWithCurrentAgeOfCacheEntryIfNonZero() {
+        final HttpCacheEntry cacheEntry = cacheEntry(HttpResponseStatus.OK, 1234L);
+
+        final FullHttpResponse response = responseGenerator.generate(request(), cacheEntry);
+
+        assertThat(response.headers().get(HttpHeaderNames.AGE), is("1234"));
+    }
+
+    @Test
+    public void ageHeaderIsNotPopulatedWithCurrentAgeOfCacheEntryIfZero() {
+        final HttpCacheEntry cacheEntry = cacheEntry(HttpResponseStatus.OK, 0L);
+
+        final FullHttpResponse response = responseGenerator.generate(request(), cacheEntry);
+
+        assertThat(response.headers().get(HttpHeaderNames.AGE), nullValue());
+    }
+
+    @Test
+    public void ageHeaderIsPopulatedWithMaxAgeIfAgeTooBig() {
+        final HttpCacheEntry cacheEntry = cacheEntry(HttpResponseStatus.OK, MAXIMUM_AGE + 1L);
+
+        final FullHttpResponse response = responseGenerator.generate(request(), cacheEntry);
+
+        assertThat(response.headers().get(HttpHeaderNames.AGE), is(Long.toString(MAXIMUM_AGE)));
+    }
+
+    private DefaultFullHttpRequest request(CharSequence... headerNameValuePairs) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test", EMPTY_BUFFER,
+                new ReadOnlyHttpHeaders(false, headerNameValuePairs), new ReadOnlyHttpHeaders(false));
+    }
+
+    private HttpCacheEntry cacheEntry(HttpResponseStatus status, long age) {
+        return cacheEntry(status, age, EMPTY_BUFFER);
+    }
+
+    private HttpCacheEntry cacheEntry(HttpResponseStatus status, long age, ByteBuf content, CharSequence... headerNameValuePairs) {
+        final HttpCacheEntry cacheEntry = mock(HttpCacheEntry.class);
+        when(cacheEntry.getResponseHeaders()).thenReturn(new ReadOnlyHttpHeaders(false, headerNameValuePairs));
+        when(cacheEntry.getCurrentAgeInSeconds(any(Date.class))).thenReturn(age);
+        when(cacheEntry.getContent()).thenReturn(new DefaultByteBufHolder(content));
+        when(cacheEntry.getStatus()).thenReturn(status);
+
+        return cacheEntry;
+    }
+
+
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGeneratorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/HttpResponseFromCacheGeneratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http.cache;
 
 import io.netty.buffer.ByteBuf;
@@ -18,14 +33,12 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Date;
 
-import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
-import static io.netty.handler.codec.http.cache.CacheControlDecoder.MAXIMUM_AGE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static io.netty.buffer.Unpooled.*;
+import static io.netty.handler.codec.http.cache.CacheControlDecoder.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class HttpResponseFromCacheGeneratorTest {
     @Rule
@@ -40,8 +53,9 @@ public class HttpResponseFromCacheGeneratorTest {
 
     @Test
     public void contentLengthHeaderIsPopulated() {
-        final byte[] content = {1, 2, 3, 4, 5};
-        final HttpCacheEntry cacheEntry = cacheEntry(HttpResponseStatus.NO_CONTENT, 0L, Unpooled.wrappedBuffer(content));
+        final byte[] content = { 1, 2, 3, 4, 5 };
+        final HttpCacheEntry cacheEntry =
+                cacheEntry(HttpResponseStatus.NO_CONTENT, 0L, Unpooled.wrappedBuffer(content));
 
         final FullHttpResponse response = responseGenerator.generate(request(), cacheEntry);
 
@@ -50,9 +64,10 @@ public class HttpResponseFromCacheGeneratorTest {
 
     @Test
     public void contentLengthHeaderIsNotPopulatedWhenTransferEncodingHeaderIsPresent() {
-        final byte[] content = {1, 2, 3, 4, 5};
+        final byte[] content = { 1, 2, 3, 4, 5 };
         final HttpCacheEntry cacheEntry = cacheEntry(HttpResponseStatus.NO_CONTENT, 0L,
-                Unpooled.wrappedBuffer(content), HttpHeaderNames.TRANSFER_ENCODING, "gzip");
+                                                     Unpooled.wrappedBuffer(content), HttpHeaderNames.TRANSFER_ENCODING,
+                                                     "gzip");
 
         final FullHttpResponse response = responseGenerator.generate(request(), cacheEntry);
 
@@ -97,14 +112,16 @@ public class HttpResponseFromCacheGeneratorTest {
 
     private DefaultFullHttpRequest request(CharSequence... headerNameValuePairs) {
         return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/test", EMPTY_BUFFER,
-                new ReadOnlyHttpHeaders(false, headerNameValuePairs), new ReadOnlyHttpHeaders(false));
+                                          new ReadOnlyHttpHeaders(false, headerNameValuePairs),
+                                          new ReadOnlyHttpHeaders(false));
     }
 
     private HttpCacheEntry cacheEntry(HttpResponseStatus status, long age) {
         return cacheEntry(status, age, EMPTY_BUFFER);
     }
 
-    private HttpCacheEntry cacheEntry(HttpResponseStatus status, long age, ByteBuf content, CharSequence... headerNameValuePairs) {
+    private HttpCacheEntry cacheEntry(HttpResponseStatus status, long age, ByteBuf content,
+                                      CharSequence... headerNameValuePairs) {
         final HttpCacheEntry cacheEntry = mock(HttpCacheEntry.class);
         when(cacheEntry.getResponseHeaders()).thenReturn(new ReadOnlyHttpHeaders(false, headerNameValuePairs));
         when(cacheEntry.getCurrentAgeInSeconds(any(Date.class))).thenReturn(age);
@@ -113,6 +130,4 @@ public class HttpResponseFromCacheGeneratorTest {
 
         return cacheEntry;
     }
-
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/RequestCachingPolicyTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/RequestCachingPolicyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http.cache;
 
 import io.netty.buffer.ByteBuf;
@@ -9,12 +24,11 @@ import io.netty.util.CharsetUtil;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.netty.buffer.Unpooled.copiedBuffer;
-import static io.netty.buffer.Unpooled.unreleasableBuffer;
-import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
-import static io.netty.handler.codec.http.HttpHeaderValues.NO_STORE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static io.netty.buffer.Unpooled.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
+import static io.netty.handler.codec.http.HttpHeaderValues.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class RequestCachingPolicyTest {
 
@@ -27,25 +41,29 @@ public class RequestCachingPolicyTest {
 
     @Test
     public void getRequestCanBeServedFromCache() {
-        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "uri", true);
+        final DefaultFullHttpRequest request =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "uri", true);
         assertThat(requestPolicy.canBeServedFromCache(request), is(true));
     }
 
     @Test
     public void headRequestCanBeServedFromCache() {
-        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.HEAD, "uri", true);
+        final DefaultFullHttpRequest request =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.HEAD, "uri", true);
         assertThat(requestPolicy.canBeServedFromCache(request), is(true));
     }
 
     @Test
     public void postRequestCanNotBeServedFromCache() {
-        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "uri", true);
+        final DefaultFullHttpRequest request =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "uri", true);
         assertThat(requestPolicy.canBeServedFromCache(request), is(false));
     }
 
     @Test
     public void http1RequestCanNotBeServedFromCache() {
-        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "uri", true);
+        final DefaultFullHttpRequest request =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "uri", true);
         assertThat(requestPolicy.canBeServedFromCache(request), is(false));
     }
 
@@ -53,7 +71,9 @@ public class RequestCachingPolicyTest {
     public void cacheControlNoStoreRequestCanNotBeServedFromCache() {
         final ReadOnlyHttpHeaders headers = new ReadOnlyHttpHeaders(true, CACHE_CONTROL, NO_STORE);
         final ByteBuf content = unreleasableBuffer(copiedBuffer("Hello World", CharsetUtil.UTF_8));
-        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "uri", content, headers, new ReadOnlyHttpHeaders(true));
+        final DefaultFullHttpRequest request =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "uri", content, headers,
+                                           new ReadOnlyHttpHeaders(true));
         assertThat(requestPolicy.canBeServedFromCache(request), is(false));
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/RequestCachingPolicyTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/RequestCachingPolicyTest.java
@@ -1,0 +1,59 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import io.netty.util.CharsetUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.netty.buffer.Unpooled.copiedBuffer;
+import static io.netty.buffer.Unpooled.unreleasableBuffer;
+import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
+import static io.netty.handler.codec.http.HttpHeaderValues.NO_STORE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class RequestCachingPolicyTest {
+
+    private RequestCachingPolicy requestPolicy;
+
+    @Before
+    public void setUp() {
+        requestPolicy = new RequestCachingPolicy();
+    }
+
+    @Test
+    public void getRequestCanBeServedFromCache() {
+        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "uri", true);
+        assertThat(requestPolicy.canBeServedFromCache(request), is(true));
+    }
+
+    @Test
+    public void headRequestCanBeServedFromCache() {
+        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.HEAD, "uri", true);
+        assertThat(requestPolicy.canBeServedFromCache(request), is(true));
+    }
+
+    @Test
+    public void postRequestCanNotBeServedFromCache() {
+        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "uri", true);
+        assertThat(requestPolicy.canBeServedFromCache(request), is(false));
+    }
+
+    @Test
+    public void http1RequestCanNotBeServedFromCache() {
+        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "uri", true);
+        assertThat(requestPolicy.canBeServedFromCache(request), is(false));
+    }
+
+    @Test
+    public void cacheControlNoStoreRequestCanNotBeServedFromCache() {
+        final ReadOnlyHttpHeaders headers = new ReadOnlyHttpHeaders(true, CACHE_CONTROL, NO_STORE);
+        final ByteBuf content = unreleasableBuffer(copiedBuffer("Hello World", CharsetUtil.UTF_8));
+        final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "uri", content, headers, new ReadOnlyHttpHeaders(true));
+        assertThat(requestPolicy.canBeServedFromCache(request), is(false));
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/ResponseCachingPolicyTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/ResponseCachingPolicyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http.cache;
 
 import io.netty.handler.codec.DateFormatter;
@@ -17,15 +32,11 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Date;
 
-import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
-import static io.netty.handler.codec.http.HttpHeaderNames.AUTHORIZATION;
-import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
-import static io.netty.handler.codec.http.HttpHeaderValues.MUST_REVALIDATE;
-import static io.netty.handler.codec.http.HttpHeaderValues.NO_CACHE;
-import static io.netty.handler.codec.http.HttpHeaderValues.NO_STORE;
-import static io.netty.handler.codec.http.HttpHeaderValues.PUBLIC;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static io.netty.buffer.Unpooled.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.*;
+import static io.netty.handler.codec.http.HttpHeaderValues.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class ResponseCachingPolicyTest {
     @Rule
@@ -41,7 +52,8 @@ public class ResponseCachingPolicyTest {
     @Test
     public void http1RequestCanNotBeCached() {
         final DefaultFullHttpResponse response = response(HttpResponseStatus.OK);
-        assertThat(responseCachingPolicy.canBeCached(request(HttpVersion.HTTP_1_0, HttpMethod.GET), response), is(false));
+        assertThat(responseCachingPolicy.canBeCached(request(HttpVersion.HTTP_1_0, HttpMethod.GET), response),
+                   is(false));
     }
 
     @Test
@@ -76,8 +88,10 @@ public class ResponseCachingPolicyTest {
 
     @Test
     public void responseWithDateHeaderCanNotBeCached() {
-        final DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
-                EMPTY_BUFFER, new ReadOnlyHttpHeaders(false), new ReadOnlyHttpHeaders(false));
+        final DefaultFullHttpResponse response =
+                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                                            EMPTY_BUFFER, new ReadOnlyHttpHeaders(false),
+                                            new ReadOnlyHttpHeaders(false));
         assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.GET), response), is(false));
     }
 
@@ -122,7 +136,8 @@ public class ResponseCachingPolicyTest {
     @Test
     public void authorizedResponseWithSMaxAgeCanBeCachedBySharedCache() {
         final DefaultFullHttpResponse response = response(HttpResponseStatus.OK,
-                AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, "s-maxage=3600");
+                                                          AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL,
+                                                          "s-maxage=3600");
         responseCachingPolicy = new ResponseCachingPolicy(true);
         assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(true));
     }
@@ -130,7 +145,8 @@ public class ResponseCachingPolicyTest {
     @Test
     public void authorizedResponseWithMustRevalidateCanBeCachedBySharedCache() {
         final DefaultFullHttpResponse response = response(HttpResponseStatus.OK,
-                AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, MUST_REVALIDATE);
+                                                          AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL,
+                                                          MUST_REVALIDATE);
         responseCachingPolicy = new ResponseCachingPolicy(true);
         assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(true));
     }
@@ -138,7 +154,7 @@ public class ResponseCachingPolicyTest {
     @Test
     public void authorizedResponseWithPublicCanBeCachedBySharedCache() {
         final DefaultFullHttpResponse response = response(HttpResponseStatus.OK,
-                AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, PUBLIC);
+                                                          AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, PUBLIC);
         responseCachingPolicy = new ResponseCachingPolicy(true);
         assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(true));
     }
@@ -146,7 +162,8 @@ public class ResponseCachingPolicyTest {
     @Test
     public void authorizedResponseWithMaxAgeCanNotBeCachedBySharedCache() {
         final DefaultFullHttpResponse response = response(HttpResponseStatus.OK,
-                AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, "max-age=3600");
+                                                          AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL,
+                                                          "max-age=3600");
         responseCachingPolicy = new ResponseCachingPolicy(true);
         assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(false));
     }
@@ -159,8 +176,11 @@ public class ResponseCachingPolicyTest {
         return new DefaultFullHttpRequest(httpVersion, httpMethod, "/test", EMPTY_BUFFER);
     }
 
-    private DefaultFullHttpResponse response(final HttpResponseStatus partialContent, CharSequence... headerNameValuePairs) {
-        final DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, partialContent, EMPTY_BUFFER, new DefaultHttpHeaders(false), new ReadOnlyHttpHeaders(false));
+    private DefaultFullHttpResponse response(final HttpResponseStatus partialContent,
+                                             CharSequence... headerNameValuePairs) {
+        final DefaultFullHttpResponse response =
+                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, partialContent, EMPTY_BUFFER,
+                                            new DefaultHttpHeaders(false), new ReadOnlyHttpHeaders(false));
         response.headers().add(HttpHeaderNames.DATE, DateFormatter.format(new Date()));
 
         for (int i = 0; i < headerNameValuePairs.length; i += 2) {
@@ -169,5 +189,4 @@ public class ResponseCachingPolicyTest {
 
         return response;
     }
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cache/ResponseCachingPolicyTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cache/ResponseCachingPolicyTest.java
@@ -1,0 +1,173 @@
+package io.netty.handler.codec.http.cache;
+
+import io.netty.handler.codec.DateFormatter;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Date;
+
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.handler.codec.http.HttpHeaderNames.AUTHORIZATION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CACHE_CONTROL;
+import static io.netty.handler.codec.http.HttpHeaderValues.MUST_REVALIDATE;
+import static io.netty.handler.codec.http.HttpHeaderValues.NO_CACHE;
+import static io.netty.handler.codec.http.HttpHeaderValues.NO_STORE;
+import static io.netty.handler.codec.http.HttpHeaderValues.PUBLIC;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ResponseCachingPolicyTest {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    private ResponseCachingPolicy responseCachingPolicy;
+
+    @Before
+    public void setUp() {
+        responseCachingPolicy = new ResponseCachingPolicy(false);
+    }
+
+    @Test
+    public void http1RequestCanNotBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpVersion.HTTP_1_0, HttpMethod.GET), response), is(false));
+    }
+
+    @Test
+    public void getRequestCanBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.GET), response), is(true));
+    }
+
+    @Test
+    public void headRequestCanBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(true));
+    }
+
+    @Test
+    public void postRequestCanNotBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.POST), response), is(false));
+    }
+
+    @Test
+    public void partialContentCanNotBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.PARTIAL_CONTENT);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.GET), response), is(false));
+    }
+
+    @Test
+    public void unknownStatusCodeCanNotBeCached() {
+        final DefaultFullHttpResponse response = response(new HttpResponseStatus(123, "Unknown"));
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.GET), response), is(false));
+    }
+
+    @Test
+    public void responseWithDateHeaderCanNotBeCached() {
+        final DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                EMPTY_BUFFER, new ReadOnlyHttpHeaders(false), new ReadOnlyHttpHeaders(false));
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.GET), response), is(false));
+    }
+
+    @Test
+    public void responseToGetWithNoStoreCacheControlHeaderCanNotBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK, CACHE_CONTROL, NO_STORE);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.GET), response), is(false));
+    }
+
+    @Test
+    public void responseToHeadWithNoStoreCacheControlHeaderCanNotBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK, CACHE_CONTROL, NO_STORE);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.GET), response), is(false));
+    }
+
+    @Test
+    public void responseToGetWithNoCacheCacheControlHeaderCanNotBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK, CACHE_CONTROL, NO_CACHE);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.GET), response), is(false));
+    }
+
+    @Test
+    public void responseToHeadWithNoCacheCacheControlHeaderCanNotBeCached() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK, CACHE_CONTROL, NO_CACHE);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(false));
+    }
+
+    @Test
+    public void authorizedResponseCanNotBeCachedBySharedCache() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK, AUTHORIZATION, "Basic abcdefgh");
+        responseCachingPolicy = new ResponseCachingPolicy(true);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(false));
+    }
+
+    @Test
+    public void authorizedResponseCanBeCachedByPrivateCache() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK, AUTHORIZATION, "Basic abcdefgh");
+        responseCachingPolicy = new ResponseCachingPolicy(false);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(true));
+    }
+
+    @Test
+    public void authorizedResponseWithSMaxAgeCanBeCachedBySharedCache() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK,
+                AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, "s-maxage=3600");
+        responseCachingPolicy = new ResponseCachingPolicy(true);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(true));
+    }
+
+    @Test
+    public void authorizedResponseWithMustRevalidateCanBeCachedBySharedCache() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK,
+                AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, MUST_REVALIDATE);
+        responseCachingPolicy = new ResponseCachingPolicy(true);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(true));
+    }
+
+    @Test
+    public void authorizedResponseWithPublicCanBeCachedBySharedCache() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK,
+                AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, PUBLIC);
+        responseCachingPolicy = new ResponseCachingPolicy(true);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(true));
+    }
+
+    @Test
+    public void authorizedResponseWithMaxAgeCanNotBeCachedBySharedCache() {
+        final DefaultFullHttpResponse response = response(HttpResponseStatus.OK,
+                AUTHORIZATION, "Basic abcdefgh", CACHE_CONTROL, "max-age=3600");
+        responseCachingPolicy = new ResponseCachingPolicy(true);
+        assertThat(responseCachingPolicy.canBeCached(request(HttpMethod.HEAD), response), is(false));
+    }
+
+    private DefaultFullHttpRequest request(final HttpMethod httpMethod) {
+        return request(HttpVersion.HTTP_1_1, httpMethod);
+    }
+
+    private DefaultFullHttpRequest request(final HttpVersion httpVersion, final HttpMethod httpMethod) {
+        return new DefaultFullHttpRequest(httpVersion, httpMethod, "/test", EMPTY_BUFFER);
+    }
+
+    private DefaultFullHttpResponse response(final HttpResponseStatus partialContent, CharSequence... headerNameValuePairs) {
+        final DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, partialContent, EMPTY_BUFFER, new DefaultHttpHeaders(false), new ReadOnlyHttpHeaders(false));
+        response.headers().add(HttpHeaderNames.DATE, DateFormatter.format(new Date()));
+
+        for (int i = 0; i < headerNameValuePairs.length; i += 2) {
+            response.headers().add(headerNameValuePairs[i], headerNameValuePairs[i + 1]);
+        }
+
+        return response;
+    }
+
+}


### PR DESCRIPTION
Motivation:

This PR is a proof of concept for adding http caching #2646. Opening it now so I can gather feedback early and correct course if needed. 

Modification:

- Introduce a new ChannelDuplexHandler: `HttpClientCacheHandler` . Outbound shortcircuits and return cache value (if request can be served from cache and cache entry available). Inbound will cache  response if cacheable. Works with or without `HttpObjectAggregator`
- `HttpCacheStorage` interface to store cache data, only dumb memory one available for now, will improve

