### PR TITLE
Fix flaky ChannelInitializerTest.testChannelInitializerEventExecutor()

### DIFF
--- a/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
@@ -335,7 +335,7 @@ public class ChannelInitializerTest {
                                             }
 
                                             @Override
-                                            public void channelUnregistered(ChannelHandlerContext ctx) {
+                                            public void handlerRemoved(ChannelHandlerContext ctx) {
                                                 latch.countDown();
                                             }
                                         });
@@ -369,6 +369,7 @@ public class ChannelInitializerTest {
         client.closeFuture().sync();
         server.closeFuture().sync();
 
+        // Wait until the handler is removed from the pipeline and so no more events are handled by it.
         latch.await();
 
         assertEquals(1, invokeCount.get());


### PR DESCRIPTION
Motivation:

testChannelInitializerEventExecutor() did sometimes fail as we sometimes miss to count down the latch. This can happen when we remove the handler from the pipeline before channelUnregistered(...) was called for it.

Modifications:

Countdown the latch in handlerRemoved(...).

Result:

Fix flaky test.