### PR TITLE
Probable bug. Endless recursion in CompositeByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -801,7 +801,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
      */
     public int toComponentIndex(int offset) {
         checkIndex(offset);
-        return toComponentIndex(offset);
+        return toComponentIndex0(offset);
     }
 
     private int toComponentIndex0(int offset) {


### PR DESCRIPTION
Motivation:

During review found strange code:

```
    public int toComponentIndex(int offset) {
        checkIndex(offset);
        return toComponentIndex(offset);
    }
```

Seems like it was a typo and code should be 

```
    public int toComponentIndex(int offset) {
        checkIndex(offset);
        return toComponentIndex0(offset);
    }
```

Introduced with https://github.com/netty/netty/pull/8437. FYI @njhill