### PR TITLE
Revert "Ability to run a task at the end of an eventloop iteration."

### DIFF
--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -20,9 +20,7 @@ import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
-import io.netty.util.internal.UnstableApi;
 
-import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -34,8 +32,6 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
 
     protected static final int DEFAULT_MAX_PENDING_TASKS = Math.max(16,
             SystemPropertyUtil.getInt("io.netty.eventLoop.maxPendingTasks", Integer.MAX_VALUE));
-
-    private final Queue<Runnable> tailTasks;
 
     protected SingleThreadEventLoop(EventLoopGroup parent, ThreadFactory threadFactory, boolean addTaskWakesUp) {
         this(parent, threadFactory, addTaskWakesUp, DEFAULT_MAX_PENDING_TASKS, RejectedExecutionHandlers.reject());
@@ -49,14 +45,12 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
                                     boolean addTaskWakesUp, int maxPendingTasks,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, threadFactory, addTaskWakesUp, maxPendingTasks, rejectedExecutionHandler);
-        tailTasks = newTaskQueue(maxPendingTasks);
     }
 
     protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor,
                                     boolean addTaskWakesUp, int maxPendingTasks,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, executor, addTaskWakesUp, maxPendingTasks, rejectedExecutionHandler);
-        tailTasks = newTaskQueue(maxPendingTasks);
     }
 
     @Override
@@ -95,57 +89,9 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
         return promise;
     }
 
-    /**
-     * Adds a task to be run once at the end of next (or current) {@code eventloop} iteration.
-     *
-     * @param task to be added.
-     */
-    @UnstableApi
-    public final void executeAfterEventLoopIteration(Runnable task) {
-        ObjectUtil.checkNotNull(task, "task");
-        if (isShutdown()) {
-            reject();
-        }
-
-        if (!tailTasks.offer(task)) {
-            reject(task);
-        }
-
-        if (wakesUpForTask(task)) {
-            wakeup(inEventLoop());
-        }
-    }
-
-    /**
-     * Removes a task that was added previously via {@link #executeAfterEventLoopIteration(Runnable)}.
-     *
-     * @param task to be removed.
-     *
-     * @return {@code true} if the task was removed as a result of this call.
-     */
-    @UnstableApi
-    final boolean removeAfterEventLoopIterationTask(Runnable task) {
-        return tailTasks.remove(ObjectUtil.checkNotNull(task, "task"));
-    }
-
     @Override
     protected boolean wakesUpForTask(Runnable task) {
         return !(task instanceof NonWakeupRunnable);
-    }
-
-    @Override
-    protected void afterRunningAllTasks() {
-        runAllTasksFrom(tailTasks);
-    }
-
-    @Override
-    protected boolean hasTasks() {
-        return super.hasTasks() || !tailTasks.isEmpty();
-    }
-
-    @Override
-    public int pendingTasks() {
-        return super.pendingTasks() + tailTasks.size();
     }
 
     /**

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -20,7 +20,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import io.netty.channel.local.LocalChannel;
 import io.netty.util.concurrent.EventExecutor;
-import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,13 +51,11 @@ public class SingleThreadEventLoopTest {
 
     private SingleThreadEventLoopA loopA;
     private SingleThreadEventLoopB loopB;
-    private SingleThreadEventLoopC loopC;
 
     @Before
     public void newEventLoop() {
         loopA = new SingleThreadEventLoopA();
         loopB = new SingleThreadEventLoopB();
-        loopC = new SingleThreadEventLoopC();
     }
 
     @After
@@ -68,9 +65,6 @@ public class SingleThreadEventLoopTest {
         }
         if (!loopB.isShuttingDown()) {
             loopB.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
-        }
-        if (!loopC.isShuttingDown()) {
-            loopC.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
         }
 
         while (!loopA.isTerminated()) {
@@ -85,14 +79,6 @@ public class SingleThreadEventLoopTest {
         while (!loopB.isTerminated()) {
             try {
                 loopB.awaitTermination(1, TimeUnit.DAYS);
-            } catch (InterruptedException e) {
-                // Ignore
-            }
-        }
-
-        while (!loopC.isTerminated()) {
-            try {
-                loopC.awaitTermination(1, TimeUnit.DAYS);
             } catch (InterruptedException e) {
                 // Ignore
             }
@@ -149,11 +135,6 @@ public class SingleThreadEventLoopTest {
     @Test
     public void scheduleTaskB() throws Exception {
         testScheduleTask(loopB);
-    }
-
-    @Test
-    public void scheduleTaskC() throws Exception {
-        testScheduleTask(loopC);
     }
 
     private static void testScheduleTask(EventLoop loopA) throws InterruptedException, ExecutionException {
@@ -473,39 +454,7 @@ public class SingleThreadEventLoopTest {
         assertThat(loopA.isShutdown(), is(true));
     }
 
-    @Test(timeout = 10000)
-    public void testOnEventLoopIteration() throws Exception {
-        CountingRunnable onIteration = new CountingRunnable();
-        loopC.executeAfterEventLoopIteration(onIteration);
-        CountingRunnable noopTask = new CountingRunnable();
-        loopC.submit(noopTask).sync();
-        loopC.iterationEndSignal.take();
-        MatcherAssert.assertThat("Unexpected invocation count for regular task.",
-                                 noopTask.getInvocationCount(), is(1));
-        MatcherAssert.assertThat("Unexpected invocation count for on every eventloop iteration task.",
-                                 onIteration.getInvocationCount(), is(1));
-    }
-
-    @Test(timeout = 10000)
-    public void testRemoveOnEventLoopIteration() throws Exception {
-        CountingRunnable onIteration1 = new CountingRunnable();
-        loopC.executeAfterEventLoopIteration(onIteration1);
-        CountingRunnable onIteration2 = new CountingRunnable();
-        loopC.executeAfterEventLoopIteration(onIteration2);
-        loopC.removeAfterEventLoopIterationTask(onIteration1);
-        CountingRunnable noopTask = new CountingRunnable();
-        loopC.submit(noopTask).sync();
-
-        loopC.iterationEndSignal.take();
-        MatcherAssert.assertThat("Unexpected invocation count for regular task.",
-                                 noopTask.getInvocationCount(), is(1));
-        MatcherAssert.assertThat("Unexpected invocation count for on every eventloop iteration task.",
-                                 onIteration2.getInvocationCount(), is(1));
-        MatcherAssert.assertThat("Unexpected invocation count for on every eventloop iteration task.",
-                                 onIteration1.getInvocationCount(), is(0));
-    }
-
-    private static final class SingleThreadEventLoopA extends SingleThreadEventLoop {
+    private static class SingleThreadEventLoopA extends SingleThreadEventLoop {
 
         final AtomicInteger cleanedUp = new AtomicInteger();
 
@@ -549,7 +498,7 @@ public class SingleThreadEventLoopTest {
                     // Waken up by interruptThread()
                 }
 
-                runTasks0();
+                runAllTasks();
 
                 if (confirmShutdown()) {
                     break;
@@ -557,47 +506,9 @@ public class SingleThreadEventLoopTest {
             }
         }
 
-        protected void runTasks0() {
-            runAllTasks();
-        }
-
         @Override
         protected void wakeup(boolean inEventLoop) {
             interruptThread();
-        }
-    }
-
-    private static final class SingleThreadEventLoopC extends SingleThreadEventLoopB {
-
-        final LinkedBlockingQueue<Boolean> iterationEndSignal = new LinkedBlockingQueue<Boolean>(1);
-
-        @Override
-        protected void afterRunningAllTasks() {
-            super.afterRunningAllTasks();
-            iterationEndSignal.offer(true);
-        }
-
-        @Override
-        protected void runTasks0() {
-            runAllTasks(TimeUnit.MINUTES.toNanos(1));
-        }
-    }
-
-    private static class CountingRunnable implements Runnable {
-
-        private final AtomicInteger invocationCount = new AtomicInteger();
-
-        @Override
-        public void run() {
-            invocationCount.incrementAndGet();
-        }
-
-        public int getInvocationCount() {
-            return invocationCount.get();
-        }
-
-        public void resetInvocationCount() {
-            invocationCount.set(0);
         }
     }
 }


### PR DESCRIPTION
Motivation:

executeAfterEventLoopIteration is an Unstable API and isnt used in Netty. We should remove it to reduce complexity.

Changes:

This reverts commit 77770374fbe6b0767cfe5eccd0b59a5d66ec998a.

Result:

Simplify implementation / cleanup.

