### PR TITLE
DefaultFileRegion.transferTo with invalid count may cause busy-spin

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -367,13 +367,13 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
      * </ul>
      */
     private int writeDefaultFileRegion(ChannelOutboundBuffer in, DefaultFileRegion region) throws Exception {
+        final long offset = region.transferred();
         final long regionCount = region.count();
-        if (region.transferred() >= regionCount) {
+        if (offset >= regionCount) {
             in.remove();
             return 0;
         }
 
-        final long offset = region.transferred();
         final long flushedAmount = socket.sendFile(region, region.position(), offset, regionCount - offset);
         if (flushedAmount > 0) {
             in.progress(flushedAmount);
@@ -381,6 +381,8 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                 in.remove();
             }
             return 1;
+        } else if (flushedAmount == 0) {
+            validateFileRegion(region, offset);
         }
         return WRITE_STATUS_SNDBUF_FULL;
     }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -1149,6 +1149,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         return msg;
     }
 
+    protected void validateFileRegion(DefaultFileRegion region, long position) throws IOException {
+        DefaultFileRegion.validate(region, position);
+    }
+
     static final class CloseFuture extends DefaultChannelPromise {
 
         CloseFuture(AbstractChannel ch) {

--- a/transport/src/test/java/io/netty/channel/DefaultFileRegionTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultFileRegionTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.internal.PlatformDependent;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class DefaultFileRegionTest {
+
+    private static final byte[] data = new byte[1048576 * 10];
+
+    static {
+        PlatformDependent.threadLocalRandom().nextBytes(data);
+    }
+
+    private static File newFile() throws IOException {
+        File file = File.createTempFile("netty-", ".tmp");
+        file.deleteOnExit();
+
+        final FileOutputStream out = new FileOutputStream(file);
+        out.write(data);
+        out.close();
+        return file;
+    }
+
+    @Test
+    public void testCreateFromFile() throws IOException  {
+        File file = newFile();
+        try {
+            testFileRegion(new DefaultFileRegion(file, 0, data.length));
+        } finally {
+            file.delete();
+        }
+    }
+
+    @Test
+    public void testCreateFromFileChannel() throws IOException  {
+        File file = newFile();
+        RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
+        try {
+            testFileRegion(new DefaultFileRegion(randomAccessFile.getChannel(), 0, data.length));
+        } finally {
+            randomAccessFile.close();
+            file.delete();
+        }
+    }
+
+    private static void testFileRegion(FileRegion region) throws IOException  {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        WritableByteChannel channel = Channels.newChannel(outputStream);
+
+        try {
+            assertEquals(data.length, region.count());
+            assertEquals(0, region.transferred());
+            assertEquals(data.length, region.transferTo(channel, 0));
+            assertEquals(data.length, region.count());
+            assertEquals(data.length, region.transferred());
+            assertArrayEquals(data, outputStream.toByteArray());
+        } finally {
+            channel.close();
+        }
+    }
+
+    @Test
+    public void testTruncated() throws IOException  {
+        File file = newFile();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        WritableByteChannel channel = Channels.newChannel(outputStream);
+        RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw");
+
+        try {
+            FileRegion region = new DefaultFileRegion(randomAccessFile.getChannel(), 0, data.length);
+
+            randomAccessFile.getChannel().truncate(data.length - 1024);
+
+            assertEquals(data.length, region.count());
+            assertEquals(0, region.transferred());
+
+            assertEquals(data.length - 1024, region.transferTo(channel, 0));
+            assertEquals(data.length, region.count());
+            assertEquals(data.length - 1024, region.transferred());
+            try {
+                region.transferTo(channel, data.length - 1024);
+                fail();
+            } catch (IOException expected) {
+                // expected
+            }
+        } finally {
+            channel.close();
+
+            randomAccessFile.close();
+            file.delete();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

`DefaultFileRegion.transferTo` will return 0 all the time when we request more data then the actual file size. This may result in a busy spin while processing the fileregion during writes.

Modifications:

- If we wrote 0 bytes check if the underlying file size is smaller then the requested count and if so throw an IOException
- Add DefaultFileRegionTest
- Add a test to the testsuite

Result:

Fixes https://github.com/netty/netty/issues/8868.