### PR TITLE
Add docker-compose config to run build with OpenJ9 JVM

### DIFF
--- a/docker/docker-compose.centos-6.openj9111.yaml
+++ b/docker/docker-compose.centos-6.openj9111.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-openj9-1.11
+    build:
+      args:
+        centos_version : "6"
+        java_version : "adopt-openj9@1.11.0-2"
+
+  test:
+    image: netty:centos-6-openj9-1.11
+
+  test-leak:
+    image: netty:centos-6-openj9-1.11
+
+  test-boringssl-static:
+    image: netty:centos-6-openj9-1.11
+
+  shell:
+    image: netty:centos-6-openj9-1.11


### PR DESCRIPTION
Motivation:

To ensure Netty works on different JVMs we should also run tests on the CI with these.

Modifications:

Add docker-compose config to run build with OpenJ9 JVM

Result:

Ensure Netty works with different JVMs