### PR TITLE
Add docker-sync config to step up docker-usage on macOS.

### DIFF
--- a/docker/docker-sync-compose.centos-6.18.yaml
+++ b/docker/docker-sync-compose.centos-6.18.yaml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-1.8
+    build:
+      args:
+        centos_version : "6"
+        java_version : "1.8.202"
+
+  test:
+    image: netty:centos-6-1.8
+    volumes:
+      - code-sync:/code:nocopy
+
+  test-leak:
+    image: netty:centos-6-1.8
+    volumes:
+      - code-sync:/code:nocopy
+
+  test-boringssl-static:
+    image: netty:centos-6-1.8
+    volumes:
+      - code-sync:/code:nocopy
+
+  shell:
+    image: netty:centos-6-1.8
+    volumes:
+      - code-sync:/code:nocopy
+
+volumes:
+  code-sync:
+    external: true

--- a/docker/docker-sync.centos-6.18.yaml
+++ b/docker/docker-sync.centos-6.18.yaml
@@ -1,0 +1,8 @@
+version: "2"
+
+compose-dev-file-path: 'docker-sync-compose.centos-6.18.yaml'
+
+syncs:
+  #IMPORTANT: ensure this name is unique and does not match your other application container name
+  code-sync: #tip: add -sync and you keep consistent names as a convention
+    src: '../'


### PR DESCRIPTION
Motivation:

docker-sync.io helps to speed up docker FS access on macOS and so make builds there a lot faster. We should add some config to help users use it.

Modifications:

Add docker-sync configs for centos-6.18 which is what we use for releases.

Result:

Faster builds via docker and when using macOS possible.