### PR TITLE
Java 8 migration. Auto close try catch blocks

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -125,8 +125,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                 }
                 return;
             }
-            FileOutputStream outputStream = new FileOutputStream(file);
-            try {
+            try (FileOutputStream outputStream = new FileOutputStream(file)) {
                 FileChannel localfileChannel = outputStream.getChannel();
                 ByteBuffer byteBuffer = buffer.nioBuffer();
                 int written = 0;
@@ -135,8 +134,6 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                 }
                 buffer.readerIndex(buffer.readerIndex() + written);
                 localfileChannel.force(false);
-            } finally {
-                outputStream.close();
             }
             setCompleted();
         } finally {
@@ -217,9 +214,8 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             delete();
         }
         file = tempFile();
-        FileOutputStream outputStream = new FileOutputStream(file);
         int written = 0;
-        try {
+        try (FileOutputStream outputStream = new FileOutputStream(file)) {
             FileChannel localfileChannel = outputStream.getChannel();
             byte[] bytes = new byte[4096 * 4];
             ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
@@ -231,8 +227,6 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                 read = inputStream.read(bytes);
             }
             localfileChannel.force(false);
-        } finally {
-            outputStream.close();
         }
         size = written;
         if (definedSize > 0 && definedSize < size) {
@@ -422,17 +416,14 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             throw new IllegalArgumentException(
                     "File too big to be loaded in memory");
         }
-        FileInputStream inputStream = new FileInputStream(src);
         byte[] array = new byte[(int) srcsize];
-        try {
+        try (FileInputStream inputStream = new FileInputStream(src)) {
             FileChannel fileChannel = inputStream.getChannel();
             ByteBuffer byteBuffer = ByteBuffer.wrap(array);
             int read = 0;
             while (read < srcsize) {
                 read += fileChannel.read(byteBuffer);
             }
-        } finally {
-            inputStream.close();
         }
         return array;
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/LzmaFrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzmaFrameEncoder.java
@@ -175,22 +175,12 @@ public class LzmaFrameEncoder extends MessageToByteEncoder<ByteBuf> {
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) throws Exception {
         final int length = in.readableBytes();
-        InputStream bbIn = null;
-        ByteBufOutputStream bbOut = null;
-        try {
-            bbIn = new ByteBufInputStream(in);
-            bbOut = new ByteBufOutputStream(out);
+        try (InputStream bbIn = new ByteBufInputStream(in);
+             ByteBufOutputStream bbOut = new ByteBufOutputStream(out)) {
             bbOut.writeByte(properties);
             bbOut.writeInt(littleEndianDictionarySize);
             bbOut.writeLong(Long.reverseBytes(length));
             encoder.code(bbIn, bbOut, -1, -1, null);
-        } finally {
-            if (bbIn != null) {
-                bbIn.close();
-            }
-            if (bbOut != null) {
-                bbOut.close();
-            }
         }
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/marshalling/MarshallingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/marshalling/MarshallingDecoder.java
@@ -65,18 +65,14 @@ public class MarshallingDecoder extends LengthFieldBasedFrameDecoder {
             return null;
         }
 
-        Unmarshaller unmarshaller = provider.getUnmarshaller(ctx);
-        ByteInput input = new ChannelBufferByteInput(frame);
-
-        try {
+        // Call close in a finally block as the ReplayingDecoder will throw an Error if not enough bytes are
+        // readable. This helps to be sure that we do not leak resource
+        try (Unmarshaller unmarshaller = provider.getUnmarshaller(ctx)) {
+            ByteInput input = new ChannelBufferByteInput(frame);
             unmarshaller.start(input);
             Object obj = unmarshaller.readObject();
             unmarshaller.finish();
             return obj;
-        } finally {
-            // Call close in a finally block as the ReplayingDecoder will throw an Error if not enough bytes are
-            // readable. This helps to be sure that we do not leak resource
-            unmarshaller.close();
         }
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
@@ -73,11 +73,10 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
 
     @Override
     protected void encode(ChannelHandlerContext ctx, Serializable msg, ByteBuf out) throws Exception {
-        ObjectOutputStream oos = newObjectOutputStream(new ByteBufOutputStream(out));
-        try {
+        try (ObjectOutputStream oos = newObjectOutputStream(new ByteBufOutputStream(out))) {
             if (resetInterval != 0) {
                 // Resetting will prevent OOM on the receiving side.
-                writtenObjects ++;
+                writtenObjects++;
                 if (writtenObjects % resetInterval == 0) {
                     oos.reset();
                 }
@@ -85,8 +84,6 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
 
             oos.writeObject(msg);
             oos.flush();
-        } finally {
-            oos.close();
         }
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoder.java
@@ -71,11 +71,9 @@ public class ObjectDecoder extends LengthFieldBasedFrameDecoder {
             return null;
         }
 
-        ObjectInputStream ois = new CompactObjectInputStream(new ByteBufInputStream(frame, true), classResolver);
-        try {
+        try (ObjectInputStream ois =
+                     new CompactObjectInputStream(new ByteBufInputStream(frame, true), classResolver)) {
             return ois.readObject();
-        } finally {
-            ois.close();
         }
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
@@ -82,12 +82,9 @@ public class ObjectEncoderOutputStream extends OutputStream implements
     public void writeObject(Object obj) throws IOException {
         ByteBuf buf = Unpooled.buffer(estimatedLength);
         try {
-            ObjectOutputStream oout = new CompactObjectOutputStream(new ByteBufOutputStream(buf));
-            try {
+            try (ObjectOutputStream oout = new CompactObjectOutputStream(new ByteBufOutputStream(buf))) {
                 oout.writeObject(obj);
                 oout.flush();
-            } finally {
-                oout.close();
             }
 
             int objectSize = buf.readableBytes();

--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -317,8 +317,7 @@ public final class NetUtil {
         try {
             InputStream is = process.getInputStream();
             InputStreamReader isr = new InputStreamReader(is);
-            BufferedReader br = new BufferedReader(isr);
-            try {
+            try (BufferedReader br = new BufferedReader(isr)) {
                 String line = br.readLine();
                 if (line.startsWith(sysctlKey)) {
                     for (int i = line.length() - 1; i > sysctlKey.length(); --i) {
@@ -328,13 +327,9 @@ public final class NetUtil {
                     }
                 }
                 return null;
-            } finally {
-                br.close();
             }
         } finally {
-            if (process != null) {
-                process.destroy();
-            }
+            process.destroy();
         }
     }
 

--- a/common/src/main/java/io/netty/util/Version.java
+++ b/common/src/main/java/io/netty/util/Version.java
@@ -72,16 +72,10 @@ public final class Version {
             Enumeration<URL> resources = classLoader.getResources("META-INF/io.netty.versions.properties");
             while (resources.hasMoreElements()) {
                 URL url = resources.nextElement();
-                InputStream in = url.openStream();
-                try {
+                try (InputStream in = url.openStream()) {
                     props.load(in);
-                } finally {
-                    try {
-                        in.close();
-                    } catch (Exception ignore) {
-                        // Ignore.
-                    }
                 }
+                // Ignore.
             }
         } catch (Exception ignore) {
             // Not critical. Just ignore.

--- a/example/src/main/java/io/netty/example/ocsp/OcspServerExample.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspServerExample.java
@@ -170,11 +170,8 @@ public class OcspServerExample {
         }
 
         try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(in, CharsetUtil.US_ASCII));
-            try {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, CharsetUtil.US_ASCII))) {
                 return parseCertificates(reader);
-            } finally {
-                reader.close();
             }
         } finally {
             in.close();

--- a/example/src/main/java/io/netty/example/ocsp/OcspUtils.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspUtils.java
@@ -130,13 +130,11 @@ public final class OcspUtils {
             connection.setRequestProperty("accept", OCSP_RESPONSE_TYPE);
             connection.setRequestProperty("content-length", String.valueOf(encoded.length));
 
-            OutputStream out = connection.getOutputStream();
-            try {
+            try (OutputStream out = connection.getOutputStream()) {
                 out.write(encoded);
                 out.flush();
 
-                InputStream in = connection.getInputStream();
-                try {
+                try (InputStream in = connection.getInputStream()) {
                     int code = connection.getResponseCode();
                     if (code != HttpsURLConnection.HTTP_OK) {
                         throw new IOException("Unexpected status-code=" + code);
@@ -169,11 +167,7 @@ public final class OcspUtils {
                         baos.close();
                     }
                     return new OCSPResp(baos.toByteArray());
-                } finally {
-                    in.close();
                 }
-            } finally {
-                out.close();
             }
         } finally {
             connection.disconnect();

--- a/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
+++ b/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
@@ -156,11 +156,8 @@ public final class TestUtils {
             long lastLogTime = System.nanoTime();
             long counter = 0;
 
-            InputStream in = null;
-            OutputStream out = null;
-            try {
-                in = new FileInputStream(filename);
-                out = new XZOutputStream(new FileOutputStream(xzFilename), options);
+            try (InputStream in = new FileInputStream(filename);
+                 OutputStream out = new XZOutputStream(new FileOutputStream(xzFilename), options)) {
                 for (;;) {
                     int readBytes = in.read(buf);
                     if (readBytes < 0) {
@@ -180,25 +177,8 @@ public final class TestUtils {
                         lastLogTime = currentTime;
                     }
                 }
-                out.close();
-                in.close();
             } catch (Throwable t) {
                 logger.warn("Failed to compress the heap dump: {}", xzFilename, t);
-            } finally {
-                if (in != null) {
-                    try {
-                        in.close();
-                    } catch (IOException ignored) {
-                        // Ignore.
-                    }
-                }
-                if (out != null) {
-                    try {
-                        out.close();
-                    } catch (IOException ignored) {
-                        // Ignore.
-                    }
-                }
             }
 
             // Delete the uncompressed dump in favor of the compressed one.


### PR DESCRIPTION
Motivation:

Since Java 7 we can automatically close resources in `try ()` construction.

Modification:

Changed all try catches in the code with autoclose `try (resource)`

