### PR TITLE
Use ByteBufUtil.BYTE_ARRAYS ThreadLocal temporary arrays in more places

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -17,7 +17,6 @@
 package io.netty.buffer;
 
 import io.netty.util.Recycler;
-import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -352,8 +351,8 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     @Override
     public int setBytes(int index, InputStream in, int length) throws IOException {
         checkIndex(index, length);
-        byte[] tmp = PlatformDependent.allocateUninitializedArray(length);
-        int readBytes = in.read(tmp);
+        byte[] tmp = ByteBufUtil.threadLocalTempArray(length);
+        int readBytes = in.read(tmp, 0, length);
         if (readBytes <= 0) {
             return readBytes;
         }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
 import java.io.IOException;
@@ -356,11 +355,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
         if (buffer.hasArray()) {
             out.write(buffer.array(), index + buffer.arrayOffset(), length);
         } else {
-            byte[] tmp = PlatformDependent.allocateUninitializedArray(length);
+            byte[] tmp = ByteBufUtil.threadLocalTempArray(length);
             ByteBuffer tmpBuf = internalNioBuffer();
             tmpBuf.clear().position(index);
-            tmpBuf.get(tmp);
-            out.write(tmp);
+            tmpBuf.get(tmp, 0, length);
+            out.write(tmp, 0, length);
         }
         return this;
     }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -561,8 +561,8 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
         if (buffer.hasArray()) {
             return in.read(buffer.array(), buffer.arrayOffset() + index, length);
         } else {
-            byte[] tmp = PlatformDependent.allocateUninitializedArray(length);
-            int readBytes = in.read(tmp);
+            byte[] tmp = ByteBufUtil.threadLocalTempArray(length);
+            int readBytes = in.read(tmp, 0, length);
             if (readBytes <= 0) {
                 return readBytes;
             }

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -584,7 +584,9 @@ final class UnsafeByteBufUtil {
         buf.checkIndex(index, length);
         if (length != 0) {
             int len = Math.min(length, ByteBufUtil.WRITE_CHUNK_SIZE);
-            if (buf.alloc().isDirectBufferPooled()) {
+            if (len <= ByteBufUtil.MAX_TL_ARRAY_LEN || !buf.alloc().isDirectBufferPooled()) {
+                getBytes(addr, ByteBufUtil.threadLocalTempArray(length), 0, len, out, length);
+            } else {
                 // if direct buffers are pooled chances are good that heap buffers are pooled as well.
                 ByteBuf tmpBuf = buf.alloc().heapBuffer(len);
                 try {
@@ -594,9 +596,6 @@ final class UnsafeByteBufUtil {
                 } finally {
                     tmpBuf.release();
                 }
-            } else {
-                byte[] tmp = PlatformDependent.allocateUninitializedArray(len);
-                getBytes(addr, tmp, 0, len, out, length);
             }
         }
     }


### PR DESCRIPTION
Motivation:

#8388 introduced a reusable `ThreadLocal<byte[]>` for use in `decodeString(...)`. It can be used in more places in the buffer package to avoid temporary allocations of small arrays.

Modifications:

Encapsulate use of the ThreadLocal in a static package-private `ByteBufUtil.threadLocalTempArray(int)` method, and make use of it from a handful of new places including `ByteBufUtil.readBytes(...)`.

Result:

Fewer short-lived small byte array allocations.