### PR TITLE
Remove old internal code that is not used anymore after removing usag…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -139,33 +139,7 @@ public class FastThreadLocal<V> {
             return (V) v;
         }
 
-        V value = initialize(threadLocalMap);
-        registerCleaner(threadLocalMap);
-        return value;
-    }
-
-    private void registerCleaner(final InternalThreadLocalMap threadLocalMap) {
-        Thread current = Thread.currentThread();
-        if (FastThreadLocalThread.willCleanupFastThreadLocals(current) || threadLocalMap.isCleanerFlagSet(index)) {
-            return;
-        }
-
-        threadLocalMap.setCleanerFlag(index);
-
-        // TODO: We need to find a better way to handle this.
-        /*
-        // We will need to ensure we will trigger remove(InternalThreadLocalMap) so everything will be released
-        // and FastThreadLocal.onRemoval(...) will be called.
-        ObjectCleaner.register(current, new Runnable() {
-            @Override
-            public void run() {
-                remove(threadLocalMap);
-
-                // It's fine to not call InternalThreadLocalMap.remove() here as this will only be triggered once
-                // the Thread is collected by GC. In this case the ThreadLocal will be gone away already.
-            }
-        });
-        */
+        return initialize(threadLocalMap);
     }
 
     /**
@@ -201,9 +175,7 @@ public class FastThreadLocal<V> {
     public final void set(V value) {
         if (value != InternalThreadLocalMap.UNSET) {
             InternalThreadLocalMap threadLocalMap = InternalThreadLocalMap.get();
-            if (setKnownNotUnset(threadLocalMap, value)) {
-                registerCleaner(threadLocalMap);
-            }
+            setKnownNotUnset(threadLocalMap, value);
         } else {
             remove();
         }
@@ -223,12 +195,10 @@ public class FastThreadLocal<V> {
     /**
      * @return see {@link InternalThreadLocalMap#setIndexedVariable(int, Object)}.
      */
-    private boolean setKnownNotUnset(InternalThreadLocalMap threadLocalMap, V value) {
+    private void setKnownNotUnset(InternalThreadLocalMap threadLocalMap, V value) {
         if (threadLocalMap.setIndexedVariable(index, value)) {
             addToVariablesToRemove(threadLocalMap, this);
-            return true;
         }
-        return false;
     }
 
     /**


### PR DESCRIPTION
…e of ObjectCleaner

Motivation:

We dont use ObjectCleaner in our FastThreadLocal / InternalThreadLocalMap anymore so we also dont need to take special care to store it there anymore.

Modifications:

Remove code that is not needed anymore.

Result:

Code cleanup.