### PR TITLE
Defer HTTP/2 stream transition state on initial write until headers are written

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -164,9 +164,10 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             if (stream == null) {
                 try {
                     // We don't create the stream in a `halfClosed` state because if this is an initial
-                    // HEADERS frame we don't want to connection state to transition until after the
-                    // headers have been encoded and placed in the outbound buffer. The `LifeCycleManager`
-                    // will take care of transitioning the state as appropriate.
+                    // HEADERS frame we don't want the connection state to signify that the HEADERS have
+                    // been sent until after they have been encoded and placed in the outbound buffer.
+                    // Therefore, we let the `LifeCycleManager` will take care of transitioning the state
+                    // as appropriate.
                     stream = connection.local().createStream(streamId, /*endOfStream*/ false);
                 } catch (Http2Exception cause) {
                     if (connection.remote().mayHaveCreatedStream(streamId)) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -163,7 +163,11 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             Http2Stream stream = connection.stream(streamId);
             if (stream == null) {
                 try {
-                    stream = connection.local().createStream(streamId, endOfStream);
+                    // We don't create the stream in a `halfClosed` state because if this is an initial
+                    // HEADERS frame we don't want to connection state to transition until after the
+                    // headers have been encoded and placed in the outbound buffer. The `LifeCycleManager`
+                    // will take care of transitioning the state as appropriate.
+                    stream = connection.local().createStream(streamId, /*endOfStream*/ false);
                 } catch (Http2Exception cause) {
                     if (connection.remote().mayHaveCreatedStream(streamId)) {
                         promise.tryFailure(new IllegalStateException("Stream no longer exists: " + streamId, cause));


### PR DESCRIPTION
Motivation:
When the `DefaultHttp2ConnectionEncoder` writes the initial headers for a new
locally created stream we create the stream in the half-closed state if the
end-stream flag is set which signals to the life cycle manager that the headers
have been sent. However, if we synchronously fail to write the headers the
life cycle manager then sends a RST_STREAM on our behalf which is a connection
level PROTOCOL_ERROR because the peer sees the stream in an IDLE state.

Modification:
Don't open the stream in the half-closed state if the end-stream flag is
set and let the life cycle manager take care of it.

Result:
Cleaner state management in the `DefaultHttp2ConnectionEncoder`.

Fixes #8434.