### PR TITLE
Access the Constructor of the Channel in the constructor of Reflectiv…

### DIFF
--- a/transport/src/main/java/io/netty/channel/ReflectiveChannelFactory.java
+++ b/transport/src/main/java/io/netty/channel/ReflectiveChannelFactory.java
@@ -16,33 +16,40 @@
 
 package io.netty.channel;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
+
+import java.lang.reflect.Constructor;
 
 /**
  * A {@link ChannelFactory} that instantiates a new {@link Channel} by invoking its default constructor reflectively.
  */
 public class ReflectiveChannelFactory<T extends Channel> implements ChannelFactory<T> {
 
-    private final Class<? extends T> clazz;
+    private final Constructor<? extends T> constructor;
 
     public ReflectiveChannelFactory(Class<? extends T> clazz) {
-        if (clazz == null) {
-            throw new NullPointerException("clazz");
+        ObjectUtil.checkNotNull(clazz, "clazz");
+        try {
+            this.constructor = clazz.getConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException("Class " + StringUtil.simpleClassName(clazz) +
+                    " does not have a public non-arg constructor", e);
         }
-        this.clazz = clazz;
     }
 
     @Override
     public T newChannel() {
         try {
-            return clazz.getConstructor().newInstance();
+            return constructor.newInstance();
         } catch (Throwable t) {
-            throw new ChannelException("Unable to create Channel from class " + clazz, t);
+            throw new ChannelException("Unable to create Channel from class " + constructor.getDeclaringClass(), t);
         }
     }
 
     @Override
     public String toString() {
-        return StringUtil.simpleClassName(clazz) + ".class";
+        return StringUtil.simpleClassName(ReflectiveChannelFactory.class) +
+                '(' + StringUtil.simpleClassName(constructor.getDeclaringClass()) + ".class)";
     }
 }


### PR DESCRIPTION
…eChannelFactory.

Motivation:

We should access the Constructor of the passed in class in the Constructor of ReflectiveChannelFactory only to reduce the overhead but also fail-fast.

Modifications:

Access the Constructor early.

Result:

Fails fast and less performance overhead.
