### PR TITLE
Set-Cookie headers should not be combined

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
@@ -22,9 +22,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.SET_COOKIE;
 import static io.netty.util.AsciiString.contentEquals;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class CombinedHttpHeadersTest {
@@ -64,6 +67,28 @@ public class CombinedHttpHeadersTest {
         otherHeaders.add(HEADER_NAME, "c");
         headers.add(otherHeaders);
         assertEquals("a,b,c", headers.get(HEADER_NAME).toString());
+    }
+
+    @Test
+    public void dontCombineSetCookieHeaders() {
+        final CombinedHttpHeaders headers = newCombinedHttpHeaders();
+        headers.add(SET_COOKIE, "a");
+        final CombinedHttpHeaders otherHeaders = newCombinedHttpHeaders();
+        otherHeaders.add(SET_COOKIE, "b");
+        otherHeaders.add(SET_COOKIE, "c");
+        headers.add(otherHeaders);
+        assertThat(headers.getAll(SET_COOKIE), hasSize(3));
+    }
+
+    @Test
+    public void dontCombineSetCookieHeadersRegardlessOfCase() {
+        final CombinedHttpHeaders headers = newCombinedHttpHeaders();
+        headers.add("Set-Cookie", "a");
+        final CombinedHttpHeaders otherHeaders = newCombinedHttpHeaders();
+        otherHeaders.add("set-cookie", "b");
+        otherHeaders.add("SET-COOKIE", "c");
+        headers.add(otherHeaders);
+        assertThat(headers.getAll(SET_COOKIE), hasSize(3));
     }
 
     @Test
@@ -275,6 +300,15 @@ public class CombinedHttpHeadersTest {
     }
 
     @Test
+    public void getAllDontCombineSetCookie() {
+        final CombinedHttpHeaders headers = newCombinedHttpHeaders();
+        headers.add(SET_COOKIE, "a");
+        headers.add(SET_COOKIE, "b");
+        assertThat(headers.getAll(SET_COOKIE), hasSize(2));
+        assertEquals(Arrays.asList("a", "b"), headers.getAll(SET_COOKIE));
+    }
+
+    @Test
     public void owsTrimming() {
         final CombinedHttpHeaders headers = newCombinedHttpHeaders();
         headers.set(HEADER_NAME, Arrays.asList("\ta", "   ", "  b ", "\t \t"));
@@ -312,6 +346,22 @@ public class CombinedHttpHeadersTest {
         assertValueIterator(headers.valueStringIterator(HEADER_NAME));
         assertFalse(headers.valueCharSequenceIterator("foo").hasNext());
         assertValueIterator(headers.valueCharSequenceIterator(HEADER_NAME));
+    }
+
+    @Test
+    public void nonCombinableHeaderIterator() {
+        final CombinedHttpHeaders headers = newCombinedHttpHeaders();
+        headers.add(SET_COOKIE, "c");
+        headers.add(SET_COOKIE, "b");
+        headers.add(SET_COOKIE, "a");
+
+        final Iterator<String> strItr = headers.valueStringIterator(SET_COOKIE);
+        assertTrue(strItr.hasNext());
+        assertEquals("a", strItr.next());
+        assertTrue(strItr.hasNext());
+        assertEquals("b", strItr.next());
+        assertTrue(strItr.hasNext());
+        assertEquals("c", strItr.next());
     }
 
     private static void assertValueIterator(Iterator<? extends CharSequence> strItr) {


### PR DESCRIPTION
Motivation:

According to the HTTP spec set-cookie headers should not be combined
because they are not using the list syntax.

Modifications:

Added a blacklist to CombinedHttpHeaders, headers in the blacklist are
not combined. The default blacklist contains Set-Cookie.

Result:

Set-Cookie headers won't be combined anymore
Fixes #6473
