### PR TITLE
Remove the `maxChunkSize` parameter for HTTP codecs

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -61,40 +61,40 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
      * {@code maxChunkSize (8192)}).
      */
     public HttpClientCodec() {
-        this(4096, 8192, 8192, false);
+        this(4096, 8192, false);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
      */
-    public HttpClientCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, false);
-    }
-
-    /**
-     * Creates a new instance with the specified decoder options.
-     */
-    public HttpClientCodec(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, true);
+    public HttpClientCodec(int maxInitialLineLength, int maxHeaderSize) {
+        this(maxInitialLineLength, maxHeaderSize, false);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
      */
     public HttpClientCodec(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            int maxInitialLineLength, int maxHeaderSize, boolean failOnMissingResponse) {
+        this(maxInitialLineLength, maxHeaderSize, failOnMissingResponse, true);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public HttpClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, boolean failOnMissingResponse,
             boolean validateHeaders) {
-        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, validateHeaders, false);
+        this(maxInitialLineLength, maxHeaderSize, failOnMissingResponse, validateHeaders, false);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
      */
     public HttpClientCodec(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            int maxInitialLineLength, int maxHeaderSize, boolean failOnMissingResponse,
             boolean validateHeaders, boolean parseHttpAfterConnectRequest) {
-        init(new Decoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders), new Encoder());
+        init(new Decoder(maxInitialLineLength, maxHeaderSize, validateHeaders), new Encoder());
         this.failOnMissingResponse = failOnMissingResponse;
         this.parseHttpAfterConnectRequest = parseHttpAfterConnectRequest;
     }
@@ -115,7 +115,7 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
     public HttpClientCodec(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
             boolean validateHeaders, int initialBufferSize, boolean parseHttpAfterConnectRequest) {
-        init(new Decoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize),
+        init(new Decoder(maxInitialLineLength, maxHeaderSize, validateHeaders, initialBufferSize),
              new Encoder());
         this.parseHttpAfterConnectRequest = parseHttpAfterConnectRequest;
         this.failOnMissingResponse = failOnMissingResponse;
@@ -177,13 +177,13 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
     }
 
     private final class Decoder extends HttpResponseDecoder {
-        Decoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders);
+        Decoder(int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders) {
+            super(maxInitialLineLength, maxHeaderSize, validateHeaders);
         }
 
-        Decoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
+        Decoder(int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders,
                 int initialBufferSize) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize);
+            super(maxInitialLineLength, maxHeaderSize, validateHeaders, initialBufferSize);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -66,19 +66,19 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
      * Creates a new instance with the specified parameters.
      */
     public HttpRequestDecoder(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true);
+            int maxInitialLineLength, int maxHeaderSize) {
+        super(maxInitialLineLength, maxHeaderSize, true);
     }
 
     public HttpRequestDecoder(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true, validateHeaders);
+            int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders) {
+        super(maxInitialLineLength, maxHeaderSize, true, validateHeaders);
     }
 
     public HttpRequestDecoder(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
+            int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders,
             int initialBufferSize) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true, validateHeaders, initialBufferSize);
+        super(maxInitialLineLength, maxHeaderSize, true, validateHeaders, initialBufferSize);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -97,19 +97,19 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
      * Creates a new instance with the specified parameters.
      */
     public HttpResponseDecoder(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true);
+            int maxInitialLineLength, int maxHeaderSize) {
+        super(maxInitialLineLength, maxHeaderSize, true);
     }
 
     public HttpResponseDecoder(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true, validateHeaders);
+            int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders) {
+        super(maxInitialLineLength, maxHeaderSize, true, validateHeaders);
     }
 
     public HttpResponseDecoder(
-            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
+            int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders,
             int initialBufferSize) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true, validateHeaders, initialBufferSize);
+        super(maxInitialLineLength, maxHeaderSize, true, validateHeaders, initialBufferSize);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -41,32 +41,32 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
      * {@code maxChunkSize (8192)}).
      */
     public HttpServerCodec() {
-        this(4096, 8192, 8192);
+        this(4096, 8192);
     }
 
     /**
      * Creates a new instance with the specified decoder options.
      */
-    public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize),
+    public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize) {
+        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize),
                 new HttpServerResponseEncoder());
     }
 
     /**
      * Creates a new instance with the specified decoder options.
      */
-    public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
-        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders),
+    public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders) {
+        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, validateHeaders),
                 new HttpServerResponseEncoder());
     }
 
     /**
      * Creates a new instance with the specified decoder options.
      */
-    public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
+    public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders,
                            int initialBufferSize) {
         init(
-          new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize,
+          new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize,
                   validateHeaders, initialBufferSize),
           new HttpServerResponseEncoder());
     }
@@ -81,18 +81,18 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
     }
 
     private final class HttpServerRequestDecoder extends HttpRequestDecoder {
-        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize);
+        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize) {
+            super(maxInitialLineLength, maxHeaderSize);
         }
 
-        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
+        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize,
                                         boolean validateHeaders) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders);
+            super(maxInitialLineLength, maxHeaderSize, validateHeaders);
         }
 
-        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
+        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize,
                                         boolean validateHeaders, int initialBufferSize) {
-            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize);
+            super(maxInitialLineLength, maxHeaderSize, validateHeaders, initialBufferSize);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspDecoder.java
@@ -106,7 +106,7 @@ public class RtspDecoder extends HttpObjectDecoder {
     public RtspDecoder(final int maxInitialLineLength,
                        final int maxHeaderSize,
                        final int maxContentLength) {
-        super(maxInitialLineLength, maxHeaderSize, maxContentLength * 2, false);
+        super(maxInitialLineLength, maxHeaderSize, false);
     }
 
     /**
@@ -122,7 +122,6 @@ public class RtspDecoder extends HttpObjectDecoder {
                        final boolean validateHeaders) {
         super(maxInitialLineLength,
               maxHeaderSize,
-              maxContentLength * 2,
               false,
               validateHeaders);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspObjectDecoder.java
@@ -55,23 +55,22 @@ public abstract class RtspObjectDecoder extends HttpObjectDecoder {
 
     /**
      * Creates a new instance with the default
-     * {@code maxInitialLineLength (4096)}, {@code maxHeaderSize (8192)}, and
-     * {@code maxContentLength (8192)}.
+     * {@code maxInitialLineLength (4096)}, {@code maxHeaderSize (8192)}.
      */
     protected RtspObjectDecoder() {
-        this(4096, 8192, 8192);
+        this(4096, 8192);
     }
 
     /**
      * Creates a new instance with the specified parameters.
      */
-    protected RtspObjectDecoder(int maxInitialLineLength, int maxHeaderSize, int maxContentLength) {
-        super(maxInitialLineLength, maxHeaderSize, maxContentLength * 2, false);
+    protected RtspObjectDecoder(int maxInitialLineLength, int maxHeaderSize) {
+        super(maxInitialLineLength, maxHeaderSize, false);
     }
 
     protected RtspObjectDecoder(
-            int maxInitialLineLength, int maxHeaderSize, int maxContentLength, boolean validateHeaders) {
-        super(maxInitialLineLength, maxHeaderSize, maxContentLength * 2, false, validateHeaders);
+            int maxInitialLineLength, int maxHeaderSize, boolean validateHeaders) {
+        super(maxInitialLineLength, maxHeaderSize, false, validateHeaders);
     }
 
     @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -59,7 +59,7 @@ public class HttpClientCodecTest {
 
     @Test
     public void testConnectWithResponseContent() {
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
         sendRequestAndReadResponse(ch, HttpMethod.CONNECT, RESPONSE);
@@ -68,7 +68,7 @@ public class HttpClientCodecTest {
 
     @Test
     public void testFailsNotOnRequestResponseChunked() {
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
         sendRequestAndReadResponse(ch, HttpMethod.GET, CHUNKED_RESPONSE);
@@ -77,7 +77,7 @@ public class HttpClientCodecTest {
 
     @Test
     public void testFailsOnMissingResponse() {
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
         assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
@@ -95,7 +95,7 @@ public class HttpClientCodecTest {
 
     @Test
     public void testFailsOnIncompleteChunkedResponse() {
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
         ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost/"));
@@ -130,7 +130,7 @@ public class HttpClientCodecTest {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
                     // Don't use the HttpServerCodec, because we don't want to have content-length or anything added.
-                    ch.pipeline().addLast(new HttpRequestDecoder(4096, 8192, 8192, true));
+                    ch.pipeline().addLast(new HttpRequestDecoder(4096, 8192, true));
                     ch.pipeline().addLast(new HttpObjectAggregator(4096));
                     ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpRequest>() {
                         @Override
@@ -174,7 +174,7 @@ public class HttpClientCodecTest {
             cb.handler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
-                    ch.pipeline().addLast(new HttpClientCodec(4096, 8192, 8192, true, true));
+                    ch.pipeline().addLast(new HttpClientCodec(4096, 8192, true, true));
                     ch.pipeline().addLast(new HttpObjectAggregator(4096));
                     ch.pipeline().addLast(new SimpleChannelInboundHandler<FullHttpResponse>() {
                         @Override
@@ -212,7 +212,7 @@ public class HttpClientCodecTest {
     }
 
     private static void testAfterConnect(final boolean parseAfterConnect) throws Exception {
-        EmbeddedChannel ch = new EmbeddedChannel(new HttpClientCodec(4096, 8192, 8192, true, true, parseAfterConnect));
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpClientCodec(4096, 8192, true, true, parseAfterConnect));
 
         Consumer connectResponseConsumer = new Consumer();
         sendRequestAndReadResponse(ch, HttpMethod.CONNECT, EMPTY_RESPONSE, connectResponseConsumer);
@@ -284,7 +284,7 @@ public class HttpClientCodecTest {
                 "Connection: Upgrade\r\n" +
                 "Upgrade: TLS/1.2, HTTP/1.1\r\n\r\n";
 
-        HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
+        HttpClientCodec codec = new HttpClientCodec(4096, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec, new HttpObjectAggregator(1024));
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost/");

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
@@ -284,7 +284,7 @@ public class HttpContentDecoderTest {
         // or removes it completely (handlers down the chain must rely on LastHttpContent object)
 
         // force content to be in more than one chunk (5 bytes/chunk)
-        HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096, 5);
+        HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096);
         HttpContentDecoder decompressor = new HttpContentDecompressor();
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor);
         String headers = "POST / HTTP/1.1\r\n" +
@@ -313,7 +313,7 @@ public class HttpContentDecoderTest {
         // case 2: if HttpObjectAggregator is down the chain, then correct Content-Length header must be set
 
         // force content to be in more than one chunk (5 bytes/chunk)
-        HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096, 5);
+        HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096);
         HttpContentDecoder decompressor = new HttpContentDecompressor();
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
@@ -345,7 +345,7 @@ public class HttpContentDecoderTest {
         // or removes it completely (handlers down the chain must rely on LastHttpContent object)
 
         // force content to be in more than one chunk (5 bytes/chunk)
-        HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
+        HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096);
         HttpContentDecoder decompressor = new HttpContentDecompressor();
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor);
         String headers = "HTTP/1.1 200 OK\r\n" +
@@ -377,7 +377,7 @@ public class HttpContentDecoderTest {
         // case 2: if HttpObjectAggregator is down the chain, then correct Content-Length header must be set
 
         // force content to be in more than one chunk (5 bytes/chunk)
-        HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
+        HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096);
         HttpContentDecoder decompressor = new HttpContentDecompressor();
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor, aggregator);
@@ -405,7 +405,7 @@ public class HttpContentDecoderTest {
     @Test
     public void testFullHttpRequest() {
         // test that ContentDecoder can be used after the ObjectAggregator
-        HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096, 5);
+        HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         HttpContentDecoder decompressor = new HttpContentDecompressor();
         EmbeddedChannel channel = new EmbeddedChannel(decoder, aggregator, decompressor);
@@ -432,7 +432,7 @@ public class HttpContentDecoderTest {
     @Test
     public void testFullHttpResponse() {
         // test that ContentDecoder can be used after the ObjectAggregator
-        HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
+        HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
         HttpContentDecoder decompressor = new HttpContentDecompressor();
         EmbeddedChannel channel = new EmbeddedChannel(decoder, aggregator, decompressor);
@@ -460,7 +460,7 @@ public class HttpContentDecoderTest {
     @Test
     public void testFullHttpResponseEOF() {
         // test that ContentDecoder can be used after the ObjectAggregator
-        HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
+        HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096);
         HttpContentDecoder decompressor = new HttpContentDecompressor();
         EmbeddedChannel channel = new EmbeddedChannel(decoder, decompressor);
         String headers = "HTTP/1.1 200 OK\r\n" +

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -297,7 +297,7 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testTooLargeInitialLine() {
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(10, 1024, 1024));
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(10, 1024));
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Host: localhost1\r\n\r\n";
 
@@ -310,7 +310,7 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testTooLargeHeaders() {
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(1024, 10, 1024));
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(1024, 10));
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Host: localhost1\r\n\r\n";
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -49,7 +49,7 @@ public class HttpResponseDecoderTest {
     public void testMaxHeaderSize1() {
         final int maxHeaderSize = 8192;
 
-        final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, maxHeaderSize, 8192));
+        final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, maxHeaderSize));
         final char[] bytes = new char[maxHeaderSize / 2 - 2];
         Arrays.fill(bytes, 'a');
 
@@ -81,7 +81,7 @@ public class HttpResponseDecoderTest {
     public void testMaxHeaderSize2() {
         final int maxHeaderSize = 8192;
 
-        final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, maxHeaderSize, 8192));
+        final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, maxHeaderSize));
         final char[] bytes = new char[maxHeaderSize / 2 - 2];
         Arrays.fill(bytes, 'a');
 
@@ -128,55 +128,6 @@ public class HttpResponseDecoderTest {
 
             byte[] decodedData = new byte[data.length];
             content.content().readBytes(decodedData);
-            assertArrayEquals(data, decodedData);
-            content.release();
-
-            assertFalse(ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII)));
-        }
-
-        // Write the last chunk.
-        ch.writeInbound(Unpooled.copiedBuffer("0\r\n\r\n", CharsetUtil.US_ASCII));
-
-        // Ensure the last chunk was decoded.
-        LastHttpContent content = ch.readInbound();
-        assertFalse(content.content().isReadable());
-        content.release();
-
-        ch.finish();
-        assertNull(ch.readInbound());
-    }
-
-    @Test
-    public void testResponseChunkedExceedMaxChunkSize() {
-        EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, 8192, 32));
-        ch.writeInbound(
-                Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n", CharsetUtil.US_ASCII));
-
-        HttpResponse res = ch.readInbound();
-        assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
-        assertThat(res.status(), is(HttpResponseStatus.OK));
-
-        byte[] data = new byte[64];
-        for (int i = 0; i < data.length; i++) {
-            data[i] = (byte) i;
-        }
-
-        for (int i = 0; i < 10; i++) {
-            assertFalse(ch.writeInbound(Unpooled.copiedBuffer(Integer.toHexString(data.length) + "\r\n",
-                    CharsetUtil.US_ASCII)));
-            assertTrue(ch.writeInbound(Unpooled.wrappedBuffer(data)));
-
-            byte[] decodedData = new byte[data.length];
-            HttpContent content = ch.readInbound();
-            assertEquals(32, content.content().readableBytes());
-            content.content().readBytes(decodedData, 0, 32);
-            content.release();
-
-            content = ch.readInbound();
-            assertEquals(32, content.content().readableBytes());
-
-            content.content().readBytes(decodedData, 32, 32);
-
             assertArrayEquals(data, decodedData);
             content.release();
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
@@ -33,7 +33,7 @@ public class HttpServerCodecTest {
     public void testUnfinishedChunkedHttpRequestIsLastFlag() throws Exception {
 
         int maxChunkSize = 2000;
-        HttpServerCodec httpServerCodec = new HttpServerCodec(1000, 1000, maxChunkSize);
+        HttpServerCodec httpServerCodec = new HttpServerCodec(1000, 1000);
         EmbeddedChannel decoderEmbedder = new EmbeddedChannel(httpServerCodec);
 
         int totalContentLength = maxChunkSize * 5;


### PR DESCRIPTION
Motivation:

The `maxChunkSize` only serves to split available content into even
smaller chunks which is not all that useful since the data is already
buffered.

Modification:

Remove the parameter.

Fixes #8430. 