### PR TITLE
Mark OIO based transports as deprecated as preparation for removal in…

### DIFF
--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
@@ -58,7 +58,10 @@ import java.util.Set;
  *
  * Be aware that not all operations systems support SCTP. Please refer to the documentation of your operation system,
  * to understand what you need to do to use it. Also this feature is only supported on Java 7+.
+ *
+ * @deprecated use {@link io.netty.channel.sctp.nio.NioSctpChannel}.
  */
+@Deprecated
 public class OioSctpChannel extends AbstractOioMessageChannel
         implements io.netty.channel.sctp.SctpChannel {
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -46,7 +46,10 @@ import java.util.Set;
  *
  * Be aware that not all operations systems support SCTP. Please refer to the documentation of your operation system,
  * to understand what you need to do to use it. Also this feature is only supported on Java 7+.
+ *
+ * @deprecated use {@link io.netty.channel.sctp.nio.NioSctpServerChannel}.
  */
+@Deprecated
 public class OioSctpServerChannel extends AbstractOioMessageChannel
         implements io.netty.channel.sctp.SctpServerChannel {
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/package-info.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/package-info.java
@@ -17,5 +17,8 @@
 /**
  * Old blocking I/O based SCTP channel API implementation - recommended for
  * a small number of connections (&lt; 1000).
+ *
+ * @deprecated use NIO based SCTP implementation.
  */
+@Deprecated
 package io.netty.channel.sctp.oio;

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
@@ -19,7 +19,9 @@ package io.netty.channel;
  * {@link SingleThreadEventLoop} which is used to handle OIO {@link Channel}'s. So in general there will be
  * one {@link ThreadPerChannelEventLoop} per {@link Channel}.
  *
+ * @deprecated this will be remove in the next-major release.
  */
+@Deprecated
 public class ThreadPerChannelEventLoop extends SingleThreadEventLoop {
 
     private final ThreadPerChannelEventLoopGroup parent;

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
@@ -42,7 +42,10 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * An {@link EventLoopGroup} that creates one {@link EventLoop} per {@link Channel}.
+ *
+ * @deprecated this will be remove in the next-major release.
  */
+@Deprecated
 public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup implements EventLoopGroup {
 
     private final Object[] childArgs;

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 
 /**
  * Abstract base class for OIO which reads and writes bytes from/to a Socket
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
 public abstract class AbstractOioByteChannel extends AbstractOioChannel {
 

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioChannel.java
@@ -25,7 +25,10 @@ import java.net.SocketAddress;
 
 /**
  * Abstract base class for {@link Channel} implementations that use Old-Blocking-IO
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public abstract class AbstractOioChannel extends AbstractChannel {
 
     protected static final int SO_TIMEOUT = 1000;

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioMessageChannel.java
@@ -26,7 +26,10 @@ import java.util.List;
 
 /**
  * Abstract base class for OIO which reads and writes objects from/to a Socket
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public abstract class AbstractOioMessageChannel extends AbstractOioChannel {
 
     private final List<Object> readBuf = new ArrayList<Object>();

--- a/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
@@ -31,7 +31,10 @@ import java.nio.channels.WritableByteChannel;
 
 /**
  * Abstract base class for OIO Channels that are based on streams.
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public abstract class OioByteStreamChannel extends AbstractOioByteChannel {
 
     private static final InputStream CLOSED_IN = new InputStream() {

--- a/transport/src/main/java/io/netty/channel/oio/OioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioEventLoopGroup.java
@@ -30,7 +30,10 @@ import java.util.concurrent.ThreadFactory;
 /**
  * {@link EventLoopGroup} which is used to handle OIO {@link Channel}'s. Each {@link Channel} will be handled by its
  * own {@link EventLoop} to not block others.
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public class OioEventLoopGroup extends ThreadPerChannelEventLoopGroup {
 
     /**

--- a/transport/src/main/java/io/netty/channel/oio/package-info.java
+++ b/transport/src/main/java/io/netty/channel/oio/package-info.java
@@ -17,5 +17,8 @@
 /**
  * Old blocking I/O based channel API implementation - recommended for
  * a small number of connections (&lt; 1000).
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 package io.netty.channel.oio;

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
@@ -33,7 +33,10 @@ import static io.netty.channel.ChannelOption.*;
 
 /**
  * Default {@link OioServerSocketChannelConfig} implementation
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public class DefaultOioServerSocketChannelConfig extends DefaultServerSocketChannelConfig implements
         OioServerSocketChannelConfig {
 

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
@@ -33,7 +33,10 @@ import static io.netty.channel.ChannelOption.*;
 
 /**
  * Default {@link OioSocketChannelConfig} implementation
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public class DefaultOioSocketChannelConfig extends DefaultSocketChannelConfig implements OioSocketChannelConfig {
     @Deprecated
     public DefaultOioSocketChannelConfig(SocketChannel channel, Socket javaSocket) {

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
@@ -54,7 +54,9 @@ import java.util.Locale;
  *
  * @see AddressedEnvelope
  * @see DatagramPacket
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public class OioDatagramChannel extends AbstractOioMessageChannel
                                 implements DatagramChannel {
 

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannelConfig.java
@@ -24,6 +24,10 @@ import io.netty.channel.socket.DatagramChannelConfig;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 
+/**
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
+ */
+@Deprecated
 public interface OioDatagramChannelConfig extends DatagramChannelConfig {
     /**
      * Sets the maximal time a operation on the underlying socket may block.

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -38,7 +38,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * {@link ServerSocketChannel} which accepts new connections and create the {@link OioSocketChannel}'s for them.
  *
  * This implementation use Old-Blocking-IO.
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public class OioServerSocketChannel extends AbstractOioMessageChannel
                                     implements ServerSocketChannel {
 

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannelConfig.java
@@ -39,7 +39,10 @@ import io.netty.channel.socket.ServerSocketChannelConfig;
  * <td>{@link ChannelOption#SO_TIMEOUT}</td><td>{@link #setSoTimeout(int)}</td>
  * </tr>
  * </table>
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public interface OioServerSocketChannelConfig extends ServerSocketChannelConfig {
 
     /**

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
@@ -39,7 +39,10 @@ import java.net.SocketTimeoutException;
 
 /**
  * A {@link SocketChannel} which is using Old-Blocking-IO
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public class OioSocketChannel extends OioByteStreamChannel implements SocketChannel {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(OioSocketChannel.class);

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannelConfig.java
@@ -39,7 +39,10 @@ import io.netty.channel.socket.SocketChannelConfig;
  * <td>{@link ChannelOption#SO_TIMEOUT}</td><td>{@link #setSoTimeout(int)}</td>
  * </tr>
  * </table>
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 public interface OioSocketChannelConfig extends SocketChannelConfig {
 
     /**

--- a/transport/src/main/java/io/netty/channel/socket/oio/package-info.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/package-info.java
@@ -17,5 +17,8 @@
 /**
  * Old blocking I/O based socket channel API implementation - recommended for
  * a small number of connections (&lt; 1000).
+ *
+ * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
+@Deprecated
 package io.netty.channel.socket.oio;


### PR DESCRIPTION
… Netty 5.

Motivation:

We plan to remove the OIO based transports in Netty 5 so we should mark these as deprecated already.

Modifications:

Mark all OIO based transports as deprecated.

Result:

Give the user a heads-up for removal.