### PR TITLE
Update to latest stable jython release

### DIFF
--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -88,6 +88,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.python</groupId>
+            <artifactId>jython-standalone</artifactId>
+            <version>2.7.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Motivation:

Using the latest jython release fixes some noise that is produced by an exception that is thrown when jython is terminated.

Exception in thread "Jython-Netty-Client-4" Exception in thread "Jython-Netty-Client-7" Exception in thread "Jython-Netty-Client-5" java.lang.NoClassDefFoundError: org/python/netty/util/concurrent/DefaultPromise$2
        at org.python.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:589)
        at org.python.netty.util.concurrent.DefaultPromise.setSuccess(DefaultPromise.java:397)
        at org.python.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:151)
        at java.lang.Thread.run(Thread.java:748)
Exception in thread "Jython-Netty-Client-8" java.lang.NoClassDefFoundError: org/python/netty/util/concurrent/DefaultPromise$2
        at org.python.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:589)
        at org.python.netty.util.concurrent.DefaultPromise.setSuccess(DefaultPromise.java:397)
        at org.python.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:151)
        at java.lang.Thread.run(Thread.java:748)
Exception in thread "Jython-Netty-Client-3" java.lang.NoClassDefFoundError: org/python/netty/util/concurrent/DefaultPromise$2
        at org.python.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:589)
        at org.python.netty.util.concurrent.DefaultPromise.setSuccess(DefaultPromise.java:397)%

Modification:

Update to latest stable release.

Result:

Less noise during build.