### PR TITLE
Update to latest JDK8 and JDK11 releases

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.11.0-1"
+        java_version : "openjdk@1.11.0-2"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.8.192"
+        java_version : "1.8.202"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.11.0-1"
+        java_version : "openjdk@1.11.0-2"
 
   test:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.8.192"
+        java_version : "1.8.202"
 
   test:
     image: netty:centos-7-1.8


### PR DESCRIPTION
Motivation:

We should always build with the latest JDK releases.

Modifications:

Update JDK8 and JDK11 versions to the latest.

Result:

Run CI jobs on the latest JDK release.