### PR TITLE
Don't update state of PromiseCombiner when finish(null) is called

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/PromiseCombiner.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseCombiner.java
@@ -112,11 +112,12 @@ public final class PromiseCombiner {
      * @param aggregatePromise the promise to notify when all combined futures have finished
      */
     public void finish(Promise<Void> aggregatePromise) {
+        ObjectUtil.checkNotNull(aggregatePromise, "aggregatePromise");
         if (doneAdding) {
             throw new IllegalStateException("Already finished");
         }
         doneAdding = true;
-        this.aggregatePromise = ObjectUtil.checkNotNull(aggregatePromise, "aggregatePromise");
+        this.aggregatePromise = aggregatePromise;
         if (doneCount == expectedCount) {
             tryPromise();
         }

--- a/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.concurrent;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -56,6 +57,18 @@ public class PromiseCombinerTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         combiner = new PromiseCombiner();
+    }
+
+    @Test
+    public void testNullArgument() {
+        try {
+            combiner.finish(null);
+            Assert.fail();
+        } catch (NullPointerException expected) {
+            // expected
+        }
+        combiner.finish(p1);
+        verify(p1).trySuccess(null);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

When we fail a call to PromiseCombiner.finish(...) because of a null argument we must not update the internal state before throwing.

Modifications:

- First do the null check and only after we validated that the argument is not null update the internal state
- Add test case.

Modifications:

Do not mess up internal state of PromiseCombiner when finish(...) is called with a null argument.