### PR TITLE
Add profile to easily run testsuite against netty-tcnative-boringssl-…

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
 
   test-boringssl-static:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true -Dtcnative.artifactId=netty-tcnative-boringssl-static -Dtcnative.classifier="
+    command: /bin/bash -cl "./mvnw -P boringssl clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
 
   shell:
     <<: *common

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,13 @@
     </profile>
 
     <profile>
+      <id>boringssl</id>
+      <properties>
+        <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
+        <tcnative.classifier/>
+      </properties>
+    </profile>
+    <profile>
       <id>leak</id>
       <properties>
         <argLine.leak>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.maxRecords=32</argLine.leak>


### PR DESCRIPTION
…static

Motivation:

We should provide an easy way to run our testsuite against netty-tcnative-boringssl-static

Modifications:

- Add boringssl profile which can be used to enable usage of netty-tcnative-boringssl-static
- Make use of the profile in docker-compose

Result:

Cleaner and easier way of running testsuite against netty-tcnative-boringssl-static