### PR TITLE
Respect ctx.read() calls while processing reads for the child channel…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -446,6 +446,26 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
         return !isStreamIdValid(stream.id()) || isWritable(stream);
     }
 
+    /**
+     * The current status of the read-processing for a {@link Http2StreamChannel}.
+     */
+    private enum ReadStatus {
+        /**
+         * No read in progress and no read was requested (yet)
+         */
+        IDLE,
+
+        /**
+         * Reading in progress
+         */
+        IN_PROGRESS,
+
+        /**
+         * A read operation was requested.
+         */
+        REQUESTED
+    }
+
     // TODO: Handle writability changes due writing from outside the eventloop.
     private final class DefaultHttp2StreamChannel extends DefaultAttributeMap implements Http2StreamChannel {
         private final Http2StreamChannelConfig config = new Http2StreamChannelConfig(this);
@@ -461,13 +481,15 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
         private volatile boolean writable;
 
         private boolean outboundClosed;
+
         /**
-         * This variable represents if a read is in progress for the current channel. Note that depending upon the
-         * {@link RecvByteBufAllocator} behavior a read may extend beyond the {@link Http2ChannelUnsafe#beginRead()}
-         * method scope. The {@link Http2ChannelUnsafe#beginRead()} loop may drain all pending data, and then if the
-         * parent channel is reading this channel may still accept frames.
+         * This variable represents if a read is in progress for the current channe or was requested.
+         * Note that depending upon the {@link RecvByteBufAllocator} behavior a read may extend beyond the
+         * {@link Http2ChannelUnsafe#beginRead()} method scope. The {@link Http2ChannelUnsafe#beginRead()} loop may
+         * drain all pending data, and then if the parent channel is reading this channel may still accept frames.
          */
-        private boolean readInProgress;
+        private ReadStatus readStatus = ReadStatus.IDLE;
+
         private Queue<Object> inboundBuffer;
 
         /** {@code true} after the first HEADERS frame has been written **/
@@ -757,7 +779,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
             assert eventLoop().inEventLoop();
             if (!isActive()) {
                 ReferenceCountUtil.release(frame);
-            } else if (readInProgress) {
+            } else if (readStatus != ReadStatus.IDLE) {
                 // If readInProgress there cannot be anything in the queue, otherwise we would have drained it from the
                 // queue and processed it during the read cycle.
                 assert inboundBuffer == null || inboundBuffer.isEmpty();
@@ -783,7 +805,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
         void fireChildReadComplete() {
             assert eventLoop().inEventLoop();
-            assert readInProgress;
+            assert readStatus == ReadStatus.IN_PROGRESS;
             unsafe.notifyReadComplete(unsafe.recvBufAllocHandle());
         }
 
@@ -985,11 +1007,20 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
             @Override
             public void beginRead() {
-                if (readInProgress || !isActive()) {
+                if (!isActive()) {
                     return;
                 }
-                readInProgress = true;
-                doBeginRead();
+                switch (readStatus) {
+                    case IDLE:
+                        readStatus = ReadStatus.IN_PROGRESS;
+                        doBeginRead();
+                        break;
+                    case IN_PROGRESS:
+                        readStatus = ReadStatus.REQUESTED;
+                        break;
+                    default:
+                        break;
+                }
             }
 
             void doBeginRead() {
@@ -1026,7 +1057,11 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
             void notifyReadComplete(Handle allocHandle) {
                 assert next == null && previous == null;
-                readInProgress = false;
+                if (readStatus == ReadStatus.REQUESTED) {
+                    readStatus = ReadStatus.IN_PROGRESS;
+                } else {
+                    readStatus = ReadStatus.IDLE;
+                }
                 allocHandle.readComplete();
                 pipeline().fireChannelReadComplete();
                 // Reading data may result in frames being written (e.g. WINDOW_UPDATE, RST, etc..). If the parent


### PR DESCRIPTION
…s when using the Http2MultiplexCodec.

Motivation:

We did not correct respect ctx.read() calls while processing a read for a child Channel. This could lead to read stales when auto read is disabled and no other read was requested.

Modifications:

- Keep track of extra read() calls while processing reads
- Add unit tests that verify that read() is respected when triggered either in channelRead(...) or channelReadComplete(...)

Result:

Fixes https://github.com/netty/netty/issues/8209.