### PR TITLE
Correct respect auto read configuration when using HTTP/2

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -538,13 +538,17 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         // user did not call ctx.read() and frames were decoded.
         discardSomeReadBytes();
         if (!frameListener.frameDecoded) {
-            if (!ctx.channel().config().isAutoRead()) {
-                ctx.read();
-            }
+            readIfNeeded(ctx);
         } else {
             frameListener.frameDecoded = false;
         }
         ctx.fireChannelReadComplete();
+    }
+
+    static void readIfNeeded(ChannelHandlerContext ctx) {
+        if (!ctx.channel().config().isAutoRead()) {
+            ctx.read();
+        }
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -558,17 +558,26 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
         @Override
         public void onPriorityRead(
                 ChannelHandlerContext ctx, int streamId, int streamDependency, short weight, boolean exclusive) {
+            // The user has no way to trigger a read as we not forward the frame. Trigger a read if needed.
+            readIfNeeded(ctx);
+
             // TODO: Maybe handle me
         }
 
         @Override
         public void onSettingsAckRead(ChannelHandlerContext ctx) {
+            // The user has no way to trigger a read as we not forward the frame. Trigger a read if needed.
+            readIfNeeded(ctx);
+
             // TODO: Maybe handle me
         }
 
         @Override
         public void onPushPromiseRead(
                 ChannelHandlerContext ctx, int streamId, int promisedStreamId, Http2Headers headers, int padding)  {
+            // The user has no way to trigger a read as we not forward the frame. Trigger a read if needed.
+            readIfNeeded(ctx);
+
             // TODO: Maybe handle me
         }
 
@@ -578,6 +587,12 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 throw new IllegalStateException("Stream object required for identifier: " + streamId);
             }
             return stream;
+        }
+
+        private void readIfNeeded(ChannelHandlerContext ctx) {
+            if (!ctx.channel().config().isAutoRead()) {
+                ctx.read();
+            }
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -493,9 +493,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
     @Override
     void channelReadComplete0(ChannelHandlerContext ctx) {
         if (!frameReceived) {
-            if (!ctx.channel().config().isAutoRead()) {
-                ctx.read();
-            }
+            readIfNeeded(ctx);
         } else {
             frameReceived = false;
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -391,6 +391,12 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
             // We always flush as this is what Http2ConnectionHandler does for now.
             flush0(ctx);
         }
+
+        // Let's keep on reading for now. We will need to figure out how we coordinate this with the child channels
+        // in the future.
+        if (!ctx.channel().config().isAutoRead()) {
+            ctx.read();
+        }
         channelReadComplete0(ctx);
     }
 


### PR DESCRIPTION
Motivation:

We did not correctly respect auto read when HTTP/2 is used. This was due the fact that we extended ByteToMessageDecoder but not use the out List to put decoded messages in. This lead to the situation that we will trigger a ctx.read() in channelReadComplete() as we assume we was not able to decode any data.

Modifications:

- Correctly keep track of if we were able to decode a frame and only if not trigger a read if auto read is off.
- Fix handling in Http2FrameCodec as well
- Add unit test.

Result:

Correctly respect auto read also when using HTTP2