### PR TITLE
Add a way to control the treatment of the Http2 system frames in the …

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -40,26 +41,24 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpScheme;
-import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.util.CharsetUtil;
-
+import io.netty.util.ReferenceCountUtil;
 import org.junit.Test;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
 
 public class Http2StreamFrameToHttpObjectCodecTest {
 
@@ -932,5 +931,60 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertThat(headers.path().toString(), is("/hello/world"));
         assertTrue(headersFrame.isEndStream());
         assertNull(frames.poll());
+    }
+
+    @Test
+    public void testDefaultTreatmentOfSystemFrames() throws Exception {
+        EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false));
+        DefaultHttp2ResetFrame expected = new DefaultHttp2ResetFrame(Http2Error.NO_ERROR);
+        assertTrue(ch.writeInbound(expected));
+
+        Object actual = ch.readInbound();
+        assertEquals(expected, actual);
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testSendAsMessageTreatmentOfSystemFrames() throws Exception {
+        EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(
+                false, true
+        ));
+        DefaultHttp2ResetFrame expected = new DefaultHttp2ResetFrame(Http2Error.NO_ERROR);
+        assertTrue(ch.writeInbound(expected));
+
+        Object actual = ch.readInbound();
+        assertEquals(expected, actual);
+
+        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testIgnoreTreatmentOfSystemFrames() throws Exception {
+        EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false, true) {
+            @Override
+            protected void processSystemFrame(ChannelHandlerContext ctx, Http2Frame msg) {
+                ReferenceCountUtil.release(msg);
+            }
+        });
+        assertFalse(ch.writeInbound(new DefaultHttp2ResetFrame(Http2Error.NO_ERROR)));
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testSendAsUserEventTreatmentOfSystemFrames() throws Exception {
+        ChannelInboundHandler mockHandler = mock(ChannelInboundHandler.class);
+        EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false, true) {
+            @Override
+            protected void processSystemFrame(ChannelHandlerContext ctx, Http2Frame msg) {
+                ctx.fireUserEventTriggered(msg);
+            }
+        }, mockHandler);
+        DefaultHttp2ResetFrame expected = new DefaultHttp2ResetFrame(Http2Error.NO_ERROR);
+        assertFalse(ch.writeInbound(expected));
+        assertFalse(ch.finish());
+        verify(mockHandler).userEventTriggered(any(ChannelHandlerContext.class), eq(expected));
     }
 }


### PR DESCRIPTION
…http2-to-http1 flow

**Motivation:**

`Http2StreamFrameToHttpObjectCodec` is used to convert objects in the pipeline from HTTP/2 classes to their HTTP1 counterparts so that the existing HTTP1 pipeline could be reused. There are some frames however that are not being converted. E.g. `Http2ResetFrame` or `Http2WindowUpdateFrame`. The existing behavior is for those frames to be sent through the `channelRead()` pipeline, which may be breaking the logic of pipelines designed to only support HTTP1 requests. This goal of this change is to allow clients to configure the treatment of the HTTP/2 "leftover" frames.

**Modification:**
A new `processSystemFrame()` method is added to the `Http2StreamFrameToHttpObjectCodec` class. The method is called for all `Http2Frame` objects that are not processed by the Codec itself.
The default implementation is to send the frame to the `channelRead()` pipeline.

**Result:**
A client now has a way to implement a custom way of handling HTTP/2 system frames.