### PR TITLE
Migrate Java8: replace with Map#computeIfAbsent where possible

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static io.netty.util.internal.ObjectUtil.*;
 import static io.netty.util.internal.StringUtil.*;
@@ -256,11 +257,13 @@ public class QueryStringDecoder {
         }
         String name = decodeComponent(s, nameStart, valueStart - 1, charset, false);
         String value = decodeComponent(s, valueStart, valueEnd, charset, false);
-        List<String> values = params.get(name);
-        if (values == null) {
-            values = new ArrayList<>(1);  // Often there's only 1 value.
-            params.put(name, values);
-        }
+        List<String> values = params.computeIfAbsent(name, new Function<String, List<String>>() {
+            @Override
+            public List<String> apply(final String s) {
+                return new ArrayList<>(1);
+            }
+        });
+        // Often there's only 1 value.
         values.add(value);
         return true;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static io.netty.util.internal.ObjectUtil.*;
 import static io.netty.util.internal.StringUtil.*;
@@ -257,12 +256,7 @@ public class QueryStringDecoder {
         }
         String name = decodeComponent(s, nameStart, valueStart - 1, charset, false);
         String value = decodeComponent(s, valueStart, valueEnd, charset, false);
-        List<String> values = params.computeIfAbsent(name, new Function<String, List<String>>() {
-            @Override
-            public List<String> apply(final String s) {
-                return new ArrayList<>(1);
-            }
-        });
+        List<String> values = params.computeIfAbsent(name, n -> new ArrayList<>(1));
         // Often there's only 1 value.
         values.add(value);
         return true;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
@@ -28,7 +28,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.Function;
 
 /**
  * Default factory giving {@link Attribute} and {@link FileUpload} according to constructor.
@@ -121,13 +120,7 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
      * @return the associated list of {@link HttpData} for the request
      */
     private List<HttpData> getList(HttpRequest request) {
-        return requestFileDeleteMap.computeIfAbsent(request,
-            new Function<HttpRequest, List<HttpData>>() {
-            @Override
-            public List<HttpData> apply(final HttpRequest httpRequest) {
-                return new ArrayList<>();
-            }
-        });
+        return requestFileDeleteMap.computeIfAbsent(request, httpRequest -> new ArrayList<>());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Function;
 
 /**
  * Default factory giving {@link Attribute} and {@link FileUpload} according to constructor.
@@ -120,12 +121,13 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
      * @return the associated list of {@link HttpData} for the request
      */
     private List<HttpData> getList(HttpRequest request) {
-        List<HttpData> list = requestFileDeleteMap.get(request);
-        if (list == null) {
-            list = new ArrayList<>();
-            requestFileDeleteMap.put(request, list);
-        }
-        return list;
+        return requestFileDeleteMap.computeIfAbsent(request,
+            new Function<HttpRequest, List<HttpData>>() {
+            @Override
+            public List<HttpData> apply(final HttpRequest httpRequest) {
+                return new ArrayList<>();
+            }
+        });
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import static io.netty.buffer.Unpooled.buffer;
 import static io.netty.handler.codec.http.multipart.HttpPostBodyUtil.BINARY_STRING;
@@ -422,11 +423,13 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         if (data == null) {
             return;
         }
-        List<InterfaceHttpData> datas = bodyMapHttpData.get(data.getName());
-        if (datas == null) {
-            datas = new ArrayList<>(1);
-            bodyMapHttpData.put(data.getName(), datas);
-        }
+        List<InterfaceHttpData> datas = bodyMapHttpData.computeIfAbsent(data.getName(),
+            new Function<String, List<InterfaceHttpData>>() {
+                @Override
+                public List<InterfaceHttpData> apply(final String s) {
+                    return new ArrayList<>(1);
+                }
+            });
         datas.add(data);
         bodyListHttpData.add(data);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Function;
 
 import static io.netty.buffer.Unpooled.buffer;
 import static io.netty.handler.codec.http.multipart.HttpPostBodyUtil.BINARY_STRING;
@@ -423,13 +422,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         if (data == null) {
             return;
         }
-        List<InterfaceHttpData> datas = bodyMapHttpData.computeIfAbsent(data.getName(),
-            new Function<String, List<InterfaceHttpData>>() {
-                @Override
-                public List<InterfaceHttpData> apply(final String s) {
-                    return new ArrayList<>(1);
-                }
-            });
+        List<InterfaceHttpData> datas = bodyMapHttpData.computeIfAbsent(data.getName(), s -> new ArrayList<>(1));
         datas.add(data);
         bodyListHttpData.add(data);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import static io.netty.buffer.Unpooled.*;
 import static io.netty.util.internal.ObjectUtil.*;
@@ -367,11 +368,13 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
         if (data == null) {
             return;
         }
-        List<InterfaceHttpData> datas = bodyMapHttpData.get(data.getName());
-        if (datas == null) {
-            datas = new ArrayList<>(1);
-            bodyMapHttpData.put(data.getName(), datas);
-        }
+        List<InterfaceHttpData> datas = bodyMapHttpData.computeIfAbsent(data.getName(),
+            new Function<String, List<InterfaceHttpData>>() {
+                @Override
+                public List<InterfaceHttpData> apply(final String s) {
+                    return new ArrayList<>(1);
+                }
+            });
         datas.add(data);
         bodyListHttpData.add(data);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Function;
 
 import static io.netty.buffer.Unpooled.*;
 import static io.netty.util.internal.ObjectUtil.*;
@@ -368,13 +367,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
         if (data == null) {
             return;
         }
-        List<InterfaceHttpData> datas = bodyMapHttpData.computeIfAbsent(data.getName(),
-            new Function<String, List<InterfaceHttpData>>() {
-                @Override
-                public List<InterfaceHttpData> apply(final String s) {
-                    return new ArrayList<>(1);
-                }
-            });
+        List<InterfaceHttpData> datas = bodyMapHttpData.computeIfAbsent(data.getName(), s -> new ArrayList<>(1));
         datas.add(data);
         bodyListHttpData.add(data);
     }

--- a/common/src/main/java/io/netty/util/internal/TypeParameterMatcher.java
+++ b/common/src/main/java/io/netty/util/internal/TypeParameterMatcher.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 public abstract class TypeParameterMatcher {
 
@@ -58,13 +57,7 @@ public abstract class TypeParameterMatcher {
                 InternalThreadLocalMap.get().typeParameterMatcherFindCache();
         final Class<?> thisClass = object.getClass();
 
-        Map<String, TypeParameterMatcher> map = findCache.computeIfAbsent(thisClass,
-            new Function<Class<?>, Map<String, TypeParameterMatcher>>() {
-                @Override
-                public Map<String, TypeParameterMatcher> apply(final Class<?> aClass) {
-                    return new HashMap<>();
-                }
-            });
+        Map<String, TypeParameterMatcher> map = findCache.computeIfAbsent(thisClass, aClass -> new HashMap<>());
 
         TypeParameterMatcher matcher = map.get(typeParamName);
         if (matcher == null) {

--- a/common/src/main/java/io/netty/util/internal/TypeParameterMatcher.java
+++ b/common/src/main/java/io/netty/util/internal/TypeParameterMatcher.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 public abstract class TypeParameterMatcher {
 
@@ -57,11 +58,13 @@ public abstract class TypeParameterMatcher {
                 InternalThreadLocalMap.get().typeParameterMatcherFindCache();
         final Class<?> thisClass = object.getClass();
 
-        Map<String, TypeParameterMatcher> map = findCache.get(thisClass);
-        if (map == null) {
-            map = new HashMap<>();
-            findCache.put(thisClass, map);
-        }
+        Map<String, TypeParameterMatcher> map = findCache.computeIfAbsent(thisClass,
+            new Function<Class<?>, Map<String, TypeParameterMatcher>>() {
+                @Override
+                public Map<String, TypeParameterMatcher> apply(final Class<?> aClass) {
+                    return new HashMap<>();
+                }
+            });
 
         TypeParameterMatcher matcher = map.get(typeParamName);
         if (matcher == null) {


### PR DESCRIPTION
Motivation:

There is a convenient m ethod to check the absence of a key and put if absent in Java8, this patch replaces the boilerplate code with the new method where possible.

Modification:

replace with Map#computeIfAbsent where possible

Result:

Codebase becomes more clean and readable