### PR TITLE
ReferenceCountedOpenSslEngine SSLSession.getLocalCertificates() / get…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/DefaultOpenSslKeyMaterial.java
+++ b/handler/src/main/java/io/netty/handler/ssl/DefaultOpenSslKeyMaterial.java
@@ -22,18 +22,27 @@ import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
 
+import java.security.cert.X509Certificate;
+
 final class DefaultOpenSslKeyMaterial extends AbstractReferenceCounted implements OpenSslKeyMaterial {
 
     private static final ResourceLeakDetector<DefaultOpenSslKeyMaterial> leakDetector =
             ResourceLeakDetectorFactory.instance().newResourceLeakDetector(DefaultOpenSslKeyMaterial.class);
     private final ResourceLeakTracker<DefaultOpenSslKeyMaterial> leak;
+    private final X509Certificate[] x509CertificateChain;
     private long chain;
     private long privateKey;
 
-    DefaultOpenSslKeyMaterial(long chain, long privateKey) {
+    DefaultOpenSslKeyMaterial(long chain, long privateKey, X509Certificate[] x509CertificateChain) {
         this.chain = chain;
         this.privateKey = privateKey;
+        this.x509CertificateChain = x509CertificateChain;
         leak = leakDetector.track(this);
+    }
+
+    @Override
+    public X509Certificate[] certificateChain() {
+        return x509CertificateChain.clone();
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterial.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterial.java
@@ -17,10 +17,17 @@ package io.netty.handler.ssl;
 
 import io.netty.util.ReferenceCounted;
 
+import java.security.cert.X509Certificate;
+
 /**
  * Holds references to the native key-material that is used by OpenSSL.
  */
 interface OpenSslKeyMaterial extends ReferenceCounted {
+
+    /**
+     * Returns the configured {@link X509Certificate}s.
+     */
+    X509Certificate[] certificateChain();
 
     /**
      * Returns the pointer to the {@code STACK_OF(X509)} which holds the certificate chain.

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
@@ -96,8 +96,7 @@ final class OpenSslKeyMaterialManager {
         try {
             keyMaterial = provider.chooseKeyMaterial(engine.alloc, alias);
             if (keyMaterial != null) {
-                SSL.setKeyMaterial(engine.sslPointer(),
-                                   keyMaterial.certificateChainAddress(), keyMaterial.privateKeyAddress());
+                engine.setKeyMaterial(keyMaterial);
             }
         } catch (SSLException e) {
             throw e;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialProvider.java
@@ -66,11 +66,11 @@ class OpenSslKeyMaterialProvider {
 
             OpenSslKeyMaterial keyMaterial;
             if (key instanceof OpenSslPrivateKey) {
-                keyMaterial = ((OpenSslPrivateKey) key).toKeyMaterial(chain);
+                keyMaterial = ((OpenSslPrivateKey) key).toKeyMaterial(chain, certificates);
             } else {
                 pkeyBio = toBIO(allocator, key);
                 pkey = key == null ? 0 : SSL.parsePrivateKey(pkeyBio, password);
-                keyMaterial = new DefaultOpenSslKeyMaterial(chain, pkey);
+                keyMaterial = new DefaultOpenSslKeyMaterial(chain, pkey, certificates);
             }
 
             // See the chain and pkey to 0 so we will not release it as the ownership was

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslPrivateKey.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslPrivateKey.java
@@ -18,9 +18,11 @@ package io.netty.handler.ssl;
 import io.netty.internal.tcnative.SSL;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.internal.EmptyArrays;
 
 import javax.security.auth.Destroyable;
 import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 
 final class OpenSslPrivateKey extends AbstractReferenceCounted implements PrivateKey {
 
@@ -110,16 +112,24 @@ final class OpenSslPrivateKey extends AbstractReferenceCounted implements Privat
     /**
      * Convert to a {@link OpenSslKeyMaterial}. Reference count of both is shared.
      */
-    OpenSslKeyMaterial toKeyMaterial(long certificateChain) {
-        return new OpenSslPrivateKeyMaterial(certificateChain);
+    OpenSslKeyMaterial toKeyMaterial(long certificateChain, X509Certificate[] chain) {
+        return new OpenSslPrivateKeyMaterial(certificateChain, chain);
     }
 
     private final class OpenSslPrivateKeyMaterial implements OpenSslKeyMaterial {
 
         private long certificateChain;
+        private final X509Certificate[] x509CertificateChain;
 
-        OpenSslPrivateKeyMaterial(long certificateChain) {
+        OpenSslPrivateKeyMaterial(long certificateChain, X509Certificate[] x509CertificateChain) {
             this.certificateChain = certificateChain;
+            this.x509CertificateChain = x509CertificateChain == null ?
+                    EmptyArrays.EMPTY_X509_CERTIFICATES : x509CertificateChain;
+        }
+
+        @Override
+        public X509Certificate[] certificateChain() {
+            return x509CertificateChain.clone();
         }
 
         @Override

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -97,6 +97,20 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     @Override
     @Test
+    public void testSessionAfterHandshakeKeyManagerFactory() throws Exception {
+        checkShouldUseKeyManagerFactory();
+        super.testSessionAfterHandshakeKeyManagerFactory();
+    }
+
+    @Override
+    @Test
+    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth() throws Exception {
+        checkShouldUseKeyManagerFactory();
+        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth();
+    }
+
+    @Override
+    @Test
     public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
         checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();


### PR DESCRIPTION
…LocalPrincipial() did not work when KeyManagerFactory was used.

Motivation:

The SSLSession.getLocalCertificates() / getLocalPrincipial() methods did not correctly return the local configured certificate / principal if a KeyManagerFactory was used when configure the SslContext.

Modifications:

- Correctly update the local certificates / principial when the key material is selected.
- Add test case that verifies the SSLSession after the handshake to ensure we correctly return all values.

Result:

SSLSession returns correct values also when KeyManagerFactory is used with the OpenSSL provider.