### PR TITLE
Update to openjdk 12ea19

### DIFF
--- a/docker/docker-compose.centos-6.112.yaml
+++ b/docker/docker-compose.centos-6.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.12.0-17"
+        java_version : "openjdk@1.12.0-19"
 
   test:
     image: netty:centos-6-1.12

--- a/docker/docker-compose.centos-7.112.yaml
+++ b/docker/docker-compose.centos-7.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.12.0-17"
+        java_version : "openjdk@1.12.0-19"
 
   test:
     image: netty:centos-7-1.12


### PR DESCRIPTION
Motivation:

We should test against latest EA releases.

Modifications:

Update to openkdk 12ea19

Result:

Use latest openjdk 12 EA build on the CI.
