### PR TITLE
Compare HttpMethod by reference

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -78,10 +78,10 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
             acceptedEncoding = HttpContentDecoder.IDENTITY;
         }
 
-        HttpMethod meth = msg.method();
-        if (meth == HttpMethod.HEAD) {
+        HttpMethod method = msg.method();
+        if (HttpMethod.HEAD.equals(method)) {
             acceptedEncoding = ZERO_LENGTH_HEAD;
-        } else if (meth == HttpMethod.CONNECT) {
+        } else if (HttpMethod.CONNECT.equals(method)) {
             acceptedEncoding = ZERO_LENGTH_CONNECT;
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -156,6 +156,9 @@ public class HttpMethod implements Comparable<HttpMethod> {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof HttpMethod)) {
             return false;
         }
@@ -171,6 +174,9 @@ public class HttpMethod implements Comparable<HttpMethod> {
 
     @Override
     public int compareTo(HttpMethod o) {
+        if (o == this) {
+            return 0;
+        }
         return name().compareTo(o.name());
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -117,7 +117,8 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
 
         @Override
         protected void sanitizeHeadersBeforeEncode(HttpResponse msg, boolean isAlwaysEmpty) {
-            if (!isAlwaysEmpty && method == HttpMethod.CONNECT && msg.status().codeClass() == HttpStatusClass.SUCCESS) {
+            if (!isAlwaysEmpty && HttpMethod.CONNECT.equals(method)
+                    && msg.status().codeClass() == HttpStatusClass.SUCCESS) {
                 // Stripping Transfer-Encoding:
                 // See https://tools.ietf.org/html/rfc7230#section-3.3.1
                 msg.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -191,7 +191,7 @@ public class CorsHandler extends ChannelDuplexHandler {
 
     private static boolean isPreflightRequest(final HttpRequest request) {
         final HttpHeaders headers = request.headers();
-        return request.method().equals(OPTIONS) &&
+        return OPTIONS.equals(request.method()) &&
                 headers.contains(HttpHeaderNames.ORIGIN) &&
                 headers.contains(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -68,7 +68,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         }
 
         try {
-            if (req.method() != GET) {
+            if (!GET.equals(req.method())) {
                 sendHttpResponse(ctx, req, new DefaultFullHttpResponse(HTTP_1_1, FORBIDDEN));
                 return;
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspMethods.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspMethods.java
@@ -38,62 +38,62 @@ public final class RtspMethods {
      * The DESCRIBE getMethod retrieves the description of a presentation or
      * media object identified by the request URL from a server.
      */
-    public static final HttpMethod DESCRIBE = new HttpMethod("DESCRIBE");
+    public static final HttpMethod DESCRIBE = HttpMethod.valueOf("DESCRIBE");
 
     /**
      * The ANNOUNCE posts the description of a presentation or media object
      * identified by the request URL to a server, or updates the client-side
      * session description in real-time.
      */
-    public static final HttpMethod ANNOUNCE = new HttpMethod("ANNOUNCE");
+    public static final HttpMethod ANNOUNCE = HttpMethod.valueOf("ANNOUNCE");
 
     /**
      * The SETUP request for a URI specifies the transport mechanism to be
      * used for the streamed media.
      */
-    public static final HttpMethod SETUP = new HttpMethod("SETUP");
+    public static final HttpMethod SETUP = HttpMethod.valueOf("SETUP");
 
     /**
      * The PLAY getMethod tells the server to start sending data via the
      * mechanism specified in SETUP.
      */
-    public static final HttpMethod PLAY = new HttpMethod("PLAY");
+    public static final HttpMethod PLAY = HttpMethod.valueOf("PLAY");
 
     /**
      * The PAUSE request causes the stream delivery to be interrupted
      * (halted) temporarily.
      */
-    public static final HttpMethod PAUSE = new HttpMethod("PAUSE");
+    public static final HttpMethod PAUSE = HttpMethod.valueOf("PAUSE");
 
     /**
      * The TEARDOWN request stops the stream delivery for the given URI,
      * freeing the resources associated with it.
      */
-    public static final HttpMethod TEARDOWN = new HttpMethod("TEARDOWN");
+    public static final HttpMethod TEARDOWN = HttpMethod.valueOf("TEARDOWN");
 
     /**
      * The GET_PARAMETER request retrieves the value of a parameter of a
      * presentation or stream specified in the URI.
      */
-    public static final HttpMethod GET_PARAMETER = new HttpMethod("GET_PARAMETER");
+    public static final HttpMethod GET_PARAMETER = HttpMethod.valueOf("GET_PARAMETER");
 
     /**
      * The SET_PARAMETER requests to set the value of a parameter for a
      * presentation or stream specified by the URI.
      */
-    public static final HttpMethod SET_PARAMETER = new HttpMethod("SET_PARAMETER");
+    public static final HttpMethod SET_PARAMETER = HttpMethod.valueOf("SET_PARAMETER");
 
     /**
      * The REDIRECT request informs the client that it must connect to another
      * server location.
      */
-    public static final HttpMethod REDIRECT = new HttpMethod("REDIRECT");
+    public static final HttpMethod REDIRECT = HttpMethod.valueOf("REDIRECT");
 
     /**
      * The RECORD getMethod initiates recording a range of media data according to
      * the presentation description.
      */
-    public static final HttpMethod RECORD = new HttpMethod("RECORD");
+    public static final HttpMethod RECORD = HttpMethod.valueOf("RECORD");
 
     private static final Map<String, HttpMethod> methodMap = new HashMap<String, HttpMethod>();
 
@@ -130,7 +130,7 @@ public final class RtspMethods {
         if (result != null) {
             return result;
         } else {
-            return new HttpMethod(name);
+            return HttpMethod.valueOf(name);
         }
     }
 

--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
@@ -117,7 +117,7 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
             return;
         }
 
-        if (request.method() != GET) {
+        if (!GET.equals(request.method())) {
             sendError(ctx, METHOD_NOT_ALLOWED);
             return;
         }

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadServerHandler.java
@@ -145,7 +145,7 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
             responseContent.append("\r\n\r\n");
 
             // if GET Method: should not try to create a HttpPostRequestDecoder
-            if (request.method().equals(HttpMethod.GET)) {
+            if (HttpMethod.GET.equals(request.method())) {
                 // GET Method: should not try to create a HttpPostRequestDecoder
                 // So stop here
                 responseContent.append("\r\n\r\nEND OF GET CONTENT\r\n");

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
@@ -71,7 +71,7 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
         }
 
         // Allow only GET methods.
-        if (req.method() != GET) {
+        if (!GET.equals(req.method())) {
             sendHttpResponse(ctx, req, new DefaultFullHttpResponse(HTTP_1_1, FORBIDDEN));
             return;
         }

--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketIndexPageHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketIndexPageHandler.java
@@ -58,7 +58,7 @@ public class WebSocketIndexPageHandler extends SimpleChannelInboundHandler<FullH
         }
 
         // Allow only GET methods.
-        if (req.method() != GET) {
+        if (!GET.equals(req.method())) {
             sendHttpResponse(ctx, req, new DefaultFullHttpResponse(HTTP_1_1, FORBIDDEN));
             return;
         }

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerHandler.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerHandler.java
@@ -78,7 +78,7 @@ public class AutobahnServerHandler extends ChannelInboundHandlerAdapter {
         }
 
         // Allow only GET methods.
-        if (req.method() != GET) {
+        if (!GET.equals(req.method())) {
             sendHttpResponse(ctx, req, new DefaultFullHttpResponse(HTTP_1_1, FORBIDDEN));
             return;
         }


### PR DESCRIPTION
Motivation:

In most cases, `HttpMethod` instance is built from the factory method and the same instance is taken for known Http Methods. So we can implement fast path for `equals()`.

Modification:

- Replace `==` checks with `HttpMethod.equals`;
- Use `this == o` within `HttpMethod.equals`;
- Replaced known new HttpMethod with HttpMethod.valueOf;

Result:

Comparisons should be a bit faster in some cases.