### PR TITLE
migrate java8: use lambda  and method reference

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufProcessor.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufProcessor.java
@@ -28,109 +28,59 @@ public interface ByteBufProcessor extends ByteProcessor {
      * @deprecated Use {@link ByteProcessor#FIND_NUL}.
      */
     @Deprecated
-    ByteBufProcessor FIND_NUL = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value != 0;
-        }
-    };
+    ByteBufProcessor FIND_NUL = value -> value != 0;
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_NUL}.
      */
     @Deprecated
-    ByteBufProcessor FIND_NON_NUL = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value == 0;
-        }
-    };
+    ByteBufProcessor FIND_NON_NUL = value -> value == 0;
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_CR}.
      */
     @Deprecated
-    ByteBufProcessor FIND_CR = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value != '\r';
-        }
-    };
+    ByteBufProcessor FIND_CR = value -> value != '\r';
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_CR}.
      */
     @Deprecated
-    ByteBufProcessor FIND_NON_CR = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value == '\r';
-        }
-    };
+    ByteBufProcessor FIND_NON_CR = value -> value == '\r';
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_LF}.
      */
     @Deprecated
-    ByteBufProcessor FIND_LF = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value != '\n';
-        }
-    };
+    ByteBufProcessor FIND_LF = value -> value != '\n';
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_LF}.
      */
     @Deprecated
-    ByteBufProcessor FIND_NON_LF = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value == '\n';
-        }
-    };
+    ByteBufProcessor FIND_NON_LF = value -> value == '\n';
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_CRLF}.
      */
     @Deprecated
-    ByteBufProcessor FIND_CRLF = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value != '\r' && value != '\n';
-        }
-    };
+    ByteBufProcessor FIND_CRLF = value -> value != '\r' && value != '\n';
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_CRLF}.
      */
     @Deprecated
-    ByteBufProcessor FIND_NON_CRLF = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value == '\r' || value == '\n';
-        }
-    };
+    ByteBufProcessor FIND_NON_CRLF = value -> value == '\r' || value == '\n';
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_LINEAR_WHITESPACE}.
      */
     @Deprecated
-    ByteBufProcessor FIND_LINEAR_WHITESPACE = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value != ' ' && value != '\t';
-        }
-    };
+    ByteBufProcessor FIND_LINEAR_WHITESPACE = value -> value != ' ' && value != '\t';
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_LINEAR_WHITESPACE}.
      */
     @Deprecated
-    ByteBufProcessor FIND_NON_LINEAR_WHITESPACE = new ByteBufProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value == ' ' || value == '\t';
-        }
-    };
+    ByteBufProcessor FIND_NON_LINEAR_WHITESPACE = value -> value == ' ' || value == '\t';
 }

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -1254,12 +1254,7 @@ public final class ByteBufUtil {
     /**
      * Aborts on a byte which is not a valid ASCII character.
      */
-    private static final ByteProcessor FIND_NON_ASCII = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) {
-            return value >= 0;
-        }
-    };
+    private static final ByteProcessor FIND_NON_ASCII = value -> value >= 0;
 
     /**
      * Returns {@code true} if the specified {@link ByteBuf} starting at {@code index} with {@code length} is valid

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -680,16 +680,13 @@ public class ByteBufUtilTest {
             final AtomicReference<Throwable> errorRef = new AtomicReference<>();
             List<Thread> threads = new ArrayList<>();
             for (int i = 0; i < 10; i++) {
-                Thread thread = new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            while (errorRef.get() == null && counter.decrementAndGet() > 0) {
-                                assertTrue(ByteBufUtil.isText(buffer, CharsetUtil.ISO_8859_1));
-                            }
-                        } catch (Throwable cause) {
-                            errorRef.compareAndSet(null, cause);
+                Thread thread = new Thread(() -> {
+                    try {
+                        while (errorRef.get() == null && counter.decrementAndGet() > 0) {
+                            assertTrue(ByteBufUtil.isText(buffer, CharsetUtil.ISO_8859_1));
                         }
+                    } catch (Throwable cause) {
+                        errorRef.compareAndSet(null, cause);
                     }
                 });
                 threads.add(thread);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -57,24 +57,14 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
 
         private CsvValueEscaper<Object> objectEscaper() {
             if (objectEscaper == null) {
-                objectEscaper = new CsvValueEscaper<Object>() {
-                    @Override
-                    public CharSequence escape(Object value) {
-                        return StringUtil.escapeCsv(valueConverter().convertObject(value), true);
-                    }
-                };
+                objectEscaper = value -> StringUtil.escapeCsv(valueConverter().convertObject(value), true);
             }
             return objectEscaper;
         }
 
         private CsvValueEscaper<CharSequence> charSequenceEscaper() {
             if (charSequenceEscaper == null) {
-                charSequenceEscaper = new CsvValueEscaper<CharSequence>() {
-                    @Override
-                    public CharSequence escape(CharSequence value) {
-                        return StringUtil.escapeCsv(value, true);
-                    }
-                };
+                charSequenceEscaper = value -> StringUtil.escapeCsv(value, true);
             }
             return charSequenceEscaper;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
@@ -115,15 +115,12 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
     }
 
     private static final class TrailingHttpHeaders extends DefaultHttpHeaders {
-        private static final NameValidator<CharSequence> TrailerNameValidator = new NameValidator<CharSequence>() {
-            @Override
-            public void validateName(CharSequence name) {
-                DefaultHttpHeaders.HttpNameValidator.validateName(name);
-                if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
-                        || HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
-                        || HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name)) {
-                    throw new IllegalArgumentException("prohibited trailing header: " + name);
-                }
+        private static final NameValidator<CharSequence> TrailerNameValidator = name -> {
+            DefaultHttpHeaders.HttpNameValidator.validateName(name);
+            if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
+                    || HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
+                    || HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name)) {
+                throw new IllegalArgumentException("prohibited trailing header: " + name);
             }
         };
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -251,23 +251,17 @@ public class HttpObjectAggregator
             if (oversized instanceof FullHttpMessage ||
                 !HttpUtil.is100ContinueExpected(oversized) && !HttpUtil.isKeepAlive(oversized)) {
                 ChannelFuture future = ctx.writeAndFlush(TOO_LARGE_CLOSE.retainedDuplicate());
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            logger.debug("Failed to send a 413 Request Entity Too Large.", future.cause());
-                        }
-                        ctx.close();
+                future.addListener((ChannelFutureListener) future1 -> {
+                    if (!future1.isSuccess()) {
+                        logger.debug("Failed to send a 413 Request Entity Too Large.", future1.cause());
                     }
+                    ctx.close();
                 });
             } else {
-                ctx.writeAndFlush(TOO_LARGE.retainedDuplicate()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            logger.debug("Failed to send a 413 Request Entity Too Large.", future.cause());
-                            ctx.close();
-                        }
+                ctx.writeAndFlush(TOO_LARGE.retainedDuplicate()).addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        logger.debug("Failed to send a 413 Request Entity Too Large.", future.cause());
+                        ctx.close();
                     }
                 });
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -91,26 +91,23 @@ public final class ClientCookieEncoder extends CookieEncoder {
      * Sort cookies into decreasing order of path length, breaking ties by sorting into increasing chronological
      * order of creation time, as recommended by RFC 6265.
      */
-    private static final Comparator<Cookie> COOKIE_COMPARATOR = new Comparator<Cookie>() {
-        @Override
-        public int compare(Cookie c1, Cookie c2) {
-            String path1 = c1.path();
-            String path2 = c2.path();
-            // Cookies with unspecified path default to the path of the request. We don't
-            // know the request path here, but we assume that the length of an unspecified
-            // path is longer than any specified path (i.e. pathless cookies come first),
-            // because setting cookies with a path longer than the request path is of
-            // limited use.
-            int len1 = path1 == null ? Integer.MAX_VALUE : path1.length();
-            int len2 = path2 == null ? Integer.MAX_VALUE : path2.length();
-            int diff = len2 - len1;
-            if (diff != 0) {
-                return diff;
-            }
-            // Rely on Java's sort stability to retain creation order in cases where
-            // cookies have same path length.
-            return -1;
+    private static final Comparator<Cookie> COOKIE_COMPARATOR = (c1, c2) -> {
+        String path1 = c1.path();
+        String path2 = c2.path();
+        // Cookies with unspecified path default to the path of the request. We don't
+        // know the request path here, but we assume that the length of an unspecified
+        // path is longer than any specified path (i.e. pathless cookies come first),
+        // because setting cookies with a path longer than the request path is of
+        // limited use.
+        int len1 = path1 == null ? Integer.MAX_VALUE : path1.length();
+        int len2 = path2 == null ? Integer.MAX_VALUE : path2.length();
+        int diff = len2 - len1;
+        if (diff != 0) {
+            return diff;
         }
+        // Rely on Java's sort stability to retain creation order in cases where
+        // cookies have same path length.
+        return -1;
     };
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -174,26 +174,23 @@ public abstract class WebSocketClientHandshaker {
             }
         }
 
-        channel.writeAndFlush(request).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    ChannelPipeline p = future.channel().pipeline();
-                    ChannelHandlerContext ctx = p.context(HttpRequestEncoder.class);
-                    if (ctx == null) {
-                        ctx = p.context(HttpClientCodec.class);
-                    }
-                    if (ctx == null) {
-                        promise.setFailure(new IllegalStateException("ChannelPipeline does not contain " +
-                                "a HttpRequestEncoder or HttpClientCodec"));
-                        return;
-                    }
-                    p.addAfter(ctx.name(), "ws-encoder", newWebSocketEncoder());
-
-                    promise.setSuccess();
-                } else {
-                    promise.setFailure(future.cause());
+        channel.writeAndFlush(request).addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+                ChannelPipeline p = future.channel().pipeline();
+                ChannelHandlerContext ctx = p.context(HttpRequestEncoder.class);
+                if (ctx == null) {
+                    ctx = p.context(HttpClientCodec.class);
                 }
+                if (ctx == null) {
+                    promise.setFailure(new IllegalStateException("ChannelPipeline does not contain " +
+                            "a HttpRequestEncoder or HttpClientCodec"));
+                    return;
+                }
+                p.addAfter(ctx.name(), "ws-encoder", newWebSocketEncoder());
+
+                promise.setSuccess();
+            } else {
+                promise.setFailure(future.cause());
             }
         });
         return promise;
@@ -274,12 +271,7 @@ public abstract class WebSocketClientHandshaker {
             // Delay the removal of the decoder so the user can setup the pipeline if needed to handle
             // WebSocketFrame messages.
             // See https://github.com/netty/netty/issues/4533
-            channel.eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    p.remove(codec);
-                }
-            });
+            channel.eventLoop().execute(() -> p.remove(codec));
         } else {
             if (p.get(HttpRequestEncoder.class) != null) {
                 // Remove the encoder part of the codec as the user may start writing frames after this method returns.
@@ -291,12 +283,7 @@ public abstract class WebSocketClientHandshaker {
             // Delay the removal of the decoder so the user can setup the pipeline if needed to handle
             // WebSocketFrame messages.
             // See https://github.com/netty/netty/issues/4533
-            channel.eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    p.remove(context.handler());
-                }
-            });
+            channel.eventLoop().execute(() -> p.remove(context.handler()));
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -31,15 +31,12 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         super.channelActive(ctx);
-        handshaker.handshake(ctx.channel()).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                if (!future.isSuccess()) {
-                    ctx.fireExceptionCaught(future.cause());
-                } else {
-                    ctx.fireUserEventTriggered(
-                            WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_ISSUED);
-                }
+        handshaker.handshake(ctx.channel()).addListener((ChannelFutureListener) future -> {
+            if (!future.isSuccess()) {
+                ctx.fireExceptionCaught(future.cause());
+            } else {
+                ctx.fireUserEventTriggered(
+                        WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_ISSUED);
             }
         });
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -191,16 +191,13 @@ public abstract class WebSocketServerHandshaker {
             encoderName = p.context(HttpResponseEncoder.class).name();
             p.addBefore(encoderName, "wsencoder", newWebSocketEncoder());
         }
-        channel.writeAndFlush(response).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                if (future.isSuccess()) {
-                    ChannelPipeline p = future.channel().pipeline();
-                    p.remove(encoderName);
-                    promise.setSuccess();
-                } else {
-                    promise.setFailure(future.cause());
-                }
+        channel.writeAndFlush(response).addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+                ChannelPipeline p1 = future.channel().pipeline();
+                p1.remove(encoderName);
+                promise.setSuccess();
+            } else {
+                promise.setFailure(future.cause());
             }
         });
         return promise;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -81,19 +81,16 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
                 WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
             } else {
                 final ChannelFuture handshakeFuture = handshaker.handshake(ctx.channel(), req);
-                handshakeFuture.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            ctx.fireExceptionCaught(future.cause());
-                        } else {
-                            // Kept for compatibility
-                            ctx.fireUserEventTriggered(
-                                    WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE);
-                            ctx.fireUserEventTriggered(
-                                    new WebSocketServerProtocolHandler.HandshakeComplete(
-                                            req.uri(), req.headers(), handshaker.selectedSubprotocol()));
-                        }
+                handshakeFuture.addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        ctx.fireExceptionCaught(future.cause());
+                    } else {
+                        // Kept for compatibility
+                        ctx.fireUserEventTriggered(
+                                WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE);
+                        ctx.fireUserEventTriggered(
+                                new WebSocketServerProtocolHandler.HandshakeComplete(
+                                        req.uri(), req.headers(), handshaker.selectedSubprotocol()));
                     }
                 });
                 WebSocketServerProtocolHandler.setHandshaker(ctx.channel(), handshaker);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -115,20 +115,17 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
                         extensionData.name(), extensionData.parameters());
             }
 
-            promise.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    if (future.isSuccess()) {
-                        for (WebSocketServerExtension extension : validExtensions) {
-                            WebSocketExtensionDecoder decoder = extension.newExtensionDecoder();
-                            WebSocketExtensionEncoder encoder = extension.newExtensionEncoder();
-                            ctx.pipeline().addAfter(ctx.name(), decoder.getClass().getName(), decoder);
-                            ctx.pipeline().addAfter(ctx.name(), encoder.getClass().getName(), encoder);
-                        }
+            promise.addListener((ChannelFutureListener) future -> {
+                if (future.isSuccess()) {
+                    for (WebSocketServerExtension extension : validExtensions) {
+                        WebSocketExtensionDecoder decoder = extension.newExtensionDecoder();
+                        WebSocketExtensionEncoder encoder = extension.newExtensionEncoder();
+                        ctx.pipeline().addAfter(ctx.name(), decoder.getClass().getName(), decoder);
+                        ctx.pipeline().addAfter(ctx.name(), encoder.getClass().getName(), encoder);
                     }
-
-                    ctx.pipeline().remove(ctx.name());
                 }
+
+                ctx.pipeline().remove(ctx.name());
             });
 
             if (headerValue != null) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
@@ -27,12 +27,7 @@ import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 
 public class DefaultSpdyHeaders extends DefaultHeaders<CharSequence, CharSequence, SpdyHeaders> implements SpdyHeaders {
-    private static final NameValidator<CharSequence> SpdyNameValidator = new NameValidator<CharSequence>() {
-        @Override
-        public void validateName(CharSequence name) {
-            SpdyCodecUtil.validateHeaderName(name);
-        }
-    };
+    private static final NameValidator<CharSequence> SpdyNameValidator = SpdyCodecUtil::validateHeaderName;
 
     public DefaultSpdyHeaders() {
         this(true);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -109,12 +109,9 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         super.handlerAdded(ctx);
         this.ctx = ctx;
-        ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                spdyHeaderBlockDecoder.end();
-                spdyHeaderBlockEncoder.end();
-            }
+        ctx.channel().closeFuture().addListener((ChannelFutureListener) future -> {
+            spdyHeaderBlockDecoder.end();
+            spdyHeaderBlockEncoder.end();
         });
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -504,12 +504,9 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 final ChannelHandlerContext context = ctx;
-                ctx.write(partialDataFrame).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.write(partialDataFrame).addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
                 return;
@@ -521,12 +518,9 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 final ChannelHandlerContext context = ctx;
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                promise.addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             }
@@ -781,12 +775,9 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
 
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
-                ctx.writeAndFlush(partialDataFrame).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.writeAndFlush(partialDataFrame).addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             } else {
@@ -802,12 +793,9 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
 
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
-                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise).addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -147,22 +147,16 @@ public class HttpClientCodecTest {
                             sChannel.writeAndFlush(Unpooled.wrappedBuffer(("HTTP/1.0 200 OK\r\n" +
                             "Date: Fri, 31 Dec 1999 23:59:59 GMT\r\n" +
                             "Content-Type: text/html\r\n\r\n").getBytes(CharsetUtil.ISO_8859_1)))
-                                    .addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture future) throws Exception {
-                                    assertTrue(future.isSuccess());
-                                    sChannel.writeAndFlush(Unpooled.wrappedBuffer(
-                                            "<html><body>hello half closed!</body></html>\r\n"
-                                            .getBytes(CharsetUtil.ISO_8859_1)))
-                                            .addListener(new ChannelFutureListener() {
-                                        @Override
-                                        public void operationComplete(ChannelFuture future) throws Exception {
-                                            assertTrue(future.isSuccess());
-                                            sChannel.shutdownOutput();
-                                        }
+                                    .addListener((ChannelFutureListener) future -> {
+                                        assertTrue(future.isSuccess());
+                                        sChannel.writeAndFlush(Unpooled.wrappedBuffer(
+                                                "<html><body>hello half closed!</body></html>\r\n"
+                                                .getBytes(CharsetUtil.ISO_8859_1)))
+                                                .addListener((ChannelFutureListener) future1 -> {
+                                                    assertTrue(future1.isSuccess());
+                                                    sChannel.shutdownOutput();
+                                                });
                                     });
-                                }
-                            });
                         }
                     });
                     serverChannelLatch.countDown();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -186,12 +186,7 @@ public class CorsHandlerTest {
     @Test
     public void preflightRequestWithValueGenerator() {
         final CorsConfig config = forOrigin("http://localhost:8888")
-                .preflightResponseHeader("GenHeader", new Callable<String>() {
-                    @Override
-                    public String call() throws Exception {
-                        return "generatedValue";
-                    }
-                }).build();
+                .preflightResponseHeader("GenHeader", () -> "generatedValue").build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
         assertThat(response.headers().get(of("GenHeader")), equalTo("generatedValue"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -277,14 +277,11 @@ public class DefaultHttp2Connection implements Http2Connection {
 
     private void closeStreamsGreaterThanLastKnownStreamId(final int lastKnownStream,
                                                           final DefaultEndpoint<?> endpoint) throws Http2Exception {
-        forEachActiveStream(new Http2StreamVisitor() {
-            @Override
-            public boolean visit(Http2Stream stream) {
-                if (stream.id() > lastKnownStream && endpoint.isValidStreamId(stream.id())) {
-                    stream.close();
-                }
-                return true;
+        forEachActiveStream(stream -> {
+            if (stream.id() > lastKnownStream && endpoint.isValidStreamId(stream.id())) {
+                stream.close();
             }
+            return true;
         });
     }
 
@@ -942,12 +939,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             if (allowModifications()) {
                 addToActiveStreams(stream);
             } else {
-                pendingEvents.add(new Event() {
-                    @Override
-                    public void process() {
-                        addToActiveStreams(stream);
-                    }
-                });
+                pendingEvents.add(() -> addToActiveStreams(stream));
             }
         }
 
@@ -955,12 +947,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             if (allowModifications() || itr != null) {
                 removeFromActiveStreams(stream, itr);
             } else {
-                pendingEvents.add(new Event() {
-                    @Override
-                    public void process() {
-                        removeFromActiveStreams(stream, itr);
-                    }
-                });
+                pendingEvents.add(() -> removeFromActiveStreams(stream, itr));
             }
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -463,13 +463,10 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
     }
 
     private void notifyLifecycleManagerOnError(ChannelFuture future, final ChannelHandlerContext ctx) {
-        future.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                Throwable cause = future.cause();
-                if (cause != null) {
-                    lifecycleManager.onError(ctx, true, cause);
-                }
+        future.addListener((ChannelFutureListener) future1 -> {
+            Throwable cause = future1.cause();
+            if (cause != null) {
+                lifecycleManager.onError(ctx, true, cause);
             }
         });
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -641,12 +641,9 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
 
             final int delta = newWindowSize - initialWindowSize;
             initialWindowSize = newWindowSize;
-            connection.forEachActiveStream(new Http2StreamVisitor() {
-                @Override
-                public boolean visit(Http2Stream stream) throws Http2Exception {
-                    state(stream).incrementStreamWindow(delta);
-                    return true;
-                }
+            connection.forEachActiveStream(stream -> {
+                state(stream).incrementStreamWindow(delta);
+                return true;
             });
 
             if (delta > 0 && isChannelWritable()) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -606,12 +606,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (future.isDone()) {
             checkCloseConnection(future);
         } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    checkCloseConnection(future);
-                }
-            });
+            future.addListener((ChannelFutureListener) this::checkCloseConnection);
         }
     }
 
@@ -750,12 +745,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (future.isDone()) {
             closeConnectionOnError(ctx, future);
         } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    closeConnectionOnError(ctx, future);
-                }
-            });
+            future.addListener((ChannelFutureListener) future1 -> closeConnectionOnError(ctx, future1));
         }
         return future;
     }
@@ -795,12 +785,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (future.isDone()) {
             processRstStreamWriteResult(ctx, stream, future);
         } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    processRstStreamWriteResult(ctx, stream, future);
-                }
-            });
+            future.addListener((ChannelFutureListener) future1 -> processRstStreamWriteResult(ctx, stream, future1));
         }
 
         return future;
@@ -831,12 +816,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (future.isDone()) {
             processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
         } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
-                }
-            });
+            future.addListener((ChannelFutureListener) future1 ->
+                    processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future1));
         }
 
         return future;
@@ -938,11 +919,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                                      long timeout, TimeUnit unit) {
             this.ctx = ctx;
             this.promise = promise;
-            timeoutTask = ctx.executor().schedule(new Runnable() {
-                @Override
-                public void run() {
-                    ctx.close(promise);
-                }
+            timeoutTask = ctx.executor().schedule(() -> {
+                ctx.close(promise);
             }, timeout, unit);
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -183,15 +183,12 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
     final void forEachActiveStream(final Http2FrameStreamVisitor streamVisitor) throws Http2Exception {
         assert ctx.executor().inEventLoop();
 
-        connection().forEachActiveStream(new Http2StreamVisitor() {
-            @Override
-            public boolean visit(Http2Stream stream) {
-                try {
-                    return streamVisitor.visit((Http2FrameStream) stream.getProperty(streamKey));
-                } catch (Throwable cause) {
-                    onError(ctx, false, cause);
-                    return false;
-                }
+        connection().forEachActiveStream(stream -> {
+            try {
+                return streamVisitor.visit((Http2FrameStream) stream.getProperty(streamKey));
+            } catch (Throwable cause) {
+                onError(ctx, false, cause);
+                return false;
             }
         });
     }
@@ -381,13 +378,10 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
             } else {
                 numBufferedStreams++;
 
-                writePromise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        numBufferedStreams--;
+                writePromise.addListener((ChannelFutureListener) future -> {
+                    numBufferedStreams--;
 
-                        notifyHeaderWritePromise(future, promise);
-                    }
+                    notifyHeaderWritePromise(future, promise);
                 });
             }
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
@@ -90,20 +90,10 @@ public interface Http2HeadersEncoder {
     /**
      * Always return {@code false} for {@link SensitivityDetector#isSensitive(CharSequence, CharSequence)}.
      */
-    SensitivityDetector NEVER_SENSITIVE = new SensitivityDetector() {
-        @Override
-        public boolean isSensitive(CharSequence name, CharSequence value) {
-            return false;
-        }
-    };
+    SensitivityDetector NEVER_SENSITIVE = (name, value) -> false;
 
     /**
      * Always return {@code true} for {@link SensitivityDetector#isSensitive(CharSequence, CharSequence)}.
      */
-    SensitivityDetector ALWAYS_SENSITIVE = new SensitivityDetector() {
-        @Override
-        public boolean isSensitive(CharSequence name, CharSequence value) {
-            return true;
-        }
-    };
+    SensitivityDetector ALWAYS_SENSITIVE = (name, value) -> true;
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/AbstractWeightedFairQueueByteDistributorDependencyTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/AbstractWeightedFairQueueByteDistributorDependencyTest.java
@@ -35,21 +35,18 @@ abstract class AbstractWeightedFairQueueByteDistributorDependencyTest {
     }
 
     Answer<Void> writeAnswer(final boolean closeIfNoFrame) {
-        return new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                Http2Stream stream = in.getArgument(0);
-                int numBytes = in.getArgument(1);
-                TestStreamByteDistributorStreamState state = stateMap.get(stream.id());
-                state.pendingBytes -= numBytes;
-                state.hasFrame = state.pendingBytes > 0;
-                state.isWriteAllowed = state.hasFrame;
-                if (closeIfNoFrame && !state.hasFrame) {
-                    stream.close();
-                }
-                distributor.updateStreamableBytes(state);
-                return null;
+        return in -> {
+            Http2Stream stream = in.getArgument(0);
+            int numBytes = in.getArgument(1);
+            TestStreamByteDistributorStreamState state = stateMap.get(stream.id());
+            state.pendingBytes -= numBytes;
+            state.hasFrame = state.pendingBytes > 0;
+            state.isWriteAllowed = state.hasFrame;
+            if (closeIfNoFrame && !state.hasFrame) {
+                stream.close();
             }
+            distributor.updateStreamableBytes(state);
+            return null;
         };
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -63,12 +63,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
         http2ConnectionHandler = new Http2ConnectionHandlerBuilder()
                 .frameListener(frameListener).build();
 
-        UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
-            @Override
-            public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
-                return new Http2ServerUpgradeCodec(http2ConnectionHandler);
-            }
-        };
+        UpgradeCodecFactory upgradeCodecFactory = protocol -> new Http2ServerUpgradeCodec(http2ConnectionHandler);
 
         userEvents = new ArrayList<>();
 
@@ -205,12 +200,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
             protected void initChannel(Channel ch) throws Exception {
             }
         }).build();
-        UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
-            @Override
-            public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
-                return new Http2ServerUpgradeCodec(http2Codec);
-            }
-        };
+        UpgradeCodecFactory upgradeCodecFactory = protocol -> new Http2ServerUpgradeCodec(http2Codec);
         http2ConnectionHandler = http2Codec;
 
         userEvents = new ArrayList<>();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -127,82 +127,55 @@ public class DefaultHttp2ConnectionEncoderTest {
         when(channel.unsafe()).thenReturn(unsafe);
         ChannelConfig config = new DefaultChannelConfig(channel);
         when(channel.config()).thenReturn(config);
-        doAnswer(new Answer<ChannelFuture>() {
-            @Override
-            public ChannelFuture answer(InvocationOnMock in) {
-                return newPromise().setFailure((Throwable) in.getArgument(0));
-            }
-        }).when(channel).newFailedFuture(any(Throwable.class));
+        doAnswer(in -> newPromise()
+                .setFailure((Throwable) in.getArgument(0))).when(channel).newFailedFuture(any(Throwable.class));
 
         when(writer.configuration()).thenReturn(writerConfig);
         when(writerConfig.frameSizePolicy()).thenReturn(frameSizePolicy);
         when(frameSizePolicy.maxFrameSize()).thenReturn(64);
-        doAnswer(new Answer<ChannelFuture>() {
-            @Override
-            public ChannelFuture answer(InvocationOnMock in) throws Throwable {
-                return ((ChannelPromise) in.getArguments()[2]).setSuccess();
-            }
-        }).when(writer).writeSettings(eq(ctx), any(Http2Settings.class), any(ChannelPromise.class));
-        doAnswer(new Answer<ChannelFuture>() {
-            @Override
-            public ChannelFuture answer(InvocationOnMock in) throws Throwable {
-                ((ByteBuf) in.getArguments()[3]).release();
-                return ((ChannelPromise) in.getArguments()[4]).setSuccess();
-            }
+        doAnswer((Answer<ChannelFuture>) in -> ((ChannelPromise) in.getArguments()[2])
+                .setSuccess()).when(writer).writeSettings(eq(ctx), any(Http2Settings.class), any(ChannelPromise.class));
+        doAnswer((Answer<ChannelFuture>) in -> {
+            ((ByteBuf) in.getArguments()[3]).release();
+            return ((ChannelPromise) in.getArguments()[4]).setSuccess();
         }).when(writer).writeGoAway(eq(ctx), anyInt(), anyInt(), any(ByteBuf.class), any(ChannelPromise.class));
         writtenData = new ArrayList<>();
         writtenPadding = new ArrayList<>();
         when(writer.writeData(eq(ctx), anyInt(), any(ByteBuf.class), anyInt(), anyBoolean(),
-                any(ChannelPromise.class))).then(new Answer<ChannelFuture>() {
-                    @Override
-                    public ChannelFuture answer(InvocationOnMock in) throws Throwable {
-                        // Make sure we only receive stream closure on the last frame and that void promises
-                        // are used for all writes except the last one.
-                        ChannelPromise promise = (ChannelPromise) in.getArguments()[5];
-                        if (streamClosed) {
-                            fail("Stream already closed");
-                        } else {
-                            streamClosed = (Boolean) in.getArguments()[4];
-                        }
-                        writtenPadding.add((Integer) in.getArguments()[3]);
-                        ByteBuf data = (ByteBuf) in.getArguments()[2];
-                        writtenData.add(data.toString(UTF_8));
-                        // Release the buffer just as DefaultHttp2FrameWriter does
-                        data.release();
-                        // Let the promise succeed to trigger listeners.
-                        return promise.setSuccess();
+                any(ChannelPromise.class))).then((Answer<ChannelFuture>) in -> {
+                    // Make sure we only receive stream closure on the last frame and that void promises
+                    // are used for all writes except the last one.
+                    ChannelPromise promise = (ChannelPromise) in.getArguments()[5];
+                    if (streamClosed) {
+                        fail("Stream already closed");
+                    } else {
+                        streamClosed = (Boolean) in.getArguments()[4];
                     }
+                    writtenPadding.add((Integer) in.getArguments()[3]);
+                    ByteBuf data = (ByteBuf) in.getArguments()[2];
+                    writtenData.add(data.toString(UTF_8));
+                    // Release the buffer just as DefaultHttp2FrameWriter does
+                    data.release();
+                    // Let the promise succeed to trigger listeners.
+                    return promise.setSuccess();
                 });
         when(writer.writeHeaders(eq(ctx), anyInt(), any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(),
                 anyInt(), anyBoolean(), any(ChannelPromise.class)))
-                .then(new Answer<ChannelFuture>() {
-                    @Override
-                    public ChannelFuture answer(InvocationOnMock invocationOnMock) throws Throwable {
-                        ChannelPromise promise = (ChannelPromise) invocationOnMock.getArguments()[8];
-                        if (streamClosed) {
-                            fail("Stream already closed");
-                        } else {
-                            streamClosed = (Boolean) invocationOnMock.getArguments()[5];
-                        }
-                        return promise.setSuccess();
+                .then((Answer<ChannelFuture>) invocationOnMock -> {
+                    ChannelPromise promise = (ChannelPromise) invocationOnMock.getArguments()[8];
+                    if (streamClosed) {
+                        fail("Stream already closed");
+                    } else {
+                        streamClosed = (Boolean) invocationOnMock.getArguments()[5];
                     }
+                    return promise.setSuccess();
                 });
         payloadCaptor = ArgumentCaptor.forClass(Http2RemoteFlowController.FlowControlled.class);
         doNothing().when(remoteFlow).addFlowControlled(any(Http2Stream.class), payloadCaptor.capture());
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(ctx.channel()).thenReturn(channel);
-        doAnswer(new Answer<ChannelPromise>() {
-            @Override
-            public ChannelPromise answer(InvocationOnMock in) throws Throwable {
-                return newPromise();
-            }
-        }).when(ctx).newPromise();
-        doAnswer(new Answer<ChannelFuture>() {
-            @Override
-            public ChannelFuture answer(InvocationOnMock in) throws Throwable {
-                return newSucceededFuture();
-            }
-        }).when(ctx).newSucceededFuture();
+        doAnswer((Answer<ChannelPromise>) in -> newPromise()).when(ctx).newPromise();
+        doAnswer((Answer<ChannelFuture>) in -> newSucceededFuture()).when(ctx).newSucceededFuture();
         when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
         when(channel.alloc()).thenReturn(PooledByteBufAllocator.DEFAULT);
 
@@ -337,13 +310,10 @@ public class DefaultHttp2ConnectionEncoderTest {
         final Throwable cause = new RuntimeException("fake exception");
         when(writer.writeHeaders(eq(ctx), eq(STREAM_ID), any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(),
                                  anyInt(), anyBoolean(), any(ChannelPromise.class)))
-                .then(new Answer<ChannelFuture>() {
-                    @Override
-                    public ChannelFuture answer(InvocationOnMock invocationOnMock) throws Throwable {
-                        ChannelPromise promise = invocationOnMock.getArgument(8);
-                        assertFalse(promise.isVoid());
-                        return promise.setFailure(cause);
-                    }
+                .then((Answer<ChannelFuture>) invocationOnMock -> {
+                    ChannelPromise promise = invocationOnMock.getArgument(8);
+                    assertFalse(promise.isVoid());
+                    return promise.setFailure(cause);
                 });
         createStream(STREAM_ID, false);
         // END_STREAM flag, so that a listener is added to the future.
@@ -754,12 +724,9 @@ public class DefaultHttp2ConnectionEncoderTest {
         // Fake an encoding error, like HPACK's HeaderListSizeException
         when(writer.writeHeaders(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE), eq(0),
                 eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(true), eq(promise)))
-            .thenAnswer(new Answer<ChannelFuture>() {
-                @Override
-                public ChannelFuture answer(InvocationOnMock invocation) {
-                    promise.setFailure(ex);
-                    return promise;
-                }
+            .thenAnswer((Answer<ChannelFuture>) invocation -> {
+                promise.setFailure(ex);
+                return promise;
             });
 
         writeAllFlowControlledFrames();
@@ -781,12 +748,9 @@ public class DefaultHttp2ConnectionEncoderTest {
         // Fake an encoding error, like HPACK's HeaderListSizeException
         when(writer.writeHeaders(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE), eq(0),
             eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(true), eq(promise)))
-            .thenAnswer(new Answer<ChannelFuture>() {
-                @Override
-                public ChannelFuture answer(InvocationOnMock invocation) {
-                    promise.setFailure(ex);
-                    return promise;
-                }
+            .thenAnswer((Answer<ChannelFuture>) invocation -> {
+                promise.setFailure(ex);
+                return promise;
             });
 
         writeAllFlowControlledFrames();
@@ -873,14 +837,11 @@ public class DefaultHttp2ConnectionEncoderTest {
     }
 
     private void writeAllFlowControlledFrames() {
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
-                FlowControlled flowControlled = (FlowControlled) invocationOnMock.getArguments()[1];
-                flowControlled.write(ctx, Integer.MAX_VALUE);
-                flowControlled.writeComplete();
-                return null;
-            }
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            FlowControlled flowControlled = (FlowControlled) invocationOnMock.getArguments()[1];
+            flowControlled.write(ctx, Integer.MAX_VALUE);
+            flowControlled.writeComplete();
+            return null;
         }).when(remoteFlow).addFlowControlled(any(Http2Stream.class), payloadCaptor.capture());
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -77,16 +77,13 @@ public class DefaultHttp2FrameWriterTest {
 
         http2HeadersEncoder = new DefaultHttp2HeadersEncoder();
 
-        Answer<Object> answer = new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock var1) throws Throwable {
-                Object msg = var1.getArgument(0);
-                if (msg instanceof ByteBuf) {
-                    outbound.writeBytes((ByteBuf) msg);
-                }
-                ReferenceCountUtil.release(msg);
-                return future;
+        Answer<Object> answer = var1 -> {
+            Object msg = var1.getArgument(0);
+            if (msg instanceof ByteBuf) {
+                outbound.writeBytes((ByteBuf) msg);
             }
+            ReferenceCountUtil.release(msg);
+            return future;
         };
         when(ctx.write(any())).then(answer);
         when(ctx.write(any(), any(ChannelPromise.class))).then(answer);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -691,12 +691,9 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     public void flowControlledWriteThrowsAnException() throws Exception {
         final Http2RemoteFlowController.FlowControlled flowControlled = mockedFlowControlledThatThrowsOnWrite();
         final Http2Stream stream = stream(STREAM_A);
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocationOnMock) {
-                stream.closeLocalSide();
-                return null;
-            }
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            stream.closeLocalSide();
+            return null;
         }).when(flowControlled).error(any(ChannelHandlerContext.class), any(Throwable.class));
 
         int windowBefore = window(STREAM_A);
@@ -724,11 +721,8 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         final Http2RemoteFlowController.FlowControlled flowControlled = mockedFlowControlledThatThrowsOnWrite();
         final Http2Stream stream = stream(STREAM_A);
         final RuntimeException fakeException = new RuntimeException("error failed");
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocationOnMock) {
-                throw fakeException;
-            }
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            throw fakeException;
         }).when(flowControlled).error(any(ChannelHandlerContext.class), any(Throwable.class));
 
         int windowBefore = window(STREAM_A);
@@ -757,26 +751,15 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
                 mock(Http2RemoteFlowController.FlowControlled.class);
         Http2Stream streamA = stream(STREAM_A);
         final AtomicInteger size = new AtomicInteger(150);
-        doAnswer(new Answer<Integer>() {
-            @Override
-            public Integer answer(InvocationOnMock invocationOnMock) throws Throwable {
-                return size.get();
-            }
-        }).when(flowControlled).size();
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
-                size.addAndGet(-50);
-                return null;
-            }
+        doAnswer((Answer<Integer>) invocationOnMock -> size.get()).when(flowControlled).size();
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            size.addAndGet(-50);
+            return null;
         }).when(flowControlled).write(any(ChannelHandlerContext.class), anyInt());
 
         final Http2Stream stream = stream(STREAM_A);
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocationOnMock) {
-                throw new RuntimeException("writeComplete failed");
-            }
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            throw new RuntimeException("writeComplete failed");
         }).when(flowControlled).writeComplete();
 
         int windowBefore = window(STREAM_A);
@@ -807,12 +790,9 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         when(flowControlled.size()).thenReturn(100);
         doThrow(new RuntimeException("write failed"))
             .when(flowControlled).write(any(ChannelHandlerContext.class), anyInt());
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocationOnMock) {
-                stream.close();
-                return null;
-            }
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            stream.close();
+            return null;
         }).when(flowControlled).error(any(ChannelHandlerContext.class), any(Throwable.class));
 
         controller.addFlowControlled(stream, flowControlled);
@@ -960,13 +940,10 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         final Http2RemoteFlowController.FlowControlled flowControlled =
                 mock(Http2RemoteFlowController.FlowControlled.class);
         when(flowControlled.size()).thenReturn(100);
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                // Write most of the bytes and then fail
-                when(flowControlled.size()).thenReturn(10);
-                throw new RuntimeException("Write failed");
-            }
+        doAnswer((Answer<Void>) in -> {
+            // Write most of the bytes and then fail
+            when(flowControlled.size()).thenReturn(10);
+            throw new RuntimeException("Write failed");
         }).when(flowControlled).write(any(ChannelHandlerContext.class), anyInt());
         return flowControlled;
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HashCollisionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HashCollisionTest.java
@@ -51,28 +51,20 @@ public final class HashCollisionTest {
         // More "english words" can be found here:
         // https://gist.github.com/Scottmitch/de2f03912778016ecee3c140478f07e0#file-englishwords-txt
 
-        Map<Integer, List<CharSequence>> dups = calculateDuplicates(strings, new Function<CharSequence, Integer>() {
-            @Override
-            public Integer apply(CharSequence string) {
-                int h = 0;
-                for (int i = 0; i < string.length(); ++i) {
-                    // masking with 0x1F reduces the number of overall bits that impact the hash code but makes the hash
-                    // code the same regardless of character case (upper case or lower case hash is the same).
-                    h = h * 31 + (string.charAt(i) & 0x1F);
-                }
-                return h;
+        Map<Integer, List<CharSequence>> dups = calculateDuplicates(strings, string -> {
+            int h = 0;
+            for (int i = 0; i < string.length(); ++i) {
+                // masking with 0x1F reduces the number of overall bits that impact the hash code but makes the hash
+                // code the same regardless of character case (upper case or lower case hash is the same).
+                h = h * 31 + (string.charAt(i) & 0x1F);
             }
+            return h;
         });
         PrintStream writer = System.out;
         writer.println("==Old Duplicates==");
         printResults(writer, dups);
 
-        dups = calculateDuplicates(strings, new Function<CharSequence, Integer>() {
-            @Override
-            public Integer apply(CharSequence string) {
-                return PlatformDependent.hashCodeAscii(string);
-            }
-        });
+        dups = calculateDuplicates(strings, PlatformDependent::hashCodeAscii);
         writer.println();
         writer.println("==New Duplicates==");
         printResults(writer, dups);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
@@ -180,12 +180,7 @@ final class HpackTestCase {
     private static byte[] encode(HpackEncoder hpackEncoder, List<HpackHeaderField> headers, int maxHeaderTableSize,
                                  final boolean sensitive) throws Http2Exception {
         Http2Headers http2Headers = toHttp2Headers(headers);
-        Http2HeadersEncoder.SensitivityDetector sensitivityDetector = new Http2HeadersEncoder.SensitivityDetector() {
-            @Override
-            public boolean isSensitive(CharSequence name, CharSequence value) {
-                return sensitive;
-            }
-        };
+        Http2HeadersEncoder.SensitivityDetector sensitivityDetector = (name, value) -> sensitive;
         ByteBuf buffer = Unpooled.buffer();
         try {
             if (maxHeaderTableSize != -1) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -573,15 +573,12 @@ public class Http2FrameCodecTest {
         final Promise<Void> listenerExecuted = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
 
         channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), false).stream(stream))
-               .addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        assertTrue(future.isSuccess());
-                        assertTrue(isStreamIdValid(stream.id()));
-                        listenerExecuted.setSuccess(null);
-                    }
-                }
-        );
+               .addListener((ChannelFutureListener) future -> {
+                   assertTrue(future.isSuccess());
+                   assertTrue(isStreamIdValid(stream.id()));
+                   listenerExecuted.setSuccess(null);
+               }
+               );
         ByteBuf data = Unpooled.buffer().writeZero(100);
         ChannelFuture f = channel.writeAndFlush(new DefaultHttp2DataFrame(data).stream(stream));
         assertTrue(f.isSuccess());
@@ -735,12 +732,9 @@ public class Http2FrameCodecTest {
         Http2FrameStream idleStream = frameCodec.newStream();
 
         final Set<Http2FrameStream> activeStreams = new HashSet<>();
-        frameCodec.forEachActiveStream(new Http2FrameStreamVisitor() {
-            @Override
-            public boolean visit(Http2FrameStream stream) {
-                activeStreams.add(stream);
-                return true;
-            }
+        frameCodec.forEachActiveStream(stream -> {
+            activeStreams.add(stream);
+            return true;
         });
 
         assertEquals(2, activeStreams.size());
@@ -758,13 +752,10 @@ public class Http2FrameCodecTest {
 
         final AtomicBoolean listenerExecuted = new AtomicBoolean();
         channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()).stream(stream2))
-                .addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        assertTrue(future.isSuccess());
-                        assertEquals(State.OPEN, stream2.state());
-                        listenerExecuted.set(true);
-                    }
+                .addListener((ChannelFutureListener) future -> {
+                    assertTrue(future.isSuccess());
+                    assertEquals(State.OPEN, stream2.state());
+                    listenerExecuted.set(true);
                 });
 
         assertTrue(listenerExecuted.get());
@@ -795,15 +786,12 @@ public class Http2FrameCodecTest {
                     // Simulate consuming the frame and update the flow-controller.
                     Http2DataFrame data = (Http2DataFrame) msg;
                     ctx.writeAndFlush(new DefaultHttp2WindowUpdateFrame(data.initialFlowControlledBytes())
-                            .stream(data.stream())).addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            Throwable cause = future.cause();
-                            if (cause != null) {
-                                ctx.fireExceptionCaught(cause);
-                            }
-                        }
-                    });
+                            .stream(data.stream())).addListener((ChannelFutureListener) future -> {
+                                Throwable cause = future.cause();
+                                if (cause != null) {
+                                    ctx.fireExceptionCaught(cause);
+                                }
+                            });
                 }
                 ReferenceCountUtil.release(msg);
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -97,24 +97,10 @@ public class Http2FrameRoundtripTest {
         when(ctx.alloc()).thenReturn(alloc);
         when(ctx.executor()).thenReturn(executor);
         when(ctx.channel()).thenReturn(channel);
-        doAnswer(new Answer<ByteBuf>() {
-            @Override
-            public ByteBuf answer(InvocationOnMock in) throws Throwable {
-                return Unpooled.buffer();
-            }
-        }).when(alloc).buffer();
-        doAnswer(new Answer<ByteBuf>() {
-            @Override
-            public ByteBuf answer(InvocationOnMock in) throws Throwable {
-                return Unpooled.buffer((Integer) in.getArguments()[0]);
-            }
-        }).when(alloc).buffer(anyInt());
-        doAnswer(new Answer<ChannelPromise>() {
-            @Override
-            public ChannelPromise answer(InvocationOnMock invocation) throws Throwable {
-                return new DefaultChannelPromise(channel, GlobalEventExecutor.INSTANCE);
-            }
-        }).when(ctx).newPromise();
+        doAnswer((Answer<ByteBuf>) in -> Unpooled.buffer()).when(alloc).buffer();
+        doAnswer((Answer<ByteBuf>) in -> Unpooled.buffer((Integer) in.getArguments()[0])).when(alloc).buffer(anyInt());
+        doAnswer((Answer<ChannelPromise>) invocation ->
+                new DefaultChannelPromise(channel, GlobalEventExecutor.INSTANCE)).when(ctx).newPromise();
 
         writer = new DefaultHttp2FrameWriter(new DefaultHttp2HeadersEncoder(NEVER_SENSITIVE, newTestEncoder()));
         reader = new DefaultHttp2FrameReader(new DefaultHttp2HeadersDecoder(false, newTestDecoder()));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -337,12 +337,9 @@ public class HttpToHttp2ConnectionHandlerTest {
     public void testRequestWithBody() throws Exception {
         final String text = "foooooogoooo";
         final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<>());
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
-                return null;
-            }
+        doAnswer((Answer<Void>) in -> {
+            receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
+            return null;
         }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3),
                 any(ByteBuf.class), eq(0), eq(true));
         bootstrapEnv(3, 1, 0);
@@ -380,12 +377,9 @@ public class HttpToHttp2ConnectionHandlerTest {
     public void testRequestWithBodyAndTrailingHeaders() throws Exception {
         final String text = "foooooogoooo";
         final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<>());
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
-                return null;
-            }
+        doAnswer((Answer<Void>) in -> {
+            receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
+            return null;
         }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3),
                 any(ByteBuf.class), eq(0), eq(false));
         bootstrapEnv(4, 1, 1);
@@ -432,12 +426,9 @@ public class HttpToHttp2ConnectionHandlerTest {
         final String text = "foooooo";
         final String text2 = "goooo";
         final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<>());
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
-                return null;
-            }
+        doAnswer((Answer<Void>) in -> {
+            receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
+            return null;
         }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3),
                 any(ByteBuf.class), eq(0), eq(false));
         bootstrapEnv(4, 1, 1);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -148,12 +148,9 @@ public class InboundHttp2ToHttpAdapterTest {
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).
                     scheme(new AsciiString("https")).authority(new AsciiString("example.org"))
                     .path(new AsciiString("/some/path/resource2"));
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -184,12 +181,9 @@ public class InboundHttp2ToHttpAdapterTest {
                     .add(HttpHeaderNames.COOKIE, "a=b")
                     .add(HttpHeaderNames.COOKIE, "c=d")
                     .add(HttpHeaderNames.COOKIE, "e=f");
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -219,12 +213,9 @@ public class InboundHttp2ToHttpAdapterTest {
                     .path(new AsciiString("/some/path/resource2"))
                     .add(HttpHeaderNames.COOKIE, "a=b; c=d")
                     .add(HttpHeaderNames.COOKIE, "e=f");
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -246,12 +237,9 @@ public class InboundHttp2ToHttpAdapterTest {
                 .path(new AsciiString("/some/path/resource2"))
                 .add(new AsciiString("çã".getBytes(CharsetUtil.UTF_8)),
                         new AsciiString("Ãã".getBytes(CharsetUtil.UTF_8)));
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() throws Http2Exception {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
-                clientChannel.flush();
-            }
+        runInChannel(clientChannel, () -> {
+            clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+            clientChannel.flush();
         });
         awaitResponses();
         assertTrue(isStreamError(clientException));
@@ -271,14 +259,11 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setShort(HttpConversionUtil.ExtensionHeaderNames.STREAM_WEIGHT.text(), (short) 16);
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).path(
                     new AsciiString("/some/path/resource2"));
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
-                                                      newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
+                                                  newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -305,17 +290,14 @@ public class InboundHttp2ToHttpAdapterTest {
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).path(
                     new AsciiString("/some/path/resource2"));
             final int midPoint = text.length() / 2;
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(
-                            ctxClient(), 3, content.retainedSlice(0, midPoint), 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(
-                            ctxClient(), 3, content.retainedSlice(midPoint, text.length() - midPoint),
-                            0, true, newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientHandler.encoder().writeData(
+                        ctxClient(), 3, content.retainedSlice(0, midPoint), 0, false, newPromiseClient());
+                clientHandler.encoder().writeData(
+                        ctxClient(), 3, content.retainedSlice(midPoint, text.length() - midPoint),
+                        0, true, newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -341,15 +323,12 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setShort(HttpConversionUtil.ExtensionHeaderNames.STREAM_WEIGHT.text(), (short) 16);
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).path(
                     new AsciiString("/some/path/resource2"));
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, true, newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, true, newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -383,15 +362,12 @@ public class InboundHttp2ToHttpAdapterTest {
                     .set(new AsciiString("foo"), new AsciiString("goo"))
                     .set(new AsciiString("foo2"), new AsciiString("goo2"))
                     .add(new AsciiString("foo2"), new AsciiString("goo3"));
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, false,
-                                                      newPromiseClient());
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers2, 0, true, newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, false,
+                                                  newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers2, 0, true, newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -428,19 +404,16 @@ public class InboundHttp2ToHttpAdapterTest {
                     new AsciiString("/some/path/resource"));
             final Http2Headers http2Headers2 = new DefaultHttp2Headers().method(new AsciiString("PUT")).path(
                     new AsciiString("/some/path/resource2"));
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeHeaders(ctxClient(), 5, http2Headers2, 3, (short) 123, true, 0,
-                            false, newPromiseClient());
-                    clientChannel.flush(); // Headers are queued in the flow controller and so flush them.
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
-                                                      newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 5, content2.retainedDuplicate(), 0, true,
-                                                      newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 5, http2Headers2, 3, (short) 123, true, 0,
+                        false, newPromiseClient());
+                clientChannel.flush(); // Headers are queued in the flow controller and so flush them.
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
+                                                  newPromiseClient());
+                clientHandler.encoder().writeData(ctxClient(), 5, content2.retainedDuplicate(), 0, true,
+                                                  newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> httpObjectCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -485,12 +458,9 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setShort(HttpConversionUtil.ExtensionHeaderNames.STREAM_WEIGHT.text(), (short) 16);
             final Http2Headers http2Headers3 = new DefaultHttp2Headers().method(new AsciiString("GET"))
                     .path(new AsciiString("/push/test"));
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers3, 0, true, newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers3, 0, true, newPromiseClient());
+                clientChannel.flush();
             });
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -507,17 +477,14 @@ public class InboundHttp2ToHttpAdapterTest {
             final Http2Headers http2Headers2 = new DefaultHttp2Headers()
                     .scheme(new AsciiString("https"))
                     .authority(new AsciiString("example.org"));
-            runInChannel(serverConnectedChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    serverHandler.encoder().writeHeaders(ctxServer(), 3, http2Headers, 0, false, newPromiseServer());
-                    serverHandler.encoder().writePushPromise(ctxServer(), 3, 2, http2Headers2, 0, newPromiseServer());
-                    serverHandler.encoder().writeData(ctxServer(), 3, content.retainedDuplicate(), 0, true,
-                                                      newPromiseServer());
-                    serverHandler.encoder().writeData(ctxServer(), 5, content2.retainedDuplicate(), 0, true,
-                                                      newPromiseServer());
-                    serverConnectedChannel.flush();
-                }
+            runInChannel(serverConnectedChannel, () -> {
+                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2Headers, 0, false, newPromiseServer());
+                serverHandler.encoder().writePushPromise(ctxServer(), 3, 2, http2Headers2, 0, newPromiseServer());
+                serverHandler.encoder().writeData(ctxServer(), 3, content.retainedDuplicate(), 0, true,
+                                                  newPromiseServer());
+                serverHandler.encoder().writeData(ctxServer(), 5, content2.retainedDuplicate(), 0, true,
+                                                  newPromiseServer());
+                serverConnectedChannel.flush();
             });
             awaitResponses();
             ArgumentCaptor<FullHttpMessage> responseCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
@@ -553,12 +520,9 @@ public class InboundHttp2ToHttpAdapterTest {
         final FullHttpMessage response2 = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
 
         try {
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientChannel.flush();
             });
 
             awaitRequests();
@@ -566,26 +530,20 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3);
             httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
             final Http2Headers http2HeadersResponse = new DefaultHttp2Headers().status(new AsciiString("100"));
-            runInChannel(serverConnectedChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    serverHandler.encoder().writeHeaders(ctxServer(), 3, http2HeadersResponse, 0, false,
-                                                         newPromiseServer());
-                    serverConnectedChannel.flush();
-                }
+            runInChannel(serverConnectedChannel, () -> {
+                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2HeadersResponse, 0, false,
+                                                     newPromiseServer());
+                serverConnectedChannel.flush();
             });
 
             awaitResponses();
             httpHeaders = request2.headers();
             httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, text.length());
             httpHeaders.remove(HttpHeaderNames.EXPECT);
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() {
-                    clientHandler.encoder().writeData(ctxClient(), 3, payload.retainedDuplicate(), 0, true,
-                                                      newPromiseClient());
-                    clientChannel.flush();
-                }
+            runInChannel(clientChannel, () -> {
+                clientHandler.encoder().writeData(ctxClient(), 3, payload.retainedDuplicate(), 0, true,
+                                                  newPromiseClient());
+                clientChannel.flush();
             });
 
             awaitRequests2();
@@ -595,13 +553,10 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setShort(HttpConversionUtil.ExtensionHeaderNames.STREAM_WEIGHT.text(), (short) 16);
 
             final Http2Headers http2HeadersResponse2 = new DefaultHttp2Headers().status(new AsciiString("200"));
-            runInChannel(serverConnectedChannel, new Http2Runnable() {
-                @Override
-                public void run() throws Http2Exception {
-                    serverHandler.encoder().writeHeaders(ctxServer(), 3, http2HeadersResponse2, 0, true,
-                                                         newPromiseServer());
-                    serverConnectedChannel.flush();
-                }
+            runInChannel(serverConnectedChannel, () -> {
+                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2HeadersResponse2, 0, true,
+                                                     newPromiseServer());
+                serverConnectedChannel.flush();
             });
 
             awaitResponses2();
@@ -633,12 +588,9 @@ public class InboundHttp2ToHttpAdapterTest {
     public void propagateSettings() throws Exception {
         boostrapEnv(1, 1, 2);
         final Http2Settings settings = new Http2Settings().pushEnabled(true);
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                clientHandler.encoder().writeSettings(ctxClient(), settings, newPromiseClient());
-                clientChannel.flush();
-            }
+        runInChannel(clientChannel, () -> {
+            clientHandler.encoder().writeSettings(ctxClient(), settings, newPromiseClient());
+            clientChannel.flush();
         });
         assertTrue(settingsLatch.await(5, SECONDS));
         ArgumentCaptor<Http2Settings> settingsCaptor = ArgumentCaptor.forClass(Http2Settings.class);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
@@ -46,10 +46,7 @@ public class LastInboundHandler extends ChannelDuplexHandler {
         void accept(T obj);
     }
 
-    private static final Consumer<Object> NOOP_CONSUMER = new Consumer<Object>() {
-        @Override
-        public void accept(Object obj) {
-        }
+    private static final Consumer<Object> NOOP_CONSUMER = obj -> {
     };
 
     @SuppressWarnings("unchecked")

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -130,12 +130,7 @@ public class StreamBufferingEncoderTest {
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(executor.inEventLoop()).thenReturn(true);
-        doAnswer(new Answer<ChannelPromise>() {
-            @Override
-            public ChannelPromise answer(InvocationOnMock invocation) throws Throwable {
-                return newPromise();
-            }
-        }).when(ctx).newPromise();
+        doAnswer((Answer<ChannelPromise>) invocation -> newPromise()).when(ctx).newPromise();
         when(ctx.executor()).thenReturn(executor);
         when(channel.isActive()).thenReturn(false);
         when(channel.config()).thenReturn(config);
@@ -519,17 +514,14 @@ public class StreamBufferingEncoderTest {
     }
 
     private Answer<ChannelFuture> successAnswer() {
-        return new Answer<ChannelFuture>() {
-            @Override
-            public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
-                for (Object a : invocation.getArguments()) {
-                    ReferenceCountUtil.safeRelease(a);
-                }
-
-                ChannelPromise future = newPromise();
-                future.setSuccess();
-                return future;
+        return invocation -> {
+            for (Object a : invocation.getArguments()) {
+                ReferenceCountUtil.safeRelease(a);
             }
+
+            ChannelPromise future = newPromise();
+            future.setSuccess();
+            return future;
         };
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/UniformStreamByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/UniformStreamByteDistributorTest.java
@@ -83,17 +83,14 @@ public class UniformStreamByteDistributorTest {
     }
 
     private Answer<Void> writeAnswer() {
-        return new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                Http2Stream stream = in.getArgument(0);
-                int numBytes = in.getArgument(1);
-                TestStreamByteDistributorStreamState state = stateMap.get(stream.id());
-                state.pendingBytes -= numBytes;
-                state.hasFrame = state.pendingBytes > 0;
-                distributor.updateStreamableBytes(state);
-                return null;
-            }
+        return in -> {
+            Http2Stream stream = in.getArgument(0);
+            int numBytes = in.getArgument(1);
+            TestStreamByteDistributorStreamState state = stateMap.get(stream.id());
+            state.pendingBytes -= numBytes;
+            state.hasFrame = state.pendingBytes > 0;
+            distributor.updateStreamableBytes(state);
+            return null;
         };
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorDependencyTreeTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorDependencyTreeTest.java
@@ -79,13 +79,10 @@ public class WeightedFairQueueByteDistributorDependencyTreeTest extends
         final Http2Stream streamB = connection.local().createStream(5, false);
         final Http2Stream streamC = connection.local().createStream(7, false);
         setPriority(streamB.id(), streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
-        connection.forEachActiveStream(new Http2StreamVisitor() {
-            @Override
-            public boolean visit(Http2Stream stream) throws Http2Exception {
-                streamA.close();
-                setPriority(streamB.id(), streamC.id(), DEFAULT_PRIORITY_WEIGHT, false);
-                return true;
-            }
+        connection.forEachActiveStream(stream -> {
+            streamA.close();
+            setPriority(streamB.id(), streamC.id(), DEFAULT_PRIORITY_WEIGHT, false);
+            return true;
         });
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressEncoder.java
@@ -29,33 +29,30 @@ import io.netty.util.NetUtil;
  */
 public interface Socks5AddressEncoder {
 
-    Socks5AddressEncoder DEFAULT = new Socks5AddressEncoder() {
-        @Override
-        public void encodeAddress(Socks5AddressType addrType, String addrValue, ByteBuf out) throws Exception {
-            final byte typeVal = addrType.byteValue();
-            if (typeVal == Socks5AddressType.IPv4.byteValue()) {
-                if (addrValue != null) {
-                    out.writeBytes(NetUtil.createByteArrayFromIpAddressString(addrValue));
-                } else {
-                    out.writeInt(0);
-                }
-            } else if (typeVal == Socks5AddressType.DOMAIN.byteValue()) {
-                if (addrValue != null) {
-                    out.writeByte(addrValue.length());
-                    out.writeCharSequence(addrValue, CharsetUtil.US_ASCII);
-                } else {
-                    out.writeByte(0);
-                }
-            } else if (typeVal == Socks5AddressType.IPv6.byteValue()) {
-                if (addrValue != null) {
-                    out.writeBytes(NetUtil.createByteArrayFromIpAddressString(addrValue));
-                } else {
-                    out.writeLong(0);
-                    out.writeLong(0);
-                }
+    Socks5AddressEncoder DEFAULT = (addrType, addrValue, out) -> {
+        final byte typeVal = addrType.byteValue();
+        if (typeVal == Socks5AddressType.IPv4.byteValue()) {
+            if (addrValue != null) {
+                out.writeBytes(NetUtil.createByteArrayFromIpAddressString(addrValue));
             } else {
-                throw new EncoderException("unsupported addrType: " + (addrType.byteValue() & 0xFF));
+                out.writeInt(0);
             }
+        } else if (typeVal == Socks5AddressType.DOMAIN.byteValue()) {
+            if (addrValue != null) {
+                out.writeByte(addrValue.length());
+                out.writeCharSequence(addrValue, CharsetUtil.US_ASCII);
+            } else {
+                out.writeByte(0);
+            }
+        } else if (typeVal == Socks5AddressType.IPv6.byteValue()) {
+            if (addrValue != null) {
+                out.writeBytes(NetUtil.createByteArrayFromIpAddressString(addrValue));
+            } else {
+                out.writeLong(0);
+                out.writeLong(0);
+            }
+        } else {
+            throw new EncoderException("unsupported addrType: " + (addrType.byteValue() & 0xFF));
         }
     };
 

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -72,31 +72,28 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     /**
      * Cumulate {@link ByteBuf}s by merge them into one {@link ByteBuf}'s, using memory copies.
      */
-    public static final Cumulator MERGE_CUMULATOR = new Cumulator() {
-        @Override
-        public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
-            try {
-                final ByteBuf buffer;
-                if (cumulation.writerIndex() > cumulation.maxCapacity() - in.readableBytes()
-                    || cumulation.refCnt() > 1 || cumulation.isReadOnly()) {
-                    // Expand cumulation (by replace it) when either there is not more room in the buffer
-                    // or if the refCnt is greater then 1 which may happen when the user use slice().retain() or
-                    // duplicate().retain() or if its read-only.
-                    //
-                    // See:
-                    // - https://github.com/netty/netty/issues/2327
-                    // - https://github.com/netty/netty/issues/1764
-                    buffer = expandCumulation(alloc, cumulation, in.readableBytes());
-                } else {
-                    buffer = cumulation;
-                }
-                buffer.writeBytes(in);
-                return buffer;
-            } finally {
-                // We must release in in all cases as otherwise it may produce a leak if writeBytes(...) throw
-                // for whatever release (for example because of OutOfMemoryError)
-                in.release();
+    public static final Cumulator MERGE_CUMULATOR = (alloc, cumulation, in) -> {
+        try {
+            final ByteBuf buffer;
+            if (cumulation.writerIndex() > cumulation.maxCapacity() - in.readableBytes()
+                || cumulation.refCnt() > 1 || cumulation.isReadOnly()) {
+                // Expand cumulation (by replace it) when either there is not more room in the buffer
+                // or if the refCnt is greater then 1 which may happen when the user use slice().retain() or
+                // duplicate().retain() or if its read-only.
+                //
+                // See:
+                // - https://github.com/netty/netty/issues/2327
+                // - https://github.com/netty/netty/issues/1764
+                buffer = expandCumulation(alloc, cumulation, in.readableBytes());
+            } else {
+                buffer = cumulation;
             }
+            buffer.writeBytes(in);
+            return buffer;
+        } finally {
+            // We must release in in all cases as otherwise it may produce a leak if writeBytes(...) throw
+            // for whatever release (for example because of OutOfMemoryError)
+            in.release();
         }
     };
 
@@ -105,39 +102,36 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
      * Be aware that {@link CompositeByteBuf} use a more complex indexing implementation so depending on your use-case
      * and the decoder implementation this may be slower then just use the {@link #MERGE_CUMULATOR}.
      */
-    public static final Cumulator COMPOSITE_CUMULATOR = new Cumulator() {
-        @Override
-        public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
-            ByteBuf buffer;
-            try {
-                if (cumulation.refCnt() > 1) {
-                    // Expand cumulation (by replace it) when the refCnt is greater then 1 which may happen when the
-                    // user use slice().retain() or duplicate().retain().
-                    //
-                    // See:
-                    // - https://github.com/netty/netty/issues/2327
-                    // - https://github.com/netty/netty/issues/1764
-                    buffer = expandCumulation(alloc, cumulation, in.readableBytes());
-                    buffer.writeBytes(in);
+    public static final Cumulator COMPOSITE_CUMULATOR = (alloc, cumulation, in) -> {
+        ByteBuf buffer;
+        try {
+            if (cumulation.refCnt() > 1) {
+                // Expand cumulation (by replace it) when the refCnt is greater then 1 which may happen when the
+                // user use slice().retain() or duplicate().retain().
+                //
+                // See:
+                // - https://github.com/netty/netty/issues/2327
+                // - https://github.com/netty/netty/issues/1764
+                buffer = expandCumulation(alloc, cumulation, in.readableBytes());
+                buffer.writeBytes(in);
+            } else {
+                CompositeByteBuf composite;
+                if (cumulation instanceof CompositeByteBuf) {
+                    composite = (CompositeByteBuf) cumulation;
                 } else {
-                    CompositeByteBuf composite;
-                    if (cumulation instanceof CompositeByteBuf) {
-                        composite = (CompositeByteBuf) cumulation;
-                    } else {
-                        composite = alloc.compositeBuffer(Integer.MAX_VALUE);
-                        composite.addComponent(true, cumulation);
-                    }
-                    composite.addComponent(true, in);
-                    in = null;
-                    buffer = composite;
+                    composite = alloc.compositeBuffer(Integer.MAX_VALUE);
+                    composite.addComponent(true, cumulation);
                 }
-                return buffer;
-            } finally {
-                if (in != null) {
-                    // We must release if the ownership was not transferred as otherwise it may produce a leak if
-                    // writeBytes(...) throw for whatever release (for example because of OutOfMemoryError).
-                    in.release();
-                }
+                composite.addComponent(true, in);
+                in = null;
+                buffer = composite;
+            }
+            return buffer;
+        } finally {
+            if (in != null) {
+                // We must release if the ownership was not transferred as otherwise it may produce a leak if
+                // writeBytes(...) throw for whatever release (for example because of OutOfMemoryError).
+                in.release();
             }
         }
     };

--- a/codec/src/main/java/io/netty/handler/codec/CodecOutputList.java
+++ b/codec/src/main/java/io/netty/handler/codec/CodecOutputList.java
@@ -28,11 +28,8 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  */
 final class CodecOutputList extends AbstractList<Object> implements RandomAccess {
 
-    private static final CodecOutputListRecycler NOOP_RECYCLER = new CodecOutputListRecycler() {
-        @Override
-        public void recycle(CodecOutputList object) {
-            // drop on the floor and let the GC handle it.
-        }
+    private static final CodecOutputListRecycler NOOP_RECYCLER = object -> {
+        // drop on the floor and let the GC handle it.
     };
 
     private static final FastThreadLocal<CodecOutputLists> CODEC_OUTPUT_LISTS_POOL =

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -64,12 +64,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         void validateName(K name);
 
         @SuppressWarnings("rawtypes")
-        NameValidator NOT_NULL = new NameValidator() {
-            @Override
-            public void validateName(Object name) {
-                checkNotNull(name, "name");
-            }
-        };
+        NameValidator NOT_NULL = name -> checkNotNull(name, "name");
     }
 
     @SuppressWarnings("unchecked")

--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -210,12 +210,9 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
                 // Cache the write listener for reuse.
                 ChannelFutureListener listener = continueResponseWriteListener;
                 if (listener == null) {
-                    continueResponseWriteListener = listener = new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            if (!future.isSuccess()) {
-                                ctx.fireExceptionCaught(future.cause());
-                            }
+                    continueResponseWriteListener = listener = future -> {
+                        if (!future.isSuccess()) {
+                            ctx.fireExceptionCaught(future.cause());
                         }
                     };
                 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ByteBufChecksum.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ByteBufChecksum.java
@@ -43,12 +43,9 @@ abstract class ByteBufChecksum implements Checksum {
         CRC32_UPDATE_METHOD = updateByteBuffer(new CRC32());
     }
 
-    private final ByteProcessor updateProcessor = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            update(value);
-            return true;
-        }
+    private final ByteProcessor updateProcessor = value -> {
+        update(value);
+        return true;
     };
 
     private static Method updateByteBuffer(Checksum checksum) {

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BlockCompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BlockCompressor.java
@@ -33,12 +33,7 @@ import static io.netty.handler.codec.compression.Bzip2Constants.*;
  * 7. Huffman encode and write data - {@link #close(ByteBuf)} (through {@link Bzip2HuffmanStageEncoder})
  */
 final class Bzip2BlockCompressor {
-    private final ByteProcessor writeProcessor = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return write(value);
-        }
-    };
+    private final ByteProcessor writeProcessor = this::write;
 
     /**
      * A writer that provides bit-level writes.

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -252,12 +252,9 @@ public class JZlibEncoder extends ZlibEncoder {
             return finishEncode(ctx, promise);
         } else {
             final ChannelPromise p = ctx.newPromise();
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    ChannelFuture f = finishEncode(ctx(), p);
-                    f.addListener(new ChannelPromiseNotifier(promise));
-                }
+            executor.execute(() -> {
+                ChannelFuture f = finishEncode(ctx(), p);
+                f.addListener(new ChannelPromiseNotifier(promise));
             });
             return p;
         }
@@ -342,20 +339,12 @@ public class JZlibEncoder extends ZlibEncoder {
             final ChannelHandlerContext ctx,
             final ChannelPromise promise) {
         ChannelFuture f = finishEncode(ctx, ctx.newPromise());
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture f) throws Exception {
-                ctx.close(promise);
-            }
-        });
+        f.addListener((ChannelFutureListener) f1 -> ctx.close(promise));
 
         if (!f.isDone()) {
             // Ensure the channel is closed even if the write operation completes in time.
-            ctx.executor().schedule(new Runnable() {
-                @Override
-                public void run() {
-                    ctx.close(promise);
-                }
+            ctx.executor().schedule(() -> {
+                ctx.close(promise);
             }, 10, TimeUnit.SECONDS); // FIXME: Magic number
         }
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -364,12 +364,9 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
         if (executor.inEventLoop()) {
             return finishEncode(ctx, promise);
         } else {
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    ChannelFuture f = finishEncode(ctx(), promise);
-                    f.addListener(new ChannelPromiseNotifier(promise));
-                }
+            executor.execute(() -> {
+                ChannelFuture f = finishEncode(ctx(), promise);
+                f.addListener(new ChannelPromiseNotifier(promise));
             });
             return promise;
         }
@@ -378,20 +375,12 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
     @Override
     public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
         ChannelFuture f = finishEncode(ctx, ctx.newPromise());
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture f) throws Exception {
-                ctx.close(promise);
-            }
-        });
+        f.addListener((ChannelFutureListener) f1 -> ctx.close(promise));
 
         if (!f.isDone()) {
             // Ensure the channel is closed even if the write operation completes in time.
-            ctx.executor().schedule(new Runnable() {
-                @Override
-                public void run() {
-                    ctx.close(promise);
-                }
+            ctx.executor().schedule(() -> {
+                ctx.close(promise);
             }, 10, TimeUnit.SECONDS); // FIXME: Magic number
         }
     }

--- a/common/src/main/java/io/netty/util/BooleanSupplier.java
+++ b/common/src/main/java/io/netty/util/BooleanSupplier.java
@@ -29,20 +29,10 @@ public interface BooleanSupplier {
     /**
      * A supplier which always returns {@code false} and never throws.
      */
-    BooleanSupplier FALSE_SUPPLIER = new BooleanSupplier() {
-        @Override
-        public boolean get() {
-            return false;
-        }
-    };
+    BooleanSupplier FALSE_SUPPLIER = () -> false;
 
     /**
      * A supplier which always returns {@code true} and never throws.
      */
-    BooleanSupplier TRUE_SUPPLIER = new BooleanSupplier() {
-        @Override
-        public boolean get() {
-            return true;
-        }
-    };
+    BooleanSupplier TRUE_SUPPLIER = () -> true;
 }

--- a/common/src/main/java/io/netty/util/ByteProcessor.java
+++ b/common/src/main/java/io/netty/util/ByteProcessor.java
@@ -103,42 +103,22 @@ public interface ByteProcessor {
     /**
      * Aborts on a {@code CR ('\r')} or a {@code LF ('\n')}.
      */
-    ByteProcessor FIND_CRLF = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) {
-            return value != CARRIAGE_RETURN && value != LINE_FEED;
-        }
-    };
+    ByteProcessor FIND_CRLF = value -> value != CARRIAGE_RETURN && value != LINE_FEED;
 
     /**
      * Aborts on a byte which is neither a {@code CR ('\r')} nor a {@code LF ('\n')}.
      */
-    ByteProcessor FIND_NON_CRLF = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) {
-            return value == CARRIAGE_RETURN || value == LINE_FEED;
-        }
-    };
+    ByteProcessor FIND_NON_CRLF = value -> value == CARRIAGE_RETURN || value == LINE_FEED;
 
     /**
      * Aborts on a linear whitespace (a ({@code ' '} or a {@code '\t'}).
      */
-    ByteProcessor FIND_LINEAR_WHITESPACE = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) {
-            return value != SPACE && value != HTAB;
-        }
-    };
+    ByteProcessor FIND_LINEAR_WHITESPACE = value -> value != SPACE && value != HTAB;
 
     /**
      * Aborts on a byte which is not a linear whitespace (neither {@code ' '} nor {@code '\t'}).
      */
-    ByteProcessor FIND_NON_LINEAR_WHITESPACE = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) {
-            return value == SPACE || value == HTAB;
-        }
-    };
+    ByteProcessor FIND_NON_LINEAR_WHITESPACE = value -> value == SPACE || value == HTAB;
 
     /**
      * @return {@code true} if the processor wants to continue the loop and handle the next byte in the buffer.

--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -250,59 +250,56 @@ public final class NetUtil {
         // As a SecurityManager may prevent reading the somaxconn file we wrap this in a privileged block.
         //
         // See https://github.com/netty/netty/issues/3680
-        SOMAXCONN = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-            @Override
-            public Integer run() {
-                // Determine the default somaxconn (server socket backlog) value of the platform.
-                // The known defaults:
-                // - Windows NT Server 4.0+: 200
-                // - Linux and Mac OS X: 128
-                int somaxconn = PlatformDependent.isWindows() ? 200 : 128;
-                File file = new File("/proc/sys/net/core/somaxconn");
-                BufferedReader in = null;
-                try {
-                    // file.exists() may throw a SecurityException if a SecurityManager is used, so execute it in the
-                    // try / catch block.
-                    // See https://github.com/netty/netty/issues/4936
-                    if (file.exists()) {
-                        in = new BufferedReader(new FileReader(file));
-                        somaxconn = Integer.parseInt(in.readLine());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("{}: {}", file, somaxconn);
-                        }
-                    } else {
-                        // Try to get from sysctl
-                        Integer tmp = null;
-                        if (SystemPropertyUtil.getBoolean("io.netty.net.somaxconn.trySysctl", false)) {
-                            tmp = sysctlGetInt("kern.ipc.somaxconn");
-                            if (tmp == null) {
-                                tmp = sysctlGetInt("kern.ipc.soacceptqueue");
-                                if (tmp != null) {
-                                    somaxconn = tmp;
-                                }
-                            } else {
+        SOMAXCONN = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
+            // Determine the default somaxconn (server socket backlog) value of the platform.
+            // The known defaults:
+            // - Windows NT Server 4.0+: 200
+            // - Linux and Mac OS X: 128
+            int somaxconn = PlatformDependent.isWindows() ? 200 : 128;
+            File file = new File("/proc/sys/net/core/somaxconn");
+            BufferedReader in = null;
+            try {
+                // file.exists() may throw a SecurityException if a SecurityManager is used, so execute it in the
+                // try / catch block.
+                // See https://github.com/netty/netty/issues/4936
+                if (file.exists()) {
+                    in = new BufferedReader(new FileReader(file));
+                    somaxconn = Integer.parseInt(in.readLine());
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("{}: {}", file, somaxconn);
+                    }
+                } else {
+                    // Try to get from sysctl
+                    Integer tmp = null;
+                    if (SystemPropertyUtil.getBoolean("io.netty.net.somaxconn.trySysctl", false)) {
+                        tmp = sysctlGetInt("kern.ipc.somaxconn");
+                        if (tmp == null) {
+                            tmp = sysctlGetInt("kern.ipc.soacceptqueue");
+                            if (tmp != null) {
                                 somaxconn = tmp;
                             }
-                        }
-
-                        if (tmp == null) {
-                            logger.debug("Failed to get SOMAXCONN from sysctl and file {}. Default: {}", file,
-                                         somaxconn);
+                        } else {
+                            somaxconn = tmp;
                         }
                     }
-                } catch (Exception e) {
-                    logger.debug("Failed to get SOMAXCONN from sysctl and file {}. Default: {}", file, somaxconn, e);
-                } finally {
-                    if (in != null) {
-                        try {
-                            in.close();
-                        } catch (Exception e) {
-                            // Ignored.
-                        }
+
+                    if (tmp == null) {
+                        logger.debug("Failed to get SOMAXCONN from sysctl and file {}. Default: {}", file,
+                                     somaxconn);
                     }
                 }
-                return somaxconn;
+            } catch (Exception e) {
+                logger.debug("Failed to get SOMAXCONN from sysctl and file {}. Default: {}", file, somaxconn, e);
+            } finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    } catch (Exception e) {
+                        // Ignored.
+                    }
+                }
             }
+            return somaxconn;
         });
     }
 

--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -41,11 +41,8 @@ public abstract class Recycler<T> {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Recycler.class);
 
     @SuppressWarnings("rawtypes")
-    private static final Handle NOOP_HANDLE = new Handle() {
-        @Override
-        public void recycle(Object object) {
-            // NOOP
-        }
+    private static final Handle NOOP_HANDLE = object -> {
+        // NOOP
     };
     private static final AtomicInteger ID_GENERATOR = new AtomicInteger(Integer.MIN_VALUE);
     private static final int OWN_THREAD_ID = ID_GENERATOR.getAndIncrement();

--- a/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
@@ -103,12 +103,8 @@ public abstract class ResourceLeakDetectorFactory {
         DefaultResourceLeakDetectorFactory() {
             String customLeakDetector;
             try {
-                customLeakDetector = AccessController.doPrivileged(new PrivilegedAction<String>() {
-                    @Override
-                    public String run() {
-                        return SystemPropertyUtil.get("io.netty.customResourceLeakDetector");
-                    }
-                });
+                customLeakDetector = AccessController.doPrivileged((PrivilegedAction<String>) () ->
+                        SystemPropertyUtil.get("io.netty.customResourceLeakDetector"));
             } catch (Throwable cause) {
                 logger.error("Could not access System property: io.netty.customResourceLeakDetector", cause);
                 customLeakDetector = null;

--- a/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
+++ b/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
@@ -114,12 +114,9 @@ public final class ThreadDeathWatcher {
             // See:
             // - https://github.com/netty/netty/issues/7290
             // - https://bugs.openjdk.java.net/browse/JDK-7008595
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    watcherThread.setContextClassLoader(null);
-                    return null;
-                }
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                watcherThread.setContextClassLoader(null);
+                return null;
             });
 
             watcherThread.start();

--- a/common/src/main/java/io/netty/util/UncheckedBooleanSupplier.java
+++ b/common/src/main/java/io/netty/util/UncheckedBooleanSupplier.java
@@ -29,20 +29,10 @@ public interface UncheckedBooleanSupplier extends BooleanSupplier {
     /**
      * A supplier which always returns {@code false} and never throws.
      */
-    UncheckedBooleanSupplier FALSE_SUPPLIER = new UncheckedBooleanSupplier() {
-        @Override
-        public boolean get() {
-            return false;
-        }
-    };
+    UncheckedBooleanSupplier FALSE_SUPPLIER = () -> false;
 
     /**
      * A supplier which always returns {@code true} and never throws.
      */
-    UncheckedBooleanSupplier TRUE_SUPPLIER = new UncheckedBooleanSupplier() {
-        @Override
-        public boolean get() {
-            return true;
-        }
-    };
+    UncheckedBooleanSupplier TRUE_SUPPLIER = () -> true;
 }

--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -36,12 +36,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     static final long START_TIME = System.nanoTime();
 
     private static final Comparator<RunnableScheduledFutureNode<?>> SCHEDULED_FUTURE_TASK_COMPARATOR =
-            new Comparator<RunnableScheduledFutureNode<?>>() {
-                @Override
-                public int compare(RunnableScheduledFutureNode<?> o1, RunnableScheduledFutureNode<?> o2) {
-                    return o1.compareTo(o2);
-                }
-            };
+            Comparable::compareTo;
 
     private PriorityQueue<RunnableScheduledFutureNode<?>> scheduledTaskQueue;
 
@@ -234,12 +229,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (inEventLoop()) {
             add0(task);
         } else {
-            execute(new Runnable() {
-                @Override
-                public void run() {
-                    add0(task);
-                }
-            });
+            execute(() -> add0(task));
         }
         return task;
     }
@@ -258,12 +248,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (inEventLoop()) {
             scheduledTaskQueue().removeTyped(task);
         } else {
-            execute(new Runnable() {
-                @Override
-                public void run() {
-                    removeScheduled(task);
-                }
-            });
+            execute(() -> removeScheduled(task));
         }
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -429,12 +429,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
             }
         }
 
-        safeExecute(executor, new Runnable() {
-            @Override
-            public void run() {
-                notifyListenersNow();
-            }
-        });
+        safeExecute(executor, this::notifyListenersNow);
     }
 
     /**
@@ -459,12 +454,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
             }
         }
 
-        safeExecute(executor, new Runnable() {
-            @Override
-            public void run() {
-                notifyListener0(future, listener);
-            }
-        });
+        safeExecute(executor, () -> notifyListener0(future, listener));
     }
 
     private void notifyListenersNow() {
@@ -662,21 +652,11 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
             if (listeners instanceof GenericProgressiveFutureListener[]) {
                 final GenericProgressiveFutureListener<?>[] array =
                         (GenericProgressiveFutureListener<?>[]) listeners;
-                safeExecute(executor, new Runnable() {
-                    @Override
-                    public void run() {
-                        notifyProgressiveListeners0(self, array, progress, total);
-                    }
-                });
+                safeExecute(executor, () -> notifyProgressiveListeners0(self, array, progress, total));
             } else {
                 final GenericProgressiveFutureListener<ProgressiveFuture<V>> l =
                         (GenericProgressiveFutureListener<ProgressiveFuture<V>>) listeners;
-                safeExecute(executor, new Runnable() {
-                    @Override
-                    public void run() {
-                        notifyProgressiveListener0(self, l, progress, total);
-                    }
-                });
+                safeExecute(executor, () -> notifyProgressiveListener0(self, l, progress, total));
             }
         }
     }

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -46,12 +46,9 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
     static {
         INSTANCE = new GlobalEventExecutor();
         QUIET_PERIOD_TASK = new RunnableScheduledFutureAdapter<>(
-                INSTANCE, INSTANCE.newPromise(), Executors.callable(new Runnable() {
-            @Override
-            public void run() {
-                // NOOP
-            }
-        }, null), deadlineNanos(SCHEDULE_QUIET_PERIOD_INTERVAL), -SCHEDULE_QUIET_PERIOD_INTERVAL);
+                INSTANCE, INSTANCE.newPromise(), Executors.callable(() -> {
+                    // NOOP
+                }, null), deadlineNanos(SCHEDULE_QUIET_PERIOD_INTERVAL), -SCHEDULE_QUIET_PERIOD_INTERVAL);
 
         INSTANCE.scheduledTaskQueue().add(QUIET_PERIOD_TASK);
     }
@@ -228,12 +225,9 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
             // See:
             // - https://github.com/netty/netty/issues/7290
             // - https://bugs.openjdk.java.net/browse/JDK-7008595
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    t.setContextClassLoader(null);
-                    return null;
-                }
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                t.setContextClassLoader(null);
+                return null;
             });
 
             // Set the thread before starting it as otherwise inEventLoop() may return false and so produce

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -154,12 +154,9 @@ public class MultithreadEventExecutorGroup extends AbstractEventExecutorGroup {
             }
         }
 
-        final FutureListener<Object> terminationListener = new FutureListener<Object>() {
-            @Override
-            public void operationComplete(Future<Object> future) throws Exception {
-                if (terminatedChildren.incrementAndGet() == children.length) {
-                    terminationFuture.setSuccess(null);
-                }
+        final FutureListener<Object> terminationListener = future -> {
+            if (terminatedChildren.incrementAndGet() == children.length) {
+                terminationFuture.setSuccess(null);
             }
         };
 

--- a/common/src/main/java/io/netty/util/concurrent/RejectedExecutionHandlers.java
+++ b/common/src/main/java/io/netty/util/concurrent/RejectedExecutionHandlers.java
@@ -25,11 +25,8 @@ import java.util.concurrent.locks.LockSupport;
  * Expose helper methods which create different {@link RejectedExecutionHandler}s.
  */
 public final class RejectedExecutionHandlers {
-    private static final RejectedExecutionHandler REJECT = new RejectedExecutionHandler() {
-        @Override
-        public void rejected(Runnable task, SingleThreadEventExecutor executor) {
-            throw new RejectedExecutionException();
-        }
+    private static final RejectedExecutionHandler REJECT = (task, executor) -> {
+        throw new RejectedExecutionException();
     };
 
     private RejectedExecutionHandlers() { }
@@ -49,24 +46,21 @@ public final class RejectedExecutionHandlers {
     public static RejectedExecutionHandler backoff(final int retries, long backoffAmount, TimeUnit unit) {
         ObjectUtil.checkPositive(retries, "retries");
         final long backOffNanos = unit.toNanos(backoffAmount);
-        return new RejectedExecutionHandler() {
-            @Override
-            public void rejected(Runnable task, SingleThreadEventExecutor executor) {
-                if (!executor.inEventLoop()) {
-                    for (int i = 0; i < retries; i++) {
-                        // Try to wake up the executor so it will empty its task queue.
-                        executor.wakeup(false);
+        return (task, executor) -> {
+            if (!executor.inEventLoop()) {
+                for (int i = 0; i < retries; i++) {
+                    // Try to wake up the executor so it will empty its task queue.
+                    executor.wakeup(false);
 
-                        LockSupport.parkNanos(backOffNanos);
-                        if (executor.offerTask(task)) {
-                            return;
-                        }
+                    LockSupport.parkNanos(backOffNanos);
+                    if (executor.offerTask(task)) {
+                        return;
                     }
                 }
-                // Either we tried to add the task from within the EventLoop or we was not able to add it even with
-                // backoff.
-                throw new RejectedExecutionException();
             }
+            // Either we tried to add the task from within the EventLoop or we was not able to add it even with
+            // backoff.
+            throw new RejectedExecutionException();
         };
     }
 }

--- a/common/src/main/java/io/netty/util/internal/CleanerJava6.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava6.java
@@ -45,20 +45,17 @@ final class CleanerJava6 implements Cleaner {
         Throwable error = null;
         final ByteBuffer direct = ByteBuffer.allocateDirect(1);
         try {
-            Object mayBeCleanerField = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                @Override
-                public Object run() {
-                    try {
-                        Field cleanerField =  direct.getClass().getDeclaredField("cleaner");
-                        if (!PlatformDependent.hasUnsafe()) {
-                            // We need to make it accessible if we do not use Unsafe as we will access it via
-                            // reflection.
-                            cleanerField.setAccessible(true);
-                        }
-                        return cleanerField;
-                    } catch (Throwable cause) {
-                        return cause;
+            Object mayBeCleanerField = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+                try {
+                    Field cleanerField1 =  direct.getClass().getDeclaredField("cleaner");
+                    if (!PlatformDependent.hasUnsafe()) {
+                        // We need to make it accessible if we do not use Unsafe as we will access it via
+                        // reflection.
+                        cleanerField1.setAccessible(true);
                     }
+                    return cleanerField1;
+                } catch (Throwable cause) {
+                    return cause;
                 }
             });
             if (mayBeCleanerField instanceof Throwable) {
@@ -119,15 +116,12 @@ final class CleanerJava6 implements Cleaner {
     }
 
     private static void freeDirectBufferPrivileged(final ByteBuffer buffer) {
-        Throwable cause = AccessController.doPrivileged(new PrivilegedAction<Throwable>() {
-            @Override
-            public Throwable run() {
-                try {
-                    freeDirectBuffer0(buffer);
-                    return null;
-                } catch (Throwable cause) {
-                    return cause;
-                }
+        Throwable cause = AccessController.doPrivileged((PrivilegedAction<Throwable>) () -> {
+            try {
+                freeDirectBuffer0(buffer);
+                return null;
+            } catch (Throwable cause1) {
+                return cause1;
             }
         });
         if (cause != null) {

--- a/common/src/main/java/io/netty/util/internal/CleanerJava9.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava9.java
@@ -37,18 +37,15 @@ final class CleanerJava9 implements Cleaner {
         final Throwable error;
         if (PlatformDependent0.hasUnsafe()) {
             final ByteBuffer buffer = ByteBuffer.allocateDirect(1);
-            Object maybeInvokeMethod = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                @Override
-                public Object run() {
-                    try {
-                        // See https://bugs.openjdk.java.net/browse/JDK-8171377
-                        Method m = PlatformDependent0.UNSAFE.getClass().getDeclaredMethod(
-                                "invokeCleaner", ByteBuffer.class);
-                        m.invoke(PlatformDependent0.UNSAFE, buffer);
-                        return m;
-                    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                        return e;
-                    }
+            Object maybeInvokeMethod = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+                try {
+                    // See https://bugs.openjdk.java.net/browse/JDK-8171377
+                    Method m = PlatformDependent0.UNSAFE.getClass().getDeclaredMethod(
+                            "invokeCleaner", ByteBuffer.class);
+                    m.invoke(PlatformDependent0.UNSAFE, buffer);
+                    return m;
+                } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                    return e;
                 }
             });
 
@@ -91,16 +88,13 @@ final class CleanerJava9 implements Cleaner {
     }
 
     private static void freeDirectBufferPrivileged(final ByteBuffer buffer) {
-        Exception error = AccessController.doPrivileged(new PrivilegedAction<Exception>() {
-            @Override
-            public Exception run() {
-                try {
-                    INVOKE_CLEANER.invoke(PlatformDependent0.UNSAFE, buffer);
-                } catch (InvocationTargetException | IllegalAccessException e) {
-                    return e;
-                }
-                return null;
+        Exception error = AccessController.doPrivileged((PrivilegedAction<Exception>) () -> {
+            try {
+                INVOKE_CLEANER.invoke(PlatformDependent0.UNSAFE, buffer);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                return e;
             }
+            return null;
         });
         if (error != null) {
             PlatformDependent0.throwException(error);

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -99,11 +99,8 @@ public final class PlatformDependent {
 
     public static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
-    private static final Cleaner NOOP = new Cleaner() {
-        @Override
-        public void freeDirectBuffer(ByteBuffer buffer) {
-            // NOOP
-        }
+    private static final Cleaner NOOP = buffer -> {
+        // NOOP
     };
 
     static {
@@ -775,12 +772,9 @@ public final class PlatformDependent {
                 // jctools goes through its own process of initializing unsafe; of
                 // course, this requires permissions which might not be granted to calling code, so we
                 // must mark this block as privileged too
-                unsafe = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                    @Override
-                    public Object run() {
-                        // force JCTools to initialize unsafe
-                        return UnsafeAccess.UNSAFE;
-                    }
+                unsafe = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+                    // force JCTools to initialize unsafe
+                    return UnsafeAccess.UNSAFE;
                 });
             }
 

--- a/common/src/main/java/io/netty/util/internal/SocketUtils.java
+++ b/common/src/main/java/io/netty/util/internal/SocketUtils.java
@@ -48,12 +48,9 @@ public final class SocketUtils {
     public static void connect(final Socket socket, final SocketAddress remoteAddress, final int timeout)
             throws IOException {
         try {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                @Override
-                public Void run() throws IOException {
-                    socket.connect(remoteAddress, timeout);
-                    return null;
-                }
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                socket.connect(remoteAddress, timeout);
+                return null;
             });
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
@@ -62,12 +59,9 @@ public final class SocketUtils {
 
     public static void bind(final Socket socket, final SocketAddress bindpoint) throws IOException {
         try {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                @Override
-                public Void run() throws IOException {
-                    socket.bind(bindpoint);
-                    return null;
-                }
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                socket.bind(bindpoint);
+                return null;
             });
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
@@ -77,12 +71,8 @@ public final class SocketUtils {
     public static boolean connect(final SocketChannel socketChannel, final SocketAddress remoteAddress)
             throws IOException {
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<Boolean>() {
-                @Override
-                public Boolean run() throws IOException {
-                    return socketChannel.connect(remoteAddress);
-                }
-            });
+            return AccessController.doPrivileged((PrivilegedExceptionAction<Boolean>) () ->
+                    socketChannel.connect(remoteAddress));
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
         }
@@ -90,12 +80,9 @@ public final class SocketUtils {
 
     public static void bind(final SocketChannel socketChannel, final SocketAddress address) throws IOException {
         try {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                @Override
-                public Void run() throws IOException {
-                    socketChannel.bind(address);
-                    return null;
-                }
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                socketChannel.bind(address);
+                return null;
             });
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
@@ -104,12 +91,8 @@ public final class SocketUtils {
 
     public static SocketChannel accept(final ServerSocketChannel serverSocketChannel) throws IOException {
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<SocketChannel>() {
-                @Override
-                public SocketChannel run() throws IOException {
-                    return serverSocketChannel.accept();
-                }
-            });
+            return AccessController.doPrivileged(
+                    (PrivilegedExceptionAction<SocketChannel>) serverSocketChannel::accept);
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
         }
@@ -117,12 +100,9 @@ public final class SocketUtils {
 
     public static void bind(final DatagramChannel networkChannel, final SocketAddress address) throws IOException {
         try {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                @Override
-                public Void run() throws IOException {
-                    networkChannel.bind(address);
-                    return null;
-                }
+            AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                networkChannel.bind(address);
+                return null;
             });
         } catch (PrivilegedActionException e) {
             throw (IOException) e.getCause();
@@ -130,22 +110,13 @@ public final class SocketUtils {
     }
 
     public static SocketAddress localSocketAddress(final ServerSocket socket) {
-        return AccessController.doPrivileged(new PrivilegedAction<SocketAddress>() {
-            @Override
-            public SocketAddress run() {
-                return socket.getLocalSocketAddress();
-            }
-        });
+        return AccessController.doPrivileged((PrivilegedAction<SocketAddress>) socket::getLocalSocketAddress);
     }
 
     public static InetAddress addressByName(final String hostname) throws UnknownHostException {
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<InetAddress>() {
-                @Override
-                public InetAddress run() throws UnknownHostException {
-                    return InetAddress.getByName(hostname);
-                }
-            });
+            return AccessController.doPrivileged((PrivilegedExceptionAction<InetAddress>) () ->
+                    InetAddress.getByName(hostname));
         } catch (PrivilegedActionException e) {
             throw (UnknownHostException) e.getCause();
         }
@@ -153,52 +124,29 @@ public final class SocketUtils {
 
     public static InetAddress[] allAddressesByName(final String hostname) throws UnknownHostException {
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<InetAddress[]>() {
-                @Override
-                public InetAddress[] run() throws UnknownHostException {
-                    return InetAddress.getAllByName(hostname);
-                }
-            });
+            return AccessController.doPrivileged((PrivilegedExceptionAction<InetAddress[]>) () ->
+                    InetAddress.getAllByName(hostname));
         } catch (PrivilegedActionException e) {
             throw (UnknownHostException) e.getCause();
         }
     }
 
     public static InetSocketAddress socketAddress(final String hostname, final int port) {
-        return AccessController.doPrivileged(new PrivilegedAction<InetSocketAddress>() {
-            @Override
-            public InetSocketAddress run() {
-                return new InetSocketAddress(hostname, port);
-            }
-        });
+        return AccessController.doPrivileged((PrivilegedAction<InetSocketAddress>) () ->
+                new InetSocketAddress(hostname, port));
     }
 
     public static Enumeration<InetAddress> addressesFromNetworkInterface(final NetworkInterface intf) {
-        return AccessController.doPrivileged(new PrivilegedAction<Enumeration<InetAddress>>() {
-            @Override
-            public Enumeration<InetAddress> run() {
-                return intf.getInetAddresses();
-            }
-        });
+        return AccessController.doPrivileged((PrivilegedAction<Enumeration<InetAddress>>) intf::getInetAddresses);
     }
 
     public static InetAddress loopbackAddress() {
-        return AccessController.doPrivileged(new PrivilegedAction<InetAddress>() {
-            @Override
-            public InetAddress run() {
-                return InetAddress.getLoopbackAddress();
-            }
-        });
+        return AccessController.doPrivileged((PrivilegedAction<InetAddress>) InetAddress::getLoopbackAddress);
     }
 
     public static byte[] hardwareAddressFromNetworkInterface(final NetworkInterface intf) throws SocketException {
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<byte[]>() {
-                @Override
-                public byte[] run() throws SocketException {
-                    return intf.getHardwareAddress();
-                }
-            });
+            return AccessController.doPrivileged((PrivilegedExceptionAction<byte[]>) intf::getHardwareAddress);
         } catch (PrivilegedActionException e) {
             throw (SocketException) e.getCause();
         }

--- a/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
+++ b/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
@@ -68,12 +68,7 @@ public final class SystemPropertyUtil {
             if (System.getSecurityManager() == null) {
                 value = System.getProperty(key);
             } else {
-                value = AccessController.doPrivileged(new PrivilegedAction<String>() {
-                    @Override
-                    public String run() {
-                        return System.getProperty(key);
-                    }
-                });
+                value = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(key));
             }
         } catch (SecurityException e) {
             logger.warn("Unable to retrieve a system property '{}'; default values will be used.", key, e);

--- a/common/src/main/java/io/netty/util/internal/logging/Log4J2Logger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4J2Logger.java
@@ -35,19 +35,16 @@ class Log4J2Logger extends ExtendedLoggerWrapper implements InternalLogger {
         // Older Log4J2 versions have only log methods that takes the format + varargs. So we should not use
         // Log4J2 if the version is too old.
         // See https://github.com/netty/netty/issues/8217
-        VARARGS_ONLY = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-            @Override
-            public Boolean run() {
-                try {
-                    Logger.class.getMethod("debug", String.class, Object.class);
-                    return false;
-                } catch (NoSuchMethodException ignore) {
-                    // Log4J2 version too old.
-                    return true;
-                } catch (SecurityException ignore) {
-                    // We could not detect the version so we will use Log4J2 if its on the classpath.
-                    return false;
-                }
+        VARARGS_ONLY = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+            try {
+                Logger.class.getMethod("debug", String.class, Object.class);
+                return false;
+            } catch (NoSuchMethodException ignore) {
+                // Log4J2 version too old.
+                return true;
+            } catch (SecurityException ignore) {
+                // We could not detect the version so we will use Log4J2 if its on the classpath.
+                return false;
             }
         });
     }

--- a/common/src/test/java/io/netty/util/ConstantPoolTest.java
+++ b/common/src/test/java/io/netty/util/ConstantPoolTest.java
@@ -79,12 +79,7 @@ public class ConstantPoolTest {
         assertThat(array.length, is(5));
 
         // Sort by name
-        Arrays.sort(array, new Comparator<TestConstant>() {
-            @Override
-            public int compare(TestConstant o1, TestConstant o2) {
-                return o1.name().compareTo(o2.name());
-            }
-        });
+        Arrays.sort(array, (o1, o2) -> o1.name().compareTo(o2.name()));
 
         assertThat(array[0], is(sameInstance(a)));
         assertThat(array[1], is(sameInstance(b)));

--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -35,12 +35,9 @@ public class HashedWheelTimerTest {
     public void testScheduleTimeoutShouldNotRunBeforeDelay() throws InterruptedException {
         final Timer timer = new HashedWheelTimer();
         final CountDownLatch barrier = new CountDownLatch(1);
-        final Timeout timeout = timer.newTimeout(new TimerTask() {
-            @Override
-            public void run(Timeout timeout) throws Exception {
-                fail("This should not have run");
-                barrier.countDown();
-            }
+        final Timeout timeout = timer.newTimeout(timeout1 -> {
+            fail("This should not have run");
+            barrier.countDown();
         }, 10, TimeUnit.SECONDS);
         assertFalse(barrier.await(3, TimeUnit.SECONDS));
         assertFalse("timer should not expire", timeout.isExpired());
@@ -51,12 +48,7 @@ public class HashedWheelTimerTest {
     public void testScheduleTimeoutShouldRunAfterDelay() throws InterruptedException {
         final Timer timer = new HashedWheelTimer();
         final CountDownLatch barrier = new CountDownLatch(1);
-        final Timeout timeout = timer.newTimeout(new TimerTask() {
-            @Override
-            public void run(Timeout timeout) throws Exception {
-                barrier.countDown();
-            }
-        }, 2, TimeUnit.SECONDS);
+        final Timeout timeout = timer.newTimeout(timeout1 -> barrier.countDown(), 2, TimeUnit.SECONDS);
         assertTrue(barrier.await(3, TimeUnit.SECONDS));
         assertTrue("timer should expire", timeout.isExpired());
         timer.stop();
@@ -67,12 +59,7 @@ public class HashedWheelTimerTest {
         final CountDownLatch latch = new CountDownLatch(3);
         final Timer timerProcessed = new HashedWheelTimer();
         for (int i = 0; i < 3; i ++) {
-            timerProcessed.newTimeout(new TimerTask() {
-                @Override
-                public void run(final Timeout timeout) throws Exception {
-                    latch.countDown();
-                }
-            }, 1, TimeUnit.MILLISECONDS);
+            timerProcessed.newTimeout(timeout -> latch.countDown(), 1, TimeUnit.MILLISECONDS);
         }
 
         latch.await();
@@ -80,10 +67,7 @@ public class HashedWheelTimerTest {
 
         final Timer timerUnprocessed = new HashedWheelTimer();
         for (int i = 0; i < 5; i ++) {
-            timerUnprocessed.newTimeout(new TimerTask() {
-                @Override
-                public void run(Timeout timeout) throws Exception {
-                }
+            timerUnprocessed.newTimeout(timeout -> {
             }, 5, TimeUnit.SECONDS);
         }
         Thread.sleep(1000L); // sleep for a second
@@ -95,12 +79,7 @@ public class HashedWheelTimerTest {
         final CountDownLatch latch = new CountDownLatch(3);
         final Timer timer = new HashedWheelTimer();
         for (int i = 0; i < 3; i ++) {
-            timer.newTimeout(new TimerTask() {
-                @Override
-                public void run(Timeout timeout) throws Exception {
-                    latch.countDown();
-                }
-            }, 1, TimeUnit.MILLISECONDS);
+            timer.newTimeout(timeout -> latch.countDown(), 1, TimeUnit.MILLISECONDS);
         }
 
         latch.await();
@@ -143,12 +122,8 @@ public class HashedWheelTimerTest {
         int scheduledTasks = 100000;
         for (int i = 0; i < scheduledTasks; i++) {
             final long start = System.nanoTime();
-            timer.newTimeout(new TimerTask() {
-                @Override
-                public void run(final Timeout timeout) throws Exception {
-                    queue.add(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start));
-                }
-            }, timeout, TimeUnit.MILLISECONDS);
+            timer.newTimeout(timeout1 -> queue.add(
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)), timeout, TimeUnit.MILLISECONDS);
         }
 
         for (int i = 0; i < scheduledTasks; i++) {
@@ -234,31 +209,18 @@ public class HashedWheelTimerTest {
     public void testOverflow() throws InterruptedException  {
         final HashedWheelTimer timer = new HashedWheelTimer();
         final CountDownLatch latch = new CountDownLatch(1);
-        Timeout timeout = timer.newTimeout(new TimerTask() {
-            @Override
-            public void run(Timeout timeout) {
-                latch.countDown();
-            }
-        }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        Timeout timeout = timer.newTimeout(timeout1 -> latch.countDown(), Long.MAX_VALUE, TimeUnit.MILLISECONDS);
         assertFalse(latch.await(1, TimeUnit.SECONDS));
         timeout.cancel();
         timer.stop();
     }
 
     private static TimerTask createNoOpTimerTask() {
-        return new TimerTask() {
-            @Override
-            public void run(final Timeout timeout) throws Exception {
-            }
+        return timeout -> {
         };
     }
 
     private static TimerTask createCountDownLatchTimerTask(final CountDownLatch latch) {
-        return new TimerTask() {
-            @Override
-            public void run(final Timeout timeout) throws Exception {
-                latch.countDown();
-            }
-        };
+        return timeout -> latch.countDown();
     }
 }

--- a/common/src/test/java/io/netty/util/NettyRuntimeTests.java
+++ b/common/src/test/java/io/netty/util/NettyRuntimeTests.java
@@ -102,17 +102,14 @@ public class NettyRuntimeTests {
             final NettyRuntime.AvailableProcessorsHolder holder,
             final CyclicBarrier barrier,
             final AtomicReference<IllegalStateException> reference) {
-        return new Runnable() {
-            @Override
-            public void run() {
-                await(barrier);
-                try {
-                    holder.availableProcessors();
-                } catch (final IllegalStateException e) {
-                    reference.set(e);
-                }
-                await(barrier);
+        return () -> {
+            await(barrier);
+            try {
+                holder.availableProcessors();
+            } catch (final IllegalStateException e) {
+                reference.set(e);
             }
+            await(barrier);
         };
     }
 
@@ -120,28 +117,22 @@ public class NettyRuntimeTests {
     public void testRacingGetAndSet() throws InterruptedException {
         final NettyRuntime.AvailableProcessorsHolder holder = new NettyRuntime.AvailableProcessorsHolder();
         final CyclicBarrier barrier = new CyclicBarrier(3);
-        final Thread get = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                await(barrier);
-                holder.availableProcessors();
-                await(barrier);
-            }
+        final Thread get = new Thread(() -> {
+            await(barrier);
+            holder.availableProcessors();
+            await(barrier);
         });
         get.start();
 
         final AtomicReference<IllegalStateException> setException = new AtomicReference<>();
-        final Thread set = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                await(barrier);
-                try {
-                    holder.setAvailableProcessors(2048);
-                } catch (final IllegalStateException e) {
-                    setException.set(e);
-                }
-                await(barrier);
+        final Thread set = new Thread(() -> {
+            await(barrier);
+            try {
+                holder.setAvailableProcessors(2048);
+            } catch (final IllegalStateException e) {
+                setException.set(e);
             }
+            await(barrier);
         });
         set.start();
 

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -41,13 +41,10 @@ public class RecyclerTest {
         final Recycler<HandledObject> recycler = newRecycler(1024);
         final AtomicBoolean collected = new AtomicBoolean();
         final AtomicReference<HandledObject> reference = new AtomicReference<>();
-        Thread thread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                HandledObject object = recycler.get();
-                // Store a reference to the HandledObject to ensure it is not collected when the run method finish.
-                reference.set(object);
-            }
+        Thread thread = new Thread(() -> {
+            HandledObject object = recycler.get();
+            // Store a reference to the HandledObject to ensure it is not collected when the run method finish.
+            reference.set(object);
         }) {
             @Override
             protected void finalize() throws Throwable {
@@ -86,23 +83,15 @@ public class RecyclerTest {
         Recycler<HandledObject> recycler = newRecycler(1024);
         final HandledObject object = recycler.get();
         final AtomicReference<IllegalStateException> exceptionStore = new AtomicReference<>();
-        final Thread thread1 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                object.recycle();
-            }
-        });
+        final Thread thread1 = new Thread(object::recycle);
         thread1.start();
         thread1.join();
 
-        final Thread thread2 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    object.recycle();
-                } catch (IllegalStateException e) {
-                    exceptionStore.set(e);
-                }
+        final Thread thread2 = new Thread(() -> {
+            try {
+                object.recycle();
+            } catch (IllegalStateException e) {
+                exceptionStore.set(e);
             }
         });
         thread2.start();

--- a/common/src/test/java/io/netty/util/ThreadDeathWatcherTest.java
+++ b/common/src/test/java/io/netty/util/ThreadDeathWatcherTest.java
@@ -46,12 +46,9 @@ public class ThreadDeathWatcherTest {
             }
         };
 
-        final Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                if (!t.isAlive()) {
-                    latch.countDown();
-                }
+        final Runnable task = () -> {
+            if (!t.isAlive()) {
+                latch.countDown();
             }
         };
 
@@ -91,12 +88,7 @@ public class ThreadDeathWatcherTest {
             }
         };
 
-        final Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                run.set(true);
-            }
-        };
+        final Runnable task = () -> run.set(true);
 
         t.start();
 
@@ -121,16 +113,10 @@ public class ThreadDeathWatcherTest {
     public void testThreadGroup() throws InterruptedException {
         final ThreadGroup group = new ThreadGroup("group");
         final AtomicReference<ThreadGroup> capturedGroup = new AtomicReference<>();
-        final Thread thread = new Thread(group, new Runnable() {
-            @Override
-            public void run() {
-                final Thread t = ThreadDeathWatcher.threadFactory.newThread(new Runnable() {
-                    @Override
-                    public void run() {
-                    }
-                });
-                capturedGroup.set(t.getThreadGroup());
-            }
+        final Thread thread = new Thread(group, () -> {
+            final Thread t = ThreadDeathWatcher.threadFactory.newThread(() -> {
+            });
+            capturedGroup.set(t.getThreadGroup());
         });
         thread.start();
         thread.join();

--- a/common/src/test/java/io/netty/util/concurrent/AbstractScheduledEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AbstractScheduledEventExecutorTest.java
@@ -27,11 +27,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class AbstractScheduledEventExecutorTest {
-    private static final Runnable TEST_RUNNABLE = new Runnable() {
-
-        @Override
-        public void run() {
-        }
+    private static final Runnable TEST_RUNNABLE = () -> {
     };
 
     private static final Callable<?> TEST_CALLABLE = Executors.callable(TEST_RUNNABLE);

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -157,12 +157,7 @@ public class DefaultPromiseTest {
                     }
                 };
 
-                GlobalEventExecutor.INSTANCE.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        promise.setSuccess(null);
-                    }
-                });
+                GlobalEventExecutor.INSTANCE.execute(() -> promise.setSuccess(null));
 
                 promise.addListener(listener1).addListener(listener2).addListener(listener3);
 
@@ -217,12 +212,7 @@ public class DefaultPromiseTest {
             final Map<Thread, DefaultPromise<Void>> promises = new HashMap<>();
             for (int i = 0; i < numberOfAttempts; i++) {
                 final DefaultPromise<Void> promise = new DefaultPromise<>(executor);
-                final Thread thread = new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        promise.setSuccess(null);
-                    }
-                });
+                final Thread thread = new Thread(() -> promise.setSuccess(null));
                 promises.put(thread, promise);
             }
 
@@ -278,12 +268,7 @@ public class DefaultPromiseTest {
         final CountDownLatch latch = new CountDownLatch(promiseChainLength);
 
         if (runTestInExecutorThread) {
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    testStackOverFlowChainedFuturesA(executor, p, latch);
-                }
-            });
+            executor.execute(() -> testStackOverFlowChainedFuturesA(executor, p, latch));
         } else {
             testStackOverFlowChainedFuturesA(executor, p, latch);
         }
@@ -299,14 +284,11 @@ public class DefaultPromiseTest {
         for (int i = 0; i < p.length; i ++) {
             final int finalI = i;
             p[i] = new DefaultPromise<>(executor);
-            p[i].addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) throws Exception {
-                    if (finalI + 1 < p.length) {
-                        p[finalI + 1].setSuccess(null);
-                    }
-                    latch.countDown();
+            p[i].addListener((FutureListener<Void>) future -> {
+                if (finalI + 1 < p.length) {
+                    p[finalI + 1].setSuccess(null);
                 }
+                latch.countDown();
             });
         }
 
@@ -320,12 +302,7 @@ public class DefaultPromiseTest {
         final CountDownLatch latch = new CountDownLatch(promiseChainLength);
 
         if (runTestInExecutorThread) {
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    testStackOverFlowChainedFuturesA(executor, p, latch);
-                }
-            });
+            executor.execute(() -> testStackOverFlowChainedFuturesA(executor, p, latch));
         } else {
             testStackOverFlowChainedFuturesA(executor, p, latch);
         }
@@ -341,20 +318,12 @@ public class DefaultPromiseTest {
         for (int i = 0; i < p.length; i ++) {
             final int finalI = i;
             p[i] = new DefaultPromise<>(executor);
-            p[i].addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) throws Exception {
-                    future.addListener(new FutureListener<Void>() {
-                        @Override
-                        public void operationComplete(Future<Void> future) throws Exception {
-                            if (finalI + 1 < p.length) {
-                                p[finalI + 1].setSuccess(null);
-                            }
-                            latch.countDown();
-                        }
-                    });
+            p[i].addListener((FutureListener<Void>) future -> future.addListener((FutureListener<Void>) future1 -> {
+                if (finalI + 1 < p.length) {
+                    p[finalI + 1].setSuccess(null);
                 }
-            });
+                latch.countDown();
+            }));
         }
 
         p[0].setSuccess(null);
@@ -379,12 +348,7 @@ public class DefaultPromiseTest {
             final Promise<Void> promise = new DefaultPromise<>(executor);
 
             // Add a listener before completion so "lateListener" is used next time we add a listener.
-            promise.addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) throws Exception {
-                    assertTrue(state.compareAndSet(0, 1));
-                }
-            });
+            promise.addListener((FutureListener<Void>) future -> assertTrue(state.compareAndSet(0, 1)));
 
             // Simulate write operation completing, which will execute listeners in another thread.
             if (cause == null) {
@@ -394,12 +358,9 @@ public class DefaultPromiseTest {
             }
 
             // Add a "late listener"
-            promise.addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) throws Exception {
-                    assertTrue(state.compareAndSet(1, 2));
-                    latch1.countDown();
-                }
+            promise.addListener((FutureListener<Void>) future -> {
+                assertTrue(state.compareAndSet(1, 2));
+                latch1.countDown();
             });
 
             // Wait for the listeners and late listeners to be completed.
@@ -408,27 +369,16 @@ public class DefaultPromiseTest {
 
             // This is the important listener. A late listener that is added after all late listeners
             // have completed, and needs to update state before a read operation (on the same executor).
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    promise.addListener(new FutureListener<Void>() {
-                        @Override
-                        public void operationComplete(Future<Void> future) throws Exception {
-                            assertTrue(state.compareAndSet(2, 3));
-                            latch2.countDown();
-                        }
-                    });
-                }
-            });
+            executor.execute(() -> promise.addListener((FutureListener<Void>) future -> {
+                assertTrue(state.compareAndSet(2, 3));
+                latch2.countDown();
+            }));
 
             // Simulate a read operation being queued up in the executor.
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    // This is the key, we depend upon the state being set in the next listener.
-                    assertEquals(3, state.get());
-                    latch2.countDown();
-                }
+            executor.execute(() -> {
+                // This is the key, we depend upon the state being set in the next listener.
+                assertEquals(3, state.get());
+                latch2.countDown();
             });
 
             latch2.await();
@@ -440,17 +390,8 @@ public class DefaultPromiseTest {
     private static void testPromiseListenerAddWhenComplete(Throwable cause) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final Promise<Void> promise = new DefaultPromise<>(ImmediateEventExecutor.INSTANCE);
-        promise.addListener(new FutureListener<Void>() {
-            @Override
-            public void operationComplete(Future<Void> future) throws Exception {
-                promise.addListener(new FutureListener<Void>() {
-                    @Override
-                    public void operationComplete(Future<Void> future) throws Exception {
-                        latch.countDown();
-                    }
-                });
-            }
-        });
+        promise.addListener((FutureListener<Void>) future ->
+                promise.addListener((FutureListener<Void>) future1 -> latch.countDown()));
         if (cause == null) {
             promise.setSuccess(null);
         } else {
@@ -463,29 +404,16 @@ public class DefaultPromiseTest {
         EventExecutor executor = new TestEventExecutor();
         int expectedCount = numListenersBefore + 2;
         final CountDownLatch latch = new CountDownLatch(expectedCount);
-        final FutureListener<Void> listener = new FutureListener<Void>() {
-            @Override
-            public void operationComplete(Future<Void> future) throws Exception {
-                latch.countDown();
-            }
-        };
+        final FutureListener<Void> listener = future -> latch.countDown();
         final Promise<Void> promise = new DefaultPromise<>(executor);
-        executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                for (int i = 0; i < numListenersBefore; i++) {
-                    promise.addListener(listener);
-                }
-                promise.setSuccess(null);
-
-                GlobalEventExecutor.INSTANCE.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        promise.addListener(listener);
-                    }
-                });
+        executor.execute(() -> {
+            for (int i = 0; i < numListenersBefore; i++) {
                 promise.addListener(listener);
             }
+            promise.setSuccess(null);
+
+            GlobalEventExecutor.INSTANCE.execute(() -> promise.addListener(listener));
+            promise.addListener(listener);
         });
 
         assertTrue("Should have notified " + expectedCount + " listeners",

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -82,14 +82,11 @@ public class FastThreadLocalTest {
     @Test
     public void testMultipleSetRemove() throws Exception {
         final FastThreadLocal<String> threadLocal = new FastThreadLocal<>();
-        final Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                threadLocal.set("1");
-                threadLocal.remove();
-                threadLocal.set("2");
-                threadLocal.remove();
-            }
+        final Runnable runnable = () -> {
+            threadLocal.set("1");
+            threadLocal.remove();
+            threadLocal.set("2");
+            threadLocal.remove();
         };
 
         final int sizeWhenStart = ObjectCleaner.getLiveSetCount();
@@ -110,18 +107,15 @@ public class FastThreadLocalTest {
     public void testMultipleSetRemove_multipleThreadLocal() throws Exception {
         final FastThreadLocal<String> threadLocal = new FastThreadLocal<>();
         final FastThreadLocal<String> threadLocal2 = new FastThreadLocal<>();
-        final Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                threadLocal.set("1");
-                threadLocal.remove();
-                threadLocal.set("2");
-                threadLocal.remove();
-                threadLocal2.set("1");
-                threadLocal2.remove();
-                threadLocal2.set("2");
-                threadLocal2.remove();
-            }
+        final Runnable runnable = () -> {
+            threadLocal.set("1");
+            threadLocal.remove();
+            threadLocal.set("2");
+            threadLocal.remove();
+            threadLocal2.set("1");
+            threadLocal2.remove();
+            threadLocal2.set("2");
+            threadLocal2.remove();
         };
 
         final int sizeWhenStart = ObjectCleaner.getLiveSetCount();
@@ -165,16 +159,13 @@ public class FastThreadLocalTest {
         final TestFastThreadLocal threadLocal = new TestFastThreadLocal();
         final TestFastThreadLocal threadLocal2 = new TestFastThreadLocal();
 
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                if (callGet) {
-                    assertEquals(Thread.currentThread().getName(), threadLocal.get());
-                    assertEquals(Thread.currentThread().getName(), threadLocal2.get());
-                } else {
-                    threadLocal.set(Thread.currentThread().getName());
-                    threadLocal2.set(Thread.currentThread().getName());
-                }
+        Runnable runnable = () -> {
+            if (callGet) {
+                assertEquals(Thread.currentThread().getName(), threadLocal.get());
+                assertEquals(Thread.currentThread().getName(), threadLocal2.get());
+            } else {
+                threadLocal.set(Thread.currentThread().getName());
+                threadLocal2.set(Thread.currentThread().getName());
             }
         };
         Thread thread = fastThreadLocal ? new FastThreadLocalThread(runnable) : new Thread(runnable);

--- a/common/src/test/java/io/netty/util/concurrent/GlobalEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/GlobalEventExecutorTest.java
@@ -99,16 +99,10 @@ public class GlobalEventExecutorTest {
     public void testThreadGroup() throws InterruptedException {
         final ThreadGroup group = new ThreadGroup("group");
         final AtomicReference<ThreadGroup> capturedGroup = new AtomicReference<>();
-        final Thread thread = new Thread(group, new Runnable() {
-            @Override
-            public void run() {
-                final Thread t = e.threadFactory.newThread(new Runnable() {
-                    @Override
-                    public void run() {
-                    }
-                });
-                capturedGroup.set(t.getThreadGroup());
-            }
+        final Thread thread = new Thread(group, () -> {
+            final Thread t = e.threadFactory.newThread(() -> {
+            });
+            capturedGroup.set(t.getThreadGroup());
         });
         thread.start();
         thread.join();

--- a/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java
@@ -178,13 +178,9 @@ public class PromiseCombinerTest {
 
     @SuppressWarnings("unchecked")
     private static void mockListener(final Promise<Void> p, final GenericFutureListenerConsumer consumer) {
-        doAnswer(new Answer<Promise<Void>>() {
-            @SuppressWarnings({ "unchecked", "raw-types" })
-            @Override
-            public Promise<Void> answer(InvocationOnMock invocation) throws Throwable {
-                consumer.accept((GenericFutureListener) invocation.getArgument(0));
-                return p;
-            }
+        doAnswer(invocation -> {
+            consumer.accept((GenericFutureListener) invocation.getArgument(0));
+            return p;
         }).when(p).addListener(any(GenericFutureListener.class));
     }
 

--- a/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -29,19 +29,9 @@ public class UnorderedThreadPoolEventExecutorTest {
 
         try {
             final CountDownLatch latch = new CountDownLatch(3);
-            Runnable task = new Runnable() {
-                @Override
-                public void run() {
-                    latch.countDown();
-                }
-            };
+            Runnable task = latch::countDown;
             executor.execute(task);
-            Future<?> future = executor.submit(task).addListener(new FutureListener<Object>() {
-                @Override
-                public void operationComplete(Future<Object> future) throws Exception {
-                    latch.countDown();
-                }
-            });
+            Future<?> future = executor.submit(task).addListener((FutureListener<Object>) future1 -> latch.countDown());
             latch.await();
             future.syncUninterruptibly();
 

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -29,22 +29,13 @@ public class PlatformDependentTest {
     private static final Random r = new Random();
     @Test
     public void testEqualsConsistentTime() {
-        testEquals(new EqualityChecker() {
-            @Override
-            public boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length) {
-                return PlatformDependent.equalsConstantTime(bytes1, startPos1, bytes2, startPos2, length) != 0;
-            }
-        });
+        testEquals((bytes1, startPos1, bytes2, startPos2, length) ->
+                PlatformDependent.equalsConstantTime(bytes1, startPos1, bytes2, startPos2, length) != 0);
     }
 
     @Test
     public void testEquals() {
-        testEquals(new EqualityChecker() {
-            @Override
-            public boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length) {
-                return PlatformDependent.equals(bytes1, startPos1, bytes2, startPos2, length);
-            }
-        });
+        testEquals(PlatformDependent::equals);
     }
 
     @Test

--- a/example/src/main/java/io/netty/example/discard/DiscardClientHandler.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardClientHandler.java
@@ -65,15 +65,12 @@ public class DiscardClientHandler extends SimpleChannelInboundHandler<Object> {
         ctx.writeAndFlush(content.retainedDuplicate()).addListener(trafficGenerator);
     }
 
-    private final ChannelFutureListener trafficGenerator = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            if (future.isSuccess()) {
-                generateTraffic();
-            } else {
-                future.cause().printStackTrace();
-                future.channel().close();
-            }
+    private final ChannelFutureListener trafficGenerator = future -> {
+        if (future.isSuccess()) {
+            generateTraffic();
+        } else {
+            future.cause().printStackTrace();
+            future.channel().close();
         }
     };
 }

--- a/example/src/main/java/io/netty/example/factorial/FactorialClientHandler.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialClientHandler.java
@@ -66,12 +66,9 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
         receivedMessages ++;
         if (receivedMessages == FactorialClient.COUNT) {
             // Offer the answer after closing the connection.
-            ctx.channel().close().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    boolean offered = answer.offer(msg);
-                    assert offered;
-                }
+            ctx.channel().close().addListener((ChannelFutureListener) future -> {
+                boolean offered = answer.offer(msg);
+                assert offered;
             });
         }
     }
@@ -96,15 +93,12 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
         ctx.flush();
     }
 
-    private final ChannelFutureListener numberSender = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
-            if (future.isSuccess()) {
-                sendNumbers();
-            } else {
-                future.cause().printStackTrace();
-                future.channel().close();
-            }
+    private final ChannelFutureListener numberSender = future -> {
+        if (future.isSuccess()) {
+            sendNumbers();
+        } else {
+            future.cause().printStackTrace();
+            future.channel().close();
         }
     };
 }

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2ServerInitializer.java
@@ -42,15 +42,12 @@ import io.netty.util.ReferenceCountUtil;
  */
 public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
 
-    private static final UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
-        @Override
-        public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
-            if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                return new Http2ServerUpgradeCodec(
-                        Http2FrameCodecBuilder.forServer().build(), new HelloWorldHttp2Handler());
-            } else {
-                return null;
-            }
+    private static final UpgradeCodecFactory upgradeCodecFactory = protocol -> {
+        if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
+            return new Http2ServerUpgradeCodec(
+                    Http2FrameCodecBuilder.forServer().build(), new HelloWorldHttp2Handler());
+        } else {
+            return null;
         }
     };
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2ServerInitializer.java
@@ -42,15 +42,12 @@ import io.netty.util.ReferenceCountUtil;
  */
 public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
 
-    private static final UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
-        @Override
-        public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
-            if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                return new Http2ServerUpgradeCodec(
-                        Http2MultiplexCodecBuilder.forServer(new HelloWorldHttp2Handler()).build());
-            } else {
-                return null;
-            }
+    private static final UpgradeCodecFactory upgradeCodecFactory = protocol -> {
+        if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
+            return new Http2ServerUpgradeCodec(
+                    Http2MultiplexCodecBuilder.forServer(new HelloWorldHttp2Handler()).build());
+        } else {
+            return null;
         }
     };
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
@@ -41,14 +41,11 @@ import io.netty.util.ReferenceCountUtil;
  */
 public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
 
-    private static final UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
-        @Override
-        public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
-            if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                return new Http2ServerUpgradeCodec(new HelloWorldHttp2HandlerBuilder().build());
-            } else {
-                return null;
-            }
+    private static final UpgradeCodecFactory upgradeCodecFactory = protocol -> {
+        if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
+            return new Http2ServerUpgradeCodec(new HelloWorldHttp2HandlerBuilder().build());
+        } else {
+            return null;
         }
     };
 

--- a/example/src/main/java/io/netty/example/http2/tiles/Http1RequestHandler.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http1RequestHandler.java
@@ -47,15 +47,12 @@ public final class Http1RequestHandler extends Http2RequestHandler {
     protected void sendResponse(final ChannelHandlerContext ctx, String streamId, int latency,
             final FullHttpResponse response, final FullHttpRequest request) {
         HttpUtil.setContentLength(response, response.content().readableBytes());
-        ctx.executor().schedule(new Runnable() {
-            @Override
-            public void run() {
-                if (isKeepAlive(request)) {
-                    response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
-                    ctx.writeAndFlush(response);
-                } else {
-                    ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
-                }
+        ctx.executor().schedule(() -> {
+            if (isKeepAlive(request)) {
+                response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+                ctx.writeAndFlush(response);
+            } else {
+                ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
             }
         }, latency, TimeUnit.MILLISECONDS);
     }

--- a/example/src/main/java/io/netty/example/http2/tiles/Http2RequestHandler.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http2RequestHandler.java
@@ -98,11 +98,8 @@ public class Http2RequestHandler extends SimpleChannelInboundHandler<FullHttpReq
             final FullHttpResponse response, final FullHttpRequest request) {
         setContentLength(response, response.content().readableBytes());
         streamId(response, streamId);
-        ctx.executor().schedule(new Runnable() {
-            @Override
-            public void run() {
-                ctx.writeAndFlush(response);
-            }
+        ctx.executor().schedule(() -> {
+            ctx.writeAndFlush(response);
         }, latency, TimeUnit.MILLISECONDS);
     }
 

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
@@ -36,14 +36,11 @@ public class HexDumpProxyBackendHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-        inboundChannel.writeAndFlush(msg).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    ctx.channel().read();
-                } else {
-                    future.channel().close();
-                }
+        inboundChannel.writeAndFlush(msg).addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+                ctx.channel().read();
+            } else {
+                future.channel().close();
             }
         });
     }

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
@@ -50,16 +50,13 @@ public class HexDumpProxyFrontendHandler extends ChannelInboundHandlerAdapter {
          .option(ChannelOption.AUTO_READ, false);
         ChannelFuture f = b.connect(remoteHost, remotePort);
         outboundChannel = f.channel();
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    // connection complete start to read first data
-                    inboundChannel.read();
-                } else {
-                    // Close the connection if the connection attempt has failed.
-                    inboundChannel.close();
-                }
+        f.addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+                // connection complete start to read first data
+                inboundChannel.read();
+            } else {
+                // Close the connection if the connection attempt has failed.
+                inboundChannel.close();
             }
         });
     }
@@ -67,15 +64,12 @@ public class HexDumpProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) {
         if (outboundChannel.isActive()) {
-            outboundChannel.writeAndFlush(msg).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        // was able to flush out data, start to read the next chunk
-                        ctx.channel().read();
-                    } else {
-                        future.channel().close();
-                    }
+            outboundChannel.writeAndFlush(msg).addListener((ChannelFutureListener) future -> {
+                if (future.isSuccess()) {
+                    // was able to flush out data, start to read the next chunk
+                    ctx.channel().read();
+                } else {
+                    future.channel().close();
                 }
             });
         }

--- a/example/src/main/java/io/netty/example/redis/RedisClient.java
+++ b/example/src/main/java/io/netty/example/redis/RedisClient.java
@@ -77,13 +77,10 @@ public class RedisClient {
                 }
                 // Sends the received line to the server.
                 lastWriteFuture = ch.writeAndFlush(line);
-                lastWriteFuture.addListener(new GenericFutureListener<ChannelFuture>() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            System.err.print("write failed: ");
-                            future.cause().printStackTrace(System.err);
-                        }
+                lastWriteFuture.addListener((GenericFutureListener<ChannelFuture>) future -> {
+                    if (!future.isSuccess()) {
+                        System.err.print("write failed: ");
+                        future.cause().printStackTrace(System.err);
                     }
                 });
             }

--- a/example/src/main/java/io/netty/example/securechat/SecureChatServerHandler.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatServerHandler.java
@@ -39,19 +39,16 @@ public class SecureChatServerHandler extends SimpleChannelInboundHandler<String>
         // Once session is secured, send a greeting and register the channel to the global channel
         // list so the channel received the messages from others.
         ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(
-                new GenericFutureListener<Future<Channel>>() {
-                    @Override
-                    public void operationComplete(Future<Channel> future) throws Exception {
-                        ctx.writeAndFlush(
-                                "Welcome to " + InetAddress.getLocalHost().getHostName() + " secure chat service!\n");
-                        ctx.writeAndFlush(
-                                "Your session is protected by " +
-                                        ctx.pipeline().get(SslHandler.class).engine().getSession().getCipherSuite() +
-                                        " cipher suite.\n");
+                (GenericFutureListener<Future<Channel>>) future -> {
+                    ctx.writeAndFlush(
+                            "Welcome to " + InetAddress.getLocalHost().getHostName() + " secure chat service!\n");
+                    ctx.writeAndFlush(
+                            "Your session is protected by " +
+                                    ctx.pipeline().get(SslHandler.class).engine().getSession().getCipherSuite() +
+                                    " cipher suite.\n");
 
-                        channels.add(ctx.channel());
-                    }
-        });
+                    channels.add(ctx.channel());
+                });
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/uptime/UptimeClient.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClient.java
@@ -59,13 +59,10 @@ public final class UptimeClient {
     }
 
     static void connect() {
-        bs.connect().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                if (future.cause() != null) {
-                    handler.startTime = -1;
-                    handler.println("Failed to connect: " + future.cause());
-                }
+        bs.connect().addListener((ChannelFutureListener) future -> {
+            if (future.cause() != null) {
+                handler.startTime = -1;
+                handler.println("Failed to connect: " + future.cause());
             }
         });
     }

--- a/example/src/main/java/io/netty/example/uptime/UptimeClientHandler.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClientHandler.java
@@ -68,12 +68,9 @@ public class UptimeClientHandler extends SimpleChannelInboundHandler<Object> {
     public void channelUnregistered(final ChannelHandlerContext ctx) throws Exception {
         println("Sleeping for: " + UptimeClient.RECONNECT_DELAY + 's');
 
-        ctx.channel().eventLoop().schedule(new Runnable() {
-            @Override
-            public void run() {
-                println("Reconnecting to: " + UptimeClient.HOST + ':' + UptimeClient.PORT);
-                UptimeClient.connect();
-            }
+        ctx.channel().eventLoop().schedule(() -> {
+            println("Reconnecting to: " + UptimeClient.HOST + ':' + UptimeClient.PORT);
+            UptimeClient.connect();
         }, UptimeClient.RECONNECT_DELAY, TimeUnit.SECONDS);
     }
 

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -521,14 +521,11 @@ public class ProxyHandlerTest {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             ctx.writeAndFlush(Unpooled.copiedBuffer("A\n", CharsetUtil.US_ASCII)).addListener(
-                    new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            latch.countDown();
-                            if (!(future.cause() instanceof ProxyConnectException)) {
-                                exceptions.add(new AssertionError(
-                                        "Unexpected failure cause for initial write: " + future.cause()));
-                            }
+                    (ChannelFutureListener) future -> {
+                        latch.countDown();
+                        if (!(future.cause() instanceof ProxyConnectException)) {
+                            exceptions.add(new AssertionError(
+                                    "Unexpected failure cause for initial write: " + future.cause()));
                         }
                     });
         }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
@@ -169,16 +169,13 @@ abstract class ProxyServer {
             if (finished) {
                 this.finished = true;
                 ChannelFuture f = connectToDestination(ctx.channel().eventLoop(), new BackendHandler(ctx));
-                f.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            recordException(future.cause());
-                            ctx.close();
-                        } else {
-                            backend = future.channel();
-                            flush();
-                        }
+                f.addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        recordException(future.cause());
+                        ctx.close();
+                    } else {
+                        backend = future.channel();
+                        flush();
                     }
                 });
             }

--- a/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java
+++ b/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java
@@ -102,15 +102,12 @@ public class FlushConsolidationHandler extends ChannelDuplexHandler {
         this.explicitFlushAfterFlushes = explicitFlushAfterFlushes;
         this.consolidateWhenNoReadInProgress = consolidateWhenNoReadInProgress;
         flushTask = consolidateWhenNoReadInProgress ?
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        if (flushPendingCount > 0 && !readInProgress) {
-                            flushPendingCount = 0;
-                            ctx.flush();
-                            nextScheduledFlush = null;
-                        } // else we'll flush when the read completes
-                    }
+                () -> {
+                    if (flushPendingCount > 0 && !readInProgress) {
+                        flushPendingCount = 0;
+                        ctx.flush();
+                        nextScheduledFlush = null;
+                    } // else we'll flush when the read completes
                 }
                 : null;
     }

--- a/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
@@ -41,12 +41,7 @@ public class UniqueIpFilter extends AbstractRemoteAddressFilter<InetSocketAddres
         if (!connected.add(remoteIp)) {
             return false;
         } else {
-            ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    connected.remove(remoteIp);
-                }
-            });
+            ctx.channel().closeFuture().addListener((ChannelFutureListener) future -> connected.remove(remoteIp));
             return true;
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
@@ -229,26 +229,23 @@ public abstract class AbstractSniHandler<T> extends ByteToMessageDecoder impleme
             onLookupComplete(ctx, hostname, future);
         } else {
             suppressRead = true;
-            future.addListener(new FutureListener<T>() {
-                @Override
-                public void operationComplete(Future<T> future) throws Exception {
+            future.addListener((FutureListener<T>) future1 -> {
+                try {
+                    suppressRead = false;
                     try {
-                        suppressRead = false;
-                        try {
-                            fireSniCompletionEvent(ctx, hostname, future);
-                            onLookupComplete(ctx, hostname, future);
-                        } catch (DecoderException err) {
-                            ctx.fireExceptionCaught(err);
-                        } catch (Exception cause) {
-                            ctx.fireExceptionCaught(new DecoderException(cause));
-                        } catch (Throwable cause) {
-                            ctx.fireExceptionCaught(cause);
-                        }
-                    } finally {
-                        if (readPending) {
-                            readPending = false;
-                            ctx.read();
-                        }
+                        fireSniCompletionEvent(ctx, hostname, future1);
+                        onLookupComplete(ctx, hostname, future1);
+                    } catch (DecoderException err) {
+                        ctx.fireExceptionCaught(err);
+                    } catch (Exception cause) {
+                        ctx.fireExceptionCaught(new DecoderException(cause));
+                    } catch (Throwable cause) {
+                        ctx.fireExceptionCaught(cause);
+                    }
+                } finally {
+                    if (readPending) {
+                        readPending = false;
+                        ctx.read();
                     }
                 }
             });

--- a/handler/src/main/java/io/netty/handler/ssl/Java9SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java9SslUtils.java
@@ -49,50 +49,26 @@ final class Java9SslUtils {
             SSLContext context = SSLContext.getInstance(JdkSslContext.PROTOCOL);
             context.init(null, null, null);
             SSLEngine engine = context.createSSLEngine();
-            getHandshakeApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return SSLEngine.class.getMethod("getHandshakeApplicationProtocol");
-                }
-            });
+            getHandshakeApplicationProtocol = AccessController.doPrivileged((PrivilegedExceptionAction<Method>) () ->
+                    SSLEngine.class.getMethod("getHandshakeApplicationProtocol"));
             getHandshakeApplicationProtocol.invoke(engine);
-            getApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return SSLEngine.class.getMethod("getApplicationProtocol");
-                }
-            });
+            getApplicationProtocol = AccessController.doPrivileged((PrivilegedExceptionAction<Method>) () ->
+                    SSLEngine.class.getMethod("getApplicationProtocol"));
             getApplicationProtocol.invoke(engine);
 
-            setApplicationProtocols = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
-                }
-            });
+            setApplicationProtocols = AccessController.doPrivileged((PrivilegedExceptionAction<Method>) () ->
+                    SSLParameters.class.getMethod("setApplicationProtocols", String[].class));
             setApplicationProtocols.invoke(engine.getSSLParameters(), new Object[]{EmptyArrays.EMPTY_STRINGS});
 
             setHandshakeApplicationProtocolSelector =
-                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return SSLEngine.class.getMethod("setHandshakeApplicationProtocolSelector", BiFunction.class);
-                }
-            });
-            setHandshakeApplicationProtocolSelector.invoke(engine, new BiFunction<SSLEngine, List<String>, String>() {
-                @Override
-                public String apply(SSLEngine sslEngine, List<String> strings) {
-                    return null;
-                }
-            });
+                    AccessController.doPrivileged((PrivilegedExceptionAction<Method>) () ->
+                            SSLEngine.class.getMethod("setHandshakeApplicationProtocolSelector", BiFunction.class));
+            setHandshakeApplicationProtocolSelector.invoke(engine,
+                    (BiFunction<SSLEngine, List<String>, String>) (sslEngine, strings) -> null);
 
             getHandshakeApplicationProtocolSelector =
-                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return SSLEngine.class.getMethod("getHandshakeApplicationProtocolSelector");
-                }
-            });
+                    AccessController.doPrivileged((PrivilegedExceptionAction<Method>) () ->
+                            SSLEngine.class.getMethod("getHandshakeApplicationProtocolSelector"));
             getHandshakeApplicationProtocolSelector.invoke(engine);
         } catch (Throwable t) {
             logger.error("Unable to initialize Java9SslUtils, but the detected javaVersion was: {}",

--- a/handler/src/main/java/io/netty/handler/ssl/JdkBaseApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkBaseApplicationProtocolNegotiator.java
@@ -96,35 +96,17 @@ class JdkBaseApplicationProtocolNegotiator implements JdkApplicationProtocolNego
         return wrapperFactory;
     }
 
-    static final ProtocolSelectorFactory FAIL_SELECTOR_FACTORY = new ProtocolSelectorFactory() {
-        @Override
-        public ProtocolSelector newSelector(SSLEngine engine, Set<String> supportedProtocols) {
-            return new FailProtocolSelector((JdkSslEngine) engine, supportedProtocols);
-        }
-    };
+    static final ProtocolSelectorFactory FAIL_SELECTOR_FACTORY = (engine, supportedProtocols) ->
+            new FailProtocolSelector((JdkSslEngine) engine, supportedProtocols);
 
-    static final ProtocolSelectorFactory NO_FAIL_SELECTOR_FACTORY = new ProtocolSelectorFactory() {
-        @Override
-        public ProtocolSelector newSelector(SSLEngine engine, Set<String> supportedProtocols) {
-            return new NoFailProtocolSelector((JdkSslEngine) engine, supportedProtocols);
-        }
-    };
+    static final ProtocolSelectorFactory NO_FAIL_SELECTOR_FACTORY = (engine, supportedProtocols) ->
+            new NoFailProtocolSelector((JdkSslEngine) engine, supportedProtocols);
 
-    static final ProtocolSelectionListenerFactory FAIL_SELECTION_LISTENER_FACTORY =
-            new ProtocolSelectionListenerFactory() {
-        @Override
-        public ProtocolSelectionListener newListener(SSLEngine engine, List<String> supportedProtocols) {
-            return new FailProtocolSelectionListener((JdkSslEngine) engine, supportedProtocols);
-        }
-    };
+    static final ProtocolSelectionListenerFactory FAIL_SELECTION_LISTENER_FACTORY = (engine, supportedProtocols) ->
+                    new FailProtocolSelectionListener((JdkSslEngine) engine, supportedProtocols);
 
-    static final ProtocolSelectionListenerFactory NO_FAIL_SELECTION_LISTENER_FACTORY =
-            new ProtocolSelectionListenerFactory() {
-        @Override
-        public ProtocolSelectionListener newListener(SSLEngine engine, List<String> supportedProtocols) {
-            return new NoFailProtocolSelectionListener((JdkSslEngine) engine, supportedProtocols);
-        }
-    };
+    static final ProtocolSelectionListenerFactory NO_FAIL_SELECTION_LISTENER_FACTORY = (engine, supportedProtocols) ->
+            new NoFailProtocolSelectionListener((JdkSslEngine) engine, supportedProtocols);
 
     static class NoFailProtocolSelector implements ProtocolSelector {
         private final JdkSslEngine engineWrapper;

--- a/handler/src/main/java/io/netty/handler/ssl/JdkDefaultApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkDefaultApplicationProtocolNegotiator.java
@@ -27,13 +27,8 @@ import javax.net.ssl.SSLEngine;
 final class JdkDefaultApplicationProtocolNegotiator implements JdkApplicationProtocolNegotiator {
     public static final JdkDefaultApplicationProtocolNegotiator INSTANCE =
             new JdkDefaultApplicationProtocolNegotiator();
-    private static final SslEngineWrapperFactory DEFAULT_SSL_ENGINE_WRAPPER_FACTORY = new SslEngineWrapperFactory() {
-        @Override
-        public SSLEngine wrapSslEngine(SSLEngine engine,
-                                       JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
-            return engine;
-        }
-    };
+    private static final SslEngineWrapperFactory DEFAULT_SSL_ENGINE_WRAPPER_FACTORY =
+            (engine, applicationNegotiator, isServer) -> engine;
 
     private JdkDefaultApplicationProtocolNegotiator() {
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -200,13 +200,9 @@ public final class OpenSsl {
                             SSL.setCertificateChainBio(ssl, certBio, false);
                             supportsKeyManagerFactory = true;
                             try {
-                                useKeyManagerFactory = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-                                    @Override
-                                    public Boolean run() {
-                                        return SystemPropertyUtil.getBoolean(
-                                                "io.netty.handler.ssl.openssl.useKeyManagerFactory", true);
-                                    }
-                                });
+                                useKeyManagerFactory = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
+                                        SystemPropertyUtil.getBoolean(
+                                                "io.netty.handler.ssl.openssl.useKeyManagerFactory", true));
                             } catch (Throwable ignore) {
                                 logger.debug("Failed to get useKeyManagerFactory system property.");
                             }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -78,14 +78,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             InternalLoggerFactory.getInstance(ReferenceCountedOpenSslContext.class);
 
     private static final int DEFAULT_BIO_NON_APPLICATION_BUFFER_SIZE =
-            AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-                @Override
-                public Integer run() {
-                    return Math.max(1,
-                            SystemPropertyUtil.getInt("io.netty.handler.ssl.openssl.bioNonApplicationBufferSize",
-                                                      2048));
-                }
-            });
+            AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Math.max(1,
+                    SystemPropertyUtil.getInt("io.netty.handler.ssl.openssl.bioNonApplicationBufferSize",
+                                              2048)));
 
     private static final Integer DH_KEY_LENGTH;
     private static final ResourceLeakDetector<ReferenceCountedOpenSslContext> leakDetector =
@@ -165,12 +160,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         Integer dhLen = null;
 
         try {
-            String dhKeySize = AccessController.doPrivileged(new PrivilegedAction<String>() {
-                @Override
-                public String run() {
-                    return SystemPropertyUtil.get("jdk.tls.ephemeralDHKeySize");
-                }
-            });
+            String dhKeySize = AccessController.doPrivileged((PrivilegedAction<String>) () ->
+                    SystemPropertyUtil.get("jdk.tls.ephemeralDHKeySize"));
             if (dhKeySize != null) {
                 try {
                     dhLen = Integer.valueOf(dhKeySize);

--- a/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
@@ -192,12 +192,7 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
             checkWriteSuspend(ctx, delay, queueSize);
         }
         final long futureNow = newToSend.relativeTimeAction;
-        ctx.executor().schedule(new Runnable() {
-            @Override
-            public void run() {
-                sendAllValid(ctx, futureNow);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        ctx.executor().schedule(() -> sendAllValid(ctx, futureNow), delay, TimeUnit.MILLISECONDS);
     }
 
     private void sendAllValid(final ChannelHandlerContext ctx, final long now) {

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -734,12 +734,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
         }
         final long futureNow = newToSend.relativeTimeAction;
         final PerChannel forSchedule = perChannel;
-        ctx.executor().schedule(new Runnable() {
-            @Override
-            public void run() {
-                sendAllValid(ctx, forSchedule, futureNow);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        ctx.executor().schedule(() -> sendAllValid(ctx, forSchedule, futureNow), delay, TimeUnit.MILLISECONDS);
     }
 
     private void sendAllValid(final ChannelHandlerContext ctx, final PerChannel perChannel, final long now) {

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -365,12 +365,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
         }
         final long futureNow = newToSend.relativeTimeAction;
         final PerChannel forSchedule = perChannel;
-        ctx.executor().schedule(new Runnable() {
-            @Override
-            public void run() {
-                sendAllValid(ctx, forSchedule, futureNow);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        ctx.executor().schedule(() -> sendAllValid(ctx, forSchedule, futureNow), delay, TimeUnit.MILLISECONDS);
     }
 
     private void sendAllValid(final ChannelHandlerContext ctx, final PerChannel perChannel, final long now) {

--- a/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
@@ -57,17 +57,14 @@ public class UniqueIpFilterTest {
     private static Future<EmbeddedChannel> newChannelAsync(final CyclicBarrier barrier,
             ExecutorService executorService,
             final ChannelHandler... handler) {
-        return executorService.submit(new Callable<EmbeddedChannel>() {
-            @Override
-            public EmbeddedChannel call() throws Exception {
-                barrier.await();
-                return new EmbeddedChannel(handler) {
-                    @Override
-                    protected SocketAddress remoteAddress0() {
-                        return isActive() ? SocketUtils.socketAddress("91.92.93.1", 5421) : null;
-                    }
-                };
-            }
+        return executorService.submit(() -> {
+            barrier.await();
+            return new EmbeddedChannel(handler) {
+                @Override
+                protected SocketAddress remoteAddress0() {
+                    return isActive() ? SocketUtils.socketAddress("91.92.93.1", 5421) : null;
+                }
+            };
         });
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
@@ -215,21 +215,16 @@ public class JdkSslEngineTest extends SSLEngineTest {
                 JdkApplicationProtocolNegotiator clientApn = new JdkAlpnApplicationProtocolNegotiator(true, true,
                     PREFERRED_APPLICATION_LEVEL_PROTOCOL);
                 JdkApplicationProtocolNegotiator serverApn = new JdkAlpnApplicationProtocolNegotiator(
-                    new ProtocolSelectorFactory() {
-                        @Override
-                        public ProtocolSelector newSelector(SSLEngine engine, Set<String> supportedProtocols) {
-                            return new ProtocolSelector() {
-                                @Override
-                                public void unsupported() {
-                                }
+                        (engine, supportedProtocols) -> new ProtocolSelector() {
+                            @Override
+                            public void unsupported() {
+                            }
 
-                                @Override
-                                public String select(List<String> protocols) {
-                                    return APPLICATION_LEVEL_PROTOCOL_NOT_COMPATIBLE;
-                                }
-                            };
-                        }
-                    }, JdkBaseApplicationProtocolNegotiator.FAIL_SELECTION_LISTENER_FACTORY,
+                            @Override
+                            public String select(List<String> protocols) {
+                                return APPLICATION_LEVEL_PROTOCOL_NOT_COMPATIBLE;
+                            }
+                        }, JdkBaseApplicationProtocolNegotiator.FAIL_SELECTION_LISTENER_FACTORY,
                     APPLICATION_LEVEL_PROTOCOL_NOT_COMPATIBLE);
 
                 SslContext serverSslCtx = new JdkSslServerContext(providerType.provider(),

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -169,13 +169,10 @@ public class ParameterizedSslHandlerTest {
                                                 buf.writerIndex(buf.writerIndex() + singleComponentSize);
                                                 content.addComponent(true, buf);
                                             }
-                                            ctx.writeAndFlush(content).addListener(new ChannelFutureListener() {
-                                                @Override
-                                                public void operationComplete(ChannelFuture future) throws Exception {
-                                                    writeCause = future.cause();
-                                                    if (writeCause == null) {
-                                                        sentData = true;
-                                                    }
+                                            ctx.writeAndFlush(content).addListener((ChannelFutureListener) future -> {
+                                                writeCause = future.cause();
+                                                if (writeCause == null) {
+                                                    sentData = true;
                                                 }
                                             });
                                         } else {
@@ -415,13 +412,10 @@ public class ParameterizedSslHandlerTest {
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
                             handler.sslCloseFuture().addListener(
                                     new PromiseNotifier<>(serverPromise));
-                            handler.handshakeFuture().addListener(new FutureListener<Channel>() {
-                                @Override
-                                public void operationComplete(Future<Channel> future) {
-                                    if (!future.isSuccess()) {
-                                        // Something bad happened during handshake fail the promise!
-                                        serverPromise.tryFailure(future.cause());
-                                    }
+                            handler.handshakeFuture().addListener((FutureListener<Channel>) future -> {
+                                if (!future.isSuccess()) {
+                                    // Something bad happened during handshake fail the promise!
+                                    serverPromise.tryFailure(future.cause());
                                 }
                             });
                             ch.pipeline().addLast(handler);
@@ -454,16 +448,13 @@ public class ParameterizedSslHandlerTest {
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
                             handler.sslCloseFuture().addListener(
                                     new PromiseNotifier<>(clientPromise));
-                            handler.handshakeFuture().addListener(new FutureListener<Channel>() {
-                                @Override
-                                public void operationComplete(Future<Channel> future) {
-                                    if (future.isSuccess()) {
-                                        closeSent.compareAndSet(false, true);
-                                        future.getNow().close();
-                                    } else {
-                                        // Something bad happened during handshake fail the promise!
-                                        clientPromise.tryFailure(future.cause());
-                                    }
+                            handler.handshakeFuture().addListener((FutureListener<Channel>) future -> {
+                                if (future.isSuccess()) {
+                                    closeSent.compareAndSet(false, true);
+                                    future.getNow().close();
+                                } else {
+                                    // Something bad happened during handshake fail the promise!
+                                    clientPromise.tryFailure(future.cause());
                                 }
                             });
                             ch.pipeline().addLast(handler);

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -72,14 +72,11 @@ public abstract class RenegotiateTest {
                                             final SslHandler handler = ctx.pipeline().get(SslHandler.class);
 
                                             renegotiate = true;
-                                            handler.renegotiate().addListener(new FutureListener<Channel>() {
-                                                @Override
-                                                public void operationComplete(Future<Channel> future) throws Exception {
-                                                    if (!future.isSuccess()) {
-                                                        error.compareAndSet(null, future.cause());
-                                                        latch.countDown();
-                                                        ctx.close();
-                                                    }
+                                            handler.renegotiate().addListener((FutureListener<Channel>) future -> {
+                                                if (!future.isSuccess()) {
+                                                    error.compareAndSet(null, future.cause());
+                                                    latch.countDown();
+                                                    ctx.close();
                                                 }
                                             });
                                         } else {

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1280,11 +1280,8 @@ public abstract class SSLEngineTest {
                                 // The server then attempts to trigger a flush operation once the application data is
                                 // received from the client. The flush will encrypt all data and should not result in
                                 // deadlock.
-                                ctx.channel().eventLoop().schedule(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        ctx.writeAndFlush(ctx.alloc().buffer(1).writeByte(101));
-                                    }
+                                ctx.channel().eventLoop().schedule(() -> {
+                                    ctx.writeAndFlush(ctx.alloc().buffer(1).writeByte(101));
                                 }, 500, TimeUnit.MILLISECONDS);
                             }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -122,12 +122,9 @@ public class SniClientTest {
             sc = sb.group(group).channel(LocalServerChannel.class).childHandler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
-                    ch.pipeline().addFirst(new SniHandler(new Mapping<String, SslContext>() {
-                        @Override
-                        public SslContext map(String input) {
-                            promise.setSuccess(input);
-                            return finalContext;
-                        }
+                    ch.pipeline().addFirst(new SniHandler(input -> {
+                        promise.setSuccess(input);
+                        return finalContext;
                     }));
                 }
             }).bind(address).syncUninterruptibly().channel();

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -432,12 +432,7 @@ public class SniHandlerTest {
                             .sslProvider(provider)
                             .build();
 
-                    final Mapping<String, SslContext> mapping = new Mapping<String, SslContext>() {
-                        @Override
-                        public SslContext map(String input) {
-                            return sslServerContext;
-                        }
-                    };
+                    final Mapping<String, SslContext> mapping = input -> sslServerContext;
 
                     final Promise<Void> releasePromise = group.next().newPromise();
 

--- a/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
@@ -315,11 +315,8 @@ public class OcspTest {
 
         final OcspTestException clientException = new OcspTestException("testClientException");
         byte[] response = newOcspResponse();
-        OcspClientCallback callback = new OcspClientCallback() {
-            @Override
-            public boolean verify(byte[] response) throws Exception {
-                throw clientException;
-            }
+        OcspClientCallback callback = response1 -> {
+            throw clientException;
         };
 
         handshake(sslProvider, latch, null, response, clientHandler, callback);

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -154,13 +154,7 @@ public class ChunkedWriteHandlerTest {
         };
 
         final AtomicBoolean listenerNotified = new AtomicBoolean(false);
-        final ChannelFutureListener listener = new ChannelFutureListener() {
-
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                listenerNotified.set(true);
-            }
-        };
+        final ChannelFutureListener listener = future -> listenerNotified.set(true);
 
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
         ch.writeAndFlush(input).addListener(listener).syncUninterruptibly();

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
@@ -105,12 +105,7 @@ public class IdleStateHandlerTest {
         TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
                 false, 1L, 0L, 0L, TimeUnit.SECONDS);
 
-        Action action = new Action() {
-            @Override
-            public void run(EmbeddedChannel channel) throws Exception {
-                channel.writeInbound("Hello, World!");
-            }
-        };
+        Action action = channel -> channel.writeInbound("Hello, World!");
 
         anyNotIdle(idleStateHandler, action, IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT);
     }
@@ -120,12 +115,7 @@ public class IdleStateHandlerTest {
         TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
                 false, 0L, 1L, 0L, TimeUnit.SECONDS);
 
-        Action action = new Action() {
-            @Override
-            public void run(EmbeddedChannel channel) throws Exception {
-                channel.writeAndFlush("Hello, World!");
-            }
-        };
+        Action action = channel -> channel.writeAndFlush("Hello, World!");
 
         anyNotIdle(idleStateHandler, action, IdleStateEvent.FIRST_WRITER_IDLE_STATE_EVENT);
     }
@@ -136,12 +126,7 @@ public class IdleStateHandlerTest {
         TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
                 false, 0L, 0L, 1L, TimeUnit.SECONDS);
 
-        Action reader = new Action() {
-            @Override
-            public void run(EmbeddedChannel channel) throws Exception {
-                channel.writeInbound("Hello, World!");
-            }
-        };
+        Action reader = channel -> channel.writeInbound("Hello, World!");
 
         anyNotIdle(idleStateHandler, reader, IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT);
 
@@ -149,12 +134,7 @@ public class IdleStateHandlerTest {
         idleStateHandler = new TestableIdleStateHandler(
                 false, 0L, 0L, 1L, TimeUnit.SECONDS);
 
-        Action writer = new Action() {
-            @Override
-            public void run(EmbeddedChannel channel) throws Exception {
-                channel.writeAndFlush("Hello, World!");
-            }
-        };
+        Action writer = channel -> channel.writeAndFlush("Hello, World!");
 
         anyNotIdle(idleStateHandler, writer, IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT);
     }

--- a/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/CompositeByteBufSequentialBenchmark.java
@@ -70,11 +70,8 @@ public class CompositeByteBufSequentialBenchmark extends AbstractMicrobenchmark 
         buffer.release();
     }
 
-    private static final ByteProcessor TEST_PROCESSOR = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value == 'b'; // false
-        }
+    private static final ByteProcessor TEST_PROCESSOR = value -> {
+        return value == 'b'; // false
     };
 
     @Benchmark

--- a/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -48,11 +48,8 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
         group = new MultithreadEventLoopGroup(1, EpollHandler.newFactory());
 
         // add an arbitrary timeout to make the timer reschedule
-        future = group.schedule(new Runnable() {
-            @Override
-            public void run() {
-                throw new AssertionError();
-            }
+        future = group.schedule((Runnable) () -> {
+            throw new AssertionError();
         }, 5, TimeUnit.MINUTES);
         serverChan = new ServerBootstrap()
             .channel(EpollServerSocketChannel.class)

--- a/microbench/src/main/java/io/netty/microbench/http2/NoPriorityByteDistributionBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoPriorityByteDistributionBenchmark.java
@@ -98,16 +98,13 @@ public class NoPriorityByteDistributionBenchmark extends AbstractMicrobenchmark 
         }
     }
 
-    private Http2StreamVisitor invocationVisitor = new Http2StreamVisitor() {
-        @Override
-        public boolean visit(Http2Stream stream) throws Http2Exception {
-            // Restore the connection window.
-            resetWindow(stream);
+    private Http2StreamVisitor invocationVisitor = stream -> {
+        // Restore the connection window.
+        resetWindow(stream);
 
-            // Restore the data to each stream.
-            dataRefresher(stream).refreshData();
-            return true;
-        }
+        // Restore the data to each stream.
+        dataRefresher(stream).refreshData();
+        return true;
     };
 
     @TearDown(Level.Trial)

--- a/microbench/src/main/java/io/netty/microbench/internal/PrivilegedSocketOperationsBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/internal/PrivilegedSocketOperationsBenchmark.java
@@ -81,15 +81,12 @@ public class PrivilegedSocketOperationsBenchmark extends AbstractMicrobenchmark 
     public ServerSocketChannel testWithSM(final SecurityManagerInstalled sm) throws IOException {
         try {
             final ServerSocketChannel ssc = AccessController.doPrivileged(
-                    new PrivilegedExceptionAction<ServerSocketChannel>() {
-                        @Override
-                        public ServerSocketChannel run() throws Exception {
-                            final ServerSocketChannel ssc = ServerSocketChannel.open();
-                            ssc.socket().bind(null);
-                            ssc.configureBlocking(false);
-                            ssc.accept();
-                            return ssc;
-                        }
+                    (PrivilegedExceptionAction<ServerSocketChannel>) () -> {
+                        final ServerSocketChannel ssc1 = ServerSocketChannel.open();
+                        ssc1.socket().bind(null);
+                        ssc1.configureBlocking(false);
+                        ssc1.accept();
+                        return ssc1;
                     });
             ssc.close();
             return ssc;
@@ -103,15 +100,12 @@ public class PrivilegedSocketOperationsBenchmark extends AbstractMicrobenchmark 
         if (System.getSecurityManager() != null) {
             try {
                 final ServerSocketChannel ssc = AccessController.doPrivileged(
-                        new PrivilegedExceptionAction<ServerSocketChannel>() {
-                            @Override
-                            public ServerSocketChannel run() throws Exception {
-                                final ServerSocketChannel ssc = ServerSocketChannel.open();
-                                ssc.socket().bind(null);
-                                ssc.configureBlocking(false);
-                                ssc.accept();
-                                return ssc;
-                            }
+                        (PrivilegedExceptionAction<ServerSocketChannel>) () -> {
+                            final ServerSocketChannel ssc1 = ServerSocketChannel.open();
+                            ssc1.socket().bind(null);
+                            ssc1.configureBlocking(false);
+                            ssc1.accept();
+                            return ssc1;
                         });
                 ssc.close();
                 return ssc;
@@ -143,15 +137,12 @@ public class PrivilegedSocketOperationsBenchmark extends AbstractMicrobenchmark 
     public ServerSocketChannel testWithoutSM(final SecurityManagerEmpty sm) throws IOException {
         try {
             final ServerSocketChannel ssc = AccessController.doPrivileged(
-                    new PrivilegedExceptionAction<ServerSocketChannel>() {
-                        @Override
-                        public ServerSocketChannel run() throws Exception {
-                            final ServerSocketChannel ssc = ServerSocketChannel.open();
-                            ssc.socket().bind(null);
-                            ssc.configureBlocking(false);
-                            ssc.accept();
-                            return ssc;
-                        }
+                    (PrivilegedExceptionAction<ServerSocketChannel>) () -> {
+                        final ServerSocketChannel ssc1 = ServerSocketChannel.open();
+                        ssc1.socket().bind(null);
+                        ssc1.configureBlocking(false);
+                        ssc1.accept();
+                        return ssc1;
                     });
             ssc.close();
             return ssc;
@@ -166,15 +157,12 @@ public class PrivilegedSocketOperationsBenchmark extends AbstractMicrobenchmark 
             // this should never happen during benchmarking, but we write the correct code here
             try {
                 final ServerSocketChannel ssc = AccessController.doPrivileged(
-                        new PrivilegedExceptionAction<ServerSocketChannel>() {
-                            @Override
-                            public ServerSocketChannel run() throws Exception {
-                                final ServerSocketChannel ssc = ServerSocketChannel.open();
-                                ssc.socket().bind(null);
-                                ssc.configureBlocking(false);
-                                ssc.accept();
-                                return ssc;
-                            }
+                        (PrivilegedExceptionAction<ServerSocketChannel>) () -> {
+                            final ServerSocketChannel ssc1 = ServerSocketChannel.open();
+                            ssc1.socket().bind(null);
+                            ssc1.configureBlocking(false);
+                            ssc1.accept();
+                            return ssc1;
                         });
                 ssc.close();
                 return ssc;

--- a/microbench/src/main/java/io/netty/microbench/util/ResourceLeakDetectorRecordBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/ResourceLeakDetectorRecordBenchmark.java
@@ -26,12 +26,7 @@ import org.openjdk.jmh.annotations.TearDown;
 
 public class ResourceLeakDetectorRecordBenchmark extends AbstractMicrobenchmark {
     private static final Object TRACKED = new Object();
-    private static final ResourceLeakHint HINT = new ResourceLeakHint() {
-        @Override
-        public String toHintString() {
-            return "BenchmarkHint";
-        }
-    };
+    private static final ResourceLeakHint HINT = () -> "BenchmarkHint";
 
     @Param({ "8", "16" })
     private int recordTimes;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -63,12 +63,9 @@ import static java.lang.Math.min;
 abstract class DnsResolveContext<T> {
 
     private static final FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>> RELEASE_RESPONSE =
-            new FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>() {
-                @Override
-                public void operationComplete(Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> future) {
-                    if (future.isSuccess()) {
-                        future.getNow().release();
-                    }
+            future -> {
+                if (future.isSuccess()) {
+                    future.getNow().release();
                 }
             };
     private static final RuntimeException NXDOMAIN_QUERY_FAILED_EXCEPTION = ThrowableUtil.unknownStackTrace(
@@ -354,41 +351,38 @@ abstract class DnsResolveContext<T> {
 
         queryLifecycleObserver.queryWritten(nameServerAddr, writePromise);
 
-        f.addListener(new FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>() {
-            @Override
-            public void operationComplete(Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> future) {
-                queriesInProgress.remove(future);
+        f.addListener((FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>) future -> {
+            queriesInProgress.remove(future);
 
-                if (promise.isDone() || future.isCancelled()) {
-                    queryLifecycleObserver.queryCancelled(allowedQueries);
+            if (promise.isDone() || future.isCancelled()) {
+                queryLifecycleObserver.queryCancelled(allowedQueries);
 
-                    // Check if we need to release the envelope itself. If the query was cancelled the getNow() will
-                    // return null as well as the Future will be failed with a CancellationException.
-                    AddressedEnvelope<DnsResponse, InetSocketAddress> result = future.getNow();
-                    if (result != null) {
-                        result.release();
-                    }
-                    return;
+                // Check if we need to release the envelope itself. If the query was cancelled the getNow() will
+                // return null as well as the Future will be failed with a CancellationException.
+                AddressedEnvelope<DnsResponse, InetSocketAddress> result = future.getNow();
+                if (result != null) {
+                    result.release();
                 }
+                return;
+            }
 
-                final Throwable queryCause = future.cause();
-                try {
-                    if (queryCause == null) {
-                        onResponse(nameServerAddrStream, nameServerAddrStreamIndex, question, future.getNow(),
-                                   queryLifecycleObserver, promise);
-                    } else {
-                        // Server did not respond or I/O error occurred; try again.
-                        queryLifecycleObserver.queryFailed(queryCause);
-                        query(nameServerAddrStream, nameServerAddrStreamIndex + 1, question,
-                              newDnsQueryLifecycleObserver(question), true, promise, queryCause);
-                    }
-                } finally {
-                    tryToFinishResolve(nameServerAddrStream, nameServerAddrStreamIndex, question,
-                                       // queryLifecycleObserver has already been terminated at this point so we must
-                                       // not allow it to be terminated again by tryToFinishResolve.
-                                       NoopDnsQueryLifecycleObserver.INSTANCE,
-                                       promise, queryCause);
+            final Throwable queryCause = future.cause();
+            try {
+                if (queryCause == null) {
+                    onResponse(nameServerAddrStream, nameServerAddrStreamIndex, question, future.getNow(),
+                               queryLifecycleObserver, promise);
+                } else {
+                    // Server did not respond or I/O error occurred; try again.
+                    queryLifecycleObserver.queryFailed(queryCause);
+                    query(nameServerAddrStream, nameServerAddrStreamIndex + 1, question,
+                          newDnsQueryLifecycleObserver(question), true, promise, queryCause);
                 }
+            } finally {
+                tryToFinishResolve(nameServerAddrStream, nameServerAddrStreamIndex, question,
+                                   // queryLifecycleObserver has already been terminated at this point so we must
+                                   // not allow it to be terminated again by tryToFinishResolve.
+                                   NoopDnsQueryLifecycleObserver.INSTANCE,
+                                   promise, queryCause);
             }
         });
     }
@@ -409,23 +403,20 @@ abstract class DnsResolveContext<T> {
         queriesInProgress.add(resolveFuture);
 
         Promise<List<InetAddress>> resolverPromise = parent.executor().newPromise();
-        resolverPromise.addListener(new FutureListener<List<InetAddress>>() {
-            @Override
-            public void operationComplete(final Future<List<InetAddress>> future) {
-                // Remove placeholder.
-                queriesInProgress.remove(resolveFuture);
+        resolverPromise.addListener((FutureListener<List<InetAddress>>) future -> {
+            // Remove placeholder.
+            queriesInProgress.remove(resolveFuture);
 
-                if (future.isSuccess()) {
-                    List<InetAddress> resolvedAddresses = future.getNow();
-                    DnsServerAddressStream addressStream = new CombinedDnsServerAddressStream(
-                            nameServerAddr, resolvedAddresses, nameServerAddrStream);
-                    query(addressStream, nameServerAddrStreamIndex, question,
-                          queryLifecycleObserver, true, promise, cause);
-                } else {
-                    // Ignore the server and try the next one...
-                    query(nameServerAddrStream, nameServerAddrStreamIndex + 1,
-                          question, queryLifecycleObserver, true, promise, cause);
-                }
+            if (future.isSuccess()) {
+                List<InetAddress> resolvedAddresses = future.getNow();
+                DnsServerAddressStream addressStream = new CombinedDnsServerAddressStream(
+                        nameServerAddr, resolvedAddresses, nameServerAddrStream);
+                query(addressStream, nameServerAddrStreamIndex, question,
+                      queryLifecycleObserver, true, promise, cause);
+            } else {
+                // Ignore the server and try the next one...
+                query(nameServerAddrStream, nameServerAddrStreamIndex + 1,
+                      question, queryLifecycleObserver, true, promise, cause);
             }
         });
         if (!DnsNameResolver.doResolveAllCached(nameServerName, additionals, resolverPromise, resolveCache(),

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
@@ -81,12 +81,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
             if (earlyPromise.isDone()) {
                 transferResult(earlyPromise, promise);
             } else {
-                earlyPromise.addListener(new FutureListener<U>() {
-                    @Override
-                    public void operationComplete(Future<U> f) throws Exception {
-                        transferResult(f, promise);
-                    }
-                });
+                earlyPromise.addListener((FutureListener<U>) f -> transferResult(f, promise));
             }
         } else {
             try {
@@ -103,12 +98,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
                 if (promise.isDone()) {
                     resolveMap.remove(inetHost);
                 } else {
-                    promise.addListener(new FutureListener<U>() {
-                        @Override
-                        public void operationComplete(Future<U> f) throws Exception {
-                            resolveMap.remove(inetHost);
-                        }
-                    });
+                    promise.addListener((FutureListener<U>) f -> resolveMap.remove(inetHost));
                 }
             }
         }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
@@ -47,15 +47,12 @@ public class DefaultAuthoritativeDnsServerCacheTest {
             cache.cache("netty.io", resolved1, 1, loop);
             cache.cache("netty.io", resolved2, 10000, loop);
 
-            Throwable error = loop.schedule(new Callable<Throwable>() {
-                @Override
-                public Throwable call() {
-                    try {
-                        assertNull(cache.get("netty.io"));
-                        return null;
-                    } catch (Throwable cause) {
-                        return cause;
-                    }
+            Throwable error = loop.schedule(() -> {
+                try {
+                    assertNull(cache.get("netty.io"));
+                    return null;
+                } catch (Throwable cause) {
+                    return cause;
                 }
             }, 1, TimeUnit.SECONDS).get();
             if (error != null) {
@@ -163,19 +160,16 @@ public class DefaultAuthoritativeDnsServerCacheTest {
                 cache = new DefaultAuthoritativeDnsServerCache(10000, 10000, null);
             }  else {
                 cache = new DefaultAuthoritativeDnsServerCache(10000, 10000,
-                                                               new Comparator<InetSocketAddress>() {
-                    @Override
-                    public int compare(InetSocketAddress o1, InetSocketAddress o2) {
-                        if (o1.equals(o2)) {
-                            return 0;
-                        }
-                        if (o1.isUnresolved()) {
-                            return 1;
-                        } else {
-                            return -1;
-                        }
-                    }
-                });
+                        (o1, o2) -> {
+                            if (o1.equals(o2)) {
+                                return 0;
+                            }
+                            if (o1.isUnresolved()) {
+                                return 1;
+                            } else {
+                                return -1;
+                            }
+                        });
             }
             cache.cache("netty.io", unresolved, 100, loop);
             cache.cache("netty.io", resolved, 10000, loop);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
@@ -49,15 +49,12 @@ public class DefaultDnsCacheTest {
             cache.cache("netty.io", null, addr1, 1, loop);
             cache.cache("netty.io", null, addr2, 10000, loop);
 
-            Throwable error = loop.schedule(new Callable<Throwable>() {
-                @Override
-                public Throwable call() {
-                    try {
-                        assertNull(cache.get("netty.io", null));
-                        return null;
-                    } catch (Throwable cause) {
-                        return cause;
-                    }
+            Throwable error = loop.schedule(() -> {
+                try {
+                    assertNull(cache.get("netty.io", null));
+                    return null;
+                } catch (Throwable cause) {
+                    return cause;
                 }
             }, 1, TimeUnit.SECONDS).get();
             if (error != null) {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCnameCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCnameCacheTest.java
@@ -38,15 +38,12 @@ public class DefaultDnsCnameCacheTest {
             final DefaultDnsCnameCache cache = new DefaultDnsCnameCache();
             cache.cache("netty.io", "mapping.netty.io", 1, loop);
 
-            Throwable error = loop.schedule(new Callable<Throwable>() {
-                @Override
-                public Throwable call() {
-                    try {
-                        assertNull(cache.get("netty.io"));
-                        return null;
-                    } catch (Throwable cause) {
-                        return cause;
-                    }
+            Throwable error = loop.schedule(() -> {
+                try {
+                    assertNull(cache.get("netty.io"));
+                    return null;
+                } catch (Throwable cause) {
+                    return cause;
                 }
             }, 1, TimeUnit.SECONDS).get();
             if (error != null) {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -397,19 +397,16 @@ public class DnsNameResolverTest {
     @Test
     public void testNameServerCache() throws IOException, InterruptedException {
         final String overriddenIP = "12.34.12.34";
-        final TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) {
-                switch (question.getRecordType()) {
-                    case A:
-                        Map<String, Object> attr = new HashMap<>();
-                        attr.put(DnsAttribute.IP_ADDRESS.toLowerCase(Locale.US), overriddenIP);
-                        return Collections.<ResourceRecord>singleton(
-                                new TestDnsServer.TestResourceRecord(
-                                        question.getDomainName(), question.getRecordType(), attr));
-                    default:
-                        return null;
-                }
+        final TestDnsServer dnsServer2 = new TestDnsServer(question -> {
+            switch (question.getRecordType()) {
+                case A:
+                    Map<String, Object> attr = new HashMap<>();
+                    attr.put(DnsAttribute.IP_ADDRESS.toLowerCase(Locale.US), overriddenIP);
+                    return Collections.<ResourceRecord>singleton(
+                            new TestDnsServer.TestResourceRecord(
+                                    question.getDomainName(), question.getRecordType(), attr));
+                default:
+                    return null;
             }
         });
         dnsServer2.start();
@@ -423,13 +420,9 @@ public class DnsNameResolverTest {
                     overriddenHostnames.add(name);
                 }
             }
-            DnsNameResolver resolver = newResolver(false, new DnsServerAddressStreamProvider() {
-                @Override
-                public DnsServerAddressStream nameServerAddressStream(String hostname) {
-                    return overriddenHostnames.contains(hostname) ? sequential(dnsServer2.localAddress()).stream() :
-                            null;
-                }
-            }).build();
+            DnsNameResolver resolver = newResolver(false, hostname ->
+                    overriddenHostnames.contains(hostname) ? sequential(dnsServer2.localAddress()).stream() : null)
+                    .build();
             try {
                 final Map<String, InetAddress> resultA = testResolve0(resolver, EXCLUSIONS_RESOLVE_A, AAAA);
                 for (Entry<String, InetAddress> resolvedEntry : resultA.entrySet()) {
@@ -785,36 +778,33 @@ public class DnsNameResolverTest {
         final String lastName = "lastname.com";
         final String ipv4Addr = "1.2.3.4";
         final String ipv6Addr = "::1";
-        TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) {
-                ResourceRecordModifier rm = new ResourceRecordModifier();
-                rm.setDnsClass(RecordClass.IN);
-                rm.setDnsName(question.getDomainName());
-                rm.setDnsTtl(100);
-                rm.setDnsType(RecordType.CNAME);
+        TestDnsServer dnsServer2 = new TestDnsServer(question -> {
+            ResourceRecordModifier rm = new ResourceRecordModifier();
+            rm.setDnsClass(RecordClass.IN);
+            rm.setDnsName(question.getDomainName());
+            rm.setDnsTtl(100);
+            rm.setDnsType(RecordType.CNAME);
 
-                if (question.getDomainName().equals(firstName)) {
-                    rm.put(DnsAttribute.DOMAIN_NAME, secondName);
-                } else if (question.getDomainName().equals(secondName)) {
-                    rm.put(DnsAttribute.DOMAIN_NAME, lastName);
-                } else if (question.getDomainName().equals(lastName)) {
-                    rm.setDnsType(question.getRecordType());
-                    switch (question.getRecordType()) {
-                        case A:
-                            rm.put(DnsAttribute.IP_ADDRESS, ipv4Addr);
-                            break;
-                        case AAAA:
-                            rm.put(DnsAttribute.IP_ADDRESS, ipv6Addr);
-                            break;
-                        default:
-                            return null;
-                    }
-                } else {
-                    return null;
+            if (question.getDomainName().equals(firstName)) {
+                rm.put(DnsAttribute.DOMAIN_NAME, secondName);
+            } else if (question.getDomainName().equals(secondName)) {
+                rm.put(DnsAttribute.DOMAIN_NAME, lastName);
+            } else if (question.getDomainName().equals(lastName)) {
+                rm.setDnsType(question.getRecordType());
+                switch (question.getRecordType()) {
+                    case A:
+                        rm.put(DnsAttribute.IP_ADDRESS, ipv4Addr);
+                        break;
+                    case AAAA:
+                        rm.put(DnsAttribute.IP_ADDRESS, ipv6Addr);
+                        break;
+                    default:
+                        return null;
                 }
-                return Collections.singleton(rm.getEntry());
+            } else {
+                return null;
             }
+            return Collections.singleton(rm.getEntry());
         });
         dnsServer2.start();
         DnsNameResolver resolver = null;
@@ -860,47 +850,41 @@ public class DnsNameResolverTest {
         final String ipv4Addr = "1.2.3.4";
         final String ipv6Addr = "::1";
         final AtomicBoolean hitServer2 = new AtomicBoolean();
-        final TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) throws DnsException {
-                hitServer2.set(true);
-                if (question.getDomainName().equals(firstName)) {
-                    ResourceRecordModifier rm = new ResourceRecordModifier();
-                    rm.setDnsClass(RecordClass.IN);
-                    rm.setDnsName(question.getDomainName());
-                    rm.setDnsTtl(100);
-                    rm.setDnsType(RecordType.CNAME);
-                    rm.put(DnsAttribute.DOMAIN_NAME, lastName);
-                    return Collections.singleton(rm.getEntry());
-                } else {
-                    throw new DnsException(ResponseCode.REFUSED);
-                }
+        final TestDnsServer dnsServer2 = new TestDnsServer(question -> {
+            hitServer2.set(true);
+            if (question.getDomainName().equals(firstName)) {
+                ResourceRecordModifier rm = new ResourceRecordModifier();
+                rm.setDnsClass(RecordClass.IN);
+                rm.setDnsName(question.getDomainName());
+                rm.setDnsTtl(100);
+                rm.setDnsType(RecordType.CNAME);
+                rm.put(DnsAttribute.DOMAIN_NAME, lastName);
+                return Collections.singleton(rm.getEntry());
+            } else {
+                throw new DnsException(ResponseCode.REFUSED);
             }
         });
-        final TestDnsServer dnsServer3 = new TestDnsServer(new RecordStore() {
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) throws DnsException {
-                if (question.getDomainName().equals(lastName)) {
-                    ResourceRecordModifier rm = new ResourceRecordModifier();
-                    rm.setDnsClass(RecordClass.IN);
-                    rm.setDnsName(question.getDomainName());
-                    rm.setDnsTtl(100);
-                    rm.setDnsType(question.getRecordType());
-                    switch (question.getRecordType()) {
-                        case A:
-                            rm.put(DnsAttribute.IP_ADDRESS, ipv4Addr);
-                            break;
-                        case AAAA:
-                            rm.put(DnsAttribute.IP_ADDRESS, ipv6Addr);
-                            break;
-                        default:
-                            return null;
-                    }
-
-                    return Collections.singleton(rm.getEntry());
-                } else {
-                    throw new DnsException(ResponseCode.REFUSED);
+        final TestDnsServer dnsServer3 = new TestDnsServer(question -> {
+            if (question.getDomainName().equals(lastName)) {
+                ResourceRecordModifier rm = new ResourceRecordModifier();
+                rm.setDnsClass(RecordClass.IN);
+                rm.setDnsName(question.getDomainName());
+                rm.setDnsTtl(100);
+                rm.setDnsType(question.getRecordType());
+                switch (question.getRecordType()) {
+                    case A:
+                        rm.put(DnsAttribute.IP_ADDRESS, ipv4Addr);
+                        break;
+                    case AAAA:
+                        rm.put(DnsAttribute.IP_ADDRESS, ipv6Addr);
+                        break;
+                    default:
+                        return null;
                 }
+
+                return Collections.singleton(rm.getEntry());
+            } else {
+                throw new DnsException(ResponseCode.REFUSED);
             }
         });
         dnsServer2.start();
@@ -1021,18 +1005,15 @@ public class DnsNameResolverTest {
     public void testResolveAllHostsFile() {
         final DnsNameResolver resolver = new DnsNameResolverBuilder(group.next())
                 .channelType(NioDatagramChannel.class)
-                .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
-                    @Override
-                    public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
-                        if ("foo.com.".equals(inetHost)) {
-                            try {
-                                return InetAddress.getByAddress("foo.com", new byte[] { 1, 2, 3, 4 });
-                            } catch (UnknownHostException e) {
-                                throw new Error(e);
-                            }
+                .hostsFileEntriesResolver((inetHost, resolvedAddressTypes) -> {
+                    if ("foo.com.".equals(inetHost)) {
+                        try {
+                            return InetAddress.getByAddress("foo.com", new byte[] { 1, 2, 3, 4 });
+                        } catch (UnknownHostException e) {
+                            throw new Error(e);
                         }
-                        return null;
                     }
+                    return null;
                 }).build();
 
         final List<DnsRecord> records = resolver.resolveAll(new DefaultDnsQuestion("foo.com.", A))
@@ -1221,12 +1202,7 @@ public class DnsNameResolverTest {
             records.add(Collections.singleton(TestDnsServer.newAddressRecord(name, RecordType.AAAA, ipv6Address)));
         }
         final Iterator<Set<ResourceRecord>> recordsIterator = records.iterator();
-        RecordStore arbitrarilyOrderedStore = new RecordStore() {
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord questionRecord) {
-                return recordsIterator.next();
-            }
-        };
+        RecordStore arbitrarilyOrderedStore = questionRecord -> recordsIterator.next();
         TestDnsServer nonCompliantDnsServer = new TestDnsServer(arbitrarilyOrderedStore);
         nonCompliantDnsServer.start();
         try {
@@ -1389,15 +1365,12 @@ public class DnsNameResolverTest {
         // This is used to simulate a query timeout...
         final DatagramSocket socket = new DatagramSocket(new InetSocketAddress(0));
 
-        final TestDnsServer dnsServerAuthority = new TestDnsServer(new RecordStore() {
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) {
-                if (question.getDomainName().equals(expected.getHostName())) {
-                    return Collections.singleton(TestDnsServer.newARecord(
-                            expected.getHostName(), expected.getHostAddress()));
-                }
-                return Collections.emptySet();
+        final TestDnsServer dnsServerAuthority = new TestDnsServer(question -> {
+            if (question.getDomainName().equals(expected.getHostName())) {
+                return Collections.singleton(TestDnsServer.newARecord(
+                        expected.getHostName(), expected.getHostAddress()));
             }
+            return Collections.emptySet();
         });
         dnsServerAuthority.start();
 
@@ -2091,28 +2064,24 @@ public class DnsNameResolverTest {
 
     @Test
     public void testFollowCNAMEEvenIfARecordIsPresent() throws IOException {
-        TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
+        TestDnsServer dnsServer2 = new TestDnsServer(question -> {
+            if (question.getDomainName().equals("cname.netty.io")) {
+                Map<String, Object> map1 = new HashMap<>();
+                map1.put(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99");
+                return Collections.<ResourceRecord>singleton(
+                        new TestDnsServer.TestResourceRecord(question.getDomainName(), RecordType.A, map1));
+            } else {
+                Set<ResourceRecord> records = new LinkedHashSet<>(2);
+                Map<String, Object> map = new HashMap<>();
+                map.put(DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io");
+                records.add(new TestDnsServer.TestResourceRecord(
+                        question.getDomainName(), RecordType.CNAME, map));
 
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) {
-                if (question.getDomainName().equals("cname.netty.io")) {
-                    Map<String, Object> map1 = new HashMap<>();
-                    map1.put(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99");
-                    return Collections.<ResourceRecord>singleton(
-                            new TestDnsServer.TestResourceRecord(question.getDomainName(), RecordType.A, map1));
-                } else {
-                    Set<ResourceRecord> records = new LinkedHashSet<>(2);
-                    Map<String, Object> map = new HashMap<>();
-                    map.put(DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io");
-                    records.add(new TestDnsServer.TestResourceRecord(
-                            question.getDomainName(), RecordType.CNAME, map));
-
-                    Map<String, Object> map1 = new HashMap<>();
-                    map1.put(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.2");
-                    records.add(new TestDnsServer.TestResourceRecord(
-                            question.getDomainName(), RecordType.A, map1));
-                    return records;
-                }
+                Map<String, Object> map1 = new HashMap<>();
+                map1.put(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.2");
+                records.add(new TestDnsServer.TestResourceRecord(
+                        question.getDomainName(), RecordType.A, map1));
+                return records;
             }
         });
         dnsServer2.start();
@@ -2141,29 +2110,25 @@ public class DnsNameResolverTest {
     @Test
     public void testFollowCNAMELoop() throws IOException {
         expectedException.expect(UnknownHostException.class);
-        TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
+        TestDnsServer dnsServer2 = new TestDnsServer(question -> {
+            Set<ResourceRecord> records = new LinkedHashSet<>(4);
 
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) {
-                Set<ResourceRecord> records = new LinkedHashSet<>(4);
-
-                records.add(new TestDnsServer.TestResourceRecord("x." + question.getDomainName(),
-                        RecordType.A, Collections.<String, Object>singletonMap(
-                                DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
-                records.add(new TestDnsServer.TestResourceRecord(
-                        "cname2.netty.io", RecordType.CNAME,
-                        Collections.<String, Object>singletonMap(
-                                DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
-                records.add(new TestDnsServer.TestResourceRecord(
-                        "cname.netty.io", RecordType.CNAME,
-                        Collections.<String, Object>singletonMap(
-                                DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname2.netty.io")));
-                records.add(new TestDnsServer.TestResourceRecord(
-                        question.getDomainName(), RecordType.CNAME,
-                        Collections.<String, Object>singletonMap(
-                                DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
-                return records;
-            }
+            records.add(new TestDnsServer.TestResourceRecord("x." + question.getDomainName(),
+                    RecordType.A, Collections.<String, Object>singletonMap(
+                            DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
+            records.add(new TestDnsServer.TestResourceRecord(
+                    "cname2.netty.io", RecordType.CNAME,
+                    Collections.<String, Object>singletonMap(
+                            DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
+            records.add(new TestDnsServer.TestResourceRecord(
+                    "cname.netty.io", RecordType.CNAME,
+                    Collections.<String, Object>singletonMap(
+                            DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname2.netty.io")));
+            records.add(new TestDnsServer.TestResourceRecord(
+                    question.getDomainName(), RecordType.CNAME,
+                    Collections.<String, Object>singletonMap(
+                            DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
+            return records;
         });
         dnsServer2.start();
         DnsNameResolver resolver = null;
@@ -2326,11 +2291,8 @@ public class DnsNameResolverTest {
     public void testChannelFactoryException() {
         final IllegalStateException exception = new IllegalStateException();
         try {
-            newResolver().channelFactory(new ChannelFactory<DatagramChannel>() {
-                @Override
-                public DatagramChannel newChannel(EventLoop eventLoop) {
-                    throw exception;
-                }
+            newResolver().channelFactory(eventLoop -> {
+                throw exception;
             }).build();
             fail();
         } catch (Exception e) {
@@ -2344,36 +2306,32 @@ public class DnsNameResolverTest {
         final AtomicInteger cnameQueries = new AtomicInteger();
         final AtomicInteger aQueries = new AtomicInteger();
 
-        TestDnsServer dnsServer2 = new TestDnsServer(new RecordStore() {
+        TestDnsServer dnsServer2 = new TestDnsServer(question -> {
+            if ("cname.netty.io".equals(question.getDomainName())) {
+                aQueries.incrementAndGet();
 
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) {
-                if ("cname.netty.io".equals(question.getDomainName())) {
-                    aQueries.incrementAndGet();
-
-                    return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
-                            question.getDomainName(), RecordType.A,
-                            Collections.<String, Object>singletonMap(
-                                    DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
-                }
-                if ("x.netty.io".equals(question.getDomainName())) {
-                    cnameQueries.incrementAndGet();
-
-                    return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
-                            question.getDomainName(), RecordType.CNAME,
-                            Collections.<String, Object>singletonMap(
-                                    DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
-                }
-                if ("y.netty.io".equals(question.getDomainName())) {
-                    cnameQueries.incrementAndGet();
-
-                    return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
-                            question.getDomainName(), RecordType.CNAME,
-                            Collections.<String, Object>singletonMap(
-                                    DnsAttribute.DOMAIN_NAME.toLowerCase(), "x.netty.io")));
-                }
-                return Collections.emptySet();
+                return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
+                        question.getDomainName(), RecordType.A,
+                        Collections.<String, Object>singletonMap(
+                                DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
             }
+            if ("x.netty.io".equals(question.getDomainName())) {
+                cnameQueries.incrementAndGet();
+
+                return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
+                        question.getDomainName(), RecordType.CNAME,
+                        Collections.<String, Object>singletonMap(
+                                DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
+            }
+            if ("y.netty.io".equals(question.getDomainName())) {
+                cnameQueries.incrementAndGet();
+
+                return Collections.<ResourceRecord>singleton(new TestDnsServer.TestResourceRecord(
+                        question.getDomainName(), RecordType.CNAME,
+                        Collections.<String, Object>singletonMap(
+                                DnsAttribute.DOMAIN_NAME.toLowerCase(), "x.netty.io")));
+            }
+            return Collections.emptySet();
         });
         dnsServer2.start();
         DnsNameResolver resolver = null;

--- a/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
@@ -71,14 +71,11 @@ public abstract class AddressResolverGroup<T extends SocketAddress> implements C
                 }
 
                 resolvers.put(executor, newResolver);
-                executor.terminationFuture().addListener(new FutureListener<Object>() {
-                    @Override
-                    public void operationComplete(Future<Object> future) throws Exception {
-                        synchronized (resolvers) {
-                            resolvers.remove(executor);
-                        }
-                        newResolver.close();
+                executor.terminationFuture().addListener((FutureListener<Object>) future -> {
+                    synchronized (resolvers) {
+                        resolvers.remove(executor);
                     }
+                    newResolver.close();
                 });
 
                 r = newResolver;

--- a/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
@@ -69,14 +69,11 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
             promise.setFailure(lastFailure);
         } else {
             NameResolver<T> resolver = resolvers[resolverIndex];
-            resolver.resolve(inetHost).addListener(new FutureListener<T>() {
-                @Override
-                public void operationComplete(Future<T> future) throws Exception {
-                    if (future.isSuccess()) {
-                        promise.setSuccess(future.getNow());
-                    } else {
-                        doResolveRec(inetHost, promise, resolverIndex + 1, future.cause());
-                    }
+            resolver.resolve(inetHost).addListener((FutureListener<T>) future -> {
+                if (future.isSuccess()) {
+                    promise.setSuccess(future.getNow());
+                } else {
+                    doResolveRec(inetHost, promise, resolverIndex + 1, future.cause());
                 }
             });
         }
@@ -95,14 +92,11 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
             promise.setFailure(lastFailure);
         } else {
             NameResolver<T> resolver = resolvers[resolverIndex];
-            resolver.resolveAll(inetHost).addListener(new FutureListener<List<T>>() {
-                @Override
-                public void operationComplete(Future<List<T>> future) throws Exception {
-                    if (future.isSuccess()) {
-                        promise.setSuccess(future.getNow());
-                    } else {
-                        doResolveAllRec(inetHost, promise, resolverIndex + 1, future.cause());
-                    }
+            resolver.resolveAll(inetHost).addListener((FutureListener<List<T>>) future -> {
+                if (future.isSuccess()) {
+                    promise.setSuccess(future.getNow());
+                } else {
+                    doResolveAllRec(inetHost, promise, resolverIndex + 1, future.cause());
                 }
             });
         }

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -55,14 +55,11 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
         nameResolver.resolve(unresolvedAddress.getHostName())
-                .addListener(new FutureListener<InetAddress>() {
-                    @Override
-                    public void operationComplete(Future<InetAddress> future) throws Exception {
-                        if (future.isSuccess()) {
-                            promise.setSuccess(new InetSocketAddress(future.getNow(), unresolvedAddress.getPort()));
-                        } else {
-                            promise.setFailure(future.cause());
-                        }
+                .addListener((FutureListener<InetAddress>) future -> {
+                    if (future.isSuccess()) {
+                        promise.setSuccess(new InetSocketAddress(future.getNow(), unresolvedAddress.getPort()));
+                    } else {
+                        promise.setFailure(future.cause());
                     }
                 });
     }
@@ -73,20 +70,17 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
         nameResolver.resolveAll(unresolvedAddress.getHostName())
-                .addListener(new FutureListener<List<InetAddress>>() {
-                    @Override
-                    public void operationComplete(Future<List<InetAddress>> future) throws Exception {
-                        if (future.isSuccess()) {
-                            List<InetAddress> inetAddresses = future.getNow();
-                            List<InetSocketAddress> socketAddresses =
-                                    new ArrayList<>(inetAddresses.size());
-                            for (InetAddress inetAddress : inetAddresses) {
-                                socketAddresses.add(new InetSocketAddress(inetAddress, unresolvedAddress.getPort()));
-                            }
-                            promise.setSuccess(socketAddresses);
-                        } else {
-                            promise.setFailure(future.cause());
+                .addListener((FutureListener<List<InetAddress>>) future -> {
+                    if (future.isSuccess()) {
+                        List<InetAddress> inetAddresses = future.getNow();
+                        List<InetSocketAddress> socketAddresses =
+                                new ArrayList<>(inetAddresses.size());
+                        for (InetAddress inetAddress : inetAddresses) {
+                            socketAddresses.add(new InetSocketAddress(inetAddress, unresolvedAddress.getPort()));
                         }
+                        promise.setSuccess(socketAddresses);
+                    } else {
+                        promise.setFailure(future.cause());
                     }
                 });
     }

--- a/testsuite-http2/src/main/java/io/netty/testsuite/http2/Http2ServerInitializer.java
+++ b/testsuite-http2/src/main/java/io/netty/testsuite/http2/Http2ServerInitializer.java
@@ -41,14 +41,11 @@ import io.netty.util.ReferenceCountUtil;
  */
 public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
 
-    private static final UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
-        @Override
-        public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
-            if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                return new Http2ServerUpgradeCodec(new HelloWorldHttp2HandlerBuilder().build());
-            } else {
-                return null;
-            }
+    private static final UpgradeCodecFactory upgradeCodecFactory = protocol -> {
+        if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
+            return new Http2ServerUpgradeCodec(new HelloWorldHttp2HandlerBuilder().build());
+        } else {
+            return null;
         }
     };
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpTestPermutation.java
@@ -48,14 +48,9 @@ public final class SctpTestPermutation {
         }
 
         // Make the list of ServerBootstrap factories.
-        return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(new BootstrapFactory<ServerBootstrap>() {
-            @Override
-            public ServerBootstrap newInstance() {
-                return new ServerBootstrap().
-                        group(nioBossGroup, nioWorkerGroup).
-                        channel(NioSctpServerChannel.class);
-            }
-        });
+        return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(() -> new ServerBootstrap().
+                group(nioBossGroup, nioWorkerGroup).
+                channel(NioSctpServerChannel.class));
     }
 
     static List<BootstrapFactory<Bootstrap>> sctpClientChannel() {
@@ -63,12 +58,8 @@ public final class SctpTestPermutation {
             return Collections.emptyList();
         }
 
-        return Collections.<BootstrapFactory<Bootstrap>>singletonList(new BootstrapFactory<Bootstrap>() {
-            @Override
-            public Bootstrap newInstance() {
-                return new Bootstrap().group(nioWorkerGroup).channel(NioSctpChannel.class);
-            }
-        });
+        return Collections.<BootstrapFactory<Bootstrap>>singletonList(() ->
+                new Bootstrap().group(nioWorkerGroup).channel(NioSctpChannel.class));
     }
 
     static List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> sctpChannel() {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -90,12 +90,7 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
             // call retain on it so it can't be put back on the pool
             buf.writeBytes(data).retain();
 
-            ctx.channel().writeAndFlush(buf).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    latch.countDown();
-                }
-            });
+            ctx.channel().writeAndFlush(buf).addListener((ChannelFutureListener) future -> latch.countDown());
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
@@ -36,12 +36,9 @@ public class SocketCloseForciblyTest extends AbstractSocketTest {
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                 final SocketChannel childChannel = (SocketChannel) msg;
                 // Dispatch on the EventLoop as all operation on Unsafe should be done while on the EventLoop.
-                childChannel.eventLoop().execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        childChannel.config().setSoLinger(0);
-                        childChannel.unsafe().closeForcibly();
-                    }
+                childChannel.eventLoop().execute(() -> {
+                    childChannel.config().setSoLinger(0);
+                    childChannel.unsafe().closeForcibly();
                 });
             }
         }).childHandler(new ChannelInboundHandlerAdapter());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -103,22 +103,17 @@ public class SocketTestPermutation {
     public List<BootstrapComboFactory<Bootstrap, Bootstrap>> datagram() {
         // Make the list of Bootstrap factories.
         List<BootstrapFactory<Bootstrap>> bfs = Collections.<BootstrapFactory<Bootstrap>>singletonList(
-                new BootstrapFactory<Bootstrap>() {
+                () -> new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
                     @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
-                            @Override
-                            public Channel newChannel(EventLoop eventLoop) {
-                                return new NioDatagramChannel(eventLoop, InternetProtocolFamily.IPv4);
-                            }
-
-                            @Override
-                            public String toString() {
-                                return NioDatagramChannel.class.getSimpleName() + ".class";
-                            }
-                        });
+                    public Channel newChannel(EventLoop eventLoop) {
+                        return new NioDatagramChannel(eventLoop, InternetProtocolFamily.IPv4);
                     }
-                }
+
+                    @Override
+                    public String toString() {
+                        return NioDatagramChannel.class.getSimpleName() + ".class";
+                    }
+                })
         );
 
         // Populare the combinations.
@@ -127,35 +122,20 @@ public class SocketTestPermutation {
 
     public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
         return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(
-                new BootstrapFactory<ServerBootstrap>() {
-                    @Override
-                    public ServerBootstrap newInstance() {
-                        return new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
-                                .channel(NioServerSocketChannel.class);
-                    }
-                }
+                () -> new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
+                        .channel(NioServerSocketChannel.class)
         );
     }
 
     public List<BootstrapFactory<Bootstrap>> clientSocket() {
         return Collections.<BootstrapFactory<Bootstrap>>singletonList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
-                    }
-                }
+                () -> new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class)
         );
     }
 
     public List<BootstrapFactory<Bootstrap>> datagramSocket() {
         return Collections.<BootstrapFactory<Bootstrap>>singletonList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channel(NioDatagramChannel.class);
-                    }
-                }
+                () -> new Bootstrap().group(nioWorkerGroup).channel(NioDatagramChannel.class)
         );
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -513,23 +513,17 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
                         if (isAutoRead == -3) {
                             wait = stepms * 3;
                         }
-                        executor.schedule(new Runnable() {
-                            @Override
-                            public void run() {
-                                loggerServer.info("Step: " + exactStep + " Reset AutoRead");
-                                channel.config().setAutoRead(true);
-                            }
+                        executor.schedule(() -> {
+                            loggerServer.info("Step: " + exactStep + " Reset AutoRead");
+                            channel.config().setAutoRead(true);
                         }, wait, TimeUnit.MILLISECONDS);
                     } else {
                         if (isAutoRead > 1) {
                             loggerServer.debug("Step: " + step + " Will Set AutoRead: True");
                             final int exactStep = step;
-                            executor.schedule(new Runnable() {
-                                @Override
-                                public void run() {
-                                    loggerServer.info("Step: " + exactStep + " Set AutoRead: True");
-                                    channel.config().setAutoRead(true);
-                                }
+                            executor.schedule(() -> {
+                                loggerServer.info("Step: " + exactStep + " Set AutoRead: True");
+                                channel.config().setAutoRead(true);
                             }, stepms + minimalms, TimeUnit.MILLISECONDS);
                         }
                     }

--- a/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
+++ b/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
@@ -136,12 +136,7 @@ public final class TestUtils {
     }
 
     public static void compressHeapDumps() throws IOException {
-        final File[] files = new File(System.getProperty("user.dir")).listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return name.endsWith(".hprof");
-            }
-        });
+        final File[] files = new File(System.getProperty("user.dir")).listFiles((dir, name) -> name.endsWith(".hprof"));
 
         final byte[] buf = new byte[65536];
         final LZMA2Options options = new LZMA2Options(LZMA2Options.PRESET_DEFAULT);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollHandler.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollHandler.java
@@ -69,12 +69,7 @@ public class EpollHandler implements IoHandler {
     private NativeDatagramPacketArray datagramPacketArray;
 
     private final SelectStrategy selectStrategy;
-    private final IntSupplier selectNowSupplier = new IntSupplier() {
-        @Override
-        public int get() throws Exception {
-            return epollWaitNow();
-        }
-    };
+    private final IntSupplier selectNowSupplier = this::epollWaitNow;
     @SuppressWarnings("unused") // AtomicIntegerFieldUpdater
     private volatile int wakenUp;
 
@@ -152,12 +147,7 @@ public class EpollHandler implements IoHandler {
      * Returns a new {@link IoHandlerFactory} that creates {@link EpollHandler} instances.
      */
     public static IoHandlerFactory newFactory() {
-        return new IoHandlerFactory() {
-            @Override
-            public IoHandler newHandler() {
-                return new EpollHandler();
-            }
-        };
+        return EpollHandler::new;
     }
 
     /**
@@ -167,12 +157,7 @@ public class EpollHandler implements IoHandler {
                                               final SelectStrategyFactory selectStrategyFactory) {
         ObjectUtil.checkPositiveOrZero(maxEvents, "maxEvents");
         ObjectUtil.checkNotNull(selectStrategyFactory, "selectStrategyFactory");
-        return new IoHandlerFactory() {
-            @Override
-            public IoHandler newHandler() {
-                return new EpollHandler(maxEvents, selectStrategyFactory.newSelectStrategy());
-            }
-        };
+        return () -> new EpollHandler(maxEvents, selectStrategyFactory.newSelectStrategy());
     }
 
     private IovArray cleanIovArray() {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorHandle.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorHandle.java
@@ -27,12 +27,7 @@ class EpollRecvByteAllocatorHandle implements RecvByteBufAllocator.ExtendedHandl
     private final PreferredDirectByteBufAllocator preferredDirectByteBufAllocator =
             new PreferredDirectByteBufAllocator();
     private final RecvByteBufAllocator.ExtendedHandle delegate;
-    private final UncheckedBooleanSupplier defaultMaybeMoreDataSupplier = new UncheckedBooleanSupplier() {
-        @Override
-        public boolean get() {
-            return maybeMoreDataToRead();
-        }
-    };
+    private final UncheckedBooleanSupplier defaultMaybeMoreDataSupplier = this::maybeMoreDataToRead;
     private boolean isEdgeTriggered;
     private boolean receivedRdHup;
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -59,13 +59,10 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
                 // Create new channel and obtain a file descriptor from it.
                 final EpollDomainSocketChannel ch = new EpollDomainSocketChannel(ctx.channel().eventLoop());
 
-                ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            Throwable cause = future.cause();
-                            queue.offer(cause);
-                        }
+                ctx.writeAndFlush(ch.fd()).addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        Throwable cause = future.cause();
+                        queue.offer(cause);
                     }
                 });
             }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -49,11 +49,8 @@ public class EpollEventLoopTest {
 
         try {
             final EventLoop eventLoop = group.next();
-            Future<?> future = eventLoop.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    // NOOP
-                }
+            Future<?> future = eventLoop.schedule(() -> {
+                // NOOP
             }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
             assertFalse(future.awaitUninterruptibly(1000));

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
@@ -138,21 +138,18 @@ public class EpollReuseAddrTest {
         // on both sockets.
         int count = 16;
         final CountDownLatch latch = new CountDownLatch(count);
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    DatagramSocket socket = new DatagramSocket();
-                    while (!received1.get() || !received2.get()) {
-                        socket.send(new DatagramPacket(
-                                bytes, 0, bytes.length, address1.getAddress(), address1.getPort()));
-                    }
-                    socket.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
+        Runnable r = () -> {
+            try {
+                DatagramSocket socket = new DatagramSocket();
+                while (!received1.get() || !received2.get()) {
+                    socket.send(new DatagramPacket(
+                            bytes, 0, bytes.length, address1.getAddress(), address1.getPort()));
                 }
-                latch.countDown();
+                socket.close();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
+            latch.countDown();
         };
 
         ExecutorService executor = Executors.newFixedThreadPool(count);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
@@ -41,17 +41,7 @@ public class EpollSocketStringEchoBusyWaitTest extends SocketStringEchoTest {
     @BeforeClass
     public static void setup() throws Exception {
         EPOLL_LOOP = new MultithreadEventLoopGroup(2, new DefaultThreadFactory("testsuite-epoll-busy-wait", true),
-                EpollHandler.newFactory(0, new SelectStrategyFactory() {
-                    @Override
-                    public SelectStrategy newSelectStrategy() {
-                        return new SelectStrategy() {
-                            @Override
-                            public int calculateStrategy(IntSupplier selectSupplier, boolean hasTasks) {
-                                return SelectStrategy.BUSY_WAIT;
-                            }
-                        };
-                    }
-                }));
+                EpollHandler.newFactory(0, () -> (selectSupplier, hasTasks) -> SelectStrategy.BUSY_WAIT));
     }
 
     @AfterClass
@@ -83,20 +73,10 @@ public class EpollSocketStringEchoBusyWaitTest extends SocketStringEchoTest {
     }
 
     private static BootstrapFactory<ServerBootstrap> serverSocket() {
-        return new BootstrapFactory<ServerBootstrap>() {
-            @Override
-            public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(EPOLL_LOOP, EPOLL_LOOP).channel(EpollServerSocketChannel.class);
-            }
-        };
+        return () -> new ServerBootstrap().group(EPOLL_LOOP, EPOLL_LOOP).channel(EpollServerSocketChannel.class);
     }
 
     private static BootstrapFactory<Bootstrap> clientSocket() {
-        return new BootstrapFactory<Bootstrap>() {
-            @Override
-            public Bootstrap newInstance() {
-                return new Bootstrap().group(EPOLL_LOOP).channel(EpollSocketChannel.class);
-            }
-        };
+        return () -> new Bootstrap().group(EPOLL_LOOP).channel(EpollSocketChannel.class);
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -73,31 +73,18 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     @Override
     public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
         List<BootstrapFactory<ServerBootstrap>> toReturn = new ArrayList<>();
-        toReturn.add(new BootstrapFactory<ServerBootstrap>() {
-            @Override
-            public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
-                                            .channel(EpollServerSocketChannel.class);
-            }
-        });
+        toReturn.add(() -> new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
+                                    .channel(EpollServerSocketChannel.class));
         if (isServerFastOpen()) {
-            toReturn.add(new BootstrapFactory<ServerBootstrap>() {
-                @Override
-                public ServerBootstrap newInstance() {
-                    ServerBootstrap serverBootstrap = new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
-                                                                           .channel(EpollServerSocketChannel.class);
-                    serverBootstrap.option(EpollChannelOption.TCP_FASTOPEN, 5);
-                    return serverBootstrap;
-                }
+            toReturn.add(() -> {
+                ServerBootstrap serverBootstrap = new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
+                                                                       .channel(EpollServerSocketChannel.class);
+                serverBootstrap.option(EpollChannelOption.TCP_FASTOPEN, 5);
+                return serverBootstrap;
             });
         }
-        toReturn.add(new BootstrapFactory<ServerBootstrap>() {
-            @Override
-            public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
-                                            .channel(NioServerSocketChannel.class);
-            }
-        });
+        toReturn.add(() -> new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
+                                    .channel(NioServerSocketChannel.class));
 
         return toReturn;
     }
@@ -106,18 +93,8 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     @Override
     public List<BootstrapFactory<Bootstrap>> clientSocket() {
         return Arrays.asList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollSocketChannel.class);
-                    }
-                },
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
-                    }
-                }
+                () -> new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollSocketChannel.class),
+                () -> new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class)
         );
     }
 
@@ -126,28 +103,18 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         // Make the list of Bootstrap factories.
         @SuppressWarnings("unchecked")
         List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
-                new BootstrapFactory<Bootstrap>() {
+                () -> new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
                     @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
-                            @Override
-                            public Channel newChannel(EventLoop eventLoop) {
-                                return new NioDatagramChannel(eventLoop, InternetProtocolFamily.IPv4);
-                            }
+                    public Channel newChannel(EventLoop eventLoop) {
+                        return new NioDatagramChannel(eventLoop, InternetProtocolFamily.IPv4);
+                    }
 
-                            @Override
-                            public String toString() {
-                                return NioDatagramChannel.class.getSimpleName() + ".class";
-                            }
-                        });
-                    }
-                },
-                new BootstrapFactory<Bootstrap>() {
                     @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDatagramChannel.class);
+                    public String toString() {
+                        return NioDatagramChannel.class.getSimpleName() + ".class";
                     }
-                }
+                }),
+                () -> new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDatagramChannel.class)
         );
         return combo(bfs, bfs);
     }
@@ -161,71 +128,53 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
 
     public List<BootstrapFactory<ServerBootstrap>> serverDomainSocket() {
         return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(
-                new BootstrapFactory<ServerBootstrap>() {
-                    @Override
-                    public ServerBootstrap newInstance() {
-                        return new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
-                                .channel(EpollServerDomainSocketChannel.class);
-                    }
-                }
+                () -> new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
+                        .channel(EpollServerDomainSocketChannel.class)
         );
     }
 
     public List<BootstrapFactory<Bootstrap>> clientDomainSocket() {
         return Collections.<BootstrapFactory<Bootstrap>>singletonList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDomainSocketChannel.class);
-                    }
-                }
+                () -> new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDomainSocketChannel.class)
         );
     }
 
     @Override
     public List<BootstrapFactory<Bootstrap>> datagramSocket() {
         return Collections.<BootstrapFactory<Bootstrap>>singletonList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDatagramChannel.class);
-                    }
-                }
+                () -> new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDatagramChannel.class)
         );
     }
 
     public boolean isServerFastOpen() {
-        return AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-            @Override
-            public Integer run() {
-                int fastopen = 0;
-                File file = new File("/proc/sys/net/ipv4/tcp_fastopen");
-                if (file.exists()) {
-                    BufferedReader in = null;
-                    try {
-                        in = new BufferedReader(new FileReader(file));
-                        fastopen = Integer.parseInt(in.readLine());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("{}: {}", file, fastopen);
-                        }
-                    } catch (Exception e) {
-                        logger.debug("Failed to get TCP_FASTOPEN from: {}", file, e);
-                    } finally {
-                        if (in != null) {
-                            try {
-                                in.close();
-                            } catch (Exception e) {
-                                // Ignored.
-                            }
-                        }
-                    }
-                } else {
+        return AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
+            int fastopen = 0;
+            File file = new File("/proc/sys/net/ipv4/tcp_fastopen");
+            if (file.exists()) {
+                BufferedReader in = null;
+                try {
+                    in = new BufferedReader(new FileReader(file));
+                    fastopen = Integer.parseInt(in.readLine());
                     if (logger.isDebugEnabled()) {
-                        logger.debug("{}: {} (non-existent)", file, fastopen);
+                        logger.debug("{}: {}", file, fastopen);
+                    }
+                } catch (Exception e) {
+                    logger.debug("Failed to get TCP_FASTOPEN from: {}", file, e);
+                } finally {
+                    if (in != null) {
+                        try {
+                            in.close();
+                        } catch (Exception e) {
+                            // Ignored.
+                        }
                     }
                 }
-                return fastopen;
+            } else {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("{}: {} (non-existent)", file, fastopen);
+                }
             }
+            return fastopen;
         }) == 3;
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -81,12 +81,9 @@ public class EpollSpliceTest {
                         // the data transfer only in kernel space!
 
                         // Integer.MAX_VALUE will splice infinitly.
-                        ch.spliceTo(ch2, Integer.MAX_VALUE).addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
-                                if (!future.isSuccess()) {
-                                    future.channel().close();
-                                }
+                        ch.spliceTo(ch2, Integer.MAX_VALUE).addListener((ChannelFutureListener) future -> {
+                            if (!future.isSuccess()) {
+                                future.channel().close();
                             }
                         });
                         // Trigger multiple splices to see if partial splicing works as well.
@@ -108,19 +105,11 @@ public class EpollSpliceTest {
                         context.close();
                     }
                 });
-                bs.connect(sc.localAddress()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            ctx.close();
-                        } else {
-                            future.channel().closeFuture().addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture future) throws Exception {
-                                    ctx.close();
-                                }
-                            });
-                        }
+                bs.connect(sc.localAddress()).addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        ctx.close();
+                    } else {
+                        future.channel().closeFuture().addListener((ChannelFutureListener) future1 -> ctx.close());
                     }
                 });
             }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
@@ -43,16 +43,13 @@ public class EpollTest {
             Native.epollCtlAdd(epoll.intValue(), eventfd.intValue(), Native.EPOLLIN);
 
             final AtomicReference<Throwable> ref = new AtomicReference<>();
-            Thread t = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        assertEquals(1, Native.epollWait(epoll, eventArray, timerFd, -1, -1));
-                        // This should have been woken up because of eventfd_write.
-                        assertEquals(eventfd.intValue(), eventArray.fd(0));
-                    } catch (Throwable cause) {
-                        ref.set(cause);
-                    }
+            Thread t = new Thread(() -> {
+                try {
+                    assertEquals(1, Native.epollWait(epoll, eventArray, timerFd, -1, -1));
+                    // This should have been woken up because of eventfd_write.
+                    assertEquals(eventfd.intValue(), eventArray.fd(0));
+                } catch (Throwable cause) {
+                    ref.set(cause);
                 }
             });
             t.start();

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueHandler.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueHandler.java
@@ -62,12 +62,7 @@ public final class KQueueHandler implements IoHandler {
     private final KQueueEventArray eventList;
     private final SelectStrategy selectStrategy;
     private final IovArray iovArray = new IovArray();
-    private final IntSupplier selectNowSupplier = new IntSupplier() {
-        @Override
-        public int get() throws Exception {
-            return kqueueWaitNow();
-        }
-    };
+    private final IntSupplier selectNowSupplier = this::kqueueWaitNow;
     private final IntObjectMap<AbstractKQueueChannel> channels = new IntObjectHashMap<AbstractKQueueChannel>(4096);
 
     private volatile int wakenUp;
@@ -105,12 +100,7 @@ public final class KQueueHandler implements IoHandler {
      * Returns a new {@link IoHandlerFactory} that creates {@link KQueueHandler} instances.
      */
     public static IoHandlerFactory newFactory() {
-        return new IoHandlerFactory() {
-            @Override
-            public IoHandler newHandler() {
-                return new KQueueHandler();
-            }
-        };
+        return KQueueHandler::new;
     }
 
     /**
@@ -120,12 +110,7 @@ public final class KQueueHandler implements IoHandler {
                                               final SelectStrategyFactory selectStrategyFactory) {
         ObjectUtil.checkPositiveOrZero(maxEvents, "maxEvents");
         ObjectUtil.checkNotNull(selectStrategyFactory, "selectStrategyFactory");
-        return new IoHandlerFactory() {
-            @Override
-            public IoHandler newHandler() {
-                return new KQueueHandler(maxEvents, selectStrategyFactory.newSelectStrategy());
-            }
-        };
+        return () -> new KQueueHandler(maxEvents, selectStrategyFactory.newSelectStrategy());
     }
 
     @Override

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueRecvByteAllocatorHandle.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueRecvByteAllocatorHandle.java
@@ -31,12 +31,7 @@ final class KQueueRecvByteAllocatorHandle implements RecvByteBufAllocator.Extend
             new PreferredDirectByteBufAllocator();
     private final RecvByteBufAllocator.ExtendedHandle delegate;
 
-    private final UncheckedBooleanSupplier defaultMaybeMoreDataSupplier = new UncheckedBooleanSupplier() {
-        @Override
-        public boolean get() {
-            return maybeMoreDataToRead();
-        }
-    };
+    private final UncheckedBooleanSupplier defaultMaybeMoreDataSupplier = this::maybeMoreDataToRead;
     private boolean overrideGuess;
     private boolean readEOF;
     private long numberBytesPending;

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -58,13 +58,10 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
                 // Create new channel and obtain a file descriptor from it.
                 final KQueueDomainSocketChannel ch = new KQueueDomainSocketChannel(ctx.channel().eventLoop());
 
-                ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            Throwable cause = future.cause();
-                            queue.offer(cause);
-                        }
+                ctx.writeAndFlush(ch.fd()).addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        Throwable cause = future.cause();
+                        queue.offer(cause);
                     }
                 });
             }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
@@ -33,11 +33,8 @@ public class KQueueEventLoopTest {
         EventLoopGroup group = new MultithreadEventLoopGroup(1, KQueueHandler.newFactory());
 
         final EventLoop el = group.next();
-        Future<?> future = el.schedule(new Runnable() {
-            @Override
-            public void run() {
-                // NOOP
-            }
+        Future<?> future = el.schedule(() -> {
+            // NOOP
         }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
         assertFalse(future.awaitUninterruptibly(1000));

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -68,21 +68,11 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     @Override
     public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
         List<BootstrapFactory<ServerBootstrap>> toReturn = new ArrayList<>();
-        toReturn.add(new BootstrapFactory<ServerBootstrap>() {
-            @Override
-            public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
-                                            .channel(KQueueServerSocketChannel.class);
-            }
-        });
+        toReturn.add(() -> new ServerBootstrap().group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
+                                    .channel(KQueueServerSocketChannel.class));
 
-        toReturn.add(new BootstrapFactory<ServerBootstrap>() {
-            @Override
-            public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
-                                            .channel(NioServerSocketChannel.class);
-            }
-        });
+        toReturn.add(() -> new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
+                                    .channel(NioServerSocketChannel.class));
 
         return toReturn;
     }
@@ -91,18 +81,8 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     @Override
     public List<BootstrapFactory<Bootstrap>> clientSocket() {
         return Arrays.asList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class);
-                    }
-                },
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
-                    }
-                }
+                () -> new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class),
+                () -> new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class)
         );
     }
 
@@ -111,28 +91,18 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
         // Make the list of Bootstrap factories.
         @SuppressWarnings("unchecked")
         List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
-                new BootstrapFactory<Bootstrap>() {
+                () -> new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
                     @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
-                            @Override
-                            public Channel newChannel(EventLoop eventLoop) {
-                                return new NioDatagramChannel(eventLoop, InternetProtocolFamily.IPv4);
-                            }
+                    public Channel newChannel(EventLoop eventLoop) {
+                        return new NioDatagramChannel(eventLoop, InternetProtocolFamily.IPv4);
+                    }
 
-                            @Override
-                            public String toString() {
-                                return NioDatagramChannel.class.getSimpleName() + ".class";
-                            }
-                        });
-                    }
-                },
-                new BootstrapFactory<Bootstrap>() {
                     @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDatagramChannel.class);
+                    public String toString() {
+                        return NioDatagramChannel.class.getSimpleName() + ".class";
                     }
-                }
+                }),
+                () -> new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDatagramChannel.class)
         );
         return combo(bfs, bfs);
     }
@@ -146,36 +116,21 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
 
     public List<BootstrapFactory<ServerBootstrap>> serverDomainSocket() {
         return Collections.<BootstrapFactory<ServerBootstrap>>singletonList(
-                new BootstrapFactory<ServerBootstrap>() {
-                    @Override
-                    public ServerBootstrap newInstance() {
-                        return new ServerBootstrap().group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
-                                .channel(KQueueServerDomainSocketChannel.class);
-                    }
-                }
+                () -> new ServerBootstrap().group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
+                        .channel(KQueueServerDomainSocketChannel.class)
         );
     }
 
     public List<BootstrapFactory<Bootstrap>> clientDomainSocket() {
         return Collections.<BootstrapFactory<Bootstrap>>singletonList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDomainSocketChannel.class);
-                    }
-                }
+                () -> new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDomainSocketChannel.class)
         );
     }
 
     @Override
     public List<BootstrapFactory<Bootstrap>> datagramSocket() {
         return Collections.<BootstrapFactory<Bootstrap>>singletonList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDatagramChannel.class);
-                    }
-                }
+                () -> new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDatagramChannel.class)
         );
     }
     public static DomainSocketAddress newSocketAddress() {

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -354,12 +354,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
                 promise.setFailure(t);
             }
         } else {
-            eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    bindAddress(localAddress, promise);
-                }
-            });
+            eventLoop().execute(() -> bindAddress(localAddress, promise));
         }
         return promise;
     }
@@ -379,12 +374,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
                 promise.setFailure(t);
             }
         } else {
-            eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    unbindAddress(localAddress, promise);
-                }
-            });
+            eventLoop().execute(() -> unbindAddress(localAddress, promise));
         }
         return promise;
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -169,12 +169,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
                 promise.setFailure(t);
             }
         } else {
-            eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    bindAddress(localAddress, promise);
-                }
-            });
+            eventLoop().execute(() -> bindAddress(localAddress, promise));
         }
         return promise;
     }
@@ -194,12 +189,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
                 promise.setFailure(t);
             }
         } else {
-            eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    unbindAddress(localAddress, promise);
-                }
-            });
+            eventLoop().execute(() -> unbindAddress(localAddress, promise));
         }
         return promise;
     }


### PR DESCRIPTION
Motivation:

use lambda function for all package, #8751 only migrate transport package.
