### PR TITLE
Allow adjusting of lead detection sampling interval.

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -48,7 +48,12 @@ public class ResourceLeakDetector<T> {
     private static final String PROP_TARGET_RECORDS = "io.netty.leakDetection.targetRecords";
     private static final int DEFAULT_TARGET_RECORDS = 4;
 
+    private static final String PROP_SAMPLING_INTERVAL = "io.netty.leakDetection.samplingInterval";
+    // There is a minor performance benefit in TLR if this is a power of 2.
+    private static final int DEFAULT_SAMPLING_INTERVAL = 128;
+
     private static final int TARGET_RECORDS;
+    static final int SAMPLING_INTERVAL;
 
     /**
      * Represents the level of resource leak detection.
@@ -117,6 +122,7 @@ public class ResourceLeakDetector<T> {
         Level level = Level.parseLevel(levelStr);
 
         TARGET_RECORDS = SystemPropertyUtil.getInt(PROP_TARGET_RECORDS, DEFAULT_TARGET_RECORDS);
+        SAMPLING_INTERVAL = SystemPropertyUtil.getInt(PROP_SAMPLING_INTERVAL, DEFAULT_SAMPLING_INTERVAL);
 
         ResourceLeakDetector.level = level;
         if (logger.isDebugEnabled()) {
@@ -124,9 +130,6 @@ public class ResourceLeakDetector<T> {
             logger.debug("-D{}: {}", PROP_TARGET_RECORDS, TARGET_RECORDS);
         }
     }
-
-    // There is a minor performance benefit in TLR if this is a power of 2.
-    static final int DEFAULT_SAMPLING_INTERVAL = 128;
 
     /**
      * @deprecated Use {@link #setLevel(Level)} instead.

--- a/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
@@ -62,7 +62,7 @@ public abstract class ResourceLeakDetectorFactory {
      * @return a new instance of {@link ResourceLeakDetector}
      */
     public final <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource) {
-        return newResourceLeakDetector(resource, ResourceLeakDetector.DEFAULT_SAMPLING_INTERVAL);
+        return newResourceLeakDetector(resource, ResourceLeakDetector.SAMPLING_INTERVAL);
     }
 
     /**
@@ -90,7 +90,7 @@ public abstract class ResourceLeakDetectorFactory {
      */
     @SuppressWarnings("deprecation")
     public <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource, int samplingInterval) {
-        return newResourceLeakDetector(resource, ResourceLeakDetector.DEFAULT_SAMPLING_INTERVAL, Long.MAX_VALUE);
+        return newResourceLeakDetector(resource, ResourceLeakDetector.SAMPLING_INTERVAL, Long.MAX_VALUE);
     }
 
     /**


### PR DESCRIPTION
    Motivation:

    We should allow adjustment of the leak detecting sampling interval when in SAMPLE mode.

    Modifications:

    Added new int property io.netty.leakDetection.samplingInterval

    Result:

    Be able to consume changes made by the user.