### PR TITLE
Fix NPE when trying to build a DnsNameResolver with a null resolvedAddressTypes

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -374,7 +374,7 @@ public class DnsNameResolver extends InetNameResolver {
             default:
                 throw new IllegalArgumentException("Unknown ResolvedAddressTypes " + resolvedAddressTypes);
         }
-        preferredAddressType = preferredAddressType(resolvedAddressTypes);
+        preferredAddressType = preferredAddressType(this.resolvedAddressTypes);
         this.authoritativeDnsServerCache = checkNotNull(authoritativeDnsServerCache, "authoritativeDnsServerCache");
         nameServerComparator = new NameServerComparator(preferredAddressType.addressType());
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2403,4 +2403,27 @@ public class DnsNameResolverTest {
             }
         }
     }
+
+    @Test
+    public void testInstanceWithNullPreferredAddressType() {
+        new DnsNameResolver(
+                group.next(), // eventLoop
+                new ReflectiveChannelFactory<DatagramChannel>(NioDatagramChannel.class), // channelFactory
+                NoopDnsCache.INSTANCE, // resolveCache
+                NoopAuthoritativeDnsServerCache.INSTANCE, // authoritativeDnsServerCache
+                NoopDnsQueryLifecycleObserverFactory.INSTANCE, // dnsQueryLifecycleObserverFactory
+                100, // queryTimeoutMillis
+                null, // resolvedAddressTypes, see https://github.com/netty/netty/pull/8445
+                true, // recursionDesired
+                1, // maxQueriesPerResolve
+                false, // traceEnabled
+                4096, // maxPayloadSize
+                true, // optResourceEnabled
+                HostsFileEntriesResolver.DEFAULT, // hostsFileEntriesResolver
+                DnsServerAddressStreamProviders.platformDefault(), // dnsServerAddressStreamProvider
+                null, // searchDomains
+                1, // ndots
+                true // decodeIdn
+        ).close();
+    }
 }


### PR DESCRIPTION
Motivation:

It should be possible to build a DnsNameResolver with a null resolvedAddressTypes, defaulting then to DEFAULT_RESOLVE_ADDRESS_TYPES (see line 309).

Sadly, `preferredAddressType` is then called on line 377 with the original parameter instead of the instance attribute, causing an NPE when it's null.

Modification:

Call preferredAddressType with instance attribuet instead of constructor parameter.

Result:

No more NPE