### PR TITLE
Introduce test that manually decrypts TLS via OpenSSL

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/PseudoRandomFunction.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PseudoRandomFunction.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.util.internal.EmptyArrays;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+
+/**
+ * This pseudorandom function (PRF) takes as input a secret, a seed, and
+ * an identifying label and produces an output of arbitrary length.
+ *
+ * This is used by the TLS RFC to construct/deconstruct an array of bytes into
+ * composite secrets.
+ *
+ * {@link <a href="https://tools.ietf.org/html/rfc5246">rfc5246</a>}
+ */
+final class PseudoRandomFunction {
+
+    /**
+     * Constructor never to be called.
+     */
+    private PseudoRandomFunction() {
+    }
+
+    /**
+     * Use a single hash function to expand a secret and seed into an
+     * arbitrary quantity of output.
+     *
+     * P_hash(secret, seed) = HMAC_hash(secret, A(1) + seed) +
+     *                        HMAC_hash(secret, A(2) + seed) +
+     *                        HMAC_hash(secret, A(3) + seed) + ...
+     * where + indicates concatenation.
+     * A() is defined as:
+     *       A(0) = seed
+     *       A(i) = HMAC_hash(secret, A(i-1))
+     * @param secret The starting secret to use for expansion
+     * @param label An ascii string without a length byte or trailing null character.
+     * @param seed The seed of the hash
+     * @param length The number of bytes to return
+     * @param algo the hmac algorithm to use
+     * @return The expanded secrets
+     * @throws IllegalArgumentException if the algo could not be found.
+     */
+    static byte[] hash(byte[] secret, byte[] label, byte[] seed, int length, String algo) {
+        if (length < 0) {
+            throw new IllegalArgumentException("You must provide a length greater than zero.");
+        }
+        try {
+            Mac hmac = Mac.getInstance(algo);
+            hmac.init(new SecretKeySpec(secret, algo));
+            /*
+             * P_hash(secret, seed) = HMAC_hash(secret, A(1) + seed) +
+             * HMAC_hash(secret, A(2) + seed) + HMAC_hash(secret, A(3) + seed) + ...
+             * where + indicates concatenation. A() is defined as: A(0) = seed, A(i)
+             * = HMAC_hash(secret, A(i-1))
+             */
+
+            int iterations = (int) Math.ceil(length / (double) hmac.getMacLength());
+            byte[] expansion = EmptyArrays.EMPTY_BYTES;
+            byte[] data = concat(label, seed);
+            byte[] A = data;
+            for (int i = 0; i < iterations; i++) {
+                A = hmac.doFinal(A);
+                expansion = concat(expansion, hmac.doFinal(concat(A, data)));
+            }
+            return Arrays.copyOf(expansion, length);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException("Could not find algo: " + algo, e);
+        }
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        byte[] result = Arrays.copyOf(first, first.length + second.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/PseudoRandomFunctionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PseudoRandomFunctionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+import io.netty.util.CharsetUtil;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * The test vectors here were provided via:
+ * https://www.ietf.org/mail-archive/web/tls/current/msg03416.html
+ */
+public class PseudoRandomFunctionTest {
+
+    @Test
+    public void testPrfSha256() {
+        byte[] secret = Hex.decode("9b be 43 6b a9 40 f0 17 b1 76 52 84 9a 71 db 35");
+        byte[] seed = Hex.decode("a0 ba 9f 93 6c da 31 18 27 a6 f7 96 ff d5 19 8c");
+        byte[] label = "test label".getBytes(CharsetUtil.US_ASCII);
+        byte[] expected = Hex.decode(
+                 "e3 f2 29 ba 72 7b e1 7b" +
+                 "8d 12 26 20 55 7c d4 53" +
+                 "c2 aa b2 1d 07 c3 d4 95" +
+                 "32 9b 52 d4 e6 1e db 5a" +
+                 "6b 30 17 91 e9 0d 35 c9" +
+                 "c9 a4 6b 4e 14 ba f9 af" +
+                 "0f a0 22 f7 07 7d ef 17" +
+                 "ab fd 37 97 c0 56 4b ab" +
+                 "4f bc 91 66 6e 9d ef 9b" +
+                 "97 fc e3 4f 79 67 89 ba" +
+                 "a4 80 82 d1 22 ee 42 c5" +
+                 "a7 2e 5a 51 10 ff f7 01" +
+                 "87 34 7b 66");
+        byte[] actual = PseudoRandomFunction.hash(secret, label, seed, expected.length, "HmacSha256");
+        assertArrayEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Motivation:

I've introduced https://github.com/netty/netty-tcnative/pull/421 that introduced exposing OpenSSL master key & client/server random values with the purpose of allowing someone to log them to debug the traffic via auxiliary tools like Wireshark (see also https://github.com/netty/netty/pull/8653)

Modification:

Augmented _OpenSslEngineTest_ to include a test which manually decrypts the TLS ciphertext after exposing the masterkey + client/server random. This acts as proof that the tc-native new methods work correctly!

It would be great to include the test in _netty-tcnative_ itself however I leveraged the JDK SSLEngine implementation to perform the TLS handshake.

Result:
Tests pass!

