### PR TITLE
Remove uninterpolated `{}` in DefaultHttp2ConnectionDecoder log message

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -537,7 +537,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 // elsewhere so we don't close the stream or otherwise modify the stream's state.
 
                 if (logger.isInfoEnabled()) {
-                    logger.info("{} ignoring {} frame for stream {} {}", ctx.channel(), frameName,
+                    logger.info("{} ignoring {} frame for stream {}", ctx.channel(), frameName,
                             stream.isResetSent() ? "RST_STREAM sent." :
                                 ("Stream created after GOAWAY sent. Last known stream by peer " +
                                  connection.remote().lastStreamKnownByPeer()));


### PR DESCRIPTION
Motivation:

There are log messages emitted from Http2ConnectionDecoder of the form
```
INF i.n.h.c.h.DefaultHttp2ConnectionDecoder ignoring HEADERS frame for stream RST_STREAM sent. {}
```

Modifications:

Remove the trailing `{}` in the log message that doesn't have a value.

Result:

Log messages no longer have a trailing `{}`.
