### PR TITLE
Fix of the issue #8501: In case of connection issue channel.remoteAdd…

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -515,4 +515,13 @@ public abstract class AbstractNioChannel extends AbstractChannel {
             connectTimeoutFuture = null;
         }
     }
+
+    @Override
+    public SocketAddress remoteAddress() {
+        final SocketAddress remoteAddress = super.remoteAddress();
+        if (remoteAddress == null) {
+            return requestedRemoteAddress;
+        }
+        return remoteAddress;
+    }
 }


### PR DESCRIPTION
In case of connection issue channel.remoteAddress() returns null

Motivation:

In case of connection issue channel.remoteAddress() returns null.  Would be nice to have it at least for AbstractNioChannel, which stores this remoteAddress in the `requestedRemoteAddress` field before trying to connect.

Modification:

If the `remoteAddress` calculated by the super method is null, then return the `requestedRemoteAddress`.

Result:

Fixes #8501 . 

