### PR TITLE
Refresh DNS configuration each 5 minutes.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -33,7 +33,7 @@ public final class DnsServerAddressStreamProviders {
     // https://msdn.microsoft.com/en-us/library/aa365968(VS.85).aspx.
     private static final DnsServerAddressStreamProvider DEFAULT_DNS_SERVER_ADDRESS_STREAM_PROVIDER =
             new DnsServerAddressStreamProvider() {
-        private volatile DnsServerAddressStreamProvider currentProvider;
+        private volatile DnsServerAddressStreamProvider currentProvider = provider();
         private final AtomicLong lastRefresh = new AtomicLong(System.nanoTime());
 
         @Override
@@ -41,6 +41,8 @@ public final class DnsServerAddressStreamProviders {
             long last = lastRefresh.get();
             DnsServerAddressStreamProvider current = currentProvider;
             if (System.nanoTime() - last > REFRESH_INTERVAL) {
+                // This is slightly racy which means it will be possible still use the old configuration for a small
+                // amount of time, but that's ok.
                 if (lastRefresh.compareAndSet(last, System.nanoTime())) {
                     current = currentProvider = provider();
                 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -18,18 +18,43 @@ package io.netty.resolver.dns;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * Utility methods related to {@link DnsServerAddressStreamProvider}.
  */
 @UnstableApi
 public final class DnsServerAddressStreamProviders {
+    // We use 5 minutes which is the same as what OpenJDK is using in sun.net.dns.ResolverConfigurationImpl.
+    private static final long REFRESH_INTERVAL = TimeUnit.MINUTES.toNanos(5);
+
     // TODO(scott): how is this done on Windows? This may require a JNI call to GetNetworkParams
     // https://msdn.microsoft.com/en-us/library/aa365968(VS.85).aspx.
     private static final DnsServerAddressStreamProvider DEFAULT_DNS_SERVER_ADDRESS_STREAM_PROVIDER =
+            new DnsServerAddressStreamProvider() {
+        private volatile DnsServerAddressStreamProvider currentProvider;
+        private final AtomicLong lastRefresh = new AtomicLong(System.nanoTime());
+
+        @Override
+        public DnsServerAddressStream nameServerAddressStream(String hostname) {
+            long last = lastRefresh.get();
+            DnsServerAddressStreamProvider current = currentProvider;
+            if (System.nanoTime() - last > REFRESH_INTERVAL) {
+                if (lastRefresh.compareAndSet(last, System.nanoTime())) {
+                    current = currentProvider = provider();
+                }
+            }
+            return current.nameServerAddressStream(hostname);
+        }
+
+        private DnsServerAddressStreamProvider provider() {
             // If on windows just use the DefaultDnsServerAddressStreamProvider.INSTANCE as otherwise
             // we will log some error which may be confusing.
-            PlatformDependent.isWindows() ? DefaultDnsServerAddressStreamProvider.INSTANCE :
+            return PlatformDependent.isWindows() ? DefaultDnsServerAddressStreamProvider.INSTANCE :
                     UnixResolverDnsServerAddressStreamProvider.parseSilently();
+        }
+    };
 
     private DnsServerAddressStreamProviders() {
     }


### PR DESCRIPTION
Motivation:

We should refresh the DNS configuration each 5 minutes to be able to detect changes done by the user. This is inline with what OpenJDK is doing

Modifications:

Refresh config every 5 minutes.

Result:

Be able to consume changes made by the user.
