### PR TITLE
ReadTimeoutHandler - missing ) within JavaDoc example

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  *
  * public class MyChannelInitializer extends {@link ChannelInitializer}&lt;{@link Channel}&gt; {
  *     public void initChannel({@link Channel} channel) {
- *         channel.pipeline().addLast("readTimeoutHandler", new {@link ReadTimeoutHandler}(30);
+ *         channel.pipeline().addLast("readTimeoutHandler", new {@link ReadTimeoutHandler}(30));
  *         channel.pipeline().addLast("myHandler", new MyHandler());
  *     }
  * }


### PR DESCRIPTION
Motivation:

improve docs

Modification:

ReadTimeoutHandler - missing ) within JavaDoc example


No logic/unit tests affected