### PR TITLE
Return the correct pointer from ReferenceCountedOpenSslContext.contex…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -421,13 +421,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
      */
     @Deprecated
     public final long context() {
-        Lock readerLock = ctxLock.readLock();
-        readerLock.lock();
-        try {
-            return ctx;
-        } finally {
-            readerLock.unlock();
-        }
+        return sslCtxPointer();
     }
 
     /**
@@ -502,7 +496,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         Lock readerLock = ctxLock.readLock();
         readerLock.lock();
         try {
-            return ctx;
+            return SSLContext.getSslCtx(ctx);
         } finally {
             readerLock.unlock();
         }


### PR DESCRIPTION
…t() and sslCtxPointer()

Motivation:

We did not return the pointer to SSL_CTX put to the internal datastructure of tcnative.

Modifications:

Return the correct pointer.

Result:

Methods work as documented in the javadocs.