### PR TITLE
Use maven plugin to prevent API/ABI breakage as part of build process

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <generatedSourceDir>${project.build.directory}/src</generatedSourceDir>
     <dependencyVersionsDir>${project.build.directory}/versions</dependencyVersionsDir>
+    <skipJapicmp>true</skipJapicmp>
   </properties>
 
   <profiles>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -57,7 +57,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-handler</artifactId>
       <version>${project.version}</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.jcraft</groupId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -29,6 +29,9 @@
 
   <name>Netty/Example</name>
 
+  <properties>
+    <skipJapicmp>true</skipJapicmp>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -172,7 +172,7 @@ public final class HttpProxyHandler extends ProxyHandler {
     }
 
     @Override
-    protected boolean handleResponse(ChannelHandlerContext ctx, Object response) throws HttpProxyConnectException {
+    protected boolean handleResponse(ChannelHandlerContext ctx, Object response) throws Exception {
         if (response instanceof HttpResponse) {
             if (status != null) {
                 throw new HttpProxyConnectException(exceptionMessage("too many responses"), /*headers=*/ null);

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -38,8 +38,8 @@
     <!-- This only be set when run on mac as on other platforms we just want to include the jar without native
          code -->
     <kqueue.classifier />
+    <skipJapicmp>true</skipJapicmp>
   </properties>
-
   <profiles>
     <profile>
       <id>linux</id>

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,7 @@
     <skipOsgiTestsuite>false</skipOsgiTestsuite>
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
+    <skipJapicmp>false</skipJapicmp>
   </properties>
 
   <modules>
@@ -670,6 +671,36 @@
     </extensions>
 
     <plugins>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>0.13.1</version>
+        <configuration>
+          <parameter>
+            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+            <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+            <oldVersionPattern>\d+\.\d+\.\d+\.Final</oldVersionPattern>
+            <ignoreMissingClassesByRegularExpressions>
+              <!-- ignore everything which is not part of netty itself as the plugin can not handle optional dependencies -->
+              <ignoreMissingClassesByRegularExpression>^(?!io\.netty\.).*</ignoreMissingClassesByRegularExpression>
+              <ignoreMissingClassesByRegularExpression>^io\.netty\.internal\.tcnative\..*</ignoreMissingClassesByRegularExpression>
+            </ignoreMissingClassesByRegularExpressions>
+            <excludes>
+              <exclude>io.netty.util.internal</exclude>
+              <exclude>@io.netty.util.internal.UnstableApi</exclude>
+            </excludes>
+          </parameter>
+          <skip>${skipJapicmp}</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>${enforcer.plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -686,7 +686,6 @@
               <ignoreMissingClassesByRegularExpression>^io\.netty\.internal\.tcnative\..*</ignoreMissingClassesByRegularExpression>
             </ignoreMissingClassesByRegularExpressions>
             <excludes>
-              <exclude>io.netty.util.internal</exclude>
               <exclude>@io.netty.util.internal.UnstableApi</exclude>
             </excludes>
           </parameter>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Testsuite/Autobahn</name>
 
+  <properties>
+    <skipJapicmp>true</skipJapicmp>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Testsuite/Http2</name>
 
+  <properties>
+    <skipJapicmp>true</skipJapicmp>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <exam.version>4.13.0</exam.version>
     <argLine.java9.extras>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED</argLine.java9.extras>
+    <skipJapicmp>true</skipJapicmp>
   </properties>
 
   <profiles>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -38,6 +38,7 @@
 
     <jarName>${project.artifactId}-${project.version}.jar</jarName>
     <shadedPackagePrefix>io.netty.</shadedPackagePrefix>
+    <skipJapicmp>true</skipJapicmp>
   </properties>
 
   <build>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -104,6 +104,7 @@
   <properties>
     <!-- Needed for SSL tests as these use the SelfSignedCertificate --> 
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
+    <skipJapicmp>true</skipJapicmp>
   </properties>
 
   <build>


### PR DESCRIPTION
Motivation:

Netty is very widely used which can lead to a lot of pain when we break API / ABI. We should make use japicmp-maven-plugin during the build to verify we do not introduce breakage by mistake.

Modifications:

- Add japicmp-maven-plugin to the build process
- Fix a method signature change in HttpProxyHandler that was flagged as a possible problem.

Result:

Ensure no API/ABI breakage accour between releases.