### PR TITLE
Further reduce ByteBuf checkAccessible() overhead

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
@@ -32,6 +32,11 @@ public abstract class AbstractDerivedByteBuf extends AbstractByteBuf {
     }
 
     @Override
+    final boolean isAccessible() {
+        return unwrap().isAccessible();
+    }
+
+    @Override
     public final int refCnt() {
         return refCnt0();
     }

--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -64,10 +64,8 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
     }
 
     @Override
-    int internalRefCnt() {
-        // Try to do non-volatile read for performance as the ensureAccessible() is racy anyway and only provide
-        // a best-effort guard.
-        return realRefCnt(nonVolatileRawCnt());
+    final boolean isAccessible() {
+        return maxCapacity() != -1;
     }
 
     @Override
@@ -133,6 +131,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
         int rawCnt = nonVolatileRawCnt(), realCnt = toLiveRealCnt(rawCnt, decrement);
         if (decrement == realCnt) {
             if (refCntUpdater.compareAndSet(this, rawCnt, 1)) {
+                maxCapacity(-1);
                 deallocate();
                 return true;
             }
@@ -155,6 +154,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
             int rawCnt = refCntUpdater.get(this), realCnt = toLiveRealCnt(rawCnt, decrement);
             if (decrement == realCnt) {
                 if (refCntUpdater.compareAndSet(this, rawCnt, 1)) {
+                    maxCapacity(-1);
                     deallocate();
                     return true;
                 }

--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -65,7 +65,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
 
     @Override
     final boolean isAccessible() {
-        return maxCapacity() != -1;
+        return rawMaxCapacity() >= 0;
     }
 
     @Override
@@ -131,7 +131,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
         int rawCnt = nonVolatileRawCnt(), realCnt = toLiveRealCnt(rawCnt, decrement);
         if (decrement == realCnt) {
             if (refCntUpdater.compareAndSet(this, rawCnt, 1)) {
-                maxCapacity(-1);
+                maxCapacity(-rawMaxCapacity());
                 deallocate();
                 return true;
             }
@@ -154,7 +154,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
             int rawCnt = refCntUpdater.get(this), realCnt = toLiveRealCnt(rawCnt, decrement);
             if (decrement == realCnt) {
                 if (refCntUpdater.compareAndSet(this, rawCnt, 1)) {
-                    maxCapacity(-1);
+                    maxCapacity(-rawMaxCapacity());
                     deallocate();
                     return true;
                 }

--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -64,8 +64,8 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
     }
 
     @Override
-    final boolean isAccessible() {
-        return rawMaxCapacity() >= 0;
+    boolean isAccessible() {
+        return rawMaxCapacity() > 0 || (rawMaxCapacity() == 0 && (nonVolatileRawCnt() & 1) == 0);
     }
 
     @Override
@@ -131,7 +131,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
         int rawCnt = nonVolatileRawCnt(), realCnt = toLiveRealCnt(rawCnt, decrement);
         if (decrement == realCnt) {
             if (refCntUpdater.compareAndSet(this, rawCnt, 1)) {
-                maxCapacity(-rawMaxCapacity());
+                maxCapacity(-maxCapacity());
                 deallocate();
                 return true;
             }
@@ -154,7 +154,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
             int rawCnt = refCntUpdater.get(this), realCnt = toLiveRealCnt(rawCnt, decrement);
             if (decrement == realCnt) {
                 if (refCntUpdater.compareAndSet(this, rawCnt, 1)) {
-                    maxCapacity(-rawMaxCapacity());
+                    maxCapacity(-maxCapacity());
                     deallocate();
                     return true;
                 }

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -2445,4 +2445,12 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
 
     @Override
     public abstract ByteBuf touch(Object hint);
+
+    /**
+     * Used internally by {@link AbstractByteBuf#ensureAccessible()} to try to guard
+     * against using the buffer after it was released (best-effort).
+     */
+    boolean isAccessible() {
+        return refCnt() != 0;
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -2123,6 +2123,11 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     @Override
+    boolean isAccessible() {
+        return componentCount != -1;
+    }
+
+    @Override
     public ByteBuf unwrap() {
         return null;
     }

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -470,8 +470,8 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     private void checkComponentIndex(int cIndex) {
+        ensureAccessible();
         if (cIndex < 0 || cIndex > componentCount) {
-            ensureAccessible();
             throw new IndexOutOfBoundsException(String.format(
                     "cIndex: %d (expected: >= 0 && <= numComponents(%d))",
                     cIndex, componentCount));
@@ -479,8 +479,8 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     private void checkComponentIndex(int cIndex, int numComponents) {
+        ensureAccessible();
         if (cIndex < 0 || cIndex + numComponents > componentCount) {
-            ensureAccessible();
             throw new IndexOutOfBoundsException(String.format(
                     "cIndex: %d, numComponents: %d " +
                     "(expected: cIndex >= 0 && cIndex + numComponents <= totalNumComponents(%d))",
@@ -1603,9 +1603,9 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
      * Consolidate the composed {@link ByteBuf}s
      */
     public CompositeByteBuf consolidate() {
+        ensureAccessible();
         final int numComponents = componentCount;
         if (numComponents <= 1) {
-            ensureAccessible();
             return this;
         }
 
@@ -2118,13 +2118,11 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         for (int i = 0, size = componentCount; i < size; i++) {
             components[i].free();
         }
-        // allows us to omit explicit accessibility check in most cases
-        componentCount = -1;
     }
 
     @Override
     boolean isAccessible() {
-        return componentCount != -1;
+        return !freed;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -300,7 +300,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
 
     @SuppressWarnings("deprecation")
     private Component newComponent(ByteBuf buf, int offset) {
-        if (checkAccessible && buf.refCnt() == 0) {
+        if (checkAccessible && !buf.isAccessible()) {
             throw new IllegalReferenceCountException(0);
         }
         int srcIndex = buf.readerIndex(), len = buf.readableBytes();
@@ -470,8 +470,8 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     private void checkComponentIndex(int cIndex) {
-        ensureAccessible();
         if (cIndex < 0 || cIndex > componentCount) {
+            ensureAccessible();
             throw new IndexOutOfBoundsException(String.format(
                     "cIndex: %d (expected: >= 0 && <= numComponents(%d))",
                     cIndex, componentCount));
@@ -479,8 +479,8 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     private void checkComponentIndex(int cIndex, int numComponents) {
-        ensureAccessible();
         if (cIndex < 0 || cIndex + numComponents > componentCount) {
+            ensureAccessible();
             throw new IndexOutOfBoundsException(String.format(
                     "cIndex: %d, numComponents: %d " +
                     "(expected: cIndex >= 0 && cIndex + numComponents <= totalNumComponents(%d))",
@@ -1603,9 +1603,9 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
      * Consolidate the composed {@link ByteBuf}s
      */
     public CompositeByteBuf consolidate() {
-        ensureAccessible();
         final int numComponents = componentCount;
         if (numComponents <= 1) {
+            ensureAccessible();
             return this;
         }
 
@@ -2118,6 +2118,8 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         for (int i = 0, size = componentCount; i < size; i++) {
             components[i].free();
         }
+        // allows us to omit explicit accessibility check in most cases
+        componentCount = -1;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -998,6 +998,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    final boolean isAccessible() {
+        return buf.isAccessible();
+    }
+
+    @Override
     public ByteBuf retain() {
         buf.retain();
         return this;

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -1035,7 +1035,7 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
-    boolean isAccessible() {
+    final boolean isAccessible() {
         return buf.isAccessible();
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -1033,4 +1033,9 @@ class WrappedByteBuf extends ByteBuf {
     public boolean release(int decrement) {
         return buf.release(decrement);
     }
+
+    @Override
+    boolean isAccessible() {
+        return buf.isAccessible();
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -424,11 +424,6 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
-    int internalRefCnt() {
-        return wrapped.internalRefCnt();
-    }
-
-    @Override
     public ByteBuf duplicate() {
         return wrapped.duplicate();
     }
@@ -1253,6 +1248,9 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
 
     @Override
     public final void deallocate() {
+        // this is to avoid overriding isAccessible(), so that it can be
+        // final in AbstractReferenceCountedByteBuf
+        maxCapacity(-1);
         wrapped.deallocate();
     }
 

--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -1250,7 +1250,7 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     public final void deallocate() {
         // this is to avoid overriding isAccessible(), so that it can be
         // final in AbstractReferenceCountedByteBuf
-        maxCapacity(-1);
+        maxCapacity(-rawMaxCapacity());
         wrapped.deallocate();
     }
 

--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -424,6 +424,11 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
+    final boolean isAccessible() {
+        return wrapped.isAccessible();
+    }
+
+    @Override
     public ByteBuf duplicate() {
         return wrapped.duplicate();
     }
@@ -1248,9 +1253,6 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
 
     @Override
     public final void deallocate() {
-        // this is to avoid overriding isAccessible(), so that it can be
-        // final in AbstractReferenceCountedByteBuf
-        maxCapacity(-rawMaxCapacity());
         wrapped.deallocate();
     }
 

--- a/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
@@ -132,28 +132,12 @@ public class ByteBufAccessBenchmark extends AbstractMicrobenchmark {
     }
 
     @Benchmark
-    public ByteBuf setLong() {
-        return buffer.setLong(0, 1);
-    }
-
-    @Benchmark
-    public void readEightBytes(final Blackhole bh) {
+    public int readBatch() {
         buffer.readerIndex(0).touch();
-        byte b1 = buffer.readByte();
-        byte b2 = buffer.readByte();
-        byte b3 = buffer.readByte();
-        byte b4 = buffer.readByte();
-        byte b5 = buffer.readByte();
-        byte b6 = buffer.readByte();
-        byte b7 = buffer.readByte();
-        byte b8 = buffer.readByte();
-        bh.consume(b1);
-        bh.consume(b2);
-        bh.consume(b3);
-        bh.consume(b4);
-        bh.consume(b5);
-        bh.consume(b6);
-        bh.consume(b7);
-        bh.consume(b8);
+        int result = 0;
+        for (int i = 0; i < 8; i++) {
+            result += buffer.readByte();
+        }
+        return result;
     }
 }

--- a/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
@@ -106,12 +106,20 @@ public class ByteBufAccessBenchmark extends AbstractMicrobenchmark {
     @Param
     public ByteBufType bufferType;
 
-    private ByteBuf buffer;
+    @Param({ "true", "false" })
+    public String checkAccessible;
+
+    @Param({ "true", "false" })
+    public String checkBounds;
 
     @Setup
     public void setup() {
+        System.setProperty("io.netty.buffer.checkAccessible", checkAccessible);
+        System.setProperty("io.netty.buffer.checkBounds", checkBounds);
         buffer = bufferType.newBuffer();
     }
+
+    private ByteBuf buffer;
 
     @TearDown
     public void tearDown() {
@@ -131,20 +139,21 @@ public class ByteBufAccessBenchmark extends AbstractMicrobenchmark {
     @Benchmark
     public void readEightBytes(final Blackhole bh) {
         buffer.readerIndex(0).touch();
-        bh.consume(buffer.readByte());
-        bh.consume(buffer.readByte());
-        bh.consume(buffer.readByte());
-        bh.consume(buffer.readByte());
-        bh.consume(buffer.readByte());
-        bh.consume(buffer.readByte());
-        bh.consume(buffer.readByte());
-        bh.consume(buffer.readByte());
+        byte b1 = buffer.readByte();
+        byte b2 = buffer.readByte();
+        byte b3 = buffer.readByte();
+        byte b4 = buffer.readByte();
+        byte b5 = buffer.readByte();
+        byte b6 = buffer.readByte();
+        byte b7 = buffer.readByte();
+        byte b8 = buffer.readByte();
+        bh.consume(b1);
+        bh.consume(b2);
+        bh.consume(b3);
+        bh.consume(b4);
+        bh.consume(b5);
+        bh.consume(b6);
+        bh.consume(b7);
+        bh.consume(b8);
     }
-
-    // doesn't seem to be possible to parameterize JVM args with JMH right now
-//  @Test
-//  public void runWithNoCheck() throws Exception {
-//      new Runner(newOptionsBuilder()
-//              .jvmArgsAppend("-Dio.netty.buffer.checkAccessible=false").build()).run();
-//  }
 }

--- a/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
@@ -1,0 +1,150 @@
+/*
+* Copyright 2019 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.buffer;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.PlatformDependent;
+
+@Warmup(iterations = 5, time = 1500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+public class ByteBufAccessBenchmark extends AbstractMicrobenchmark {
+
+    static final class NioFacade extends WrappedByteBuf {
+        private final ByteBuffer byteBuffer;
+        NioFacade(ByteBuffer byteBuffer) {
+            super(Unpooled.EMPTY_BUFFER);
+            this.byteBuffer = byteBuffer;
+        }
+        @Override
+        public ByteBuf setLong(int index, long value) {
+            byteBuffer.putLong(index, value);
+            return this;
+        }
+        @Override
+        public long getLong(int index) {
+            return byteBuffer.getLong(index);
+        }
+        @Override
+        public byte readByte() {
+            return byteBuffer.get();
+        }
+        @Override
+        public ByteBuf touch() {
+            // hack since WrappedByteBuf.readerIndex(int) is final
+            byteBuffer.position(0);
+            return this;
+        }
+        @Override
+        public boolean release() {
+            PlatformDependent.freeDirectBuffer(byteBuffer);
+            return true;
+        }
+    }
+
+    public enum ByteBufType {
+        UNSAFE {
+            @Override
+            ByteBuf newBuffer() {
+                return new UnpooledUnsafeDirectByteBuf(
+                        UnpooledByteBufAllocator.DEFAULT, 64, 64).setIndex(0, 64);
+            }
+        },
+        UNSAFE_SLICE {
+            @Override
+            ByteBuf newBuffer() {
+                return UNSAFE.newBuffer().slice(16, 48);
+            }
+        },
+        HEAP {
+            @Override
+            ByteBuf newBuffer() {
+                return new UnpooledUnsafeHeapByteBuf(
+                        UnpooledByteBufAllocator.DEFAULT, 64, 64).setIndex(0,  64);
+            }
+        },
+        COMPOSITE {
+            @Override
+            ByteBuf newBuffer() {
+                return Unpooled.wrappedBuffer(UNSAFE.newBuffer(), HEAP.newBuffer());
+            }
+        },
+        NIO {
+            @Override
+            ByteBuf newBuffer() {
+                return new NioFacade(ByteBuffer.allocateDirect(64));
+            }
+        };
+        abstract ByteBuf newBuffer();
+    }
+
+    @Param
+    public ByteBufType bufferType;
+
+    private ByteBuf buffer;
+
+    @Setup
+    public void setup() {
+        buffer = bufferType.newBuffer();
+    }
+
+    @TearDown
+    public void tearDown() {
+        buffer.release();
+    }
+
+    @Benchmark
+    public long setGetLong() {
+        return buffer.setLong(0, 1).getLong(0);
+    }
+
+    @Benchmark
+    public ByteBuf setLong() {
+        return buffer.setLong(0, 1);
+    }
+
+    @Benchmark
+    public void readEightBytes(final Blackhole bh) {
+        buffer.readerIndex(0).touch();
+        bh.consume(buffer.readByte());
+        bh.consume(buffer.readByte());
+        bh.consume(buffer.readByte());
+        bh.consume(buffer.readByte());
+        bh.consume(buffer.readByte());
+        bh.consume(buffer.readByte());
+        bh.consume(buffer.readByte());
+        bh.consume(buffer.readByte());
+    }
+
+    // doesn't seem to be possible to parameterize JVM args with JMH right now
+//  @Test
+//  public void runWithNoCheck() throws Exception {
+//      new Runner(newOptionsBuilder()
+//              .jvmArgsAppend("-Dio.netty.buffer.checkAccessible=false").build()).run();
+//  }
+}


### PR DESCRIPTION
Motivation:

Some profiles of grpc-java indicate that overhead from `AbstractByteBuf.checkAccessible()` is quite significant due the relatively fine-grained way that `ByteBuf`s are accessed by the http2 hpack logic (5-10% of an entire end-to-end roundtrip benchmark!)

This PR takes the great improvement done in #8266 a bit further, simpliyfing the non-volatile/best-effort check. I did not dig deep enough to see why the existing `internalRefCnt()` logic was relatively slower
given that it does appear to get inlined. One observation though is that the prior optimization wasn't applied to derived buffers (slices etc.) which presumably was an oversight - this would be fairly simple to fix without the rest of this change (by overriding/delegating `internalRefCnt`) but that wouldn't help with the non-derived case.

Modifications:

- Replace `AbstractByteBuf.internalRefCnt()` with an internal (package-private) `ByteBuf.isAccessible()` method; the default impl still checks for nonzero `refCnt()`
- Set `maxCapacity` to -1 upon deallocation in `AbstractRefCountedByteBuf`, and add a final override of `isAccessible()` which checks this
- Appropriately forward `isAccessible()` invocations in `AbstractDerivedByteBuf`/`WrappedByteBuf`/`SwappedByteBuf` (also final overrides)
- Have `CompositeByteBuf` set `numComponents` to -1 upon deallocation so that the existing component index checks done on most methods also serve to check accessibility
- Add `ByteBufAccessBenchmark` which is an extension of `UnsafeByteBufBenchmark` (maybe latter could now be removed)

This change is similar to @ejona86's suggestion in #8266 (making use of `maxCapacity`), and I'd also thought of "invalidating" the reader/writer indices upon deallocation and having existing bounds checks do double-duty where possible. That could be a worthwhile addition irrespective of whether `checkAccessible` is otherwise changed to be false by default, but decided to keep this iteration minimally invasive. A complication is that bounds checking logic is in `AbstractByteBuf` but the index-invalidation-upon-deallocate logic must live in `AbstractReferenceCountedByteBuf` meaning that some further rework would be needed to avoid breaking the checks for any third-party impls that extend `AbstractByteBuf` directly. It's also the case that not all of the bounds checks involve these fields (absolute ones currently only use `capacity()` which is impl-specific),

Results:

Non-negligible speedups, especially for `CompositeByteBuf` which is twice as fast in some cases.

Before:
```
Benchmark                              (bufferType)   Mode  Cnt
Score         Error  Units
ByteBufAccessBenchmark.setGetLong            UNSAFE  thrpt   30 242844273.620 ± 1778416.963  ops/s
ByteBufAccessBenchmark.setGetLong      UNSAFE_SLICE  thrpt   30 184970819.249 ± 1990964.278  ops/s
ByteBufAccessBenchmark.setGetLong              HEAP  thrpt   30 242099517.501 ± 2661438.140  ops/s
ByteBufAccessBenchmark.setGetLong         COMPOSITE  thrpt   30  76961466.906 ± 1318414.178  ops/s
ByteBufAccessBenchmark.setGetLong               NIO  thrpt   30 279181674.131 ± 2162611.704  ops/s
```

After:
```
Benchmark                              (bufferType)   Mode  Cnt
Score          Error  Units
ByteBufAccessBenchmark.setGetLong            UNSAFE  thrpt   30 285754526.496 ±  3292540.505  ops/s
ByteBufAccessBenchmark.setGetLong      UNSAFE_SLICE  thrpt   30 209794441.861 ±  1646039.479  ops/s
ByteBufAccessBenchmark.setGetLong              HEAP  thrpt   30 283203453.736 ±  1987854.916  ops/s
ByteBufAccessBenchmark.setGetLong         COMPOSITE  thrpt   30 155437066.991 ±  1492219.965  ops/s
ByteBufAccessBenchmark.setGetLong               NIO  thrpt   30 277362327.090 ±  3070532.642  ops/s
```
