### PR TITLE
Add testing ByteBufAllocator for leak unit testing (almson version)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
@@ -34,7 +34,7 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
         ResourceLeakDetector.addExclusions(AbstractByteBufAllocator.class, "toLeakAwareBuffer");
     }
 
-    protected static ByteBuf toLeakAwareBuffer(ByteBuf buf) {
+    protected ByteBuf toLeakAwareBuffer(ByteBuf buf) {
         ResourceLeakTracker<ByteBuf> leak;
         switch (ResourceLeakDetector.getLevel()) {
             case SIMPLE:
@@ -56,7 +56,7 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
         return buf;
     }
 
-    protected static CompositeByteBuf toLeakAwareBuffer(CompositeByteBuf buf) {
+    protected CompositeByteBuf toLeakAwareBuffer(CompositeByteBuf buf) {
         ResourceLeakTracker<ByteBuf> leak;
         switch (ResourceLeakDetector.getLevel()) {
             case SIMPLE:

--- a/buffer/src/main/java/io/netty/buffer/TestingPooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/TestingPooledByteBufAllocator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakTracker;
+
+import java.io.Closeable;
+
+/**
+ * A {@link ByteBufAllocator} for unit testing. This allocator maintains a private, non-static leak detector
+ * and performs leak tracking on all allocated buffers. At the end the test, call {@link #close} to assert
+ * that all buffers have been freed.
+ */
+public class TestingPooledByteBufAllocator extends PooledByteBufAllocator implements Closeable {
+
+    private final ResourceLeakDetector leakDetector = new ResourceLeakDetector(AbstractByteBuf.class, 1);
+
+    {
+        // While we might try to set the level manually, or try other hacks,
+        // this check maintains generality should ResourceLeakDetector change in the future.
+        // Don't run your tests with leak detection disabled.
+        if (!ResourceLeakDetector.isEnabled()) {
+            throw new AssertionError("ResourceLeakDetector.isEnabled() returns false. Cannot continue.");
+        }
+    }
+
+    public TestingPooledByteBufAllocator() {
+    }
+
+    public TestingPooledByteBufAllocator(boolean preferDirect) {
+        super(preferDirect);
+    }
+
+    @Override
+    public ByteBuf toLeakAwareBuffer(ByteBuf buf) {
+        ResourceLeakTracker<ByteBuf> leak = leakDetector.track(buf);
+        if (leak != null) {
+            buf = new AdvancedLeakAwareByteBuf(buf, leak);
+        }
+        return buf;
+    }
+
+    @Override
+    public CompositeByteBuf toLeakAwareBuffer(CompositeByteBuf buf) {
+        ResourceLeakTracker<ByteBuf> leak = leakDetector.track(buf);
+        if (leak != null) {
+            buf = new AdvancedLeakAwareCompositeByteBuf(buf, leak);
+        }
+        return buf;
+    }
+
+    /**
+     * Throws an exception if all allocated buffers have been not freed.
+     * @throws AssertionError if buffers have been leaked.
+     */
+    @Override
+    public void close() {
+        leakDetector.assertAllResourcesDisposed();
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/TestingPooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/TestingPooledByteBufAllocatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class TestingPooledByteBufAllocatorTest {
+
+    @Test
+    public void testNoLeakByteBuffer() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator();
+        try {
+            allocator.buffer(100).release();
+        } finally {
+            allocator.close();
+        }
+    }
+
+    @Test
+    public void testLeakByteBuffer() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator();
+        try {
+            allocator.buffer(100).getByte(0);
+            allocator.buffer(100).getByte(0);
+        } finally {
+            assertLeaked(allocator);
+        }
+    }
+
+    @Test
+    public void testNoLeakByteBufferDirect() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator(true);
+        try {
+            allocator.buffer(100).release();
+        } finally {
+            allocator.close();
+        }
+    }
+
+    @Test
+    public void testLeakByteBufferDirect() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator(true);
+        try {
+            allocator.buffer(100).getByte(0);
+            allocator.buffer(100).getByte(0);
+        } finally {
+            assertLeaked(allocator);
+        }
+    }
+
+    @Test
+    public void testNoLeakCompositeBuffer() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator();
+        try {
+            allocator.compositeBuffer().release();
+        } finally {
+            allocator.close();
+        }
+    }
+
+    @Test
+    public void testLeakCompositeBuffer() {
+        TestingPooledByteBufAllocator allocator = new TestingPooledByteBufAllocator();
+        try {
+            allocator.compositeBuffer();
+            allocator.compositeBuffer();
+        } finally {
+            assertLeaked(allocator);
+        }
+    }
+
+    private static void assertLeaked(TestingPooledByteBufAllocator allocator) {
+        try {
+            allocator.close();
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("LEAK"));
+            assertThat(e.getMessage(), containsString("2 resource leak(s) detected."));
+            assertThat(e.getMessage(), containsString("leak 1:"));
+            assertThat(e.getMessage(), containsString("leak 2:"));
+        }
+    }
+}

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -247,20 +247,26 @@ public class ResourceLeakDetector<T> {
 
     @SuppressWarnings("unchecked")
     private DefaultResourceLeak track0(T obj) {
-        Level level = ResourceLeakDetector.level;
-        if (level == Level.DISABLED) {
-            return null;
-        }
-
-        if (level.ordinal() < Level.PARANOID.ordinal()) {
-            if ((PlatformDependent.threadLocalRandom().nextInt(samplingInterval)) == 0) {
-                reportLeak();
-                return new DefaultResourceLeak(obj, refQueue, allLeaks);
-            }
+        if (!shouldTrack(obj)) {
             return null;
         }
         reportLeak();
         return new DefaultResourceLeak(obj, refQueue, allLeaks);
+    }
+    
+    protected boolean shouldTrack(T obj) {
+        Level level = ResourceLeakDetector.level;
+        if (level == Level.DISABLED) {
+            return false;
+        }
+
+        if (level.ordinal() < Level.PARANOID.ordinal()) {
+            if ((PlatformDependent.threadLocalRandom().nextInt(samplingInterval)) == 0) {
+                return true;
+            }
+            return false;
+        }
+        return true;
     }
 
     private void reportLeak() {


### PR DESCRIPTION
This is an alternate proposal for PR #8423 https://github.com/netty/netty/pull/8423 It makes fewer changes and is more general, in my opinion. Does not require subclassing the leak detector.


Motivation:

Currently the only way to detect leaks during testing is log scanning which is
difficult to automate. As an alternative it would be nice to fail unit tests
that leak buffers.

Modifications:

Added ResourceLeakDetector.assertAllResourcesDisposed which can be used in unit tests to ensure that all resources have been disposed. However, invoking assertAllResourcesDisposed directly can be problematic due to the fact that the leak detector is usually a static singleton and/or private in the classes that use it.

To that end, added TestingPooledByteBufAllocator which maintains a non-static leak detector and is useful for concurrent tests. It implements AutoCloseable (for use with try-with-resources) and invokes assertAllResourcesDisposed in the close method. To implement this, AbstractByteBufAllocator.toLeakAwareBuffer was made non-static to allow sub classes to use their own leak detector.

ResourceLeakDetector.clearRefQueue was removed because it created a danger that assertAllResourcesDisposed would not detect all leaks. This method is a useless optimization which saves a few cycles in the unlikely event that error logging is off, leaks are happening, and the leak detector is enabled.

Result:

Developers using Netty can now easily verify that all buffers have been released in unit tests.