### PR TITLE
Java 8 migration: replace anonymous class with lambda

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -206,19 +206,16 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
             final ChannelPromise promise = channel.newPromise();
-            regFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    // Directly obtain the cause and do a null check so we only need one volatile read in case of a
-                    // failure.
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
-                        // IllegalStateException once we try to access the EventLoop of the Channel.
-                        promise.setFailure(cause);
-                    } else {
-                        doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
-                    }
+            regFuture.addListener((ChannelFutureListener) future -> {
+                // Directly obtain the cause and do a null check so we only need one volatile read in case of a
+                // failure.
+                Throwable cause = future.cause();
+                if (cause != null) {
+                    // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
+                    // IllegalStateException once we try to access the EventLoop of the Channel.
+                    promise.setFailure(cause);
+                } else {
+                    doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
                 }
             });
             return promise;
@@ -254,15 +251,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
             }
 
             // Wait until the name resolution is finished.
-            resolveFuture.addListener(new FutureListener<SocketAddress>() {
-                @Override
-                public void operationComplete(Future<SocketAddress> future) throws Exception {
-                    if (future.cause() != null) {
-                        channel.close();
-                        promise.setFailure(future.cause());
-                    } else {
-                        doConnect(future.getNow(), localAddress, promise);
-                    }
+            resolveFuture.addListener((FutureListener<SocketAddress>) future -> {
+                if (future.cause() != null) {
+                    channel.close();
+                    promise.setFailure(future.cause());
+                } else {
+                    doConnect(future.getNow(), localAddress, promise);
                 }
             });
         } catch (Throwable cause) {
@@ -277,16 +271,13 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
         // This method is invoked before channelRegistered() is triggered.  Give user handlers a chance to set up
         // the pipeline in its channelRegistered() implementation.
         final Channel channel = connectPromise.channel();
-        channel.eventLoop().execute(new Runnable() {
-            @Override
-            public void run() {
-                if (localAddress == null) {
-                    channel.connect(remoteAddress, connectPromise);
-                } else {
-                    channel.connect(remoteAddress, localAddress, connectPromise);
-                }
-                connectPromise.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+        channel.eventLoop().execute(() -> {
+            if (localAddress == null) {
+                channel.connect(remoteAddress, connectPromise);
+            } else {
+                channel.connect(remoteAddress, localAddress, connectPromise);
             }
+            connectPromise.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
         });
     }
 

--- a/transport/src/main/java/io/netty/channel/ChannelFutureListener.java
+++ b/transport/src/main/java/io/netty/channel/ChannelFutureListener.java
@@ -38,23 +38,15 @@ public interface ChannelFutureListener extends GenericFutureListener<ChannelFutu
      * A {@link ChannelFutureListener} that closes the {@link Channel} which is
      * associated with the specified {@link ChannelFuture}.
      */
-    ChannelFutureListener CLOSE = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            future.channel().close();
-        }
-    };
+    ChannelFutureListener CLOSE = future -> future.channel().close();
 
     /**
      * A {@link ChannelFutureListener} that closes the {@link Channel} when the
      * operation ended up with a failure or cancellation rather than a success.
      */
-    ChannelFutureListener CLOSE_ON_FAILURE = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            if (!future.isSuccess()) {
-                future.channel().close();
-            }
+    ChannelFutureListener CLOSE_ON_FAILURE = future -> {
+        if (!future.isSuccess()) {
+            future.channel().close();
         }
     };
 
@@ -62,12 +54,9 @@ public interface ChannelFutureListener extends GenericFutureListener<ChannelFutu
      * A {@link ChannelFutureListener} that forwards the {@link Throwable} of the {@link ChannelFuture} into the
      * {@link ChannelPipeline}. This mimics the old behavior of Netty 3.
      */
-    ChannelFutureListener FIRE_EXCEPTION_ON_FAILURE = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            if (!future.isSuccess()) {
-                future.channel().pipeline().fireExceptionCaught(future.cause());
-            }
+    ChannelFutureListener FIRE_EXCEPTION_ON_FAILURE = future -> {
+        if (!future.isSuccess()) {
+            future.channel().pipeline().fireExceptionCaught(future.cause());
         }
     };
 

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -602,12 +602,7 @@ public final class ChannelOutboundBuffer {
         if (invokeLater) {
             Runnable task = fireChannelWritabilityChangedTask;
             if (task == null) {
-                fireChannelWritabilityChangedTask = task = new Runnable() {
-                    @Override
-                    public void run() {
-                        pipeline.fireChannelWritabilityChanged();
-                    }
-                };
+                fireChannelWritabilityChangedTask = task = pipeline::fireChannelWritabilityChanged;
             }
             channel.eventLoop().execute(task);
         } else {
@@ -654,12 +649,7 @@ public final class ChannelOutboundBuffer {
 
     void close(final Throwable cause, final boolean allowChannelOpen) {
         if (inFail) {
-            channel.eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    close(cause, allowChannelOpen);
-                }
-            });
+            channel.eventLoop().execute(() -> close(cause, allowChannelOpen));
             return;
         }
 

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -614,12 +614,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
             if (executor.inEventLoop()) {
                 remove0();
             } else {
-                executor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        remove0();
-                    }
-                });
+                executor.execute(this::remove0);
             }
         }
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -123,12 +123,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             EventExecutor ctxExecutor = newCtx.executor();
             if (!ctxExecutor.inEventLoop()) {
                 newCtx.setAddPending();
-                ctxExecutor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        callHandlerAdded0(newCtx);
-                    }
-                });
+                ctxExecutor.execute(() -> callHandlerAdded0(newCtx));
                 return this;
             }
         }
@@ -162,12 +157,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             EventExecutor ctxExecutor = newCtx.executor();
             if (!ctxExecutor.inEventLoop()) {
                 newCtx.setAddPending();
-                ctxExecutor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        callHandlerAdded0(newCtx);
-                    }
-                });
+                ctxExecutor.execute(() -> callHandlerAdded0(newCtx));
                 return this;
             }
         }
@@ -205,12 +195,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             EventExecutor ctxExecutor = newCtx.executor();
             if (!ctxExecutor.inEventLoop()) {
                 newCtx.setAddPending();
-                ctxExecutor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        callHandlerAdded0(newCtx);
-                    }
-                });
+                ctxExecutor.execute(() -> callHandlerAdded0(newCtx));
                 return this;
             }
         }
@@ -256,12 +241,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             EventExecutor ctxExecutor = newCtx.executor();
             if (!ctxExecutor.inEventLoop()) {
                 newCtx.setAddPending();
-                ctxExecutor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        callHandlerAdded0(newCtx);
-                    }
-                });
+                ctxExecutor.execute(() -> callHandlerAdded0(newCtx));
                 return this;
             }
         }
@@ -407,12 +387,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
             EventExecutor executor = ctx.executor();
             if (!executor.inEventLoop()) {
-                executor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        callHandlerRemoved0(ctx);
-                    }
-                });
+                executor.execute(() -> callHandlerRemoved0(ctx));
                 return ctx;
             }
         }
@@ -483,15 +458,12 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
             EventExecutor executor = ctx.executor();
             if (!executor.inEventLoop()) {
-                executor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        // Invoke newHandler.handlerAdded() first (i.e. before oldHandler.handlerRemoved() is invoked)
-                        // because callHandlerRemoved() will trigger channelRead() or flush() on newHandler and
-                        // those event handlers must be called after handlerAdded().
-                        callHandlerAdded0(newCtx);
-                        callHandlerRemoved0(ctx);
-                    }
+                executor.execute(() -> {
+                    // Invoke newHandler.handlerAdded() first (i.e. before oldHandler.handlerRemoved() is invoked)
+                    // because callHandlerRemoved() will trigger channelRead() or flush() on newHandler and
+                    // those event handlers must be called after handlerAdded().
+                    callHandlerAdded0(newCtx);
+                    callHandlerRemoved0(ctx);
                 });
                 return ctx.handler();
             }
@@ -776,12 +748,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             final EventExecutor executor = ctx.executor();
             if (!inEventLoop && !executor.inEventLoop(currentThread)) {
                 final AbstractChannelHandlerContext finalCtx = ctx;
-                executor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        destroyUp(finalCtx, true);
-                    }
-                });
+                executor.execute(() -> destroyUp(finalCtx, true));
                 break;
             }
 
@@ -806,12 +773,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
                 callHandlerRemoved0(ctx);
             } else {
                 final AbstractChannelHandlerContext finalCtx = ctx;
-                executor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        destroyDown(Thread.currentThread(), finalCtx, true);
-                    }
-                });
+                executor.execute(() -> destroyDown(Thread.currentThread(), finalCtx, true));
                 break;
             }
 

--- a/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
+++ b/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
@@ -40,13 +40,10 @@ public final class VoidChannelPromise extends AbstractFuture<Void> implements Ch
         }
         this.channel = channel;
         if (fireException) {
-            fireExceptionListener = new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        fireException0(cause);
-                    }
+            fireExceptionListener = future -> {
+                Throwable cause = future.cause();
+                if (cause != null) {
+                    fireException0(cause);
                 }
             };
         } else {

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -59,12 +59,7 @@ public class EmbeddedChannel extends AbstractChannel {
     private static final ChannelMetadata METADATA_NO_DISCONNECT = new ChannelMetadata(false);
     private static final ChannelMetadata METADATA_DISCONNECT = new ChannelMetadata(true);
 
-    private final ChannelFutureListener recordExceptionListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
-            recordException(future);
-        }
-    };
+    private final ChannelFutureListener recordExceptionListener = this::recordException;
 
     private final ChannelMetadata metadata;
     private final ChannelConfig config;

--- a/transport/src/main/java/io/netty/channel/group/ChannelMatchers.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelMatchers.java
@@ -23,12 +23,7 @@ import io.netty.channel.ServerChannel;
  */
 public final class ChannelMatchers {
 
-    private static final ChannelMatcher ALL_MATCHER = new ChannelMatcher() {
-        @Override
-        public boolean matches(Channel channel) {
-            return true;
-        }
-    };
+    private static final ChannelMatcher ALL_MATCHER = channel -> true;
 
     private static final ChannelMatcher SERVER_CHANNEL_MATCHER = isInstanceOf(ServerChannel.class);
     private static final ChannelMatcher NON_SERVER_CHANNEL_MATCHER = isNotInstanceOf(ServerChannel.class);

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
@@ -46,12 +46,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
     private final EventExecutor executor;
     private final ConcurrentMap<ChannelId, Channel> serverChannels = new ConcurrentHashMap<>();
     private final ConcurrentMap<ChannelId, Channel> nonServerChannels = new ConcurrentHashMap<>();
-    private final ChannelFutureListener remover = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
-            remove(future.channel());
-        }
-    };
+    private final ChannelFutureListener remover = future -> remove(future.channel());
     private final VoidChannelGroupFuture voidFuture = new VoidChannelGroupFuture(this);
     private final boolean stayClosed;
     private volatile boolean closed;

--- a/transport/src/main/java/io/netty/channel/local/LocalHandler.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalHandler.java
@@ -38,12 +38,7 @@ public final class LocalHandler implements IoHandler {
      * Returns a new {@link IoHandlerFactory} that creates {@link LocalHandler} instances.
      */
     public static IoHandlerFactory newFactory() {
-        return new IoHandlerFactory() {
-            @Override
-            public IoHandler newHandler() {
-                return new LocalHandler();
-            }
-        };
+        return LocalHandler::new;
     }
 
     private static LocalChannelUnsafe cast(Channel channel) {

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -115,12 +115,7 @@ public class LocalServerChannel extends AbstractServerChannel {
         if (eventLoop().inEventLoop()) {
             serve0(child);
         } else {
-            eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    serve0(child);
-                }
-            });
+            eventLoop().execute(() -> serve0(child));
         }
         return child;
     }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -47,13 +47,10 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
             " (expected: " + StringUtil.simpleClassName(ByteBuf.class) + ", " +
             StringUtil.simpleClassName(FileRegion.class) + ')';
 
-    private final Runnable flushTask = new Runnable() {
-        @Override
-        public void run() {
-            // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
-            // meantime.
-            ((AbstractNioUnsafe) unsafe()).flush0();
-        }
+    private final Runnable flushTask = () -> {
+        // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
+        // meantime.
+        ((AbstractNioUnsafe) unsafe()).flush0();
     };
     private boolean inputClosedSeenErrorOnRead;
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -174,12 +174,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         if (loop.inEventLoop()) {
             ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
         } else {
-            loop.execute(new Runnable() {
-                @Override
-                public void run() {
-                    ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
-                }
-            });
+            loop.execute(() -> ((AbstractUnsafe) unsafe()).shutdownOutput(promise));
         }
         return promise;
     }
@@ -200,12 +195,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         if (loop.inEventLoop()) {
             shutdownInput0(promise);
         } else {
-            loop.execute(new Runnable() {
-                @Override
-                public void run() {
-                    shutdownInput0(promise);
-                }
-            });
+            loop.execute(() -> shutdownInput0(promise));
         }
         return promise;
     }
@@ -221,12 +211,8 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         if (shutdownOutputFuture.isDone()) {
             shutdownOutputDone(shutdownOutputFuture, promise);
         } else {
-            shutdownOutputFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(final ChannelFuture shutdownOutputFuture) throws Exception {
-                    shutdownOutputDone(shutdownOutputFuture, promise);
-                }
-            });
+            shutdownOutputFuture.addListener((ChannelFutureListener) shutdownOutputFuture1 ->
+                    shutdownOutputDone(shutdownOutputFuture1, promise));
         }
         return promise;
     }
@@ -236,12 +222,8 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         if (shutdownInputFuture.isDone()) {
             shutdownDone(shutdownOutputFuture, shutdownInputFuture, promise);
         } else {
-            shutdownInputFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture shutdownInputFuture) throws Exception {
-                    shutdownDone(shutdownOutputFuture, shutdownInputFuture, promise);
-                }
-            });
+            shutdownInputFuture.addListener((ChannelFutureListener) shutdownInputFuture1 ->
+                    shutdownDone(shutdownOutputFuture, shutdownInputFuture1, promise));
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -51,12 +51,9 @@ public class AbstractChannelTest {
         when(eventLoop.inEventLoop()).thenReturn(true);
         when(eventLoop.unsafe()).thenReturn(mock(EventLoop.Unsafe.class));
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((Runnable) invocationOnMock.getArgument(0)).run();
-                return null;
-            }
+        doAnswer(invocationOnMock -> {
+            ((Runnable) invocationOnMock.getArgument(0)).run();
+            return null;
         }).when(eventLoop).execute(any(Runnable.class));
 
         final TestChannel channel = new TestChannel(eventLoop);

--- a/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
@@ -146,11 +146,8 @@ public class ChannelInitializerTest {
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
-            channel.eventLoop().submit(new Runnable() {
-                @Override
-                public void run() {
-                    // NOOP
-                }
+            channel.eventLoop().submit(() -> {
+                // NOOP
             }).syncUninterruptibly();
             Iterator<Map.Entry<String, ChannelHandler>> handlers = channel.pipeline().iterator();
             assertSame(handler1, handlers.next().getValue());
@@ -186,11 +183,8 @@ public class ChannelInitializerTest {
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
-            channel.eventLoop().submit(new Runnable() {
-                @Override
-                public void run() {
-                    // NOOP
-                }
+            channel.eventLoop().submit(() -> {
+                // NOOP
             }).syncUninterruptibly();
             assertEquals(1, initChannelCalled.get());
             assertEquals(2, registeredCalled.get());

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -424,25 +424,19 @@ public class ChannelOutboundBufferTest {
 
         final CountDownLatch executeLatch = new CountDownLatch(1);
         final CountDownLatch runLatch = new CountDownLatch(1);
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    runLatch.countDown();
-                    executeLatch.await();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
+        executor.execute(() -> {
+            try {
+                runLatch.countDown();
+                executeLatch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
         });
 
         runLatch.await();
 
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                // Will not be executed but ensure the pending count is 1.
-            }
+        executor.execute(() -> {
+            // Will not be executed but ensure the pending count is 1.
         });
 
         assertEquals(1, executor.pendingTasks());

--- a/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
@@ -53,12 +53,9 @@ public class CoalescingBufferQueueTest {
         channel = new EmbeddedChannel();
         writeQueue = new CoalescingBufferQueue(channel, 16, true);
         catPromise = newPromise();
-        mouseListener = new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                mouseDone = true;
-                mouseSuccess = future.isSuccess();
-            }
+        mouseListener = future -> {
+            mouseDone = true;
+            mouseSuccess = future.isSuccess();
         };
         emptyPromise = newPromise();
         voidPromise = channel.voidPromise();

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -368,17 +368,14 @@ public class DefaultChannelPipelineTest {
 
             // Add handler.
             p.addFirst(handler.name, handler);
-            self.eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    // Validate handler life-cycle methods called.
-                    handler.validate(true, false);
+            self.eventLoop().execute(() -> {
+                // Validate handler life-cycle methods called.
+                handler.validate(true, false);
 
-                    // Store handler into the list.
-                    handlers.add(handler);
+                // Store handler into the list.
+                handlers.add(handler);
 
-                    addLatch.countDown();
-                }
+                addLatch.countDown();
             });
         }
         addLatch.await();
@@ -391,13 +388,10 @@ public class DefaultChannelPipelineTest {
         for (final LifeCycleAwareTestHandler handler : handlers) {
             assertSame(handler, p.remove(handler.name));
 
-            self.eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    // Validate handler life-cycle methods called.
-                    handler.validate(true, true);
-                    removeLatch.countDown();
-                }
+            self.eventLoop().execute(() -> {
+                // Validate handler life-cycle methods called.
+                handler.validate(true, true);
+                removeLatch.countDown();
             });
         }
         removeLatch.await();
@@ -410,17 +404,14 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1, handler2);
 
-        self.eventLoop().submit(new Runnable() {
-            @Override
-            public void run() {
-                ChannelPipeline p = self.pipeline();
-                handler1.inboundBuffer.add(8);
-                assertEquals(8, handler1.inboundBuffer.peek());
-                assertTrue(handler2.inboundBuffer.isEmpty());
-                p.remove(handler1);
-                assertEquals(1, handler2.inboundBuffer.size());
-                assertEquals(8, handler2.inboundBuffer.peek());
-            }
+        self.eventLoop().submit(() -> {
+            ChannelPipeline p = self.pipeline();
+            handler1.inboundBuffer.add(8);
+            assertEquals(8, handler1.inboundBuffer.peek());
+            assertTrue(handler2.inboundBuffer.isEmpty());
+            p.remove(handler1);
+            assertEquals(1, handler2.inboundBuffer.size());
+            assertEquals(8, handler2.inboundBuffer.peek());
         }).sync();
     }
 
@@ -431,17 +422,14 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1, handler2);
 
-        self.eventLoop().submit(new Runnable() {
-            @Override
-            public void run() {
-                ChannelPipeline p = self.pipeline();
-                handler2.outboundBuffer.add(8);
-                assertEquals(8, handler2.outboundBuffer.peek());
-                assertTrue(handler1.outboundBuffer.isEmpty());
-                p.remove(handler2);
-                assertEquals(1, handler1.outboundBuffer.size());
-                assertEquals(8, handler1.outboundBuffer.peek());
-            }
+        self.eventLoop().submit(() -> {
+            ChannelPipeline p = self.pipeline();
+            handler2.outboundBuffer.add(8);
+            assertEquals(8, handler2.outboundBuffer.peek());
+            assertTrue(handler1.outboundBuffer.isEmpty());
+            p.remove(handler2);
+            assertEquals(1, handler1.outboundBuffer.size());
+            assertEquals(8, handler1.outboundBuffer.peek());
         }).sync();
     }
 
@@ -452,16 +440,13 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1);
 
-        self.eventLoop().submit(new Runnable() {
-            @Override
-            public void run() {
-                ChannelPipeline p = self.pipeline();
-                handler1.outboundBuffer.add(8);
-                assertEquals(8, handler1.outboundBuffer.peek());
-                assertTrue(handler2.outboundBuffer.isEmpty());
-                p.replace(handler1, "handler2", handler2);
-                assertEquals(8, handler2.outboundBuffer.peek());
-            }
+        self.eventLoop().submit(() -> {
+            ChannelPipeline p = self.pipeline();
+            handler1.outboundBuffer.add(8);
+            assertEquals(8, handler1.outboundBuffer.peek());
+            assertTrue(handler2.outboundBuffer.isEmpty());
+            p.replace(handler1, "handler2", handler2);
+            assertEquals(8, handler2.outboundBuffer.peek());
         }).sync();
     }
 
@@ -472,22 +457,19 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1);
 
-        self.eventLoop().submit(new Runnable() {
-            @Override
-            public void run() {
-                ChannelPipeline p = self.pipeline();
-                handler1.inboundBuffer.add(8);
-                handler1.outboundBuffer.add(8);
+        self.eventLoop().submit(() -> {
+            ChannelPipeline p = self.pipeline();
+            handler1.inboundBuffer.add(8);
+            handler1.outboundBuffer.add(8);
 
-                assertEquals(8, handler1.inboundBuffer.peek());
-                assertEquals(8, handler1.outboundBuffer.peek());
-                assertTrue(handler2.inboundBuffer.isEmpty());
-                assertTrue(handler2.outboundBuffer.isEmpty());
+            assertEquals(8, handler1.inboundBuffer.peek());
+            assertEquals(8, handler1.outboundBuffer.peek());
+            assertTrue(handler2.inboundBuffer.isEmpty());
+            assertTrue(handler2.outboundBuffer.isEmpty());
 
-                p.replace(handler1, "handler2", handler2);
-                assertEquals(8, handler2.outboundBuffer.peek());
-                assertEquals(8, handler2.inboundBuffer.peek());
-            }
+            p.replace(handler1, "handler2", handler2);
+            assertEquals(8, handler2.outboundBuffer.peek());
+            assertEquals(8, handler2.inboundBuffer.peek());
         }).sync();
     }
 
@@ -499,23 +481,20 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1, handler2, handler3);
 
-        self.eventLoop().submit(new Runnable() {
-            @Override
-            public void run() {
-                ChannelPipeline p = self.pipeline();
-                handler2.inboundBuffer.add(8);
-                handler2.outboundBuffer.add(8);
+        self.eventLoop().submit(() -> {
+            ChannelPipeline p = self.pipeline();
+            handler2.inboundBuffer.add(8);
+            handler2.outboundBuffer.add(8);
 
-                assertEquals(8, handler2.inboundBuffer.peek());
-                assertEquals(8, handler2.outboundBuffer.peek());
+            assertEquals(8, handler2.inboundBuffer.peek());
+            assertEquals(8, handler2.outboundBuffer.peek());
 
-                assertEquals(0, handler1.outboundBuffer.size());
-                assertEquals(0, handler3.inboundBuffer.size());
+            assertEquals(0, handler1.outboundBuffer.size());
+            assertEquals(0, handler3.inboundBuffer.size());
 
-                p.remove(handler2);
-                assertEquals(8, handler3.inboundBuffer.peek());
-                assertEquals(8, handler1.outboundBuffer.peek());
-            }
+            p.remove(handler2);
+            assertEquals(8, handler3.inboundBuffer.peek());
+            assertEquals(8, handler1.outboundBuffer.peek());
         }).sync();
     }
 
@@ -870,12 +849,7 @@ public class DefaultChannelPipelineTest {
                 @Override
                 public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
                     // Execute this later so we are sure the exception is handled first.
-                    ctx.executor().execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            latch.countDown();
-                        }
-                    });
+                    ctx.executor().execute(latch::countDown);
                     throw exceptionRemoved;
                 }
             });
@@ -986,34 +960,31 @@ public class DefaultChannelPipelineTest {
         try {
             final Object event = new Object();
             final Promise<Object> promise = ImmediateEventExecutor.INSTANCE.newPromise();
-            pipeline1.channel().register().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    ChannelPipeline pipeline = future.channel().pipeline();
-                    final AtomicBoolean handlerAddedCalled = new AtomicBoolean();
-                    pipeline.addLast(new ChannelInboundHandlerAdapter() {
-                        @Override
-                        public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-                            handlerAddedCalled.set(true);
-                        }
-
-                        @Override
-                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-                            promise.setSuccess(event);
-                        }
-
-                        @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-                            promise.setFailure(cause);
-                        }
-                    });
-                    if (!handlerAddedCalled.get()) {
-                        promise.setFailure(new AssertionError("handlerAdded(...) should have been called"));
-                        return;
+            pipeline1.channel().register().addListener((ChannelFutureListener) future -> {
+                ChannelPipeline pipeline = future.channel().pipeline();
+                final AtomicBoolean handlerAddedCalled = new AtomicBoolean();
+                pipeline.addLast(new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+                        handlerAddedCalled.set(true);
                     }
-                    // This event must be captured by the added handler.
-                    pipeline.fireUserEventTriggered(event);
+
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                        promise.setSuccess(event);
+                    }
+
+                    @Override
+                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                        promise.setFailure(cause);
+                    }
+                });
+                if (!handlerAddedCalled.get()) {
+                    promise.setFailure(new AssertionError("handlerAdded(...) should have been called"));
+                    return;
                 }
+                // This event must be captured by the added handler.
+                pipeline.fireUserEventTriggered(event);
             });
             assertSame(event, promise.syncUninterruptibly().getNow());
         } finally {
@@ -1184,11 +1155,8 @@ public class DefaultChannelPipelineTest {
                 pipeline.channel().closeFuture().syncUninterruptibly();
 
                 // Schedule something on the EventLoop to ensure all other scheduled tasks had a chance to complete.
-                pipeline.channel().eventLoop().submit(new Runnable() {
-                    @Override
-                    public void run() {
-                        // NOOP
-                    }
+                pipeline.channel().eventLoop().submit(() -> {
+                    // NOOP
                 }).syncUninterruptibly();
                 Error error = errorRef.get();
                 if (error != null) {
@@ -1646,33 +1614,30 @@ public class DefaultChannelPipelineTest {
         final Object writeObject = new Object();
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                pipeline.addLast(new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-                        if (evt == userEvent) {
-                            ctx.write(writeObject);
-                        }
-                        ctx.fireUserEventTriggered(evt);
+        Runnable r = () -> {
+            pipeline.addLast(new ChannelInboundHandlerAdapter() {
+                @Override
+                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                    if (evt == userEvent) {
+                        ctx.write(writeObject);
                     }
-                });
-                pipeline.addFirst(new ChannelDuplexHandler() {
-                    @Override
-                    public void handlerAdded(ChannelHandlerContext ctx) {
-                        ctx.fireUserEventTriggered(userEvent);
-                    }
+                    ctx.fireUserEventTriggered(evt);
+                }
+            });
+            pipeline.addFirst(new ChannelDuplexHandler() {
+                @Override
+                public void handlerAdded(ChannelHandlerContext ctx) {
+                    ctx.fireUserEventTriggered(userEvent);
+                }
 
-                    @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                        if (msg == writeObject) {
-                            doneLatch.countDown();
-                        }
-                        ctx.write(msg, promise);
+                @Override
+                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                    if (msg == writeObject) {
+                        doneLatch.countDown();
                     }
-                });
-            }
+                    ctx.write(msg, promise);
+                }
+            });
         };
 
         if (executeInEventLoop) {

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -40,12 +40,7 @@ public class PendingWriteQueueTest {
                 assertFalse("Should not be writable anymore", ctx.channel().isWritable());
 
                 ChannelFuture future = queue.removeAndWrite();
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        assertQueueEmpty(queue);
-                    }
-                });
+                future.addListener((ChannelFutureListener) future1 -> assertQueueEmpty(queue));
                 super.flush(ctx);
             }
         }, 1);
@@ -59,12 +54,7 @@ public class PendingWriteQueueTest {
                 assertFalse("Should not be writable anymore", ctx.channel().isWritable());
 
                 ChannelFuture future = queue.removeAndWriteAll();
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        assertQueueEmpty(queue);
-                    }
-                });
+                future.addListener((ChannelFutureListener) future1 -> assertQueueEmpty(queue));
                 super.flush(ctx);
             }
         }, 3);
@@ -209,12 +199,7 @@ public class PendingWriteQueueTest {
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                queue.removeAndFailAll(new IllegalStateException());
-            }
-        });
+        promise.addListener((ChannelFutureListener) future -> queue.removeAndFailAll(new IllegalStateException()));
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();
@@ -241,12 +226,7 @@ public class PendingWriteQueueTest {
 
         ChannelPromise promise = channel.newPromise();
         final ChannelPromise promise3 = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.add(3L, promise3);
-            }
-        });
+        promise.addListener((ChannelFutureListener) future -> queue.add(3L, promise3));
         queue.add(1L, promise);
         ChannelPromise promise2 = channel.newPromise();
         queue.add(2L, promise2);
@@ -296,28 +276,15 @@ public class PendingWriteQueueTest {
 
         ChannelPromise promise = channel.newPromise();
         final ChannelPromise promise3 = channel.newPromise();
-        promise3.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                failOrder.add(3);
-            }
-        });
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                failOrder.add(1);
-                queue.add(3L, promise3);
-            }
+        promise3.addListener((ChannelFutureListener) future -> failOrder.add(3));
+        promise.addListener((ChannelFutureListener) future -> {
+            failOrder.add(1);
+            queue.add(3L, promise3);
         });
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();
-        promise2.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                failOrder.add(2);
-            }
-        });
+        promise2.addListener((ChannelFutureListener) future -> failOrder.add(2));
         queue.add(2L, promise2);
         queue.removeAndFailAll(new Exception());
         assertTrue(promise.isDone());
@@ -338,12 +305,7 @@ public class PendingWriteQueueTest {
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                queue.removeAndWriteAll();
-            }
-        });
+        promise.addListener((ChannelFutureListener) future -> queue.removeAndWriteAll());
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -226,12 +226,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
             @Override
             public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-                promise.addListener(new GenericFutureListener<Future<? super Void>>() {
-                    @Override
-                    public void operationComplete(Future<? super Void> future) throws Exception {
-                        ctx.channel().close();
-                    }
-                });
+                promise.addListener(future -> ctx.channel().close());
                 super.write(ctx, msg, promise);
                 ctx.channel().flush();
             }

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
@@ -266,12 +266,9 @@ public class LocalTransportThreadModelTest {
                 final int end = i + ELEMS_PER_ROUNDS;
                 i = end;
 
-                ch.eventLoop().execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int j = start; j < end; j ++) {
-                            ch.pipeline().fireChannelRead(Integer.valueOf(j));
-                        }
+                ch.eventLoop().execute(() -> {
+                    for (int j = start; j < end; j ++) {
+                        ch.pipeline().fireChannelRead(Integer.valueOf(j));
                     }
                 });
             }
@@ -304,14 +301,11 @@ public class LocalTransportThreadModelTest {
                 final int end = i + ELEMS_PER_ROUNDS;
                 i = end;
 
-                ch.pipeline().context(h6).executor().execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int j = start; j < end; j ++) {
-                            ch.write(Integer.valueOf(j));
-                        }
-                        ch.flush();
+                ch.pipeline().context(h6).executor().execute(() -> {
+                    for (int j = start; j < end; j ++) {
+                        ch.write(Integer.valueOf(j));
                     }
+                    ch.flush();
                 });
             }
 

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
@@ -83,12 +83,7 @@ public class LocalTransportThreadModelTest2 {
             return;
         }
 
-        localChannel.eventLoop().execute(new Runnable() {
-            @Override
-            public void run() {
-                close(localChannel, localRegistrationHandler);
-            }
-        });
+        localChannel.eventLoop().execute(() -> close(localChannel, localRegistrationHandler));
 
         // Wait until the connection is closed or the connection attempt fails.
         localChannel.closeFuture().awaitUninterruptibly();

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest3.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest3.java
@@ -152,25 +152,22 @@ public class LocalTransportThreadModelTest3 {
 
             Throwable cause = new Throwable();
 
-            Thread pipelineModifier = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    Random random = new Random();
+            Thread pipelineModifier = new Thread(() -> {
+                Random random = new Random();
 
-                    while (true) {
-                        try {
-                            Thread.sleep(100);
-                        } catch (InterruptedException e) {
-                            return;
-                        }
-                        if (!ch.isRegistered()) {
-                            continue;
-                        }
-                        //EventForwardHandler forwardHandler = forwarders[random.nextInt(forwarders.length)];
-                        ChannelHandler handler = ch.pipeline().removeFirst();
-                        ch.pipeline().addBefore(groups[random.nextInt(groups.length)].next(), "recorder",
-                                UUID.randomUUID().toString(), handler);
+                while (true) {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        return;
                     }
+                    if (!ch.isRegistered()) {
+                        continue;
+                    }
+                    //EventForwardHandler forwardHandler = forwarders[random.nextInt(forwarders.length)];
+                    ChannelHandler handler = ch.pipeline().removeFirst();
+                    ch.pipeline().addBefore(groups[random.nextInt(groups.length)].next(), "recorder",
+                            UUID.randomUUID().toString(), handler);
                 }
             });
             pipelineModifier.setDaemon(true);

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -132,12 +132,9 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                     // Trigger a gathering write by writing two buffers.
                     ctx.write(Unpooled.wrappedBuffer(new byte[] { 'a' }));
                     ChannelFuture f = ctx.write(Unpooled.wrappedBuffer(new byte[] { 'b' }));
-                    f.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            // This message must be flushed
-                            ctx.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{'c'}));
-                        }
+                    f.addListener((ChannelFutureListener) future -> {
+                        // This message must be flushed
+                        ctx.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{'c'}));
                     });
                     ctx.flush();
                 }
@@ -197,12 +194,9 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                              // As soon as the channel becomes active re-register it to another
                              // EventLoop. After this is done we should still receive the data that
                              // was written to the channel.
-                             ctx.deregister().addListener(new ChannelFutureListener() {
-                                 @Override
-                                 public void operationComplete(ChannelFuture cf) {
-                                     Channel channel = cf.channel();
-                                     channel.register();
-                                 }
+                             ctx.deregister().addListener((ChannelFutureListener) cf -> {
+                                 Channel channel = cf.channel();
+                                 channel.register();
                              });
                          }
                      });


### PR DESCRIPTION
Motivation:

Using lambda instead of anonymous inner class to imporve readablity

Modification:

Replace anonymous inner class with lambda
