### PR TITLE
Use OpenJDK 12 EA 27 when running CI jobs for JDK 12.

### DIFF
--- a/docker/docker-compose.centos-6.112.yaml
+++ b/docker/docker-compose.centos-6.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.12.0-24"
+        java_version : "openjdk@1.12.0-27"
 
   test:
     image: netty:centos-6-1.12

--- a/docker/docker-compose.centos-7.112.yaml
+++ b/docker/docker-compose.centos-7.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.12.0-24"
+        java_version : "openjdk@1.12.0-27"
 
   test:
     image: netty:centos-7-1.12


### PR DESCRIPTION
Motivation:

A new EA release was done for OpenJDK12.

Modifications:

Use OpenJDK12 EA 27 when running CI jobs for JDK 12.

Result:

Test against latest OpenJDK 12 EA build.