### PR TITLE
More correct fix for using ChannelInitializer with custom EventExecutor.

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelInitializer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInitializer.java
@@ -80,8 +80,8 @@ public abstract class ChannelInitializer<C extends Channel> extends ChannelInbou
             // miss an event.
             ctx.pipeline().fireChannelRegistered();
 
-            // We are done with init the Channel, removing the initializer now.
-            remove(ctx);
+            // We are done with init the Channel, removing all the state for the Channel now.
+            removeState(ctx);
         } else {
             // Called initChannel(...) before which is the expected behavior, so just forward the event.
             ctx.fireChannelRegistered();
@@ -112,7 +112,7 @@ public abstract class ChannelInitializer<C extends Channel> extends ChannelInbou
             if (initChannel(ctx)) {
 
                 // We are done with init the Channel, removing the initializer now.
-                remove(ctx);
+                removeState(ctx);
             }
         }
     }
@@ -142,7 +142,7 @@ public abstract class ChannelInitializer<C extends Channel> extends ChannelInbou
         return false;
     }
 
-    private void remove(final ChannelHandlerContext ctx) {
+    private void removeState(final ChannelHandlerContext ctx) {
         // The removal may happen in an async fashion if the EventExecutor we use does something funky.
         if (ctx.isRemoved()) {
             initMap.remove(ctx);


### PR DESCRIPTION
Motivation:

8331248671b9c0ea07cf8dbdfa5d8d2f89fdf459 did make some changes to fix a race in ChannelInitializer when using with a custom EventExecutor. Unfortunally these where a bit racy and so the testcase failed sometimes.

Modifications:

- More correct fix when using a custom EventExecutor
- Adjust the testcase to be more correct.

Result:

Proper fix for https://github.com/netty/netty/issues/8616.