### PR TITLE
Update to latest openjdk 12 ea release.

### DIFF
--- a/docker/docker-compose.centos-6.112.yaml
+++ b/docker/docker-compose.centos-6.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.12.0-16"
+        java_version : "openjdk@1.12.0-17"
 
   test:
     image: netty:centos-6-1.12

--- a/docker/docker-compose.centos-7.112.yaml
+++ b/docker/docker-compose.centos-7.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.12.0-16"
+        java_version : "openjdk@1.12.0-17"
 
   test:
     image: netty:centos-7-1.12


### PR DESCRIPTION
Motivation:

We should always test against the latest EA release.

Modifications:

Update to openjdk 12 ea17

Result:

Test against latest release