### PR TITLE
Update to new checkstyle plugin (#8777)

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -461,7 +461,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         private final ByteBufAllocator allocator;
         private final AtomicReference<Object> finish = new AtomicReference<Object>();
 
-        public AllocationThread(ByteBufAllocator allocator) {
+        AllocationThread(ByteBufAllocator allocator) {
             this.allocator = allocator;
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -79,7 +79,7 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
             return charSequenceEscaper;
         }
 
-        public CombinedHttpHeadersImpl(HashingStrategy<CharSequence> nameHashingStrategy,
+        CombinedHttpHeadersImpl(HashingStrategy<CharSequence> nameHashingStrategy,
                 ValueConverter<CharSequence> valueConverter,
                 io.netty.handler.codec.DefaultHeaders.NameValidator<CharSequence> nameValidator) {
             super(nameHashingStrategy, valueConverter, nameValidator);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -81,16 +81,18 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
     }
 
     private final class HttpServerRequestDecoder extends HttpRequestDecoder {
-        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
+
+        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
             super(maxInitialLineLength, maxHeaderSize, maxChunkSize);
         }
 
-        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
+        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
                                         boolean validateHeaders) {
             super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders);
         }
 
-        public HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
+        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
+
                                         boolean validateHeaders, int initialBufferSize) {
             super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize);
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
@@ -59,7 +59,9 @@ public abstract class AbstractHttpData extends AbstractReferenceCounted implemen
     }
 
     @Override
-    public long getMaxSize() { return maxSize; }
+    public long getMaxSize() {
+        return maxSize;
+    }
 
     @Override
     public void setMaxSize(long maxSize) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -45,7 +45,9 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
     /**
      * Returns the used handshaker
      */
-    public WebSocketClientHandshaker handshaker() { return handshaker; }
+    public WebSocketClientHandshaker handshaker() {
+        return handshaker;
+    }
 
     /**
      * Events that are fired to notify about handshake status

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
@@ -47,7 +47,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
      * Constructor
      * @param noContext true to disable context takeover.
      */
-    public DeflateDecoder(boolean noContext) {
+    DeflateDecoder(boolean noContext) {
         this.noContext = noContext;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
@@ -49,7 +49,7 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
      * @param windowSize maximum size of the window compressor buffer.
      * @param noContext true to disable context takeover.
      */
-    public DeflateEncoder(int compressionLevel, int windowSize, boolean noContext) {
+    DeflateEncoder(int compressionLevel, int windowSize, boolean noContext) {
         this.compressionLevel = compressionLevel;
         this.windowSize = windowSize;
         this.noContext = noContext;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshaker.java
@@ -81,7 +81,7 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
 
         private final int compressionLevel;
 
-        public DeflateFrameClientExtension(int compressionLevel) {
+        DeflateFrameClientExtension(int compressionLevel) {
             this.compressionLevel = compressionLevel;
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
@@ -74,7 +74,7 @@ public final class DeflateFrameServerExtensionHandshaker implements WebSocketSer
         private final String extensionName;
         private final int compressionLevel;
 
-        public DeflateFrameServerExtension(int compressionLevel, String extensionName) {
+        DeflateFrameServerExtension(int compressionLevel, String extensionName) {
             this.extensionName = extensionName;
             this.compressionLevel = compressionLevel;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoder.java
@@ -30,7 +30,7 @@ class PerFrameDeflateDecoder extends DeflateDecoder {
      * Constructor
      * @param noContext true to disable context takeover.
      */
-    public PerFrameDeflateDecoder(boolean noContext) {
+    PerFrameDeflateDecoder(boolean noContext) {
         super(noContext);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoder.java
@@ -32,7 +32,7 @@ class PerFrameDeflateEncoder extends DeflateEncoder {
      * @param windowSize maximum size of the window compressor buffer.
      * @param noContext true to disable context takeover.
      */
-    public PerFrameDeflateEncoder(int compressionLevel, int windowSize, boolean noContext) {
+    PerFrameDeflateEncoder(int compressionLevel, int windowSize, boolean noContext) {
         super(compressionLevel, windowSize, noContext);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
@@ -176,7 +176,7 @@ public final class PerMessageDeflateClientExtensionHandshaker implements WebSock
             return RSV1;
         }
 
-        public PermessageDeflateExtension(boolean serverNoContext, int serverWindowSize,
+        PermessageDeflateExtension(boolean serverNoContext, int serverWindowSize,
                 boolean clientNoContext, int clientWindowSize) {
             this.serverNoContext = serverNoContext;
             this.serverWindowSize = serverWindowSize;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoder.java
@@ -35,7 +35,7 @@ class PerMessageDeflateDecoder extends DeflateDecoder {
      * Constructor
      * @param noContext true to disable context takeover.
      */
-    public PerMessageDeflateDecoder(boolean noContext) {
+    PerMessageDeflateDecoder(boolean noContext) {
         super(noContext);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoder.java
@@ -37,7 +37,7 @@ class PerMessageDeflateEncoder extends DeflateEncoder {
      * @param windowSize maximum size of the window compressor buffer.
      * @param noContext true to disable context takeover.
      */
-    public PerMessageDeflateEncoder(int compressionLevel, int windowSize, boolean noContext) {
+    PerMessageDeflateEncoder(int compressionLevel, int windowSize, boolean noContext) {
         super(compressionLevel, windowSize, noContext);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -151,7 +151,7 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
         private final boolean clientNoContext;
         private final int clientWindowSize;
 
-        public PermessageDeflateExtension(int compressionLevel, boolean serverNoContext,
+        PermessageDeflateExtension(int compressionLevel, boolean serverNoContext,
                 int serverWindowSize, boolean clientNoContext, int clientWindowSize) {
             this.compressionLevel = compressionLevel;
             this.serverNoContext = serverNoContext;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionTestUtil.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionTestUtil.java
@@ -69,7 +69,7 @@ public final class WebSocketExtensionTestUtil {
 
         private final String name;
 
-        public WebSocketExtensionDataMatcher(String name) {
+        WebSocketExtensionDataMatcher(String name) {
             this.name = name;
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -930,7 +930,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         private final Set<Http2Stream> streams = new LinkedHashSet<Http2Stream>();
         private int pendingIterations;
 
-        public ActiveStreams(List<Listener> listeners) {
+        ActiveStreams(List<Listener> listeners) {
             this.listeners = listeners;
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -296,7 +296,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
      * received.
      */
     private final class AutoRefillState extends DefaultState {
-        public AutoRefillState(Http2Stream stream, int initialWindowSize) {
+        AutoRefillState(Http2Stream stream, int initialWindowSize) {
             super(stream, initialWindowSize);
         }
 
@@ -349,7 +349,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
         private int lowerBound;
         private boolean endOfStream;
 
-        public DefaultState(Http2Stream stream, int initialWindowSize) {
+        DefaultState(Http2Stream stream, int initialWindowSize) {
             this.stream = stream;
             window(initialWindowSize);
             streamWindowUpdateRatio = windowUpdateRatio;
@@ -613,7 +613,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
         private CompositeStreamException compositeException;
         private final int delta;
 
-        public WindowUpdateVisitor(int delta) {
+        WindowUpdateVisitor(int delta) {
             this.delta = delta;
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -528,7 +528,7 @@ final class HpackDecoder {
         private HeaderType previousType;
         private Http2Exception validationException;
 
-        public Http2HeadersSink(int streamId, Http2Headers headers, long maxHeaderListSize, boolean validate) {
+        Http2HeadersSink(int streamId, Http2Headers headers, long maxHeaderListSize, boolean validate) {
             this.headers = headers;
             this.maxHeaderListSize = maxHeaderListSize;
             this.streamId = streamId;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
@@ -75,14 +75,14 @@ final class HpackEncoder {
     /**
      * Creates a new encoder.
      */
-    public HpackEncoder(boolean ignoreMaxHeaderListSize) {
+    HpackEncoder(boolean ignoreMaxHeaderListSize) {
         this(ignoreMaxHeaderListSize, 16);
     }
 
     /**
      * Creates a new encoder.
      */
-    public HpackEncoder(boolean ignoreMaxHeaderListSize, int arraySizeHint) {
+    HpackEncoder(boolean ignoreMaxHeaderListSize, int arraySizeHint) {
         this.ignoreMaxHeaderListSize = ignoreMaxHeaderListSize;
         maxHeaderTableSize = DEFAULT_HEADER_TABLE_SIZE;
         maxHeaderListSize = MAX_HEADER_LIST_SIZE;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -233,7 +233,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         private ByteBuf clientPrefaceString;
         private boolean prefaceSent;
 
-        public PrefaceDecoder(ChannelHandlerContext ctx) throws Exception {
+        PrefaceDecoder(ChannelHandlerContext ctx) throws Exception {
             clientPrefaceString = clientPrefaceString(encoder.connection());
             // This handler was just added to the context. In case it was handled after
             // the connection became active, send the connection preface now.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
@@ -194,7 +194,7 @@ public class Http2Exception extends Exception {
     /**
      * Provides a hint as to if shutdown is justified, what type of shutdown should be executed.
      */
-    public static enum ShutdownHint {
+    public enum ShutdownHint {
         /**
          * Do not shutdown the underlying channel.
          */

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -624,7 +624,7 @@ public class DefaultHttp2ConnectionTest {
         private final boolean[] array;
         private final int index;
 
-        public ListenerExceptionThrower(boolean[] array, int index) {
+        ListenerExceptionThrower(boolean[] array, int index) {
             this.array = array;
             this.index = index;
         }
@@ -640,7 +640,7 @@ public class DefaultHttp2ConnectionTest {
         private final boolean[] array;
         private final int index;
 
-        public ListenerVerifyCallAnswer(boolean[] array, int index) {
+        ListenerVerifyCallAnswer(boolean[] array, int index) {
             this.array = array;
             this.index = index;
         }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlAttribute.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlAttribute.java
@@ -57,16 +57,30 @@ public class XmlAttribute {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         XmlAttribute that = (XmlAttribute) o;
 
-        if (!name.equals(that.name)) { return false; }
-        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) { return false; }
-        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) { return false; }
-        if (type != null ? !type.equals(that.type) : that.type != null) { return false; }
-        if (value != null ? !value.equals(that.value) : that.value != null) { return false; }
+        if (!name.equals(that.name)) {
+            return false;
+        }
+        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) {
+            return false;
+        }
+        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlContent.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlContent.java
@@ -32,12 +32,18 @@ public abstract class XmlContent {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         XmlContent that = (XmlContent) o;
 
-        if (data != null ? !data.equals(that.data) : that.data != null) { return false; }
+        if (data != null ? !data.equals(that.data) : that.data != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDTD.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDTD.java
@@ -32,12 +32,18 @@ public class XmlDTD {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         XmlDTD xmlDTD = (XmlDTD) o;
 
-        if (text != null ? !text.equals(xmlDTD.text) : xmlDTD.text != null) { return false; }
+        if (text != null ? !text.equals(xmlDTD.text) : xmlDTD.text != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDocumentStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDocumentStart.java
@@ -54,17 +54,27 @@ public class XmlDocumentStart {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         XmlDocumentStart that = (XmlDocumentStart) o;
 
-        if (standalone != that.standalone) { return false; }
-        if (encoding != null ? !encoding.equals(that.encoding) : that.encoding != null) { return false; }
+        if (standalone != that.standalone) {
+            return false;
+        }
+        if (encoding != null ? !encoding.equals(that.encoding) : that.encoding != null) {
+            return false;
+        }
         if (encodingScheme != null ? !encodingScheme.equals(that.encodingScheme) : that.encodingScheme != null) {
             return false;
         }
-        if (version != null ? !version.equals(that.version) : that.version != null) { return false; }
+        if (version != null ? !version.equals(that.version) : that.version != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
@@ -54,15 +54,27 @@ public abstract class XmlElement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         XmlElement that = (XmlElement) o;
 
-        if (!name.equals(that.name)) { return false; }
-        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) { return false; }
-        if (namespaces != null ? !namespaces.equals(that.namespaces) : that.namespaces != null) { return false; }
-        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) { return false; }
+        if (!name.equals(that.name)) {
+            return false;
+        }
+        if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) {
+            return false;
+        }
+        if (namespaces != null ? !namespaces.equals(that.namespaces) : that.namespaces != null) {
+            return false;
+        }
+        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
@@ -35,13 +35,21 @@ public class XmlElementStart extends XmlElement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
-        if (!super.equals(o)) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
 
         XmlElementStart that = (XmlElementStart) o;
 
-        if (attributes != null ? !attributes.equals(that.attributes) : that.attributes != null) { return false; }
+        if (attributes != null ? !attributes.equals(that.attributes) : that.attributes != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlEntityReference.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlEntityReference.java
@@ -38,13 +38,21 @@ public class XmlEntityReference {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         XmlEntityReference that = (XmlEntityReference) o;
 
-        if (name != null ? !name.equals(that.name) : that.name != null) { return false; }
-        if (text != null ? !text.equals(that.text) : that.text != null) { return false; }
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        if (text != null ? !text.equals(that.text) : that.text != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlNamespace.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlNamespace.java
@@ -38,13 +38,21 @@ public class XmlNamespace {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         XmlNamespace that = (XmlNamespace) o;
 
-        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) { return false; }
-        if (uri != null ? !uri.equals(that.uri) : that.uri != null) { return false; }
+        if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
+            return false;
+        }
+        if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlProcessingInstruction.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlProcessingInstruction.java
@@ -38,13 +38,21 @@ public class XmlProcessingInstruction {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) { return true; }
-        if (o == null || getClass() != o.getClass()) { return false; }
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         XmlProcessingInstruction that = (XmlProcessingInstruction) o;
 
-        if (data != null ? !data.equals(that.data) : that.data != null) { return false; }
-        if (target != null ? !target.equals(that.target) : that.target != null) { return false; }
+        if (data != null ? !data.equals(that.data) : that.data != null) {
+            return false;
+        }
+        if (target != null ? !target.equals(that.target) : that.target != null) {
+            return false;
+        }
 
         return true;
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2DivSufSort.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2DivSufSort.java
@@ -568,7 +568,9 @@ final class Bzip2DivSufSort {
                     SA[i++] = SA[k];
                     SA[k++] = SA[i];
                     if (last <= k) {
-                        while (j < bufend) { SA[i++] = buf[j]; buf[j++] = SA[i]; }
+                        while (j < bufend) {
+                            SA[i++] = buf[j]; buf[j++] = SA[i];
+                        }
                         SA[i] = buf[j]; buf[j] = t;
                         return;
                     }

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -41,11 +41,11 @@ public class DefaultHeadersTest {
 
     private static final class TestDefaultHeaders extends
             DefaultHeaders<CharSequence, CharSequence, TestDefaultHeaders> {
-        public TestDefaultHeaders() {
+        TestDefaultHeaders() {
             this(CharSequenceValueConverter.INSTANCE);
         }
 
-        public TestDefaultHeaders(ValueConverter<CharSequence> converter) {
+        TestDefaultHeaders(ValueConverter<CharSequence> converter) {
             super(converter);
         }
     }

--- a/common/src/main/java/io/netty/util/CharsetUtil.java
+++ b/common/src/main/java/io/netty/util/CharsetUtil.java
@@ -65,7 +65,9 @@ public final class CharsetUtil {
     private static final Charset[] CHARSETS = new Charset[]
             { UTF_16, UTF_16BE, UTF_16LE, UTF_8, ISO_8859_1, US_ASCII };
 
-    public static Charset[] values() { return CHARSETS; }
+    public static Charset[] values() {
+        return CHARSETS;
+    }
 
     /**
      * @deprecated Use {@link #encoder(Charset)}.

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -498,8 +498,9 @@ public class ResourceLeakDetector<T> {
          */
         private static void reachabilityFence0(Object ref) {
             if (ref != null) {
-                // Empty synchronized is ok: https://stackoverflow.com/a/31933260/1151521
-                synchronized (ref) { }
+                synchronized (ref) {
+                    // Empty synchronized is ok: https://stackoverflow.com/a/31933260/1151521
+                }
             }
         }
 

--- a/example/src/main/java/io/netty/example/ocsp/OcspClientExample.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspClientExample.java
@@ -157,7 +157,7 @@ public class OcspClientExample {
 
         private final Promise<FullHttpResponse> promise;
 
-        public HttpClientHandler(String host, Promise<FullHttpResponse> promise) {
+        HttpClientHandler(String host, Promise<FullHttpResponse> promise) {
             this.host = host;
             this.promise = promise;
         }
@@ -203,7 +203,7 @@ public class OcspClientExample {
 
     private static class ExampleOcspClientHandler extends OcspClientHandler {
 
-        public ExampleOcspClientHandler(ReferenceCountedOpenSslEngine engine) {
+        ExampleOcspClientHandler(ReferenceCountedOpenSslEngine engine) {
             super(engine);
         }
 

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -431,7 +431,9 @@ public class ProxyHandlerTest {
 
     private final TestItem testItem;
 
-    public ProxyHandlerTest(TestItem testItem) { this.testItem = testItem; }
+    public ProxyHandlerTest(TestItem testItem) {
+        this.testItem = testItem;
+    }
 
     @Before
     public void clearServerExceptions() throws Exception {

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslJavaxX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslJavaxX509Certificate.java
@@ -32,7 +32,7 @@ final class OpenSslJavaxX509Certificate extends X509Certificate {
     private final byte[] bytes;
     private X509Certificate wrapped;
 
-    public OpenSslJavaxX509Certificate(byte[] bytes) {
+    OpenSslJavaxX509Certificate(byte[] bytes) {
         this.bytes = bytes;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509Certificate.java
@@ -41,7 +41,7 @@ final class OpenSslX509Certificate extends X509Certificate {
     private final byte[] bytes;
     private X509Certificate wrapped;
 
-    public OpenSslX509Certificate(byte[] bytes) {
+    OpenSslX509Certificate(byte[] bytes) {
         this.bytes = bytes;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/PemValue.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemValue.java
@@ -34,7 +34,7 @@ class PemValue extends AbstractReferenceCounted implements PemEncoded {
 
     private final boolean sensitive;
 
-    public PemValue(ByteBuf content, boolean sensitive) {
+    PemValue(ByteBuf content, boolean sensitive) {
         this.content = ObjectUtil.checkNotNull(content, "content");
         this.sensitive = sensitive;
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -542,7 +542,7 @@ public class SniHandlerTest {
     private static class CustomSslHandler extends SslHandler {
         private final SslContext sslContext;
 
-        public CustomSslHandler(SslContext sslContext, SSLEngine sslEngine) {
+        CustomSslHandler(SslContext sslContext, SSLEngine sslEngine) {
             super(sslEngine);
             this.sslContext = ObjectUtil.checkNotNull(sslContext, "sslContext");
         }

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -262,7 +262,7 @@ public class SslErrorTest {
     private static final class TestCertificateException extends CertificateException {
         private static final long serialVersionUID = -5816338303868751410L;
 
-        public TestCertificateException(Throwable cause) {
+        TestCertificateException(Throwable cause) {
             super(cause);
         }
     }

--- a/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
@@ -459,7 +459,7 @@ public class OcspTest {
 
         private volatile byte[] response;
 
-        public TestClientOcspContext(boolean valid) {
+        TestClientOcspContext(boolean valid) {
             this.valid = valid;
         }
 
@@ -481,7 +481,7 @@ public class OcspTest {
 
         private final OcspClientCallback callback;
 
-        public OcspClientCallbackHandler(ReferenceCountedOpenSslEngine engine, OcspClientCallback callback) {
+        OcspClientCallbackHandler(ReferenceCountedOpenSslEngine engine, OcspClientCallback callback) {
             super(engine);
             this.callback = callback;
         }
@@ -496,7 +496,7 @@ public class OcspTest {
     private static final class OcspTestException extends IllegalStateException {
         private static final long serialVersionUID = 4516426833250228159L;
 
-        public OcspTestException(String message) {
+        OcspTestException(String message) {
             super(message);
         }
     }

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
@@ -317,7 +317,7 @@ public class IdleStateHandlerTest {
 
         private long ticksInNanos;
 
-        public TestableIdleStateHandler(boolean observeOutput,
+        TestableIdleStateHandler(boolean observeOutput,
                 long readerIdleTime, long writerIdleTime, long allIdleTime,
                 TimeUnit unit) {
             super(observeOutput, readerIdleTime, writerIdleTime, allIdleTime, unit);
@@ -369,7 +369,7 @@ public class IdleStateHandlerTest {
 
     private static class ObservableChannel extends EmbeddedChannel {
 
-        public ObservableChannel(ChannelHandler... handlers) {
+        ObservableChannel(ChannelHandler... handlers) {
             super(handlers);
         }
 

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackBenchmarkUtil.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackBenchmarkUtil.java
@@ -49,7 +49,7 @@ public final class HpackBenchmarkUtil {
         final HpackHeadersSize size;
         final boolean limitToAscii;
 
-        public HeadersKey(HpackHeadersSize size, boolean limitToAscii) {
+        HeadersKey(HpackHeadersSize size, boolean limitToAscii) {
             this.size = size;
             this.limitToAscii = limitToAscii;
         }

--- a/microbench/src/main/java/io/netty/microbench/concurrent/BurstCostExecutorsBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/concurrent/BurstCostExecutorsBenchmark.java
@@ -67,7 +67,7 @@ public class BurstCostExecutorsBenchmark extends AbstractMicrobenchmark {
         private final AtomicBoolean poisoned = new AtomicBoolean();
         private final Thread executorThread;
 
-        public SpinExecutorService(int maxTasks) {
+        SpinExecutorService(int maxTasks) {
             tasks = PlatformDependent.newFixedMpscQueue(maxTasks);
             executorThread = new Thread(new Runnable() {
                 @Override

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
     <netty.dev.tools.directory>${project.build.directory}/dev-tools</netty.dev.tools.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <netty.build.version>22</netty.build.version>
+    <netty.build.version>23</netty.build.version>
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.8</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
@@ -830,7 +830,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.12.1</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>check-style</id>
@@ -844,7 +844,10 @@
               <failsOnError>true</failsOnError>
               <failOnViolation>true</failOnViolation>
               <configLocation>io/netty/checkstyle.xml</configLocation>
-              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <sourceDirectories>
+                <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+              </sourceDirectories>
             </configuration>
           </execution>
         </executions>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -161,7 +161,6 @@
                   <goal>generate</goal>
                   <goal>build</goal>
                 </goals>
-                <phase>compile</phase>
               </execution>
             </executions>
           </plugin>

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -388,7 +388,9 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
          */
         abstract void epollInReady();
 
-        final void epollInBefore() { maybeMoreDataToRead = false; }
+        final void epollInBefore() {
+            maybeMoreDataToRead = false;
+        }
 
         final void epollInFinally(ChannelConfig config) {
             maybeMoreDataToRead = allocHandle.maybeMoreDataToRead();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorStreamingHandle.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorStreamingHandle.java
@@ -18,7 +18,7 @@ package io.netty.channel.epoll;
 import io.netty.channel.RecvByteBufAllocator;
 
 final class EpollRecvByteAllocatorStreamingHandle extends EpollRecvByteAllocatorHandle {
-    public EpollRecvByteAllocatorStreamingHandle(RecvByteBufAllocator.ExtendedHandle handle) {
+    EpollRecvByteAllocatorStreamingHandle(RecvByteBufAllocator.ExtendedHandle handle) {
         super(handle);
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -40,7 +40,7 @@ final class LinuxSocket extends Socket {
     private static final ClosedChannelException SENDFILE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
             new ClosedChannelException(), Native.class, "sendfile(...)");
 
-    public LinuxSocket(int fd) {
+    LinuxSocket(int fd) {
         super(fd);
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -296,7 +296,7 @@ public class EpollSpliceTest {
         volatile ChannelFuture future;
         final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
 
-        public SpliceHandler(File file) {
+        SpliceHandler(File file) {
             this.file = file;
         }
 

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -90,7 +90,6 @@
                   <goal>generate</goal>
                   <goal>build</goal>
                 </goals>
-                <phase>compile</phase>
               </execution>
             </executions>
           </plugin>
@@ -198,7 +197,6 @@
                   <goal>generate</goal>
                   <goal>build</goal>
                 </goals>
-                <phase>compile</phase>
               </execution>
             </executions>
           </plugin>
@@ -305,7 +303,6 @@
                   <goal>generate</goal>
                   <goal>build</goal>
                 </goals>
-                <phase>compile</phase>
               </execution>
             </executions>
           </plugin>

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -392,7 +392,9 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
         abstract void readReady(KQueueRecvByteAllocatorHandle allocHandle);
 
-        final void readReadyBefore() { maybeMoreDataToRead = false; }
+        final void readReadyBefore() {
+            maybeMoreDataToRead = false;
+        }
 
         final void readReadyFinally(ChannelConfig config) {
             maybeMoreDataToRead = allocHandle.maybeMoreDataToRead();

--- a/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
@@ -95,7 +95,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
         private int nextReceiveBufferSize;
         private boolean decreaseNow;
 
-        public HandleImpl(int minIndex, int maxIndex, int initial) {
+        HandleImpl(int minIndex, int maxIndex, int initial) {
             this.minIndex = minIndex;
             this.maxIndex = maxIndex;
 

--- a/transport/src/main/java/io/netty/channel/FixedRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/FixedRecvByteBufAllocator.java
@@ -26,7 +26,7 @@ public class FixedRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllo
     private final class HandleImpl extends MaxMessageHandle {
         private final int bufferSize;
 
-        public HandleImpl(int bufferSize) {
+        HandleImpl(int bufferSize) {
             this.bufferSize = bufferSize;
         }
 

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -366,7 +366,7 @@ public class FixedChannelPool extends SimpleChannelPool {
         final long expireNanoTime = System.nanoTime() + acquireTimeoutNanos;
         ScheduledFuture<?> timeoutFuture;
 
-        public AcquireTask(Promise<Channel> promise) {
+        AcquireTask(Promise<Channel> promise) {
             super(promise);
             // We need to create a new promise as we need to ensure the AcquireListener runs in the correct
             // EventLoop.

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -96,7 +96,7 @@ public class AbstractChannelTest {
             public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) { }
         }
 
-        public TestChannel() {
+        TestChannel() {
             super(null);
         }
 

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
@@ -237,7 +237,7 @@ public class DefaultChannelPipelineTailTest {
     private static class MyChannelFactory implements ChannelFactory<MyChannel> {
         private final MyChannel channel;
 
-        public MyChannelFactory(MyChannel channel) {
+        MyChannelFactory(MyChannel channel) {
             this.channel = channel;
         }
 
@@ -365,7 +365,7 @@ public class DefaultChannelPipelineTailTest {
 
         private class MyChannelPipeline extends DefaultChannelPipeline {
 
-            public MyChannelPipeline(Channel channel) {
+            MyChannelPipeline(Channel channel) {
                 super(channel);
             }
 


### PR DESCRIPTION
Motivation:

We need to update to a new checkstyle plugin to allow the usage of lambdas.

Modifications:

- Update to new plugin version.
- Fix checkstyle problems.

Result:

Be able to use checkstyle plugin which supports new Java syntax.