### PR TITLE
Java 8 migration. Removed custom MathUtil.compare methods

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -432,7 +432,7 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
 
         @Override
         public int compare(State o1, State o2) {
-            return MathUtil.compare(o1.pseudoTimeToWrite, o2.pseudoTimeToWrite);
+            return Long.compare(o1.pseudoTimeToWrite, o2.pseudoTimeToWrite);
         }
     }
 

--- a/common/src/main/java/io/netty/util/internal/MathUtil.java
+++ b/common/src/main/java/io/netty/util/internal/MathUtil.java
@@ -64,32 +64,4 @@ public final class MathUtil {
         return (index | length | (index + length) | (capacity - (index + length))) < 0;
     }
 
-    /**
-     * Compares two {@code int} values.
-     *
-     * @param  x the first {@code int} to compare
-     * @param  y the second {@code int} to compare
-     * @return the value {@code 0} if {@code x == y};
-     *         {@code -1} if {@code x < y}; and
-     *         {@code 1} if {@code x > y}
-     */
-    public static int compare(final int x, final int y) {
-        // do not subtract for comparison, it could overflow
-        return x < y ? -1 : (x > y ? 1 : 0);
-    }
-
-    /**
-     * Compare two {@code long} values.
-     * @param x the first {@code long} to compare.
-     * @param y the second {@code long} to compare.
-     * @return
-     * <ul>
-     * <li>0 if {@code x == y}</li>
-     * <li>{@code > 0} if {@code x > y}</li>
-     * <li>{@code < 0} if {@code x < y}</li>
-     * </ul>
-     */
-    public static int compare(long x, long y) {
-        return (x < y) ? -1 : (x > y) ? 1 : 0;
-    }
 }

--- a/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
+++ b/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
@@ -16,7 +16,6 @@
 package io.netty.channel.embedded;
 
 import io.netty.channel.ChannelId;
-import io.netty.util.internal.MathUtil;
 
 public class CustomChannelId implements ChannelId {
 
@@ -31,7 +30,7 @@ public class CustomChannelId implements ChannelId {
     @Override
     public int compareTo(final ChannelId o) {
         if (o instanceof CustomChannelId) {
-            return MathUtil.compare(id, ((CustomChannelId) o).id);
+            return Integer.compare(id, ((CustomChannelId) o).id);
         }
 
         return asLongText().compareTo(o.asLongText());


### PR DESCRIPTION
Motivation:

Netty uses own `Integer.compare` and `Long.compare` methods. Since Java 7 we can use Java implementation instead.