### PR TITLE
Fix concurrency problem

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
@@ -38,10 +38,9 @@ public class UniqueIpFilter extends AbstractRemoteAddressFilter<InetSocketAddres
     @Override
     protected boolean accept(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) throws Exception {
         final InetAddress remoteIp = remoteAddress.getAddress();
-        if (connected.contains(remoteIp)) {
+        if (!connected.add(remoteIp)) {
             return false;
         } else {
-            connected.add(remoteIp);
             ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {

--- a/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
@@ -1,0 +1,54 @@
+package io.netty.handler.ipfilter;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.internal.SocketUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.SocketAddress;
+import java.util.concurrent.*;
+
+public class UniqueIpFilterTest {
+
+    @Test
+    public void testUniqueIpFilterHandler() throws ExecutionException, InterruptedException {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        for (int round = 0; round < 10000; round++) {
+            System.out.println("round = " + round);
+            final UniqueIpFilter handler = new UniqueIpFilter();
+            java.util.concurrent.Future<EmbeddedChannel> future1 = submit(handler, barrier, executorService);
+            java.util.concurrent.Future<EmbeddedChannel> future2 = submit(handler, barrier, executorService);
+            EmbeddedChannel channel1 = future1.get();
+            EmbeddedChannel channel2 = future2.get();
+            Assert.assertTrue(channel1.isActive() || channel2.isActive());
+            Assert.assertFalse(channel1.isActive() && channel2.isActive());
+
+            barrier.reset();
+            channel1.close().await();
+            channel2.close().await();
+        }
+    }
+
+    private java.util.concurrent.Future<EmbeddedChannel> submit(final UniqueIpFilter handler, final CyclicBarrier barrier, ExecutorService executorService) {
+        return executorService.submit(new Callable<EmbeddedChannel>() {
+            @Override
+            public EmbeddedChannel call() throws Exception {
+                try {
+                    barrier.await();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } catch (BrokenBarrierException e) {
+                    e.printStackTrace();
+                }
+                return new EmbeddedChannel(handler) {
+                    @Override
+                    protected SocketAddress remoteAddress0() {
+                        return isActive() ? SocketUtils.socketAddress("91.92.93.1", 5421) : null;
+                    }
+                };
+            }
+        });
+    }
+
+}

--- a/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -32,8 +32,8 @@ public class UniqueIpFilterTest {
         try {
             for (int round = 0; round < 10000; round++) {
                 final UniqueIpFilter handler = new UniqueIpFilter();
-                java.util.concurrent.Future<EmbeddedChannel> future1 = submit(handler, barrier, executorService);
-                java.util.concurrent.Future<EmbeddedChannel> future2 = submit(handler, barrier, executorService);
+                Future<EmbeddedChannel> future1 = submit(handler, barrier, executorService);
+                Future<EmbeddedChannel> future2 = submit(handler, barrier, executorService);
                 EmbeddedChannel channel1 = future1.get();
                 EmbeddedChannel channel2 = future2.get();
                 Assert.assertTrue(channel1.isActive() || channel2.isActive());
@@ -46,10 +46,9 @@ public class UniqueIpFilterTest {
         } finally {
             executorService.shutdown();
         }
-
     }
 
-    private java.util.concurrent.Future<EmbeddedChannel> submit(final UniqueIpFilter handler, final CyclicBarrier barrier, ExecutorService executorService) {
+    private static Future<EmbeddedChannel> submit(final UniqueIpFilter handler, final CyclicBarrier barrier, ExecutorService executorService) {
         return executorService.submit(new Callable<EmbeddedChannel>() {
             @Override
             public EmbeddedChannel call() throws Exception {

--- a/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.ipfilter;
 
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -14,33 +29,31 @@ public class UniqueIpFilterTest {
     public void testUniqueIpFilterHandler() throws ExecutionException, InterruptedException {
         final CyclicBarrier barrier = new CyclicBarrier(2);
         ExecutorService executorService = Executors.newFixedThreadPool(2);
-        for (int round = 0; round < 10000; round++) {
-            System.out.println("round = " + round);
-            final UniqueIpFilter handler = new UniqueIpFilter();
-            java.util.concurrent.Future<EmbeddedChannel> future1 = submit(handler, barrier, executorService);
-            java.util.concurrent.Future<EmbeddedChannel> future2 = submit(handler, barrier, executorService);
-            EmbeddedChannel channel1 = future1.get();
-            EmbeddedChannel channel2 = future2.get();
-            Assert.assertTrue(channel1.isActive() || channel2.isActive());
-            Assert.assertFalse(channel1.isActive() && channel2.isActive());
+        try {
+            for (int round = 0; round < 10000; round++) {
+                final UniqueIpFilter handler = new UniqueIpFilter();
+                java.util.concurrent.Future<EmbeddedChannel> future1 = submit(handler, barrier, executorService);
+                java.util.concurrent.Future<EmbeddedChannel> future2 = submit(handler, barrier, executorService);
+                EmbeddedChannel channel1 = future1.get();
+                EmbeddedChannel channel2 = future2.get();
+                Assert.assertTrue(channel1.isActive() || channel2.isActive());
+                Assert.assertFalse(channel1.isActive() && channel2.isActive());
 
-            barrier.reset();
-            channel1.close().await();
-            channel2.close().await();
+                barrier.reset();
+                channel1.close().await();
+                channel2.close().await();
+            }
+        } finally {
+            executorService.shutdown();
         }
+
     }
 
     private java.util.concurrent.Future<EmbeddedChannel> submit(final UniqueIpFilter handler, final CyclicBarrier barrier, ExecutorService executorService) {
         return executorService.submit(new Callable<EmbeddedChannel>() {
             @Override
             public EmbeddedChannel call() throws Exception {
-                try {
-                    barrier.await();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                } catch (BrokenBarrierException e) {
-                    e.printStackTrace();
-                }
+                barrier.await();
                 return new EmbeddedChannel(handler) {
                     @Override
                     protected SocketAddress remoteAddress0() {


### PR DESCRIPTION
Motivation:

If two requests from the same IP are reached at the same time, `connected.contains(remoteIp)` may return false in both threads.

Modifications:

Check if there is already a connection with the same IP using return values.

Result:

Become thread safe.