### PR TITLE
Other ByteToMessageDecoder streamlining

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -449,7 +449,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 // If it was removed, it is not safe to continue to operate on the buffer.
                 //
                 // See https://github.com/netty/netty/issues/1664
-                if (ctx.isRemoved()) {
+                if (isRemoved()) {
                     break;
                 }
 

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -81,7 +81,8 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
         @Override
         public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
             int discardable = cumulation.readerIndex();
-            if (cumulation.writerIndex() == discardable && !(in instanceof CompositeByteBuf)) {
+            if (cumulation.writerIndex() == discardable && in.isContiguous()) {
+                // If cumulation is empty and input buffer is contiguous, use it directly
                 cumulation.release();
                 return in;
             }

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -83,7 +83,9 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             try {
                 int required = in.readableBytes();
                 int discardable = cumulation.readerIndex();
-                int remaining = cumulation.maxCapacity() - cumulation.writerIndex();
+                // If discardable == 0 then we allow the buffer resize itself internally (equivalent to explicit
+                // allocation + copy but cheaper)
+                int remaining = discardable > 0 ? cumulation.maxFastWritableBytes() : cumulation.maxWritableBytes();
                 if ((remaining + discardable) < required || cumulation.refCnt() > 1 || cumulation.isReadOnly()) {
                     // Expand cumulation (by replace it) when either there is not more room in the buffer
                     // or if the refCnt is greater then 1 which may happen when the user use slice().retain() or

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -255,20 +255,23 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             decodeState = STATE_HANDLER_REMOVED_PENDING;
             return;
         }
-        ByteBuf buf = cumulation;
-        if (buf != null) {
-            // Directly set this to null so we are sure we not access it in any other method here anymore.
-            cumulation = null;
-            int readable = buf.readableBytes();
-            if (readable > 0) {
-                ctx.fireChannelRead(buf);
-                ctx.fireChannelReadComplete();
-            } else {
-                buf.release();
+        try {
+            ByteBuf buf = cumulation;
+            if (buf != null) {
+                // Directly set this to null so we are sure we not access it in any other method here anymore.
+                cumulation = null;
+                int readable = buf.readableBytes();
+                if (readable > 0) {
+                    ctx.fireChannelRead(buf);
+                    ctx.fireChannelReadComplete();
+                } else {
+                    buf.release();
+                }
             }
+            handlerRemoved0(ctx);
+        } finally {
+            decodeState = STATE_REMOVED;
         }
-        handlerRemoved0(ctx);
-        decodeState = STATE_REMOVED;
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -138,6 +138,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 if (in != null) {
                     // We must release if the ownership was not transferred as otherwise it may produce a leak
                     in.release();
+                    // Also release any new buffer allocated if we're not returning it
                     if (composite != null && composite != cumulation) {
                         composite.release();
                     }

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -354,7 +354,7 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
                     //
                     // See:
                     // - https://github.com/netty/netty/issues/4635
-                    if (ctx.isRemoved()) {
+                    if (isRemoved()) {
                         break;
                     }
                     outSize = 0;
@@ -369,7 +369,7 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
                     // If it was removed, it is not safe to continue to operate on the buffer.
                     //
                     // See https://github.com/netty/netty/issues/1664
-                    if (ctx.isRemoved()) {
+                    if (isRemoved()) {
                         break;
                     }
 
@@ -391,7 +391,7 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
                     // If it was removed, it is not safe to continue to operate on the buffer.
                     //
                     // See https://github.com/netty/netty/issues/1664
-                    if (ctx.isRemoved()) {
+                    if (isRemoved()) {
                         break;
                     }
 

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -337,6 +337,10 @@ public class ByteToMessageDecoderTest {
             public CompositeByteBuf addComponent(boolean increaseWriterIndex, ByteBuf buffer) {
                 throw error;
             }
+            @Override
+            public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+                throw error;
+            }
         };
         ByteBuf in = Unpooled.buffer().writeZero(12);
         try {

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -317,7 +317,7 @@ public class ByteToMessageDecoderTest {
             public ByteBuf writeBytes(ByteBuf src) {
                 throw error;
             }
-        };
+        }.writeZero(1);
         ByteBuf in = Unpooled.buffer().writeZero(12);
         try {
             ByteToMessageDecoder.MERGE_CUMULATOR.cumulate(UnpooledByteBufAllocator.DEFAULT, cumulation, in);
@@ -341,7 +341,7 @@ public class ByteToMessageDecoderTest {
             public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
                 throw error;
             }
-        };
+        }.writeZero(1);
         ByteBuf in = Unpooled.buffer().writeZero(12);
         try {
             ByteToMessageDecoder.COMPOSITE_CUMULATOR.cumulate(UnpooledByteBufAllocator.DEFAULT, cumulation, in);

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -816,7 +816,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             final int wrapDataSize = this.wrapDataSize;
             // Only continue to loop if the handler was not removed in the meantime.
             // See https://github.com/netty/netty/issues/5860
-            outer: while (!ctx.isRemoved()) {
+            outer: while (!isRemoved()) {
                 promise = ctx.newPromise();
                 buf = wrapDataSize > 0 ?
                         pendingUnencryptedWrites.remove(alloc, wrapDataSize, promise) :
@@ -927,7 +927,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         try {
             // Only continue to loop if the handler was not removed in the meantime.
             // See https://github.com/netty/netty/issues/5860
-            outer: while (!ctx.isRemoved()) {
+            outer: while (!isRemoved()) {
                 if (out == null) {
                     // As this is called for the handshake we have no real idea how big the buffer needs to be.
                     // That said 2048 should give us enough room to include everything like ALPN / NPN data.
@@ -1328,7 +1328,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         try {
             // Only continue to loop if the handler was not removed in the meantime.
             // See https://github.com/netty/netty/issues/5860
-            unwrapLoop: while (!ctx.isRemoved()) {
+            unwrapLoop: while (!isRemoved()) {
                 final SSLEngineResult result = engineType.unwrap(this, packet, offset, length, decodeOut);
                 final Status status = result.getStatus();
                 final HandshakeStatus handshakeStatus = result.getHandshakeStatus();


### PR DESCRIPTION
Motivation

While inspecting `ByteToMessageDecoder` during review of #8890 I noticed some other possibilities for optimization. These are independent of and should be complimentary to the changes under discussion in that PR.

Modifications

- Introduce local `STATE_REMOVED` state and use this in preference to `ctx.isRemoved()` to check for handler removal on the event loop (avoiding some volatile reads)
- Avoid allocating new buffer in `MERGE_CUMULATOR` if there is room after shifting existing live bytes
- Avoid copying bytes in `COMPOSITE_CUMULATOR` in all cases, performing a shallow copy instead when necessary; also guard against (unusual) case where input buffer is composite with writer index != capacity
- Optimize some related parts of `CompositeByteBuf` - in particular the discardReadBytes / discardReadComponents logic
- Integrate read-bytes discarding decision into cumulation logic and have it based on size of accumulated bytes - this is more of an RFC but to me makes more logical sense since in many cases the discard happens naturally (e.g. when a new buffer is used) and we are trying to guard against growth of unused bytes. It also means some fields and the counting logic can be removed. I have set the threshold to 1024 for now, maybe it could be made overridable similar to `setDiscardAfterReads` (assuming we go with this approach at all).

Result

Less copying/allocation in some existing cases, fewer volatile reads, simplified read-bytes discard logic.