### PR TITLE
Add logs for allocating large bytebuf in PooledByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -307,6 +307,11 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
 
     @Override
     protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+        if (initialCapacity > 1024 * 1024) {
+            logger.info("Try to allocate heap buffer with initialCapacity: " +
+                initialCapacity + " maxCapacity: " + maxCapacity + ", current usedHeapMemory: " +
+                metric.usedHeapMemory());
+        }
         PoolThreadCache cache = threadCache.get();
         PoolArena<byte[]> heapArena = cache.heapArena;
 
@@ -324,6 +329,11 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
 
     @Override
     protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+        if (initialCapacity > 1024 * 1024) {
+            logger.info("Try to allocate direct buffer with initialCapacity: " +
+                initialCapacity + " maxCapacity: " + maxCapacity + ", current usedDirectMemory: " +
+                metric.usedDirectMemory());
+        }
         PoolThreadCache cache = threadCache.get();
         PoolArena<ByteBuffer> directArena = cache.directArena;
 


### PR DESCRIPTION
Motivation:

Print logs for allocating large bytebuf in PooledByteBufAllocator, because many applications may care about the memory consumption, and want's to know more info about the memory allocation in case of OOM(for instance, Direct Memory OOM).

Modification:

This PR added logs when allocating large bytebuf

Result:

Fixes #8743 .

NOTE: This is a reopen PR for https://github.com/netty/netty/pull/8744, when I put this PR to spark community as @normanmaurer 's suggestion, I got the following feedback:

> Good log is essential for all analysis. However, this is not a Spark specific issue. This is a little overkill if all `Netty`-based projects do this. Could you contribute to `Netty` project itself? Inside `Netty` project, it is one liner for each functions, isn't it?

> * https://github.com/netty/netty/blob/4.1/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java#L321

Ref link: https://github.com/apache/spark/pull/23610

I do agree with the point of spark community, this is a general need for analyzing memory issue, so we can not just let all up-level application/frameworks do this repeated work.

Can more reviewer to look at this PR? cc @normanmaurer 