### PR TITLE
Ensure retain(...) will always throw once it did once.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.PlatformDependent;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static java.lang.Math.max;
 
 /**
  * Abstract base class for {@link ByteBuf} implementations that count references.
@@ -57,12 +58,14 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
         // a best-effort guard.
         //
         // TODO: Once we compile against later versions of Java we can replace the Unsafe usage here by varhandles.
-        return REFCNT_FIELD_OFFSET != -1 ? PlatformDependent.getInt(this, REFCNT_FIELD_OFFSET) : refCnt();
+        return REFCNT_FIELD_OFFSET != -1 ?
+                PlatformDependent.getInt(this, REFCNT_FIELD_OFFSET) : refCntUpdater.get(this);
     }
 
     @Override
     public int refCnt() {
-        return refCnt;
+        // Never return anything smaller then 0 to give the user a consistent few all the time.
+        return max(0, refCntUpdater.get(this));
     }
 
     /**
@@ -82,14 +85,25 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
         return retain0(checkPositive(increment, "increment"));
     }
 
-    private ByteBuf retain0(final int increment) {
-        int oldRef = refCntUpdater.getAndAdd(this, increment);
-        if (oldRef <= 0 || oldRef + increment < oldRef) {
-            // Ensure we don't resurrect (which means the refCnt was 0) and also that we encountered an overflow.
-            refCntUpdater.getAndAdd(this, -increment);
-            throw new IllegalReferenceCountException(oldRef, increment);
+    private ByteBuf retain0(int increment) {
+        int oldRef = refCntUpdater.get(this);
+        if (oldRef <= 0 || oldRef + increment < 0) {
+            // Either already released or we overflow.
+            throw newReferenceCountException(oldRef, increment);
         }
-        return this;
+        int ref = refCntUpdater.addAndGet(this, increment);
+        if (ref > increment) {
+            // Most likely code-path to hit.
+            return this;
+        }
+        if (ref <= 0) {
+            // Overflow happened, trying to recover.
+            refCntUpdater.addAndGet(this, -increment);
+            throw newReferenceCountException(ref, increment);
+        }
+        // Set the reference count back to 0 which signals this reference was deallocated already.
+        refCntUpdater.set(this, 0);
+        throw newReferenceCountException(ref, increment);
     }
 
     @Override
@@ -115,16 +129,24 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
     private boolean release0(int decrement) {
         int oldRef = refCntUpdater.getAndAdd(this, -decrement);
         if (oldRef == decrement) {
+            // Most likely code-path to hit.
             deallocate();
             return true;
         }
+
         if (oldRef < decrement || oldRef - decrement > oldRef) {
             // Ensure we don't over-release, and avoid underflow.
-            refCntUpdater.getAndAdd(this, decrement);
-            throw new IllegalReferenceCountException(oldRef, -decrement);
+            // Also set the reference count back to 0 as this signals we already completely released it.
+            refCntUpdater.set(this, 0);
+            throw newReferenceCountException(oldRef, -decrement);
         }
         return false;
     }
+
+    private static IllegalReferenceCountException newReferenceCountException(int oldCnt, int cnt) {
+        return new IllegalReferenceCountException(max(0, oldCnt), cnt);
+    }
+
     /**
      * Called once {@link #refCnt()} is equals 0.
      */


### PR DESCRIPTION
Motivation:

83a19d5 did make some optimizations which could lead to the situation that retain(...) may throw IllegalReferenceCountException once but may not throw it again when invoked concurrently.

Modification:

- Change code be more robust and more correct in terms of how reference count issues are reported.
- Add unit test.

Result:

Fixes https://github.com/netty/netty/issues/8563.

Before:

```
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                           1  sample  33113962     648.130 ?  0.290  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00              1  sample                42.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50              1  sample               533.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90              1  sample              1258.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95              1  sample              1518.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99              1  sample              2168.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999             1  sample              3492.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999            1  sample             15296.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00              1  sample            367104.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                          10  sample  37599393     494.185 ?  0.170  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00             10  sample                56.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50             10  sample               427.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90             10  sample               821.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95             10  sample               992.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99             10  sample              1432.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999            10  sample              2472.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999           10  sample              7744.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00             10  sample            166656.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                         100  sample  38506222     514.284 ?  0.120  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00            100  sample               268.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50            100  sample               476.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90            100  sample               662.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95            100  sample               767.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99            100  sample              1052.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999           100  sample              1560.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999          100  sample              9040.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00            100  sample            168704.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                        1000  sample  25227982    2988.675 ?  0.469  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00           1000  sample              2404.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50           1000  sample              2748.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90           1000  sample              3616.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95           1000  sample              4264.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99           1000  sample              6136.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999          1000  sample              6408.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999         1000  sample             20480.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00           1000  sample            218368.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                       10000  sample  20740699   28886.175 ?  4.364  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00          10000  sample             23424.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50          10000  sample             26208.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90          10000  sample             35328.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95          10000  sample             41536.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99          10000  sample             58944.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999         10000  sample             59200.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999        10000  sample             74112.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00          10000  sample            178688.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                         1  sample   6692625      55.262 ?  0.097  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00          1  sample                40.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50          1  sample                49.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90          1  sample                71.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95          1  sample                82.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99          1  sample               110.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999         1  sample               110.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999        1  sample              1617.475           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00          1  sample             19168.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                        10  sample   4794123      75.339 ?  0.143  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00         10  sample                62.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50         10  sample                66.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90         10  sample                98.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95         10  sample               115.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99         10  sample               147.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999        10  sample               150.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999       10  sample              2364.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00         10  sample             22048.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                       100  sample   5040621     343.582 ?  0.263  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00        100  sample               228.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50        100  sample               301.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90        100  sample               449.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95        100  sample               510.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99        100  sample               676.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999       100  sample               683.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999      100  sample              8135.502           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00        100  sample             26112.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                      1000  sample   4150252    3032.540 ?  1.298  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00       1000  sample              2160.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50       1000  sample              2648.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90       1000  sample              3968.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95       1000  sample              4760.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99       1000  sample              5960.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999      1000  sample              6504.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999     1000  sample             19904.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00       1000  sample             52352.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                     10000  sample   3275578   30489.966 ? 14.050  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00      10000  sample             25952.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50      10000  sample             26112.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90      10000  sample             41472.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95      10000  sample             47040.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99      10000  sample             58752.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999     10000  sample             59008.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999    10000  sample             75520.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00      10000  sample            125056.000           ns/op
```

After:

```
Benchmark                                                                                           (delay)    Mode       Cnt       Score    Error  Units
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                           1  sample  31059953     690.194 ?  0.257  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00              1  sample                44.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50              1  sample               627.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90              1  sample              1148.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95              1  sample              1362.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99              1  sample              1926.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999             1  sample              3272.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999            1  sample             15792.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00              1  sample            178432.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                          10  sample  28862663     725.757 ?  0.277  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00             10  sample                55.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50             10  sample               652.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90             10  sample              1210.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95             10  sample              1432.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99             10  sample              2000.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999            10  sample              3528.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999           10  sample             15952.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00             10  sample            213504.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                         100  sample  31823478     751.129 ?  0.187  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00            100  sample               273.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50            100  sample               699.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90            100  sample              1032.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95            100  sample              1188.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99            100  sample              1618.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999           100  sample              2508.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999          100  sample             15952.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00            100  sample            168704.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                        1000  sample  25430205    2967.247 ?  0.474  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00           1000  sample              2396.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50           1000  sample              2700.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90           1000  sample              3628.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95           1000  sample              4248.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99           1000  sample              6056.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999          1000  sample              6464.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999         1000  sample             20640.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00           1000  sample            261632.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended                                       10000  sample  21113138   28377.341 ?  3.951  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.00          10000  sample             23424.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.50          10000  sample             26176.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.90          10000  sample             33600.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.95          10000  sample             37376.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.99          10000  sample             58816.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.999         10000  sample             59072.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p0.9999        10000  sample             73216.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseContended:retainReleaseContended?p1.00          10000  sample            245504.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                         1  sample   5966172      58.417 ?  0.095  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00          1  sample                37.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50          1  sample                52.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90          1  sample                74.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95          1  sample                86.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99          1  sample               117.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999         1  sample               120.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999        1  sample              1630.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00          1  sample             21952.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                        10  sample   4535644      75.899 ?  0.165  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00         10  sample                54.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50         10  sample                66.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90         10  sample                98.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95         10  sample               116.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99         10  sample               147.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999        10  sample               200.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999       10  sample              2769.742           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00         10  sample             30528.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                       100  sample   5096864     340.189 ?  0.262  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00        100  sample               228.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50        100  sample               301.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90        100  sample               430.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95        100  sample               508.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99        100  sample               676.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999       100  sample               723.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999      100  sample              9430.224           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00        100  sample             22976.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                      1000  sample   4192970    3001.264 ?  1.275  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00       1000  sample              2096.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50       1000  sample              2648.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90       1000  sample              3964.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95       1000  sample              4472.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99       1000  sample              5952.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999      1000  sample              6232.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999     1000  sample             19808.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00       1000  sample             69760.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended                                     10000  sample   3390281   29459.064 ? 12.376  ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.00      10000  sample             20704.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.50      10000  sample             26112.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.90      10000  sample             39040.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.95      10000  sample             44032.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.99      10000  sample             58752.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.999     10000  sample             58816.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p0.9999    10000  sample             74368.000           ns/op
AbstractReferenceCountedByteBufBenchmark.retainReleaseUncontended:retainReleaseUncontended?p1.00      10000  sample            123136.000           ns/op
```

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
