### PR TITLE
Remove @Deprecated from package-info.java file

### DIFF
--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/package-info.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/package-info.java
@@ -20,5 +20,4 @@
  *
  * @deprecated use NIO based SCTP implementation.
  */
-@Deprecated
 package io.netty.channel.sctp.oio;

--- a/transport/src/main/java/io/netty/channel/oio/package-info.java
+++ b/transport/src/main/java/io/netty/channel/oio/package-info.java
@@ -20,5 +20,4 @@
  *
  * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
-@Deprecated
 package io.netty.channel.oio;

--- a/transport/src/main/java/io/netty/channel/socket/oio/package-info.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/package-info.java
@@ -20,5 +20,4 @@
  *
  * @deprecated use NIO / EPOLL / KQUEUE transport.
  */
-@Deprecated
 package io.netty.channel.socket.oio;


### PR DESCRIPTION
Motivation:

31fd66b617dd6ea5a851e80338263f2866cb4c3d added @Deprecated to some classes but also to the package-info.java files. IntelliJ does not like to have these annotations on package-info.java

Modifications:

Remove annotation from package-info.java

Result:

Be able to compile against via IntelliJ