### PR TITLE
Unlogged throwable (fix of the issue #8499)

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -172,6 +172,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 this.localAddress = localAddress = unsafe().localAddress();
             } catch (Throwable t) {
                 // Sometimes fails on a closed socket in Windows.
+                logger.error(t.getMessage(), t);
                 return null;
             }
         }
@@ -194,6 +195,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 this.remoteAddress = remoteAddress = unsafe().remoteAddress();
             } catch (Throwable t) {
                 // Sometimes fails on a closed socket in Windows.
+                logger.error(t.getMessage(), t);
                 return null;
             }
         }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -171,8 +171,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             try {
                 this.localAddress = localAddress = unsafe().localAddress();
             } catch (Error e) {
-                logger.error("Error during obtaining localAddress", e);
-                return null;
+                throw e;
             } catch (Throwable t) {
                 // Sometimes fails on a closed socket in Windows.
                 return null;
@@ -196,8 +195,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             try {
                 this.remoteAddress = remoteAddress = unsafe().remoteAddress();
             } catch (Error e) {
-                logger.error("Error during obtaining remoteAddress", e);
-                return null;
+                throw e;
             } catch (Throwable t) {
                 // Sometimes fails on a closed socket in Windows.
                 return null;

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -170,9 +170,11 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         if (localAddress == null) {
             try {
                 this.localAddress = localAddress = unsafe().localAddress();
+            } catch (Error e) {
+                logger.error("Error during obtaining localAddress", e);
+                return null;
             } catch (Throwable t) {
                 // Sometimes fails on a closed socket in Windows.
-                logger.error(t.getMessage(), t);
                 return null;
             }
         }
@@ -193,9 +195,11 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         if (remoteAddress == null) {
             try {
                 this.remoteAddress = remoteAddress = unsafe().remoteAddress();
+            } catch (Error e) {
+                logger.error("Error during obtaining remoteAddress", e);
+                return null;
             } catch (Throwable t) {
                 // Sometimes fails on a closed socket in Windows.
-                logger.error(t.getMessage(), t);
                 return null;
             }
         }


### PR DESCRIPTION
Unlogged throwable.

Motivation:

Besides an error caused by closing socket in Windows a bunch of other errors may happen at this place which won't be somehow logged. For instance any `VirtualMachineError` as `OutOfMemoryError` will be simply ignored. The library should at least log the problem.

Modification:

Added logging of the throwable object.

Result:

Fixes #8499. 