### PR TITLE
Avoid unnecessary char casts for CookieEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java
@@ -97,24 +97,24 @@ final class CookieUtil {
 
     static void add(StringBuilder sb, String name, long val) {
         sb.append(name);
-        sb.append((char) HttpConstants.EQUALS);
+        sb.append('=');
         sb.append(val);
-        sb.append((char) HttpConstants.SEMICOLON);
-        sb.append((char) HttpConstants.SP);
+        sb.append(';');
+        sb.append(HttpConstants.SP_CHAR);
     }
 
     static void add(StringBuilder sb, String name, String val) {
         sb.append(name);
-        sb.append((char) HttpConstants.EQUALS);
+        sb.append('=');
         sb.append(val);
-        sb.append((char) HttpConstants.SEMICOLON);
-        sb.append((char) HttpConstants.SP);
+        sb.append(';');
+        sb.append(HttpConstants.SP_CHAR);
     }
 
     static void add(StringBuilder sb, String name) {
         sb.append(name);
-        sb.append((char) HttpConstants.SEMICOLON);
-        sb.append((char) HttpConstants.SP);
+        sb.append(';');
+        sb.append(HttpConstants.SP_CHAR);
     }
 
     static void addQuoted(StringBuilder sb, String name, String val) {
@@ -123,12 +123,12 @@ final class CookieUtil {
         }
 
         sb.append(name);
-        sb.append((char) HttpConstants.EQUALS);
-        sb.append((char) HttpConstants.DOUBLE_QUOTE);
+        sb.append('=');
+        sb.append('"');
         sb.append(val);
-        sb.append((char) HttpConstants.DOUBLE_QUOTE);
-        sb.append((char) HttpConstants.SEMICOLON);
-        sb.append((char) HttpConstants.SP);
+        sb.append('"');
+        sb.append(';');
+        sb.append(HttpConstants.SP_CHAR);
     }
 
     static int firstInvalidCookieNameOctet(CharSequence cs) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -105,10 +105,10 @@ public final class ServerCookieEncoder extends CookieEncoder {
             add(buf, CookieHeaderNames.MAX_AGE, cookie.maxAge());
             Date expires = new Date(cookie.maxAge() * 1000 + System.currentTimeMillis());
             buf.append(CookieHeaderNames.EXPIRES);
-            buf.append((char) HttpConstants.EQUALS);
+            buf.append('=');
             DateFormatter.append(expires, buf);
-            buf.append((char) HttpConstants.SEMICOLON);
-            buf.append((char) HttpConstants.SP);
+            buf.append(';');
+            buf.append(HttpConstants.SP_CHAR);
         }
 
         if (cookie.path() != null) {


### PR DESCRIPTION
Motivation:

Avoid unnecessary (char) casts by changing variables types.