### PR TITLE
Java 8 migration. Use reference to StandardCharsets in CharsetUtil.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoder.java
@@ -17,8 +17,9 @@ package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.CharsetUtil;
 
-import static io.netty.handler.codec.spdy.SpdyCodecUtil.*;
+import static io.netty.handler.codec.spdy.SpdyCodecUtil.getSignedInt;
 
 public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
 
@@ -136,7 +137,7 @@ public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
 
                     byte[] nameBytes = new byte[length];
                     headerBlock.readBytes(nameBytes);
-                    name = new String(nameBytes, "UTF-8");
+                    name = new String(nameBytes, CharsetUtil.UTF_8);
 
                     // Check for identically named headers
                     if (frame.headers().contains(name)) {
@@ -226,7 +227,7 @@ public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
                                 break;
                             }
                         }
-                        String value = new String(valueBytes, offset, index - offset, "UTF-8");
+                        String value = new String(valueBytes, offset, index - offset, CharsetUtil.UTF_8);
 
                         try {
                             frame.headers().add(name, value);

--- a/common/src/main/java/io/netty/util/CharsetUtil.java
+++ b/common/src/main/java/io/netty/util/CharsetUtil.java
@@ -22,6 +22,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -34,38 +35,33 @@ public final class CharsetUtil {
      * 16-bit UTF (UCS Transformation Format) whose byte order is identified by
      * an optional byte-order mark
      */
-    public static final Charset UTF_16 = Charset.forName("UTF-16");
+    public static final Charset UTF_16 = StandardCharsets.UTF_16;
 
     /**
      * 16-bit UTF (UCS Transformation Format) whose byte order is big-endian
      */
-    public static final Charset UTF_16BE = Charset.forName("UTF-16BE");
+    public static final Charset UTF_16BE = StandardCharsets.UTF_16BE;
 
     /**
      * 16-bit UTF (UCS Transformation Format) whose byte order is little-endian
      */
-    public static final Charset UTF_16LE = Charset.forName("UTF-16LE");
+    public static final Charset UTF_16LE = StandardCharsets.UTF_16LE;
 
     /**
      * 8-bit UTF (UCS Transformation Format)
      */
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_8 = StandardCharsets.UTF_8;
 
     /**
      * ISO Latin Alphabet No. 1, as known as <tt>ISO-LATIN-1</tt>
      */
-    public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
+    public static final Charset ISO_8859_1 = StandardCharsets.ISO_8859_1;
 
     /**
      * 7-bit ASCII, as known as ISO646-US or the Basic Latin block of the
      * Unicode character set
      */
-    public static final Charset US_ASCII = Charset.forName("US-ASCII");
-
-    private static final Charset[] CHARSETS = new Charset[]
-            { UTF_16, UTF_16BE, UTF_16LE, UTF_8, ISO_8859_1, US_ASCII };
-
-    public static Charset[] values() { return CHARSETS; }
+    public static final Charset US_ASCII = StandardCharsets.US_ASCII;
 
     /**
      * @deprecated Use {@link #encoder(Charset)}.

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -23,6 +23,12 @@ import java.util.Random;
 
 import static io.netty.util.AsciiString.contains;
 import static io.netty.util.AsciiString.containsIgnoreCase;
+import static io.netty.util.CharsetUtil.ISO_8859_1;
+import static io.netty.util.CharsetUtil.US_ASCII;
+import static io.netty.util.CharsetUtil.UTF_16;
+import static io.netty.util.CharsetUtil.UTF_16BE;
+import static io.netty.util.CharsetUtil.UTF_16LE;
+import static io.netty.util.CharsetUtil.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -37,6 +43,9 @@ import static org.junit.Assert.assertTrue;
 public class AsciiStringCharacterTest {
     private static final Random r = new Random();
 
+    private static final Charset[] CHARSETS = new Charset[]
+            { UTF_16, UTF_16BE, UTF_16LE, UTF_8, ISO_8859_1, US_ASCII };
+
     @Test
     public void testGetBytesStringBuilder() {
         final StringBuilder b = new StringBuilder();
@@ -44,9 +53,7 @@ public class AsciiStringCharacterTest {
             b.append("eéaà");
         }
         final String bString = b.toString();
-        final Charset[] charsets = CharsetUtil.values();
-        for (int i = 0; i < charsets.length; ++i) {
-            final Charset charset = charsets[i];
+        for (final Charset charset : CHARSETS) {
             byte[] expected = bString.getBytes(charset);
             byte[] actual = new AsciiString(b, charset).toByteArray();
             assertArrayEquals("failure for " + charset, expected, actual);
@@ -60,9 +67,7 @@ public class AsciiStringCharacterTest {
             b.append("eéaà");
         }
         final String bString = b.toString();
-        final Charset[] charsets = CharsetUtil.values();
-        for (int i = 0; i < charsets.length; ++i) {
-            final Charset charset = charsets[i];
+        for (final Charset charset : CHARSETS) {
             byte[] expected = bString.getBytes(charset);
             byte[] actual = new AsciiString(bString, charset).toByteArray();
             assertArrayEquals("failure for " + charset, expected, actual);
@@ -77,7 +82,7 @@ public class AsciiStringCharacterTest {
         }
         final String bString = b.toString();
         // The AsciiString class actually limits the Charset to ISO_8859_1
-        byte[] expected = bString.getBytes(CharsetUtil.ISO_8859_1);
+        byte[] expected = bString.getBytes(ISO_8859_1);
         byte[] actual = new AsciiString(bString).toByteArray();
         assertArrayEquals(expected, actual);
     }
@@ -215,7 +220,7 @@ public class AsciiStringCharacterTest {
 
     @Test
     public void caseInsensitiveHasherCharBuffer() {
-        String s1 = new String("TRANSFER-ENCODING");
+        String s1 = "TRANSFER-ENCODING";
         char[] array = new char[128];
         final int offset = 100;
         for (int i = 0; i < s1.length(); ++i) {


### PR DESCRIPTION
Motivation:

No need to initialize charsets from the string. We can take already allocated charset from `StandardCharsets` class.

Modification:

Replace `Charset.forName("US-ASCII")` with `StandardCharsets.US_ASCII`.
Removed `Charset[] values()` method and internal static variable as it was used only in tests.
