### PR TITLE
Add test to verify that invalid ciphers are handled in all SSLEngine …

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -63,6 +63,7 @@ import java.security.KeyStore;
 import java.security.Provider;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -82,6 +83,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.TrustManagerFactorySpi;
@@ -2634,6 +2636,28 @@ public abstract class SSLEngineTest {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
             cert.delete();
+        }
+    }
+
+    @Test
+    public void testInvalidCipher() throws Exception {
+        SelfSignedCertificate cert = new SelfSignedCertificate();
+        List<String> cipherList = new ArrayList<String>();
+        Collections.addAll(cipherList, ((SSLSocketFactory) SSLSocketFactory.getDefault()).getDefaultCipherSuites());
+        cipherList.add("InvalidCipher");
+        SSLEngine server = null;
+        try {
+            serverSslCtx = SslContextBuilder.forServer(cert.key(), cert.cert()).sslProvider(sslClientProvider())
+                                            .ciphers(cipherList).build();
+            server = serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            // expected when invalid cipher is used.
+        } catch (SSLException expected) {
+            // expected when invalid cipher is used.
+        } finally {
+            cert.delete();
+            cleanupServerSslEngine(server);
         }
     }
 


### PR DESCRIPTION
…implementations correctly.

Motivation:

https://github.com/netty/netty/issues/8442 reported that we fail to build a SslContext when an invalid cipher is used with netty-tcnative-boringssl-static, while it worked before. This test verifies that this is now consistent with all other SSLEngine implementations.

Modifications:

Add test-case to verify consistent behaviour

Result:

More tests to assert consistent behaviour across SSLEngine implementations