### PR TITLE
Introduce ChannelOption for FIRE_EXCEPTION_ON_FAILURE

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -878,12 +878,13 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
 
     @Override
     public ChannelPromise newPromise() {
-        return new DefaultChannelPromise(channel(), executor());
+        return DefaultChannelPipeline.fireExceptionOndFailure(new DefaultChannelPromise(channel(), executor()));
     }
 
     @Override
     public ChannelProgressivePromise newProgressivePromise() {
-        return new DefaultChannelProgressivePromise(channel(), executor());
+        return DefaultChannelPipeline.fireExceptionOndFailure(
+                new DefaultChannelProgressivePromise(channel(), executor()));
     }
 
     @Override
@@ -897,7 +898,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
 
     @Override
     public ChannelFuture newFailedFuture(Throwable cause) {
-        return new FailedChannelFuture(channel(), executor(), cause);
+        return DefaultChannelPipeline.fireExceptionOndFailure(new FailedChannelFuture(channel(), executor(), cause));
     }
 
     private boolean isNotValidPromise(ChannelPromise promise, boolean allowVoidPromise) {

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -130,6 +130,12 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
             valueOf("SINGLE_EVENTEXECUTOR_PER_GROUP");
 
     /**
+     * If {@code true} {@link ChannelPipeline#fireExceptionCaught(Throwable)} is called whenever a {@link ChannelFuture}
+     * is failed.
+     */
+    public static final ChannelOption<Boolean> FIRE_EXCEPTION_ON_FAILURE = valueOf("FIRE_EXCEPTION_ON_FAILURE");
+
+    /**
      * Creates a new {@link ChannelOption} with the specified unique {@code name}.
      */
     private ChannelOption(int id, String name) {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -23,18 +23,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import static io.netty.channel.ChannelOption.ALLOCATOR;
-import static io.netty.channel.ChannelOption.AUTO_CLOSE;
-import static io.netty.channel.ChannelOption.AUTO_READ;
-import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
-import static io.netty.channel.ChannelOption.MAX_MESSAGES_PER_READ;
-import static io.netty.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
-import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
-import static io.netty.channel.ChannelOption.SINGLE_EVENTEXECUTOR_PER_GROUP;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_LOW_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_SPIN_COUNT;
+import static io.netty.channel.ChannelOption.*;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -64,6 +53,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     private volatile boolean autoClose = true;
     private volatile WriteBufferWaterMark writeBufferWaterMark = WriteBufferWaterMark.DEFAULT;
     private volatile boolean pinEventExecutor = true;
+    private volatile boolean fireExceptionOnFailure;
 
     public DefaultChannelConfig(Channel channel) {
         this(channel, new AdaptiveRecvByteBufAllocator());
@@ -82,7 +72,7 @@ public class DefaultChannelConfig implements ChannelConfig {
                 CONNECT_TIMEOUT_MILLIS, MAX_MESSAGES_PER_READ, WRITE_SPIN_COUNT,
                 ALLOCATOR, AUTO_READ, AUTO_CLOSE, RCVBUF_ALLOCATOR, WRITE_BUFFER_HIGH_WATER_MARK,
                 WRITE_BUFFER_LOW_WATER_MARK, WRITE_BUFFER_WATER_MARK, MESSAGE_SIZE_ESTIMATOR,
-                SINGLE_EVENTEXECUTOR_PER_GROUP);
+                SINGLE_EVENTEXECUTOR_PER_GROUP, FIRE_EXCEPTION_ON_FAILURE);
     }
 
     protected Map<ChannelOption<?>, Object> getOptions(
@@ -156,6 +146,9 @@ public class DefaultChannelConfig implements ChannelConfig {
         if (option == SINGLE_EVENTEXECUTOR_PER_GROUP) {
             return (T) Boolean.valueOf(getPinEventExecutorPerGroup());
         }
+        if (option == FIRE_EXCEPTION_ON_FAILURE) {
+            return (T) Boolean.valueOf(getFireExceptionOnFailure());
+        }
         return null;
     }
 
@@ -188,6 +181,8 @@ public class DefaultChannelConfig implements ChannelConfig {
             setMessageSizeEstimator((MessageSizeEstimator) value);
         } else if (option == SINGLE_EVENTEXECUTOR_PER_GROUP) {
             setPinEventExecutorPerGroup((Boolean) value);
+        } else if (option == FIRE_EXCEPTION_ON_FAILURE) {
+            setFireExceptionOnFailure((Boolean) value);
         } else {
             return false;
         }
@@ -436,4 +431,13 @@ public class DefaultChannelConfig implements ChannelConfig {
         return pinEventExecutor;
     }
 
+    private ChannelConfig setFireExceptionOnFailure(boolean fireExceptionOnFailure) {
+        this.fireExceptionOnFailure = fireExceptionOnFailure;
+        return this;
+    }
+
+    // Package-private to allow fast access without using ChannelOption in DefaultChannelPipeline.
+    boolean getFireExceptionOnFailure() {
+        return fireExceptionOnFailure;
+    }
 }


### PR DESCRIPTION
Motivation:

Sometimes users just want to have an easy way to handle errors without the need to manually add a ChannelFutureListener to each ChannelFuture / ChannelPromise (just like in netty 3.x). This is not easy to do at the moment in netty as handlers in between may create new ChannelPromises etc.

Modifications:

Introdue ChannelOption.FIRE_EXCEPTION_ON_FAILURE which will (when true) have the effect of automatically calling ChannelPipeline.fireExceptionCaught(...) when a ChannelPromise is failed.

Result:

Fixes https://github.com/netty/netty/issues/8429.
