### PR TITLE
Fix "Upgrade" header value case

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -203,7 +203,7 @@ public final class HttpHeaderValues {
     /**
      * {@code "upgrade"}
      */
-    public static final AsciiString UPGRADE = AsciiString.cached("upgrade");
+    public static final AsciiString UPGRADE = AsciiString.cached("Upgrade");
     /**
      * {@code "websocket"}
      */


### PR DESCRIPTION
Motivation:

According to [RFC6455](https://tools.ietf.org/html/rfc6455#section-4.1):

> The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token.

Sadly, `HttpHeaderValues#UPGRADE` is in minor case, which causes some WebSocket servers implementation to reject the upgrade request generated by `WebSocketClientHandshaker`.

Modification:

Fix `HttpHeaderValues#UPGRADE` case from `upgrade` to `Upgrade`.

Result:

`WebSocketClientHandshaker` sends upgrade requests that are compliant with RFC6455