### PR TITLE
support publishing snapshots from docker based ci

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.SANOTYPE_USER}</username>
+      <password>${env.SANOTYPE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -31,6 +31,9 @@ services:
 
   shell:
     <<: *common
+    environment:
+      - SANOTYPE_USER
+      - SANOTYPE_PASSWORD
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg


### PR DESCRIPTION
motivation: automate snapshot publishing from docker based ci

changes:
* add local settings.xml with env variables for publishing to sonatype-nexus-snapshots
* pipe UID/PWD env variable in docker compose

