### PR TITLE
Support handshake timeout in websocket handlers

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -41,6 +41,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
 
     private final WebSocketClientHandshaker handshaker;
     private final boolean handleCloseFrames;
+    private volatile long handshakeTimeoutMillis = 10000;
 
     /**
      * Returns the used handshaker
@@ -53,6 +54,11 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      * Events that are fired to notify about handshake status
      */
     public enum ClientHandshakeStateEvent {
+        /**
+         * The Handshake was timed out
+         */
+        HANDSHAKE_TIMEOUT,
+
         /**
          * The Handshake was started but the server did not response yet to the request
          */
@@ -200,12 +206,18 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
         if (cp.get(WebSocketClientProtocolHandshakeHandler.class) == null) {
             // Add the WebSocketClientProtocolHandshakeHandler before this one.
             ctx.pipeline().addBefore(ctx.name(), WebSocketClientProtocolHandshakeHandler.class.getName(),
-                    new WebSocketClientProtocolHandshakeHandler(handshaker));
+                                     new WebSocketClientProtocolHandshakeHandler(handshaker)
+                                             .handshakeTimeoutMillis(handshakeTimeoutMillis));
         }
         if (cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.
             ctx.pipeline().addBefore(ctx.name(), Utf8FrameValidator.class.getName(),
                     new Utf8FrameValidator());
         }
+    }
+
+    public WebSocketClientProtocolHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
+        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+        return this;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -23,6 +23,8 @@ import io.netty.handler.codec.http.HttpHeaders;
 import java.net.URI;
 import java.util.List;
 
+import static io.netty.util.internal.ObjectUtil.*;
+
 /**
  * This handler does all the heavy lifting for you to run a websocket client.
  *
@@ -38,7 +40,7 @@ import java.util.List;
  * {@link ClientHandshakeStateEvent#HANDSHAKE_ISSUED} or {@link ClientHandshakeStateEvent#HANDSHAKE_COMPLETE}.
  */
 public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
-    private static final long DEFAULT_HANDSHAKE_TIMEOUT = 10000L;
+    private static final long DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000L;
 
     private final WebSocketClientHandshaker handshaker;
     private final boolean handleCloseFrames;
@@ -100,7 +102,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
                                           int maxFramePayloadLength, boolean handleCloseFrames,
                                           boolean performMasking, boolean allowMaskMismatch) {
         this(webSocketURL, version, subprotocol, allowExtensions, customHeaders,
-             maxFramePayloadLength, handleCloseFrames, performMasking, allowMaskMismatch, DEFAULT_HANDSHAKE_TIMEOUT);
+             maxFramePayloadLength, handleCloseFrames, performMasking, allowMaskMismatch, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     /**
@@ -161,7 +163,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
                                                    boolean allowExtensions, HttpHeaders customHeaders,
                                                    int maxFramePayloadLength, boolean handleCloseFrames) {
         this(webSocketURL, version, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength,
-             handleCloseFrames, DEFAULT_HANDSHAKE_TIMEOUT);
+             handleCloseFrames, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     /**
@@ -210,7 +212,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
                                           boolean allowExtensions, HttpHeaders customHeaders,
                                           int maxFramePayloadLength) {
         this(webSocketURL, version, subprotocol,
-             allowExtensions, customHeaders, maxFramePayloadLength, DEFAULT_HANDSHAKE_TIMEOUT);
+             allowExtensions, customHeaders, maxFramePayloadLength, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     /**
@@ -248,7 +250,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            {@code true} if close frames should not be forwarded and just close the channel
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames) {
-        this(handshaker, handleCloseFrames, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(handshaker, handleCloseFrames, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     /**
@@ -281,7 +283,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           boolean dropPongFrames) {
-        this(handshaker, handleCloseFrames, dropPongFrames, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(handshaker, handleCloseFrames, dropPongFrames, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     /**
@@ -303,7 +305,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
         super(dropPongFrames);
         this.handshaker = handshaker;
         this.handleCloseFrames = handleCloseFrames;
-        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+        this.handshakeTimeoutMillis = checkPositive(handshakeTimeoutMillis, "handshakeTimeoutMillis");
     }
 
     /**
@@ -314,7 +316,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            was established to the remote peer.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker) {
-        this(handshaker, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(handshaker, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -105,7 +105,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             return;
         }
 
-        final ScheduledFuture<?> timeoutFuture = ctx.executor().schedule(new Runnable() {
+        final Future<?> timeoutFuture = ctx.executor().schedule(new Runnable() {
             @Override
             public void run() {
                 if (localHandshakePromise.isDone()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -23,11 +22,8 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
-import io.netty.util.concurrent.DefaultPromise;
-import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.ThrowableUtil;
 
@@ -95,12 +91,12 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         }
     }
 
-    public WebSocketClientProtocolHandshakeHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
+    WebSocketClientProtocolHandshakeHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
         this.handshakeTimeoutMillis = handshakeTimeoutMillis;
         return this;
     }
 
-    public void applyHandshakeTimeout() {
+    private void applyHandshakeTimeout() {
         final ChannelPromise localHandshakePromise = handshakePromise;
         final long handshakeTimeoutMillis = this.handshakeTimeoutMillis;
         if (handshakeTimeoutMillis <= 0 || localHandshakePromise.isDone()) {
@@ -131,7 +127,12 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         });
     }
 
-    public ChannelFuture getHandshakeFuture() {
+    /**
+     * This method is visible for testing.
+     *
+     * @return current handshake future
+     */
+    ChannelFuture getHandshakeFuture() {
         return handshakePromise;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -36,12 +36,17 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             "channelActive(...)");
 
     private final WebSocketClientHandshaker handshaker;
-    private volatile long handshakeTimeoutMillis;
+    private final long handshakeTimeoutMillis;
     private volatile ChannelHandlerContext ctx;
     private volatile ChannelPromise handshakePromise;
 
     WebSocketClientProtocolHandshakeHandler(WebSocketClientHandshaker handshaker) {
+        this(handshaker, 10000);
+    }
+
+    WebSocketClientProtocolHandshakeHandler(WebSocketClientHandshaker handshaker, long handshakeTimeoutMillis) {
         this.handshaker = handshaker;
+        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
     }
 
     @Override
@@ -91,14 +96,8 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         }
     }
 
-    WebSocketClientProtocolHandshakeHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
-        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
-        return this;
-    }
-
     private void applyHandshakeTimeout() {
         final ChannelPromise localHandshakePromise = handshakePromise;
-        final long handshakeTimeoutMillis = this.handshakeTimeoutMillis;
         if (handshakeTimeoutMillis <= 0 || localHandshakePromise.isDone()) {
             return;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -29,24 +29,27 @@ import io.netty.util.internal.ThrowableUtil;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.netty.util.internal.ObjectUtil.*;
+
 class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapter {
     private static final WebSocketHandshakeException HANDSHAKE_TIMED_OUT_EXCEPTION = ThrowableUtil.unknownStackTrace(
             new WebSocketHandshakeException("handshake timed out"),
             WebSocketClientProtocolHandshakeHandler.class,
             "channelActive(...)");
+    private static final long DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000L;
 
     private final WebSocketClientHandshaker handshaker;
     private final long handshakeTimeoutMillis;
-    private volatile ChannelHandlerContext ctx;
-    private volatile ChannelPromise handshakePromise;
+    private ChannelHandlerContext ctx;
+    private ChannelPromise handshakePromise;
 
     WebSocketClientProtocolHandshakeHandler(WebSocketClientHandshaker handshaker) {
-        this(handshaker, 10000);
+        this(handshaker, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     WebSocketClientProtocolHandshakeHandler(WebSocketClientHandshaker handshaker, long handshakeTimeoutMillis) {
         this.handshaker = handshaker;
-        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+        this.handshakeTimeoutMillis = checkPositive(handshakeTimeoutMillis, "handshakeTimeoutMillis");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -130,4 +130,8 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             }
         });
     }
+
+    public ChannelFuture getHandshakeFuture() {
+        return handshakePromise;
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -15,17 +15,41 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
+import io.netty.util.internal.ThrowableUtil;
+
+import java.util.concurrent.TimeUnit;
 
 class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapter {
+    private static final WebSocketHandshakeException HANDSHAKE_TIMED_OUT_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new WebSocketHandshakeException("handshake timed out"),
+            WebSocketClientProtocolHandshakeHandler.class,
+            "channelActive(...)");
+
     private final WebSocketClientHandshaker handshaker;
+    private volatile long handshakeTimeoutMillis;
+    private volatile ChannelHandlerContext ctx;
+    private final Promise<Channel> handshakePromise = new LazyChannelPromise();
 
     WebSocketClientProtocolHandshakeHandler(WebSocketClientHandshaker handshaker) {
         this.handshaker = handshaker;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        this.ctx = ctx;
     }
 
     @Override
@@ -35,6 +59,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 if (!future.isSuccess()) {
+                    handshakePromise.tryFailure(future.cause());
                     ctx.fireExceptionCaught(future.cause());
                 } else {
                     ctx.fireUserEventTriggered(
@@ -42,6 +67,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
                 }
             }
         });
+        applyHandshakeTimeout();
     }
 
     @Override
@@ -55,6 +81,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         try {
             if (!handshaker.isHandshakeComplete()) {
                 handshaker.finishHandshake(ctx.channel(), response);
+                handshakePromise.trySuccess(ctx.channel());
                 ctx.fireUserEventTriggered(
                         WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_COMPLETE);
                 ctx.pipeline().remove(this);
@@ -63,6 +90,67 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             throw new IllegalStateException("WebSocketClientHandshaker should have been non finished yet");
         } finally {
             response.release();
+        }
+    }
+
+    public WebSocketClientProtocolHandshakeHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
+        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+        return this;
+    }
+
+    public void applyHandshakeTimeout() {
+        final Promise<Channel> localHandshakePromise = handshakePromise;
+        final long handshakeTimeoutMillis = this.handshakeTimeoutMillis;
+        if (handshakeTimeoutMillis <= 0 || localHandshakePromise.isDone()) {
+            return;
+        }
+
+        final ScheduledFuture<?> timeoutFuture = ctx.executor().schedule(new Runnable() {
+            @Override
+            public void run() {
+                if (localHandshakePromise.isDone()) {
+                    return;
+                }
+
+                if (localHandshakePromise.tryFailure(HANDSHAKE_TIMED_OUT_EXCEPTION)) {
+                    ctx.flush()
+                       .fireUserEventTriggered(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT)
+                       .close();
+                }
+            }
+        }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
+
+        // Cancel the handshake timeout when handshake is finished.
+        localHandshakePromise.addListener(new FutureListener<Channel>() {
+            @Override
+            public void operationComplete(Future<Channel> f) throws Exception {
+                timeoutFuture.cancel(false);
+            }
+        });
+    }
+
+    private final class LazyChannelPromise extends DefaultPromise<Channel> {
+
+        @Override
+        protected EventExecutor executor() {
+            if (ctx == null) {
+                throw new IllegalStateException();
+            }
+            return ctx.executor();
+        }
+
+        @Override
+        protected void checkDeadLock() {
+            if (ctx == null) {
+                // If ctx is null the handlerAdded(...) callback was not called, in this case the checkDeadLock()
+                // method was called from another Thread then the one that is used by ctx.executor(). We need to
+                // guard against this as a user can see a race if handshakeFuture().sync() is called but the
+                // handlerAdded(..) method was not yet as it is called from the EventExecutor of the
+                // ChannelHandlerContext. If we not guard against this super.checkDeadLock() would cause an
+                // IllegalStateException when trying to call executor().
+                return;
+            }
+            super.checkDeadLock();
         }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -64,7 +64,12 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
          * it provides extra information about the handshake
          */
         @Deprecated
-        HANDSHAKE_COMPLETE
+        HANDSHAKE_COMPLETE,
+
+        /**
+         * The Handshake was timed out
+         */
+        HANDSHAKE_TIMEOUT
     }
 
     /**
@@ -103,6 +108,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     private final int maxFramePayloadLength;
     private final boolean allowMaskMismatch;
     private final boolean checkStartsWith;
+    private volatile long handshakeTimeoutMillis = 10000;
 
     public WebSocketServerProtocolHandler(String websocketPath) {
         this(websocketPath, null, false);
@@ -154,7 +160,8 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
             // Add the WebSocketHandshakeHandler before this one.
             ctx.pipeline().addBefore(ctx.name(), WebSocketServerProtocolHandshakeHandler.class.getName(),
                     new WebSocketServerProtocolHandshakeHandler(websocketPath, subprotocols,
-                            allowExtensions, maxFramePayloadLength, allowMaskMismatch, checkStartsWith));
+                            allowExtensions, maxFramePayloadLength, allowMaskMismatch, checkStartsWith)
+                            .handshakeTimeoutMillis(handshakeTimeoutMillis));
         }
         if (cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.
@@ -212,5 +219,10 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
                 }
             }
         };
+    }
+
+    public WebSocketServerProtocolHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
+        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+        return this;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -102,48 +102,93 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     private static final AttributeKey<WebSocketServerHandshaker> HANDSHAKER_ATTR_KEY =
             AttributeKey.valueOf(WebSocketServerHandshaker.class, "HANDSHAKER");
 
+    private static final long DEFAULT_HANDSHAKE_TIMEOUT = 10000L;
+
     private final String websocketPath;
     private final String subprotocols;
     private final boolean allowExtensions;
     private final int maxFramePayloadLength;
     private final boolean allowMaskMismatch;
     private final boolean checkStartsWith;
-    private volatile long handshakeTimeoutMillis = 10000;
+    private final long handshakeTimeoutMillis;
 
     public WebSocketServerProtocolHandler(String websocketPath) {
+        this(websocketPath, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, long handshakeTimeoutMillis) {
         this(websocketPath, null, false);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, boolean checkStartsWith) {
-        this(websocketPath, null, false, 65536, false, checkStartsWith);
+        this(websocketPath, checkStartsWith, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, boolean checkStartsWith, long handshakeTimeoutMillis) {
+        this(websocketPath, null, false, 65536, false, checkStartsWith, handshakeTimeoutMillis);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols) {
-        this(websocketPath, subprotocols, false);
+        this(websocketPath, subprotocols, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, long handshakeTimeoutMillis) {
+        this(websocketPath, subprotocols, false, handshakeTimeoutMillis);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions) {
-        this(websocketPath, subprotocols, allowExtensions, 65536);
+        this(websocketPath, subprotocols, allowExtensions, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,
+                                          long handshakeTimeoutMillis) {
+        this(websocketPath, subprotocols, allowExtensions, 65536, handshakeTimeoutMillis);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
                                           boolean allowExtensions, int maxFrameSize) {
-        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, false);
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
+                                          boolean allowExtensions, int maxFrameSize, long handshakeTimeoutMillis) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, false, handshakeTimeoutMillis);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch) {
-        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, false);
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,
+                                          int maxFrameSize, boolean allowMaskMismatch, long handshakeTimeoutMillis) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, false,
+             handshakeTimeoutMillis);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
-        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith, true);
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith,
+             DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
+                                          boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch,
+                                          boolean checkStartsWith, long handshakeTimeoutMillis) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith, true,
+             handshakeTimeoutMillis);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
                                           boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch,
                                           boolean checkStartsWith, boolean dropPongFrames) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith,
+             dropPongFrames, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,
+                                          int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith,
+                                          boolean dropPongFrames, long handshakeTimeoutMillis) {
         super(dropPongFrames);
         this.websocketPath = websocketPath;
         this.subprotocols = subprotocols;
@@ -151,6 +196,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         maxFramePayloadLength = maxFrameSize;
         this.allowMaskMismatch = allowMaskMismatch;
         this.checkStartsWith = checkStartsWith;
+        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
     }
 
     @Override
@@ -159,9 +205,11 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         if (cp.get(WebSocketServerProtocolHandshakeHandler.class) == null) {
             // Add the WebSocketHandshakeHandler before this one.
             ctx.pipeline().addBefore(ctx.name(), WebSocketServerProtocolHandshakeHandler.class.getName(),
-                    new WebSocketServerProtocolHandshakeHandler(websocketPath, subprotocols,
-                            allowExtensions, maxFramePayloadLength, allowMaskMismatch, checkStartsWith)
-                            .handshakeTimeoutMillis(handshakeTimeoutMillis));
+                                     new WebSocketServerProtocolHandshakeHandler(websocketPath, subprotocols,
+                                                                                 allowExtensions, maxFramePayloadLength,
+                                                                                 allowMaskMismatch,
+                                                                                 checkStartsWith,
+                                                                                 handshakeTimeoutMillis));
         }
         if (cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.
@@ -219,10 +267,5 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
                 }
             }
         };
-    }
-
-    public WebSocketServerProtocolHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
-        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
-        return this;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -33,6 +33,7 @@ import io.netty.util.AttributeKey;
 import java.util.List;
 
 import static io.netty.handler.codec.http.HttpVersion.*;
+import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * This handler does all the heavy lifting for you to run a websocket server.
@@ -102,7 +103,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     private static final AttributeKey<WebSocketServerHandshaker> HANDSHAKER_ATTR_KEY =
             AttributeKey.valueOf(WebSocketServerHandshaker.class, "HANDSHAKER");
 
-    private static final long DEFAULT_HANDSHAKE_TIMEOUT = 10000L;
+    private static final long DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000L;
 
     private final String websocketPath;
     private final String subprotocols;
@@ -113,7 +114,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     private final long handshakeTimeoutMillis;
 
     public WebSocketServerProtocolHandler(String websocketPath) {
-        this(websocketPath, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(websocketPath, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, long handshakeTimeoutMillis) {
@@ -121,7 +122,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, boolean checkStartsWith) {
-        this(websocketPath, checkStartsWith, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(websocketPath, checkStartsWith, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, boolean checkStartsWith, long handshakeTimeoutMillis) {
@@ -129,7 +130,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols) {
-        this(websocketPath, subprotocols, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(websocketPath, subprotocols, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, long handshakeTimeoutMillis) {
@@ -137,7 +138,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions) {
-        this(websocketPath, subprotocols, allowExtensions, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(websocketPath, subprotocols, allowExtensions, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,
@@ -147,7 +148,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
                                           boolean allowExtensions, int maxFrameSize) {
-        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
@@ -157,7 +158,8 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch) {
-        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch,
+             DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,
@@ -169,7 +171,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
         this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith,
-             DEFAULT_HANDSHAKE_TIMEOUT);
+             DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
@@ -183,7 +185,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
                                           boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch,
                                           boolean checkStartsWith, boolean dropPongFrames) {
         this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith,
-             dropPongFrames, DEFAULT_HANDSHAKE_TIMEOUT);
+             dropPongFrames, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,
@@ -196,7 +198,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         maxFramePayloadLength = maxFrameSize;
         this.allowMaskMismatch = allowMaskMismatch;
         this.checkStartsWith = checkStartsWith;
-        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+        this.handshakeTimeoutMillis = checkPositive(handshakeTimeoutMillis, "handshakeTimeoutMillis");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -49,29 +49,46 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             WebSocketServerProtocolHandshakeHandler.class,
             "channelRead(...)");
 
+    private static final long DEFAULT_HANDSHAKE_TIMEOUT = 10000L;
+
     private final String websocketPath;
     private final String subprotocols;
     private final boolean allowExtensions;
     private final int maxFramePayloadSize;
     private final boolean allowMaskMismatch;
     private final boolean checkStartsWith;
-    private volatile long handshakeTimeoutMillis;
+    private final long handshakeTimeoutMillis;
     private volatile ChannelHandlerContext ctx;
     private volatile ChannelPromise handshakePromise;
 
     WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch) {
-        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, false);
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
+                                            boolean allowExtensions, int maxFrameSize,
+                                            boolean allowMaskMismatch, long handshakeTimeoutMillis) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch,
+             false, handshakeTimeoutMillis);
     }
 
     WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch,
+             checkStartsWith, DEFAULT_HANDSHAKE_TIMEOUT);
+    }
+
+    WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
+                                            boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch,
+                                            boolean checkStartsWith, long handshakeTimeoutMillis) {
         this.websocketPath = websocketPath;
         this.subprotocols = subprotocols;
         this.allowExtensions = allowExtensions;
         maxFramePayloadSize = maxFrameSize;
         this.allowMaskMismatch = allowMaskMismatch;
         this.checkStartsWith = checkStartsWith;
+        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
     }
 
     @Override
@@ -149,11 +166,6 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         }
         String host = req.headers().get(HttpHeaderNames.HOST);
         return protocol + "://" + host + path;
-    }
-
-    WebSocketServerProtocolHandshakeHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
-        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
-        return this;
     }
 
     private void applyHandshakeTimeout() {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -27,22 +26,18 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.ServerHandshakeStateEvent;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.util.concurrent.DefaultPromise;
-import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.ThrowableUtil;
 
 import java.util.concurrent.TimeUnit;
 
-import static io.netty.handler.codec.http.HttpUtil.*;
 import static io.netty.handler.codec.http.HttpMethod.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static io.netty.handler.codec.http.HttpUtil.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
 
 /**
@@ -156,16 +151,12 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         return protocol + "://" + host + path;
     }
 
-    public WebSocketServerProtocolHandshakeHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
+    WebSocketServerProtocolHandshakeHandler handshakeTimeoutMillis(long handshakeTimeoutMillis) {
         this.handshakeTimeoutMillis = handshakeTimeoutMillis;
         return this;
     }
 
-    public ChannelFuture getHandshakeFuture() {
-        return handshakePromise;
-    }
-
-    public void applyHandshakeTimeout() {
+    private void applyHandshakeTimeout() {
         final ChannelPromise localHandshakePromise = handshakePromise;
         final long handshakeTimeoutMillis = this.handshakeTimeoutMillis;
         if (handshakeTimeoutMillis <= 0 || localHandshakePromise.isDone()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -39,6 +39,7 @@ import static io.netty.handler.codec.http.HttpMethod.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpUtil.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
+import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * Handles the HTTP handshake (the HTTP Upgrade request) for {@link WebSocketServerProtocolHandler}.
@@ -49,7 +50,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             WebSocketServerProtocolHandshakeHandler.class,
             "channelRead(...)");
 
-    private static final long DEFAULT_HANDSHAKE_TIMEOUT = 10000L;
+    private static final long DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000L;
 
     private final String websocketPath;
     private final String subprotocols;
@@ -58,12 +59,13 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
     private final boolean allowMaskMismatch;
     private final boolean checkStartsWith;
     private final long handshakeTimeoutMillis;
-    private volatile ChannelHandlerContext ctx;
-    private volatile ChannelPromise handshakePromise;
+    private ChannelHandlerContext ctx;
+    private ChannelPromise handshakePromise;
 
     WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch) {
-        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, DEFAULT_HANDSHAKE_TIMEOUT);
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch,
+             DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
@@ -76,7 +78,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
     WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
         this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch,
-             checkStartsWith, DEFAULT_HANDSHAKE_TIMEOUT);
+             checkStartsWith, DEFAULT_HANDSHAKE_TIMEOUT_MS);
     }
 
     WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
@@ -88,7 +90,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         maxFramePayloadSize = maxFrameSize;
         this.allowMaskMismatch = allowMaskMismatch;
         this.checkStartsWith = checkStartsWith;
-        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+        this.handshakeTimeoutMillis = checkPositive(handshakeTimeoutMillis, "handshakeTimeoutMillis");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -180,10 +180,6 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         final Future<?> timeoutFuture = ctx.executor().schedule(new Runnable() {
             @Override
             public void run() {
-                if (localHandshakePromise.isDone()) {
-                    return;
-                }
-
                 if (localHandshakePromise.tryFailure(HANDSHAKE_TIMED_OUT_EXCEPTION)) {
                     ctx.flush()
                        .fireUserEventTriggered(ServerHandshakeStateEvent.HANDSHAKE_TIMEOUT)

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -161,6 +161,10 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         return this;
     }
 
+    public ChannelFuture getHandshakeFuture() {
+        return handshakePromise;
+    }
+
     public void applyHandshakeTimeout() {
         final ChannelPromise localHandshakePromise = handshakePromise;
         final long handshakeTimeoutMillis = this.handshakeTimeoutMillis;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -177,7 +177,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             return;
         }
 
-        final ScheduledFuture<?> timeoutFuture = ctx.executor().schedule(new Runnable() {
+        final Future<?> timeoutFuture = ctx.executor().schedule(new Runnable() {
             @Override
             public void run() {
                 if (localHandshakePromise.isDone()) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -45,6 +45,7 @@ public class WebSocketHandshakeHandOverTest {
     private boolean clientReceivedMessage;
     private boolean serverReceivedCloseHandshake;
     private boolean clientForceClosed;
+    private boolean clientHandshakeTimeout;
 
     private final class CloseNoOpServerProtocolHandler extends WebSocketServerProtocolHandler {
         CloseNoOpServerProtocolHandler(String websocketPath) {
@@ -69,6 +70,7 @@ public class WebSocketHandshakeHandOverTest {
         clientReceivedMessage = false;
         serverReceivedCloseHandshake = false;
         clientForceClosed = false;
+        clientHandshakeTimeout = false;
     }
 
     @Test
@@ -116,6 +118,68 @@ public class WebSocketHandshakeHandOverTest {
         transferAllDataWithMerge(serverChannel, clientChannel);
         assertTrue(clientReceivedHandshake);
         assertTrue(clientReceivedMessage);
+    }
+
+    @Test(expected = WebSocketHandshakeException.class)
+    public void testClientHandshakeTimeout() throws Exception {
+        EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<Object>() {
+            @Override
+            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                if (evt == ServerHandshakeStateEvent.HANDSHAKE_COMPLETE) {
+                    serverReceivedHandshake = true;
+                    // immediately send a message to the client on connect
+                    ctx.writeAndFlush(new TextWebSocketFrame("abc"));
+                } else if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
+                    serverHandshakeComplete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
+                }
+            }
+
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+            }
+        });
+
+        EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<Object>() {
+            @Override
+            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
+                    clientReceivedHandshake = true;
+                }
+
+                if (evt == ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT) {
+                    clientHandshakeTimeout = true;
+                }
+            }
+
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+                if (msg instanceof TextWebSocketFrame) {
+                    clientReceivedMessage = true;
+                }
+            }
+        }, 100);
+        // Client send the handshake request to server
+        transferAllDataWithMerge(clientChannel, serverChannel);
+        // Server do not send the response back
+        // transferAllDataWithMerge(serverChannel, clientChannel);
+        WebSocketClientProtocolHandshakeHandler handshakeHandler =
+                (WebSocketClientProtocolHandshakeHandler) clientChannel
+                        .pipeline().get(WebSocketClientProtocolHandshakeHandler.class.getName());
+
+        while (!handshakeHandler.getHandshakeFuture().isDone()) {
+            Thread.sleep(10);
+            // We need to run all pending tasks as the handshake timeout is scheduled on the EventLoop.
+            clientChannel.runScheduledPendingTasks();
+        }
+        assertTrue(clientHandshakeTimeout);
+        assertFalse(clientReceivedHandshake);
+        assertFalse(clientReceivedMessage);
+        // Should throw WebSocketHandshakeException
+        try {
+            handshakeHandler.getHandshakeFuture().syncUninterruptibly();
+        } finally {
+            serverChannel.finishAndReleaseAll();
+        }
     }
 
     @Test(timeout = 10000)
@@ -245,4 +309,14 @@ public class WebSocketHandshakeHandOverTest {
                 handler);
     }
 
+    private static EmbeddedChannel createClientChannel(ChannelHandler handler, long timeoutMillis) throws Exception {
+        return new EmbeddedChannel(
+                new HttpClientCodec(),
+                new HttpObjectAggregator(8192),
+                new WebSocketClientProtocolHandler(new URI("ws://localhost:1234/test"),
+                                                   WebSocketVersion.V13, "test-proto-2",
+                                                   false, null, 65536)
+                        .handshakeTimeoutMillis(timeoutMillis),
+                handler);
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -144,9 +144,7 @@ public class WebSocketHandshakeHandOverTest {
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     clientReceivedHandshake = true;
-                }
-
-                if (evt == ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT) {
+                } else if (evt == ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT) {
                     clientHandshakeTimeout = true;
                 }
             }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -313,8 +313,7 @@ public class WebSocketHandshakeHandOverTest {
                 new HttpObjectAggregator(8192),
                 new WebSocketClientProtocolHandler(new URI("ws://localhost:1234/test"),
                                                    WebSocketVersion.V13, "test-proto-2",
-                                                   false, null, 65536)
-                        .handshakeTimeoutMillis(timeoutMillis),
+                                                   false, null, 65536, timeoutMillis),
                 handler);
     }
 }


### PR DESCRIPTION
Motivation:

Support handshake timeout option in websocket handlers. It makes sense to limit the time we need to move from `HANDSHAKE_ISSUED` to `HANDSHAKE_COMPLETE` states when upgrading to WebSockets

Modification:

- Add `handshakeTimeoutMillis` option in `WebSocketClientProtocolHandshakeHandler`  and `WebSocketServerProtocolHandshakeHandler`.
- Schedule a timeout task, the task will trigger user event `HANDSHAKE_TIMEOUT` if the handshake timed out.

Result:

Fixes issue https://github.com/netty/netty/issues/8841
