### PR TITLE
Also use java.util.Base64 in handler-proxy module

### DIFF
--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -18,11 +18,9 @@ package io.netty.handler.proxy;
 
 import static java.util.Objects.requireNonNull;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.base64.Base64;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
@@ -35,15 +33,19 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AsciiString;
-import io.netty.util.CharsetUtil;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
 
 public final class HttpProxyHandler extends ProxyHandler {
 
     private static final String PROTOCOL = "http";
     private static final String AUTH_BASIC = "basic";
+
+    private static final byte[] BASIC_BYTES = "Basic ".getBytes(StandardCharsets.UTF_8);
 
     private final HttpClientCodec codec = new HttpClientCodec();
     private final String username;
@@ -93,13 +95,12 @@ public final class HttpProxyHandler extends ProxyHandler {
         this.username = username;
         this.password = password;
 
-        ByteBuf authz = Unpooled.copiedBuffer(username + ':' + password, CharsetUtil.UTF_8);
-        ByteBuf authzBase64 = Base64.encode(authz, false);
+        byte[] authzBase64 = Base64.getEncoder().encode(
+                (username + ':' + password).getBytes(StandardCharsets.UTF_8));
+        byte[] authzHeader = Arrays.copyOf(BASIC_BYTES, 6 + authzBase64.length);
+        System.arraycopy(authzBase64, 0, authzHeader, 6, authzBase64.length);
 
-        authorization = new AsciiString("Basic " + authzBase64.toString(CharsetUtil.US_ASCII));
-
-        authz.release();
-        authzBase64.release();
+        authorization = new AsciiString(authzHeader, /*copy=*/ false);
 
         this.outboundHeaders = headers;
         this.ignoreDefaultPortsInConnectHostHeader = ignoreDefaultPortsInConnectHostHeader;


### PR DESCRIPTION
Motivation

In netty 5 we can use `java.util.Base64` which is simpler/faster for some purposes than netty's own `ByteBuf`-based Base64 utilities. This covers a couple of additional places to the one changed in #8837.

Modifications

Modify `HttpProxyHandler` and `HttpProxyServer` classes to use `java.util.Base64` instead of
`io.netty.handler.codec.base64.Base64` (latter is a test one).

Result

More efficient base64 processing in proxy impl.

cc @doom369