### PR TITLE
Adjust tests to be able to build / test when using IBM J9 / OpenJ9

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -74,6 +74,7 @@ public final class PlatformDependent {
 
     private static final boolean IS_WINDOWS = isWindows0();
     private static final boolean IS_OSX = isOsx0();
+    private static final boolean IS_J9_JVM = isJ9Jvm0();
 
     private static final boolean MAYBE_SUPER_USER;
 
@@ -996,6 +997,19 @@ public final class PlatformDependent {
             // Probably failed to initialize PlatformDependent0.
             return new UnsupportedOperationException("Could not determine if Unsafe is available", t);
         }
+    }
+
+    /**
+     * Returns {@code true} if the running JVM is either <a href="https://developer.ibm.com/javasdk/">IBM J9</a> or
+     * <a href="https://www.eclipse.org/openj9/">Eclipse OpenJ9</a>, {@code false} otherwise.
+     */
+    public static boolean isJ9Jvm() {
+        return IS_J9_JVM;
+    }
+
+    private static boolean isJ9Jvm0() {
+        String vmName = SystemPropertyUtil.get("java.vm.name", "").toLowerCase();
+        return vmName.startsWith("ibm j9") || vmName.startsWith("eclipse openj9");
     }
 
     private static long maxDirectMemory0() {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
@@ -35,6 +35,8 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.GlobalEventExecutor;
+import io.netty.util.internal.PlatformDependent;
+import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -338,6 +340,8 @@ public class UDTClientServerConnectionTest {
      */
     @Test
     public void connection() throws Exception {
+        Assume.assumeFalse("Not supported on J9 JVM", PlatformDependent.isJ9Jvm());
+
         log.info("Starting server.");
         // Using LOCALHOST4 as UDT transport does not support IPV6 :(
         final Server server = new Server(new InetSocketAddress(NetUtil.LOCALHOST4, 0));


### PR DESCRIPTION
Motivation:

We should run a CI job using J9 to ensure netty also works when using different JVMs.

Modifications:

- Adjust PooledByteBufAllocatorTest to be able to complete faster when using a JVM which takes longer when joining Threads (this seems to be the case with J9).
- Skip UDT tests on J9 as UDT is not supported there.

Result:

Be able to run CI against J9.