### PR TITLE
Mark ChannelHandlerAdapter.exceptionCaught(...) as @deprecated.

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
@@ -81,8 +81,11 @@ public abstract class ChannelHandlerAdapter implements ChannelHandler {
      * to the next {@link ChannelHandler} in the {@link ChannelPipeline}.
      *
      * Sub-classes may override this method to change behavior.
+     *
+     * @deprecated is part of {@link ChannelInboundHandler}
      */
     @Override
+    @Deprecated
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         ctx.fireExceptionCaught(cause);
     }


### PR DESCRIPTION
Motivation:

41e03adf249ee9d23938fecf9be980a096710b36 marked ChannelHandler.exceptionCaught(...) as @deprecated but missed to also mark ChannelHandlerAdapter.exceptionCaught(...) as @deprecated. We should do so as most people extend the base classes and not implement the interfaces directly.

Modifications:

Mark ChannelHandlerAdapter.exceptionCaught(...) as @deprecated as well.

Result:

Mark method as @deprecated to warn users about its removal.