### PR TITLE
Java 8 migration. Similar catch blocks joined

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -68,12 +68,12 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
     /**
      * HttpDatas from Body
      */
-    private final List<InterfaceHttpData> bodyListHttpData = new ArrayList<InterfaceHttpData>();
+    private final List<InterfaceHttpData> bodyListHttpData = new ArrayList<>();
 
     /**
      * HttpDatas as Map from Body
      */
-    private final Map<String, List<InterfaceHttpData>> bodyMapHttpData = new TreeMap<String, List<InterfaceHttpData>>(
+    private final Map<String, List<InterfaceHttpData>> bodyMapHttpData = new TreeMap<>(
             CaseIgnoringComparator.INSTANCE);
 
     /**
@@ -369,7 +369,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
         }
         List<InterfaceHttpData> datas = bodyMapHttpData.get(data.getName());
         if (datas == null) {
-            datas = new ArrayList<InterfaceHttpData>(1);
+            datas = new ArrayList<>(1);
             bodyMapHttpData.put(data.getName(), datas);
         }
         datas.add(data);
@@ -599,11 +599,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
             // error while decoding
             undecodedChunk.readerIndex(firstpos);
             throw e;
-        } catch (IOException e) {
-            // error while decoding
-            undecodedChunk.readerIndex(firstpos);
-            throw new ErrorDataDecoderException(e);
-        } catch (IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             // error while decoding
             undecodedChunk.readerIndex(firstpos);
             throw new ErrorDataDecoderException(e);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -235,14 +235,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 // immediately processed.
                 bytesToReturn = listener.onDataRead(ctx, streamId, data, padding, endOfStream);
                 return bytesToReturn;
-            } catch (Http2Exception e) {
-                // If an exception happened during delivery, the listener may have returned part
-                // of the bytes before the error occurred. If that's the case, subtract that from
-                // the total processed bytes so that we don't return too many bytes.
-                int delta = unconsumedBytes - unconsumedBytes(stream);
-                bytesToReturn -= delta;
-                throw e;
-            } catch (RuntimeException e) {
+            } catch (Http2Exception | RuntimeException e) {
                 // If an exception happened during delivery, the listener may have returned part
                 // of the bytes before the error occurred. If that's the case, subtract that from
                 // the total processed bytes so that we don't return too many bytes.

--- a/common/src/main/java/io/netty/util/internal/CleanerJava9.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava9.java
@@ -46,11 +46,7 @@ final class CleanerJava9 implements Cleaner {
                                 "invokeCleaner", ByteBuffer.class);
                         m.invoke(PlatformDependent0.UNSAFE, buffer);
                         return m;
-                    } catch (NoSuchMethodException e) {
-                        return e;
-                    } catch (InvocationTargetException e) {
-                        return e;
-                    } catch (IllegalAccessException e) {
+                    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
                         return e;
                     }
                 }
@@ -100,9 +96,7 @@ final class CleanerJava9 implements Cleaner {
             public Exception run() {
                 try {
                     INVOKE_CLEANER.invoke(PlatformDependent0.UNSAFE, buffer);
-                } catch (InvocationTargetException e) {
-                    return e;
-                } catch (IllegalAccessException e) {
+                } catch (InvocationTargetException | IllegalAccessException e) {
                     return e;
                 }
                 return null;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -93,17 +93,11 @@ final class PlatformDependent0 {
                         }
                         // the unsafe instance
                         return unsafeField.get(null);
-                    } catch (NoSuchFieldException e) {
+                    } catch (NoSuchFieldException | SecurityException
+                            | IllegalAccessException | NoClassDefFoundError e) {
                         return e;
-                    } catch (SecurityException e) {
-                        return e;
-                    } catch (IllegalAccessException e) {
-                        return e;
-                    } catch (NoClassDefFoundError e) {
-                        // Also catch NoClassDefFoundError in case someone uses for example OSGI and it made
-                        // Unsafe unloadable.
-                        return e;
-                    }
+                    } // Also catch NoClassDefFoundError in case someone uses for example OSGI and it made
+                    // Unsafe unloadable.
                 }
             });
 
@@ -132,9 +126,7 @@ final class PlatformDependent0 {
                             finalUnsafe.getClass().getDeclaredMethod(
                                     "copyMemory", Object.class, long.class, Object.class, long.class, long.class);
                             return null;
-                        } catch (NoSuchMethodException e) {
-                            return e;
-                        } catch (SecurityException e) {
+                        } catch (NoSuchMethodException | SecurityException e) {
                             return e;
                         }
                     }
@@ -169,9 +161,7 @@ final class PlatformDependent0 {
                                 return null;
                             }
                             return field;
-                        } catch (NoSuchFieldException e) {
-                            return e;
-                        } catch (SecurityException e) {
+                        } catch (NoSuchFieldException | SecurityException e) {
                             return e;
                         }
                     }
@@ -226,9 +216,7 @@ final class PlatformDependent0 {
                                         return cause;
                                     }
                                     return constructor;
-                                } catch (NoSuchMethodException e) {
-                                    return e;
-                                } catch (SecurityException e) {
+                                } catch (NoSuchMethodException | SecurityException e) {
                                     return e;
                                 }
                             }
@@ -241,11 +229,7 @@ final class PlatformDependent0 {
                         ((Constructor<?>) maybeDirectBufferConstructor).newInstance(address, 1);
                         directBufferConstructor = (Constructor<?>) maybeDirectBufferConstructor;
                         logger.debug("direct buffer constructor: available");
-                    } catch (InstantiationException e) {
-                        directBufferConstructor = null;
-                    } catch (IllegalAccessException e) {
-                        directBufferConstructor = null;
-                    } catch (InvocationTargetException e) {
+                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
                         directBufferConstructor = null;
                     }
                 } else {
@@ -294,15 +278,8 @@ final class PlatformDependent0 {
                             return cause;
                         }
                         return unalignedMethod.invoke(null);
-                    } catch (NoSuchMethodException e) {
-                        return e;
-                    } catch (SecurityException e) {
-                        return e;
-                    } catch (IllegalAccessException e) {
-                        return e;
-                    } catch (ClassNotFoundException e) {
-                        return e;
-                    } catch (InvocationTargetException e) {
+                    } catch (NoSuchMethodException | SecurityException
+                            | IllegalAccessException | ClassNotFoundException | InvocationTargetException e) {
                         return e;
                     }
                 }
@@ -346,9 +323,7 @@ final class PlatformDependent0 {
                             try {
                                 return finalInternalUnsafe.getClass().getDeclaredMethod(
                                         "allocateUninitializedArray", Class.class, int.class);
-                            } catch (NoSuchMethodException e) {
-                                return e;
-                            } catch (SecurityException e) {
+                            } catch (NoSuchMethodException | SecurityException e) {
                                 return e;
                             }
                         }
@@ -360,9 +335,7 @@ final class PlatformDependent0 {
                             byte[] bytes = (byte[]) m.invoke(finalInternalUnsafe, byte.class, 8);
                             assert bytes.length == 8;
                             allocateArrayMethod = m;
-                        } catch (IllegalAccessException e) {
-                            maybeException = e;
-                        } catch (InvocationTargetException e) {
+                        } catch (IllegalAccessException | InvocationTargetException e) {
                             maybeException = e;
                         }
                     }
@@ -459,9 +432,7 @@ final class PlatformDependent0 {
     static byte[] allocateUninitializedArray(int size) {
         try {
             return (byte[]) ALLOCATE_ARRAY_METHOD.invoke(INTERNAL_UNSAFE, byte.class, size);
-        } catch (IllegalAccessException e) {
-            throw new Error(e);
-        } catch (InvocationTargetException e) {
+        } catch (IllegalAccessException | InvocationTargetException e) {
             throw new Error(e);
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509TrustManagerWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509TrustManagerWrapper.java
@@ -119,9 +119,7 @@ final class OpenSslX509TrustManagerWrapper {
                                 } while (clazz != null);
                             }
                             throw new NoSuchFieldException();
-                        } catch (NoSuchFieldException e) {
-                            return e;
-                        } catch (SecurityException e) {
+                        } catch (NoSuchFieldException | SecurityException e) {
                             return e;
                         }
                     }
@@ -174,11 +172,7 @@ final class OpenSslX509TrustManagerWrapper {
                             return (X509TrustManager) tm;
                         }
                     }
-                } catch (NoSuchAlgorithmException e) {
-                    // This should never happen as we did the same in the static
-                    // before.
-                    PlatformDependent.throwException(e);
-                } catch (KeyManagementException e) {
+                } catch (NoSuchAlgorithmException | KeyManagementException e) {
                     // This should never happen as we did the same in the static
                     // before.
                     PlatformDependent.throwException(e);

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -276,9 +276,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                     selectedKeysField.set(unwrappedSelector, selectedKeySet);
                     publicSelectedKeysField.set(unwrappedSelector, selectedKeySet);
                     return null;
-                } catch (NoSuchFieldException e) {
-                    return e;
-                } catch (IllegalAccessException e) {
+                } catch (NoSuchFieldException | IllegalAccessException e) {
                     return e;
                 }
             }
@@ -311,8 +309,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
     @Override
     protected Queue<Runnable> newTaskQueue(int maxPendingTasks) {
         // This event loop never calls takeTask()
-        return maxPendingTasks == Integer.MAX_VALUE ? PlatformDependent.<Runnable>newMpscQueue()
-                                                    : PlatformDependent.<Runnable>newMpscQueue(maxPendingTasks);
+        return maxPendingTasks == Integer.MAX_VALUE ? PlatformDependent.newMpscQueue()
+                                                    : PlatformDependent.newMpscQueue(maxPendingTasks);
     }
 
     /**
@@ -738,7 +736,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
     private void closeAll() {
         selectAgain();
         Set<SelectionKey> keys = selector.keys();
-        Collection<AbstractNioChannel> channels = new ArrayList<AbstractNioChannel>(keys.size());
+        Collection<AbstractNioChannel> channels = new ArrayList<>(keys.size());
         for (SelectionKey k: keys) {
             Object a = k.attachment();
             if (a instanceof AbstractNioChannel) {


### PR DESCRIPTION
Motivation:

Avoid IDE warnings, easier to read.

Modification:

Same catch blocks joined.

