### PR TITLE
Harden ref-counting concurrency semantics

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -130,36 +130,55 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
     }
 
     private boolean release0(int decrement) {
-        int rawCnt = nonVolatileRawCnt();
-        for (boolean firstTry = true;; firstTry = false) {
-            if ((rawCnt & 1) != 0) {
-                throw new IllegalReferenceCountException(0, -decrement);
+        int rawCnt = nonVolatileRawCnt(), realCnt = toLiveRealCnt(rawCnt, decrement);
+        if (decrement == realCnt) {
+            if (refCntUpdater.compareAndSet(this, rawCnt, 1)) {
+                deallocate();
+                return true;
             }
-            int realCnt = rawCnt >>> 1;
+            return retryRelease0(decrement);
+        }
+        return releaseNonFinal0(decrement, rawCnt, realCnt);
+    }
+
+    private boolean releaseNonFinal0(int decrement, int rawCnt, int realCnt) {
+        if (decrement < realCnt
+                // all changes to the raw count are 2x the "real" change
+                && refCntUpdater.compareAndSet(this, rawCnt, rawCnt - (decrement << 1))) {
+            return false;
+        }
+        return retryRelease0(decrement);
+    }
+
+    private boolean retryRelease0(int decrement) {
+        for (;;) {
+            int rawCnt = refCntUpdater.get(this), realCnt = toLiveRealCnt(rawCnt, decrement);
             if (decrement == realCnt) {
-                // most likely case
-                if (refCntUpdater.compareAndSet(this, rawCnt, 1)) { // any odd number
+                if (refCntUpdater.compareAndSet(this, rawCnt, 1)) {
                     deallocate();
                     return true;
-                }
-                if (!firstTry) {
-                    // this benefits throughput under high contention
-                    Thread.yield();
                 }
             } else if (decrement < realCnt) {
                 // all changes to the raw count are 2x the "real" change
                 if (refCntUpdater.compareAndSet(this, rawCnt, rawCnt - (decrement << 1))) {
                     return false;
                 }
-                if (!firstTry) {
-                    // this benefits throughput under high contention
-                    Thread.yield();
-                }
-            } else if (!firstTry) {
+            } else {
                 throw new IllegalReferenceCountException(realCnt, -decrement);
             }
-            rawCnt = refCntUpdater.get(this);
+            Thread.yield(); // this benefits throughput under high contention
         }
+    }
+
+    /**
+     * Like {@link #realRefCnt(int)} but throws if refCnt == 0
+     */
+    private static int toLiveRealCnt(int rawCnt, int decrement) {
+        if ((rawCnt & 1) == 0) {
+            return rawCnt >>> 1;
+        }
+        // odd rawCnt => already deallocated
+        throw new IllegalReferenceCountException(0, -decrement);
     }
 
     /**

--- a/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
@@ -38,16 +38,18 @@ public class AbstractReferenceCountedByteBufTest {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         referenceCounted.setRefCnt(Integer.MAX_VALUE);
         assertEquals(Integer.MAX_VALUE, referenceCounted.refCnt());
-        // extra retain since we can actually go one higher before overflowing
-        referenceCounted.retain().retain();
+        referenceCounted.retain();
+    }
+    
+    public static void main(String[] args) {
+        System.out.println(Integer.MAX_VALUE << 1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testRetainOverflow2() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         assertEquals(1, referenceCounted.refCnt());
-        // extra retain since we can actually go one higher before overflowing
-        referenceCounted.retain().retain(Integer.MAX_VALUE);
+        referenceCounted.retain(Integer.MAX_VALUE);
     }
 
     @Test(expected = IllegalReferenceCountException.class)

--- a/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
@@ -40,10 +40,6 @@ public class AbstractReferenceCountedByteBufTest {
         assertEquals(Integer.MAX_VALUE, referenceCounted.refCnt());
         referenceCounted.retain();
     }
-    
-    public static void main(String[] args) {
-        System.out.println(Integer.MAX_VALUE << 1);
-    }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testRetainOverflow2() {

--- a/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
@@ -38,14 +38,16 @@ public class AbstractReferenceCountedByteBufTest {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         referenceCounted.setRefCnt(Integer.MAX_VALUE);
         assertEquals(Integer.MAX_VALUE, referenceCounted.refCnt());
-        referenceCounted.retain();
+        // extra retain since we can actually go one higher before overflowing
+        referenceCounted.retain().retain();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testRetainOverflow2() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         assertEquals(1, referenceCounted.refCnt());
-        referenceCounted.retain(Integer.MAX_VALUE);
+        // extra retain since we can actually go one higher before overflowing
+        referenceCounted.retain().retain(Integer.MAX_VALUE);
     }
 
     @Test(expected = IllegalReferenceCountException.class)

--- a/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
+++ b/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
@@ -15,30 +15,58 @@
  */
 package io.netty.util;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static io.netty.util.internal.ObjectUtil.checkPositive;
+import io.netty.util.internal.PlatformDependent;
 
 /**
  * Abstract base class for classes wants to implement {@link ReferenceCounted}.
  */
 public abstract class AbstractReferenceCounted implements ReferenceCounted {
-
+    private static final long REFCNT_FIELD_OFFSET;
     private static final AtomicIntegerFieldUpdater<AbstractReferenceCounted> refCntUpdater =
             AtomicIntegerFieldUpdater.newUpdater(AbstractReferenceCounted.class, "refCnt");
 
-    private volatile int refCnt = 1;
+    // even => "real" refcount is (refCnt >>> 1); odd => "real" refcount is 0
+    @SuppressWarnings("unused")
+    private volatile int refCnt = 2;
+
+    static {
+        long refCntFieldOffset = -1;
+        try {
+            if (PlatformDependent.hasUnsafe()) {
+                refCntFieldOffset = PlatformDependent.objectFieldOffset(
+                        AbstractReferenceCounted.class.getDeclaredField("refCnt"));
+            }
+        } catch (Throwable ignore) {
+            refCntFieldOffset = -1;
+        }
+
+        REFCNT_FIELD_OFFSET = refCntFieldOffset;
+    }
+
+    private static int realRef(int refCnt) {
+        return (refCnt & 1) != 0 ? 0 : refCnt >>> 1;
+    }
+
+    private int nonVolatileRawCnt() {
+        // TODO: Once we compile against later versions of Java we can replace the Unsafe usage here by varhandles.
+        return REFCNT_FIELD_OFFSET != -1 ? PlatformDependent.getInt(this, REFCNT_FIELD_OFFSET)
+                : refCntUpdater.get(this);
+    }
 
     @Override
-    public final int refCnt() {
-        return refCnt;
+    public int refCnt() {
+        return realRef(refCntUpdater.get(this));
     }
 
     /**
      * An unsafe operation intended for use by a subclass that sets the reference count of the buffer directly
      */
     protected final void setRefCnt(int refCnt) {
-        refCntUpdater.set(this, refCnt);
+        refCntUpdater.set(this, refCnt << 1); // overflow OK here
     }
 
     @Override
@@ -51,12 +79,19 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
         return retain0(checkPositive(increment, "increment"));
     }
 
-    private ReferenceCounted retain0(int increment) {
-        int oldRef = refCntUpdater.getAndAdd(this, increment);
-        if (oldRef <= 0 || oldRef + increment < oldRef) {
-            // Ensure we don't resurrect (which means the refCnt was 0) and also that we encountered an overflow.
+    private ReferenceCounted retain0(final int increment) {
+        // all changes to the raw count are 2x the "real" change
+        int adjustIncrement = increment << 1; // overflow OK here
+        int oldRef = refCntUpdater.getAndAdd(this, adjustIncrement);
+        if ((oldRef & 1) != 0) {
+            throw new IllegalReferenceCountException(0, increment);
+        }
+        // don't pass 0!
+        if ((oldRef <= 0 && oldRef + adjustIncrement >= 0)
+                || (oldRef >= 0 && oldRef + adjustIncrement < oldRef)) {
+            // overflow case
             refCntUpdater.getAndAdd(this, -increment);
-            throw new IllegalReferenceCountException(oldRef, increment);
+            throw new IllegalReferenceCountException(realRef(oldRef), increment);
         }
         return this;
     }
@@ -77,16 +112,36 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
     }
 
     private boolean release0(int decrement) {
-        int oldRef = refCntUpdater.getAndAdd(this, -decrement);
-        if (oldRef == decrement) {
-            deallocate();
-            return true;
-        } else if (oldRef < decrement || oldRef - decrement > oldRef) {
-            // Ensure we don't over-release, and avoid underflow.
-            refCntUpdater.getAndAdd(this, decrement);
-            throw new IllegalReferenceCountException(oldRef, -decrement);
+        int rawCnt = nonVolatileRawCnt();
+        for (boolean firstTry = true;; firstTry = false) {
+            if ((rawCnt & 1) != 0) {
+                throw new IllegalReferenceCountException(0, -decrement);
+            }
+            int realCnt = rawCnt >>> 1;
+            if (decrement == realCnt) {
+                // most likely case
+                if (refCntUpdater.compareAndSet(this, rawCnt, 1)) { // any odd number
+                    deallocate();
+                    return true;
+                }
+                if (!firstTry) {
+                    // this benefits throughput under high contention
+                    Thread.yield();
+                }
+            } else if (decrement < realCnt) {
+                // all changes to the raw count are 2x the "real" change
+                if (refCntUpdater.compareAndSet(this, rawCnt, rawCnt - (decrement << 1))) {
+                    return false;
+                }
+                if (!firstTry) {
+                    // this benefits throughput under high contention
+                    Thread.yield();
+                }
+            } else if (!firstTry) {
+                throw new IllegalReferenceCountException(realCnt, -decrement);
+            }
+            rawCnt = refCntUpdater.get(this);
         }
-        return false;
     }
 
     /**

--- a/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
+++ b/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
@@ -47,8 +47,8 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
         REFCNT_FIELD_OFFSET = refCntFieldOffset;
     }
 
-    private static int realRef(int refCnt) {
-        return (refCnt & 1) != 0 ? 0 : refCnt >>> 1;
+    private static int realRefCnt(int rawCnt) {
+        return (rawCnt & 1) != 0 ? 0 : rawCnt >>> 1;
     }
 
     private int nonVolatileRawCnt() {
@@ -59,14 +59,14 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
 
     @Override
     public int refCnt() {
-        return realRef(refCntUpdater.get(this));
+        return realRefCnt(refCntUpdater.get(this));
     }
 
     /**
      * An unsafe operation intended for use by a subclass that sets the reference count of the buffer directly
      */
-    protected final void setRefCnt(int refCnt) {
-        refCntUpdater.set(this, refCnt << 1); // overflow OK here
+    protected final void setRefCnt(int newRefCnt) {
+        refCntUpdater.set(this, newRefCnt << 1); // overflow OK here
     }
 
     @Override
@@ -81,17 +81,17 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
 
     private ReferenceCounted retain0(final int increment) {
         // all changes to the raw count are 2x the "real" change
-        int adjustIncrement = increment << 1; // overflow OK here
-        int oldRef = refCntUpdater.getAndAdd(this, adjustIncrement);
+        int adjustedIncrement = increment << 1; // overflow OK here
+        int oldRef = refCntUpdater.getAndAdd(this, adjustedIncrement);
         if ((oldRef & 1) != 0) {
             throw new IllegalReferenceCountException(0, increment);
         }
         // don't pass 0!
-        if ((oldRef <= 0 && oldRef + adjustIncrement >= 0)
-                || (oldRef >= 0 && oldRef + adjustIncrement < oldRef)) {
+        if ((oldRef <= 0 && oldRef + adjustedIncrement >= 0)
+                || (oldRef >= 0 && oldRef + adjustedIncrement < oldRef)) {
             // overflow case
-            refCntUpdater.getAndAdd(this, -increment);
-            throw new IllegalReferenceCountException(realRef(oldRef), increment);
+            refCntUpdater.getAndAdd(this, -adjustedIncrement);
+            throw new IllegalReferenceCountException(realRefCnt(oldRef), increment);
         }
         return this;
     }

--- a/common/src/test/java/io/netty/util/AbstractReferenceCountedTest.java
+++ b/common/src/test/java/io/netty/util/AbstractReferenceCountedTest.java
@@ -19,16 +19,12 @@ import io.netty.util.internal.ThreadLocalRandom;
 import org.junit.Test;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Motivation

#8563 highlighted race conditions introduced by the prior optimistic update optimization in 83a19d565064ee36998eb94f946e5a4264001065. These were known at the time but considered acceptable given the perf benefit in high contention scenarios.

This PR proposes a modified approach which provides roughly half the gains but stronger concurrency semantics. Race conditions still exist but their scope is narrowed to much less likely cases (releases
coinciding with retain overflow), and even in those cases certain guarantees are still assured. Once `release()` returns true, all subsequent release/retains are guaranteed to throw, and in particular `deallocate()` will be called at most once.

Modifications

- Use even numbers internally (including -ve) for live refcounts
- "Final" release changes to odd number (equivalent to refcount 0)
- Retain still uses faster `getAndAdd`, release uses CAS loop
- First CAS attempt uses non-volatile read
- `Thread.yield()` after a failed CAS appears to provide a net gain
- New tests in `AbstractReferenceCountedTest` written by @normanmaurer 

Result

More (though not completely) robust concurrency semantics for ref counting; increased latency under high contention, but still roughly twice as fast as the original logic. Bench results to follow