### PR TITLE
Java 8 migration. Move WebSocketUtil.base64 to java version instead o…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
@@ -15,14 +15,12 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.base64.Base64;
-import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -91,13 +89,8 @@ final class WebSocketUtil {
      * @return An encoded string containing the data
      */
     static String base64(byte[] data) {
-        ByteBuf encodedData = Unpooled.wrappedBuffer(data);
-        ByteBuf encoded = Base64.encode(encodedData);
-        String encodedString = encoded.toString(CharsetUtil.UTF_8);
-        encoded.release();
-        return encodedString;
+        return Base64.getEncoder().encodeToString(data);
     }
-
     /**
      * Creates an arbitrary number of random bytes
      *


### PR DESCRIPTION
…f netty

Motivation:

Since Java 8, JDK has `java.util.Base64` that could replace custom netty implementation. It is faster (3x for this particular PR) and simpler.
This PR changes only `WebSocketUtil.base64` that used in websockets handshake. However, netty `io.netty.handler.codec.base64` the package is untouched as it requires a lot of refactorings, don't have enough time for this right now.

```
@State(Scope.Benchmark)
@Warmup(iterations = 5)
@Measurement(iterations = 5)
@Threads(1)
public class Base64Benchmark extends AbstractMicrobenchmark {

    String d = "TlRMTVNTUAACAAAAAAAAACgAAAABggAAU3J2Tm9uY2UAAAAAAAAAAA==";
    byte[] data = java.util.Base64.getDecoder().decode(d);

    @Benchmark
    public String base64New() {
        byte[] encodedData = java.util.Base64.getEncoder().encode(data);
        return new String(encodedData, StandardCharsets.UTF_8);
    }

    @Benchmark
    public String base64Old() {
        ByteBuf encodedData = Unpooled.wrappedBuffer(data);
        ByteBuf encoded = io.netty.handler.codec.base64.Base64.encode(encodedData);
        String encodedString = encoded.toString(CharsetUtil.UTF_8);
        encoded.release();
        return encodedString;
    }
}
```

Result:
```
Benchmark                   Mode  Cnt        Score        Error  Units
Base64Benchmark.base64New  thrpt    6  7739181.025 ± 114230.467  ops/s
Base64Benchmark.base64Old  thrpt    6  2689783.304 ± 454710.641  ops/s
```

Old discussions with @slandelle https://github.com/AsyncHttpClient/async-http-client/pull/1516
