### PR TITLE
Fix AppendableCharSequence.subSequence(...) where start == end.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/AppendableCharSequence.java
+++ b/common/src/main/java/io/netty/util/internal/AppendableCharSequence.java
@@ -63,6 +63,12 @@ public final class AppendableCharSequence implements CharSequence, Appendable {
 
     @Override
     public AppendableCharSequence subSequence(int start, int end) {
+        if (start == end) {
+            // If start and end index is the same we need to return an empty sequence to conform to the interface.
+            // As our expanding logic depends on the fact that we have a char[] with length > 0 we need to construct
+            // an instance for which this is true.
+            return new AppendableCharSequence(Math.min(16, chars.length));
+        }
         return new AppendableCharSequence(Arrays.copyOfRange(chars, start, end));
     }
 

--- a/common/src/test/java/io/netty/util/internal/AppendableCharSequenceTest.java
+++ b/common/src/test/java/io/netty/util/internal/AppendableCharSequenceTest.java
@@ -64,6 +64,16 @@ public class AppendableCharSequenceTest {
         assertEquals("abcdefghij", master.subSequence(0, 10).toString());
     }
 
+    @Test
+    public void testEmptySubSequence() {
+        AppendableCharSequence master = new AppendableCharSequence(26);
+        master.append("abcdefghijlkmonpqrstuvwxyz");
+        AppendableCharSequence sub =  master.subSequence(0, 0);
+        assertEquals(0, sub.length());
+        sub.append('b');
+        assertEquals('b', sub.charAt(0));
+    }
+
     private static void testSimpleAppend0(AppendableCharSequence seq) {
         String text = "testdata";
         for (int i = 0; i < text.length(); i++) {


### PR DESCRIPTION
Motivation:

To conform to the CharSequence interface we need to return an empty CharSequence when start == end index and a subSequence is requested.

Modifications:

- Correctly handle the case where start == end
- Add unit test

Result:

Fix https://github.com/netty/netty/issues/8796.