### PR TITLE
Correctly convert between openssl / boringssl and java cipher names w…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -250,7 +250,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                     }
                 } else {
                     CipherSuiteConverter.convertToCipherStrings(
-                            unmodifiableCiphers, cipherBuilder, cipherTLSv13Builder);
+                            unmodifiableCiphers, cipherBuilder, cipherTLSv13Builder, OpenSsl.isBoringSSL());
 
                     // Set non TLSv1.3 ciphers.
                     SSLContext.setCipherSuite(ctx, cipherBuilder.toString(), false);

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -134,7 +134,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private static final AtomicIntegerFieldUpdater<ReferenceCountedOpenSslEngine> DESTROYED_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(ReferenceCountedOpenSslEngine.class, "destroyed");
 
-    private static final String INVALID_CIPHER = "SSL_NULL_WITH_NULL_NULL";
     private static final SSLEngineResult NEED_UNWRAP_OK = new SSLEngineResult(OK, NEED_UNWRAP, 0, 0);
     private static final SSLEngineResult NEED_UNWRAP_CLOSED = new SSLEngineResult(CLOSED, NEED_UNWRAP, 0, 0);
     private static final SSLEngineResult NEED_WRAP_OK = new SSLEngineResult(OK, NEED_WRAP, 0, 0);
@@ -1409,7 +1408,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         final StringBuilder buf = new StringBuilder();
         final StringBuilder bufTLSv13 = new StringBuilder();
 
-        CipherSuiteConverter.convertToCipherStrings(Arrays.asList(cipherSuites), buf, bufTLSv13);
+        CipherSuiteConverter.convertToCipherStrings(Arrays.asList(cipherSuites), buf, bufTLSv13, OpenSsl.isBoringSSL());
         final String cipherSuiteSpec = buf.toString();
         final String cipherSuiteSpecTLSv13 = bufTLSv13.toString();
 
@@ -1715,7 +1714,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             return null;
         }
 
-        String prefix = toJavaCipherSuitePrefix(SSL.getVersion(ssl));
+        String version = SSL.getVersion(ssl);
+        String prefix = toJavaCipherSuitePrefix(version);
         return CipherSuiteConverter.toJava(openSslCipherSuite, prefix);
     }
 
@@ -2238,7 +2238,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         public String getCipherSuite() {
             synchronized (ReferenceCountedOpenSslEngine.this) {
                 if (cipher == null) {
-                    return INVALID_CIPHER;
+                    return SslUtils.INVALID_CIPHER;
                 }
                 return cipher;
             }

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -29,7 +29,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -42,7 +42,7 @@ import static java.util.Arrays.asList;
  */
 final class SslUtils {
     // See https://tools.ietf.org/html/rfc8446#appendix-B.4
-    private static final Set<String> TLSV13_CIPHERS = Collections.unmodifiableSet(new HashSet<String>(
+    static final Set<String> TLSV13_CIPHERS = Collections.unmodifiableSet(new LinkedHashSet<String>(
             asList("TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256",
                           "TLS_AES_128_GCM_SHA256", "TLS_AES_128_CCM_8_SHA256",
                           "TLS_AES_128_CCM_SHA256")));
@@ -54,6 +54,8 @@ final class SslUtils {
     static final String PROTOCOL_TLS_V1_1 = "TLSv1.1";
     static final String PROTOCOL_TLS_V1_2 = "TLSv1.2";
     static final String PROTOCOL_TLS_V1_3 = "TLSv1.3";
+
+    static final String INVALID_CIPHER = "SSL_NULL_WITH_NULL_NULL";
 
     /**
      * change cipher spec

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
@@ -122,10 +122,14 @@ public class CipherSuiteConverterTest {
         testJ2OMapping("TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "ECDHE-PSK-CHACHA20-POLY1305");
         testJ2OMapping("TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "DHE-PSK-CHACHA20-POLY1305");
         testJ2OMapping("TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256", "RSA-PSK-CHACHA20-POLY1305");
+
+        testJ2OMapping("TLS_AES_128_GCM_SHA256", "TLS_AES_128_GCM_SHA256");
+        testJ2OMapping("TLS_AES_256_GCM_SHA384", "TLS_AES_256_GCM_SHA384");
+        testJ2OMapping("TLS_CHACHA20_POLY1305_SHA256", "TLS_CHACHA20_POLY1305_SHA256");
     }
 
     private static void testJ2OMapping(String javaCipherSuite, String openSslCipherSuite) {
-        final String actual = CipherSuiteConverter.toOpenSslUncached(javaCipherSuite);
+        final String actual = CipherSuiteConverter.toOpenSslUncached(javaCipherSuite, false);
         logger.info("{} => {}", javaCipherSuite, actual);
         assertThat(actual, is(openSslCipherSuite));
     }
@@ -316,15 +320,18 @@ public class CipherSuiteConverterTest {
     private static void testUnknownJavaCiphersToOpenSSL(String javaCipherSuite) {
         CipherSuiteConverter.clearCache();
 
-        assertNull(CipherSuiteConverter.toOpenSsl(javaCipherSuite));
-        assertNull(CipherSuiteConverter.toOpenSsl(javaCipherSuite));
+        assertNull(CipherSuiteConverter.toOpenSsl(javaCipherSuite, false));
+        assertNull(CipherSuiteConverter.toOpenSsl(javaCipherSuite, true));
     }
 
     private static void testCachedJ2OMapping(String javaCipherSuite, String openSslCipherSuite) {
         CipherSuiteConverter.clearCache();
 
-        final String actual1 = CipherSuiteConverter.toOpenSsl(javaCipherSuite);
+        // For TLSv1.3 this should make no diffierence if boringSSL is true or false
+        final String actual1 = CipherSuiteConverter.toOpenSsl(javaCipherSuite, false);
         assertThat(actual1, is(openSslCipherSuite));
+        final String actual2 = CipherSuiteConverter.toOpenSsl(javaCipherSuite, true);
+        assertEquals(actual1, actual2);
 
         // Ensure that the cache entries have been created.
         assertThat(CipherSuiteConverter.isJ2OCached(javaCipherSuite, actual1), is(true));
@@ -332,12 +339,12 @@ public class CipherSuiteConverterTest {
         assertThat(CipherSuiteConverter.isO2JCached(actual1, "SSL", "SSL_" + javaCipherSuite.substring(4)), is(true));
         assertThat(CipherSuiteConverter.isO2JCached(actual1, "TLS", "TLS_" + javaCipherSuite.substring(4)), is(true));
 
-        final String actual2 = CipherSuiteConverter.toOpenSsl(javaCipherSuite);
-        assertThat(actual2, is(openSslCipherSuite));
+        final String actual3 = CipherSuiteConverter.toOpenSsl(javaCipherSuite, false);
+        assertThat(actual3, is(openSslCipherSuite));
 
         // Test if the returned cipher strings are identical,
         // so that the TLS sessions with the same cipher suite do not create many strings.
-        assertThat(actual1, is(sameInstance(actual2)));
+        assertThat(actual1, is(sameInstance(actual3)));
     }
 
     @Test
@@ -372,5 +379,35 @@ public class CipherSuiteConverterTest {
         // so that the TLS sessions with the same cipher suite do not create many strings.
         assertThat(tlsActual1, is(sameInstance(tlsActual2)));
         assertThat(sslActual1, is(sameInstance(sslActual2)));
+    }
+
+    @Test
+    public void testTlsv13Mappings() {
+        CipherSuiteConverter.clearCache();
+
+        assertEquals("TLS_AES_128_GCM_SHA256",
+                     CipherSuiteConverter.toJava("TLS_AES_128_GCM_SHA256", "TLS"));
+        assertNull(CipherSuiteConverter.toJava("TLS_AES_128_GCM_SHA256", "SSL"));
+        assertEquals("TLS_AES_256_GCM_SHA384",
+                     CipherSuiteConverter.toJava("TLS_AES_256_GCM_SHA384", "TLS"));
+        assertNull(CipherSuiteConverter.toJava("TLS_AES_256_GCM_SHA384", "SSL"));
+        assertEquals("TLS_CHACHA20_POLY1305_SHA256",
+                     CipherSuiteConverter.toJava("TLS_CHACHA20_POLY1305_SHA256", "TLS"));
+        assertNull(CipherSuiteConverter.toJava("TLS_CHACHA20_POLY1305_SHA256", "SSL"));
+
+        // BoringSSL use different cipher naming then OpenSSL so we need to test for both
+        assertEquals("TLS_AES_128_GCM_SHA256",
+                     CipherSuiteConverter.toOpenSsl("TLS_AES_128_GCM_SHA256", false));
+        assertEquals("TLS_AES_256_GCM_SHA384",
+                     CipherSuiteConverter.toOpenSsl("TLS_AES_256_GCM_SHA384", false));
+        assertEquals("TLS_CHACHA20_POLY1305_SHA256",
+                     CipherSuiteConverter.toOpenSsl("TLS_CHACHA20_POLY1305_SHA256", false));
+
+        assertEquals("AEAD-AES128-GCM-SHA256",
+                     CipherSuiteConverter.toOpenSsl("TLS_AES_128_GCM_SHA256", true));
+        assertEquals("AEAD-AES256-GCM-SHA384",
+                     CipherSuiteConverter.toOpenSsl("TLS_AES_256_GCM_SHA384", true));
+        assertEquals("AEAD-CHACHA20-POLY1305-SHA256",
+                     CipherSuiteConverter.toOpenSsl("TLS_CHACHA20_POLY1305_SHA256", true));
     }
 }


### PR DESCRIPTION
…hen using TLSv1.3

Motivation:

We did not correctly convert between openssl / boringssl and java ciphers when using TLV1.3 which had different effects when either using openssl or boringssl.
 - When using openssl and TLSv1.3 we always returned SSL_NULL_WITH_NULL_NULL as cipher name
 - When using boringssl with TLSv1.3 we always returned an incorrect constructed cipher name which does not match what is defined by Java.

Modifications:

 - Add correct mappings in CipherSuiteConverter for both openssl and boringssl
 - Add unit tests for CipherSuiteConvert
 - Add unit in SSLEngine which checks that we do not return SSL_NULL_WITH_NULL_NULL ever and that server and client returns the same cipher name.

Result:

Fixes https://github.com/netty/netty/issues/8477.