### PR TITLE
Fix three bugs in CompositeByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -497,7 +497,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
             return;
         }
 
-        int nextIndex = cIndex > 0 ? components[cIndex].endOffset : 0;
+        int nextIndex = cIndex > 0 ? components[cIndex - 1].endOffset : 0;
         for (; cIndex < size; cIndex++) {
             Component c = components[cIndex];
             c.reposition(nextIndex);
@@ -748,6 +748,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
                 consolidateIfNeeded();
             }
         } else if (newCapacity < oldCapacity) {
+            lastAccessed = null;
             int i = size - 1;
             for (int bytesToTrim = oldCapacity - newCapacity; i >= 0; i--) {
                 Component c = components[i];
@@ -801,7 +802,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
      */
     public int toComponentIndex(int offset) {
         checkIndex(offset);
-        return toComponentIndex(offset);
+        return toComponentIndex0(offset);
     }
 
     private int toComponentIndex0(int offset) {

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -136,6 +136,41 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     }
 
     @Test
+    public void testToComponentIndex() {
+        CompositeByteBuf buf = (CompositeByteBuf) wrappedBuffer(new byte[]{1, 2, 3, 4, 5},
+                new byte[]{4, 5, 6, 7, 8, 9, 26}, new byte[]{10, 9, 8, 7, 6, 5, 33});
+
+        // spot checks
+        assertEquals(0, buf.toComponentIndex(4));
+        assertEquals(1, buf.toComponentIndex(5));
+        assertEquals(2, buf.toComponentIndex(15));
+
+        //Loop through each byte
+
+        byte index = 0;
+
+        while (index < buf.capacity()) {
+            int cindex = buf.toComponentIndex(index++);
+            assertTrue(cindex >= 0 && cindex < buf.numComponents());
+        }
+
+        buf.release();
+    }
+
+    @Test
+    public void testToByteIndex() {
+        CompositeByteBuf buf = (CompositeByteBuf) wrappedBuffer(new byte[]{1, 2, 3, 4, 5},
+                new byte[]{4, 5, 6, 7, 8, 9, 26}, new byte[]{10, 9, 8, 7, 6, 5, 33});
+
+        // spot checks
+        assertEquals(0, buf.toByteIndex(0));
+        assertEquals(5, buf.toByteIndex(1));
+        assertEquals(12, buf.toByteIndex(2));
+
+        buf.release();
+    }
+
+    @Test
     public void testDiscardReadBytes3() {
         ByteBuf a, b;
         a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
@@ -744,6 +779,20 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertEquals(2, buf.numComponents());
         buf.removeComponent(1);
         assertEquals(1, buf.numComponents());
+        buf.release();
+    }
+
+    @Test
+    public void testRemoveComponents() {
+        CompositeByteBuf buf = compositeBuffer();
+        for (int i = 0; i < 10; i++) {
+            buf.addComponent(wrappedBuffer(new byte[]{1, 2}));
+        }
+        assertEquals(10, buf.numComponents());
+        assertEquals(20, buf.capacity());
+        buf.removeComponents(4, 3);
+        assertEquals(7, buf.numComponents());
+        assertEquals(14, buf.capacity());
         buf.release();
     }
 


### PR DESCRIPTION
Motivation

In #8758, @doom369 reported an infinite loop bug in `CompositeByteBuf` which was introduced in #8437.

This is the same small fix for that, along with fixes for two other bugs (also introduced in #8437 :disappointed:) found while re-inspecting the changes and adding unit tests.

Modifications

- Replace recursive call to `toComponentIndex` with `toComponentIndex0` as intended
- Add missed `lastAccessed` racy cache invalidation in `capacity(int)` method
- Fix incorrect determination of initial offset in non-zero cIndex case of `updateComponentOffsets` method
- New unit tests for previously uncovered methods

Results

Fewer bugs.