### PR TITLE
Java 8 migration. Inline PlatformDependent.newConcurrentHashMap() and remove from PlatformDependent

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySession.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySession.java
@@ -16,12 +16,12 @@
 package io.netty.handler.codec.spdy;
 
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.PlatformDependent;
 
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Queue;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -31,7 +31,7 @@ final class SpdySession {
 
     private final AtomicInteger activeLocalStreams  = new AtomicInteger();
     private final AtomicInteger activeRemoteStreams = new AtomicInteger();
-    private final Map<Integer, StreamState> activeStreams = PlatformDependent.newConcurrentHashMap();
+    private final Map<Integer, StreamState> activeStreams = new ConcurrentHashMap<>();
     private final StreamComparator streamComparator = new StreamComparator();
     private final AtomicInteger sendWindowSize;
     private final AtomicInteger receiveWindowSize;

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ClassResolvers.java
@@ -17,8 +17,8 @@ package io.netty.handler.codec.serialization;
 
 import io.netty.util.internal.PlatformDependent;
 
-import java.lang.ref.Reference;
 import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 public final class ClassResolvers {
 
@@ -67,8 +67,7 @@ public final class ClassResolvers {
     public static ClassResolver weakCachingConcurrentResolver(ClassLoader classLoader) {
         return new CachingClassResolver(
                 new ClassLoaderClassResolver(defaultClassLoader(classLoader)),
-                new WeakReferenceMap<>(
-                        PlatformDependent.<String, Reference<Class<?>>>newConcurrentHashMap()));
+                new WeakReferenceMap<>(new ConcurrentHashMap<>()));
     }
 
     /**
@@ -81,8 +80,7 @@ public final class ClassResolvers {
     public static ClassResolver softCachingConcurrentResolver(ClassLoader classLoader) {
         return new CachingClassResolver(
                 new ClassLoaderClassResolver(defaultClassLoader(classLoader)),
-                new SoftReferenceMap<>(
-                        PlatformDependent.<String, Reference<Class<?>>>newConcurrentHashMap()));
+                new SoftReferenceMap<>(new ConcurrentHashMap<>()));
     }
 
     static ClassLoader defaultClassLoader(ClassLoader classLoader) {

--- a/common/src/main/java/io/netty/util/ConstantPool.java
+++ b/common/src/main/java/io/netty/util/ConstantPool.java
@@ -17,8 +17,8 @@
 package io.netty.util;
 
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.PlatformDependent;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public abstract class ConstantPool<T extends Constant<T>> {
 
-    private final ConcurrentMap<String, T> constants = PlatformDependent.newConcurrentHashMap();
+    private final ConcurrentMap<String, T> constants = new ConcurrentHashMap<>();
 
     private final AtomicInteger nextId = new AtomicInteger(1);
 

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -168,7 +168,7 @@ public class ResourceLeakDetector<T> {
             Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private final ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
-    private final ConcurrentMap<String, Boolean> reportedLeaks = PlatformDependent.newConcurrentHashMap();
+    private final ConcurrentMap<String, Boolean> reportedLeaks = new ConcurrentHashMap<>();
 
     private final String resourceType;
     private final int samplingInterval;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -338,42 +338,6 @@ public final class PlatformDependent {
     }
 
     /**
-     * Creates a new fastest {@link ConcurrentMap} implementation for the current platform.
-     */
-    public static <K, V> ConcurrentMap<K, V> newConcurrentHashMap() {
-        return new ConcurrentHashMap<>();
-    }
-
-    /**
-     * Creates a new fastest {@link ConcurrentMap} implementation for the current platform.
-     */
-    public static <K, V> ConcurrentMap<K, V> newConcurrentHashMap(int initialCapacity) {
-        return new ConcurrentHashMap<>(initialCapacity);
-    }
-
-    /**
-     * Creates a new fastest {@link ConcurrentMap} implementation for the current platform.
-     */
-    public static <K, V> ConcurrentMap<K, V> newConcurrentHashMap(int initialCapacity, float loadFactor) {
-        return new ConcurrentHashMap<>(initialCapacity, loadFactor);
-    }
-
-    /**
-     * Creates a new fastest {@link ConcurrentMap} implementation for the current platform.
-     */
-    public static <K, V> ConcurrentMap<K, V> newConcurrentHashMap(
-            int initialCapacity, float loadFactor, int concurrencyLevel) {
-        return new ConcurrentHashMap<>(initialCapacity, loadFactor, concurrencyLevel);
-    }
-
-    /**
-     * Creates a new fastest {@link ConcurrentMap} implementation for the current platform.
-     */
-    public static <K, V> ConcurrentMap<K, V> newConcurrentHashMap(Map<? extends K, ? extends V> map) {
-        return new ConcurrentHashMap<>(map);
-    }
-
-    /**
      * Try to deallocate the specified direct {@link ByteBuffer}. Please note this method does nothing if
      * the current platform does not support this operation or the specified buffer is not a direct buffer.
      */

--- a/example/src/main/java/io/netty/example/http2/helloworld/client/HttpResponseHandler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/HttpResponseHandler.java
@@ -22,12 +22,12 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.util.CharsetUtil;
-import io.netty.util.internal.PlatformDependent;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -40,7 +40,7 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
     public HttpResponseHandler() {
         // Use a concurrent map because we add and iterate from the main thread (just for the purposes of the example),
         // but Netty also does a get on the map when messages are received in a EventLoop thread.
-        streamidPromiseMap = PlatformDependent.newConcurrentHashMap();
+        streamidPromiseMap = new ConcurrentHashMap<>();
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
@@ -16,13 +16,13 @@
 
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -89,14 +89,14 @@ final class CipherSuiteConverter {
      * Java-to-OpenSSL cipher suite conversion map
      * Note that the Java cipher suite has the protocol prefix (TLS_, SSL_)
      */
-    private static final ConcurrentMap<String, String> j2o = PlatformDependent.newConcurrentHashMap();
+    private static final ConcurrentMap<String, String> j2o = new ConcurrentHashMap<>();
 
     /**
      * OpenSSL-to-Java cipher suite conversion map.
      * Note that one OpenSSL cipher suite can be converted to more than one Java cipher suites because
      * a Java cipher suite has the protocol name prefix (TLS_, SSL_)
      */
-    private static final ConcurrentMap<String, Map<String, String>> o2j = PlatformDependent.newConcurrentHashMap();
+    private static final ConcurrentMap<String, Map<String, String>> o2j = new ConcurrentHashMap<>();
 
     private static final Map<String, String> j2oTls13;
     private static final Map<String, Map<String, String>> o2jTls13;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -709,7 +710,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     private static final class DefaultOpenSslEngineMap implements OpenSslEngineMap {
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines = PlatformDependent.newConcurrentHashMap();
+        private final Map<Long, ReferenceCountedOpenSslEngine> engines = new ConcurrentHashMap<>();
 
         @Override
         public ReferenceCountedOpenSslEngine remove(long ssl) {

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.Attribute;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -31,6 +30,7 @@ import java.util.AbstractCollection;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -90,7 +90,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
     /**
      * All queues per channel
      */
-    final ConcurrentMap<Integer, PerChannel> channelQueues = PlatformDependent.newConcurrentHashMap();
+    final ConcurrentMap<Integer, PerChannel> channelQueues = new ConcurrentHashMap<>();
 
     /**
      * Global queues size

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -21,9 +21,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.internal.PlatformDependent;
 
 import java.util.ArrayDeque;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +79,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
     /**
      * All queues per channel
      */
-    private final ConcurrentMap<Integer, PerChannel> channelQueues = PlatformDependent.newConcurrentHashMap();
+    private final ConcurrentMap<Integer, PerChannel> channelQueues = new ConcurrentHashMap<>();
 
     /**
      * Global queues size

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/Cache.java
@@ -16,7 +16,6 @@
 package io.netty.resolver.dns;
 
 import io.netty.channel.EventLoop;
-import io.netty.util.internal.PlatformDependent;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ScheduledFuture;
@@ -86,7 +86,7 @@ abstract class Cache<E> {
     // See also: https://github.com/netty/netty/commit/b47fb817991b42ec8808c7d26538f3f2464e1fa6
     static final int MAX_SUPPORTED_TTL_SECS = (int) TimeUnit.DAYS.toSeconds(365 * 2);
 
-    private final ConcurrentMap<String, Entries> resolveCache = PlatformDependent.newConcurrentHashMap();
+    private final ConcurrentMap<String, Entries> resolveCache = new ConcurrentHashMap<>();
 
     /**
      * Remove everything from the cache.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -18,7 +18,6 @@ package io.netty.resolver.dns;
 
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.EventLoop;
-import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.AddressResolverGroup;
@@ -32,9 +31,8 @@ import io.netty.util.internal.UnstableApi;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import static io.netty.util.internal.PlatformDependent.newConcurrentHashMap;
 
 /**
  * A {@link AddressResolverGroup} of {@link DnsNameResolver}s.
@@ -44,8 +42,8 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
 
     private final DnsNameResolverBuilder dnsResolverBuilder;
 
-    private final ConcurrentMap<String, Promise<InetAddress>> resolvesInProgress = newConcurrentHashMap();
-    private final ConcurrentMap<String, Promise<List<InetAddress>>> resolveAllsInProgress = newConcurrentHashMap();
+    private final ConcurrentMap<String, Promise<InetAddress>> resolvesInProgress = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Promise<List<InetAddress>>> resolveAllsInProgress = new ConcurrentHashMap<>();
 
     public DnsAddressResolverGroup(DnsNameResolverBuilder dnsResolverBuilder) {
         this.dnsResolverBuilder = dnsResolverBuilder.copy();

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
@@ -24,7 +24,6 @@ import io.netty.channel.ChannelId;
 import io.netty.channel.ServerChannel;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
 import java.util.AbstractSet;
@@ -33,6 +32,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -44,8 +44,8 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
     private static final AtomicInteger nextId = new AtomicInteger();
     private final String name;
     private final EventExecutor executor;
-    private final ConcurrentMap<ChannelId, Channel> serverChannels = PlatformDependent.newConcurrentHashMap();
-    private final ConcurrentMap<ChannelId, Channel> nonServerChannels = PlatformDependent.newConcurrentHashMap();
+    private final ConcurrentMap<ChannelId, Channel> serverChannels = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ChannelId, Channel> nonServerChannels = new ConcurrentHashMap<>();
     private final ChannelFutureListener remover = new ChannelFutureListener() {
         @Override
         public void operationComplete(ChannelFuture future) throws Exception {

--- a/transport/src/main/java/io/netty/channel/local/LocalChannelRegistry.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannelRegistry.java
@@ -17,15 +17,15 @@ package io.netty.channel.local;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
 import java.net.SocketAddress;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 final class LocalChannelRegistry {
 
-    private static final ConcurrentMap<LocalAddress, Channel> boundChannels = PlatformDependent.newConcurrentHashMap();
+    private static final ConcurrentMap<LocalAddress, Channel> boundChannels = new ConcurrentHashMap<>();
 
     static LocalAddress register(
             Channel channel, LocalAddress oldLocalAddress, SocketAddress localAddress) {


### PR DESCRIPTION
Motivation:

`PlatformDependent.newConcurrentHashMap()` is no longer needed so it could be easily removed and `new ConcurrentHashMap<>()` inlined instead of invoking `PlatformDependent.newConcurrentHashMap()`.
