### PR TITLE
Support removal using values iterator.

### DIFF
--- a/common/src/main/templates/io/netty/util/collection/KObjectHashMap.template
+++ b/common/src/main/templates/io/netty/util/collection/KObjectHashMap.template
@@ -236,7 +236,7 @@ public class @K@ObjectHashMap<V> implements @K@ObjectMap<V> {
 
                     @Override
                     public void remove() {
-                        throw new UnsupportedOperationException();
+                        iter.remove();
                     }
                 };
             }


### PR DESCRIPTION
Motivation:

As ActiveMQ project using netty, we want to make use of this class, unfortunately the iterator on values(), seems to not support remove method, even so the delegated iterator does. Currently we have to clone and modify this class locally albeit a one line change is needed, it would be ideal if netty could allow remove, then removing the need to maintain a clone.  

Modifications:

* remove throws UnsupportedOperationException, and instead call remove method on delegated iterator

Result

* allows users of the collection when iterating over values to call remove.