### PR TITLE
Java 8 migration. Replace Collections.sort(list, comparator) with lis…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCache.java
@@ -20,12 +20,13 @@ import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 
-import static io.netty.util.internal.ObjectUtil.*;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * Default implementation of {@link AuthoritativeDnsServerCache}, backed by a {@link ConcurrentMap}.
@@ -53,7 +54,7 @@ public class DefaultAuthoritativeDnsServerCache implements AuthoritativeDnsServe
         @Override
         protected void sortEntries(String hostname, List<InetSocketAddress> entries) {
             if (comparator != null) {
-                Collections.sort(entries, comparator);
+                entries.sort(comparator);
             }
         }
     };
@@ -83,7 +84,6 @@ public class DefaultAuthoritativeDnsServerCache implements AuthoritativeDnsServe
         this.comparator = comparator;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public DnsServerAddressStream get(String hostname) {
         checkNotNull(hostname, "hostname");

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -383,7 +383,7 @@ public class DnsNameResolver extends InetNameResolver {
         b.group(executor());
         b.channelFactory(channelFactory);
         b.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
-        final DnsResponseHandler responseHandler = new DnsResponseHandler(executor().<Channel>newPromise());
+        final DnsResponseHandler responseHandler = new DnsResponseHandler(executor().newPromise());
         b.handler(new ChannelInitializer<DatagramChannel>() {
             @Override
             protected void initChannel(DatagramChannel ch) throws Exception {
@@ -455,7 +455,7 @@ public class DnsNameResolver extends InetNameResolver {
         if (cached == null || cached.size() == 0) {
             // If there is no cache hit (which may be the case for example when a NoopAuthoritativeDnsServerCache
             // is used), we will just directly use the provided nameservers.
-            Collections.sort(nameservers, nameServerComparator);
+            nameservers.sort(nameServerComparator);
             return new SequentialDnsServerAddressStream(nameservers, 0);
         }
         return cached;
@@ -610,7 +610,7 @@ public class DnsNameResolver extends InetNameResolver {
      * @return the address as the result of the resolution
      */
     public final Future<InetAddress> resolve(String inetHost, Iterable<DnsRecord> additionals) {
-        return resolve(inetHost, additionals, executor().<InetAddress>newPromise());
+        return resolve(inetHost, additionals, executor().newPromise());
     }
 
     /**
@@ -643,7 +643,7 @@ public class DnsNameResolver extends InetNameResolver {
      * @return the list of the address as the result of the resolution
      */
     public final Future<List<InetAddress>> resolveAll(String inetHost, Iterable<DnsRecord> additionals) {
-        return resolveAll(inetHost, additionals, executor().<List<InetAddress>>newPromise());
+        return resolveAll(inetHost, additionals, executor().newPromise());
     }
 
     /**
@@ -684,7 +684,7 @@ public class DnsNameResolver extends InetNameResolver {
      * @return the list of the {@link DnsRecord}s as the result of the resolution
      */
     public final Future<List<DnsRecord>> resolveAll(DnsQuestion question) {
-        return resolveAll(question, EMPTY_ADDITIONALS, executor().<List<DnsRecord>>newPromise());
+        return resolveAll(question, EMPTY_ADDITIONALS, executor().newPromise());
     }
 
     /**
@@ -700,7 +700,7 @@ public class DnsNameResolver extends InetNameResolver {
      * @return the list of the {@link DnsRecord}s as the result of the resolution
      */
     public final Future<List<DnsRecord>> resolveAll(DnsQuestion question, Iterable<DnsRecord> additionals) {
-        return resolveAll(question, additionals, executor().<List<DnsRecord>>newPromise());
+        return resolveAll(question, additionals, executor().newPromise());
     }
 
     /**
@@ -769,21 +769,21 @@ public class DnsNameResolver extends InetNameResolver {
             for (DnsRecord r: additionals) {
                 validateAdditional(r, validateType);
             }
-            return records.toArray(new DnsRecord[records.size()]);
+            return records.toArray(new DnsRecord[0]);
         }
 
         Iterator<DnsRecord> additionalsIt = additionals.iterator();
         if (!additionalsIt.hasNext()) {
             return EMPTY_ADDITIONALS;
         }
-        List<DnsRecord> records = new ArrayList<DnsRecord>();
+        List<DnsRecord> records = new ArrayList<>();
         do {
             DnsRecord r = additionalsIt.next();
             validateAdditional(r, validateType);
             records.add(r);
         } while (additionalsIt.hasNext());
 
-        return records.toArray(new DnsRecord[records.size()]);
+        return records.toArray(new DnsRecord[0]);
     }
 
     private static void validateAdditional(DnsRecord record, boolean validateType) {
@@ -946,7 +946,7 @@ public class DnsNameResolver extends InetNameResolver {
                     final DnsCacheEntry e = cachedEntries.get(i);
                     if (f.addressType().isInstance(e.address())) {
                         if (result == null) {
-                            result = new ArrayList<InetAddress>(numEntries);
+                            result = new ArrayList<>(numEntries);
                         }
                         result.add(e.address());
                     }
@@ -1024,7 +1024,7 @@ public class DnsNameResolver extends InetNameResolver {
      */
     public Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> query(
             DnsQuestion question, Promise<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>> promise) {
-        return query(nextNameServerAddress(), question, Collections.<DnsRecord>emptyList(), promise);
+        return query(nextNameServerAddress(), question, Collections.emptyList(), promise);
     }
 
     private InetSocketAddress nextNameServerAddress() {
@@ -1038,7 +1038,7 @@ public class DnsNameResolver extends InetNameResolver {
             InetSocketAddress nameServerAddr, DnsQuestion question) {
 
         return query0(nameServerAddr, question, EMPTY_ADDITIONALS, true, ch.newPromise(),
-                      ch.eventLoop().<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>>newPromise());
+                      ch.eventLoop().newPromise());
     }
 
     /**
@@ -1048,7 +1048,7 @@ public class DnsNameResolver extends InetNameResolver {
             InetSocketAddress nameServerAddr, DnsQuestion question, Iterable<DnsRecord> additionals) {
 
         return query0(nameServerAddr, question, toArray(additionals, false), true, ch.newPromise(),
-                     ch.eventLoop().<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>>newPromise());
+                     ch.eventLoop().newPromise());
     }
 
     /**


### PR DESCRIPTION
…t.sort(comparator)

Motivation:

Simplify code with new Java 8 api.

