### PR TITLE
Add DatagramObjectEncoder and Decoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/serialization/DatagramObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/DatagramObjectDecoder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.serialization;
+
+import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.DefaultAddressedEnvelope;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * A decoder that decodes the content of the received {@link DatagramPacket} using the specified {@link ObjectDecoder}
+ * decoder. It wraps the result in a new {@link AddressedEnvelope}<{@link DatagramPacket}, {@link InetSocketAddress}>.
+ * <p>
+ * This allows usage of the {@link ObjectDecoder} while still being able to access sender and receiver information of
+ * the packet. Used in conjuntion with {@link DatagramObjectEncoder}.
+ *
+ * <pre><code>
+ * {@link ChannelPipeline} pipeline = ...;
+ * pipeline.addLast("udpDecoder", new {@link DatagramObjectDecoder}, (...));
+ * </code></pre>
+ */
+public class DatagramObjectDecoder extends MessageToMessageDecoder<DatagramPacket> {
+
+    private final ObjectDecoder objectDecoder;
+
+    /**
+     * Creates a new datagram decoder using the specified objectDecoder
+     *
+     * @param objectDecoder the {@link ObjectDecoder} to be used
+     */
+    public DatagramObjectDecoder(ObjectDecoder objectDecoder) {
+        this.objectDecoder = objectDecoder;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, DatagramPacket msg, List<Object> out) throws Exception {
+        Object decoded = objectDecoder.decode(ctx, msg.content());
+        out.add(new DefaultAddressedEnvelope<Object, InetSocketAddress>(decoded, msg.recipient(), msg.sender()));
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/serialization/DatagramObjectEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/DatagramObjectEncoder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.serialization;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * An encoder which serializes an {@link AddressedEnvelope} object into an {@link DatagramPacket}, while keeping the
+ * information about sender and receiver address. To be used with {@link DatagramObjectDecoder}.
+ * <p>
+ * Please note that the serialized form this encoder produces is not compatible with the standard {@link
+ * ObjectInputStream}.  Please use {@link ObjectDecoder} or {@link ObjectDecoderInputStream} to ensure the
+ * interoperability with this encoder.
+ */
+@Sharable
+public class DatagramObjectEncoder<M extends Serializable>
+        extends MessageToMessageEncoder<AddressedEnvelope<M, InetSocketAddress>> {
+    private final ObjectEncoder objectEncoder;
+
+    /**
+     * Creates a new datagram encoder with the {@link ObjectEncoder}
+     */
+    public DatagramObjectEncoder() {
+        this(new ObjectEncoder());
+    }
+
+    /**
+     * Creates a new datagram encoder with a custom implementation of {@link ObjectEncoder}
+     *
+     * @param objectEncoder the {@link ObjectEncoder} to be used
+     */
+    public DatagramObjectEncoder(ObjectEncoder objectEncoder) {
+        this.objectEncoder = objectEncoder;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, AddressedEnvelope<M, InetSocketAddress> msg, List<Object> out)
+            throws Exception {
+        ByteBuf buf = ctx.alloc().buffer();
+        objectEncoder.encode(ctx, msg.content(), buf);
+        out.add(new DatagramPacket(buf, msg.recipient(), msg.sender()));
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/serialization/DatagramPacketDeEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/serialization/DatagramPacketDeEncoderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.serialization;
+
+import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.DefaultAddressedEnvelope;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.internal.SocketUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.*;
+
+public class DatagramPacketDeEncoderTest {
+
+    private EmbeddedChannel channel;
+
+    @Before
+    public void setUp() {
+        channel = new EmbeddedChannel(new DatagramObjectEncoder<TestMessage>(),
+                                      new DatagramObjectDecoder(new ObjectDecoder(ClassResolvers.cacheDisabled(null))));
+    }
+
+    @After
+    public void tearDown() {
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testDeEncode() {
+        InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
+        InetSocketAddress sender = SocketUtils.socketAddress("127.0.0.1", 20000);
+        assertTrue(channel.writeOutbound(
+                new DefaultAddressedEnvelope<TestMessage, InetSocketAddress>(new TestMessage("netty"), recipient,
+                                                                             sender)));
+        DatagramPacket packet = channel.readOutbound();
+        assertEquals(packet.recipient(), recipient);
+        assertEquals(packet.sender(), sender);
+        assertTrue(channel.writeInbound(packet));
+        AddressedEnvelope<TestMessage, InetSocketAddress> result = channel.readInbound();
+
+        assertEquals(result.content().hello, "netty");
+        assertEquals(result.recipient(), recipient);
+        assertEquals(result.sender(), sender);
+    }
+
+    private static final class TestMessage implements Serializable {
+        private final String hello;
+
+        private TestMessage(String hello) {
+            this.hello = hello;
+        }
+    }
+
+    @Test
+    public void testUnmatchedType() {
+        String netty = "netty";
+        assertTrue(channel.writeOutbound(netty));
+        assertSame(netty, channel.readOutbound());
+    }
+
+}


### PR DESCRIPTION
**Motivation**:

These two classes enable usage of ObjectEncoder and ObjectDecoder with Datagrams, while keeping sender/receiver information available.
Before a User had to do something similar to this:
```
@ChannelHandler.Sharable
public class DatagramObjectDecoder extends MessageToMessageDecoder<DatagramPacket> {

    private final ObjectDecoder decoder;
    private final Method decodeMethod;

    public DatagramObjectDecoder(ObjectDecoder decoder) {
        this.decoder = decoder;
        // Use reflection as the decode() methods are protected
        try {
            this.decodeMethod = decoder.getClass().getDeclaredMethod("decode", ChannelHandlerContext.class, ByteBuf.class);
            decodeMethod.setAccessible(true);
        } catch (NoSuchMethodException e) {
            throw new RuntimeException(e);
        }
    }

    @Override
    protected void decode(ChannelHandlerContext ctx, DatagramPacket packet, List<Object> out) throws InvocationTargetException, IllegalAccessException {
        out.add(new DefaultAddressedEnvelope<>(decodeMethod.invoke(decoder, ctx, packet.content()), packet.recipient(), packet.sender()));
    }
}
```
This solution is more elegant and user-friendly.

**Modifications**:

Added two classes DatagramObjectDecoder and DatagramObjectEncoder based on ObjectEncoder and ObjectDecoder, aswell as a test class

**Result**:
This commit does not change any existing file, only adds two files. It therefore changes nothing for people who do not use these new classes.
