### PR TITLE
Remove ChannelHandler.exceptionCaught(...) as it should only exist in…

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
@@ -43,7 +42,6 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http2.Http2TestUtil.Http2Runnable;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Future;
@@ -667,7 +665,7 @@ public class InboundHttp2ToHttpAdapterTest {
 
                 clientDelegator = new HttpResponseDelegator(clientListener, clientLatch, clientLatch2);
                 p.addLast(clientDelegator);
-                p.addLast(new ChannelHandlerAdapter() {
+                p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
                     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                         Http2Exception e = getEmbeddedHttp2Exception(cause);

--- a/codec/src/main/java/io/netty/handler/codec/DatagramPacketEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DatagramPacketEncoder.java
@@ -137,11 +137,6 @@ public class DatagramPacketEncoder<M> extends MessageToMessageEncoder<AddressedE
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        encoder.exceptionCaught(ctx, cause);
-    }
-
-    @Override
     public boolean isSharable() {
         return encoder.isSharable();
     }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelProgressivePromise;
 import io.netty.channel.ChannelPromise;
@@ -107,12 +108,15 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
 
     @Override
     public final ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+        ChannelHandler handler = handler();
         try {
-            handler().exceptionCaught(this, cause);
+            if (handler instanceof ChannelInboundHandler) {
+                ((ChannelInboundHandler) handler).exceptionCaught(this, cause);
+            }
         } catch (Exception e) {
             handleException(e);
         }
-        return null;
+        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -189,14 +189,6 @@ public interface ChannelHandler {
     void handlerRemoved(ChannelHandlerContext ctx) throws Exception;
 
     /**
-     * Gets called if a {@link Throwable} was thrown.
-     *
-     * @deprecated is part of {@link ChannelInboundHandler}
-     */
-    @Deprecated
-    void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception;
-
-    /**
      * Indicates that the same instance of the annotated {@link ChannelHandler}
      * can be added to one or more {@link ChannelPipeline}s multiple times
      * without a race condition.

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
@@ -80,16 +80,4 @@ public abstract class ChannelHandlerAdapter implements ChannelHandler {
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         // NOOP
     }
-
-    /**
-     * Calls {@link ChannelHandlerContext#fireExceptionCaught(Throwable)} to forward
-     * to the next {@link ChannelHandler} in the {@link ChannelPipeline}.
-     *
-     * Sub-classes may override this method to change behavior.
-     */
-    @Skip
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        ctx.fireExceptionCaught(cause);
-    }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInboundHandler.java
@@ -69,7 +69,5 @@ public interface ChannelInboundHandler extends ChannelHandler {
     /**
      * Gets called if a {@link Throwable} was thrown.
      */
-    @Override
-    @SuppressWarnings("deprecation")
     void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception;
 }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
@@ -82,7 +82,7 @@ final class DefaultChannelHandlerContext extends DefaultAttributeMap
     private static final int MASK_WRITE = 1 << 16;
     private static final int MASK_FLUSH = 1 << 17;
 
-    private static final int MASK_ALL_INBOUND = MASK_CHANNEL_REGISTERED |
+    private static final int MASK_ALL_INBOUND = MASK_EXCEPTION_CAUGHT | MASK_CHANNEL_REGISTERED |
             MASK_CHANNEL_UNREGISTERED | MASK_CHANNEL_ACTIVE | MASK_CHANNEL_INACTIVE | MASK_CHANNEL_READ |
             MASK_CHANNEL_READ_COMPLETE | MASK_USER_EVENT_TRIGGERED | MASK_CHANNEL_WRITABILITY_CHANGED;
     private static final int MASK_ALL_OUTBOUND = MASK_BIND | MASK_CONNECT | MASK_DISCONNECT |
@@ -154,14 +154,14 @@ final class DefaultChannelHandlerContext extends DefaultAttributeMap
      * Calculate the {@code executionMask}.
      */
     private static int mask0(Class<? extends ChannelHandler> handlerType) {
-        int mask = MASK_EXCEPTION_CAUGHT;
+        int mask = 0;
         try {
-            if (isSkippable(handlerType, "exceptionCaught", ChannelHandlerContext.class, Throwable.class)) {
-                mask &= ~MASK_EXCEPTION_CAUGHT;
-            }
-
             if (ChannelInboundHandler.class.isAssignableFrom(handlerType)) {
                 mask |= MASK_ALL_INBOUND;
+
+                if (isSkippable(handlerType, "exceptionCaught", ChannelHandlerContext.class, Throwable.class)) {
+                    mask &= ~MASK_EXCEPTION_CAUGHT;
+                }
 
                 if (isSkippable(handlerType, "channelRegistered", ChannelHandlerContext.class)) {
                     mask &= ~MASK_CHANNEL_REGISTERED;
@@ -375,7 +375,7 @@ final class DefaultChannelHandlerContext extends DefaultAttributeMap
 
     void invokeExceptionCaught(final Throwable cause) {
         try {
-            handler().exceptionCaught(this, cause);
+            ((ChannelInboundHandler) handler()).exceptionCaught(this, cause);
         } catch (Throwable error) {
             if (logger.isDebugEnabled()) {
                 logger.debug(
@@ -744,7 +744,15 @@ final class DefaultChannelHandlerContext extends DefaultAttributeMap
         try {
             ((ChannelOutboundHandler) handler()).read(this);
         } catch (Throwable t) {
-            notifyHandlerException(t);
+            invokeExceptionCaughtFromOutbound(t);
+        }
+    }
+
+    private void invokeExceptionCaughtFromOutbound(Throwable t) {
+        if ((executionMask & MASK_EXCEPTION_CAUGHT) != 0) {
+            invokeExceptionCaught(t);
+        } else {
+            findContextInbound(MASK_EXCEPTION_CAUGHT).invokeExceptionCaught(t);
         }
     }
 
@@ -790,7 +798,7 @@ final class DefaultChannelHandlerContext extends DefaultAttributeMap
         try {
             ((ChannelOutboundHandler) handler()).flush(this);
         } catch (Throwable t) {
-            notifyHandlerException(t);
+            invokeExceptionCaughtFromOutbound(t);
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1019,7 +1019,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     /**
      * Called once a {@link Throwable} hit the end of the {@link ChannelPipeline} without been handled by the user
-     * in {@link ChannelHandler#exceptionCaught(ChannelHandlerContext, Throwable)}.
+     * in {@link ChannelInboundHandler#exceptionCaught(ChannelHandlerContext, Throwable)}.
      */
     protected void onUnhandledInboundException(Throwable cause) {
         try {

--- a/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
@@ -89,19 +89,11 @@ public class CombinedChannelDuplexHandlerTest {
     }
 
     @Test
-    public void testExceptionCaughtBothCombinedHandlers() {
+    public void testExceptionCaught() {
         final Exception exception = new Exception();
         final Queue<ChannelHandler> queue = new ArrayDeque<>();
 
         ChannelInboundHandler inboundHandler = new ChannelInboundHandlerAdapter() {
-            @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-                assertSame(exception, cause);
-                queue.add(this);
-                ctx.fireExceptionCaught(cause);
-            }
-        };
-        ChannelOutboundHandler outboundHandler = new ChannelOutboundHandlerAdapter() {
             @Override
             public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
                 assertSame(exception, cause);
@@ -118,11 +110,10 @@ public class CombinedChannelDuplexHandlerTest {
         };
         EmbeddedChannel channel = new EmbeddedChannel(
                 new CombinedChannelDuplexHandler<>(
-                        inboundHandler, outboundHandler), lastHandler);
+                        inboundHandler, new ChannelOutboundHandlerAdapter()), lastHandler);
         channel.pipeline().fireExceptionCaught(exception);
         assertFalse(channel.finish());
         assertSame(inboundHandler, queue.poll());
-        assertSame(outboundHandler, queue.poll());
         assertSame(lastHandler, queue.poll());
         assertTrue(queue.isEmpty());
     }

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -1488,7 +1488,7 @@ public class DefaultChannelPipelineTest {
         fail("handler was not one of the expected handlers");
     }
 
-    private static final class CheckOrderHandler extends ChannelHandlerAdapter {
+    private static final class CheckOrderHandler extends ChannelInboundHandlerAdapter {
         private final Queue<CheckOrderHandler> addedQueue;
         private final Queue<CheckOrderHandler> removedQueue;
         private final AtomicReference<Throwable> error = new AtomicReference<>();

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -258,8 +258,9 @@ public class ReentrantChannelTest extends BaseChannelTest {
                 throw new Exception("intentional failure");
             }
 
+        }, new ChannelInboundHandlerAdapter() {
             @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 ctx.close();
             }
         });


### PR DESCRIPTION
… ChannelOutboundHandler

Motivation:

ChannelHandler.exceptionCaught(...) was marked as @deprecated as it should only exist in inbound handlers.

Modifications:

Remove ChannelHandler.exceptionCaught(...) and adjust code / tests.

Result:

Fixes https://github.com/netty/netty/issues/8527
