### PR TITLE
Support using an Executor to offload blocking / long-running tasks wh…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/DelegatingSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/DelegatingSslContext.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.ObjectUtil;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Adapter class which allows to wrap another {@link SslContext} and init {@link SSLEngine} instances.
@@ -82,6 +83,21 @@ public abstract class DelegatingSslContext extends SslContext {
     @Override
     protected final SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
         SslHandler handler = ctx.newHandler(alloc, peerHost, peerPort, startTls);
+        initHandler(handler);
+        return handler;
+    }
+
+    @Override
+    protected SslHandler newHandler(ByteBufAllocator alloc, boolean startTls, Executor executor) {
+        SslHandler handler = ctx.newHandler(alloc, startTls, executor);
+        initHandler(handler);
+        return handler;
+    }
+
+    @Override
+    protected SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort,
+                                    boolean startTls, Executor executor) {
+        SslHandler handler = ctx.newHandler(alloc, peerHost, peerPort, startTls, executor);
         initHandler(handler);
         return handler;
     }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -398,6 +399,17 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     @Override
     protected final SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
         return new SslHandler(newEngine0(alloc, peerHost, peerPort, false), startTls);
+    }
+
+    @Override
+    protected SslHandler newHandler(ByteBufAllocator alloc, boolean startTls, Executor executor) {
+        return new SslHandler(newEngine0(alloc, null, -1, false), startTls, executor);
+    }
+
+    @Override
+    protected SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort,
+                                    boolean startTls, Executor executor) {
+        return new SslHandler(newEngine0(alloc, peerHost, peerPort, false), executor);
     }
 
     SSLEngine newEngine0(ByteBufAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {

--- a/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.util.AsyncMapping;
@@ -129,7 +130,7 @@ public class SniHandler extends AbstractSniHandler<SslContext> {
     protected void replaceHandler(ChannelHandlerContext ctx, String hostname, SslContext sslContext) throws Exception {
         SslHandler sslHandler = null;
         try {
-            sslHandler = sslContext.newHandler(ctx.alloc());
+            sslHandler = newSslHandler(sslContext, ctx.alloc());
             ctx.pipeline().replace(this, SslHandler.class.getName(), sslHandler);
             sslHandler = null;
         } finally {
@@ -140,6 +141,14 @@ public class SniHandler extends AbstractSniHandler<SslContext> {
                 ReferenceCountUtil.safeRelease(sslHandler.engine());
             }
         }
+    }
+
+    /**
+     * Returns a new {@link SslHandler} using the given {@link SslContext} and {@link ByteBufAllocator}.
+     * Users may override this method to implement custom behavior.
+     */
+    protected SslHandler newSslHandler(SslContext context, ByteBufAllocator allocator) {
+        return context.newHandler(allocator);
     }
 
     private static final class AsyncMappingAdapter implements AsyncMapping<String, SslContext> {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1682,6 +1682,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                     }
                 }
             } catch (final Throwable cause) {
+                processTask = false;
                 handleException(cause);
             }
         }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1678,16 +1678,13 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                     }
                     // There was no task to process lets continue on the EventExecutor.
                 }
-                if (ctx.executor().inEventLoop()) {
-                    resumeOnEventExecutor();
-                } else {
-                    ctx.executor().execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            resumeOnEventExecutor();
-                        }
-                    });
-                }
+                // Jump back on the EventExecutor.
+                ctx.executor().execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        resumeOnEventExecutor();
+                    }
+                });
             } catch (final Throwable cause) {
                 processTask = false;
                 handleException(cause);

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -419,7 +419,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     volatile int wrapDataSize = MAX_PLAINTEXT_LENGTH;
 
     /**
-     * Creates a new instance which runs all delegating tasks directly on the {@link EventExecutor}.
+     * Creates a new instance which runs all delegated tasks directly on the {@link EventExecutor}.
      *
      * @param engine  the {@link SSLEngine} this handler will use
      */
@@ -428,7 +428,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     /**
-     * Creates a new instance which runs all delegating tasks directly on the {@link EventExecutor}.
+     * Creates a new instance which runs all delegated tasks directly on the {@link EventExecutor}.
      *
      * @param engine    the {@link SSLEngine} this handler will use
      * @param startTls  {@code true} if the first write request shouldn't be
@@ -1488,9 +1488,19 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         return executor instanceof EventExecutor && ((EventExecutor) executor).inEventLoop();
     }
 
+    private static void runAllDelegatingTasks(SSLEngine engine) {
+        for (;;) {
+            Runnable task = engine.getDelegatedTask();
+            if (task == null) {
+                return;
+            }
+            task.run();
+        }
+    }
+
     /**
-     * Will either run the delegating task directly calling {@link Runnable#run()} and return {@code true} or will
-     * offload the delegating task using {@link Executor#execute(Runnable)} and return {@code false}.
+     * Will either run the delegated task directly calling {@link Runnable#run()} and return {@code true} or will
+     * offload the delegated task using {@link Executor#execute(Runnable)} and return {@code false}.
      *
      * If the task is offloaded it will take care to resume its work on the {@link EventExecutor} once there are no
      * more tasks to process.
@@ -1499,27 +1509,19 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         if (delegatedTaskExecutor == ImmediateExecutor.INSTANCE || inEventLoop(delegatedTaskExecutor)) {
             // We should run the task directly in the EventExecutor thread and not offload at all.
             for (;;) {
-                Runnable task = engine.getDelegatedTask();
-                if (task == null) {
-                    return true;
-                }
-                task.run();
-            }
-        } else {
-            final Runnable task = engine.getDelegatedTask();
-            if (task == null) {
-                // There was nothing to do just continue execute on the EventExecutor thread.
+                runAllDelegatingTasks(engine);
                 return true;
             }
-            executeDelegatingTask(task, inUnwrap);
+        } else {
+            executeDelegatedTasks(inUnwrap);
             return false;
         }
     }
 
-    private void executeDelegatingTask(Runnable task, boolean inUnwrap) {
+    private void executeDelegatedTasks(boolean inUnwrap) {
         processTask = true;
         try {
-            delegatedTaskExecutor.execute(new SslTask(task, inUnwrap));
+            delegatedTaskExecutor.execute(new SslTasksRunner(inUnwrap));
         } catch (RejectedExecutionException e) {
             processTask = false;
             throw e;
@@ -1530,12 +1532,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * {@link Runnable} that will be scheduled on the {@code delegatedTaskExecutor} and will take care
      * of resume work on the {@link EventExecutor} once the task was executed.
      */
-    private final class SslTask implements Runnable {
-        private final Runnable task;
+    private final class SslTasksRunner implements Runnable {
         private final boolean inUnwrap;
 
-        SslTask(Runnable task, boolean inUnwrap) {
-            this.task = task;
+        SslTasksRunner(boolean inUnwrap) {
             this.inUnwrap = inUnwrap;
         }
 
@@ -1603,14 +1603,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 switch (status) {
                     // There is another task that needs to be executed and offloaded to the delegatingTaskExecutor.
                     case NEED_TASK:
-                        final Runnable task = engine.getDelegatedTask();
-
-                        if (task != null) {
-                            executeDelegatingTask(task, inUnwrap);
-                        } else {
-                            // There was no task to run so lets try to feed in more data to make progress.
-                            tryDecodeAgain();
-                        }
+                        executeDelegatedTasks(inUnwrap);
 
                         break;
 
@@ -1665,22 +1658,18 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                         throw new AssertionError();
                 }
             } catch (Throwable cause) {
-                handleException(cause);
+                safeExceptionCaught(cause);
             }
         }
 
         @Override
         public void run() {
             try {
-                task.run();
-                if (engine.getHandshakeStatus() == HandshakeStatus.NEED_TASK) {
-                    final Runnable task = engine.getDelegatedTask();
-                    if (task != null) {
-                        delegatedTaskExecutor.execute(new SslTask(task, inUnwrap));
-                        return;
-                    }
-                    // There was no task to process lets continue on the EventExecutor.
-                }
+                runAllDelegatingTasks(engine);
+
+                // All tasks were processed.
+                assert engine.getHandshakeStatus() != HandshakeStatus.NEED_TASK;
+
                 // Jump back on the EventExecutor.
                 ctx.executor().execute(new Runnable() {
                     @Override
@@ -1689,23 +1678,25 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                     }
                 });
             } catch (final Throwable cause) {
-                processTask = false;
                 handleException(cause);
             }
         }
 
         private void handleException(final Throwable cause) {
             if (ctx.executor().inEventLoop()) {
+                processTask = false;
                 safeExceptionCaught(cause);
             } else {
                 try {
                     ctx.executor().execute(new Runnable() {
                         @Override
                         public void run() {
+                            processTask = false;
                             safeExceptionCaught(cause);
                         }
                     });
                 } catch (RejectedExecutionException ignore) {
+                    processTask = false;
                     // the context itself will handle the rejected exception when try to schedule the operation so
                     // ignore the RejectedExecutionException
                     ctx.fireExceptionCaught(cause);

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1488,7 +1488,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         return executor instanceof EventExecutor && ((EventExecutor) executor).inEventLoop();
     }
 
-    private static void runAllDelegatingTasks(SSLEngine engine) {
+    private static void runAllDelegatedTasks(SSLEngine engine) {
         for (;;) {
             Runnable task = engine.getDelegatedTask();
             if (task == null) {
@@ -1509,7 +1509,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         if (delegatedTaskExecutor == ImmediateExecutor.INSTANCE || inEventLoop(delegatedTaskExecutor)) {
             // We should run the task directly in the EventExecutor thread and not offload at all.
             for (;;) {
-                runAllDelegatingTasks(engine);
+                runAllDelegatedTasks(engine);
                 return true;
             }
         } else {
@@ -1665,7 +1665,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         @Override
         public void run() {
             try {
-                runAllDelegatingTasks(engine);
+                runAllDelegatedTasks(engine);
 
                 // All tasks were processed.
                 assert engine.getHandshakeStatus() != HandshakeStatus.NEED_TASK;

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1635,10 +1635,13 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                         // Flush now as we may have written some data as part of the wrap call.
                         forceFlush(ctx);
 
-                        // deliberate fall-through
+                        tryDecodeAgain();
+                        break;
 
-                    // We need more data so lets try to call decode again which will feed us with buffered data.
+                    // We need more data so lets try to unwrap first and then call decode again which will feed us
+                    // with buffered data (if there is any).
                     case NEED_UNWRAP:
+                        unwrapNonAppData(ctx);
                         tryDecodeAgain();
                         break;
 

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -31,17 +31,18 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
     public static Collection<Object[]> data() {
         List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
         }
         return params;
     }
 
-    public ConscryptJdkSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo) {
-        super(type, combo);
+    public ConscryptJdkSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
+        super(type, combo, delegate);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
@@ -30,17 +30,18 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class ConscryptSslEngineTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
     public static Collection<Object[]> data() {
         List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
         }
         return params;
     }
 
-    public ConscryptSslEngineTest(BufferType type, ProtocolCipherCombo combo) {
-        super(type, combo);
+    public ConscryptSslEngineTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
+        super(type, combo, delegate);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
@@ -32,17 +32,18 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
     public static Collection<Object[]> data() {
         List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
         }
         return params;
     }
 
-    public JdkConscryptSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo) {
-        super(type, combo);
+    public JdkConscryptSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
+        super(type, combo, delegate);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -33,21 +33,23 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
     public static Collection<Object[]> data() {
         List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
 
             if (PlatformDependent.javaVersion() >= 11 && OpenSsl.isTlsv13Supported()) {
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13() });
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), false });
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), true });
             }
         }
         return params;
     }
 
-    public JdkOpenSslEngineInteroptTest(BufferType type, ProtocolCipherCombo protocolCipherCombo) {
-        super(type, protocolCipherCombo);
+    public JdkOpenSslEngineInteroptTest(BufferType type, ProtocolCipherCombo protocolCipherCombo, boolean delegate) {
+        super(type, protocolCipherCombo, delegate);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
@@ -142,14 +142,17 @@ public class JdkSslEngineTest extends SSLEngineTest {
     private static final String FALLBACK_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http1_1";
     private static final String APPLICATION_LEVEL_PROTOCOL_NOT_COMPATIBLE = "my-protocol-FOO";
 
-    @Parameterized.Parameters(name = "{index}: providerType = {0}, bufferType = {1}, combo = {2}")
+    @Parameterized.Parameters(name = "{index}: providerType = {0}, bufferType = {1}, combo = {2}, delegate = {3}")
     public static Collection<Object[]> data() {
         List<Object[]> params = new ArrayList<Object[]>();
         for (ProviderType providerType : ProviderType.values()) {
             for (BufferType bufferType : BufferType.values()) {
-                params.add(new Object[]{ providerType, bufferType, ProtocolCipherCombo.tlsv12()});
+                params.add(new Object[]{ providerType, bufferType, ProtocolCipherCombo.tlsv12(), true });
+                params.add(new Object[]{ providerType, bufferType, ProtocolCipherCombo.tlsv12(), false });
+
                 if (PlatformDependent.javaVersion() >= 11) {
-                    params.add(new Object[] { providerType, bufferType, ProtocolCipherCombo.tlsv13() });
+                    params.add(new Object[] { providerType, bufferType, ProtocolCipherCombo.tlsv13(), true });
+                    params.add(new Object[] { providerType, bufferType, ProtocolCipherCombo.tlsv13(), false });
                 }
             }
         }
@@ -160,8 +163,9 @@ public class JdkSslEngineTest extends SSLEngineTest {
 
     private Provider provider;
 
-    public JdkSslEngineTest(ProviderType providerType, BufferType bufferType, ProtocolCipherCombo protocolCipherCombo) {
-        super(bufferType, protocolCipherCombo);
+    public JdkSslEngineTest(ProviderType providerType, BufferType bufferType,
+                            ProtocolCipherCombo protocolCipherCombo, boolean delegate) {
+        super(bufferType, protocolCipherCombo, delegate);
         this.providerType = providerType;
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -67,21 +67,23 @@ public class OpenSslEngineTest extends SSLEngineTest {
     private static final String PREFERRED_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http2";
     private static final String FALLBACK_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http1_1";
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
     public static Collection<Object[]> data() {
         List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
 
             if (OpenSsl.isTlsv13Supported()) {
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13() });
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), false });
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), true });
             }
         }
         return params;
     }
 
-    public OpenSslEngineTest(BufferType type, ProtocolCipherCombo cipherCombo) {
-        super(type, cipherCombo);
+    public OpenSslEngineTest(BufferType type, ProtocolCipherCombo cipherCombo, boolean delegate) {
+        super(type, cipherCombo, delegate);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
@@ -35,21 +35,23 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}")
+    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
     public static Collection<Object[]> data() {
         List<Object[]> params = new ArrayList<Object[]>();
         for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12()});
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
+            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
 
             if (PlatformDependent.javaVersion() >= 11 && OpenSsl.isTlsv13Supported()) {
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13() });
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), false });
+                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), true });
             }
         }
         return params;
     }
 
-    public OpenSslJdkSslEngineInteroptTest(BufferType type, ProtocolCipherCombo combo) {
-        super(type, combo);
+    public OpenSslJdkSslEngineInteroptTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
+        super(type, combo, delegate);
     }
 
     @BeforeClass

--- a/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
@@ -23,8 +23,8 @@ import javax.net.ssl.SSLEngine;
 
 public class ReferenceCountedOpenSslEngineTest extends OpenSslEngineTest {
 
-    public ReferenceCountedOpenSslEngineTest(BufferType type, ProtocolCipherCombo combo) {
-        super(type, combo);
+    public ReferenceCountedOpenSslEngineTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
+        super(type, combo, delegate);
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -538,7 +538,7 @@ public abstract class SSLEngineTest {
         mySetupMutualAuth(clientCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
                           serverCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
         runTest(null);
-        assertTrue(serverLatch.await(2, TimeUnit.MINUTES));
+        assertTrue(serverLatch.await(2, TimeUnit.SECONDS));
     }
 
     @Test
@@ -552,7 +552,7 @@ public abstract class SSLEngineTest {
         // Client trusts server but server only trusts itself
         mySetupMutualAuth(serverCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
                           serverCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
-        assertTrue(serverLatch.await(200, TimeUnit.SECONDS));
+        assertTrue(serverLatch.await(2, TimeUnit.SECONDS));
         assertTrue(serverException instanceof SSLHandshakeException);
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -73,6 +73,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.KeyManagerFactory;
@@ -252,10 +254,13 @@ public abstract class SSLEngineTest {
 
     private final BufferType type;
     private final ProtocolCipherCombo protocolCipherCombo;
+    private final boolean delegate;
+    private ExecutorService delegatingExecutor;
 
-    protected SSLEngineTest(BufferType type, ProtocolCipherCombo protocolCipherCombo) {
+    protected SSLEngineTest(BufferType type, ProtocolCipherCombo protocolCipherCombo, boolean delegate) {
         this.type = type;
         this.protocolCipherCombo = protocolCipherCombo;
+        this.delegate = delegate;
     }
 
     protected ByteBuffer allocateBuffer(int len) {
@@ -441,6 +446,9 @@ public abstract class SSLEngineTest {
         MockitoAnnotations.initMocks(this);
         serverLatch = new CountDownLatch(1);
         clientLatch = new CountDownLatch(1);
+        if (delegate) {
+            delegatingExecutor = Executors.newCachedThreadPool();
+        }
     }
 
     @After
@@ -500,6 +508,10 @@ public abstract class SSLEngineTest {
             clientGroupShutdownFuture.sync();
         }
         serverException = null;
+
+        if (delegatingExecutor != null) {
+            delegatingExecutor.shutdown();
+        }
     }
 
     @Test
@@ -526,7 +538,7 @@ public abstract class SSLEngineTest {
         mySetupMutualAuth(clientCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
                           serverCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
         runTest(null);
-        assertTrue(serverLatch.await(2, TimeUnit.SECONDS));
+        assertTrue(serverLatch.await(2, TimeUnit.MINUTES));
     }
 
     @Test
@@ -540,7 +552,7 @@ public abstract class SSLEngineTest {
         // Client trusts server but server only trusts itself
         mySetupMutualAuth(serverCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
                           serverCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
-        assertTrue(serverLatch.await(2, TimeUnit.SECONDS));
+        assertTrue(serverLatch.await(200, TimeUnit.SECONDS));
         assertTrue(serverException instanceof SSLHandshakeException);
     }
 
@@ -703,7 +715,8 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                 ChannelPipeline p = ch.pipeline();
-                SslHandler handler = serverSslCtx.newHandler(ch.alloc());
+                SslHandler handler = delegatingExecutor == null ? serverSslCtx.newHandler(ch.alloc()) :
+                        serverSslCtx.newHandler(ch.alloc(), delegatingExecutor);
                 if (serverInitEngine) {
                     mySetupMutualAuthServerInitSslHandler(handler);
                 }
@@ -746,7 +759,10 @@ public abstract class SSLEngineTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(clientSslCtx.newHandler(ch.alloc()));
+
+                SslHandler handler = delegatingExecutor == null ? clientSslCtx.newHandler(ch.alloc()) :
+                        clientSslCtx.newHandler(ch.alloc(), delegatingExecutor);
+                p.addLast(handler);
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -849,7 +865,10 @@ public abstract class SSLEngineTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(serverSslCtx.newHandler(ch.alloc()));
+
+                SslHandler handler = delegatingExecutor == null ? serverSslCtx.newHandler(ch.alloc()) :
+                        serverSslCtx.newHandler(ch.alloc(), delegatingExecutor);
+                p.addLast(handler);
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -889,7 +908,11 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
                 ChannelPipeline p = ch.pipeline();
                 InetSocketAddress remoteAddress = (InetSocketAddress) serverChannel.localAddress();
-                SslHandler sslHandler = clientSslCtx.newHandler(ch.alloc(), expectedHost, 0);
+
+                SslHandler sslHandler = delegatingExecutor == null ?
+                        clientSslCtx.newHandler(ch.alloc(), expectedHost, 0) :
+                        clientSslCtx.newHandler(ch.alloc(), expectedHost, 0,  delegatingExecutor);
+
                 SSLParameters parameters = sslHandler.engine().getSSLParameters();
                 if (SslUtils.isValidHostNameForSNI(expectedHost)) {
                     assertEquals(1, parameters.getServerNames().size());
@@ -1053,7 +1076,10 @@ public abstract class SSLEngineTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
-                final SslHandler handler = clientSslCtx.newHandler(ch.alloc());
+                final SslHandler handler = delegatingExecutor == null ?
+                        clientSslCtx.newHandler(ch.alloc()) :
+                        clientSslCtx.newHandler(ch.alloc(), delegatingExecutor);
+
                 handler.engine().setNeedClientAuth(true);
                 ChannelPipeline p = ch.pipeline();
                 p.addLast(handler);
@@ -1125,7 +1151,7 @@ public abstract class SSLEngineTest {
                                                MessageReceiver receiver) throws Exception {
         List<ByteBuf> dataCapture = null;
         try {
-            assertTrue(sendChannel.writeAndFlush(message).await(5, TimeUnit.SECONDS));
+            assertTrue(sendChannel.writeAndFlush(message).await(50, TimeUnit.SECONDS));
             receiverLatch.await(5, TimeUnit.SECONDS);
             message.resetReaderIndex();
             ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
@@ -1248,7 +1274,12 @@ public abstract class SSLEngineTest {
                         ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                         ChannelPipeline p = ch.pipeline();
-                        p.addLast(serverSslCtx.newHandler(ch.alloc()));
+
+                        SslHandler handler = delegatingExecutor == null ?
+                                serverSslCtx.newHandler(ch.alloc()) :
+                                serverSslCtx.newHandler(ch.alloc(), delegatingExecutor);
+
+                        p.addLast(handler);
                         p.addLast(new ChannelInboundHandlerAdapter() {
                             @Override
                             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
@@ -1304,7 +1335,11 @@ public abstract class SSLEngineTest {
                         ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                         ChannelPipeline p = ch.pipeline();
-                        SslHandler sslHandler = clientSslCtx.newHandler(ch.alloc());
+
+                        SslHandler sslHandler = delegatingExecutor == null ?
+                                clientSslCtx.newHandler(ch.alloc()) :
+                                clientSslCtx.newHandler(ch.alloc(), delegatingExecutor);
+
                         // The renegotiate is not expected to succeed, so we should stop trying in a timely manner so
                         // the unit test can terminate relativley quicly.
                         sslHandler.setHandshakeTimeout(1, TimeUnit.SECONDS);
@@ -1384,7 +1419,7 @@ public abstract class SSLEngineTest {
         }
     }
 
-    protected void handshake(SSLEngine clientEngine, SSLEngine serverEngine) throws SSLException {
+    protected void handshake(SSLEngine clientEngine, SSLEngine serverEngine) throws Exception {
         ByteBuffer cTOs = allocateBuffer(clientEngine.getSession().getPacketBufferSize());
         ByteBuffer sTOc = allocateBuffer(serverEngine.getSession().getPacketBufferSize());
 
@@ -1477,14 +1512,18 @@ public abstract class SSLEngineTest {
         return result.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED;
     }
 
-    private static void runDelegatedTasks(SSLEngineResult result, SSLEngine engine) {
+    private void runDelegatedTasks(SSLEngineResult result, SSLEngine engine) throws Exception {
         if (result.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_TASK) {
             for (;;) {
                 Runnable task = engine.getDelegatedTask();
                 if (task == null) {
                     break;
                 }
-                task.run();
+                if (delegatingExecutor == null) {
+                    task.run();
+                } else {
+                    delegatingExecutor.submit(task).get();
+                }
             }
         }
     }
@@ -1586,7 +1625,12 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(serverSslCtx.newHandler(ch.alloc()));
+
+                SslHandler sslHandler = delegatingExecutor == null ?
+                        serverSslCtx.newHandler(ch.alloc()) :
+                        serverSslCtx.newHandler(ch.alloc(), delegatingExecutor);
+
+                p.addLast(sslHandler);
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -1611,7 +1655,12 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(clientSslCtx.newHandler(ch.alloc()));
+
+                SslHandler sslHandler = delegatingExecutor == null ?
+                        clientSslCtx.newHandler(ch.alloc()) :
+                        clientSslCtx.newHandler(ch.alloc(), delegatingExecutor);
+
+                p.addLast(sslHandler);
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -1661,7 +1710,11 @@ public abstract class SSLEngineTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
-                ch.pipeline().addFirst(serverSslCtx.newHandler(ch.alloc()));
+                SslHandler sslHandler = delegatingExecutor == null ?
+                        serverSslCtx.newHandler(ch.alloc()) :
+                        serverSslCtx.newHandler(ch.alloc(), delegatingExecutor);
+
+                ch.pipeline().addFirst(sslHandler);
                 ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                     @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -53,6 +53,8 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.concurrent.Promise;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
@@ -63,6 +65,9 @@ import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -813,6 +818,170 @@ public class SslHandlerTest {
             Throwable cause = sslHandler.handshakeFuture().await().cause();
             assertThat(cause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
             assertThat(cause.getMessage(), containsString("timed out"));
+        } finally {
+            if (cc != null) {
+                cc.close().syncUninterruptibly();
+            }
+            if (sc != null) {
+                sc.close().syncUninterruptibly();
+            }
+            group.shutdownGracefully();
+            ReferenceCountUtil.release(sslClientCtx);
+        }
+    }
+
+    @Test
+    public void testHandshakeWithExecutorThatExecuteDirecty() throws Exception {
+        testHandshakeWithExecutor(new Executor() {
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        });
+    }
+
+    @Test
+    public void testHandshakeWithImmediateExecutor() throws Exception {
+        testHandshakeWithExecutor(ImmediateExecutor.INSTANCE);
+    }
+
+    @Test
+    public void testHandshakeWithImmediateEventExecutor() throws Exception {
+        testHandshakeWithExecutor(ImmediateEventExecutor.INSTANCE);
+    }
+
+    @Test
+    public void testHandshakeWithExecutor() throws Exception {
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        try {
+            testHandshakeWithExecutor(executorService);
+        } finally {
+            executorService.shutdown();
+        }
+    }
+
+    private void testHandshakeWithExecutor(Executor executor) throws Exception {
+        final SslContext sslClientCtx = SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .sslProvider(SslProvider.JDK).build();
+
+        final SelfSignedCertificate cert = new SelfSignedCertificate();
+        final SslContext sslServerCtx = SslContextBuilder.forServer(cert.key(), cert.cert())
+                .sslProvider(SslProvider.JDK).build();
+
+        EventLoopGroup group = new NioEventLoopGroup();
+        Channel sc = null;
+        Channel cc = null;
+        final SslHandler clientSslHandler = sslClientCtx.newHandler(UnpooledByteBufAllocator.DEFAULT, executor);
+        final SslHandler serverSslHandler = sslServerCtx.newHandler(UnpooledByteBufAllocator.DEFAULT, executor);
+
+        try {
+            sc = new ServerBootstrap()
+                    .group(group)
+                    .channel(NioServerSocketChannel.class)
+                    .childHandler(serverSslHandler)
+                    .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+
+            ChannelFuture future = new Bootstrap()
+                    .group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ch.pipeline().addLast(clientSslHandler);
+                        }
+                    }).connect(sc.localAddress());
+            cc = future.syncUninterruptibly().channel();
+
+            assertTrue(clientSslHandler.handshakeFuture().await().isSuccess());
+            assertTrue(serverSslHandler.handshakeFuture().await().isSuccess());
+        } finally {
+            if (cc != null) {
+                cc.close().syncUninterruptibly();
+            }
+            if (sc != null) {
+                sc.close().syncUninterruptibly();
+            }
+            group.shutdownGracefully();
+            ReferenceCountUtil.release(sslClientCtx);
+        }
+    }
+
+    @Test
+    public void testClientHandshakeTimeoutBecauseExecutorNotExecute() throws Exception {
+        testHandshakeTimeoutBecauseExecutorNotExecute(true);
+    }
+
+    @Test
+    public void testServerHandshakeTimeoutBecauseExecutorNotExecute() throws Exception {
+        testHandshakeTimeoutBecauseExecutorNotExecute(false);
+    }
+
+    private void testHandshakeTimeoutBecauseExecutorNotExecute(final boolean client) throws Exception {
+        final SslContext sslClientCtx = SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .sslProvider(SslProvider.JDK).build();
+
+        final SelfSignedCertificate cert = new SelfSignedCertificate();
+        final SslContext sslServerCtx = SslContextBuilder.forServer(cert.key(), cert.cert())
+                .sslProvider(SslProvider.JDK).build();
+
+        EventLoopGroup group = new NioEventLoopGroup();
+        Channel sc = null;
+        Channel cc = null;
+        final SslHandler clientSslHandler = sslClientCtx.newHandler(UnpooledByteBufAllocator.DEFAULT, new Executor() {
+            @Override
+            public void execute(Runnable command) {
+                if (!client) {
+                    command.run();
+                }
+                // Do nothing to simulate slow execution.
+            }
+        });
+        if (client) {
+            clientSslHandler.setHandshakeTimeout(100, TimeUnit.MILLISECONDS);
+        }
+        final SslHandler serverSslHandler = sslServerCtx.newHandler(UnpooledByteBufAllocator.DEFAULT, new Executor() {
+            @Override
+            public void execute(Runnable command) {
+                if (client) {
+                    command.run();
+                }
+                // Do nothing to simulate slow execution.
+            }
+        });
+        if (!client) {
+            serverSslHandler.setHandshakeTimeout(100, TimeUnit.MILLISECONDS);
+        }
+        try {
+            sc = new ServerBootstrap()
+                    .group(group)
+                    .channel(NioServerSocketChannel.class)
+                    .childHandler(serverSslHandler)
+                    .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+
+            ChannelFuture future = new Bootstrap()
+                    .group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ch.pipeline().addLast(clientSslHandler);
+                        }
+                    }).connect(sc.localAddress());
+            cc = future.syncUninterruptibly().channel();
+
+            if (client) {
+                Throwable cause = clientSslHandler.handshakeFuture().await().cause();
+                assertThat(cause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
+                assertThat(cause.getMessage(), containsString("timed out"));
+                assertFalse(serverSslHandler.handshakeFuture().await().isSuccess());
+            } else {
+                Throwable cause = serverSslHandler.handshakeFuture().await().cause();
+                assertThat(cause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
+                assertThat(cause.getMessage(), containsString("timed out"));
+                assertFalse(clientSslHandler.handshakeFuture().await().isSuccess());
+            }
         } finally {
             if (cc != null) {
                 cc.close().syncUninterruptibly();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -18,6 +18,7 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
@@ -46,6 +47,9 @@ import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -73,7 +77,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         KEY_FILE = ssc.privateKey();
     }
 
-    @Parameters(name = "{index}: serverEngine = {0}, clientEngine = {1}")
+    @Parameters(name = "{index}: serverEngine = {0}, clientEngine = {1}, delegate = {2}")
     public static Collection<Object[]> data() throws Exception {
         List<SslContext> serverContexts = new ArrayList<SslContext>();
         List<SslContext> clientContexts = new ArrayList<SslContext>();
@@ -91,7 +95,8 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         for (SslContext sc: serverContexts) {
             for (SslContext cc: clientContexts) {
                 for (int i = 0; i < 32; i++) {
-                    params.add(new Object[] { sc, cc});
+                    params.add(new Object[] { sc, cc, true});
+                    params.add(new Object[] { sc, cc, false});
                 }
             }
         }
@@ -101,6 +106,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
 
     private final SslContext serverCtx;
     private final SslContext clientCtx;
+    private final boolean delegate;
 
     private final AtomicReference<Throwable> clientException = new AtomicReference<Throwable>();
     private final AtomicReference<Throwable> serverException = new AtomicReference<Throwable>();
@@ -116,9 +122,10 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
     private final TestHandler serverHandler = new TestHandler(serverException);
 
     public SocketSslClientRenegotiateTest(
-            SslContext serverCtx, SslContext clientCtx) {
+            SslContext serverCtx, SslContext clientCtx, boolean delegate) {
         this.serverCtx = serverCtx;
         this.clientCtx = clientCtx;
+        this.delegate = delegate;
     }
 
     @Test(timeout = 30000)
@@ -129,58 +136,74 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         run();
     }
 
+    private static SslHandler newSslHandler(SslContext sslCtx, ByteBufAllocator allocator, Executor executor) {
+        if (executor == null) {
+            return sslCtx.newHandler(allocator);
+        } else {
+            return sslCtx.newHandler(allocator, executor);
+        }
+    }
+
     public void testSslRenegotiationRejected(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         reset();
 
-        sb.childHandler(new ChannelInitializer<Channel>() {
-            @Override
-            @SuppressWarnings("deprecation")
-            public void initChannel(Channel sch) throws Exception {
-                serverChannel = sch;
-                serverSslHandler = serverCtx.newHandler(sch.alloc());
-                // As we test renegotiation we should use a protocol that support it.
-                serverSslHandler.engine().setEnabledProtocols(new String[] { "TLSv1.2" });
-                sch.pipeline().addLast("ssl", serverSslHandler);
-                sch.pipeline().addLast("handler", serverHandler);
-            }
-        });
+        final ExecutorService executorService = delegate ? Executors.newCachedThreadPool() : null;
 
-        cb.handler(new ChannelInitializer<Channel>() {
-            @Override
-            @SuppressWarnings("deprecation")
-            public void initChannel(Channel sch) throws Exception {
-                clientChannel = sch;
-                clientSslHandler = clientCtx.newHandler(sch.alloc());
-                // As we test renegotiation we should use a protocol that support it.
-                clientSslHandler.engine().setEnabledProtocols(new String[] { "TLSv1.2" });
-                sch.pipeline().addLast("ssl", clientSslHandler);
-                sch.pipeline().addLast("handler", clientHandler);
-            }
-        });
-
-        Channel sc = sb.bind().sync().channel();
-        cb.connect(sc.localAddress()).sync();
-
-        Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();
-        clientHandshakeFuture.sync();
-
-        String renegotiation = clientSslHandler.engine().getEnabledCipherSuites()[0];
-        // Use the first previous enabled ciphersuite and try to renegotiate.
-        clientSslHandler.engine().setEnabledCipherSuites(new String[] { renegotiation });
-        clientSslHandler.renegotiate().await();
-        serverChannel.close().awaitUninterruptibly();
-        clientChannel.close().awaitUninterruptibly();
-        sc.close().awaitUninterruptibly();
         try {
-            if (serverException.get() != null) {
-                throw serverException.get();
+            sb.childHandler(new ChannelInitializer<Channel>() {
+                @Override
+                @SuppressWarnings("deprecation")
+                public void initChannel(Channel sch) throws Exception {
+                    serverChannel = sch;
+                    serverSslHandler = newSslHandler(serverCtx, sch.alloc(), executorService);
+                    // As we test renegotiation we should use a protocol that support it.
+                    serverSslHandler.engine().setEnabledProtocols(new String[]{"TLSv1.2"});
+                    sch.pipeline().addLast("ssl", serverSslHandler);
+                    sch.pipeline().addLast("handler", serverHandler);
+                }
+            });
+
+            cb.handler(new ChannelInitializer<Channel>() {
+                @Override
+                @SuppressWarnings("deprecation")
+                public void initChannel(Channel sch) throws Exception {
+                    clientChannel = sch;
+                    clientSslHandler = newSslHandler(clientCtx, sch.alloc(), executorService);
+                    // As we test renegotiation we should use a protocol that support it.
+                    clientSslHandler.engine().setEnabledProtocols(new String[]{"TLSv1.2"});
+                    sch.pipeline().addLast("ssl", clientSslHandler);
+                    sch.pipeline().addLast("handler", clientHandler);
+                }
+            });
+
+            Channel sc = sb.bind().sync().channel();
+            cb.connect(sc.localAddress()).sync();
+
+            Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();
+            clientHandshakeFuture.sync();
+
+            String renegotiation = clientSslHandler.engine().getEnabledCipherSuites()[0];
+            // Use the first previous enabled ciphersuite and try to renegotiate.
+            clientSslHandler.engine().setEnabledCipherSuites(new String[]{renegotiation});
+            clientSslHandler.renegotiate().await();
+            serverChannel.close().awaitUninterruptibly();
+            clientChannel.close().awaitUninterruptibly();
+            sc.close().awaitUninterruptibly();
+            try {
+                if (serverException.get() != null) {
+                    throw serverException.get();
+                }
+                fail();
+            } catch (DecoderException e) {
+                assertTrue(e.getCause() instanceof SSLHandshakeException);
             }
-            fail();
-        } catch (DecoderException e) {
-            assertTrue(e.getCause() instanceof SSLHandshakeException);
-        }
-        if (clientException.get() != null) {
-            throw clientException.get();
+            if (clientException.get() != null) {
+                throw clientException.get();
+            }
+        } finally {
+            if (executorService != null) {
+                executorService.shutdown();
+            }
         }
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslClientRenegotiateTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslClientRenegotiateTest.java
@@ -26,8 +26,8 @@ import java.util.List;
 
 public class EpollDomainSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
 
-    public EpollDomainSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
+    public EpollDomainSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
+        super(serverCtx, clientCtx, delegate);
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslGreetingTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslGreetingTest.java
@@ -26,8 +26,8 @@ import java.util.List;
 
 public class EpollDomainSocketSslGreetingTest extends SocketSslGreetingTest {
 
-    public EpollDomainSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
+    public EpollDomainSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
+        super(serverCtx, clientCtx, delegate);
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslClientRenegotiateTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslClientRenegotiateTest.java
@@ -25,8 +25,8 @@ import java.util.List;
 
 public class EpollSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
 
-    public EpollSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
+    public EpollSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
+        super(serverCtx, clientCtx, delegate);
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslGreetingTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslGreetingTest.java
@@ -25,8 +25,8 @@ import java.util.List;
 
 public class EpollSocketSslGreetingTest extends SocketSslGreetingTest {
 
-    public EpollSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
+    public EpollSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
+        super(serverCtx, clientCtx, delegate);
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslClientRenegotiateTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslClientRenegotiateTest.java
@@ -26,8 +26,8 @@ import java.util.List;
 
 public class KQueueDomainSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
 
-    public KQueueDomainSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
+    public KQueueDomainSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
+        super(serverCtx, clientCtx, delegate);
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslGreetingTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslGreetingTest.java
@@ -26,8 +26,8 @@ import java.util.List;
 
 public class KQueueDomainSocketSslGreetingTest extends SocketSslGreetingTest {
 
-    public KQueueDomainSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
+    public KQueueDomainSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
+        super(serverCtx, clientCtx, delegate);
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslClientRenegotiateTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslClientRenegotiateTest.java
@@ -25,8 +25,8 @@ import java.util.List;
 
 public class KQueueSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
 
-    public KQueueSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
+    public KQueueSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
+        super(serverCtx, clientCtx, delegate);
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslGreetingTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslGreetingTest.java
@@ -25,8 +25,8 @@ import java.util.List;
 
 public class KQueueSocketSslGreetingTest extends SocketSslGreetingTest {
 
-    public KQueueSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
+    public KQueueSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
+        super(serverCtx, clientCtx, delegate);
     }
 
     @Override


### PR DESCRIPTION
…en processing TLS / SSL via the SslHandler.

Motivation:

The SSLEngine does provide a way to signal to the caller that it may need to execute a blocking / long-running task which then can be offloaded to an Executor to ensure the I/O thread is not blocked. Currently how we handle this in SslHandler is not really optimal as while we offload to the Executor we still block the I/O Thread.

Modifications:

- Correctly support offloading the task to the Executor while suspending processing of SSL in the I/O Thread
- Add new methods to SslContext to specify the Executor when creating a SslHandler
- Remove @deprecated annotations from SslHandler constructor that takes an Executor
- Adjust tests to also run with the Executor to ensure all works as expected.

Result:

Be able to offload long running tasks to an Executor when using SslHandler. Partly fixes https://github.com/netty/netty/issues/7862 and https://github.com/netty/netty/issues/7020.