### PR TITLE
Deprecate SICH.channelRead0(...) in favour of messageReceived(...)

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -72,7 +72,7 @@ import java.lang.annotation.Target;
  *     <b>private boolean loggedIn;</b>
  *
  *     {@code @Override}
- *     public void channelRead0({@link ChannelHandlerContext} ctx, Message message) {
+ *     public void messageReceived({@link ChannelHandlerContext} ctx, Message message) {
  *         if (message instanceof LoginMessage) {
  *             authenticate((LoginMessage) message);
  *             <b>loggedIn = true;</b>

--- a/transport/src/main/java/io/netty/channel/SimpleChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/SimpleChannelInboundHandler.java
@@ -28,7 +28,7 @@ import io.netty.util.internal.TypeParameterMatcher;
  *             {@link SimpleChannelInboundHandler}&lt;{@link String}&gt; {
  *
  *         {@code @Override}
- *         protected void channelRead0({@link ChannelHandlerContext} ctx, {@link String} message)
+ *         protected void messageReceived({@link ChannelHandlerContext} ctx, {@link String} message)
  *                 throws {@link Exception} {
  *             System.out.println(message);
  *         }
@@ -41,8 +41,8 @@ import io.netty.util.internal.TypeParameterMatcher;
  *
  * <h3>Forward compatibility notice</h3>
  * <p>
- * Please keep in mind that {@link #channelRead0(ChannelHandlerContext, I)} will be renamed to
- * {@code messageReceived(ChannelHandlerContext, I)} in 5.0.
+ * Please keep in mind that {@link #channelRead0(ChannelHandlerContext, I)} will be removed in favour of
+ * {@link messageReceived(ChannelHandlerContext, I)} in 5.0.
  * </p>
  */
 public abstract class SimpleChannelInboundHandler<I> extends ChannelInboundHandlerAdapter {
@@ -102,7 +102,7 @@ public abstract class SimpleChannelInboundHandler<I> extends ChannelInboundHandl
             if (acceptInboundMessage(msg)) {
                 @SuppressWarnings("unchecked")
                 I imsg = (I) msg;
-                channelRead0(ctx, imsg);
+                messageReceived(ctx, imsg);
             } else {
                 release = false;
                 ctx.fireChannelRead(msg);
@@ -115,9 +115,6 @@ public abstract class SimpleChannelInboundHandler<I> extends ChannelInboundHandl
     }
 
     /**
-     * <strong>Please keep in mind that this method will be renamed to
-     * {@code messageReceived(ChannelHandlerContext, I)} in 5.0.</strong>
-     *
      * Is called for each message of type {@link I}.
      *
      * @param ctx           the {@link ChannelHandlerContext} which this {@link SimpleChannelInboundHandler}
@@ -125,5 +122,16 @@ public abstract class SimpleChannelInboundHandler<I> extends ChannelInboundHandl
      * @param msg           the message to handle
      * @throws Exception    is thrown if an error occurred
      */
-    protected abstract void channelRead0(ChannelHandlerContext ctx, I msg) throws Exception;
+    protected void messageReceived(ChannelHandlerContext ctx, I msg) throws Exception {
+        channelRead0(ctx, msg);
+    }
+
+    /**
+     * @deprecated override {@link messageReceived(ChannelHandlerContext, I)} instead of this method,
+     *     it will be removed in Netty 5.x
+     */
+    @Deprecated
+    protected void channelRead0(ChannelHandlerContext ctx, I msg) throws Exception {
+        throw new IllegalStateException(getClass().getName() + " must override messageReceived(...)");
+    }
 }


### PR DESCRIPTION
Motivation

`SimpleInboundChannelHandler.channelRead0(...)` will be renamed in netty 5 to `messageReceived(...)`, but as @ejona86 suggested in #8819, we can still introduce the new name in 4.1 and mark the old one deprecated. This will allow folks to switch over in advance and so reduce the impact when later upgrading to 5.x.

Modifications

Add new `messageReceived` method to `SimpleInboundChannelHandler` which delegates to `channelRead0` by default, and update callers and doc references to use it.

Mark `channelRead0` as deprecated, and add a default implementation which throws an `IllegalStateException`, thereby removing the requirement on subclasses to implement it while still enforcing that at least one of the two methods is overridden.

Result

Method rename pre-migration is possible on 4.1.x.