### PR TITLE
Fix h2c upgrade failure when multiple connection headers are present in upgrade request

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
@@ -294,6 +294,7 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
         for (CharSequence connectionHeaderValue : connectionHeaderValues) {
             concatenatedConnectionValue.append(connectionHeaderValue).append(COMMA);
         }
+        concatenatedConnectionValue.setLength(concatenatedConnectionValue.length() - 1);
 
         // Make sure the CONNECTION header contains UPGRADE as well as all protocol-specific headers.
         Collection<CharSequence> requiredHeaders = upgradeCodec.requiredUpgradeHeaders();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
@@ -31,6 +31,8 @@ import static io.netty.util.AsciiString.containsAllContentEqualsIgnoreCase;
 import static io.netty.util.AsciiString.containsContentEqualsIgnoreCase;
 import static io.netty.util.AsciiString.containsIgnoreCase;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.StringUtil.COMMA;
+import static io.netty.util.internal.StringUtil.DOUBLE_QUOTE;
 
 /**
  * A server-side handler that receives HTTP requests and optionally performs a protocol switch if
@@ -290,24 +292,20 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
             return false;
         }
 
-        CharSequence connectionHeader = null;
-
+        // Make sure the CONNECTION header contains UPGRADE as well as all protocol-specific headers.
+        Collection<CharSequence> requiredHeaders = upgradeCodec.requiredUpgradeHeaders();
+        boolean requiredHeadersFoundWithUpgrade = false;
         for (CharSequence connectionHeaderValue : connectionHeaderValues) {
             if (containsIgnoreCase(connectionHeaderValue, HttpHeaderNames.UPGRADE)) {
-                connectionHeader = connectionHeaderValue;
-                break;
+                List<CharSequence> values = splitHeader(connectionHeaderValue);
+                if (containsContentEqualsIgnoreCase(values, HttpHeaderNames.UPGRADE) &&
+                        containsAllContentEqualsIgnoreCase(values, requiredHeaders)) {
+                    requiredHeadersFoundWithUpgrade = true;
+                }
             }
         }
 
-        if (connectionHeader == null) {
-            return false;
-        }
-
-        // Make sure the CONNECTION header contains UPGRADE as well as all protocol-specific headers.
-        Collection<CharSequence> requiredHeaders = upgradeCodec.requiredUpgradeHeaders();
-        List<CharSequence> values = splitHeader(connectionHeader);
-        if (!containsContentEqualsIgnoreCase(values, HttpHeaderNames.UPGRADE) ||
-                !containsAllContentEqualsIgnoreCase(values, requiredHeaders)) {
+        if (!requiredHeadersFoundWithUpgrade) {
             return false;
         }
 
@@ -395,5 +393,34 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
         }
 
         return protocols;
+    }
+
+    private String asCsv(final List<CharSequence> arr) {
+        if (arr == null || arr.isEmpty()) {
+            return "";
+        }
+        final StringBuilder sb = new StringBuilder(arr.size() * 10);
+        final int end = arr.size() - 1;
+        for (int i = 0; i < end; ++i) {
+            quoted(sb, arr.get(i)).append(COMMA);
+        }
+        quoted(sb, arr.get(end));
+        return sb.toString();
+    }
+
+    private static StringBuilder quoted(final StringBuilder sb, final CharSequence value) {
+        if (contains(value, COMMA) && !contains(value, DOUBLE_QUOTE)) {
+            return sb.append(DOUBLE_QUOTE).append(value).append(DOUBLE_QUOTE);
+        }
+        return sb.append(value);
+    }
+
+    private static boolean contains(CharSequence value, char c) {
+        for (int i = 0; i < value.length(); ++i) {
+            if (value.charAt(i) == c) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -202,14 +202,14 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
     }
 
     @Test
-    public void multipleUpgradeHeaders() {
+    public void requiredHeadersInSeparateConnectionHeaders() {
         setUpServerChannel();
 
         String upgradeString = "GET / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: keep-alive\r\n" +
+                "Connection: HTTP2-Settings\r\n" +
                 "Connection: Upgrade\r\n" +
-                "Connection: Upgrade, HTTP2-Settings\r\n" +
                 "Upgrade: h2c\r\n" +
                 "HTTP2-Settings: AAMAAABkAAQAAP__\r\n\r\n";
         ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -156,6 +156,52 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
     }
 
     @Test
+    public void upgradeWithMultipleConnectionHeaders() {
+        setUpServerChannel();
+
+        String upgradeString = "GET / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Connection: keep-alive\r\n" +
+                "Connection: Upgrade, HTTP2-Settings\r\n" +
+                "Upgrade: h2c\r\n" +
+                "HTTP2-Settings: AAMAAABkAAQAAP__\r\n\r\n";
+        ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
+
+        assertFalse(channel.writeInbound(upgrade));
+
+        assertEquals(1, userEvents.size());
+
+        Object userEvent = userEvents.get(0);
+        assertTrue(userEvent instanceof UpgradeEvent);
+        assertEquals("h2c", ((UpgradeEvent) userEvent).protocol());
+        ReferenceCountUtil.release(userEvent);
+
+        assertEquals(100, http2ConnectionHandler.connection().local().maxActiveStreams());
+        assertEquals(65535, http2ConnectionHandler.connection().local().flowController().initialWindowSize());
+
+        assertEquals(1, http2ConnectionHandler.connection().numActiveStreams());
+        assertNotNull(http2ConnectionHandler.connection().stream(1));
+
+        Http2Stream stream = http2ConnectionHandler.connection().stream(1);
+        assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
+        assertFalse(stream.isHeadersSent());
+
+        String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
+                "connection: upgrade\r\n" +
+                "upgrade: h2c\r\n\r\n";
+        ByteBuf responseBuffer = channel.readOutbound();
+        assertEquals(expectedHttpResponse, responseBuffer.toString(CharsetUtil.UTF_8));
+        responseBuffer.release();
+
+        // Check that the preface was send (a.k.a the settings frame)
+        ByteBuf settingsBuffer = channel.readOutbound();
+        assertNotNull(settingsBuffer);
+        settingsBuffer.release();
+
+        assertNull(channel.readOutbound());
+    }
+
+    @Test
     public void priorKnowledgeInFragments() throws Exception {
         setUpServerChannel();
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -202,6 +202,53 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
     }
 
     @Test
+    public void multipleUpgradeHeaders() {
+        setUpServerChannel();
+
+        String upgradeString = "GET / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Connection: keep-alive\r\n" +
+                "Connection: Upgrade\r\n" +
+                "Connection: Upgrade, HTTP2-Settings\r\n" +
+                "Upgrade: h2c\r\n" +
+                "HTTP2-Settings: AAMAAABkAAQAAP__\r\n\r\n";
+        ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
+
+        assertFalse(channel.writeInbound(upgrade));
+
+        assertEquals(1, userEvents.size());
+
+        Object userEvent = userEvents.get(0);
+        assertTrue(userEvent instanceof UpgradeEvent);
+        assertEquals("h2c", ((UpgradeEvent) userEvent).protocol());
+        ReferenceCountUtil.release(userEvent);
+
+        assertEquals(100, http2ConnectionHandler.connection().local().maxActiveStreams());
+        assertEquals(65535, http2ConnectionHandler.connection().local().flowController().initialWindowSize());
+
+        assertEquals(1, http2ConnectionHandler.connection().numActiveStreams());
+        assertNotNull(http2ConnectionHandler.connection().stream(1));
+
+        Http2Stream stream = http2ConnectionHandler.connection().stream(1);
+        assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
+        assertFalse(stream.isHeadersSent());
+
+        String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
+                "connection: upgrade\r\n" +
+                "upgrade: h2c\r\n\r\n";
+        ByteBuf responseBuffer = channel.readOutbound();
+        assertEquals(expectedHttpResponse, responseBuffer.toString(CharsetUtil.UTF_8));
+        responseBuffer.release();
+
+        // Check that the preface was send (a.k.a the settings frame)
+        ByteBuf settingsBuffer = channel.readOutbound();
+        assertNotNull(settingsBuffer);
+        settingsBuffer.release();
+
+        assertNull(channel.readOutbound());
+    }
+
+    @Test
     public void priorKnowledgeInFragments() throws Exception {
         setUpServerChannel();
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -119,8 +119,6 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
 
     @Test
     public void upgrade() throws Exception {
-        setUpServerChannel();
-
         String upgradeString = "GET / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: Upgrade, HTTP2-Settings\r\n" +
@@ -131,8 +129,6 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
 
     @Test
     public void upgradeWithMultipleConnectionHeaders() {
-        setUpServerChannel();
-
         String upgradeString = "GET / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: keep-alive\r\n" +
@@ -144,8 +140,6 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
 
     @Test
     public void requiredHeadersInSeparateConnectionHeaders() {
-        setUpServerChannel();
-
         String upgradeString = "GET / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: keep-alive\r\n" +
@@ -257,6 +251,8 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
     }
 
     private void validateClearTextUpgrade(String upgradeString) {
+        setUpServerChannel();
+
         ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
 
         assertFalse(channel.writeInbound(upgrade));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -42,8 +42,15 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link CleartextHttp2ServerUpgradeHandler}
@@ -115,44 +122,11 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
         setUpServerChannel();
 
         String upgradeString = "GET / HTTP/1.1\r\n" +
-                               "Host: example.com\r\n" +
-                               "Connection: Upgrade, HTTP2-Settings\r\n" +
-                               "Upgrade: h2c\r\n" +
-                               "HTTP2-Settings: AAMAAABkAAQAAP__\r\n\r\n";
-        ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
-
-        assertFalse(channel.writeInbound(upgrade));
-
-        assertEquals(1, userEvents.size());
-
-        Object userEvent = userEvents.get(0);
-        assertTrue(userEvent instanceof UpgradeEvent);
-        assertEquals("h2c", ((UpgradeEvent) userEvent).protocol());
-        ReferenceCountUtil.release(userEvent);
-
-        assertEquals(100, http2ConnectionHandler.connection().local().maxActiveStreams());
-        assertEquals(65535, http2ConnectionHandler.connection().local().flowController().initialWindowSize());
-
-        assertEquals(1, http2ConnectionHandler.connection().numActiveStreams());
-        assertNotNull(http2ConnectionHandler.connection().stream(1));
-
-        Http2Stream stream = http2ConnectionHandler.connection().stream(1);
-        assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
-        assertFalse(stream.isHeadersSent());
-
-        String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
-                "connection: upgrade\r\n" +
-                "upgrade: h2c\r\n\r\n";
-        ByteBuf responseBuffer = channel.readOutbound();
-        assertEquals(expectedHttpResponse, responseBuffer.toString(CharsetUtil.UTF_8));
-        responseBuffer.release();
-
-        // Check that the preface was send (a.k.a the settings frame)
-        ByteBuf settingsBuffer = channel.readOutbound();
-        assertNotNull(settingsBuffer);
-        settingsBuffer.release();
-
-        assertNull(channel.readOutbound());
+                "Host: example.com\r\n" +
+                "Connection: Upgrade, HTTP2-Settings\r\n" +
+                "Upgrade: h2c\r\n" +
+                "HTTP2-Settings: AAMAAABkAAQAAP__\r\n\r\n";
+        validateClearTextUpgrade(upgradeString);
     }
 
     @Test
@@ -165,40 +139,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
                 "Connection: Upgrade, HTTP2-Settings\r\n" +
                 "Upgrade: h2c\r\n" +
                 "HTTP2-Settings: AAMAAABkAAQAAP__\r\n\r\n";
-        ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
-
-        assertFalse(channel.writeInbound(upgrade));
-
-        assertEquals(1, userEvents.size());
-
-        Object userEvent = userEvents.get(0);
-        assertTrue(userEvent instanceof UpgradeEvent);
-        assertEquals("h2c", ((UpgradeEvent) userEvent).protocol());
-        ReferenceCountUtil.release(userEvent);
-
-        assertEquals(100, http2ConnectionHandler.connection().local().maxActiveStreams());
-        assertEquals(65535, http2ConnectionHandler.connection().local().flowController().initialWindowSize());
-
-        assertEquals(1, http2ConnectionHandler.connection().numActiveStreams());
-        assertNotNull(http2ConnectionHandler.connection().stream(1));
-
-        Http2Stream stream = http2ConnectionHandler.connection().stream(1);
-        assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
-        assertFalse(stream.isHeadersSent());
-
-        String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
-                "connection: upgrade\r\n" +
-                "upgrade: h2c\r\n\r\n";
-        ByteBuf responseBuffer = channel.readOutbound();
-        assertEquals(expectedHttpResponse, responseBuffer.toString(CharsetUtil.UTF_8));
-        responseBuffer.release();
-
-        // Check that the preface was send (a.k.a the settings frame)
-        ByteBuf settingsBuffer = channel.readOutbound();
-        assertNotNull(settingsBuffer);
-        settingsBuffer.release();
-
-        assertNull(channel.readOutbound());
+        validateClearTextUpgrade(upgradeString);
     }
 
     @Test
@@ -212,40 +153,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
                 "Connection: Upgrade\r\n" +
                 "Upgrade: h2c\r\n" +
                 "HTTP2-Settings: AAMAAABkAAQAAP__\r\n\r\n";
-        ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
-
-        assertFalse(channel.writeInbound(upgrade));
-
-        assertEquals(1, userEvents.size());
-
-        Object userEvent = userEvents.get(0);
-        assertTrue(userEvent instanceof UpgradeEvent);
-        assertEquals("h2c", ((UpgradeEvent) userEvent).protocol());
-        ReferenceCountUtil.release(userEvent);
-
-        assertEquals(100, http2ConnectionHandler.connection().local().maxActiveStreams());
-        assertEquals(65535, http2ConnectionHandler.connection().local().flowController().initialWindowSize());
-
-        assertEquals(1, http2ConnectionHandler.connection().numActiveStreams());
-        assertNotNull(http2ConnectionHandler.connection().stream(1));
-
-        Http2Stream stream = http2ConnectionHandler.connection().stream(1);
-        assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
-        assertFalse(stream.isHeadersSent());
-
-        String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
-                "connection: upgrade\r\n" +
-                "upgrade: h2c\r\n\r\n";
-        ByteBuf responseBuffer = channel.readOutbound();
-        assertEquals(expectedHttpResponse, responseBuffer.toString(CharsetUtil.UTF_8));
-        responseBuffer.release();
-
-        // Check that the preface was send (a.k.a the settings frame)
-        ByteBuf settingsBuffer = channel.readOutbound();
-        assertNotNull(settingsBuffer);
-        settingsBuffer.release();
-
-        assertNull(channel.readOutbound());
+        validateClearTextUpgrade(upgradeString);
     }
 
     @Test
@@ -346,5 +254,42 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
 
     private static Http2Settings expectedSettings() {
         return new Http2Settings().maxConcurrentStreams(100).initialWindowSize(65535);
+    }
+
+    private void validateClearTextUpgrade(String upgradeString) {
+        ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);
+
+        assertFalse(channel.writeInbound(upgrade));
+
+        assertEquals(1, userEvents.size());
+
+        Object userEvent = userEvents.get(0);
+        assertTrue(userEvent instanceof UpgradeEvent);
+        assertEquals("h2c", ((UpgradeEvent) userEvent).protocol());
+        ReferenceCountUtil.release(userEvent);
+
+        assertEquals(100, http2ConnectionHandler.connection().local().maxActiveStreams());
+        assertEquals(65535, http2ConnectionHandler.connection().local().flowController().initialWindowSize());
+
+        assertEquals(1, http2ConnectionHandler.connection().numActiveStreams());
+        assertNotNull(http2ConnectionHandler.connection().stream(1));
+
+        Http2Stream stream = http2ConnectionHandler.connection().stream(1);
+        assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
+        assertFalse(stream.isHeadersSent());
+
+        String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
+                "connection: upgrade\r\n" +
+                "upgrade: h2c\r\n\r\n";
+        ByteBuf responseBuffer = channel.readOutbound();
+        assertEquals(expectedHttpResponse, responseBuffer.toString(CharsetUtil.UTF_8));
+        responseBuffer.release();
+
+        // Check that the preface was send (a.k.a the settings frame)
+        ByteBuf settingsBuffer = channel.readOutbound();
+        assertNotNull(settingsBuffer);
+        settingsBuffer.release();
+
+        assertNull(channel.readOutbound());
     }
 }


### PR DESCRIPTION
Motivation:

When more than one connection header is present in h2c upgrade request, upgrade fails. This is to fix that. 

Modification:
In HttpServerUpgradeHandler's upgrade() method, check whether any of the connection header value is upgrade, not just the first header value which might return a different value other than upgrade. 

Result:
Fixes #8846. 

With this PR, now when multiple connection headers are sent with the upgrade request, upgrade will not fail. 
