### PR TITLE
Allow to run builds with OpenJDK 13.

### DIFF
--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-1.13
+    build:
+      args:
+        centos_version : "6"
+        java_version : "openjdk@1.13.0-3"
+
+  test:
+    image: netty:centos-6-1.13
+
+  test-leak:
+    image: netty:centos-6-1.13
+
+  test-boringssl-static:
+    image: netty:centos-6-1.13
+
+  shell:
+    image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-7-1.13
+    build:
+      args:
+        centos_version : "7"
+        java_version : "openjdk@1.13.0-3"
+
+  test:
+    image: netty:centos-7-1.13
+
+  test-leak:
+    image: netty:centos-7-1.13
+
+  test-boringssl-static:
+    image: netty:centos-7-1.13
+
+  shell:
+    image: netty:centos-7-1.13

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,28 @@
   </developers>
 
   <profiles>
+    <!-- JDK13 -->
+    <profile>
+      <id>java13</id>
+      <activation>
+        <jdk>13</jdk>
+      </activation>
+      <properties>
+        <!-- Not use alpn agent as Java11 supports alpn out of the box -->
+        <argLine.alpnAgent />
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
+        <enforcer.plugin.version>3.0.0-M1</enforcer.plugin.version>
+        <!-- 1.4.x does not work in Java10+ -->
+        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <!-- This is the minimum supported by Java12 -->
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <!-- pax-exam does not work on latest Java12 EA 22 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+      </properties>
+    </profile>
+
     <!-- JDK12 -->
     <profile>
       <id>java12</id>


### PR DESCRIPTION
Motivation:

There are the first EA bulds for OpenJDK 13. We should support to build with it and run builds on the CI.

Modifications:

- Add profile for JDK 13
- Add docker config to run with JDK 13.

Result:

Building and testing with OpenJDK 13 is possible.
