### PR TITLE
Remove ability to specify name when add handler to the pipeline.

### DIFF
--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -42,11 +42,9 @@ public class HAProxyMessageDecoderTest {
 
     @Test
     public void testIPV4Decode() {
-        int startChannels = ch.pipeline().names().size();
         String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n";
         ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V1, msg.protocolVersion());
@@ -62,11 +60,9 @@ public class HAProxyMessageDecoderTest {
 
     @Test
     public void testIPV6Decode() {
-        int startChannels = ch.pipeline().names().size();
         String header = "PROXY TCP6 2001:0db8:85a3:0000:0000:8a2e:0370:7334 1050:0:0:0:5:600:300c:326b 56324 443\r\n";
         ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V1, msg.protocolVersion());
@@ -82,11 +78,9 @@ public class HAProxyMessageDecoderTest {
 
     @Test
     public void testUnknownProtocolDecode() {
-        int startChannels = ch.pipeline().names().size();
         String header = "PROXY UNKNOWN 192.168.0.1 192.168.0.11 56324 443\r\n";
         ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V1, msg.protocolVersion());
@@ -249,10 +243,8 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        int startChannels = ch.pipeline().names().size();
         ch.writeInbound(copiedBuffer(header));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
@@ -304,10 +296,8 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        int startChannels = ch.pipeline().names().size();
         ch.writeInbound(copiedBuffer(header));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
@@ -383,10 +373,8 @@ public class HAProxyMessageDecoderTest {
         header[50] = 0x01; // Destination Port
         header[51] = (byte) 0xbb; // -----
 
-        int startChannels = ch.pipeline().names().size();
         ch.writeInbound(copiedBuffer(header));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
@@ -461,10 +449,8 @@ public class HAProxyMessageDecoderTest {
         header[141] = 0x6b; // -----
         header[142] = 0x00; // -----
 
-        int startChannels = ch.pipeline().names().size();
         ch.writeInbound(copiedBuffer(header));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
@@ -516,10 +502,8 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        int startChannels = ch.pipeline().names().size();
         ch.writeInbound(copiedBuffer(header));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
@@ -571,10 +555,8 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        int startChannels = ch.pipeline().names().size();
         ch.writeInbound(copiedBuffer(header));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
@@ -597,10 +579,8 @@ public class HAProxyMessageDecoderTest {
                 -55, -90, 7, 89, 32, 0, 20, 5, 0, 0, 0, 0, 33, 0, 5, 84, 76, 83, 118, 49, 34, 0, 4, 76, 69, 65, 70
         };
 
-        int startChannels = ch.pipeline().names().size();
         assertTrue(ch.writeInbound(copiedBuffer(bytes)));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         HAProxyMessage msg = (HAProxyMessage) msgObj;
 
         assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
@@ -723,10 +703,8 @@ public class HAProxyMessageDecoderTest {
         header[234] = 0x01; // -----
         header[235] = 0x01; // Payload
 
-        int startChannels = ch.pipeline().names().size();
         ch.writeInbound(copiedBuffer(header));
         Object msgObj = ch.readInbound();
-        assertEquals(startChannels - 1, ch.pipeline().names().size());
         assertTrue(msgObj instanceof HAProxyMessage);
         HAProxyMessage msg = (HAProxyMessage) msgObj;
         assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -261,7 +261,7 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
     }
 
     private static void removeThisHandler(ChannelHandlerContext ctx) {
-        ctx.pipeline().remove(ctx.name());
+        ctx.pipeline().remove(ctx);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -188,7 +188,7 @@ public abstract class WebSocketClientHandshaker {
                                 "a HttpRequestEncoder or HttpClientCodec"));
                         return;
                     }
-                    p.addAfter(ctx.name(), "ws-encoder", newWebSocketEncoder());
+                    p.addAfter(ctx, newWebSocketEncoder());
 
                     promise.setSuccess();
                 } else {
@@ -269,7 +269,7 @@ public abstract class WebSocketClientHandshaker {
             // Remove the encoder part of the codec as the user may start writing frames after this method returns.
             codec.removeOutboundHandler();
 
-            p.addAfter(ctx.name(), "ws-decoder", newWebsocketDecoder());
+            p.addAfter(ctx, newWebsocketDecoder());
 
             // Delay the removal of the decoder so the user can setup the pipeline if needed to handle
             // WebSocketFrame messages.
@@ -286,7 +286,7 @@ public abstract class WebSocketClientHandshaker {
                 p.remove(HttpRequestEncoder.class);
             }
             final ChannelHandlerContext context = ctx;
-            p.addAfter(context.name(), "ws-decoder", newWebsocketDecoder());
+            p.addAfter(context, newWebsocketDecoder());
 
             // Delay the removal of the decoder so the user can setup the pipeline if needed to handle
             // WebSocketFrame messages.
@@ -349,9 +349,8 @@ public abstract class WebSocketClientHandshaker {
             // then enough for the websockets handshake payload.
             //
             // TODO: Make handshake work without HttpObjectAggregator at all.
-            String aggregatorName = "httpAggregator";
-            p.addAfter(ctx.name(), aggregatorName, new HttpObjectAggregator(8192));
-            p.addAfter(aggregatorName, "handshaker", new SimpleChannelInboundHandler<FullHttpResponse>() {
+            ChannelHandlerContext aggregatorCtx = p.addAfter(ctx, new HttpObjectAggregator(8192));
+            p.addAfter(aggregatorCtx, new SimpleChannelInboundHandler<FullHttpResponse>() {
                 @Override
                 protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
                     // Remove ourself and do the actual handshake

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -197,13 +197,11 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
         ChannelPipeline cp = ctx.pipeline();
         if (cp.get(WebSocketClientProtocolHandshakeHandler.class) == null) {
             // Add the WebSocketClientProtocolHandshakeHandler before this one.
-            ctx.pipeline().addBefore(ctx.name(), WebSocketClientProtocolHandshakeHandler.class.getName(),
-                    new WebSocketClientProtocolHandshakeHandler(handshaker));
+            ctx.pipeline().addBefore(ctx, new WebSocketClientProtocolHandshakeHandler(handshaker));
         }
         if (cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.
-            ctx.pipeline().addBefore(ctx.name(), Utf8FrameValidator.class.getName(),
-                    new Utf8FrameValidator());
+            ctx.pipeline().addBefore(ctx, new Utf8FrameValidator());
         }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -152,14 +152,13 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         ChannelPipeline cp = ctx.pipeline();
         if (cp.get(WebSocketServerProtocolHandshakeHandler.class) == null) {
             // Add the WebSocketHandshakeHandler before this one.
-            ctx.pipeline().addBefore(ctx.name(), WebSocketServerProtocolHandshakeHandler.class.getName(),
+            ctx.pipeline().addBefore(ctx,
                     new WebSocketServerProtocolHandshakeHandler(websocketPath, subprotocols,
                             allowExtensions, maxFramePayloadLength, allowMaskMismatch, checkStartsWith));
         }
         if (cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.
-            ctx.pipeline().addBefore(ctx.name(), Utf8FrameValidator.class.getName(),
-                    new Utf8FrameValidator());
+            ctx.pipeline().addBefore(ctx, new Utf8FrameValidator());
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -97,7 +97,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
                     }
                 });
                 WebSocketServerProtocolHandler.setHandshaker(ctx.channel(), handshaker);
-                ctx.pipeline().replace(this, "WS403Responder",
+                ctx.pipeline().replace(this,
                         WebSocketServerProtocolHandler.forbiddenHttpRequestResponder());
             }
         } finally {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandler.java
@@ -116,12 +116,12 @@ public class WebSocketClientExtensionHandler extends ChannelDuplexHandler {
                     for (WebSocketClientExtension validExtension : validExtensions) {
                         WebSocketExtensionDecoder decoder = validExtension.newExtensionDecoder();
                         WebSocketExtensionEncoder encoder = validExtension.newExtensionEncoder();
-                        ctx.pipeline().addAfter(ctx.name(), decoder.getClass().getName(), decoder);
-                        ctx.pipeline().addAfter(ctx.name(), encoder.getClass().getName(), encoder);
+                        ctx.pipeline().addAfter(ctx, decoder);
+                        ctx.pipeline().addAfter(ctx, encoder);
                     }
                 }
 
-                ctx.pipeline().remove(ctx.name());
+                ctx.pipeline().remove(ctx);
             }
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -122,12 +122,12 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
                         for (WebSocketServerExtension extension : validExtensions) {
                             WebSocketExtensionDecoder decoder = extension.newExtensionDecoder();
                             WebSocketExtensionEncoder encoder = extension.newExtensionEncoder();
-                            ctx.pipeline().addAfter(ctx.name(), decoder.getClass().getName(), decoder);
-                            ctx.pipeline().addAfter(ctx.name(), encoder.getClass().getName(), encoder);
+                            ctx.pipeline().addAfter(ctx, decoder);
+                            ctx.pipeline().addAfter(ctx, encoder);
                         }
                     }
 
-                    ctx.pipeline().remove(ctx.name());
+                    ctx.pipeline().remove(ctx);
                 }
             });
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -78,7 +78,7 @@ public class HttpClientUpgradeHandlerTest {
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
         UserEventCatcher catcher = new UserEventCatcher();
         EmbeddedChannel channel = new EmbeddedChannel(catcher);
-        channel.pipeline().addFirst("upgrade", handler);
+        channel.pipeline().addFirst(handler);
 
         assertTrue(
             channel.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io")));
@@ -98,7 +98,7 @@ public class HttpClientUpgradeHandlerTest {
         assertFalse(channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
 
         assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_SUCCESSFUL, catcher.getUserEvent());
-        assertNull(channel.pipeline().get("upgrade"));
+        assertNull(channel.pipeline().context(handler));
 
         assertTrue(channel.writeInbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
         FullHttpResponse response = channel.readInbound();
@@ -114,7 +114,7 @@ public class HttpClientUpgradeHandlerTest {
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
         UserEventCatcher catcher = new UserEventCatcher();
         EmbeddedChannel channel = new EmbeddedChannel(catcher);
-        channel.pipeline().addFirst("upgrade", handler);
+        channel.pipeline().addFirst(handler);
 
         assertTrue(
             channel.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io")));
@@ -133,7 +133,7 @@ public class HttpClientUpgradeHandlerTest {
         assertTrue(channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
 
         assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED, catcher.getUserEvent());
-        assertNull(channel.pipeline().get("upgrade"));
+        assertNull(channel.pipeline().context(handler));
 
         HttpResponse response = channel.readInbound();
         assertEquals(HttpResponseStatus.OK, response.status());
@@ -151,7 +151,7 @@ public class HttpClientUpgradeHandlerTest {
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
         UserEventCatcher catcher = new UserEventCatcher();
         EmbeddedChannel channel = new EmbeddedChannel(catcher);
-        channel.pipeline().addFirst("upgrade", handler);
+        channel.pipeline().addFirst(handler);
 
         assertTrue(
             channel.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io")));
@@ -169,7 +169,7 @@ public class HttpClientUpgradeHandlerTest {
         assertTrue(channel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
 
         assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED, catcher.getUserEvent());
-        assertNull(channel.pipeline().get("upgrade"));
+        assertNull(channel.pipeline().context(handler));
 
         HttpResponse response = channel.readInbound();
         assertEquals(HttpResponseStatus.OK, response.status());
@@ -183,7 +183,7 @@ public class HttpClientUpgradeHandlerTest {
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
         UserEventCatcher catcher = new UserEventCatcher();
         EmbeddedChannel channel = new EmbeddedChannel(catcher);
-        channel.pipeline().addFirst("upgrade", handler);
+        channel.pipeline().addFirst(handler);
 
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io");
         request.headers().add("connection", "extra");

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -38,6 +38,8 @@ import static org.junit.Assert.*;
 
 public class HttpServerUpgradeHandlerTest {
 
+    private static final class Marker extends ChannelInboundHandlerAdapter { }
+
     private class TestUpgradeCodec implements UpgradeCodec {
         @Override
         public Collection<CharSequence> requiredUpgradeHeaders() {
@@ -57,7 +59,7 @@ public class HttpServerUpgradeHandlerTest {
             assertNotNull(ctx.pipeline().get(HttpServerUpgradeHandler.class));
 
             // Add a marker handler to signal that the upgrade has happened
-            ctx.pipeline().addAfter(ctx.name(), "marker", new ChannelInboundHandlerAdapter());
+            ctx.pipeline().addAfter(ctx, new Marker());
           }
     }
 
@@ -90,7 +92,7 @@ public class HttpServerUpgradeHandlerTest {
                     assertTrue(writeUpgradeMessage);
                     assertFalse(writeFlushed);
                     assertNull(ctx.pipeline().get(HttpServerCodec.class));
-                    assertNotNull(ctx.pipeline().get("marker"));
+                    assertNotNull(ctx.pipeline().get(Marker.class));
                 } finally {
                     inReadCall = false;
                 }
@@ -130,7 +132,7 @@ public class HttpServerUpgradeHandlerTest {
 
         assertFalse(channel.writeInbound(upgrade));
         assertNull(channel.pipeline().get(HttpServerCodec.class));
-        assertNotNull(channel.pipeline().get("marker"));
+        assertNotNull(channel.pipeline().get(Marker.class));
 
         channel.flushOutbound();
         ByteBuf upgradeMessage = channel.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -274,7 +274,8 @@ public abstract class WebSocketClientHandshakerTest {
         if (codec) {
             ch.pipeline().addFirst(new HttpClientCodec());
         } else {
-            ch.pipeline().addFirst(new HttpRequestEncoder(), new HttpResponseDecoder());
+            ch.pipeline().addFirst(new HttpResponseDecoder());
+            ch.pipeline().addFirst(new HttpRequestEncoder());
         }
         // We need to first write the request as HttpClientCodec will fail if we receive a response before a request
         // was written.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
@@ -65,10 +65,9 @@ public final class CleartextHttp2ServerUpgradeHandler extends ChannelHandlerAdap
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        ctx.pipeline()
-           .addBefore(ctx.name(), null, new PriorKnowledgeHandler())
-           .addBefore(ctx.name(), null, httpServerCodec)
-           .replace(this, null, httpServerUpgradeHandler);
+        ctx.pipeline().addBefore(ctx, new PriorKnowledgeHandler());
+        ctx.pipeline().addBefore(ctx, httpServerCodec);
+        ctx.pipeline().replace(this, httpServerUpgradeHandler);
     }
 
     /**
@@ -88,10 +87,11 @@ public final class CleartextHttp2ServerUpgradeHandler extends ChannelHandlerAdap
                 // Full h2 preface match, removed source codec, using http2 codec to handle
                 // following network traffic
                 ctx.pipeline()
-                   .remove(httpServerCodec)
+                   .remove(httpServerCodec);
+                ctx.pipeline()
                    .remove(httpServerUpgradeHandler);
 
-                ctx.pipeline().addAfter(ctx.name(), null, http2ServerHandler);
+                ctx.pipeline().addAfter(ctx, http2ServerHandler);
                 ctx.pipeline().remove(this);
 
                 ctx.fireUserEventTriggered(PriorKnowledgeUpgradeEvent.INSTANCE);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodec.java
@@ -44,42 +44,24 @@ public class Http2ClientUpgradeCodec implements HttpClientUpgradeHandler.Upgrade
 
     private static final List<CharSequence> UPGRADE_HEADERS = Collections.singletonList(HTTP_UPGRADE_SETTINGS_HEADER);
 
-    private final String handlerName;
     private final Http2ConnectionHandler connectionHandler;
     private final ChannelHandler upgradeToHandler;
 
     public Http2ClientUpgradeCodec(Http2FrameCodec frameCodec, ChannelHandler upgradeToHandler) {
-        this(null, frameCodec, upgradeToHandler);
-    }
-
-    public Http2ClientUpgradeCodec(String handlerName, Http2FrameCodec frameCodec, ChannelHandler upgradeToHandler) {
-        this(handlerName, (Http2ConnectionHandler) frameCodec, upgradeToHandler);
-    }
-
-    /**
-     * Creates the codec using a default name for the connection handler when adding to the
-     * pipeline.
-     *
-     * @param connectionHandler the HTTP/2 connection handler
-     */
-    public Http2ClientUpgradeCodec(Http2ConnectionHandler connectionHandler) {
-        this((String) null, connectionHandler);
+        this((Http2ConnectionHandler) frameCodec, upgradeToHandler);
     }
 
     /**
      * Creates the codec providing an upgrade to the given handler for HTTP/2.
      *
-     * @param handlerName the name of the HTTP/2 connection handler to be used in the pipeline,
-     *                    or {@code null} to auto-generate the name
      * @param connectionHandler the HTTP/2 connection handler
      */
-    public Http2ClientUpgradeCodec(String handlerName, Http2ConnectionHandler connectionHandler) {
-        this(handlerName, connectionHandler, connectionHandler);
+    public Http2ClientUpgradeCodec(Http2ConnectionHandler connectionHandler) {
+        this(connectionHandler, connectionHandler);
     }
 
-    private Http2ClientUpgradeCodec(String handlerName, Http2ConnectionHandler connectionHandler, ChannelHandler
+    private Http2ClientUpgradeCodec(Http2ConnectionHandler connectionHandler, ChannelHandler
                                     upgradeToHandler) {
-        this.handlerName = handlerName;
         this.connectionHandler = checkNotNull(connectionHandler, "connectionHandler");
         this.upgradeToHandler = checkNotNull(upgradeToHandler, "upgradeToHandler");
     }
@@ -101,7 +83,7 @@ public class Http2ClientUpgradeCodec implements HttpClientUpgradeHandler.Upgrade
     public void upgradeTo(ChannelHandlerContext ctx, FullHttpResponse upgradeResponse)
             throws Exception {
         // Add the handler to the pipeline.
-        ctx.pipeline().addAfter(ctx.name(), handlerName, upgradeToHandler);
+        ctx.pipeline().addAfter(ctx, upgradeToHandler);
 
         // Reserve local stream 1 for the response.
         connectionHandler.onHttpClientUpgrade();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.base64.Base64;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -38,7 +37,6 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.FRAME_HEADER_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER;
 import static io.netty.handler.codec.http2.Http2CodecUtil.writeFrameHeader;
 import static io.netty.handler.codec.http2.Http2FrameTypes.SETTINGS;
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * Server-side codec for performing a cleartext upgrade from HTTP/1.x to HTTP/2.
@@ -51,7 +49,6 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
             Collections.singletonList(HTTP_UPGRADE_SETTINGS_HEADER);
     private static final ChannelHandler[] EMPTY_HANDLERS = new ChannelHandler[0];
 
-    private final String handlerName;
     private final Http2ConnectionHandler connectionHandler;
     private final ChannelHandler[] handlers;
     private final Http2FrameReader frameReader;
@@ -65,38 +62,16 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
      * @param connectionHandler the HTTP/2 connection handler
      */
     public Http2ServerUpgradeCodec(Http2ConnectionHandler connectionHandler) {
-        this(null, connectionHandler, EMPTY_HANDLERS);
+        this(connectionHandler, EMPTY_HANDLERS);
     }
 
     /**
-     * Creates the codec using a default name for the connection handler when adding to the
-     * pipeline.
+     * Creates the codec providing an upgrade to the given handler for HTTP/2.
      *
      * @param http2Codec the HTTP/2 multiplexing handler.
      */
     public Http2ServerUpgradeCodec(Http2MultiplexCodec http2Codec) {
-        this(null, http2Codec, EMPTY_HANDLERS);
-    }
-
-    /**
-     * Creates the codec providing an upgrade to the given handler for HTTP/2.
-     *
-     * @param handlerName the name of the HTTP/2 connection handler to be used in the pipeline,
-     *                    or {@code null} to auto-generate the name
-     * @param connectionHandler the HTTP/2 connection handler
-     */
-    public Http2ServerUpgradeCodec(String handlerName, Http2ConnectionHandler connectionHandler) {
-        this(handlerName, connectionHandler, EMPTY_HANDLERS);
-    }
-
-    /**
-     * Creates the codec providing an upgrade to the given handler for HTTP/2.
-     *
-     * @param handlerName the name of the HTTP/2 connection handler to be used in the pipeline.
-     * @param http2Codec the HTTP/2 multiplexing handler.
-     */
-    public Http2ServerUpgradeCodec(String handlerName, Http2MultiplexCodec http2Codec) {
-        this(handlerName, http2Codec, EMPTY_HANDLERS);
+        this(http2Codec, EMPTY_HANDLERS);
     }
 
     /**
@@ -107,12 +82,11 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
      * @param handlers the handlers that will handle the {@link Http2Frame}s.
      */
     public Http2ServerUpgradeCodec(Http2FrameCodec http2Codec, ChannelHandler... handlers) {
-        this(null, http2Codec, handlers);
+        this((Http2ConnectionHandler) http2Codec, handlers);
     }
 
-    private Http2ServerUpgradeCodec(String handlerName, Http2ConnectionHandler connectionHandler,
+    private Http2ServerUpgradeCodec(Http2ConnectionHandler connectionHandler,
             ChannelHandler... handlers) {
-        this.handlerName = handlerName;
         this.connectionHandler = connectionHandler;
         this.handlers = handlers;
         frameReader = new DefaultHttp2FrameReader();
@@ -147,7 +121,7 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
     public void upgradeTo(final ChannelHandlerContext ctx, FullHttpRequest upgradeRequest) {
         try {
             // Add the HTTP/2 connection handler to the pipeline immediately following the current handler.
-            ctx.pipeline().addAfter(ctx.name(), handlerName, connectionHandler);
+            ctx.pipeline().addAfter(ctx, connectionHandler);
             connectionHandler.onHttpServerUpgrade(settings);
 
         } catch (Http2Exception e) {
@@ -157,9 +131,9 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
         }
 
         if (handlers != null) {
-            final String name = ctx.pipeline().context(connectionHandler).name();
+            final ChannelHandlerContext context = ctx.pipeline().context(connectionHandler);
             for (int i = handlers.length - 1; i >= 0; i--) {
-                ctx.pipeline().addAfter(name, null, handlers[i]);
+                ctx.pipeline().addAfter(context, handlers[i]);
             }
         }
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -14,11 +14,9 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelInitializer;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -54,13 +52,13 @@ public class Http2ClientUpgradeCodecTest {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
         ChannelHandlerContext ctx = channel.pipeline().firstContext();
-        Http2ClientUpgradeCodec codec = new Http2ClientUpgradeCodec("connectionHandler", handler);
+        Http2ClientUpgradeCodec codec = new Http2ClientUpgradeCodec(handler);
         codec.setUpgradeHeaders(ctx, request);
         // Flush the channel to ensure we write out all buffered data
         channel.flush();
 
         codec.upgradeTo(ctx, null);
-        assertNotNull(channel.pipeline().get("connectionHandler"));
+        assertNotNull(channel.pipeline().context(handler));
 
         assertTrue(channel.finishAndReleaseAll());
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -788,7 +788,7 @@ public class Http2FrameCodecTest {
 
     @Test
     public void upgradeWithoutFlowControlling() throws Exception {
-        channel.pipeline().addAfter(frameCodec.ctx.name(), null, new ChannelInboundHandlerAdapter() {
+        channel.pipeline().addAfter(frameCodec.ctx, new ChannelInboundHandlerAdapter() {
             @Override
             public void channelRead(final ChannelHandlerContext ctx, Object msg) throws Exception {
                 if (msg instanceof Http2DataFrame) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -125,11 +125,6 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public String name() {
-            return "WriteInbound";
-        }
-
-        @Override
         public ChannelHandler handler() {
             return this;
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
@@ -59,13 +59,13 @@ public class Http2ServerUpgradeCodecTest {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
         ChannelHandlerContext ctx = channel.pipeline().firstContext();
-        Http2ServerUpgradeCodec codec = new Http2ServerUpgradeCodec("connectionHandler", handler);
+        Http2ServerUpgradeCodec codec = new Http2ServerUpgradeCodec(handler);
         assertTrue(codec.prepareUpgradeResponse(ctx, request, new DefaultHttpHeaders()));
         codec.upgradeTo(ctx, request);
         // Flush the channel to ensure we write out all buffered data
         channel.flush();
 
-        assertSame(handler, channel.pipeline().remove("connectionHandler"));
+        assertSame(handler, channel.pipeline().remove(handler).handler());
         assertNull(channel.pipeline().get(handler.getClass()));
         assertTrue(channel.finish());
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/SocksPortUnificationServerHandler.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/SocksPortUnificationServerHandler.java
@@ -74,13 +74,13 @@ public class SocksPortUnificationServerHandler extends ByteToMessageDecoder {
         switch (version) {
         case SOCKS4a:
             logKnownVersion(ctx, version);
-            p.addAfter(ctx.name(), null, Socks4ServerEncoder.INSTANCE);
-            p.addAfter(ctx.name(), null, new Socks4ServerDecoder());
+            p.addAfter(ctx, Socks4ServerEncoder.INSTANCE);
+            p.addAfter(ctx, new Socks4ServerDecoder());
             break;
         case SOCKS5:
             logKnownVersion(ctx, version);
-            p.addAfter(ctx.name(), null, socks5encoder);
-            p.addAfter(ctx.name(), null, new Socks5InitialRequestDecoder());
+            p.addAfter(ctx, socks5encoder);
+            p.addAfter(ctx, new Socks5InitialRequestDecoder());
             break;
         default:
             logUnknownVersion(ctx, versionVal);

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
@@ -99,7 +99,7 @@ public class ReplayingDecoderTest {
     private static final class BloatedLineDecoder extends ChannelInboundHandlerAdapter {
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-            ctx.pipeline().replace(this, "less-bloated", new LineDecoder());
+            ctx.pipeline().replace(this, new LineDecoder());
             ctx.pipeline().fireChannelRead(msg);
         }
     }

--- a/example/src/main/java/io/netty/example/file/FileServer.java
+++ b/example/src/main/java/io/netty/example/file/FileServer.java
@@ -70,12 +70,11 @@ public final class FileServer {
                      if (sslCtx != null) {
                          p.addLast(sslCtx.newHandler(ch.alloc()));
                      }
-                     p.addLast(
-                             new StringEncoder(CharsetUtil.UTF_8),
-                             new LineBasedFrameDecoder(8192),
-                             new StringDecoder(CharsetUtil.UTF_8),
-                             new ChunkedWriteHandler(),
-                             new FileServerHandler());
+                     p.addLast(new StringEncoder(CharsetUtil.UTF_8));
+                     p.addLast(new LineBasedFrameDecoder(8192));
+                     p.addLast(new StringDecoder(CharsetUtil.UTF_8));
+                     p.addLast(new ChunkedWriteHandler());
+                     p.addLast(new FileServerHandler());
                  }
              });
 

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadClientInitializer.java
@@ -36,17 +36,17 @@ public class HttpUploadClientInitializer extends ChannelInitializer<SocketChanne
         ChannelPipeline pipeline = ch.pipeline();
 
         if (sslCtx != null) {
-            pipeline.addLast("ssl", sslCtx.newHandler(ch.alloc()));
+            pipeline.addLast(sslCtx.newHandler(ch.alloc()));
         }
 
-        pipeline.addLast("codec", new HttpClientCodec());
+        pipeline.addLast(new HttpClientCodec());
 
         // Remove the following line if you don't want automatic content decompression.
-        pipeline.addLast("inflater", new HttpContentDecompressor());
+        pipeline.addLast(new HttpContentDecompressor());
 
         // to be used since huge file transfer
-        pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
+        pipeline.addLast(new ChunkedWriteHandler());
 
-        pipeline.addLast("handler", new HttpUploadClientHandler());
+        pipeline.addLast(new HttpUploadClientHandler());
     }
 }

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -110,11 +110,10 @@ public final class WebSocketClient {
                      if (sslCtx != null) {
                          p.addLast(sslCtx.newHandler(ch.alloc(), host, port));
                      }
-                     p.addLast(
-                             new HttpClientCodec(),
-                             new HttpObjectAggregator(8192),
-                             WebSocketClientCompressionHandler.INSTANCE,
-                             handler);
+                     p.addLast(new HttpClientCodec());
+                     p.addLast(new HttpObjectAggregator(8192));
+                     p.addLast(WebSocketClientCompressionHandler.INSTANCE);
+                     p.addLast(handler);
                  }
              });
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/Http2ClientInitializer.java
@@ -86,7 +86,8 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
     }
 
     protected void configureEndOfPipeline(ChannelPipeline pipeline) {
-        pipeline.addLast(settingsHandler, responseHandler);
+        pipeline.addLast(settingsHandler);
+        pipeline.addLast(responseHandler);
     }
 
     /**
@@ -120,10 +121,10 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
         Http2ClientUpgradeCodec upgradeCodec = new Http2ClientUpgradeCodec(connectionHandler);
         HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 65536);
 
-        ch.pipeline().addLast(sourceCodec,
-                              upgradeHandler,
-                              new UpgradeRequestHandler(),
-                              new UserEventLogger());
+        ch.pipeline().addLast(sourceCodec);
+        ch.pipeline().addLast(upgradeHandler);
+        ch.pipeline().addLast(new UpgradeRequestHandler());
+        ch.pipeline().addLast(new UserEventLogger());
     }
 
     /**

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2OrHttpHandler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2OrHttpHandler.java
@@ -38,14 +38,15 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
     @Override
     protected void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception {
         if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
-            ctx.pipeline().addLast(Http2FrameCodecBuilder.forServer().build(), new HelloWorldHttp2Handler());
+            ctx.pipeline().addLast(Http2FrameCodecBuilder.forServer().build());
+            ctx.pipeline().addLast(new HelloWorldHttp2Handler());
             return;
         }
 
         if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
-            ctx.pipeline().addLast(new HttpServerCodec(),
-                                   new HttpObjectAggregator(MAX_CONTENT_LENGTH),
-                                   new HelloWorldHttp1Handler("ALPN Negotiation"));
+            ctx.pipeline().addLast(new HttpServerCodec());
+            ctx.pipeline().addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH));
+            ctx.pipeline().addLast(new HelloWorldHttp1Handler("ALPN Negotiation"));
             return;
         }
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2ServerInitializer.java
@@ -82,7 +82,8 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      * Configure the pipeline for TLS NPN negotiation to HTTP/2.
      */
     private void configureSsl(SocketChannel ch) {
-        ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()), new Http2OrHttpHandler());
+        ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()));
+        ch.pipeline().addLast(new Http2OrHttpHandler());
     }
 
     /**
@@ -101,8 +102,8 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
                 System.err.println("Directly talking: " + msg.protocolVersion() + " (no upgrade was attempted)");
                 ChannelPipeline pipeline = ctx.pipeline();
                 ChannelHandlerContext thisCtx = pipeline.context(this);
-                pipeline.addAfter(thisCtx.name(), null, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
-                pipeline.replace(this, null, new HttpObjectAggregator(maxHttpContentLength));
+                pipeline.addAfter(thisCtx, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
+                pipeline.replace(this, new HttpObjectAggregator(maxHttpContentLength));
                 ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
             }
         });

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2OrHttpHandler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2OrHttpHandler.java
@@ -42,9 +42,9 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
         }
 
         if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
-            ctx.pipeline().addLast(new HttpServerCodec(),
-                                   new HttpObjectAggregator(MAX_CONTENT_LENGTH),
-                                   new HelloWorldHttp1Handler("ALPN Negotiation"));
+            ctx.pipeline().addLast(new HttpServerCodec());
+            ctx.pipeline().addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH));
+            ctx.pipeline().addLast(new HelloWorldHttp1Handler("ALPN Negotiation"));
             return;
         }
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2ServerInitializer.java
@@ -82,7 +82,8 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      * Configure the pipeline for TLS NPN negotiation to HTTP/2.
      */
     private void configureSsl(SocketChannel ch) {
-        ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()), new Http2OrHttpHandler());
+        ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()));
+        ch.pipeline().addLast(new Http2OrHttpHandler());
     }
 
     /**
@@ -101,8 +102,8 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
                 System.err.println("Directly talking: " + msg.protocolVersion() + " (no upgrade was attempted)");
                 ChannelPipeline pipeline = ctx.pipeline();
                 ChannelHandlerContext thisCtx = pipeline.context(this);
-                pipeline.addAfter(thisCtx.name(), null, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
-                pipeline.replace(this, null, new HttpObjectAggregator(maxHttpContentLength));
+                pipeline.addAfter(thisCtx, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
+                pipeline.replace(this, new HttpObjectAggregator(maxHttpContentLength));
                 ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
             }
         });

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2OrHttpHandler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2OrHttpHandler.java
@@ -40,9 +40,9 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
         }
 
         if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
-            ctx.pipeline().addLast(new HttpServerCodec(),
-                                   new HttpObjectAggregator(MAX_CONTENT_LENGTH),
-                                   new HelloWorldHttp1Handler("ALPN Negotiation"));
+            ctx.pipeline().addLast(new HttpServerCodec());
+            ctx.pipeline().addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH));
+            ctx.pipeline().addLast(new HelloWorldHttp1Handler("ALPN Negotiation"));
             return;
         }
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
@@ -80,7 +80,8 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      * Configure the pipeline for TLS NPN negotiation to HTTP/2.
      */
     private void configureSsl(SocketChannel ch) {
-        ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()), new Http2OrHttpHandler());
+        ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()));
+        ch.pipeline().addLast(new Http2OrHttpHandler());
     }
 
     /**
@@ -102,8 +103,8 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
                 System.err.println("Directly talking: " + msg.protocolVersion() + " (no upgrade was attempted)");
                 ChannelPipeline pipeline = ctx.pipeline();
                 ChannelHandlerContext thisCtx = pipeline.context(this);
-                pipeline.addAfter(thisCtx.name(), null, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
-                pipeline.replace(this, null, new HttpObjectAggregator(maxHttpContentLength));
+                pipeline.addAfter(thisCtx, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
+                pipeline.replace(this, new HttpObjectAggregator(maxHttpContentLength));
                 ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
             }
         });

--- a/example/src/main/java/io/netty/example/http2/tiles/Http2OrHttpHandler.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http2OrHttpHandler.java
@@ -68,8 +68,8 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
     }
 
     private static void configureHttp1(ChannelHandlerContext ctx) throws Exception {
-        ctx.pipeline().addLast(new HttpServerCodec(),
-                               new HttpObjectAggregator(MAX_CONTENT_LENGTH),
-                               new FallbackRequestHandler());
+        ctx.pipeline().addLast(new HttpServerCodec());
+        ctx.pipeline().addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH));
+        ctx.pipeline().addLast(new FallbackRequestHandler());
     }
 }

--- a/example/src/main/java/io/netty/example/http2/tiles/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http2Server.java
@@ -61,7 +61,8 @@ public class Http2Server {
         b.group(group).channel(NioServerSocketChannel.class).childHandler(new ChannelInitializer<SocketChannel>() {
             @Override
             protected void initChannel(SocketChannel ch) throws Exception {
-                ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()), new Http2OrHttpHandler());
+                ch.pipeline().addLast(sslCtx.newHandler(ch.alloc()));
+                ch.pipeline().addLast(new Http2OrHttpHandler());
             }
         });
 

--- a/example/src/main/java/io/netty/example/http2/tiles/HttpServer.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/HttpServer.java
@@ -53,10 +53,10 @@ public final class HttpServer {
         .childHandler(new ChannelInitializer<SocketChannel>() {
             @Override
             protected void initChannel(SocketChannel ch) throws Exception {
-                ch.pipeline().addLast(new HttpRequestDecoder(),
-                                      new HttpResponseEncoder(),
-                                      new HttpObjectAggregator(MAX_CONTENT_LENGTH),
-                                      new Http1RequestHandler());
+                ch.pipeline().addLast(new HttpRequestDecoder());
+                ch.pipeline().addLast(new HttpResponseEncoder());
+                ch.pipeline().addLast(new HttpObjectAggregator(MAX_CONTENT_LENGTH));
+                ch.pipeline().addLast(new Http1RequestHandler());
             }
         });
 

--- a/example/src/main/java/io/netty/example/localecho/LocalEcho.java
+++ b/example/src/main/java/io/netty/example/localecho/LocalEcho.java
@@ -58,9 +58,8 @@ public final class LocalEcho {
               .childHandler(new ChannelInitializer<LocalChannel>() {
                   @Override
                   public void initChannel(LocalChannel ch) throws Exception {
-                      ch.pipeline().addLast(
-                              new LoggingHandler(LogLevel.INFO),
-                              new LocalEchoServerHandler());
+                      ch.pipeline().addLast(new LoggingHandler(LogLevel.INFO));
+                      ch.pipeline().addLast(new LocalEchoServerHandler());
                   }
               });
 
@@ -70,9 +69,8 @@ public final class LocalEcho {
               .handler(new ChannelInitializer<LocalChannel>() {
                   @Override
                   public void initChannel(LocalChannel ch) throws Exception {
-                      ch.pipeline().addLast(
-                              new LoggingHandler(LogLevel.INFO),
-                              new LocalEchoClientHandler());
+                      ch.pipeline().addLast(new LoggingHandler(LogLevel.INFO));
+                      ch.pipeline().addLast(new LocalEchoClientHandler());
                   }
               });
 

--- a/example/src/main/java/io/netty/example/objectecho/ObjectEchoClient.java
+++ b/example/src/main/java/io/netty/example/objectecho/ObjectEchoClient.java
@@ -62,10 +62,9 @@ public final class ObjectEchoClient {
                     if (sslCtx != null) {
                         p.addLast(sslCtx.newHandler(ch.alloc(), HOST, PORT));
                     }
-                    p.addLast(
-                            new ObjectEncoder(),
-                            new ObjectDecoder(ClassResolvers.cacheDisabled(null)),
-                            new ObjectEchoClientHandler());
+                    p.addLast(new ObjectEncoder());
+                    p.addLast(new ObjectDecoder(ClassResolvers.cacheDisabled(null)));
+                    p.addLast(new ObjectEchoClientHandler());
                 }
              });
 

--- a/example/src/main/java/io/netty/example/objectecho/ObjectEchoServer.java
+++ b/example/src/main/java/io/netty/example/objectecho/ObjectEchoServer.java
@@ -35,7 +35,8 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 /**
  * Modification of {@link EchoServer} which utilizes Java object serialization.
  */
-public final class ObjectEchoServer {
+public final class
+ObjectEchoServer {
 
     static final boolean SSL = System.getProperty("ssl") != null;
     static final int PORT = Integer.parseInt(System.getProperty("port", "8007"));
@@ -64,10 +65,9 @@ public final class ObjectEchoServer {
                     if (sslCtx != null) {
                         p.addLast(sslCtx.newHandler(ch.alloc()));
                     }
-                    p.addLast(
-                            new ObjectEncoder(),
-                            new ObjectDecoder(ClassResolvers.cacheDisabled(null)),
-                            new ObjectEchoServerHandler());
+                    p.addLast(new ObjectEncoder());
+                    p.addLast(new ObjectDecoder(ClassResolvers.cacheDisabled(null)));
+                    p.addLast(new ObjectEchoServerHandler());
                 }
              });
 

--- a/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
+++ b/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
@@ -112,33 +112,33 @@ public class PortUnificationServerHandler extends ByteToMessageDecoder {
 
     private void enableSsl(ChannelHandlerContext ctx) {
         ChannelPipeline p = ctx.pipeline();
-        p.addLast("ssl", sslCtx.newHandler(ctx.alloc()));
-        p.addLast("unificationA", new PortUnificationServerHandler(sslCtx, false, detectGzip));
+        p.addLast(sslCtx.newHandler(ctx.alloc()));
+        p.addLast(new PortUnificationServerHandler(sslCtx, false, detectGzip));
         p.remove(this);
     }
 
     private void enableGzip(ChannelHandlerContext ctx) {
         ChannelPipeline p = ctx.pipeline();
-        p.addLast("gzipdeflater", ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
-        p.addLast("gzipinflater", ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
-        p.addLast("unificationB", new PortUnificationServerHandler(sslCtx, detectSsl, false));
+        p.addLast(ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP));
+        p.addLast(ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP));
+        p.addLast(new PortUnificationServerHandler(sslCtx, detectSsl, false));
         p.remove(this);
     }
 
     private void switchToHttp(ChannelHandlerContext ctx) {
         ChannelPipeline p = ctx.pipeline();
-        p.addLast("decoder", new HttpRequestDecoder());
-        p.addLast("encoder", new HttpResponseEncoder());
-        p.addLast("deflater", new HttpContentCompressor());
-        p.addLast("handler", new HttpSnoopServerHandler());
+        p.addLast(new HttpRequestDecoder());
+        p.addLast(new HttpResponseEncoder());
+        p.addLast(new HttpContentCompressor());
+        p.addLast(new HttpSnoopServerHandler());
         p.remove(this);
     }
 
     private void switchToFactorial(ChannelHandlerContext ctx) {
         ChannelPipeline p = ctx.pipeline();
-        p.addLast("decoder", new BigIntegerDecoder());
-        p.addLast("encoder", new NumberEncoder());
-        p.addLast("handler", new FactorialServerHandler());
+        p.addLast(new BigIntegerDecoder());
+        p.addLast(new NumberEncoder());
+        p.addLast(new FactorialServerHandler());
         p.remove(this);
     }
 }

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyInitializer.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyInitializer.java
@@ -32,8 +32,7 @@ public class HexDumpProxyInitializer extends ChannelInitializer<SocketChannel> {
 
     @Override
     public void initChannel(SocketChannel ch) {
-        ch.pipeline().addLast(
-                new LoggingHandler(LogLevel.INFO),
-                new HexDumpProxyFrontendHandler(remoteHost, remotePort));
+        ch.pipeline().addLast(new LoggingHandler(LogLevel.INFO));
+        ch.pipeline().addLast(new HexDumpProxyFrontendHandler(remoteHost, remotePort));
     }
 }

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServerInitializer.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServerInitializer.java
@@ -24,9 +24,8 @@ import io.netty.handler.logging.LoggingHandler;
 public final class SocksServerInitializer extends ChannelInitializer<SocketChannel> {
     @Override
     public void initChannel(SocketChannel ch) throws Exception {
-        ch.pipeline().addLast(
-                new LoggingHandler(LogLevel.DEBUG),
-                new SocksPortUnificationServerHandler(),
-                SocksServerHandler.INSTANCE);
+        ch.pipeline().addLast(new LoggingHandler(LogLevel.DEBUG));
+        ch.pipeline().addLast(new SocksPortUnificationServerHandler());
+        ch.pipeline().addLast(SocksServerHandler.INSTANCE);
     }
 }

--- a/example/src/main/java/io/netty/example/spdy/client/SpdyClientInitializer.java
+++ b/example/src/main/java/io/netty/example/spdy/client/SpdyClientInitializer.java
@@ -42,13 +42,13 @@ public class SpdyClientInitializer extends ChannelInitializer<SocketChannel> {
     @Override
     public void initChannel(SocketChannel ch) {
         ChannelPipeline pipeline = ch.pipeline();
-        pipeline.addLast("ssl", sslCtx.newHandler(ch.alloc()));
-        pipeline.addLast("spdyFrameCodec", new SpdyFrameCodec(SPDY_3_1));
-        pipeline.addLast("spdyFrameLogger", new SpdyFrameLogger(INFO));
-        pipeline.addLast("spdySessionHandler", new SpdySessionHandler(SPDY_3_1, false));
-        pipeline.addLast("spdyHttpEncoder", new SpdyHttpEncoder(SPDY_3_1));
-        pipeline.addLast("spdyHttpDecoder", new SpdyHttpDecoder(SPDY_3_1, MAX_SPDY_CONTENT_LENGTH));
-        pipeline.addLast("spdyStreamIdHandler", new SpdyClientStreamIdHandler());
-        pipeline.addLast("httpHandler", httpResponseHandler);
+        pipeline.addLast(sslCtx.newHandler(ch.alloc()));
+        pipeline.addLast(new SpdyFrameCodec(SPDY_3_1));
+        pipeline.addLast(new SpdyFrameLogger(INFO));
+        pipeline.addLast(new SpdySessionHandler(SPDY_3_1, false));
+        pipeline.addLast(new SpdyHttpEncoder(SPDY_3_1));
+        pipeline.addLast(new SpdyHttpDecoder(SPDY_3_1, MAX_SPDY_CONTENT_LENGTH));
+        pipeline.addLast(new SpdyClientStreamIdHandler());
+        pipeline.addLast(httpResponseHandler);
     }
 }

--- a/example/src/main/java/io/netty/example/stomp/StompClient.java
+++ b/example/src/main/java/io/netty/example/stomp/StompClient.java
@@ -49,10 +49,10 @@ public final class StompClient {
                 @Override
                 protected void initChannel(SocketChannel ch) throws Exception {
                     ChannelPipeline pipeline = ch.pipeline();
-                    pipeline.addLast("decoder", new StompSubframeDecoder());
-                    pipeline.addLast("encoder", new StompSubframeEncoder());
-                    pipeline.addLast("aggregator", new StompSubframeAggregator(1048576));
-                    pipeline.addLast("handler", new StompClientHandler());
+                    pipeline.addLast(new StompSubframeDecoder());
+                    pipeline.addLast(new StompSubframeEncoder());
+                    pipeline.addLast(new StompSubframeAggregator(1048576));
+                    pipeline.addLast(new StompClientHandler());
                 }
             });
 

--- a/example/src/main/java/io/netty/example/uptime/UptimeClient.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClient.java
@@ -51,7 +51,8 @@ public final class UptimeClient {
                 .handler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     protected void initChannel(SocketChannel ch) throws Exception {
-                        ch.pipeline().addLast(new IdleStateHandler(READ_TIMEOUT, 0, 0), handler);
+                        ch.pipeline().addLast(new IdleStateHandler(READ_TIMEOUT, 0, 0));
+                        ch.pipeline().addLast(handler);
                     }
                 });
         bs.connect();

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -127,8 +127,7 @@ public final class HttpProxyHandler extends ProxyHandler {
     @Override
     protected void addCodec(ChannelHandlerContext ctx) throws Exception {
         ChannelPipeline p = ctx.pipeline();
-        String name = ctx.name();
-        p.addBefore(name, null, codec);
+        p.addBefore(ctx, codec);
     }
 
     @Override

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/Socks4ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/Socks4ProxyHandler.java
@@ -35,8 +35,8 @@ public final class Socks4ProxyHandler extends ProxyHandler {
 
     private final String username;
 
-    private String decoderName;
-    private String encoderName;
+    private ChannelHandlerContext decoderCtx;
+    private ChannelHandlerContext encoderCtx;
 
     public Socks4ProxyHandler(SocketAddress proxyAddress) {
         this(proxyAddress, null);
@@ -67,27 +67,22 @@ public final class Socks4ProxyHandler extends ProxyHandler {
     @Override
     protected void addCodec(ChannelHandlerContext ctx) throws Exception {
         ChannelPipeline p = ctx.pipeline();
-        String name = ctx.name();
 
         Socks4ClientDecoder decoder = new Socks4ClientDecoder();
-        p.addBefore(name, null, decoder);
-
-        decoderName = p.context(decoder).name();
-        encoderName = decoderName + ".encoder";
-
-        p.addBefore(name, encoderName, Socks4ClientEncoder.INSTANCE);
+        decoderCtx = p.addBefore(ctx, decoder);
+        encoderCtx = p.addBefore(ctx, Socks4ClientEncoder.INSTANCE);
     }
 
     @Override
     protected void removeEncoder(ChannelHandlerContext ctx) throws Exception {
         ChannelPipeline p = ctx.pipeline();
-        p.remove(encoderName);
+        p.remove(encoderCtx);
     }
 
     @Override
     protected void removeDecoder(ChannelHandlerContext ctx) throws Exception {
         ChannelPipeline p = ctx.pipeline();
-        p.remove(decoderName);
+        p.remove(decoderCtx);
     }
 
     @Override

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyServer.java
@@ -77,7 +77,7 @@ final class HttpProxyServer extends ProxyServer {
         assertThat(req.method(), is(HttpMethod.CONNECT));
 
         if (testMode != TestMode.INTERMEDIARY) {
-            ctx.pipeline().addBefore(ctx.name(), "lineDecoder", new LineBasedFrameDecoder(64, false, true));
+            ctx.pipeline().addBefore(ctx, new LineBasedFrameDecoder(64, false, true));
         }
 
         ctx.pipeline().remove(HttpObjectAggregator.class);

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -642,7 +642,9 @@ public class ProxyHandlerTest {
                 @Override
                 protected void initChannel(SocketChannel ch) throws Exception {
                     ChannelPipeline p = ch.pipeline();
-                    p.addLast(clientHandlers);
+                    for (ChannelHandler h : clientHandlers) {
+                        p.addLast(h);
+                    }
                     p.addLast(new LineBasedFrameDecoder(64));
                     p.addLast(testHandler);
                 }
@@ -690,7 +692,9 @@ public class ProxyHandlerTest {
                 @Override
                 protected void initChannel(SocketChannel ch) throws Exception {
                     ChannelPipeline p = ch.pipeline();
-                    p.addLast(clientHandlers);
+                    for (ChannelHandler h : clientHandlers) {
+                        p.addLast(h);
+                    }
                     p.addLast(new LineBasedFrameDecoder(64));
                     p.addLast(testHandler);
                 }
@@ -735,7 +739,9 @@ public class ProxyHandlerTest {
                 @Override
                 protected void initChannel(SocketChannel ch) throws Exception {
                     ChannelPipeline p = ch.pipeline();
-                    p.addLast(clientHandlers);
+                    for (ChannelHandler h : clientHandlers) {
+                        p.addLast(h);
+                    }
                     p.addLast(new LineBasedFrameDecoder(64));
                     p.addLast(testHandler);
                 }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/Socks4ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/Socks4ProxyServer.java
@@ -71,7 +71,7 @@ final class Socks4ProxyServer extends ProxyServer {
         assertThat(req.type(), is(Socks4CommandType.CONNECT));
 
         if (testMode != TestMode.INTERMEDIARY) {
-            ctx.pipeline().addBefore(ctx.name(), "lineDecoder", new LineBasedFrameDecoder(64, false, true));
+            ctx.pipeline().addBefore(ctx, new LineBasedFrameDecoder(64, false, true));
         }
 
         boolean authzSuccess;

--- a/handler/src/main/java/io/netty/handler/ssl/OptionalSslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OptionalSslHandler.java
@@ -55,7 +55,7 @@ public class OptionalSslHandler extends ByteToMessageDecoder {
         SslHandler sslHandler = null;
         try {
             sslHandler = newSslHandler(context, sslContext);
-            context.pipeline().replace(this, newSslHandlerName(), sslHandler);
+            context.pipeline().replace(this, sslHandler);
             sslHandler = null;
         } finally {
             // Since the SslHandler was not inserted into the pipeline the ownership of the SSLEngine was not
@@ -69,18 +69,10 @@ public class OptionalSslHandler extends ByteToMessageDecoder {
     private void handleNonSsl(ChannelHandlerContext context) {
         ChannelHandler handler = newNonSslHandler(context);
         if (handler != null) {
-            context.pipeline().replace(this, newNonSslHandlerName(), handler);
+            context.pipeline().replace(this, handler);
         } else {
             context.pipeline().remove(this);
         }
-    }
-
-    /**
-     * Optionally specify the SSL handler name, this method may return {@code null}.
-     * @return the name of the SSL handler.
-     */
-    protected String newSslHandlerName() {
-        return null;
     }
 
     /**
@@ -95,14 +87,6 @@ public class OptionalSslHandler extends ByteToMessageDecoder {
      */
     protected SslHandler newSslHandler(ChannelHandlerContext context, SslContext sslContext) {
         return sslContext.newHandler(context.alloc());
-    }
-
-    /**
-     * Optionally specify the non-SSL handler name, this method may return {@code null}.
-     * @return the name of the non-SSL handler.
-     */
-    protected String newNonSslHandlerName() {
-        return null;
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
@@ -130,7 +130,7 @@ public class SniHandler extends AbstractSniHandler<SslContext> {
         SslHandler sslHandler = null;
         try {
             sslHandler = sslContext.newHandler(ctx.alloc());
-            ctx.pipeline().replace(this, SslHandler.class.getName(), sslHandler);
+            ctx.pipeline().replace(this, sslHandler);
             sslHandler = null;
         } finally {
             // Since the SslHandler was not inserted into the pipeline the ownership of the SSLEngine was not

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -79,7 +79,9 @@ public class FlowControlHandlerTest {
                 protected void initChannel(Channel ch) throws Exception {
                     ChannelPipeline pipeline = ch.pipeline();
                     pipeline.addLast(new OneByteToThreeStringsDecoder());
-                    pipeline.addLast(handlers);
+                    for (ChannelHandler h: handlers) {
+                        pipeline.addLast(h);
+                    }
                 }
             });
 

--- a/handler/src/test/java/io/netty/handler/ssl/OptionalSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OptionalSslHandlerTest.java
@@ -32,9 +32,6 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class OptionalSslHandlerTest {
 
-    private static final String SSL_HANDLER_NAME = "sslhandler";
-    private static final String HANDLER_NAME = "handler";
-
     @Mock
     private ChannelHandlerContext context;
 
@@ -69,16 +66,11 @@ public class OptionalSslHandlerTest {
             protected ChannelHandler newNonSslHandler(ChannelHandlerContext context) {
                 return nonSslHandler;
             }
-
-            @Override
-            protected String newNonSslHandlerName() {
-                return HANDLER_NAME;
-            }
         };
         final ByteBuf payload = Unpooled.copiedBuffer("plaintext".getBytes());
         try {
             handler.decode(context, payload, null);
-            verify(pipeline).replace(handler, HANDLER_NAME, nonSslHandler);
+            verify(pipeline).replace(handler, nonSslHandler);
         } finally {
             payload.release();
         }
@@ -92,16 +84,11 @@ public class OptionalSslHandlerTest {
             protected SslHandler newSslHandler(ChannelHandlerContext context, SslContext sslContext) {
                 return sslHandler;
             }
-
-            @Override
-            protected String newSslHandlerName() {
-                return SSL_HANDLER_NAME;
-            }
         };
         final ByteBuf payload = Unpooled.wrappedBuffer(new byte[] { 22, 3, 1, 0, 5 });
         try {
             handler.decode(context, payload, null);
-            verify(pipeline).replace(handler, SSL_HANDLER_NAME, sslHandler);
+            verify(pipeline).replace(handler, sslHandler);
         } finally {
             payload.release();
         }

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -465,7 +465,7 @@ public class SniHandlerTest {
                                             }
                                         }
                                     };
-                                    ctx.pipeline().replace(this, CustomSslHandler.class.getName(), customSslHandler);
+                                    ctx.pipeline().replace(this, customSslHandler);
                                     success = true;
                                 } finally {
                                     if (!success) {

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -34,7 +34,6 @@ import java.net.SocketAddress;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerContext {
-    private static final String HANDLER_NAME = "microbench-delegator-ctx";
     private final EventLoop eventLoop;
     private final Channel channel;
     private final ByteBufAllocator alloc;
@@ -68,11 +67,6 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     @Override
     public final EventExecutor executor() {
         return eventLoop;
-    }
-
-    @Override
-    public final String name() {
-        return HANDLER_NAME;
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -387,7 +387,9 @@ public class DnsNameResolver extends InetNameResolver {
         b.handler(new ChannelInitializer<DatagramChannel>() {
             @Override
             protected void initChannel(DatagramChannel ch) throws Exception {
-                ch.pipeline().addLast(DECODER, ENCODER, responseHandler);
+                ch.pipeline().addLast(DECODER);
+                ch.pipeline().addLast(ENCODER);
+                ch.pipeline().addLast(responseHandler);
             }
         });
 

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerInitializer.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerInitializer.java
@@ -25,8 +25,8 @@ public class AutobahnServerInitializer extends ChannelInitializer<SocketChannel>
     @Override
     public void initChannel(SocketChannel ch) throws Exception {
         ChannelPipeline pipeline = ch.pipeline();
-        pipeline.addLast("encoder", new HttpResponseEncoder());
-        pipeline.addLast("decoder", new HttpRequestDecoder());
-        pipeline.addLast("handler", new AutobahnServerHandler());
+        pipeline.addLast(new HttpResponseEncoder());
+        pipeline.addLast(new HttpRequestDecoder());
+        pipeline.addLast(new AutobahnServerHandler());
     }
 }

--- a/testsuite-http2/src/main/java/io/netty/testsuite/http2/Http2ServerInitializer.java
+++ b/testsuite-http2/src/main/java/io/netty/testsuite/http2/Http2ServerInitializer.java
@@ -89,8 +89,8 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
                 System.err.println("Directly talking: " + msg.protocolVersion() + " (no upgrade was attempted)");
                 ChannelPipeline pipeline = ctx.pipeline();
                 ChannelHandlerContext thisCtx = pipeline.context(this);
-                pipeline.addAfter(thisCtx.name(), null, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
-                pipeline.replace(this, null, new HttpObjectAggregator(maxHttpContentLength));
+                pipeline.addAfter(thisCtx, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
+                pipeline.replace(this, new HttpObjectAggregator(maxHttpContentLength));
                 ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
             }
         });

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
@@ -73,21 +73,20 @@ public class SctpEchoTest extends AbstractSctpTest {
         sb.childHandler(new ChannelInitializer<SctpChannel>() {
             @Override
             public void initChannel(SctpChannel c) throws Exception {
-                c.pipeline().addLast(
-                        new SctpMessageCompletionHandler(),
-                        new SctpInboundByteStreamHandler(0, 0),
-                        new SctpOutboundByteStreamHandler(0, 0, unordered),
-                        sh);
+                c.pipeline().addLast(new SctpMessageCompletionHandler());
+                c.pipeline().addLast(new SctpInboundByteStreamHandler(0, 0));
+                c.pipeline().addLast(new SctpOutboundByteStreamHandler(0, 0, unordered));
+                c.pipeline().addLast(sh);
             }
         });
         cb.handler(new ChannelInitializer<SctpChannel>() {
             @Override
             public void initChannel(SctpChannel c) throws Exception {
                 c.pipeline().addLast(
-                        new SctpMessageCompletionHandler(),
-                        new SctpInboundByteStreamHandler(0, 0),
-                        new SctpOutboundByteStreamHandler(0, 0, unordered),
-                        ch);
+                        new SctpMessageCompletionHandler());
+                c.pipeline().addLast(new SctpInboundByteStreamHandler(0, 0));
+                c.pipeline().addLast(new SctpOutboundByteStreamHandler(0, 0, unordered));
+                c.pipeline().addLast(ch);
             }
         });
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -68,8 +68,8 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
-                sch.pipeline().addLast("decoder", new FixedLengthFrameDecoder(1024));
-                sch.pipeline().addAfter("decoder", "handler", sh);
+                sch.pipeline().addLast(new FixedLengthFrameDecoder(1024));
+                sch.pipeline().addLast(sh);
             }
         });
 
@@ -77,8 +77,8 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         cb.handler(new ChannelInitializer<Channel>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
-                sch.pipeline().addLast("decoder", new FixedLengthFrameDecoder(1024));
-                sch.pipeline().addAfter("decoder", "handler", ch);
+                sch.pipeline().addLast(new FixedLengthFrameDecoder(1024));
+                sch.pipeline().addLast(ch);
             }
         });
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
@@ -78,20 +78,18 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
-                sch.pipeline().addLast(
-                        new ObjectDecoder(ClassResolvers.cacheDisabled(getClass().getClassLoader())),
-                        new ObjectEncoder(),
-                        sh);
+                sch.pipeline().addLast(new ObjectDecoder(ClassResolvers.cacheDisabled(getClass().getClassLoader())));
+                sch.pipeline().addLast(new ObjectEncoder());
+                sch.pipeline().addLast(sh);
             }
         });
 
         cb.handler(new ChannelInitializer<Channel>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
-                sch.pipeline().addLast(
-                        new ObjectDecoder(ClassResolvers.cacheDisabled(getClass().getClassLoader())),
-                        new ObjectEncoder(),
-                        ch);
+                sch.pipeline().addLast(new ObjectDecoder(ClassResolvers.cacheDisabled(getClass().getClassLoader())));
+                sch.pipeline().addLast(new ObjectEncoder());
+                sch.pipeline().addLast(ch);
             }
         });
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
@@ -184,9 +184,8 @@ public class SocketSpdyEchoTest extends AbstractSocketTest {
         sb.childHandler(new ChannelInitializer<SocketChannel>() {
             @Override
             public void initChannel(SocketChannel channel) throws Exception {
-                channel.pipeline().addLast(
-                        new SpdyFrameCodec(version),
-                        sh);
+                channel.pipeline().addLast(new SpdyFrameCodec(version));
+                channel.pipeline().addLast(sh);
             }
         });
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -140,8 +140,8 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                 serverSslHandler = serverCtx.newHandler(sch.alloc());
                 // As we test renegotiation we should use a protocol that support it.
                 serverSslHandler.engine().setEnabledProtocols(new String[] { "TLSv1.2" });
-                sch.pipeline().addLast("ssl", serverSslHandler);
-                sch.pipeline().addLast("handler", serverHandler);
+                sch.pipeline().addLast(serverSslHandler);
+                sch.pipeline().addLast(serverHandler);
             }
         });
 
@@ -153,8 +153,8 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                 clientSslHandler = clientCtx.newHandler(sch.alloc());
                 // As we test renegotiation we should use a protocol that support it.
                 clientSslHandler.engine().setEnabledProtocols(new String[] { "TLSv1.2" });
-                sch.pipeline().addLast("ssl", clientSslHandler);
-                sch.pipeline().addLast("handler", clientHandler);
+                sch.pipeline().addLast(clientSslHandler);
+                sch.pipeline().addLast(clientHandler);
             }
         });
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -266,11 +266,11 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                     serverSslHandler = serverCtx.newHandler(sch.alloc());
                 }
 
-                sch.pipeline().addLast("ssl", serverSslHandler);
+                sch.pipeline().addLast(serverSslHandler);
                 if (useChunkedWriteHandler) {
                     sch.pipeline().addLast(new ChunkedWriteHandler());
                 }
-                sch.pipeline().addLast("handler", serverHandler);
+                sch.pipeline().addLast(serverHandler);
             }
         });
 
@@ -287,11 +287,11 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                     clientSslHandler = clientCtx.newHandler(sch.alloc());
                 }
 
-                sch.pipeline().addLast("ssl", clientSslHandler);
+                sch.pipeline().addLast(clientSslHandler);
                 if (useChunkedWriteHandler) {
                     sch.pipeline().addLast(new ChunkedWriteHandler());
                 }
-                sch.pipeline().addLast("handler", clientHandler);
+                sch.pipeline().addLast(clientHandler);
             }
         });
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
@@ -157,8 +157,10 @@ public class SocketStartTlsTest extends AbstractSocketTest {
             @Override
             public void initChannel(Channel sch) throws Exception {
                 ChannelPipeline p = sch.pipeline();
-                p.addLast("logger", new LoggingHandler(LOG_LEVEL));
-                p.addLast(new LineBasedFrameDecoder(64), new StringDecoder(), new StringEncoder());
+                p.addLast(new LoggingHandler(LOG_LEVEL));
+                p.addLast(new LineBasedFrameDecoder(64));
+                p.addLast(new StringDecoder());
+                p.addLast(new StringEncoder());
                 p.addLast(executor, sh);
             }
         });
@@ -167,8 +169,10 @@ public class SocketStartTlsTest extends AbstractSocketTest {
             @Override
             public void initChannel(Channel sch) throws Exception {
                 ChannelPipeline p = sch.pipeline();
-                p.addLast("logger", new LoggingHandler(LOG_LEVEL));
-                p.addLast(new LineBasedFrameDecoder(64), new StringDecoder(), new StringEncoder());
+                p.addLast(new LoggingHandler(LOG_LEVEL));
+                p.addLast(new LineBasedFrameDecoder(64));
+                p.addLast(new StringDecoder());
+                p.addLast(new StringEncoder());
                 p.addLast(executor, ch);
             }
         });
@@ -248,7 +252,8 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         @Override
         public void channelRead0(ChannelHandlerContext ctx, String msg) throws Exception {
             if ("StartTlsResponse".equals(msg)) {
-                ctx.pipeline().addAfter("logger", "ssl", sslHandler);
+
+                ctx.pipeline().addAfter(ctx.pipeline().context(LoggingHandler.class), sslHandler);
                 handshakeFuture = sslHandler.handshakeFuture();
                 ctx.writeAndFlush("EncryptedRequest\n");
                 return;
@@ -302,7 +307,7 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         @Override
         public void channelRead0(ChannelHandlerContext ctx, String msg) throws Exception {
             if ("StartTlsRequest".equals(msg)) {
-                ctx.pipeline().addAfter("logger", "ssl", sslHandler);
+                ctx.pipeline().addAfter(ctx.pipeline().context(LoggingHandler.class), sslHandler);
                 ctx.writeAndFlush("StartTlsResponse\n");
                 return;
             }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
@@ -82,20 +82,20 @@ public class SocketStringEchoTest extends AbstractSocketTest {
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
-                sch.pipeline().addLast("framer", new DelimiterBasedFrameDecoder(512, Delimiters.lineDelimiter()));
-                sch.pipeline().addLast("decoder", new StringDecoder(CharsetUtil.ISO_8859_1));
-                sch.pipeline().addBefore("decoder", "encoder", new StringEncoder(CharsetUtil.ISO_8859_1));
-                sch.pipeline().addAfter("decoder", "handler", sh);
+                sch.pipeline().addLast(new DelimiterBasedFrameDecoder(512, Delimiters.lineDelimiter()));
+                sch.pipeline().addLast(new StringEncoder(CharsetUtil.ISO_8859_1));
+                sch.pipeline().addLast(new StringDecoder(CharsetUtil.ISO_8859_1));
+                sch.pipeline().addLast(sh);
             }
         });
 
         cb.handler(new ChannelInitializer<Channel>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
-                sch.pipeline().addLast("framer", new DelimiterBasedFrameDecoder(512, Delimiters.lineDelimiter()));
-                sch.pipeline().addLast("decoder", new StringDecoder(CharsetUtil.ISO_8859_1));
-                sch.pipeline().addBefore("decoder", "encoder", new StringEncoder(CharsetUtil.ISO_8859_1));
-                sch.pipeline().addAfter("decoder", "handler", ch);
+                sch.pipeline().addLast(new DelimiterBasedFrameDecoder(512, Delimiters.lineDelimiter()));
+                sch.pipeline().addLast(new StringEncoder(CharsetUtil.ISO_8859_1));
+                sch.pipeline().addLast(new StringDecoder(CharsetUtil.ISO_8859_1));
+                sch.pipeline().addLast(ch);
             }
         });
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -59,7 +59,6 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
     private static final Random random = new Random();
     static final byte[] data = new byte[messageSize];
 
-    private static final String TRAFFIC = "traffic";
     private static String currentTestName;
     private static int currentTestRun;
 
@@ -308,7 +307,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
             @Override
             protected void initChannel(SocketChannel c) throws Exception {
                 if (limitRead) {
-                    c.pipeline().addLast(TRAFFIC, handler);
+                    c.pipeline().addLast(handler);
                 }
                 c.pipeline().addLast(sh);
             }
@@ -317,7 +316,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
             @Override
             protected void initChannel(SocketChannel c) throws Exception {
                 if (limitWrite) {
-                    c.pipeline().addLast(TRAFFIC, handler);
+                    c.pipeline().addLast(handler);
                 }
                 c.pipeline().addLast(ch);
             }

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -106,7 +106,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
     private final int executionMask;
 
     private final DefaultChannelPipeline pipeline;
-    private final String name;
     private final boolean ordered;
 
     // Will be set to null if no child executor should be used, otherwise it will be set to the
@@ -123,9 +122,8 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
 
     private volatile int handlerState = INIT;
 
-    AbstractChannelHandlerContext(DefaultChannelPipeline pipeline, EventExecutor executor, String name,
+    AbstractChannelHandlerContext(DefaultChannelPipeline pipeline, EventExecutor executor,
                                   Class<? extends ChannelHandler> handlerClass) {
-        this.name = ObjectUtil.checkNotNull(name, "name");
         this.pipeline = pipeline;
         this.executor = executor;
         this.executionMask = mask(handlerClass);
@@ -262,11 +260,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
         } else {
             return executor;
         }
-    }
-
-    @Override
-    public String name() {
-        return name;
     }
 
     @Override
@@ -1235,12 +1228,13 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
 
     @Override
     public String toHintString() {
-        return '\'' + name + "' will handle the message from this point.";
+        return '\'' + StringUtil.simpleClassName(handler()) + "' will handle the message from this point.";
     }
 
     @Override
     public String toString() {
-        return StringUtil.simpleClassName(ChannelHandlerContext.class) + '(' + name + ", " + channel() + ')';
+        return StringUtil.simpleClassName(ChannelHandlerContext.class)
+                + '(' + StringUtil.simpleClassName(handler()) + ", " + channel() + ')';
     }
 
     abstract static class AbstractWriteTask implements Runnable {

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -135,13 +135,6 @@ public interface ChannelHandlerContext extends AttributeMap, ChannelInboundInvok
     EventExecutor executor();
 
     /**
-     * The unique name of the {@link ChannelHandlerContext}.The name was used when then {@link ChannelHandler}
-     * was added to the {@link ChannelPipeline}. This name can also be used to access the registered
-     * {@link ChannelHandler} from the {@link ChannelPipeline}.
-     */
-    String name();
-
-    /**
      * The {@link ChannelHandler} that is bound this {@link ChannelHandlerContext}.
      */
     ChannelHandler handler();

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -22,9 +22,6 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 
 
@@ -214,80 +211,68 @@ import java.util.NoSuchElementException;
  * after the exchange.
  */
 public interface ChannelPipeline
-        extends ChannelInboundInvoker, ChannelOutboundInvoker, Iterable<Entry<String, ChannelHandler>> {
+        extends ChannelInboundInvoker, ChannelOutboundInvoker, Iterable<ChannelHandler> {
 
     /**
      * Inserts a {@link ChannelHandler} at the first position of this pipeline.
      *
-     * @param name     the name of the handler to insert first
      * @param handler  the handler to insert first
-     *
-     * @throws IllegalArgumentException
-     *         if there's an entry with the same name already in the pipeline
+     * @return         the {@link ChannelHandlerContext} of the added handler
+
      * @throws NullPointerException
      *         if the specified handler is {@code null}
      */
-    ChannelPipeline addFirst(String name, ChannelHandler handler);
+    ChannelHandlerContext addFirst(ChannelHandler handler);
 
     /**
      * Inserts a {@link ChannelHandler} at the first position of this pipeline.
      *
      * @param group    the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler}
      *                 methods
-     * @param name     the name of the handler to insert first
      * @param handler  the handler to insert first
+     * @return         the {@link ChannelHandlerContext} of the added handler
      *
-     * @throws IllegalArgumentException
-     *         if there's an entry with the same name already in the pipeline
      * @throws NullPointerException
      *         if the specified handler is {@code null}
      */
-    ChannelPipeline addFirst(EventExecutorGroup group, String name, ChannelHandler handler);
+    ChannelHandlerContext addFirst(EventExecutorGroup group, ChannelHandler handler);
 
     /**
      * Appends a {@link ChannelHandler} at the last position of this pipeline.
      *
-     * @param name     the name of the handler to append
      * @param handler  the handler to append
+     * @return         the {@link ChannelHandlerContext} of the added handler
      *
-     * @throws IllegalArgumentException
-     *         if there's an entry with the same name already in the pipeline
      * @throws NullPointerException
      *         if the specified handler is {@code null}
      */
-    ChannelPipeline addLast(String name, ChannelHandler handler);
+    ChannelHandlerContext addLast(ChannelHandler handler);
 
     /**
      * Appends a {@link ChannelHandler} at the last position of this pipeline.
      *
      * @param group    the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler}
      *                 methods
-     * @param name     the name of the handler to append
      * @param handler  the handler to append
+     * @return         the {@link ChannelHandlerContext} of the added handler
      *
-     * @throws IllegalArgumentException
-     *         if there's an entry with the same name already in the pipeline
      * @throws NullPointerException
      *         if the specified handler is {@code null}
      */
-    ChannelPipeline addLast(EventExecutorGroup group, String name, ChannelHandler handler);
+    ChannelHandlerContext addLast(EventExecutorGroup group, ChannelHandler handler);
 
     /**
      * Inserts a {@link ChannelHandler} before an existing handler of this
      * pipeline.
      *
-     * @param baseName  the name of the existing handler
-     * @param name      the name of the handler to insert before
+     * @param baseCtx   the {@link ChannelHandlerContext} of the existing handler
      * @param handler   the handler to insert before
+     * @return          the {@link ChannelHandlerContext} of the added handler
      *
-     * @throws NoSuchElementException
-     *         if there's no such entry with the specified {@code baseName}
-     * @throws IllegalArgumentException
-     *         if there's an entry with the same name already in the pipeline
      * @throws NullPointerException
      *         if the specified baseName or handler is {@code null}
      */
-    ChannelPipeline addBefore(String baseName, String name, ChannelHandler handler);
+    ChannelHandlerContext addBefore(ChannelHandlerContext baseCtx, ChannelHandler handler);
 
     /**
      * Inserts a {@link ChannelHandler} before an existing handler of this
@@ -295,35 +280,27 @@ public interface ChannelPipeline
      *
      * @param group     the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler}
      *                  methods
-     * @param baseName  the name of the existing handler
-     * @param name      the name of the handler to insert before
+     * @param baseCtx   the {@link ChannelHandlerContext} of the existing handler
      * @param handler   the handler to insert before
-     *
-     * @throws NoSuchElementException
-     *         if there's no such entry with the specified {@code baseName}
-     * @throws IllegalArgumentException
-     *         if there's an entry with the same name already in the pipeline
+     * @return          the {@link ChannelHandlerContext} of the added handler
+
      * @throws NullPointerException
      *         if the specified baseName or handler is {@code null}
      */
-    ChannelPipeline addBefore(EventExecutorGroup group, String baseName, String name, ChannelHandler handler);
+    ChannelHandlerContext addBefore(EventExecutorGroup group, ChannelHandlerContext baseCtx, ChannelHandler handler);
 
     /**
      * Inserts a {@link ChannelHandler} after an existing handler of this
      * pipeline.
      *
-     * @param baseName  the name of the existing handler
-     * @param name      the name of the handler to insert after
+     * @param baseCtx   the {@link ChannelHandlerContext} of the existing handler
      * @param handler   the handler to insert after
+     * @return          the {@link ChannelHandlerContext} of the added handler
      *
-     * @throws NoSuchElementException
-     *         if there's no such entry with the specified {@code baseName}
-     * @throws IllegalArgumentException
-     *         if there's an entry with the same name already in the pipeline
      * @throws NullPointerException
      *         if the specified baseName or handler is {@code null}
      */
-    ChannelPipeline addAfter(String baseName, String name, ChannelHandler handler);
+    ChannelHandlerContext addAfter(ChannelHandlerContext baseCtx, ChannelHandler handler);
 
     /**
      * Inserts a {@link ChannelHandler} after an existing handler of this
@@ -331,80 +308,41 @@ public interface ChannelPipeline
      *
      * @param group     the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler}
      *                  methods
-     * @param baseName  the name of the existing handler
-     * @param name      the name of the handler to insert after
+     * @param baseCtx   the {@link ChannelHandlerContext} of the existing handler
      * @param handler   the handler to insert after
+     * @return          the {@link ChannelHandlerContext} of the added handler
      *
-     * @throws NoSuchElementException
-     *         if there's no such entry with the specified {@code baseName}
-     * @throws IllegalArgumentException
-     *         if there's an entry with the same name already in the pipeline
      * @throws NullPointerException
      *         if the specified baseName or handler is {@code null}
      */
-    ChannelPipeline addAfter(EventExecutorGroup group, String baseName, String name, ChannelHandler handler);
-
-    /**
-     * Inserts {@link ChannelHandler}s at the first position of this pipeline.
-     *
-     * @param handlers  the handlers to insert first
-     *
-     */
-    ChannelPipeline addFirst(ChannelHandler... handlers);
-
-    /**
-     * Inserts {@link ChannelHandler}s at the first position of this pipeline.
-     *
-     * @param group     the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler}s
-     *                  methods.
-     * @param handlers  the handlers to insert first
-     *
-     */
-    ChannelPipeline addFirst(EventExecutorGroup group, ChannelHandler... handlers);
-
-    /**
-     * Inserts {@link ChannelHandler}s at the last position of this pipeline.
-     *
-     * @param handlers  the handlers to insert last
-     *
-     */
-    ChannelPipeline addLast(ChannelHandler... handlers);
-
-    /**
-     * Inserts {@link ChannelHandler}s at the last position of this pipeline.
-     *
-     * @param group     the {@link EventExecutorGroup} which will be used to execute the {@link ChannelHandler}s
-     *                  methods.
-     * @param handlers  the handlers to insert last
-     *
-     */
-    ChannelPipeline addLast(EventExecutorGroup group, ChannelHandler... handlers);
+    ChannelHandlerContext addAfter(EventExecutorGroup group, ChannelHandlerContext baseCtx, ChannelHandler handler);
 
     /**
      * Removes the specified {@link ChannelHandler} from this pipeline.
      *
      * @param  handler          the {@link ChannelHandler} to remove
-     *
+     * @return                  the {@link ChannelHandlerContext} of the removed handler
+
      * @throws NoSuchElementException
      *         if there's no such handler in this pipeline
      * @throws NullPointerException
      *         if the specified handler is {@code null}
      */
-    ChannelPipeline remove(ChannelHandler handler);
+    ChannelHandlerContext remove(ChannelHandler handler);
 
     /**
      * Removes the {@link ChannelHandler} with the specified name from this pipeline.
      *
-     * @param  name             the name under which the {@link ChannelHandler} was stored.
+     * @param  ctx the {@link ChannelHandlerContext} of the {@link ChannelHandler}.
      *
      * @return the removed handler
      *
      * @throws NoSuchElementException
-     *         if there's no such handler with the specified name in this pipeline
+     *         if there's no such handler in this pipeline
      * @throws NullPointerException
      *         if the specified name is {@code null}
      */
-    ChannelHandler remove(String name);
+    ChannelHandler remove(ChannelHandlerContext ctx);
 
     /**
      * Removes the {@link ChannelHandler} of the specified type from this pipeline.
@@ -445,62 +383,49 @@ public interface ChannelPipeline
      * Replaces the specified {@link ChannelHandler} with a new handler in this pipeline.
      *
      * @param  oldHandler    the {@link ChannelHandler} to be replaced
-     * @param  newName       the name under which the replacement should be added
      * @param  newHandler    the {@link ChannelHandler} which is used as replacement
+     * @return               the {@link ChannelHandlerContext} of the added handler
      *
-     * @return itself
-
      * @throws NoSuchElementException
      *         if the specified old handler does not exist in this pipeline
-     * @throws IllegalArgumentException
-     *         if a handler with the specified new name already exists in this
-     *         pipeline, except for the handler to be replaced
      * @throws NullPointerException
      *         if the specified old handler or new handler is
      *         {@code null}
      */
-    ChannelPipeline replace(ChannelHandler oldHandler, String newName, ChannelHandler newHandler);
+    ChannelHandlerContext replace(ChannelHandler oldHandler, ChannelHandler newHandler);
 
     /**
      * Replaces the {@link ChannelHandler} of the specified name with a new handler in this pipeline.
      *
-     * @param  oldName       the name of the {@link ChannelHandler} to be replaced
-     * @param  newName       the name under which the replacement should be added
+     * @param  oldCtx        the {@link ChannelHandlerContext} of the {@link ChannelHandler} to be replaced
      * @param  newHandler    the {@link ChannelHandler} which is used as replacement
-     *
-     * @return the removed handler
+     * @return               the {@link ChannelHandlerContext} of the added handler
      *
      * @throws NoSuchElementException
-     *         if the handler with the specified old name does not exist in this pipeline
-     * @throws IllegalArgumentException
-     *         if a handler with the specified new name already exists in this
-     *         pipeline, except for the handler to be replaced
+     *         if the handler not exist in this pipeline
      * @throws NullPointerException
      *         if the specified old handler or new handler is
      *         {@code null}
      */
-    ChannelHandler replace(String oldName, String newName, ChannelHandler newHandler);
+    ChannelHandlerContext replace(ChannelHandlerContext oldCtx, ChannelHandler newHandler);
 
     /**
      * Replaces the {@link ChannelHandler} of the specified type with a new handler in this pipeline.
      *
      * @param  oldHandlerType   the type of the handler to be removed
-     * @param  newName          the name under which the replacement should be added
      * @param  newHandler       the {@link ChannelHandler} which is used as replacement
+     * @return                  the {@link ChannelHandlerContext} of the added handler
      *
-     * @return the removed handler
+     *
      *
      * @throws NoSuchElementException
      *         if the handler of the specified old handler type does not exist
      *         in this pipeline
-     * @throws IllegalArgumentException
-     *         if a handler with the specified new name already exists in this
-     *         pipeline, except for the handler to be replaced
      * @throws NullPointerException
      *         if the specified old handler or new handler is
      *         {@code null}
      */
-    <T extends ChannelHandler> T replace(Class<T> oldHandlerType, String newName,
+     <T extends ChannelHandler> ChannelHandlerContext replace(Class<T> oldHandlerType,
                                          ChannelHandler newHandler);
 
     /**
@@ -532,15 +457,6 @@ public interface ChannelPipeline
     ChannelHandlerContext lastContext();
 
     /**
-     * Returns the {@link ChannelHandler} with the specified name in this
-     * pipeline.
-     *
-     * @return the handler with the specified name.
-     *         {@code null} if there's no such handler in this pipeline.
-     */
-    ChannelHandler get(String name);
-
-    /**
      * Returns the {@link ChannelHandler} of the specified type in this
      * pipeline.
      *
@@ -559,15 +475,6 @@ public interface ChannelPipeline
     ChannelHandlerContext context(ChannelHandler handler);
 
     /**
-     * Returns the context object of the {@link ChannelHandler} with the
-     * specified name in this pipeline.
-     *
-     * @return the context object of the handler with the specified name.
-     *         {@code null} if there's no such handler in this pipeline.
-     */
-    ChannelHandlerContext context(String name);
-
-    /**
      * Returns the context object of the {@link ChannelHandler} of the
      * specified type in this pipeline.
      *
@@ -582,17 +489,6 @@ public interface ChannelPipeline
      * @return the channel. {@code null} if this pipeline is not attached yet.
      */
     Channel channel();
-
-    /**
-     * Returns the {@link List} of the handler names.
-     */
-    List<String> names();
-
-    /**
-     * Converts this pipeline into an ordered {@link Map} whose keys are
-     * handler names and whose values are handlers.
-     */
-    Map<String, ChannelHandler> toMap();
 
     @Override
     ChannelPipeline fireChannelRegistered();

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -393,11 +393,6 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
-        public String name() {
-            return ctx.name();
-        }
-
-        @Override
         public ChannelHandler handler() {
             return ctx.handler();
         }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
@@ -23,8 +23,8 @@ final class DefaultChannelHandlerContext extends AbstractChannelHandlerContext {
     private final ChannelHandler handler;
 
     DefaultChannelHandlerContext(
-            DefaultChannelPipeline pipeline, EventExecutor executor, String name, ChannelHandler handler) {
-        super(pipeline, executor, name, ObjectUtil.checkNotNull(handler, "handler").getClass());
+            DefaultChannelPipeline pipeline, EventExecutor executor, ChannelHandler handler) {
+        super(pipeline, executor, ObjectUtil.checkNotNull(handler, "handler").getClass());
         this.handler = handler;
     }
 

--- a/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
@@ -146,11 +146,11 @@ public class ChannelInitializerTest {
                     // NOOP
                 }
             }).syncUninterruptibly();
-            Iterator<Map.Entry<String, ChannelHandler>> handlers = channel.pipeline().iterator();
-            assertSame(handler1, handlers.next().getValue());
-            assertSame(handler2, handlers.next().getValue());
-            assertSame(handler3, handlers.next().getValue());
-            assertSame(handler4, handlers.next().getValue());
+            Iterator<ChannelHandler> handlers = channel.pipeline().iterator();
+            assertSame(handler1, handlers.next());
+            assertSame(handler2, handlers.next());
+            assertSame(handler3, handlers.next());
+            assertSame(handler4, handlers.next());
             assertFalse(handlers.hasNext());
         } finally {
             channel.close().syncUninterruptibly();
@@ -331,7 +331,7 @@ public class ChannelInitializerTest {
                                 ChannelHandlerContext ctx = ch.pipeline().context(this);
                                 assertNotNull(ctx);
                                 ch.pipeline().addAfter(ctx.executor(),
-                                        ctx.name(), null, new ChannelInboundHandlerAdapter() {
+                                        ctx, new ChannelInboundHandlerAdapter() {
                                             @Override
                                             public void channelRead(ChannelHandlerContext ctx, Object msg)  {
                                                 // just drop on the floor.

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -381,7 +381,7 @@ public class ChannelOutboundBufferTest {
         final CountDownLatch handlerAddedLatch = new CountDownLatch(1);
         final CountDownLatch handlerRemovedLatch = new CountDownLatch(1);
         EmbeddedChannel ch = new EmbeddedChannel();
-        ch.pipeline().addLast(executor, "handler", new ChannelOutboundHandlerAdapter() {
+        ChannelHandlerContext handlerContext = ch.pipeline().addLast(executor, new ChannelOutboundHandlerAdapter() {
             @Override
             public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
                 promise.setFailure(new AssertionError("Should not be called"));
@@ -443,7 +443,7 @@ public class ChannelOutboundBufferTest {
             Thread.sleep(10);
         }
 
-        ch.pipeline().remove("handler");
+        ch.pipeline().remove(handlerContext);
 
         // Ensure we do not try to shutdown the executor before we handled everything for the Channel. Otherwise
         // the Executor may reject when the Channel tries to add a task to it.

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
@@ -246,12 +246,12 @@ public class LocalTransportThreadModelTest {
 
             // inbound:  int -> byte[4] -> int -> int -> byte[4] -> int -> /dev/null
             // outbound: int -> int -> byte[4] -> int -> int -> byte[4] -> /dev/null
-            ch.pipeline().addLast(h1)
-                         .addLast(e1, h2)
-                         .addLast(e2, h3)
-                         .addLast(e3, h4)
-                         .addLast(e4, h5)
-                         .addLast(e5, h6);
+            ch.pipeline().addLast(h1);
+            ch.pipeline().addLast(e1, h2);
+            ch.pipeline().addLast(e2, h3);
+            ch.pipeline().addLast(e3, h4);
+            ch.pipeline().addLast(e4, h5);
+            ch.pipeline().addLast(e5, h6);
 
             ch.register().sync().channel().connect(localAddr).sync();
 

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest3.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest3.java
@@ -137,12 +137,12 @@ public class LocalTransportThreadModelTest3 {
             if (!inbound) {
                 ch.config().setAutoRead(false);
             }
-            ch.pipeline().addLast(e1, h1)
-                    .addLast(e1, h2)
-                    .addLast(e1, h3)
-                    .addLast(e1, h4)
-                    .addLast(e1, h5)
-                    .addLast(e1, "recorder", h6);
+            ch.pipeline().addLast(e1, h1);
+            ch.pipeline().addLast(e1, h2);
+            ch.pipeline().addLast(e1, h3);
+            ch.pipeline().addLast(e1, h4);
+            ch.pipeline().addLast(e1, h5);
+            ChannelHandlerContext recorderCtx = ch.pipeline().addLast(e1, h6);
 
             ch.register().sync().channel().connect(localAddr).sync();
 
@@ -166,8 +166,7 @@ public class LocalTransportThreadModelTest3 {
                         }
                         //EventForwardHandler forwardHandler = forwarders[random.nextInt(forwarders.length)];
                         ChannelHandler handler = ch.pipeline().removeFirst();
-                        ch.pipeline().addBefore(groups[random.nextInt(groups.length)], "recorder",
-                                UUID.randomUUID().toString(), handler);
+                        ch.pipeline().addBefore(groups[random.nextInt(groups.length)], recorderCtx, handler);
                     }
                 }
             });


### PR DESCRIPTION
Motivation:

We previous allowed to add a handler with a given name to the pipeline and then later use this name to lookup the handler. This is really error-prone as names can clash.

Modifications:

- Remove methods that take name as an argument
- Let methods return ChannelHandlerContext after modification of the pipeline to allow lookup later on.
- Remove var-args method version as adding these handlers is not an atomic operation.

Result:

Less error-prone usage of the ChannelPipeline.