### PR TITLE
Remove support for marking reader and writerIndex in ByteBuf to reduc…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -68,8 +68,6 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     int readerIndex;
     int writerIndex;
-    private int markedReaderIndex;
-    private int markedWriterIndex;
     private int maxCapacity;
 
     protected AbstractByteBuf(int maxCapacity) {
@@ -189,30 +187,6 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
-    public ByteBuf markReaderIndex() {
-        markedReaderIndex = readerIndex;
-        return this;
-    }
-
-    @Override
-    public ByteBuf resetReaderIndex() {
-        readerIndex(markedReaderIndex);
-        return this;
-    }
-
-    @Override
-    public ByteBuf markWriterIndex() {
-        markedWriterIndex = writerIndex;
-        return this;
-    }
-
-    @Override
-    public ByteBuf resetWriterIndex() {
-        writerIndex(markedWriterIndex);
-        return this;
-    }
-
-    @Override
     public ByteBuf discardReadBytes() {
         ensureAccessible();
         if (readerIndex == 0) {
@@ -222,10 +196,8 @@ public abstract class AbstractByteBuf extends ByteBuf {
         if (readerIndex != writerIndex) {
             setBytes(0, this, readerIndex, writerIndex - readerIndex);
             writerIndex -= readerIndex;
-            adjustMarkers(readerIndex);
             readerIndex = 0;
         } else {
-            adjustMarkers(readerIndex);
             writerIndex = readerIndex = 0;
         }
         return this;
@@ -239,7 +211,6 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
 
         if (readerIndex == writerIndex) {
-            adjustMarkers(readerIndex);
             writerIndex = readerIndex = 0;
             return this;
         }
@@ -247,26 +218,9 @@ public abstract class AbstractByteBuf extends ByteBuf {
         if (readerIndex >= capacity() >>> 1) {
             setBytes(0, this, readerIndex, writerIndex - readerIndex);
             writerIndex -= readerIndex;
-            adjustMarkers(readerIndex);
             readerIndex = 0;
         }
         return this;
-    }
-
-    protected final void adjustMarkers(int decrement) {
-        int markedReaderIndex = this.markedReaderIndex;
-        if (markedReaderIndex <= decrement) {
-            this.markedReaderIndex = 0;
-            int markedWriterIndex = this.markedWriterIndex;
-            if (markedWriterIndex <= decrement) {
-                this.markedWriterIndex = 0;
-            } else {
-                this.markedWriterIndex = markedWriterIndex - decrement;
-            }
-        } else {
-            this.markedReaderIndex = markedReaderIndex - decrement;
-            markedWriterIndex -= decrement;
-        }
     }
 
     @Override
@@ -1462,9 +1416,5 @@ public abstract class AbstractByteBuf extends ByteBuf {
     final void setIndex0(int readerIndex, int writerIndex) {
         this.readerIndex = readerIndex;
         this.writerIndex = writerIndex;
-    }
-
-    final void discardMarks() {
-        markedReaderIndex = markedWriterIndex = 0;
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -183,15 +183,6 @@ import java.nio.charset.UnsupportedCharsetException;
  * For complicated searches, use {@link #forEachByte(int, int, ByteProcessor)} with a {@link ByteProcessor}
  * implementation.
  *
- * <h3>Mark and reset</h3>
- *
- * There are two marker indexes in every buffer. One is for storing
- * {@link #readerIndex() readerIndex} and the other is for storing
- * {@link #writerIndex() writerIndex}.  You can always reposition one of the
- * two indexes by calling a reset method.  It works in a similar fashion to
- * the mark and reset methods in {@link InputStream} except that there's no
- * {@code readlimit}.
- *
  * <h3>Derived buffers</h3>
  *
  * You can create a view of an existing buffer by calling one of the following methods:
@@ -206,7 +197,7 @@ import java.nio.charset.UnsupportedCharsetException;
  *   <li>{@link #readRetainedSlice(int)}</li>
  * </ul>
  * A derived buffer will have an independent {@link #readerIndex() readerIndex},
- * {@link #writerIndex() writerIndex} and marker indexes, while it shares
+ * {@link #writerIndex() writerIndex}, while it shares
  * other internal data representation, just like a NIO buffer does.
  * <p>
  * In case a completely fresh copy of an existing buffer is required, please
@@ -286,8 +277,8 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
 
     /**
      * Returns a buffer with the specified {@code endianness} which shares the whole region,
-     * indexes, and marks of this buffer.  Modifying the content, the indexes, or the marks of the
-     * returned buffer or this buffer affects each other's content, indexes, and marks.  If the
+     * indexes of this buffer.  Modifying the content, the indexes of the
+     * returned buffer or this buffer affects each other's content, and indexes. If the
      * specified {@code endianness} is identical to this buffer's byte order, this method can
      * return {@code this}.  This method does not modify {@code readerIndex} or {@code writerIndex}
      * of this buffer.
@@ -457,42 +448,6 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * the {@code capacity} of the buffer.
      */
     public abstract ByteBuf clear();
-
-    /**
-     * Marks the current {@code readerIndex} in this buffer.  You can
-     * reposition the current {@code readerIndex} to the marked
-     * {@code readerIndex} by calling {@link #resetReaderIndex()}.
-     * The initial value of the marked {@code readerIndex} is {@code 0}.
-     */
-    public abstract ByteBuf markReaderIndex();
-
-    /**
-     * Repositions the current {@code readerIndex} to the marked
-     * {@code readerIndex} in this buffer.
-     *
-     * @throws IndexOutOfBoundsException
-     *         if the current {@code writerIndex} is less than the marked
-     *         {@code readerIndex}
-     */
-    public abstract ByteBuf resetReaderIndex();
-
-    /**
-     * Marks the current {@code writerIndex} in this buffer.  You can
-     * reposition the current {@code writerIndex} to the marked
-     * {@code writerIndex} by calling {@link #resetWriterIndex()}.
-     * The initial value of the marked {@code writerIndex} is {@code 0}.
-     */
-    public abstract ByteBuf markWriterIndex();
-
-    /**
-     * Repositions the current {@code writerIndex} to the marked
-     * {@code writerIndex} in this buffer.
-     *
-     * @throws IndexOutOfBoundsException
-     *         if the current {@code readerIndex} is greater than the marked
-     *         {@code writerIndex}
-     */
-    public abstract ByteBuf resetWriterIndex();
 
     /**
      * Discards the bytes between the 0th index and {@code readerIndex}.
@@ -2186,7 +2141,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Returns a slice of this buffer's readable bytes. Modifying the content
      * of the returned buffer or this buffer affects each other's content
-     * while they maintain separate indexes and marks.  This method is
+     * while they maintain separate indexes.  This method is
      * identical to {@code buf.slice(buf.readerIndex(), buf.readableBytes())}.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
      * this buffer.
@@ -2199,7 +2154,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Returns a retained slice of this buffer's readable bytes. Modifying the content
      * of the returned buffer or this buffer affects each other's content
-     * while they maintain separate indexes and marks.  This method is
+     * while they maintain separate indexes.  This method is
      * identical to {@code buf.slice(buf.readerIndex(), buf.readableBytes())}.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
      * this buffer.
@@ -2213,7 +2168,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Returns a slice of this buffer's sub-region. Modifying the content of
      * the returned buffer or this buffer affects each other's content while
-     * they maintain separate indexes and marks.
+     * they maintain separate indexes.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
      * this buffer.
      * <p>
@@ -2225,7 +2180,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Returns a retained slice of this buffer's sub-region. Modifying the content of
      * the returned buffer or this buffer affects each other's content while
-     * they maintain separate indexes and marks.
+     * they maintain separate indexes.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
      * this buffer.
      * <p>
@@ -2238,11 +2193,11 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Returns a buffer which shares the whole region of this buffer.
      * Modifying the content of the returned buffer or this buffer affects
-     * each other's content while they maintain separate indexes and marks.
+     * each other's content while they maintain separate indexes.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
      * this buffer.
      * <p>
-     * The reader and writer marks will not be duplicated. Also be aware that this method will
+     * Be aware that this method will
      * NOT call {@link #retain()} and so the reference count will NOT be increased.
      * @return A buffer whose readable content is equivalent to the buffer returned by {@link #slice()}.
      * However this buffer will share the capacity of the underlying buffer, and therefore allows access to all of the
@@ -2253,7 +2208,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Returns a retained buffer which shares the whole region of this buffer.
      * Modifying the content of the returned buffer or this buffer affects
-     * each other's content while they maintain separate indexes and marks.
+     * each other's content while they maintain separate indexes.
      * This method is identical to {@code buf.slice(0, buf.capacity())}.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
      * this buffer.
@@ -2282,7 +2237,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Exposes this buffer's readable bytes as an NIO {@link ByteBuffer}. The returned buffer
      * either share or contains the copied content of this buffer, while changing the position
-     * and limit of the returned NIO buffer does not affect the indexes and marks of this buffer.
+     * and limit of the returned NIO buffer does not affect the indexes of this buffer.
      * This method is identical to {@code buf.nioBuffer(buf.readerIndex(), buf.readableBytes())}.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of this buffer.
      * Please note that the returned NIO buffer will not see the changes of this buffer if this buffer
@@ -2300,7 +2255,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Exposes this buffer's sub-region as an NIO {@link ByteBuffer}. The returned buffer
      * either share or contains the copied content of this buffer, while changing the position
-     * and limit of the returned NIO buffer does not affect the indexes and marks of this buffer.
+     * and limit of the returned NIO buffer does not affect the indexes of this buffer.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of this buffer.
      * Please note that the returned NIO buffer will not see the changes of this buffer if this buffer
      * is a dynamic buffer and it adjusted its capacity.
@@ -2322,7 +2277,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Exposes this buffer's readable bytes as an NIO {@link ByteBuffer}'s. The returned buffer
      * either share or contains the copied content of this buffer, while changing the position
-     * and limit of the returned NIO buffer does not affect the indexes and marks of this buffer.
+     * and limit of the returned NIO buffer does not affect the indexes of this buffer.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of this buffer.
      * Please note that the returned NIO buffer will not see the changes of this buffer if this buffer
      * is a dynamic buffer and it adjusted its capacity.
@@ -2340,7 +2295,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Exposes this buffer's bytes as an NIO {@link ByteBuffer}'s for the specified index and length
      * The returned buffer either share or contains the copied content of this buffer, while changing
-     * the position and limit of the returned NIO buffer does not affect the indexes and marks of this buffer.
+     * the position and limit of the returned NIO buffer does not affect the indexes of this buffer.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of this buffer. Please note that the
      * returned NIO buffer will not see the changes of this buffer if this buffer is a dynamic
      * buffer and it adjusted its capacity.

--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -45,6 +45,8 @@ public class ByteBufInputStream extends InputStream implements DataInput {
     private final int startIndex;
     private final int endIndex;
     private boolean closed;
+    private int markReaderIndex;
+
     /**
      * To preserve backwards compatibility (which didn't transfer ownership) we support a conditional flag which
      * indicates if {@link #buffer} should be released when this {@link InputStream} is closed.
@@ -123,7 +125,7 @@ public class ByteBufInputStream extends InputStream implements DataInput {
         this.buffer = buffer;
         startIndex = buffer.readerIndex();
         endIndex = startIndex + length;
-        buffer.markReaderIndex();
+        markReaderIndex = startIndex;
     }
 
     /**
@@ -153,7 +155,7 @@ public class ByteBufInputStream extends InputStream implements DataInput {
 
     @Override
     public void mark(int readlimit) {
-        buffer.markReaderIndex();
+        markReaderIndex = buffer.readerIndex();
     }
 
     @Override
@@ -183,7 +185,7 @@ public class ByteBufInputStream extends InputStream implements DataInput {
 
     @Override
     public void reset() throws IOException {
-        buffer.resetReaderIndex();
+        buffer.readerIndex(markReaderIndex);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1681,7 +1681,6 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
             lastAccessed = null;
             clearComps();
             setIndex(0, 0);
-            adjustMarkers(readerIndex);
             return this;
         }
 
@@ -1698,7 +1697,6 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         int offset = first.offset;
         updateComponentOffsets(0);
         setIndex(readerIndex - offset, writerIndex - offset);
-        adjustMarkers(offset);
         return this;
     }
 
@@ -1719,7 +1717,6 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
             lastAccessed = null;
             clearComps();
             setIndex(0, 0);
-            adjustMarkers(readerIndex);
             return this;
         }
 
@@ -1754,7 +1751,6 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         // Update indexes and markers.
         updateComponentOffsets(0);
         setIndex(0, writerIndex - readerIndex);
-        adjustMarkers(readerIndex);
         return this;
     }
 
@@ -1849,30 +1845,6 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     @Override
     public CompositeByteBuf clear() {
         super.clear();
-        return this;
-    }
-
-    @Override
-    public CompositeByteBuf markReaderIndex() {
-        super.markReaderIndex();
-        return this;
-    }
-
-    @Override
-    public CompositeByteBuf resetReaderIndex() {
-        super.resetReaderIndex();
-        return this;
-    }
-
-    @Override
-    public CompositeByteBuf markWriterIndex() {
-        super.markWriterIndex();
-        return this;
-    }
-
-    @Override
-    public CompositeByteBuf resetWriterIndex() {
-        super.resetWriterIndex();
         return this;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
@@ -54,8 +54,6 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
         }
 
         setIndex(readerIndex, writerIndex);
-        markReaderIndex();
-        markWriterIndex();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -192,26 +192,6 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
-    public ByteBuf markReaderIndex() {
-        return this;
-    }
-
-    @Override
-    public ByteBuf resetReaderIndex() {
-        return this;
-    }
-
-    @Override
-    public ByteBuf markWriterIndex() {
-        return this;
-    }
-
-    @Override
-    public ByteBuf resetWriterIndex() {
-        return this;
-    }
-
-    @Override
     public ByteBuf discardReadBytes() {
         return this;
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -74,7 +74,6 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         maxCapacity(maxCapacity);
         setRefCnt(1);
         setIndex0(0, 0);
-        discardMarks();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/PooledDuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDuplicatedByteBuf.java
@@ -41,9 +41,6 @@ final class PooledDuplicatedByteBuf extends AbstractPooledDerivedByteBuf {
                                                int readerIndex, int writerIndex) {
         final PooledDuplicatedByteBuf duplicate = RECYCLER.get();
         duplicate.init(unwrapped, wrapped, readerIndex, writerIndex, unwrapped.maxCapacity());
-        duplicate.markReaderIndex();
-        duplicate.markWriterIndex();
-
         return duplicate;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
@@ -49,7 +49,6 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
                                                     int adjustment, int length) {
         final PooledSlicedByteBuf slice = RECYCLER.get();
         slice.init(unwrapped, wrapped, 0, length, length);
-        slice.discardMarks();
         slice.adjustment = adjustment;
 
         return slice;

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -178,30 +178,6 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
-    public ByteBuf markReaderIndex() {
-        buf.markReaderIndex();
-        return this;
-    }
-
-    @Override
-    public ByteBuf resetReaderIndex() {
-        buf.resetReaderIndex();
-        return this;
-    }
-
-    @Override
-    public ByteBuf markWriterIndex() {
-        buf.markWriterIndex();
-        return this;
-    }
-
-    @Override
-    public ByteBuf resetWriterIndex() {
-        buf.resetWriterIndex();
-        return this;
-    }
-
-    @Override
     public ByteBuf discardReadBytes() {
         buf.discardReadBytes();
         return this;

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -168,30 +168,6 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
-    public final ByteBuf markReaderIndex() {
-        buf.markReaderIndex();
-        return this;
-    }
-
-    @Override
-    public final ByteBuf resetReaderIndex() {
-        buf.resetReaderIndex();
-        return this;
-    }
-
-    @Override
-    public final ByteBuf markWriterIndex() {
-        buf.markWriterIndex();
-        return this;
-    }
-
-    @Override
-    public final ByteBuf resetWriterIndex() {
-        buf.resetWriterIndex();
-        return this;
-    }
-
-    @Override
     public ByteBuf discardReadBytes() {
         buf.discardReadBytes();
         return this;

--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -922,30 +922,6 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
-    public final CompositeByteBuf markReaderIndex() {
-        wrapped.markReaderIndex();
-        return this;
-    }
-
-    @Override
-    public final CompositeByteBuf resetReaderIndex() {
-        wrapped.resetReaderIndex();
-        return this;
-    }
-
-    @Override
-    public final CompositeByteBuf markWriterIndex() {
-        wrapped.markWriterIndex();
-        return this;
-    }
-
-    @Override
-    public final CompositeByteBuf resetWriterIndex() {
-        wrapped.resetWriterIndex();
-        return this;
-    }
-
-    @Override
     public CompositeByteBuf ensureWritable(int minWritableBytes) {
         wrapped.ensureWritable(minWritableBytes);
         return this;

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -1775,9 +1775,9 @@ public abstract class AbstractByteBufTest {
 
         // Make sure there's no effect if called when readerIndex is 0.
         buffer.readerIndex(CAPACITY / 4);
-        buffer.markReaderIndex();
+        int readerIndex = buffer.readerIndex();
         buffer.writerIndex(CAPACITY / 3);
-        buffer.markWriterIndex();
+        int writerIndex = buffer.writerIndex();
         buffer.readerIndex(0);
         buffer.writerIndex(CAPACITY / 2);
         buffer.discardReadBytes();
@@ -1785,9 +1785,9 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, buffer.readerIndex());
         assertEquals(CAPACITY / 2, buffer.writerIndex());
         assertEquals(copy.slice(0, CAPACITY / 2), buffer.slice(0, CAPACITY / 2));
-        buffer.resetReaderIndex();
+        buffer.readerIndex(readerIndex);
         assertEquals(CAPACITY / 4, buffer.readerIndex());
-        buffer.resetWriterIndex();
+        buffer.writerIndex(writerIndex);
         assertEquals(CAPACITY / 3, buffer.writerIndex());
 
         // Make sure bytes after writerIndex is not copied.
@@ -1806,11 +1806,6 @@ public abstract class AbstractByteBufTest {
             assertEquals(copy.slice(CAPACITY / 2, CAPACITY / 2), buffer.slice(CAPACITY / 2 - 1, CAPACITY / 2));
         }
 
-        // Marks also should be relocated.
-        buffer.resetReaderIndex();
-        assertEquals(CAPACITY / 4 - 1, buffer.readerIndex());
-        buffer.resetWriterIndex();
-        assertEquals(CAPACITY / 3 - 1, buffer.writerIndex());
         copy.release();
     }
 
@@ -3742,11 +3737,11 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testRetainedSliceAndRetainedDuplicateContentIsExpected() {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
-        ByteBuf expected1 = newBuffer(6).resetWriterIndex();
-        ByteBuf expected2 = newBuffer(5).resetWriterIndex();
-        ByteBuf expected3 = newBuffer(4).resetWriterIndex();
-        ByteBuf expected4 = newBuffer(3).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
+        ByteBuf expected1 = newBuffer(6).writerIndex(0);
+        ByteBuf expected2 = newBuffer(5).writerIndex(0);
+        ByteBuf expected3 = newBuffer(4).writerIndex(0);
+        ByteBuf expected4 = newBuffer(3).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected1.writeBytes(new byte[] {2, 3, 4, 5, 6, 7});
         expected2.writeBytes(new byte[] {3, 4, 5, 6, 7});
@@ -3805,10 +3800,10 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testRetainedDuplicateAndRetainedSliceContentIsExpected() {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
-        ByteBuf expected1 = newBuffer(6).resetWriterIndex();
-        ByteBuf expected2 = newBuffer(5).resetWriterIndex();
-        ByteBuf expected3 = newBuffer(4).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
+        ByteBuf expected1 = newBuffer(6).writerIndex(0);
+        ByteBuf expected2 = newBuffer(5).writerIndex(0);
+        ByteBuf expected3 = newBuffer(4).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected1.writeBytes(new byte[] {2, 3, 4, 5, 6, 7});
         expected2.writeBytes(new byte[] {3, 4, 5, 6, 7});
@@ -4157,8 +4152,8 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testSliceContents(boolean retainedSlice) {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
-        ByteBuf expected = newBuffer(3).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
+        ByteBuf expected = newBuffer(3).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected.writeBytes(new byte[] {4, 5, 6});
         ByteBuf slice = retainedSlice ? buf.retainedSlice(buf.readerIndex() + 3, 3)
@@ -4180,9 +4175,9 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testSliceReleaseOriginal(boolean retainedSlice1, boolean retainedSlice2) {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
-        ByteBuf expected1 = newBuffer(3).resetWriterIndex();
-        ByteBuf expected2 = newBuffer(2).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
+        ByteBuf expected1 = newBuffer(3).writerIndex(0);
+        ByteBuf expected2 = newBuffer(2).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected1.writeBytes(new byte[] {6, 7, 8});
         expected2.writeBytes(new byte[] {7, 8});
@@ -4214,12 +4209,12 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testMultipleLevelRetainedSliceWithNonRetained(boolean doSlice1, boolean doSlice2) {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
-        ByteBuf expected1 = newBuffer(6).resetWriterIndex();
-        ByteBuf expected2 = newBuffer(4).resetWriterIndex();
-        ByteBuf expected3 = newBuffer(2).resetWriterIndex();
-        ByteBuf expected4SliceSlice = newBuffer(1).resetWriterIndex();
-        ByteBuf expected4DupSlice = newBuffer(1).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
+        ByteBuf expected1 = newBuffer(6).writerIndex(0);
+        ByteBuf expected2 = newBuffer(4).writerIndex(0);
+        ByteBuf expected3 = newBuffer(2).writerIndex(0);
+        ByteBuf expected4SliceSlice = newBuffer(1).writerIndex(0);
+        ByteBuf expected4DupSlice = newBuffer(1).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected1.writeBytes(new byte[] {2, 3, 4, 5, 6, 7});
         expected2.writeBytes(new byte[] {3, 4, 5, 6});
@@ -4284,8 +4279,8 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testDuplicateReleaseOriginal(boolean retainedDuplicate1, boolean retainedDuplicate2) {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
-        ByteBuf expected = newBuffer(8).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
+        ByteBuf expected = newBuffer(8).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected.writeBytes(buf, buf.readerIndex(), buf.readableBytes());
         ByteBuf dup1 = retainedDuplicate1 ? buf.retainedDuplicate()
@@ -4315,10 +4310,10 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testMultipleRetainedSliceReleaseOriginal(boolean retainedSlice1, boolean retainedSlice2) {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
-        ByteBuf expected1 = newBuffer(3).resetWriterIndex();
-        ByteBuf expected2 = newBuffer(2).resetWriterIndex();
-        ByteBuf expected3 = newBuffer(2).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
+        ByteBuf expected1 = newBuffer(3).writerIndex(0);
+        ByteBuf expected2 = newBuffer(2).writerIndex(0);
+        ByteBuf expected3 = newBuffer(2).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected1.writeBytes(new byte[] {6, 7, 8});
         expected2.writeBytes(new byte[] {7, 8});
@@ -4359,8 +4354,8 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testMultipleRetainedDuplicateReleaseOriginal(boolean retainedDuplicate1, boolean retainedDuplicate2) {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
-        ByteBuf expected = newBuffer(8).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
+        ByteBuf expected = newBuffer(8).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected.writeBytes(buf, buf.readerIndex(), buf.readableBytes());
         ByteBuf dup1 = retainedDuplicate1 ? buf.retainedDuplicate()
@@ -4406,7 +4401,7 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testDuplicateContents(boolean retainedDuplicate) {
-        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).writerIndex(0);
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         ByteBuf dup = retainedDuplicate ? buf.retainedDuplicate() : buf.duplicate();
         try {
@@ -4497,9 +4492,7 @@ public abstract class AbstractByteBufTest {
 
             byte[] bytes = {'a', 'b', 'c', 'd'};
             int len = bytes.length;
-            ByteBuf buffer = newBuffer(len);
-            buffer.resetReaderIndex();
-            buffer.resetWriterIndex();
+            ByteBuf buffer = newBuffer(len).writerIndex(0);
             buffer.writeBytes(bytes);
 
             int oldReaderIndex = buffer.readerIndex();
@@ -4507,9 +4500,7 @@ public abstract class AbstractByteBufTest {
             assertEquals(oldReaderIndex + len, buffer.readerIndex());
             assertEquals(channelPosition, channel.position());
 
-            ByteBuf buffer2 = newBuffer(len);
-            buffer2.resetReaderIndex();
-            buffer2.resetWriterIndex();
+            ByteBuf buffer2 = newBuffer(len).writerIndex(0);
             int oldWriterIndex = buffer2.writerIndex();
             assertEquals(len, buffer2.writeBytes(channel, 10, len));
             assertEquals(channelPosition, channel.position());
@@ -4540,9 +4531,7 @@ public abstract class AbstractByteBufTest {
 
             byte[] bytes = {'a', 'b', 'c', 'd'};
             int len = bytes.length;
-            ByteBuf buffer = newBuffer(len);
-            buffer.resetReaderIndex();
-            buffer.resetWriterIndex();
+            ByteBuf buffer = newBuffer(len).writerIndex(0);
             buffer.writeBytes(bytes);
 
             int oldReaderIndex = buffer.readerIndex();
@@ -4550,9 +4539,7 @@ public abstract class AbstractByteBufTest {
             assertEquals(oldReaderIndex, buffer.readerIndex());
             assertEquals(channelPosition, channel.position());
 
-            ByteBuf buffer2 = newBuffer(len);
-            buffer2.resetReaderIndex();
-            buffer2.resetWriterIndex();
+            ByteBuf buffer2 = newBuffer(len).writerIndex(0);
             int oldWriterIndex = buffer2.writerIndex();
             assertEquals(buffer2.setBytes(oldWriterIndex, channel, 10, len), len);
             assertEquals(channelPosition, channel.position());
@@ -4866,14 +4853,13 @@ public abstract class AbstractByteBufTest {
         ByteBuf buffer = newBuffer(length);
         buffer.setIndex(0, 0);
         buffer.writeCharSequence(content1, CharsetUtil.US_ASCII);
-        buffer.markWriterIndex();
         buffer.skipBytes(content1.length());
         buffer.writeCharSequence(content2, CharsetUtil.US_ASCII);
         buffer.skipBytes(content2.length());
         assertTrue(buffer.readerIndex() <= buffer.writerIndex());
 
         try {
-            buffer.resetWriterIndex();
+            buffer.readerIndex(buffer.writerIndex() + 1);
         } finally {
             buffer.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -143,17 +143,13 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
                 wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 0, 5).order(order),
                 wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 5, 5).order(order));
         a.skipBytes(6);
-        a.markReaderIndex();
         b.skipBytes(6);
-        b.markReaderIndex();
         assertEquals(a.readerIndex(), b.readerIndex());
         a.readerIndex(a.readerIndex() - 1);
         b.readerIndex(b.readerIndex() - 1);
         assertEquals(a.readerIndex(), b.readerIndex());
         a.writerIndex(a.writerIndex() - 1);
-        a.markWriterIndex();
         b.writerIndex(b.writerIndex() - 1);
-        b.markWriterIndex();
         assertEquals(a.writerIndex(), b.writerIndex());
         a.writerIndex(a.writerIndex() + 1);
         b.writerIndex(b.writerIndex() + 1);
@@ -165,12 +161,6 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertEquals(a.readerIndex(), b.readerIndex());
         assertEquals(a.writerIndex(), b.writerIndex());
         assertTrue(ByteBufUtil.equals(a, b));
-        a.resetReaderIndex();
-        b.resetReaderIndex();
-        assertEquals(a.readerIndex(), b.readerIndex());
-        a.resetWriterIndex();
-        b.resetWriterIndex();
-        assertEquals(a.writerIndex(), b.writerIndex());
         assertTrue(ByteBufUtil.equals(a, b));
 
         a.release();

--- a/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
@@ -31,11 +31,7 @@ public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
     protected ByteBuf newBuffer(int length, int maxCapacity) {
         ByteBuf buffer = alloc(length, maxCapacity);
 
-        // Testing if the writerIndex and readerIndex are correct when allocate and also after we reset the mark.
-        assertEquals(0, buffer.writerIndex());
-        assertEquals(0, buffer.readerIndex());
-        buffer.resetReaderIndex();
-        buffer.resetWriterIndex();
+        // Testing if the writerIndex and readerIndex are correct when allocate.
         assertEquals(0, buffer.writerIndex());
         assertEquals(0, buffer.readerIndex());
         return buffer;

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -142,14 +142,14 @@ public class ByteBufUtilTest {
         ByteBuf buf = Unpooled.buffer(2).order(ByteOrder.BIG_ENDIAN);
         ByteBufUtil.writeShortBE(buf, expected);
         assertEquals(expected, buf.readShort());
-        buf.resetReaderIndex();
+        buf.readerIndex(0);
         assertEquals(ByteBufUtil.swapShort((short) expected), buf.readShortLE());
         buf.release();
 
         buf = Unpooled.buffer(2).order(ByteOrder.LITTLE_ENDIAN);
         ByteBufUtil.writeShortBE(buf, expected);
         assertEquals((short) expected, buf.readShortLE());
-        buf.resetReaderIndex();
+        buf.readerIndex(0);
         assertEquals(ByteBufUtil.swapShort((short) expected), buf.readShort());
         buf.release();
     }
@@ -162,14 +162,14 @@ public class ByteBufUtilTest {
         ByteBuf buf = Unpooled.wrappedBuffer(new byte[2]).order(ByteOrder.BIG_ENDIAN);
         ByteBufUtil.setShortBE(buf, 0, shortValue);
         assertEquals(shortValue, buf.readShort());
-        buf.resetReaderIndex();
+        buf.readerIndex(0);
         assertEquals(ByteBufUtil.swapShort((short) shortValue), buf.readShortLE());
         buf.release();
 
         buf = Unpooled.wrappedBuffer(new byte[2]).order(ByteOrder.LITTLE_ENDIAN);
         ByteBufUtil.setShortBE(buf, 0, shortValue);
         assertEquals((short) shortValue, buf.readShortLE());
-        buf.resetReaderIndex();
+        buf.readerIndex(0);
         assertEquals(ByteBufUtil.swapShort((short) shortValue), buf.readShort());
         buf.release();
     }
@@ -182,14 +182,14 @@ public class ByteBufUtilTest {
         ByteBuf buf = Unpooled.buffer(4).order(ByteOrder.BIG_ENDIAN);
         ByteBufUtil.writeMediumBE(buf, mediumValue);
         assertEquals(mediumValue, buf.readMedium());
-        buf.resetReaderIndex();
+        buf.readerIndex(0);
         assertEquals(ByteBufUtil.swapMedium(mediumValue), buf.readMediumLE());
         buf.release();
 
         buf = Unpooled.buffer(4).order(ByteOrder.LITTLE_ENDIAN);
         ByteBufUtil.writeMediumBE(buf, mediumValue);
         assertEquals(mediumValue, buf.readMediumLE());
-        buf.resetReaderIndex();
+        buf.readerIndex(0);
         assertEquals(ByteBufUtil.swapMedium(mediumValue), buf.readMedium());
         buf.release();
     }

--- a/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
@@ -50,26 +50,4 @@ public class DuplicatedByteBufTest extends AbstractByteBufTest {
 
         assertEquals((byte) 0, buffer.readByte());
     }
-
-    @Test
-    public void testMarksInitialized() {
-        ByteBuf wrapped = Unpooled.buffer(8);
-        try {
-            wrapped.writerIndex(6);
-            wrapped.readerIndex(1);
-            ByteBuf duplicate = new DuplicatedByteBuf(wrapped);
-
-            // Test writer mark
-            duplicate.writerIndex(duplicate.writerIndex() + 1);
-            duplicate.resetWriterIndex();
-            assertEquals(wrapped.writerIndex(), duplicate.writerIndex());
-
-            // Test reader mark
-            duplicate.readerIndex(duplicate.readerIndex() + 1);
-            duplicate.resetReaderIndex();
-            assertEquals(wrapped.readerIndex(), duplicate.readerIndex());
-        } finally {
-            wrapped.release();
-        }
-    }
 }

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -147,23 +147,21 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
     }
 
     @Test
-    public void testReaderIndexAndMarks() {
+    public void testReaderIndex() {
         ByteBuf wrapped = Unpooled.buffer(16);
         try {
             wrapped.writerIndex(14);
             wrapped.readerIndex(2);
-            wrapped.markWriterIndex();
-            wrapped.markReaderIndex();
             ByteBuf slice = wrapped.slice(4, 4);
             assertEquals(0, slice.readerIndex());
             assertEquals(4, slice.writerIndex());
 
             slice.readerIndex(slice.readerIndex() + 1);
-            slice.resetReaderIndex();
+            slice.readerIndex(0);
             assertEquals(0, slice.readerIndex());
 
             slice.writerIndex(slice.writerIndex() - 1);
-            slice.resetWriterIndex();
+            slice.writerIndex(0);
             assertEquals(0, slice.writerIndex());
         } finally {
             wrapped.release();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
@@ -41,8 +41,8 @@ public class HttpRequestEncoderTest {
         return new ByteBuf[]{
                 Unpooled.buffer(128).order(ByteOrder.BIG_ENDIAN),
                 Unpooled.buffer(128).order(ByteOrder.LITTLE_ENDIAN),
-                Unpooled.wrappedBuffer(ByteBuffer.allocate(128).order(ByteOrder.BIG_ENDIAN)).resetWriterIndex(),
-                Unpooled.wrappedBuffer(ByteBuffer.allocate(128).order(ByteOrder.LITTLE_ENDIAN)).resetWriterIndex()
+                Unpooled.wrappedBuffer(ByteBuffer.allocate(128).order(ByteOrder.BIG_ENDIAN)).writerIndex(0),
+                Unpooled.wrappedBuffer(ByteBuffer.allocate(128).order(ByteOrder.LITTLE_ENDIAN)).writerIndex(0)
         };
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -255,7 +255,7 @@ public class DataCompressionHttp2Test {
                 }
             });
             awaitServer();
-            assertEquals(data.resetReaderIndex().toString(CharsetUtil.UTF_8),
+            assertEquals(data.readerIndex(0).toString(CharsetUtil.UTF_8),
                     serverOut.toString(CharsetUtil.UTF_8.name()));
         } finally {
             data.release();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilderTest.java
@@ -200,7 +200,7 @@ public class Http2MultiplexCodecBuilderTest {
         Http2DataFrame dataFrame = serverLastInboundHandler.blockingReadInbound();
         assertNotNull(dataFrame);
         assertEquals(3, dataFrame.stream().id());
-        assertEquals(data.resetReaderIndex(), dataFrame.content());
+        assertEquals(data.readerIndex(0), dataFrame.content());
         assertTrue(dataFrame.isEndStream());
         dataFrame.release();
 

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
@@ -89,7 +89,7 @@ public class SocksCmdRequestTest {
         ByteBuf buffer = Unpooled.buffer(16);
         rq.encodeAsByteBuf(buffer);
 
-        buffer.resetReaderIndex();
+        buffer.readerIndex(0);
         assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());
         assertEquals(SocksCmdType.BIND.byteValue(), buffer.readByte());
         assertEquals((byte) 0x00, buffer.readByte());
@@ -111,7 +111,7 @@ public class SocksCmdRequestTest {
         ByteBuf buffer = Unpooled.buffer(24);
         rq.encodeAsByteBuf(buffer);
 
-        buffer.resetReaderIndex();
+        buffer.readerIndex(0);
         assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());
         assertEquals(SocksCmdType.BIND.byteValue(), buffer.readByte());
         assertEquals((byte) 0x00, buffer.readByte());

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdResponseTest.java
@@ -123,7 +123,7 @@ public class SocksCmdResponseTest {
         ByteBuf buffer = Unpooled.buffer(16);
         rs.encodeAsByteBuf(buffer);
 
-        buffer.resetReaderIndex();
+        buffer.readerIndex(0);
         assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());
         assertEquals(SocksCmdStatus.SUCCESS.byteValue(), buffer.readByte());
         assertEquals((byte) 0x00, buffer.readByte());
@@ -145,7 +145,7 @@ public class SocksCmdResponseTest {
         ByteBuf buffer = Unpooled.buffer(24);
         rs.encodeAsByteBuf(buffer);
 
-        buffer.resetReaderIndex();
+        buffer.readerIndex(0);
         assertEquals(SocksProtocolVersion.SOCKS5.byteValue(), buffer.readByte());
         assertEquals(SocksCmdStatus.SUCCESS.byteValue(), buffer.readByte());
         assertEquals((byte) 0x00, buffer.readByte());

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
@@ -58,7 +58,7 @@ public class StompSubframeEncoderTest {
         aggregatedBuffer.writeBytes(byteBuf);
         byteBuf.release();
 
-        aggregatedBuffer.resetReaderIndex();
+        aggregatedBuffer.readerIndex(0);
         String content = aggregatedBuffer.toString(CharsetUtil.UTF_8);
         assertEquals(StompTestConstants.CONNECT_FRAME, content);
         aggregatedBuffer.release();

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -455,17 +455,6 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
-    public ByteBuf markReaderIndex() {
-        buffer.markReaderIndex();
-        return this;
-    }
-
-    @Override
-    public ByteBuf markWriterIndex() {
-        throw reject();
-    }
-
-    @Override
     public ByteOrder order() {
         return buffer.order();
     }
@@ -711,17 +700,6 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     public CharSequence readCharSequence(int length, Charset charset) {
         checkReadableBytes(length);
         return buffer.readCharSequence(length, charset);
-    }
-
-    @Override
-    public ByteBuf resetReaderIndex() {
-        buffer.resetReaderIndex();
-        return this;
-    }
-
-    @Override
-    public ByteBuf resetWriterIndex() {
-        throw reject();
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -390,7 +390,7 @@ public final class Snappy {
      * @return The number of bytes appended to the output buffer, or -1 to indicate "try again later"
      */
     static int decodeLiteral(byte tag, ByteBuf in, ByteBuf out) {
-        in.markReaderIndex();
+        int readerIndex = in.readerIndex();
         int length;
         switch(tag >> 2 & 0x3F) {
         case 60:
@@ -423,7 +423,7 @@ public final class Snappy {
         length += 1;
 
         if (in.readableBytes() < length) {
-            in.resetReaderIndex();
+            in.readerIndex(readerIndex);
             return NOT_ENOUGH_INPUT;
         }
 
@@ -455,7 +455,7 @@ public final class Snappy {
 
         validateOffset(offset, writtenSoFar);
 
-        out.markReaderIndex();
+        int readerIndex = out.readerIndex();
         if (offset < length) {
             int copies = length / offset;
             for (; copies > 0; copies--) {
@@ -470,7 +470,7 @@ public final class Snappy {
             out.readerIndex(initialIndex - offset);
             out.readBytes(out, length);
         }
-        out.resetReaderIndex();
+        out.readerIndex(readerIndex);
 
         return length;
     }
@@ -499,7 +499,7 @@ public final class Snappy {
 
         validateOffset(offset, writtenSoFar);
 
-        out.markReaderIndex();
+        int readerIndex = out.readerIndex();
         if (offset < length) {
             int copies = length / offset;
             for (; copies > 0; copies--) {
@@ -514,7 +514,7 @@ public final class Snappy {
             out.readerIndex(initialIndex - offset);
             out.readBytes(out, length);
         }
-        out.resetReaderIndex();
+        out.readerIndex(readerIndex);
 
         return length;
     }
@@ -543,7 +543,7 @@ public final class Snappy {
 
         validateOffset(offset, writtenSoFar);
 
-        out.markReaderIndex();
+        int readerIndex = out.readerIndex();
         if (offset < length) {
             int copies = length / offset;
             for (; copies > 0; copies--) {
@@ -558,7 +558,7 @@ public final class Snappy {
             out.readerIndex(initialIndex - offset);
             out.readBytes(out, length);
         }
-        out.resetReaderIndex();
+        out.readerIndex(readerIndex);
 
         return length;
     }

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -48,7 +48,7 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out)
             throws Exception {
-        in.markReaderIndex();
+        int readerIndex = in.readerIndex();
         int preIndex = in.readerIndex();
         int length = readRawVarint32(in);
         if (preIndex == in.readerIndex()) {
@@ -59,7 +59,7 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
         }
 
         if (in.readableBytes() < length) {
-            in.resetReaderIndex();
+            in.readerIndex(readerIndex);
         } else {
             out.add(in.readRetainedSlice(length));
         }
@@ -74,14 +74,14 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
         if (!buffer.isReadable()) {
             return 0;
         }
-        buffer.markReaderIndex();
+        int readerIndex = buffer.readerIndex();
         byte tmp = buffer.readByte();
         if (tmp >= 0) {
             return tmp;
         } else {
             int result = tmp & 127;
             if (!buffer.isReadable()) {
-                buffer.resetReaderIndex();
+                buffer.readerIndex(readerIndex);
                 return 0;
             }
             if ((tmp = buffer.readByte()) >= 0) {
@@ -89,7 +89,7 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
             } else {
                 result |= (tmp & 127) << 7;
                 if (!buffer.isReadable()) {
-                    buffer.resetReaderIndex();
+                    buffer.readerIndex(readerIndex);
                     return 0;
                 }
                 if ((tmp = buffer.readByte()) >= 0) {
@@ -97,7 +97,7 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
                 } else {
                     result |= (tmp & 127) << 14;
                     if (!buffer.isReadable()) {
-                        buffer.resetReaderIndex();
+                        buffer.readerIndex(readerIndex);
                         return 0;
                     }
                     if ((tmp = buffer.readByte()) >= 0) {
@@ -105,7 +105,7 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
                     } else {
                         result |= (tmp & 127) << 21;
                         if (!buffer.isReadable()) {
-                            buffer.resetReaderIndex();
+                            buffer.readerIndex(readerIndex);
                             return 0;
                         }
                         result |= (tmp = buffer.readByte()) << 28;

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
@@ -88,7 +88,8 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         assertTrue(channel.finish());
 
         ByteBuf decompressed = readDecompressed(dataLength);
-        assertEquals(data.resetReaderIndex(), decompressed);
+        data.readerIndex(0);
+        assertEquals(data, decompressed);
 
         decompressed.release();
         data.release();

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -160,7 +160,8 @@ public abstract class AbstractIntegrationTest {
         while ((msg = decoder.readInbound()) != null) {
             decompressed.addComponent(true, msg);
         }
-        assertEquals(in.resetReaderIndex(), decompressed);
+        in.readerIndex(0);
+        assertEquals(in, decompressed);
 
         compressed.release();
         decompressed.release();

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameEncoderTest.java
@@ -83,7 +83,7 @@ public class SnappyFrameEncoderTest {
         });
 
         channel.writeOutbound(in.retain());
-        in.resetReaderIndex(); // rewind the buffer to write the same data
+        in.readerIndex(0); // rewind the buffer to write the same data
         channel.writeOutbound(in);
         assertTrue(channel.finish());
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -118,7 +118,7 @@ public abstract class ZlibTest {
         try {
             chEncoder.writeOutbound(data.retain());
             chEncoder.flush();
-            data.resetReaderIndex();
+            data.readerIndex(0);
 
             for (;;) {
                 ByteBuf deflatedData = chEncoder.readOutbound();

--- a/example/src/main/java/io/netty/example/factorial/BigIntegerDecoder.java
+++ b/example/src/main/java/io/netty/example/factorial/BigIntegerDecoder.java
@@ -38,19 +38,19 @@ public class BigIntegerDecoder extends ByteToMessageDecoder {
             return;
         }
 
-        in.markReaderIndex();
+        int readerIndex = in.readerIndex();
 
         // Check the magic number.
         int magicNumber = in.readUnsignedByte();
         if (magicNumber != 'F') {
-            in.resetReaderIndex();
+            in.readerIndex(readerIndex);
             throw new CorruptedFrameException("Invalid magic number: " + magicNumber);
         }
 
         // Wait until the whole data is available.
         int dataLength = in.readInt();
         if (in.readableBytes() < dataLength) {
-            in.resetReaderIndex();
+            in.readerIndex(readerIndex);
             return;
         }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1124,7 +1124,7 @@ public abstract class SSLEngineTest {
         try {
             assertTrue(sendChannel.writeAndFlush(message).await(5, TimeUnit.SECONDS));
             receiverLatch.await(5, TimeUnit.SECONDS);
-            message.resetReaderIndex();
+            message.readerIndex(0);
             ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
             verify(receiver).messageReceived(captor.capture());
             dataCapture = captor.getAllValues();

--- a/microbench/src/main/java/io/netty/handler/codec/http/WriteBytesVsShortOrMediumBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/WriteBytesVsShortOrMediumBenchmark.java
@@ -43,31 +43,31 @@ public class WriteBytesVsShortOrMediumBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public ByteBuf shortInt() {
-        return ByteBufUtil.writeShortBE(buf, CRLF_SHORT).resetWriterIndex();
+        return ByteBufUtil.writeShortBE(buf, CRLF_SHORT).writerIndex(0);
     }
 
     @Benchmark
     public ByteBuf mediumInt() {
-        return ByteBufUtil.writeMediumBE(buf, ZERO_CRLF_MEDIUM).resetWriterIndex();
+        return ByteBufUtil.writeMediumBE(buf, ZERO_CRLF_MEDIUM).writerIndex(0);
     }
 
     @Benchmark
     public ByteBuf byteArray2() {
-        return buf.writeBytes(CRLF).resetWriterIndex();
+        return buf.writeBytes(CRLF).writerIndex(0);
     }
 
     @Benchmark
     public ByteBuf byteArray3() {
-        return buf.writeBytes(ZERO_CRLF).resetWriterIndex();
+        return buf.writeBytes(ZERO_CRLF).writerIndex(0);
     }
 
     @Benchmark
     public ByteBuf chainedBytes2() {
-        return buf.writeByte(CR).writeByte(LF).resetWriterIndex();
+        return buf.writeByte(CR).writeByte(LF).writerIndex(0);
     }
 
     @Benchmark
     public ByteBuf chainedBytes3() {
-        return buf.writeByte('0').writeByte(CR).writeByte(LF).resetWriterIndex();
+        return buf.writeByte('0').writeByte(CR).writeByte(LF).writerIndex(0);
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufUtilBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufUtilBenchmark.java
@@ -79,97 +79,97 @@ public class
 
     @Benchmark
     public void writeAsciiStringViaArray() {
-        buffer.resetWriterIndex();
+        buffer.writerIndex(0);
         buffer.writeBytes(ascii.getBytes(CharsetUtil.US_ASCII));
     }
 
     @Benchmark
     public void writeAsciiStringViaArrayWrapped() {
-        wrapped.resetWriterIndex();
+        wrapped.writerIndex(0);
         wrapped.writeBytes(ascii.getBytes(CharsetUtil.US_ASCII));
     }
 
     @Benchmark
     public void writeAsciiString() {
-        buffer.resetWriterIndex();
+        buffer.writerIndex(0);
         ByteBufUtil.writeAscii(buffer, ascii);
     }
 
     @Benchmark
     public void writeAsciiStringWrapped() {
-        wrapped.resetWriterIndex();
+        wrapped.writerIndex(0);
         ByteBufUtil.writeAscii(wrapped, ascii);
     }
 
     @Benchmark
     public void writeAsciiViaArray() {
-        buffer.resetWriterIndex();
+        buffer.writerIndex(0);
         buffer.writeBytes(asciiSequence.toString().getBytes(CharsetUtil.US_ASCII));
     }
 
     @Benchmark
     public void writeAsciiViaArrayWrapped() {
-        wrapped.resetWriterIndex();
+        wrapped.writerIndex(0);
         wrapped.writeBytes(asciiSequence.toString().getBytes(CharsetUtil.US_ASCII));
     }
 
     @Benchmark
     public void writeAscii() {
-        buffer.resetWriterIndex();
+        buffer.writerIndex(0);
         ByteBufUtil.writeAscii(buffer, asciiSequence);
     }
 
     @Benchmark
     public void writeAsciiWrapped() {
-        wrapped.resetWriterIndex();
+        wrapped.writerIndex(0);
         ByteBufUtil.writeAscii(wrapped, asciiSequence);
     }
 
     @Benchmark
     public void writeUtf8StringViaArray() {
-        buffer.resetWriterIndex();
+        buffer.writerIndex(0);
         buffer.writeBytes(utf8.getBytes(CharsetUtil.UTF_8));
     }
 
     @Benchmark
     public void writeUtf8StringViaArrayWrapped() {
-        wrapped.resetWriterIndex();
+        wrapped.writerIndex(0);
         wrapped.writeBytes(utf8.getBytes(CharsetUtil.UTF_8));
     }
 
     @Benchmark
     public void writeUtf8String() {
-        buffer.resetWriterIndex();
+        buffer.writerIndex(0);
         ByteBufUtil.writeUtf8(buffer, utf8);
     }
 
     @Benchmark
     public void writeUtf8StringWrapped() {
-        wrapped.resetWriterIndex();
+        wrapped.writerIndex(0);
         ByteBufUtil.writeUtf8(wrapped, utf8);
     }
 
     @Benchmark
     public void writeUtf8ViaArray() {
-        buffer.resetWriterIndex();
+        buffer.writerIndex(0);
         buffer.writeBytes(utf8Sequence.toString().getBytes(CharsetUtil.UTF_8));
     }
 
     @Benchmark
     public void writeUtf8ViaArrayWrapped() {
-        wrapped.resetWriterIndex();
+        wrapped.writerIndex(0);
         wrapped.writeBytes(utf8Sequence.toString().getBytes(CharsetUtil.UTF_8));
     }
 
     @Benchmark
     public void writeUtf8() {
-        buffer.resetWriterIndex();
+        buffer.writerIndex(0);
         ByteBufUtil.writeUtf8(buffer, utf8Sequence);
     }
 
     @Benchmark
     public void writeUtf8Wrapped() {
-        wrapped.resetWriterIndex();
+        wrapped.writerIndex(0);
         ByteBufUtil.writeUtf8(wrapped, utf8Sequence);
     }
 

--- a/microbench/src/main/java/io/netty/microbench/buffer/SlicedByteBufBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/SlicedByteBufBenchmark.java
@@ -63,13 +63,13 @@ public class SlicedByteBufBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public void writeAsciiStringSlice() {
-        slicedByteBuf.resetWriterIndex();
+        slicedByteBuf.writerIndex(0);
         ByteBufUtil.writeAscii(slicedByteBuf, ascii);
     }
 
     @Benchmark
     public void writeAsciiStringSliceAbstract() {
-        slicedAbstractByteBuf.resetWriterIndex();
+        slicedAbstractByteBuf.writerIndex(0);
         ByteBufUtil.writeAscii(slicedAbstractByteBuf, ascii);
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -857,14 +857,14 @@ abstract class DnsResolveContext<T> {
     }
 
     static String decodeDomainName(ByteBuf in) {
-        in.markReaderIndex();
+        int readerIndex = in.readerIndex();
         try {
             return DefaultDnsRecordDecoder.decodeName(in);
         } catch (CorruptedFrameException e) {
             // In this case we just return null.
             return null;
         } finally {
-            in.resetReaderIndex();
+            in.readerIndex(readerIndex);
         }
     }
 


### PR DESCRIPTION
…e overhead and complexity.

Motivation:

ByteBuf supports “marker indexes”. The intended use case for these is if a speculative operation (e.g. decode) is in process the user can “mark” and interface and refer to it later if the operation isn’t successful (e.g. not enough data). However this is rarely used in practice,
requires extra memory to maintain, and introduces complexity in the state management for derived/pooled buffer initialization, resizing, and other operations which may modify reader/writer indexes.

Modifications:

Remove support for marking and adjust testcases / code.

Result:

Fixes https://github.com/netty/netty/issues/8535.