### PR TITLE
Enable netty-tcnative shading test again

### DIFF
--- a/testsuite-shading/src/test/java/io/netty/testsuite/shading/ShadingIT.java
+++ b/testsuite-shading/src/test/java/io/netty/testsuite/shading/ShadingIT.java
@@ -16,7 +16,6 @@
 package io.netty.testsuite.shading;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -34,7 +33,6 @@ public class ShadingIT {
         testShading0(SHADING_PREFIX2, className);
     }
 
-    @Ignore("Figure out why this sometimes fail on the CI")
     @Test
     public void testShadingTcnative() throws Exception {
         String className = "io.netty.handler.ssl.OpenSsl";


### PR DESCRIPTION
Motivation:

We disabled the test at some point but it should work now without any problems.

Modifications:

Remove @Ignore from test.

Result:

Verify shading of netty-tcnative on CI.