### PR TITLE
Java 8 migration. Remove WebSocketUtil.randomNumber

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -63,6 +63,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * <p>
@@ -178,7 +179,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
 
             // Write payload
             if (maskPayload) {
-                int random = (int) (Math.random() * Integer.MAX_VALUE);
+                int random = ThreadLocalRandom.current().nextInt();
                 mask = ByteBuffer.allocate(4).putInt(random).array();
                 buf.writeBytes(mask);
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
@@ -30,6 +30,7 @@ import io.netty.util.AsciiString;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * <p>
@@ -88,14 +89,14 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
     @Override
     protected FullHttpRequest newHandshakeRequest() {
         // Make keys
-        int spaces1 = WebSocketUtil.randomNumber(1, 12);
-        int spaces2 = WebSocketUtil.randomNumber(1, 12);
+        int spaces1 = ThreadLocalRandom.current().nextInt(1, 13);
+        int spaces2 = ThreadLocalRandom.current().nextInt(1, 13);
 
         int max1 = Integer.MAX_VALUE / spaces1;
         int max2 = Integer.MAX_VALUE / spaces2;
 
-        int number1 = WebSocketUtil.randomNumber(0, max1);
-        int number2 = WebSocketUtil.randomNumber(0, max2);
+        int number1 = ThreadLocalRandom.current().nextInt(0, max1);
+        int number2 = ThreadLocalRandom.current().nextInt(0, max2);
 
         int product1 = number1 * spaces1;
         int product2 = number2 * spaces2;
@@ -201,12 +202,12 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
     }
 
     private static String insertRandomCharacters(String key) {
-        int count = WebSocketUtil.randomNumber(1, 12);
+        int count = ThreadLocalRandom.current().nextInt(1, 13);
 
         char[] randomChars = new char[count];
         int randCount = 0;
         while (randCount < count) {
-            int rand = (int) (Math.random() * 0x7e + 0x21);
+            int rand = ThreadLocalRandom.current().nextInt(0x21, 0x7e + 0x21);
             if (0x21 < rand && rand < 0x2f || 0x3a < rand && rand < 0x7e) {
                 randomChars[randCount] = (char) rand;
                 randCount += 1;
@@ -214,7 +215,7 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
         }
 
         for (int i = 0; i < count; i++) {
-            int split = WebSocketUtil.randomNumber(0, key.length());
+            int split = ThreadLocalRandom.current().nextInt(0, key.length() + 1);
             String part1 = key.substring(0, split);
             String part2 = key.substring(split);
             key = part1 + randomChars[i] + part2;
@@ -225,7 +226,7 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
 
     private static String insertSpaces(String key, int spaces) {
         for (int i = 0; i < spaces; i++) {
-            int split = WebSocketUtil.randomNumber(1, key.length() - 1);
+            int split = ThreadLocalRandom.current().nextInt(1, key.length());
             String part1 = key.substring(0, split);
             String part2 = key.substring(split);
             key = part1 + ' ' + part2;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
@@ -207,8 +207,8 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
         char[] randomChars = new char[count];
         int randCount = 0;
         while (randCount < count) {
-            int rand = ThreadLocalRandom.current().nextInt(0x21, 0x7e + 0x21);
-            if (0x21 < rand && rand < 0x2f || 0x3a < rand && rand < 0x7e) {
+            int rand = ThreadLocalRandom.current().nextInt(0x22, 0x7e);
+            if (rand < 0x2f || 0x3a < rand) {
                 randomChars[randCount] = (char) rand;
                 randCount += 1;
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
@@ -111,39 +111,6 @@ final class WebSocketUtil {
     }
 
     /**
-     * Generates a pseudo-random number
-     *
-     * @param minimum The minimum allowable value
-     * @param maximum The maximum allowable value
-     * @return A pseudo-random number
-     */
-    static int randomNumber(int minimum, int maximum) {
-        assert minimum < maximum;
-        double fraction = ThreadLocalRandom.current().nextDouble();
-
-        // the idea here is that nextDouble gives us a random value
-        //
-        //              0 <= fraction <= 1
-        //
-        // the distance from min to max declared as
-        //
-        //              dist = max - min
-        //
-        // satisfies the following
-        //
-        //              min + dist = max
-        //
-        // taking into account
-        //
-        //         0 <= fraction * dist <= dist
-        //
-        // we've got
-        //
-        //       min <= min + fraction * dist <= max
-        return (int) (minimum + fraction * (maximum - minimum));
-    }
-
-    /**
      * A private constructor to ensure that instances of this class cannot be made
      */
     private WebSocketUtil() {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtilTest.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http.websocketx;
 
 import org.junit.Test;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import static org.junit.Assert.assertTrue;
 
 public class WebSocketUtilTest {
@@ -25,7 +27,7 @@ public class WebSocketUtilTest {
     private static final int NUM_ITERATIONS = 1000;
 
     private static void assertRandomWithinBoundaries(int min, int max) {
-        int r = WebSocketUtil.randomNumber(min, max);
+        int r = ThreadLocalRandom.current().nextInt(min, max + 1);
         assertTrue(min <= r && r <= max);
     }
 


### PR DESCRIPTION
Motivation:

Use `ThreadLocalRandom.current().nextInt()` directly instead of `(int) ThreadLocalRandom.current().nextDouble()`