### PR TITLE
Remove transitive dependency on slf4j in example

### DIFF
--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketFrameHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketFrameHandler.java
@@ -21,15 +21,11 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Echoes uppercase content of text frames.
  */
 public class WebSocketFrameHandler extends SimpleChannelInboundHandler<WebSocketFrame> {
-
-    private static final Logger logger = LoggerFactory.getLogger(WebSocketFrameHandler.class);
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
@@ -38,7 +34,6 @@ public class WebSocketFrameHandler extends SimpleChannelInboundHandler<WebSocket
         if (frame instanceof TextWebSocketFrame) {
             // Send the uppercase string back.
             String request = ((TextWebSocketFrame) frame).text();
-            logger.info("{} received {}", ctx.channel(), request);
             ctx.channel().writeAndFlush(new TextWebSocketFrame(request.toUpperCase(Locale.US)));
         } else {
             String message = "unsupported frame type: " + frame.getClass().getName();


### PR DESCRIPTION
Motivation:

We currently depend on slf4j in an transitive way in one of our classes in the examples. We should not do this.

Modifications:

Replace slf4j logger usage with netty logger.

Result:

Remove not needed dependency.