### PR TITLE
#7756 Add @Sharable TYPE_USE support for inner class annotations

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -210,7 +210,7 @@ public interface ChannelHandler {
      */
     @Inherited
     @Documented
-    @Target(ElementType.TYPE)
+    @Target({ElementType.TYPE, ElementType.TYPE_USE})
     @Retention(RetentionPolicy.RUNTIME)
     @interface Sharable {
         // no value

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
@@ -18,6 +18,7 @@ package io.netty.channel;
 
 import io.netty.util.internal.InternalThreadLocalMap;
 
+import java.lang.reflect.AnnotatedType;
 import java.util.Map;
 
 /**
@@ -55,6 +56,10 @@ public abstract class ChannelHandlerAdapter implements ChannelHandler {
         Boolean sharable = cache.get(clazz);
         if (sharable == null) {
             sharable = clazz.isAnnotationPresent(Sharable.class);
+            if (!sharable) {
+                AnnotatedType annotatedType = clazz.getAnnotatedSuperclass();
+                sharable = annotatedType.isAnnotationPresent(Sharable.class);
+            }
             cache.put(clazz, sharable);
         }
         return sharable;

--- a/transport/src/test/java/io/netty/channel/ChannelHandlerAdapterTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelHandlerAdapterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.netty.channel.ChannelHandler.Sharable;
+
+public class ChannelHandlerAdapterTest {
+
+    @Sharable
+    private static final class SharableChannelHandlerAdapter extends ChannelHandlerAdapter {
+    }
+
+    @Test
+    public void testSharable() {
+        ChannelHandlerAdapter handler = new SharableChannelHandlerAdapter();
+        assertEquals(true, handler.isSharable());
+    }
+
+    @Test
+    public void testInnerClassSharable() {
+        ChannelHandlerAdapter handler = new @Sharable ChannelHandlerAdapter() { };
+        assertEquals(true, handler.isSharable());
+    }
+
+    @Test
+    public void testWithoutSharable() {
+        ChannelHandlerAdapter handler = new ChannelHandlerAdapter() { };
+        assertEquals(false, handler.isSharable());
+    }
+}


### PR DESCRIPTION
Motivation:

Make @Sharable annotation works with anonymous inner types. Add Java 8 ElementType.TYPE_USE feature that makes easy to use @Sharable annotation.

Modification:
* transport/src/main/java/io/netty/channel/ChannelHandler.java - Target ElementType.TYPE_USE added.
* transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java - isSharable method improved to verify AnnotatedSuperclass for annotation.
* transport/src/test/java/io/netty/channel/ChannelHandlerAdapterTest.java - Tests added.

Result:
```
ChannelInboundHandler handler = new @Sharable ChannelInboundHandlerAdapter() {
      @Override
      public void channelRead(ChannelHandlerContext context, Object message) {
           context.write(message);
      }
};
```

Note:
The following changes don't support local variable annotation:
 ChannelInboundHandler handler1 = new @Sharable ChannelInboundHandlerAdapter();
 @Sharable ChannelInboundHandler handler2 = new  ChannelInboundHandlerAdapter();

Fixes #7756 