### PR TITLE
Add testcase for epollWait(...) with negative timerfd values.

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
@@ -15,13 +15,58 @@
  */
 package io.netty.channel.epoll;
 
-import org.junit.Assert;
+import io.netty.channel.unix.FileDescriptor;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class EpollTest {
 
     @Test
     public void testIsAvailable() {
-        Assert.assertTrue(Epoll.isAvailable());
+        assertTrue(Epoll.isAvailable());
+    }
+
+    // Testcase for https://github.com/netty/netty/issues/8444
+    @Test(timeout = 5000)
+    public void testEpollWaitWithTimeOutMinusOne() throws Exception  {
+        final EpollEventArray eventArray = new EpollEventArray(8);
+        try {
+            final FileDescriptor epoll = Native.newEpollCreate();
+            final FileDescriptor timerFd = Native.newTimerFd();
+            final FileDescriptor eventfd = Native.newEventFd();
+            Native.epollCtlAdd(epoll.intValue(), timerFd.intValue(), Native.EPOLLIN);
+            Native.epollCtlAdd(epoll.intValue(), eventfd.intValue(), Native.EPOLLIN);
+
+            final AtomicReference<Throwable> ref = new AtomicReference<Throwable>();
+            Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        assertEquals(1, Native.epollWait(epoll, eventArray, timerFd, -1, -1));
+                        // This should have been woken up because of eventfd_write.
+                        assertEquals(eventfd.intValue(), eventArray.fd(0));
+                    } catch (Throwable cause) {
+                        ref.set(cause);
+                    }
+                }
+            });
+            t.start();
+            t.join(1000);
+            assertTrue(t.isAlive());
+            Native.eventFdWrite(eventfd.intValue(), 1);
+
+            t.join();
+            assertNull(ref.get());
+            epoll.close();
+            timerFd.close();
+            eventfd.close();
+        } finally {
+            eventArray.free();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/issues/8444 reports that there is some issue with negative values passed to timerfd_settime. This test verifies that everything is working as expected.

Modifications:

Add testcase.

Result:

Test to verify expected behaviour.