### PR TITLE
Fix incorrect assert in Http2MultiplexCodec caused by 9f9aa1a.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -805,7 +805,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
         void fireChildReadComplete() {
             assert eventLoop().inEventLoop();
-            assert readStatus == ReadStatus.IN_PROGRESS;
+            assert readStatus != ReadStatus.IDLE;
             unsafe.notifyReadComplete(unsafe.recvBufAllocHandle());
         }
 


### PR DESCRIPTION
Motivation:

9f9aa1a did some changes related to fixing how we handle ctx.read() in child channel but did incorrectly change some assert.

Modifications:

Fix assert to be correct.

Result:

Code does not throw an AssertionError due incorrect assert check.
