### PR TITLE
Skip test on windows as the semantics we expect are only true on Linu…

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -34,6 +34,8 @@ import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.util.UncheckedBooleanSupplier;
+import io.netty.util.internal.PlatformDependent;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -229,6 +231,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
 
     @Test
     public void testAutoCloseFalseDoesShutdownOutput() throws Throwable {
+        // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
+        Assume.assumeFalse(PlatformDependent.isWindows());
         run();
     }
 


### PR DESCRIPTION
…x / Unix / BSD / MacOS

Motivation:

In the test we assume some semantics on how RST is done that are not true for Windows so we should skip it.

Modifications:

Skip test when on windows.

Result:

Be able to run testsuite on windows. Fixes https://github.com/netty/netty/issues/8571.