### PR TITLE
Migrate java8: remove omitted param

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -79,7 +79,7 @@ public final class HAProxyMessage {
             String sourceAddress, String destinationAddress, int sourcePort, int destinationPort) {
 
         this(protocolVersion, command, proxiedProtocol,
-             sourceAddress, destinationAddress, sourcePort, destinationPort, Collections.<HAProxyTLV>emptyList());
+             sourceAddress, destinationAddress, sourcePort, destinationPort, Collections.emptyList());
     }
 
     /**
@@ -285,7 +285,7 @@ public final class HAProxyMessage {
 
                 return new HAProxySSLTLV(verify, client, encapsulatedTlvs, rawContent);
             }
-            return new HAProxySSLTLV(verify, client, Collections.<HAProxyTLV>emptyList(), rawContent);
+            return new HAProxySSLTLV(verify, client, Collections.emptyList(), rawContent);
         // If we're not dealing with a SSL Type, we can use the same mechanism
         case PP2_TYPE_ALPN:
         case PP2_TYPE_AUTHORITY:

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxySSLTLVTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxySSLTLVTest.java
@@ -31,7 +31,7 @@ public class HAProxySSLTLVTest {
         // 0b0000_0111
         final byte allClientsEnabled = 0x7;
         final HAProxySSLTLV allClientsEnabledTLV =
-                new HAProxySSLTLV(0, allClientsEnabled, Collections.<HAProxyTLV>emptyList(), Unpooled.buffer());
+                new HAProxySSLTLV(0, allClientsEnabled, Collections.emptyList(), Unpooled.buffer());
 
         assertTrue(allClientsEnabledTLV.isPP2ClientCertConn());
         assertTrue(allClientsEnabledTLV.isPP2ClientSSL());
@@ -43,7 +43,7 @@ public class HAProxySSLTLVTest {
         final byte clientSSLandClientCertSessEnabled = 0x5;
 
         final HAProxySSLTLV clientSSLandClientCertSessTLV =
-                new HAProxySSLTLV(0, clientSSLandClientCertSessEnabled, Collections.<HAProxyTLV>emptyList(),
+                new HAProxySSLTLV(0, clientSSLandClientCertSessEnabled, Collections.emptyList(),
                                   Unpooled.buffer());
 
         assertFalse(clientSSLandClientCertSessTLV.isPP2ClientCertConn());
@@ -55,7 +55,7 @@ public class HAProxySSLTLVTest {
         final byte noClientEnabled = 0x0;
 
         final HAProxySSLTLV noClientTlv =
-                new HAProxySSLTLV(0, noClientEnabled, Collections.<HAProxyTLV>emptyList(),
+                new HAProxySSLTLV(0, noClientEnabled, Collections.emptyList(),
                                   Unpooled.buffer());
 
         assertFalse(noClientTlv.isPP2ClientCertConn());

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshaker.java
@@ -60,7 +60,7 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
     public WebSocketExtensionData newRequestData() {
         return new WebSocketExtensionData(
                 useWebkitExtensionName ? X_WEBKIT_DEFLATE_FRAME_EXTENSION : DEFLATE_FRAME_EXTENSION,
-                Collections.<String, String>emptyMap());
+                Collections.emptyMap());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
@@ -96,7 +96,7 @@ public final class DeflateFrameServerExtensionHandshaker implements WebSocketSer
 
         @Override
         public WebSocketExtensionData newReponseData() {
-            return new WebSocketExtensionData(extensionName, Collections.<String, String>emptyMap());
+            return new WebSocketExtensionData(extensionName, Collections.emptyMap());
         }
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -41,7 +41,7 @@ public class HttpServerUpgradeHandlerTest {
     private class TestUpgradeCodec implements UpgradeCodec {
         @Override
         public Collection<CharSequence> requiredUpgradeHeaders() {
-            return Collections.<CharSequence>emptyList();
+            return Collections.emptyList();
         }
 
         @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandlerTest.java
@@ -49,10 +49,10 @@ public class WebSocketClientExtensionHandlerTest {
     public void testMainSuccess() {
         // initialize
         when(mainHandshakerMock.newRequestData()).
-                thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+                thenReturn(new WebSocketExtensionData("main", Collections.emptyMap()));
         when(mainHandshakerMock.handshakeExtension(any(WebSocketExtensionData.class))).thenReturn(mainExtensionMock);
         when(fallbackHandshakerMock.newRequestData()).
-                thenReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+                thenReturn(new WebSocketExtensionData("fallback", Collections.emptyMap()));
         when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
         when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
         when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
@@ -98,10 +98,10 @@ public class WebSocketClientExtensionHandlerTest {
     public void testFallbackSuccess() {
         // initialize
         when(mainHandshakerMock.newRequestData()).
-                thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+                thenReturn(new WebSocketExtensionData("main", Collections.emptyMap()));
         when(mainHandshakerMock.handshakeExtension(any(WebSocketExtensionData.class))).thenReturn(null);
         when(fallbackHandshakerMock.newRequestData()).
-                thenReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+                thenReturn(new WebSocketExtensionData("fallback", Collections.emptyMap()));
         when(fallbackHandshakerMock.handshakeExtension(
                 any(WebSocketExtensionData.class))).thenReturn(fallbackExtensionMock);
         when(fallbackExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
@@ -150,13 +150,13 @@ public class WebSocketClientExtensionHandlerTest {
     public void testAllSuccess() {
         // initialize
         when(mainHandshakerMock.newRequestData()).
-                thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+                thenReturn(new WebSocketExtensionData("main", Collections.emptyMap()));
         when(mainHandshakerMock.handshakeExtension(
                 webSocketExtensionDataMatcher("main"))).thenReturn(mainExtensionMock);
         when(mainHandshakerMock.handshakeExtension(
                 webSocketExtensionDataMatcher("fallback"))).thenReturn(null);
         when(fallbackHandshakerMock.newRequestData()).
-                thenReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+                thenReturn(new WebSocketExtensionData("fallback", Collections.emptyMap()));
         when(fallbackHandshakerMock.handshakeExtension(
                 webSocketExtensionDataMatcher("main"))).thenReturn(null);
         when(fallbackHandshakerMock.handshakeExtension(
@@ -222,13 +222,13 @@ public class WebSocketClientExtensionHandlerTest {
     public void testIfMainAndFallbackUseRSV1WillFail() {
         // initialize
         when(mainHandshakerMock.newRequestData()).
-                thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+                thenReturn(new WebSocketExtensionData("main", Collections.emptyMap()));
         when(mainHandshakerMock.handshakeExtension(
                 webSocketExtensionDataMatcher("main"))).thenReturn(mainExtensionMock);
         when(mainHandshakerMock.handshakeExtension(
                 webSocketExtensionDataMatcher("fallback"))).thenReturn(null);
         when(fallbackHandshakerMock.newRequestData()).
-                thenReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+                thenReturn(new WebSocketExtensionData("fallback", Collections.emptyMap()));
         when(fallbackHandshakerMock.handshakeExtension(
                 webSocketExtensionDataMatcher("main"))).thenReturn(null);
         when(fallbackHandshakerMock.handshakeExtension(

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
@@ -55,7 +55,7 @@ public class WebSocketServerExtensionHandlerTest {
 
         when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
         when(mainExtensionMock.newReponseData()).thenReturn(
-                new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData("main", Collections.emptyMap()));
         when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
         when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
 
@@ -108,13 +108,13 @@ public class WebSocketServerExtensionHandlerTest {
 
         when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
         when(mainExtensionMock.newReponseData()).thenReturn(
-                new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData("main", Collections.emptyMap()));
         when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
         when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
 
         when(fallbackExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV2);
         when(fallbackExtensionMock.newReponseData()).thenReturn(
-                new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData("fallback", Collections.emptyMap()));
         when(fallbackExtensionMock.newExtensionEncoder()).thenReturn(new Dummy2Encoder());
         when(fallbackExtensionMock.newExtensionDecoder()).thenReturn(new Dummy2Decoder());
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshakerTest.java
@@ -57,7 +57,7 @@ public class DeflateFrameClientExtensionHandshakerTest {
                 new DeflateFrameClientExtensionHandshaker(false);
 
         WebSocketClientExtension extension = handshaker.handshakeExtension(
-                new WebSocketExtensionData(DEFLATE_FRAME_EXTENSION, Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData(DEFLATE_FRAME_EXTENSION, Collections.emptyMap()));
 
         assertNotNull(extension);
         assertEquals(WebSocketClientExtension.RSV1, extension.rsv());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshakerTest.java
@@ -37,7 +37,7 @@ public class DeflateFrameServerExtensionHandshakerTest {
 
         // execute
         WebSocketServerExtension extension = handshaker.handshakeExtension(
-                new WebSocketExtensionData(DEFLATE_FRAME_EXTENSION, Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData(DEFLATE_FRAME_EXTENSION, Collections.emptyMap()));
 
         // test
         assertNotNull(extension);
@@ -54,7 +54,7 @@ public class DeflateFrameServerExtensionHandshakerTest {
 
         // execute
         WebSocketServerExtension extension = handshaker.handshakeExtension(
-                new WebSocketExtensionData(X_WEBKIT_DEFLATE_FRAME_EXTENSION, Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData(X_WEBKIT_DEFLATE_FRAME_EXTENSION, Collections.emptyMap()));
 
         // test
         assertNotNull(extension);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -67,7 +67,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
                 new PerMessageDeflateClientExtensionHandshaker();
 
         WebSocketClientExtension extension = handshaker.handshakeExtension(
-                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, Collections.emptyMap()));
 
         assertNotNull(extension);
         assertEquals(RSV1, extension.rsv());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
@@ -41,7 +41,7 @@ public class PerMessageDeflateServerExtensionHandshakerTest {
 
         // execute
         extension = handshaker.handshakeExtension(
-                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, Collections.emptyMap()));
 
         // test
         assertNotNull(extension);
@@ -62,7 +62,7 @@ public class PerMessageDeflateServerExtensionHandshakerTest {
 
         // execute
         extension = handshaker.handshakeExtension(
-                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, Collections.<String, String>emptyMap()));
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, Collections.emptyMap()));
 
         // test
         assertNotNull(extension);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CharSequenceMap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CharSequenceMap.java
@@ -33,7 +33,7 @@ public final class CharSequenceMap<V> extends DefaultHeaders<CharSequence, V, Ch
     }
 
     public CharSequenceMap(boolean caseSensitive) {
-        this(caseSensitive, UnsupportedValueConverter.<V>instance());
+        this(caseSensitive, UnsupportedValueConverter.instance());
     }
 
     public CharSequenceMap(boolean caseSensitive, ValueConverter<V> valueConverter) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -171,7 +171,7 @@ final class HpackStaticTable {
         int length = STATIC_TABLE.size();
         @SuppressWarnings("unchecked")
         CharSequenceMap<Integer> ret = new CharSequenceMap<>(true,
-                UnsupportedValueConverter.<Integer>instance(), length);
+                UnsupportedValueConverter.instance(), length);
         // Iterate through the static table in reverse order to
         // save the smallest index for a given name in the map.
         for (int index = length; index > 0; index--) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -101,7 +101,7 @@ public final class Http2StreamChannelBootstrap {
     }
 
     public Future<Http2StreamChannel> open() {
-        return open(channel.eventLoop().<Http2StreamChannel>newPromise());
+        return open(channel.eventLoop().newPromise());
     }
 
     public Future<Http2StreamChannel> open(final Promise<Http2StreamChannel> promise) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -423,7 +423,7 @@ public final class HttpConversionUtil {
 
     private static CharSequenceMap<AsciiString> toLowercaseMap(Iterator<? extends CharSequence> valuesIter,
                                                                int arraySizeHint) {
-        UnsupportedValueConverter<AsciiString> valueConverter = UnsupportedValueConverter.<AsciiString>instance();
+        UnsupportedValueConverter<AsciiString> valueConverter = UnsupportedValueConverter.instance();
         CharSequenceMap<AsciiString> result = new CharSequenceMap<>(true, valueConverter, arraySizeHint);
 
         while (valuesIter.hasNext()) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -344,7 +344,7 @@ public class Http2ConnectionHandlerTest {
         ByteBuf prefacePlusSome = addSettingsHeader(Unpooled.buffer().writeBytes(connectionPrefaceBuf()));
         handler.channelRead(ctx, prefacePlusSome);
         verify(decoder, atLeastOnce()).decodeFrame(any(ChannelHandlerContext.class),
-                any(ByteBuf.class), ArgumentMatchers.<List<Object>>any());
+                any(ByteBuf.class), ArgumentMatchers.any());
     }
 
     @Test
@@ -356,7 +356,7 @@ public class Http2ConnectionHandlerTest {
         ByteBuf preface = connectionPrefaceBuf();
         handler.channelRead(ctx, preface);
         verify(decoder, never()).decodeFrame(any(ChannelHandlerContext.class),
-                any(ByteBuf.class), ArgumentMatchers.<List<Object>>any());
+                any(ByteBuf.class), ArgumentMatchers.any());
 
         // Now remove and add the handler...this is setting up the test condition.
         handler.handlerRemoved(ctx);
@@ -365,7 +365,7 @@ public class Http2ConnectionHandlerTest {
         // Now verify we can continue as normal, reading connection preface plus more.
         ByteBuf prefacePlusSome = addSettingsHeader(Unpooled.buffer().writeBytes(connectionPrefaceBuf()));
         handler.channelRead(ctx, prefacePlusSome);
-        verify(decoder, atLeastOnce()).decodeFrame(eq(ctx), any(ByteBuf.class), ArgumentMatchers.<List<Object>>any());
+        verify(decoder, atLeastOnce()).decodeFrame(eq(ctx), any(ByteBuf.class), ArgumentMatchers.any());
     }
 
     @SuppressWarnings("unchecked")

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -203,8 +203,8 @@ public class Http2MultiplexCodecTest {
 
         assertEquals(headersFrame, inboundHandler.readInbound());
 
-        assertEqualsAndRelease(dataFrame1, inboundHandler.<Http2Frame>readInbound());
-        assertEqualsAndRelease(dataFrame2, inboundHandler.<Http2Frame>readInbound());
+        assertEqualsAndRelease(dataFrame1, inboundHandler.readInbound());
+        assertEqualsAndRelease(dataFrame2, inboundHandler.readInbound());
 
         assertNull(inboundHandler.readInbound());
     }
@@ -952,7 +952,7 @@ public class Http2MultiplexCodecTest {
 
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("1"), 0, false);
 
-        assertEqualsAndRelease(dataFrame1, inboundHandler.<Http2Frame>readInbound());
+        assertEqualsAndRelease(dataFrame1, inboundHandler.readInbound());
 
         // We want one item to be in the queue, and allow the numReads to be larger than 1. This will ensure that
         // when beginRead() is called the child channel is added to the readPending queue of the parent channel.
@@ -961,7 +961,7 @@ public class Http2MultiplexCodecTest {
         numReads.set(2);
         childChannel.read();
 
-        assertEqualsAndRelease(dataFrame2, inboundHandler.<Http2Frame>readInbound());
+        assertEqualsAndRelease(dataFrame2, inboundHandler.readInbound());
 
         assertNull(inboundHandler.readInbound());
 
@@ -969,14 +969,14 @@ public class Http2MultiplexCodecTest {
         // notify of readComplete().
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("3"), 0, false);
 
-        assertEqualsAndRelease(dataFrame3, inboundHandler.<Http2Frame>readInbound());
+        assertEqualsAndRelease(dataFrame3, inboundHandler.readInbound());
 
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("4"), 0, false);
         assertNull(inboundHandler.readInbound());
 
         childChannel.read();
 
-        assertEqualsAndRelease(dataFrame4, inboundHandler.<Http2Frame>readInbound());
+        assertEqualsAndRelease(dataFrame4, inboundHandler.readInbound());
 
         assertNull(inboundHandler.readInbound());
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
@@ -58,7 +58,7 @@ public class LastInboundHandler extends ChannelDuplexHandler {
     }
 
     public LastInboundHandler() {
-        this(LastInboundHandler.<ChannelHandlerContext>noopConsumer());
+        this(LastInboundHandler.noopConsumer());
     }
 
     public LastInboundHandler(Consumer<ChannelHandlerContext> channelReadCompleteConsumer) {

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpRequest.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpRequest.java
@@ -56,7 +56,7 @@ public final class DefaultSmtpRequest implements SmtpRequest {
     DefaultSmtpRequest(SmtpCommand command, List<CharSequence> parameters) {
         this.command = ObjectUtil.checkNotNull(command, "command");
         this.parameters = parameters != null ?
-                Collections.unmodifiableList(parameters) : Collections.<CharSequence>emptyList();
+                Collections.unmodifiableList(parameters) : Collections.emptyList();
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -36,7 +36,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     static final long DEFAULT_SHUTDOWN_QUIET_PERIOD = 2;
     static final long DEFAULT_SHUTDOWN_TIMEOUT = 15;
 
-    private final Collection<EventExecutor> selfCollection = Collections.<EventExecutor>singleton(this);
+    private final Collection<EventExecutor> selfCollection = Collections.singleton(this);
 
     @Override
     public EventExecutor next() {

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -137,7 +137,7 @@ public class SingleThreadEventExecutorTest {
                 @Override
                 public void run() {
                     try {
-                        Set<Callable<Boolean>> set = Collections.<Callable<Boolean>>singleton(new Callable<Boolean>() {
+                        Set<Callable<Boolean>> set = Collections.singleton(new Callable<Boolean>() {
                             @Override
                             public Boolean call() throws Exception {
                                 promise.setFailure(new AssertionError("Should never execute the Callable"));

--- a/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerFactoryTest.java
@@ -84,21 +84,21 @@ public class Slf4JLoggerFactoryTest {
         internalLogger.warn("{}", "warn");
         internalLogger.warn("{} {}", "warn1", "warn2");
 
-        verify(logger, times(2)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
+        verify(logger, times(2)).log(ArgumentMatchers.isNull(), eq(LocationAwareSlf4JLogger.FQCN),
                 eq(LocationAwareLogger.DEBUG_INT), captor.capture(), any(Object[].class),
-                ArgumentMatchers.<Throwable>isNull());
-        verify(logger, times(2)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
+                ArgumentMatchers.isNull());
+        verify(logger, times(2)).log(ArgumentMatchers.isNull(), eq(LocationAwareSlf4JLogger.FQCN),
                 eq(LocationAwareLogger.ERROR_INT), captor.capture(), any(Object[].class),
-                ArgumentMatchers.<Throwable>isNull());
-        verify(logger, times(2)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
+                ArgumentMatchers.isNull());
+        verify(logger, times(2)).log(ArgumentMatchers.isNull(), eq(LocationAwareSlf4JLogger.FQCN),
                 eq(LocationAwareLogger.INFO_INT), captor.capture(), any(Object[].class),
-                ArgumentMatchers.<Throwable>isNull());
-        verify(logger, times(2)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
+                ArgumentMatchers.isNull());
+        verify(logger, times(2)).log(ArgumentMatchers.isNull(), eq(LocationAwareSlf4JLogger.FQCN),
                 eq(LocationAwareLogger.TRACE_INT), captor.capture(), any(Object[].class),
-                ArgumentMatchers.<Throwable>isNull());
-        verify(logger, times(2)).log(ArgumentMatchers.<Marker>isNull(), eq(LocationAwareSlf4JLogger.FQCN),
+                ArgumentMatchers.isNull());
+        verify(logger, times(2)).log(ArgumentMatchers.isNull(), eq(LocationAwareSlf4JLogger.FQCN),
                 eq(LocationAwareLogger.WARN_INT), captor.capture(), any(Object[].class),
-                ArgumentMatchers.<Throwable>isNull());
+                ArgumentMatchers.isNull());
 
         Iterator<String> logMessages = captor.getAllValues().iterator();
         assertEquals("debug", logMessages.next());

--- a/handler/src/main/java/io/netty/handler/ssl/ConscryptAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ConscryptAlpnSslEngine.java
@@ -147,7 +147,7 @@ abstract class ConscryptAlpnSslEngine extends JdkSslEngine {
             try {
                 String protocol = Conscrypt.getApplicationProtocol(getWrappedEngine());
                 protocolSelector.select(protocol != null ? Collections.singletonList(protocol)
-                        : Collections.<String>emptyList());
+                        : Collections.emptyList());
             } catch (Throwable e) {
                 throw toSSLHandshakeException(e);
             }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -315,7 +315,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     }
                 }
                 return ocspResponse == null ?
-                        Collections.<byte[]>emptyList() : Collections.singletonList(ocspResponse);
+                        Collections.emptyList() : Collections.singletonList(ocspResponse);
             }
         };
         engineMap = context.engineMap;

--- a/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
@@ -93,7 +93,7 @@ public class SniHandler extends AbstractSniHandler<SslContext> {
      */
     @Override
     protected Future<SslContext> lookup(ChannelHandlerContext ctx, String hostname) throws Exception {
-        return mapping.map(hostname, ctx.executor().<SslContext>newPromise());
+        return mapping.map(hostname, ctx.executor().newPromise());
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1691,7 +1691,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             throw new IllegalStateException();
         }
 
-        return renegotiate(ctx.executor().<Channel>newPromise());
+        return renegotiate(ctx.executor().newPromise());
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -85,7 +85,7 @@ public class SslErrorTest {
         exceptions.add(new CertificateNotYetValidException());
         exceptions.add(new CertificateRevokedException(
                 new Date(), CRLReason.AA_COMPROMISE, new X500Principal(""),
-                Collections.<String, Extension>emptyMap()));
+                Collections.emptyMap()));
 
         // Also use wrapped exceptions as this is what the JDK implementation of X509TrustManagerFactory is doing.
         exceptions.add(newCertificateException(CertPathValidatorException.BasicReason.EXPIRED));

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -740,7 +740,7 @@ public class SslHandlerTest {
                 throw error;
             }
             assertThat(sslHandler.handshakeFuture().await().cause(),
-                       CoreMatchers.<Throwable>instanceOf(SSLException.class));
+                       CoreMatchers.instanceOf(SSLException.class));
         } finally {
             if (cc != null) {
                 cc.close().syncUninterruptibly();
@@ -812,7 +812,7 @@ public class SslHandlerTest {
             cc = future.syncUninterruptibly().channel();
 
             Throwable cause = sslHandler.handshakeFuture().await().cause();
-            assertThat(cause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
+            assertThat(cause, CoreMatchers.instanceOf(SSLException.class));
             assertThat(cause.getMessage(), containsString("timed out"));
         } finally {
             if (cc != null) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/Cache.java
@@ -166,7 +166,7 @@ abstract class Cache<E> {
         volatile ScheduledFuture<?> expirationFuture;
 
         Entries(String hostname) {
-            super(Collections.<E>emptyList());
+            super(Collections.emptyList());
             this.hostname = hostname;
         }
 
@@ -260,7 +260,7 @@ abstract class Cache<E> {
         }
 
         boolean clearAndCancel() {
-            List<E> entries = getAndSet(Collections.<E>emptyList());
+            List<E> entries = getAndSet(Collections.emptyList());
             if (entries.isEmpty()) {
                 return false;
             }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -127,7 +127,7 @@ public class DefaultDnsCache implements DnsCache {
     public List<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
         checkNotNull(hostname, "hostname");
         if (!emptyAdditionals(additionals)) {
-            return Collections.<DnsCacheEntry>emptyList();
+            return Collections.emptyList();
         }
 
         return resolveCache.get(appendDot(hostname));

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -748,7 +748,7 @@ public class DnsNameResolver extends InetNameResolver {
                 if (content != null) {
                     // Our current implementation does not support reloading the hosts file,
                     // so use a fairly large TTL (1 day, i.e. 86400 seconds).
-                    trySuccess(promise, Collections.<DnsRecord>singletonList(
+                    trySuccess(promise, Collections.singletonList(
                             new DefaultDnsRawRecord(hostname, type, 86400, content)));
                     return promise;
                 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -781,7 +781,7 @@ abstract class DnsResolveContext<T> {
             }
         }
 
-        return cnames != null? cnames : Collections.<String, String>emptyMap();
+        return cnames != null? cnames : Collections.emptyMap();
     }
 
     private void tryToFinishResolve(final DnsServerAddressStream nameServerAddrStream,

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
@@ -48,12 +48,12 @@ final class InflightNameResolver<T> implements NameResolver<T> {
 
     @Override
     public Future<T> resolve(String inetHost) {
-        return resolve(inetHost, executor.<T>newPromise());
+        return resolve(inetHost, executor.newPromise());
     }
 
     @Override
     public Future<List<T>> resolveAll(String inetHost) {
-        return resolveAll(inetHost, executor.<List<T>>newPromise());
+        return resolveAll(inetHost, executor.newPromise());
     }
 
     @Override

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -44,7 +44,7 @@ public class DnsNameResolverClientSubnetTest {
             // Same as:
             // # /.bind-9.9.3-edns/bin/dig @ns1.google.com www.google.es +client=157.88.0.0/24
             Future<List<InetAddress>> future = resolver.resolveAll("www.google.es",
-                    Collections.<DnsRecord>singleton(
+                    Collections.singleton(
                             // Suggest max payload size of 1024
                             // 157.88.0.0 / 24
                             new DefaultDnsOptEcsRecord(1024, 24,

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -404,7 +404,7 @@ public class DnsNameResolverTest {
                     case A:
                         Map<String, Object> attr = new HashMap<>();
                         attr.put(DnsAttribute.IP_ADDRESS.toLowerCase(Locale.US), overriddenIP);
-                        return Collections.<ResourceRecord>singleton(
+                        return Collections.singleton(
                                 new TestDnsServer.TestResourceRecord(
                                         question.getDomainName(), question.getRecordType(), attr));
                     default:
@@ -1037,8 +1037,8 @@ public class DnsNameResolverTest {
 
         final List<DnsRecord> records = resolver.resolveAll(new DefaultDnsQuestion("foo.com.", A))
                 .syncUninterruptibly().getNow();
-        assertThat(records, Matchers.<DnsRecord>hasSize(1));
-        assertThat(records.get(0), Matchers.<DnsRecord>instanceOf(DnsRawRecord.class));
+        assertThat(records, Matchers.hasSize(1));
+        assertThat(records.get(0), Matchers.instanceOf(DnsRawRecord.class));
 
         final DnsRawRecord record = (DnsRawRecord) records.get(0);
         final ByteBuf content = record.content();
@@ -2098,7 +2098,7 @@ public class DnsNameResolverTest {
                 if (question.getDomainName().equals("cname.netty.io")) {
                     Map<String, Object> map1 = new HashMap<>();
                     map1.put(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99");
-                    return Collections.<ResourceRecord>singleton(
+                    return Collections.singleton(
                             new TestDnsServer.TestResourceRecord(question.getDomainName(), RecordType.A, map1));
                 } else {
                     Set<ResourceRecord> records = new LinkedHashSet<>(2);
@@ -2148,19 +2148,19 @@ public class DnsNameResolverTest {
                 Set<ResourceRecord> records = new LinkedHashSet<>(4);
 
                 records.add(new TestDnsServer.TestResourceRecord("x." + question.getDomainName(),
-                        RecordType.A, Collections.<String, Object>singletonMap(
+                        RecordType.A, Collections.singletonMap(
                                 DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
                 records.add(new TestDnsServer.TestResourceRecord(
                         "cname2.netty.io", RecordType.CNAME,
-                        Collections.<String, Object>singletonMap(
+                        Collections.singletonMap(
                                 DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
                 records.add(new TestDnsServer.TestResourceRecord(
                         "cname.netty.io", RecordType.CNAME,
-                        Collections.<String, Object>singletonMap(
+                        Collections.singletonMap(
                                 DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname2.netty.io")));
                 records.add(new TestDnsServer.TestResourceRecord(
                         question.getDomainName(), RecordType.CNAME,
-                        Collections.<String, Object>singletonMap(
+                        Collections.singletonMap(
                                 DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
                 return records;
             }
@@ -2351,25 +2351,25 @@ public class DnsNameResolverTest {
                 if ("cname.netty.io".equals(question.getDomainName())) {
                     aQueries.incrementAndGet();
 
-                    return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
+                    return Collections.singleton(new TestDnsServer.TestResourceRecord(
                             question.getDomainName(), RecordType.A,
-                            Collections.<String, Object>singletonMap(
+                            Collections.singletonMap(
                                     DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
                 }
                 if ("x.netty.io".equals(question.getDomainName())) {
                     cnameQueries.incrementAndGet();
 
-                    return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
+                    return Collections.singleton(new TestDnsServer.TestResourceRecord(
                             question.getDomainName(), RecordType.CNAME,
-                            Collections.<String, Object>singletonMap(
+                            Collections.singletonMap(
                                     DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
                 }
                 if ("y.netty.io".equals(question.getDomainName())) {
                     cnameQueries.incrementAndGet();
 
-                    return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
+                    return Collections.singleton(new TestDnsServer.TestResourceRecord(
                             question.getDomainName(), RecordType.CNAME,
-                            Collections.<String, Object>singletonMap(
+                            Collections.singletonMap(
                                     DnsAttribute.DOMAIN_NAME.toLowerCase(), "x.netty.io")));
                 }
                 return Collections.emptySet();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -282,7 +282,7 @@ public class SearchDomainTest {
 
     @Test
     public void testExceptionMsgContainsSearchDomain() throws Exception {
-        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(Collections.<String>emptySet());
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(Collections.emptySet());
         dnsServer = new TestDnsServer(store);
         dnsServer.start();
 
@@ -299,7 +299,7 @@ public class SearchDomainTest {
 
     @Test
     public void testExceptionMsgDoesNotContainSearchDomainIfNdotsIsNotReached() throws Exception {
-        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(Collections.<String>emptySet());
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(Collections.emptySet());
         dnsServer = new TestDnsServer(store);
         dnsServer.start();
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -303,7 +303,7 @@ class TestDnsServer extends DnsServer {
                     default:
                         return null;
                 }
-                return Collections.<ResourceRecord>singleton(
+                return Collections.singleton(
                         new TestResourceRecord(name, questionRecord.getRecordType(), attr));
             }
             return null;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpTestPermutation.java
@@ -48,7 +48,7 @@ public final class SctpTestPermutation {
         }
 
         // Make the list of ServerBootstrap factories.
-        return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(new BootstrapFactory<ServerBootstrap>() {
+        return Collections.singletonList(new BootstrapFactory<ServerBootstrap>() {
             @Override
             public ServerBootstrap newInstance() {
                 return new ServerBootstrap().
@@ -63,7 +63,7 @@ public final class SctpTestPermutation {
             return Collections.emptyList();
         }
 
-        return Collections.<BootstrapFactory<Bootstrap>>singletonList(new BootstrapFactory<Bootstrap>() {
+        return Collections.singletonList(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
                 return new Bootstrap().group(nioWorkerGroup).channel(NioSctpChannel.class);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -102,7 +102,7 @@ public class SocketTestPermutation {
 
     public List<BootstrapComboFactory<Bootstrap, Bootstrap>> datagram() {
         // Make the list of Bootstrap factories.
-        List<BootstrapFactory<Bootstrap>> bfs = Collections.<BootstrapFactory<Bootstrap>>singletonList(
+        List<BootstrapFactory<Bootstrap>> bfs = Collections.singletonList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
@@ -126,7 +126,7 @@ public class SocketTestPermutation {
     }
 
     public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
-        return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<ServerBootstrap>() {
                     @Override
                     public ServerBootstrap newInstance() {
@@ -138,7 +138,7 @@ public class SocketTestPermutation {
     }
 
     public List<BootstrapFactory<Bootstrap>> clientSocket() {
-        return Collections.<BootstrapFactory<Bootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
@@ -149,7 +149,7 @@ public class SocketTestPermutation {
     }
 
     public List<BootstrapFactory<Bootstrap>> datagramSocket() {
-        return Collections.<BootstrapFactory<Bootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -68,8 +68,8 @@ public class EpollSocketTcpMd5Test {
     @Test
     public void testServerSocketChannelOption() throws Exception {
         server.config().setOption(EpollChannelOption.TCP_MD5SIG,
-                Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
-        server.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.<InetAddress, byte[]>emptyMap());
+                Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
+        server.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.emptyMap());
     }
 
     @Test
@@ -81,8 +81,8 @@ public class EpollSocketTcpMd5Test {
                 .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
 
         ch.config().setOption(EpollChannelOption.TCP_MD5SIG,
-                Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
-        ch.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.<InetAddress, byte[]>emptyMap());
+                Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
+        ch.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.emptyMap());
 
         ch.close().syncUninterruptibly();
     }
@@ -90,13 +90,13 @@ public class EpollSocketTcpMd5Test {
     @Test(expected = ConnectTimeoutException.class)
     public void testKeyMismatch() throws Exception {
         server.config().setOption(EpollChannelOption.TCP_MD5SIG,
-                Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
+                Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
 
         EpollSocketChannel client = (EpollSocketChannel) new Bootstrap().group(GROUP)
                 .channel(EpollSocketChannel.class)
                 .handler(new ChannelInboundHandlerAdapter())
                 .option(EpollChannelOption.TCP_MD5SIG,
-                        Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
+                        Collections.singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
                 .connect(server.localAddress()).syncUninterruptibly().channel();
         client.close().syncUninterruptibly();
@@ -105,13 +105,13 @@ public class EpollSocketTcpMd5Test {
     @Test
     public void testKeyMatch() throws Exception {
         server.config().setOption(EpollChannelOption.TCP_MD5SIG,
-                Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
+                Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
 
         EpollSocketChannel client = (EpollSocketChannel) new Bootstrap().group(GROUP)
                 .channel(EpollSocketChannel.class)
                 .handler(new ChannelInboundHandlerAdapter())
                 .option(EpollChannelOption.TCP_MD5SIG,
-                        Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
+                        Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
                 .connect(server.localAddress()).syncUninterruptibly().channel();
         client.close().syncUninterruptibly();
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -160,7 +160,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     }
 
     public List<BootstrapFactory<ServerBootstrap>> serverDomainSocket() {
-        return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<ServerBootstrap>() {
                     @Override
                     public ServerBootstrap newInstance() {
@@ -172,7 +172,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     }
 
     public List<BootstrapFactory<Bootstrap>> clientDomainSocket() {
-        return Collections.<BootstrapFactory<Bootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
@@ -184,7 +184,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
 
     @Override
     public List<BootstrapFactory<Bootstrap>> datagramSocket() {
-        return Collections.<BootstrapFactory<Bootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -145,7 +145,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     }
 
     public List<BootstrapFactory<ServerBootstrap>> serverDomainSocket() {
-        return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<ServerBootstrap>() {
                     @Override
                     public ServerBootstrap newInstance() {
@@ -157,7 +157,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     }
 
     public List<BootstrapFactory<Bootstrap>> clientDomainSocket() {
-        return Collections.<BootstrapFactory<Bootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
@@ -169,7 +169,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
 
     @Override
     public List<BootstrapFactory<Bootstrap>> datagramSocket() {
-        return Collections.<BootstrapFactory<Bootstrap>>singletonList(
+        return Collections.singletonList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -161,8 +161,8 @@ public class SingleThreadEventLoop extends SingleThreadEventExecutor implements 
     @Override
     protected Queue<Runnable> newTaskQueue(int maxPendingTasks) {
         // This event loop never calls takeTask()
-        return maxPendingTasks == Integer.MAX_VALUE ? PlatformDependent.<Runnable>newMpscQueue()
-                : PlatformDependent.<Runnable>newMpscQueue(maxPendingTasks);
+        return maxPendingTasks == Integer.MAX_VALUE ? PlatformDependent.newMpscQueue()
+                : PlatformDependent.newMpscQueue(maxPendingTasks);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

calls to parametrized methods where explicit argument types can be omitted, so remove it.