### PR TITLE
repair Http header decode bug

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -714,7 +714,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         aEnd = findWhitespace(sb, aStart);
 
         bStart = findNonWhitespace(sb, aEnd);
-        bEnd = findWhitespace(sb, bStart);
+        bEnd = findLastWhitespace(sb, bStart);
 
         cStart = findNonWhitespace(sb, bEnd);
         cEnd = findEndOfString(sb);
@@ -783,6 +783,20 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             }
         }
         return 0;
+    }
+
+    private static int findLastWhitespace(AppendableCharSequence sb, int offset) {
+        boolean isStartedNonWhitespace = false;
+        for (int result = sb.length() - 1; result >= offset; --result) {
+            if (Character.isWhitespace(sb.charAtUnsafe(result))) {
+                if (isStartedNonWhitespace) {
+                    return result;
+                }
+            } else {
+                isStartedNonWhitespace = true;
+            }
+        }
+        return sb.length();
     }
 
     private static class HeaderParser implements ByteProcessor {


### PR DESCRIPTION
if the header like this:  GET /ws?name=Bruce Lee HTTP/1.1
the decode result must be:
    initialLine[0]=GET
    initialLine[1]=/ws?name=Bruce
    initialLine[2]=Lee HTTP/1.1

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
