### PR TITLE
Correctly convert supported signature algorithms when using BoringSSL

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -42,8 +42,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.locks.Lock;
 
@@ -288,9 +290,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                                 if (algs == null) {
                                     peerSupportedSignatureAlgorithms = EmptyArrays.EMPTY_STRINGS;
                                 } else {
-                                    List<String> algorithmList = new ArrayList<String>(algs.length);
+                                    Set<String> algorithmList = new LinkedHashSet<String>(algs.length);
                                     for (String alg: algs) {
                                         String converted = SignatureAlgorithmConverter.toJavaName(alg);
+
                                         if (converted != null) {
                                             algorithmList.add(converted);
                                         }

--- a/handler/src/main/java/io/netty/handler/ssl/SignatureAlgorithmConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SignatureAlgorithmConverter.java
@@ -37,17 +37,15 @@ final class SignatureAlgorithmConverter {
     // For more details see https://github.com/openssl/openssl/blob/OpenSSL_1_0_2p/crypto/objects/obj_dat.h
     //
     // BoringSSL uses a different format:
-    // https://github.com/google/boringssl/blob/master/ssl/ssl_privkey.cc#L436
+    // https://github.com/google/boringssl/blob/8525ff3/ssl/ssl_privkey.cc#L436
     //
     private static final Pattern PATTERN = Pattern.compile(
-            // group 1 - 3
-            "((^[a-zA-Z].+)With(.+)Encryption$)|" +
-            // group 4 - 7
-            "((^[a-zA-Z].+)(_with_|-with-)(.+$))|" +
-            // group 8 - 11
-            "((^[a-zA-Z].+)(_pkcs1_|_pss_rsae_)(.+$))|" +
-            // group 12 - 14
-            "((^[a-zA-Z].+)_(.+$))");
+            // group 1 - 2
+            "(?:(^[a-zA-Z].+)With(.+)Encryption$)|" +
+            // group 3 - 4
+            "(?:(^[a-zA-Z].+)(?:_with_|-with-|_pkcs1_|_pss_rsae_)(.+$))|" +
+            // group 5 - 6
+            "(?:(^[a-zA-Z].+)_(.+$))");
 
     /**
      * Converts an OpenSSL algorithm name to a Java algorithm name and return it,
@@ -59,24 +57,16 @@ final class SignatureAlgorithmConverter {
         }
         Matcher matcher = PATTERN.matcher(opensslName);
         if (matcher.matches()) {
-            String group2 = matcher.group(2);
-            if (group2 != null) {
-                return group2.toUpperCase(Locale.ROOT) + "with" + matcher.group(3).toUpperCase(Locale.ROOT);
+            String group1 = matcher.group(1);
+            if (group1 != null) {
+                return group1.toUpperCase(Locale.ROOT) + "with" + matcher.group(2).toUpperCase(Locale.ROOT);
             }
-            if (matcher.group(4) != null) {
-                return matcher.group(7).toUpperCase(Locale.ROOT) + "with" + matcher.group(5).toUpperCase(Locale.ROOT);
-            }
-
-            if (matcher.group(8) != null) {
-                return matcher.group(11).toUpperCase(Locale.ROOT) + "with" + matcher.group(9).toUpperCase(Locale.ROOT);
+            if (matcher.group(3) != null) {
+                return matcher.group(4).toUpperCase(Locale.ROOT) + "with" + matcher.group(3).toUpperCase(Locale.ROOT);
             }
 
-            if (matcher.group(8) != null) {
-                return matcher.group(10).toUpperCase(Locale.ROOT) + "with" + matcher.group(5).toUpperCase(Locale.ROOT);
-            }
-
-            if (matcher.group(12) != null) {
-                return matcher.group(14).toUpperCase(Locale.ROOT) + "with" + matcher.group(13).toUpperCase(Locale.ROOT);
+            if (matcher.group(5) != null) {
+                return matcher.group(6).toUpperCase(Locale.ROOT) + "with" + matcher.group(5).toUpperCase(Locale.ROOT);
             }
         }
         return null;

--- a/handler/src/main/java/io/netty/handler/ssl/SignatureAlgorithmConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SignatureAlgorithmConverter.java
@@ -35,8 +35,19 @@ final class SignatureAlgorithmConverter {
     //              dsa_with_SHA224
     //
     // For more details see https://github.com/openssl/openssl/blob/OpenSSL_1_0_2p/crypto/objects/obj_dat.h
+    //
+    // BoringSSL uses a different format:
+    // https://github.com/google/boringssl/blob/master/ssl/ssl_privkey.cc#L436
+    //
     private static final Pattern PATTERN = Pattern.compile(
-            "((^[a-zA-Z].+)With(.+)Encryption$)|((^[a-zA-Z].+)(_with_|-with-)(.+$))");
+            // group 1 - 3
+            "((^[a-zA-Z].+)With(.+)Encryption$)|" +
+            // group 4 - 7
+            "((^[a-zA-Z].+)(_with_|-with-)(.+$))|" +
+            // group 8 - 11
+            "((^[a-zA-Z].+)(_pkcs1_|_pss_rsae_)(.+$))|" +
+            // group 12 - 14
+            "((^[a-zA-Z].+)_(.+$))");
 
     /**
      * Converts an OpenSSL algorithm name to a Java algorithm name and return it,
@@ -54,6 +65,18 @@ final class SignatureAlgorithmConverter {
             }
             if (matcher.group(4) != null) {
                 return matcher.group(7).toUpperCase(Locale.ROOT) + "with" + matcher.group(5).toUpperCase(Locale.ROOT);
+            }
+
+            if (matcher.group(8) != null) {
+                return matcher.group(11).toUpperCase(Locale.ROOT) + "with" + matcher.group(9).toUpperCase(Locale.ROOT);
+            }
+
+            if (matcher.group(8) != null) {
+                return matcher.group(10).toUpperCase(Locale.ROOT) + "with" + matcher.group(5).toUpperCase(Locale.ROOT);
+            }
+
+            if (matcher.group(12) != null) {
+                return matcher.group(14).toUpperCase(Locale.ROOT) + "with" + matcher.group(13).toUpperCase(Locale.ROOT);
             }
         }
         return null;

--- a/handler/src/test/java/io/netty/handler/ssl/SignatureAlgorithmConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SignatureAlgorithmConverterTest.java
@@ -38,6 +38,21 @@ public class SignatureAlgorithmConverterTest {
     }
 
     @Test
+    public void testBoringSSLOneUnderscore() {
+        assertEquals("SHA256withECDSA", SignatureAlgorithmConverter.toJavaName("ecdsa_sha256"));
+    }
+
+    @Test
+    public void testBoringSSLPkcs1() {
+        assertEquals("SHA256withRSA", SignatureAlgorithmConverter.toJavaName("rsa_pkcs1_sha256"));
+    }
+
+    @Test
+    public void testBoringSSLPSS() {
+        assertEquals("SHA256withRSA", SignatureAlgorithmConverter.toJavaName("rsa_pss_rsae_sha256"));
+    }
+
+    @Test
     public void testInvalid() {
         assertNull(SignatureAlgorithmConverter.toJavaName("ThisIsSomethingInvalid"));
     }


### PR DESCRIPTION
Motivation:

BoringSSL uses different naming schemes for the signature algorithms so we need to adjust the regex to also handle these.

Modifications:

- Adjust SignatureAlgorithmConverter to handle BoringSSL naming scheme
- Ensure we do not include duplicates
- Add unit tests.

Result:

Correctly convert boringssl signature algorithm names.