### PR TITLE
Cache next context for channelRead(...) and prev context for write(..…

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineBenchmark.java
@@ -32,11 +32,11 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-@Warmup(iterations = 5)
-@Measurement(iterations = 5)
+@Warmup(iterations = 5,  time = 5)
+@Measurement(iterations = 5, time = 5)
 @State(Scope.Benchmark)
 public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
-
+    private static final Object MSG = new Object();
     private static final ChannelInboundHandler NOOP_HANDLER = new ChannelInboundHandlerAdapter() {
         @Override
         public boolean isSharable() {
@@ -47,6 +47,11 @@ public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
     private static final ChannelInboundHandler CONSUMING_HANDLER = new ChannelInboundHandlerAdapter() {
         @Override
         public void channelReadComplete(ChannelHandlerContext ctx) {
+            // NOOP
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
             // NOOP
         }
 
@@ -76,9 +81,16 @@ public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
     }
 
     @Benchmark
-    public void propagateEvent(Blackhole hole) {
+    public void propagateChannelReadComplete(Blackhole hole) {
         for (int i = 0; i < 100; i++) {
             hole.consume(pipeline.fireChannelReadComplete());
+        }
+    }
+
+    @Benchmark
+    public void propagateChannelRead(Blackhole hole) {
+        for (int i = 0; i < 100; i++) {
+            hole.consume(pipeline.fireChannelRead(MSG));
         }
     }
 }


### PR DESCRIPTION
….) calls.

Motivation:

To determine the next ChannelHandlerContext that we need to invoke when walking the pipeline we do loop through the whole pipeline (starting at the current context) and do a bitwise operation until we find the one to use. While this is generally not super slow it still can produce some overhead, especially when you have a long pipeline. As channelRead(...) and write(...) are the operations that are called the most usually we can cache the next and prev context for these and so skip the searching for the next / prev context on each call.

Modifications:

- Cache the next and prev context for channelRead(...) / write(...) to reduce overhead
- Adjust benchmark to compare cached vs non cached invokations.

Result:

Less overhead for channelRead(...) / write(...) calls.

```
Benchmark                                                     (extraHandlers)   Mode  Cnt        Score       Error  Units
DefaultChannelPipelineBenchmark.propagateChannelRead                        4  thrpt   10  1030518.619 ± 29880.328  ops/s
DefaultChannelPipelineBenchmark.propagateChannelReadComplete                4  thrpt   10   827194.400 ± 54177.613  ops/s
```
The score for the first is cached the second is not cached.
