### PR TITLE
Upgrade to new version of autobahntestsuite maven plugin.

### DIFF
--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -70,7 +70,7 @@
       <plugin>
         <groupId>me.normanmaurer.maven.autobahntestsuite</groupId>
         <artifactId>autobahntestsuite-maven-plugin</artifactId>
-        <version>0.1.4</version>
+        <version>0.1.5</version>
         <configuration>
           <mainClass>io.netty.testsuite.autobahn.AutobahnServer</mainClass>
           <cases>


### PR DESCRIPTION
Motivation:

A new version was released that fixes a few test-cases to allow more close codes.

Modifications:

Upgrade to 0.1.5

Result:

More compliant testing of websockets.