### PR TITLE
Skip osgi testsuite on JDK11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,8 @@
         <enforcer.plugin.version>3.0.0-M1</enforcer.plugin.version>
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <!-- pax-exam does not work on latest Java11 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
     </profile>
 


### PR DESCRIPTION
Motivation:

Since the updating to OpenJDK 11.0.2 the OSGI testsuite fails. We should dissable it until there is a version of the used plugins that works with this OpenJDK version.

Modifications:

Skip osgi testsuite when using JDK11.

Result:

Build pass again with JDK11.