### PR TITLE
Change offset calculating formula to

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -728,8 +728,12 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         private int offsetCacheLine(ByteBuffer memory) {
             // We can only calculate the offset if Unsafe is present as otherwise directBufferAddress(...) will
             // throw an NPE.
-            return HAS_UNSAFE ?
-                    (int) (PlatformDependent.directBufferAddress(memory) & directMemoryCacheAlignmentMask) : 0;
+            int remainder = HAS_UNSAFE
+                    ? (int) (PlatformDependent.directBufferAddress(memory) & directMemoryCacheAlignmentMask)
+                    : 0;
+
+            // offset = alignment - address & (alignment - 1)
+            return directMemoryCacheAlignment - remainder;
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -725,7 +725,8 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             return true;
         }
 
-        private int offsetCacheLine(ByteBuffer memory) {
+        // mark as package-private, only for unit test
+        int offsetCacheLine(ByteBuffer memory) {
             // We can only calculate the offset if Unsafe is present as otherwise directBufferAddress(...) will
             // throw an NPE.
             int remainder = HAS_UNSAFE

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -16,9 +16,11 @@
 
 package io.netty.buffer;
 
+import io.netty.util.internal.PlatformDependent;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 
 public class PoolArenaTest {
@@ -40,6 +42,30 @@ public class PoolArenaTest {
         int[] expectedResult = {0, 64, 512, 1024, 1024, 2048};
         for (int i = 0; i < reqCapacities.length; i ++) {
             Assert.assertEquals(expectedResult[i], arena.normalizeCapacity(reqCapacities[i]));
+        }
+    }
+
+    @Test
+    public void testDirectArenaOffsetCacheLine() throws Exception {
+        int capacity = 5;
+        int alignment = 128;
+
+        for (int i = 0; i < 1000; i++) {
+            ByteBuffer bb = PlatformDependent.useDirectBufferNoCleaner()
+                    ? PlatformDependent.allocateDirectNoCleaner(capacity + alignment)
+                    : ByteBuffer.allocateDirect(capacity + alignment);
+
+            PoolArena.DirectArena arena = new PoolArena.DirectArena(null, 0, 0, 9, 9, alignment);
+            Method offsetCacheLineMethod = arena.getClass().getDeclaredMethod("offsetCacheLine", ByteBuffer.class);
+            offsetCacheLineMethod.setAccessible(true);
+
+            int offset = (Integer) offsetCacheLineMethod.invoke(arena, bb);
+
+            long address = PlatformDependent.directBufferAddress(bb);
+            int expected = alignment - (int) (address & (alignment - 1));
+
+            Assert.assertEquals(expected, offset);
+            PlatformDependent.freeDirectBuffer(bb);
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -20,7 +20,6 @@ import io.netty.util.internal.PlatformDependent;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 
 public class PoolArenaTest {
@@ -50,16 +49,13 @@ public class PoolArenaTest {
         int capacity = 5;
         int alignment = 128;
 
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 100000; i++) {
             ByteBuffer bb = PlatformDependent.useDirectBufferNoCleaner()
                     ? PlatformDependent.allocateDirectNoCleaner(capacity + alignment)
                     : ByteBuffer.allocateDirect(capacity + alignment);
 
             PoolArena.DirectArena arena = new PoolArena.DirectArena(null, 0, 0, 9, 9, alignment);
-            Method offsetCacheLineMethod = arena.getClass().getDeclaredMethod("offsetCacheLine", ByteBuffer.class);
-            offsetCacheLineMethod.setAccessible(true);
-
-            int offset = (Integer) offsetCacheLineMethod.invoke(arena, bb);
+            int offset = arena.offsetCacheLine(bb);
 
             long address = PlatformDependent.directBufferAddress(bb);
             int expected = alignment - (int) (address & (alignment - 1));

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -49,18 +49,16 @@ public class PoolArenaTest {
         int capacity = 5;
         int alignment = 128;
 
-        for (int i = 0; i < 100000; i++) {
+        for (int i = 0; i < 1000; i++) {
             ByteBuffer bb = PlatformDependent.useDirectBufferNoCleaner()
                     ? PlatformDependent.allocateDirectNoCleaner(capacity + alignment)
                     : ByteBuffer.allocateDirect(capacity + alignment);
 
             PoolArena.DirectArena arena = new PoolArena.DirectArena(null, 0, 0, 9, 9, alignment);
             int offset = arena.offsetCacheLine(bb);
-
             long address = PlatformDependent.directBufferAddress(bb);
-            int expected = alignment - (int) (address & (alignment - 1));
 
-            Assert.assertEquals(expected, offset);
+            Assert.assertEquals(0, (offset + address) & (alignment - 1));
             PlatformDependent.freeDirectBuffer(bb);
         }
     }


### PR DESCRIPTION
Motivation:

When we create new chunk with memory aligned, the offset of direct memory should be 
'alignment - address & (alignment - 1)',
not just 'address & (alignment - 1)'.

Modification:

Change offset calculating formula to 
offset = alignment - address & (alignment - 1)
in PoolArena.DirectArena#offsetCacheLine
and add a unit test to assert that.

Result:

Change offset calculating formula to 
offset = alignment - address & (alignment - 1)
in PoolArena.DirectArena#offsetCacheLine
and add a unit test to assert that.
