### PR TITLE
Support 1012, 1013 and 1014 WebSocket status codes

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -451,7 +451,7 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
         // Must have 2 byte integer within the valid range
         int statusCode = buffer.readShort();
         if (statusCode >= 0 && statusCode <= 999 || statusCode >= 1004 && statusCode <= 1006
-                || statusCode >= 1012 && statusCode <= 2999) {
+                || statusCode >= 1015 && statusCode <= 2999) {
             protocolViolation(ctx, "Invalid close frame getStatus code: " + statusCode);
         }
 


### PR DESCRIPTION
Motivation:

RFC 6455 doesn't define status codes 1012, 1013 and 1014.
Yet, since then, IANA has defined them, web browsers support them, applications in the wild do use them but it's currently not possible to buid a Netty based client for those services.

From https://www.iana.org/assignments/websocket/websocket.xhtml:

* 1012: Service Restart
* 1013: Try Again Later
* 1014: The server was acting as a gateway or proxy and received an invalid response from the upstream server. This is similar to 502 HTTP Status Code.

Modification:

Make status codes 1012, 1013 and 1014 legit.

Result:

WebSocket status codes as defined by IANA are supported.