### PR TITLE
Fix ref-counting when CompositeByteBuf is used with retainedSlice()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1817,9 +1817,13 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         void freeIfNecessary() {
             // Release the slice if present since it may have a different
             // refcount to the unwrapped buf if it is a PooledSlicedByteBuf
-            ByteBuf s = slice, toRelease = s == null ? buf : s;
-            toRelease.release();
-            // null out in both cases since it could be racy
+            ByteBuf buffer = slice;
+            if (buffer != null) {
+                buffer.release();
+            } else {
+                buf.release();
+            }
+            // null out in either case since it could be racy
             slice = null;
         }
     }

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1817,8 +1817,8 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         void freeIfNecessary() {
             // Release the slice if present since it may have a different
             // refcount to the unwrapped buf if it is a PooledSlicedByteBuf
-            ByteBuf s = slice;
-            (s != null ? s : buf).release();
+            ByteBuf s = slice, toRelease = s == null ? buf : s;
+            toRelease.release();
             // null out in both cases since it could be racy
             slice = null;
         }


### PR DESCRIPTION
Motivation:

`ByteBuf.retainedSlice()` and similar methods produce sliced buffers with an independent refcount to the buffer that they wrap.


One of the optimizations in 10539f4dc738c48e8d63c46b72ca32906d7f40ec was to use a ref to the unwrapped buffer object for added slices, but this did not take into account the above special case when later releasing.

Thanks to @rkapsi for discovering this via #8495.

Modifications:

Since a reference to the slice is still kept in the `Component` class, just changed `Component.freeIfNecessary()` to release the slice in preference to the unwrapped buf.

Also added a unit test which reproduces the bug.

Result:

Fixes #8495