### PR TITLE
Added ChannelSystem to easier initialize Bootstrap

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -51,7 +51,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
 
     volatile EventLoopGroup group;
     @SuppressWarnings("deprecation")
-    private volatile ChannelFactory<? extends C> channelFactory;
+    protected volatile ChannelFactory<? extends C> channelFactory;
     private volatile SocketAddress localAddress;
     private final Map<ChannelOption<?>, Object> options = new LinkedHashMap<ChannelOption<?>, Object>();
     private final Map<AttributeKey<?>, Object> attrs = new LinkedHashMap<AttributeKey<?>, Object>();
@@ -209,10 +209,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
      */
     public B validate() {
         if (group == null) {
-            throw new IllegalStateException("group not set");
-        }
-        if (channelFactory == null) {
-            throw new IllegalStateException("channel or channelFactory not set");
+            group(ChannelSystem.getOptimal().newLoopGroup());
         }
         return self();
     }

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -106,6 +106,11 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         return channelFactory(new ReflectiveChannelFactory<C>(channelClass));
     }
 
+    public B setChannelSystem(ChannelSystem channelSystem) {
+        group(channelSystem.newLoopGroup());
+        return self();
+    }
+
     /**
      * @deprecated Use {@link #channelFactory(io.netty.channel.ChannelFactory)} instead.
      */

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -283,6 +283,9 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         if (config.handler() == null) {
             throw new IllegalStateException("handler not set");
         }
+        if (channelFactory == null) {
+            channel(ChannelSystem.getOptimal().getChannelClass());
+        }
         return this;
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -106,6 +106,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         return this;
     }
 
+    @Override
+    public Bootstrap setChannelSystem(ChannelSystem channelSystem) {
+        channel(channelSystem.getChannelClass());
+        return super.setChannelSystem(channelSystem);
+    }
+
     /**
      * Connect a {@link Channel} to the remote peer.
      */

--- a/transport/src/main/java/io/netty/bootstrap/ChannelSystem.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelSystem.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.bootstrap;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+public enum ChannelSystem {
+
+    NIO(NioSocketChannel.class, NioServerSocketChannel.class) {
+        @Override
+        public EventLoopGroup newLoopGroup() {
+            return new NioEventLoopGroup();
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+    },
+    EPOLL(null, null) {
+        Class eventLoop;
+        {
+            try {
+                eventLoop = Class.forName("io.netty.channel.epoll.EpollEventLoopGroup");
+            } catch (ClassNotFoundException ignored) {
+
+            }
+        }
+        @Override
+        public EventLoopGroup newLoopGroup() {
+            try {
+                return (EventLoopGroup) eventLoop.newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public boolean isAvailable() {
+            try {
+                Class epoll = Class.forName("io.netty.channel.epoll.Epoll");
+                return (Boolean) epoll.getDeclaredMethod("isAvailable").invoke(null);
+            } catch (Exception e) {
+                return false;
+            }
+        }
+    };
+
+    static {
+        try {
+            EPOLL.channelClass = (Class<? extends Channel>) Class.forName("io.netty.channel.epoll.EpollSocketChannel");
+            EPOLL.serverChannelClass = (Class<? extends ServerChannel>) Class.forName("io.netty.channel.epoll.EpollServerSocketChannel");
+        } catch (Exception ignored) {}
+    }
+
+    private Class<? extends Channel> channelClass;
+    private Class<? extends ServerChannel> serverChannelClass;
+
+    ChannelSystem(Class<? extends Channel> channelClass, Class<? extends ServerChannel> serverChannelClass) {
+        this.channelClass = channelClass;
+        this.serverChannelClass = serverChannelClass;
+    }
+
+    public abstract EventLoopGroup newLoopGroup();
+    public abstract boolean isAvailable();
+
+    public Class<? extends Channel> getChannelClass() {
+        return channelClass;
+    }
+
+    public Class<? extends ServerChannel> getServerChannelClass() {
+        return serverChannelClass;
+    }
+
+    private static ChannelSystem optimal;
+
+    public static ChannelSystem getOptimal() {
+        if (optimal == null) {
+            optimal = EPOLL.isAvailable() ? EPOLL : NIO;
+        }
+        return optimal;
+    }
+
+}

--- a/transport/src/main/java/io/netty/bootstrap/ChannelSystem.java
+++ b/transport/src/main/java/io/netty/bootstrap/ChannelSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2019 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -187,6 +187,12 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
     }
 
     @Override
+    public ServerBootstrap setChannelSystem(ChannelSystem channelSystem) {
+        channel(channelSystem.getServerChannelClass());
+        return super.setChannelSystem(channelSystem);
+    }
+
+    @Override
     public ServerBootstrap validate() {
         super.validate();
         if (childHandler == null) {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -196,6 +196,9 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
             logger.warn("childGroup is not set. Using parentGroup instead.");
             childGroup = config.group();
         }
+        if (channelFactory == null) {
+            channel(ChannelSystem.getOptimal().getServerChannelClass());
+        }
         return this;
     }
 


### PR DESCRIPTION
Motivation:
Creating Bootstraps is harder than it must. Many people don't use EPOLL because they dont't know about it or don't want to check it EPOLL is available or if KQUEUE is available. But it also makes it easier to change the Bootstrap to a specific channel type.

Modification:
Added the ChannelSystem enum and Bootstrap#setChannelSystem(ChannelSystem).

Result:
This should make working with netty mush easier for simple projects and big projects. It should also improve performance because you don't need to change LoopGroup and ChannelType based on environment. 

This PR should not break anything and as 100% backward compatibility.
I didn't add KQUEUE but I will add it if you like the basic idea.

The ChannelSystem enum would be allot easier if we could use transport-native.