### PR TITLE
Message aware cumulators

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -307,9 +307,9 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                     cumulation = cumulator.cumulate(ctx.alloc(), cumulation, inProgress);
                     if (cumulation.readableBytes() == oldReadableBytes + newReadableBytes) {
                         inProgress = null;
-                        if (first) {
-                            break; // don't bother calling decode again if we've already passed it everything
-                        }
+                    }
+                    if (first) {
+                        break; // don't bother calling decode again if we've already passed it everything
                     }
 
                     boolean hadInProgress = inProgress != null;

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -315,8 +315,9 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                     if (cumulation == null) {
                         // this can only happen if we have been removed, so propagate any remaining bytes we may own
                         if (data != null && data.isReadable()) {
-                            ctx.fireChannelRead(data);
+                            ByteBuf propagate = data;
                             data = null;
+                            ctx.fireChannelRead(propagate);
                             ctx.fireChannelReadComplete();
                         }
                         break;

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -159,7 +159,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     private static final byte STATE_HANDLER_REMOVED_PENDING = 2;
 
     ByteBuf cumulation;
-    ByteBuf inProgress;
+    private ByteBuf inProgress;
     private Cumulator cumulator = MERGE_CUMULATOR;
     private boolean singleDecode;
     private boolean decodeWasNull;
@@ -318,10 +318,9 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                     }
                 } while (inProgress != null);
 
+            } catch (DecoderException e) {
+                throw e;
             } catch (Exception e) {
-                if (e instanceof DecoderException) {
-                    throw e;
-                }
                 throw new DecoderException(e);
             } finally {
                 saveInProgressToCumulation();

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -282,7 +282,6 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             CodecOutputList out = CodecOutputList.newInstance();
             inProgress = (ByteBuf) msg;
             try {
-
                 do {
                     first = cumulation == null;
                     if (first) {

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -78,6 +78,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
         @Override
         public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
             if (!cumulation.isReadable()) {
+                cumulation.release();
                 return in;
             }
 
@@ -115,6 +116,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
         @Override
         public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
             if (!cumulation.isReadable()) {
+                cumulation.release();
                 return in;
             }
 

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -325,6 +325,7 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
     final void channelInputClosed(ChannelHandlerContext ctx, List<Object> out) throws Exception {
         try {
             replayable.terminate();
+            saveInProgressToCumulation();
             if (cumulation != null) {
                 callDecode(ctx, internalBuffer(), out);
             } else {

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -318,7 +318,7 @@ public class ByteToMessageDecoderTest {
                 throw error;
             }
         };
-        cumulation.writeByte(1);
+        cumulation.writeByte(1); // ensure cumulation is non-null, so that cumulator writes to it instead of replacing it
         ByteBuf in = Unpooled.buffer().writeZero(12);
         try {
             ByteToMessageDecoder.MERGE_CUMULATOR.cumulate(UnpooledByteBufAllocator.DEFAULT, cumulation, in);
@@ -339,7 +339,7 @@ public class ByteToMessageDecoderTest {
                 throw error;
             }
         };
-        cumulation.writeByte(1);
+        cumulation.writeByte(1); // ensure cumulation is non-null, so that cumulator writes to it instead of replacing it
         ByteBuf in = Unpooled.buffer().writeZero(12);
         try {
             ByteToMessageDecoder.COMPOSITE_CUMULATOR.cumulate(UnpooledByteBufAllocator.DEFAULT, cumulation, in);
@@ -350,7 +350,7 @@ public class ByteToMessageDecoderTest {
         }
     }
 
-    static abstract class PartialCumulationDecoder extends ByteToMessageDecoder {
+    abstract static class PartialCumulationDecoder extends ByteToMessageDecoder {
         final int messageSize;
         int cumulations;
 
@@ -436,7 +436,7 @@ public class ByteToMessageDecoderTest {
             for (int throwAfterCount = 0 ; throwAfterCount <= 1 ; ++throwAfterCount) {
                 final int throwAfterCountFinal = throwAfterCount;
                 final PartialCumulationDecoder decoder = new PartialCumulationDecoder(2) {
-                    int count = 0;
+                    int count;
                     @Override
                     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
                         if (in.readableBytes() < 2) {

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -359,6 +359,7 @@ public class ByteToMessageDecoderTest {
             public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
                 ++cumulations;
                 if (!cumulation.isReadable()) {
+                    cumulation.release();
                     return in;
                 }
 

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -15,7 +15,12 @@
  */
 package io.netty.handler.codec;
 
-import io.netty.buffer.*;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.UnpooledHeapByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -413,12 +418,11 @@ public class ByteToMessageDecoderTest {
                 if (unreadFinalBytes > 0) {
                     assertSame(in2, decoder.cumulation);
                     assertEquals(1, decoder.cumulation.readableBytes());
-                    assertFalse(channel.finish());
                 } else {
                     assertEquals(0, in2.refCnt());
                     assertNull(decoder.cumulation);
-                    assertFalse(channel.finish());
                 }
+                assertFalse(channel.finish());
             }
         }
     }

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 
+import static io.netty.handler.codec.ByteToMessageDecoder.MERGE_CUMULATOR;
+import static io.netty.handler.codec.ByteToMessageDecoder.COMPOSITE_CUMULATOR;
 import static org.junit.Assert.*;
 
 public class ByteToMessageDecoderTest {
@@ -318,10 +320,10 @@ public class ByteToMessageDecoderTest {
                 throw error;
             }
         };
-        cumulation.writeByte(1); // ensure cumulation is non-null, so that cumulator writes to it instead of replacing it
+        cumulation.writeByte(1); // ensure cumulation is non-null, so that cumulator writes to instead of replacing it
         ByteBuf in = Unpooled.buffer().writeZero(12);
         try {
-            ByteToMessageDecoder.MERGE_CUMULATOR.cumulate(UnpooledByteBufAllocator.DEFAULT, cumulation, in);
+            MERGE_CUMULATOR.cumulate(UnpooledByteBufAllocator.DEFAULT, cumulation, in);
             fail();
         } catch (Error expected) {
             assertSame(error, expected);
@@ -339,10 +341,10 @@ public class ByteToMessageDecoderTest {
                 throw error;
             }
         };
-        cumulation.writeByte(1); // ensure cumulation is non-null, so that cumulator writes to it instead of replacing it
+        cumulation.writeByte(1); // ensure cumulation is non-null, so that cumulator writes to instead of replacing it
         ByteBuf in = Unpooled.buffer().writeZero(12);
         try {
-            ByteToMessageDecoder.COMPOSITE_CUMULATOR.cumulate(UnpooledByteBufAllocator.DEFAULT, cumulation, in);
+            COMPOSITE_CUMULATOR.cumulate(UnpooledByteBufAllocator.DEFAULT, cumulation, in);
             fail();
         } catch (Error expected) {
             assertSame(error, expected);
@@ -508,7 +510,7 @@ public class ByteToMessageDecoderTest {
 
     @Test
     public void defaultCumulatorsFreeEmptyCumulation() {
-        for (Cumulator cumulator : new Cumulator[] { ByteToMessageDecoder.MERGE_CUMULATOR, ByteToMessageDecoder.COMPOSITE_CUMULATOR }) {
+        for (Cumulator cumulator : new Cumulator[] { MERGE_CUMULATOR, COMPOSITE_CUMULATOR }) {
             ByteBuf in = Unpooled.buffer().writeZero(1);
             ByteBuf empty = Unpooled.buffer().writeZero(1);
             empty.skipBytes(1);

--- a/microbench/src/main/java/io/netty/microbench/codec/ByteToMessageDecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/codec/ByteToMessageDecoderBenchmark.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.PlatformDependent;
+import org.openjdk.jmh.annotations.*;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * This benchmark is based on HttpRequestDecoderTest class.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 10)
+@Measurement(iterations = 20)
+public class ByteToMessageDecoderBenchmark extends AbstractMicrobenchmark {
+
+    public enum SelectCumulator {
+        MERGE, COMPOSITE, MESSAGE_AWARE_MERGE
+    }
+
+    public static class MessageDecoder extends ByteToMessageDecoder {
+        final int messageSize;
+        final int skipSize;
+        public MessageDecoder(int messageSize, int skipSize, SelectCumulator cumulator) {
+            this.messageSize = messageSize;
+            this.skipSize = skipSize;
+            switch (cumulator) {
+                case MERGE:
+                    setCumulator(MERGE_CUMULATOR);
+                    break;
+                case COMPOSITE:
+                    setCumulator(COMPOSITE_CUMULATOR);
+                    break;
+                case MESSAGE_AWARE_MERGE:
+                    setCumulator(new MessageAwareCumulator(messageSize));
+                    break;
+            }
+        }
+        @Override
+        protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+            while (in.readableBytes() >= messageSize) {
+                for (int skip = messageSize; skip > 0 ; skip -= skipSize) {
+                    in.skipBytes(skipSize);
+                }
+            }
+        }
+    }
+
+    static class MessageAwareCumulator implements ByteToMessageDecoder.Cumulator {
+        final int messageSize;
+        MessageAwareCumulator(int messageSize) {
+            this.messageSize = messageSize;
+        }
+
+        @Override
+        public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
+            if (!cumulation.isReadable() && in.capacity() == messageSize) {
+                cumulation.release();
+                return in;
+            }
+            if (cumulation.capacity() < messageSize) {
+                ByteBuf newCumulation = alloc.directBuffer(messageSize);
+                newCumulation.writeBytes(cumulation);
+                cumulation.release();
+                cumulation = newCumulation;
+            }
+
+            cumulation.writeBytes(in, 0, Math.min(in.readableBytes(), messageSize - cumulation.readableBytes()));
+            if (!in.isReadable()) {
+                in.release();
+            }
+            return cumulation;
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class ThreadState {
+        @Param({ "MERGE", "COMPOSITE", "MESSAGE_AWARE_MERGE" })
+        public SelectCumulator cumulator;
+
+        @Param({ "1" })
+        public int firstInputSize;
+
+        @Param({ "1024", "16384", "65536" })
+        public int totalInputSize;
+
+        @Param({ "16", "128", "512" })
+        public int messageSize;
+
+        @Param({ "true", "false" })
+        public boolean firstBufferHasCapacityForOneMessage;
+
+        @Param({ "true", "false" })
+        public boolean decodeByByte;
+
+        MessageDecoder decoder;
+        EmbeddedChannel channel;
+        // we use a ByteBuffer so we can wrap it for each test, else we are handicapping COMPOSITE_CUMULATOR
+        ByteBuffer firstBuffer;
+        ByteBuf firstInput;
+        ByteBuf secondInput;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            decoder = new MessageDecoder(messageSize, decodeByByte ? 1 : messageSize, cumulator);
+            channel = new EmbeddedChannel(decoder);
+            firstBuffer = ByteBuffer.allocateDirect(firstBufferHasCapacityForOneMessage ? messageSize : firstInputSize);
+            secondInput = Unpooled.directBuffer(totalInputSize - firstInputSize);
+            secondInput.retain();
+        }
+
+        @Setup(Level.Invocation)
+        public void reset() {
+            firstInput = Unpooled.wrappedBuffer(firstBuffer);
+            firstInput.readerIndex(0);
+            firstInput.writerIndex(firstInputSize);
+            secondInput.retain();
+            secondInput.readerIndex(0);
+            secondInput.writerIndex(totalInputSize - firstInputSize);
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            PlatformDependent.freeDirectBuffer(firstBuffer);
+            secondInput.release();
+        }
+    }
+
+    @Benchmark
+    public void testCumulationAndDecode(ThreadState state) {
+        state.channel.writeInbound(state.firstInput);
+        state.channel.writeInbound(state.secondInput);
+    }
+
+}

--- a/microbench/src/main/java/io/netty/microbench/codec/ByteToMessageDecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/codec/ByteToMessageDecoderBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2019 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,7 +21,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import io.netty.util.internal.PlatformDependent;
 import org.openjdk.jmh.annotations.*;
@@ -41,10 +40,10 @@ public class ByteToMessageDecoderBenchmark extends AbstractMicrobenchmark {
         MERGE, COMPOSITE, MESSAGE_AWARE_MERGE
     }
 
-    public static class MessageDecoder extends ByteToMessageDecoder {
+    private static class MessageDecoder extends ByteToMessageDecoder {
         final int messageSize;
         final int skipSize;
-        public MessageDecoder(int messageSize, int skipSize, SelectCumulator cumulator) {
+        MessageDecoder(int messageSize, int skipSize, SelectCumulator cumulator) {
             this.messageSize = messageSize;
             this.skipSize = skipSize;
             switch (cumulator) {
@@ -57,6 +56,8 @@ public class ByteToMessageDecoderBenchmark extends AbstractMicrobenchmark {
                 case MESSAGE_AWARE_MERGE:
                     setCumulator(new MessageAwareCumulator(messageSize));
                     break;
+                default:
+                    throw new IllegalStateException();
             }
         }
         @Override
@@ -69,7 +70,7 @@ public class ByteToMessageDecoderBenchmark extends AbstractMicrobenchmark {
         }
     }
 
-    static class MessageAwareCumulator implements ByteToMessageDecoder.Cumulator {
+    private static final class MessageAwareCumulator implements ByteToMessageDecoder.Cumulator {
         final int messageSize;
         MessageAwareCumulator(int messageSize) {
             this.messageSize = messageSize;


### PR DESCRIPTION
Motivation:

Reduce the number of bytes that may need to be copied when parsing multiple messages in a class extending ByteToMessageDecoder, and permit bounding the size of the ByteBuf needed to stash unread bytes for future invocations.

Modification:

Modified the semantics and usage of Cumulator so that it may be "message aware" - knowing how much data is needed to be able to parse another message.  

Using this information, it may choose to only partially fill a cumulation with its input bytes, so long as an entire message may be read.  Ideally, only exactly the number of bytes necessary to read a message will be copied, after which the remaining bytes will be processed from the input ByteBuf.  

If any bytes remain unread at the end of channelRead, the Cumulator is invoked to decide how to persist them across invocations, so that a precisely sized buffer for the message may be allocated.

