### PR TITLE
Update to use OpenJDK 12 EA24 when building with Java 12

### DIFF
--- a/docker/docker-compose.centos-6.112.yaml
+++ b/docker/docker-compose.centos-6.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.12.0-22"
+        java_version : "openjdk@1.12.0-24"
 
   test:
     image: netty:centos-6-1.12

--- a/docker/docker-compose.centos-7.112.yaml
+++ b/docker/docker-compose.centos-7.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.12.0-22"
+        java_version : "openjdk@1.12.0-24"
 
   test:
     image: netty:centos-7-1.12


### PR DESCRIPTION
Motivation:

A new EA build was released for Java 12.

Modifications:

Update to OpenJDK 12 EA24

Result:

Use latest OpenJDK 12 build when building with Java 12