### PR TITLE
Fix Example HttpStaticFileServerHandler: raf is not closed closes #8604

### DIFF
--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
@@ -40,6 +40,7 @@ import io.netty.handler.stream.ChunkedFile;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 
+import java.io.IOException;
 import javax.activation.MimetypesFileTypeMap;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -165,7 +166,7 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
             }
         }
 
-        RandomAccessFile raf;
+        final RandomAccessFile raf;
         try {
             raf = new RandomAccessFile(file, "r");
         } catch (FileNotFoundException ignore) {
@@ -214,6 +215,11 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
             @Override
             public void operationComplete(ChannelProgressiveFuture future) {
                 System.err.println(future.channel() + " Transfer complete.");
+                try {
+                    raf.close();
+                } catch (IOException e) {
+                    throw new Error(e);
+                }
             }
         });
 


### PR DESCRIPTION
Motivation:

Fixes the issue as mentioned below

Recently I use this HttpStaticFileServerHandler as file server, but I can't download mp4 file correctly. Then I found raf is not closed.

There is a issue mention about it: #2235, but it seems don't fix it.

I asked about it at stackoverflow: https://stackoverflow.com/questions/53500128/netty-httpstaticfileserverhandler-problem/53511572#53511572

Modifications:

made raf as final
added raf.close() call inside try/catch block

Result:

After this change the RandomAccessFile handler will be closed

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
