### PR TITLE
Ability to interrupt/suspend reading without having to disable auto r…

### DIFF
--- a/codec-http/src/test/java/io/netty/channel/InterruptReadingTest.java
+++ b/codec-http/src/test/java/io/netty/channel/InterruptReadingTest.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.util.ReferenceCountUtil;
+
+/**
+ * This set of unit tests shows some aspects of {@link ChannelConfig#interruptReading()} by making use of
+ * HTTP Pipelining.
+ */
+public class InterruptReadingTest {
+
+    private static final int RANDOM_PORT = 0;
+
+    private static final int NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD = 1000;
+
+    private static EventLoopGroup GROUP;
+
+    @BeforeClass
+    public static void init() {
+        GROUP = new NioEventLoopGroup();
+    }
+
+    @AfterClass
+    public static void destroy() {
+        GROUP.shutdownGracefully();
+    }
+
+    /**
+     * This unit test shows a naive way of trying to implement flow-control in Netty by overriding
+     * the {@link ChannelOutboundHandler#read(ChannelHandlerContext)} method with the intent to
+     * suppress read operations.
+     *
+     * It will not work because an attacker can keep our receive buffers filled.
+     */
+    @Test(timeout = 5000L)
+    public void testAttemptDisablingRead() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountDownLatch latch = new CountDownLatch(NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+
+        Channel server = newServer(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ChannelPipeline pipeline = ch.pipeline();
+
+                pipeline.addLast(new HttpServerCodec());
+                pipeline.addLast(new ChannelDuplexHandler() {
+                    private boolean reading = true;
+
+                    @Override
+                    public void read(ChannelHandlerContext ctx) throws Exception {
+                        if (reading) {
+                            ctx.read();
+                        }
+                    }
+
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                        ReferenceCountUtil.release(msg);
+
+                        if (msg instanceof HttpRequest) {
+                            counter.incrementAndGet();
+                            latch.countDown();
+
+                            //
+                            // This is a futile attempt because deep down in the guts of the Channel
+                            // implementation there is a loop which will consume all available bytes
+                            // and the only way to break out of it is to disable auto reading or when
+                            // all bytes have been consumed.
+                            //
+                            // If you wanted to implement flow-control this way you're vulnerable to
+                            // things like HTTP pipelining because it's easy to squeeze 100s if not
+                            // a thousand(s) HTTP requests (speaking in terms of bytes) into the socket's
+                            // receive buffer and Netty will happily decode them into higher level POJOs.
+                            //
+                            reading = false;
+                        }
+                    }
+                });
+            }
+        });
+
+        try {
+            InetSocketAddress address = (InetSocketAddress) server.localAddress();
+            Channel client = newClient(address, new ChannelInboundHandlerAdapter() {
+            });
+
+            try {
+                ByteBuf request = newRequest(NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+                client.writeAndFlush(request).sync();
+
+                boolean complete = latch.await(1L, TimeUnit.SECONDS);
+                int count = counter.get();
+
+                // Disabling the read(...) method has no effect because Netty has no reason to exit its
+                // internal reader loop and we end up reading all NUMBER_OF_REQUESTS.
+                assertTrue("count=" + count, complete);
+                assertEquals("count=" + count, NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD, count);
+            } finally {
+                client.close().sync();
+            }
+        } finally {
+            server.close().sync();
+        }
+    }
+
+    /**
+     * This unit test is demonstrating that it's working with {@link ChannelConfig#setAutoRead(boolean)}
+     * but it's conceptually strange that one has to disable auto reading to make it work.
+     */
+    @Test(timeout = 5000L)
+    public void testDisableAutoReading() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountDownLatch latch = new CountDownLatch(NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+
+        Channel server = newServer(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ChannelPipeline pipeline = ch.pipeline();
+
+                pipeline.addLast(new HttpServerCodec());
+                pipeline.addLast(new ChannelDuplexHandler() {
+                    private boolean reading = true;
+
+                    @Override
+                    public void read(ChannelHandlerContext ctx) throws Exception {
+                        if (reading) {
+                            ctx.read();
+                        }
+                    }
+
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                        ReferenceCountUtil.release(msg);
+
+                        if (msg instanceof HttpRequest) {
+                            counter.incrementAndGet();
+                            latch.countDown();
+
+                            // Disabling auto reading works but it gets tricky with complex pipelines
+                            // and if there is more than one handler that fiddles with auto reading.
+                            // How do handlers coordinate amongst each other when to enable reading?
+                            //
+                            // Wouldn't it be better if you could think of your pipeline something like
+                            // an OSI layers stack and each handler can make their own local decisions?
+                            reading = false;
+                            ctx.channel().config().setAutoRead(false);
+                        }
+                    }
+                });
+            }
+        });
+
+        try {
+            InetSocketAddress address = (InetSocketAddress) server.localAddress();
+            Channel client = newClient(address, new ChannelInboundHandlerAdapter() {
+            });
+
+            try {
+                // A bunch of HTTP requests concatenated together.
+                ByteBuf request = newRequest(NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+                client.writeAndFlush(request).sync();
+
+                boolean complete = latch.await(1L, TimeUnit.SECONDS);
+                int count = counter.get();
+
+                assertFalse("count=" + count, complete);
+                assertTrue("count=" + count, count > 1 && count < NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+            } finally {
+                client.close().sync();
+            }
+        } finally {
+            server.close().sync();
+        }
+    }
+
+    /**
+     * This unit test shows basic {@link ChannelConfig#interruptReading()} without disabling
+     * auto reading.
+     */
+    @Test(timeout = 5000L)
+    public void testBasicInterruptReading() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountDownLatch latch = new CountDownLatch(NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+
+        Channel server = newServer(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ChannelPipeline pipeline = ch.pipeline();
+
+                pipeline.addLast(new HttpServerCodec());
+                pipeline.addLast(new ChannelDuplexHandler() {
+                    private boolean reading = true;
+                    @Override
+                    public void read(ChannelHandlerContext ctx) throws Exception {
+                        if (reading) {
+                            ctx.read();
+                        }
+                    }
+
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                        ReferenceCountUtil.release(msg);
+
+                        if (msg instanceof HttpRequest) {
+                            counter.incrementAndGet();
+                            latch.countDown();
+
+                            // Break out of the reader loop without outright disabling auto reading!
+                            reading = false;
+                            ctx.channel().config().interruptReading();
+                        }
+                    }
+                });
+            }
+        });
+
+        try {
+            InetSocketAddress address = (InetSocketAddress) server.localAddress();
+            Channel client = newClient(address, new ChannelInboundHandlerAdapter() {
+            });
+
+            try {
+                // A bunch of HTTP requests concatenated together.
+                ByteBuf request = newRequest(NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+                client.writeAndFlush(request).sync();
+
+                boolean complete = latch.await(1L, TimeUnit.SECONDS);
+                int count = counter.get();
+
+                assertFalse("count=" + count, complete);
+                assertTrue("count=" + count, count > 1 && count < NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+            } finally {
+                client.close().sync();
+            }
+        } finally {
+            server.close().sync();
+        }
+    }
+
+    /**
+     * Same as {@link #testBasicInterruptReading()} but with the addition of {@link Channel#read()}
+     * and showing that a handler can break out of reading and can suppress further reading without
+     * having to wield the global auto reading flag.
+     */
+    @Test(timeout = 5000L)
+    public void testAdvancedInterruptReading() throws Exception {
+        final AtomicBoolean reading = new AtomicBoolean(true);
+        final AtomicReference<Channel> peerRef = new AtomicReference<Channel>();
+        final AtomicInteger counter = new AtomicInteger();
+        final CountDownLatch latch = new CountDownLatch(NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+
+        Channel server = newServer(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ChannelPipeline pipeline = ch.pipeline();
+
+                pipeline.addLast(new HttpServerCodec());
+                pipeline.addLast(new ChannelDuplexHandler() {
+                    @Override
+                    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                        peerRef.set(ctx.channel());
+                        ctx.fireChannelActive();
+                    }
+
+                    @Override
+                    public void read(ChannelHandlerContext ctx) throws Exception {
+                        if (reading.get()) {
+                            ctx.read();
+                        }
+                    }
+
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                        ReferenceCountUtil.release(msg);
+
+                        if (msg instanceof HttpRequest) {
+                            counter.incrementAndGet();
+                            latch.countDown();
+
+                            // Break out of reading without outright disabling auto reading.
+                            reading.set(false);
+                            ctx.channel().config().interruptReading();
+                        }
+                    }
+                });
+            }
+        });
+
+        try {
+            InetSocketAddress address = (InetSocketAddress) server.localAddress();
+            Channel client = newClient(address, new ChannelInboundHandlerAdapter() {
+            });
+
+            try {
+                // A bunch of HTTP requests concatenated together.
+                ByteBuf request = newRequest(NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+                client.writeAndFlush(request).sync();
+
+                boolean complete1 = latch.await(1L, TimeUnit.SECONDS);
+                int count1 = counter.get();
+
+                assertFalse("count=" + count1, complete1);
+                assertTrue("count=" + count1, count1 > 1 && count1 < NUMBER_OF_REQUESTS_IN_ONE_PAYLOAD);
+
+                // The reading flag should be false.
+                assertFalse(reading.get());
+
+                // Let's try to call read() but one of the handlers in the pipeline is suppressing it.
+                Channel peer = peerRef.get();
+                peer.read();
+
+                // Verify the above statement. Nothing should have changed. The read() call got intercepted
+                // by the handler and no new bytes were consumed from the buffers or network wire.
+                boolean complete2 = latch.await(1L, TimeUnit.SECONDS);
+                int count2 = counter.get();
+
+                assertFalse("count=" + count2, complete2);
+                assertEquals(count1, count2);
+
+                // Let's try it again. This time we're changing the handler's flag which suppresses reading
+                // and it should work as expected.
+                reading.set(true);
+                peer.read();
+
+                boolean complete3 = latch.await(1L, TimeUnit.SECONDS);
+                int count3 = counter.get();
+
+                assertFalse("count=" + count3, complete3);
+                assertTrue("count=" + count3, count3 > count1);
+
+                assertFalse(reading.get());
+            } finally {
+                client.close().sync();
+            }
+        } finally {
+            server.close().sync();
+        }
+    }
+
+    private static Channel newServer(ChannelHandler handler) throws Exception {
+        ServerBootstrap bootstrap = new ServerBootstrap();
+
+        bootstrap.channel(NioServerSocketChannel.class)
+                .group(GROUP)
+                .option(ChannelOption.SO_REUSEADDR, true)
+                .childHandler(handler);
+
+        return bootstrap.bind(RANDOM_PORT).sync().channel();
+    }
+
+    private static Channel newClient(InetSocketAddress address, ChannelHandler handler)
+            throws Exception {
+        Bootstrap bootstrap = new Bootstrap();
+
+        bootstrap.channel(NioSocketChannel.class)
+                .group(GROUP)
+                .option(ChannelOption.SO_REUSEADDR, true)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .handler(handler);
+
+        return bootstrap.connect("localhost", address.getPort()).sync().channel();
+    }
+
+    private static ByteBuf newRequest(int count) {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < count; i++) {
+            sb.append("GET /hello HTTP/1.1\r\n")
+                .append("host: example.com\r\n")
+                .append("\r\n");
+        }
+
+        String value = sb.toString();
+        return Unpooled.wrappedBuffer(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/codec-http/src/test/java/io/netty/channel/InterruptibleTest.java
+++ b/codec-http/src/test/java/io/netty/channel/InterruptibleTest.java
@@ -43,10 +43,10 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.util.ReferenceCountUtil;
 
 /**
- * This set of unit tests shows some aspects of {@link ChannelConfig#interruptReading()} by making use of
+ * This set of unit tests shows some aspects of {@link Interruptible#interrupt()} by making use of
  * HTTP Pipelining.
  */
-public class InterruptReadingTest {
+public class InterruptibleTest {
 
     private static final int RANDOM_PORT = 0;
 
@@ -213,7 +213,7 @@ public class InterruptReadingTest {
     }
 
     /**
-     * This unit test shows basic {@link ChannelConfig#interruptReading()} without disabling
+     * This unit test shows basic {@link Interruptible#interrupt()} without disabling
      * auto reading.
      */
     @Test(timeout = 5000L)
@@ -246,7 +246,7 @@ public class InterruptReadingTest {
 
                             // Break out of the reader loop without outright disabling auto reading!
                             reading = false;
-                            ctx.channel().config().interruptReading();
+                            ((Interruptible) ctx.channel()).interrupt();
                         }
                     }
                 });
@@ -318,7 +318,7 @@ public class InterruptReadingTest {
 
                             // Break out of reading without outright disabling auto reading.
                             reading.set(false);
-                            ctx.channel().config().interruptReading();
+                            ((Interruptible) ctx.channel()).interrupt();
                         }
                     }
                 });

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -247,7 +247,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 ((SocketChannelConfig) config).isAllowHalfClosure();
     }
 
-    boolean interrupted() {
+    final boolean interrupted() {
       if (interrupted) {
         interrupted = false;
         return true;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -103,6 +103,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
             epollInBefore();
 
             Throwable exception = null;
+            boolean interrupted = false;
             try {
                 try {
                     do {
@@ -119,7 +120,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                         readPending = false;
                         pipeline.fireChannelRead(newChildChannel(allocHandle.lastBytesRead(), acceptedAddress, 1,
                                                                  acceptedAddress[0]));
-                    } while (allocHandle.continueReading());
+                    } while (!(interrupted = interrupted()) && allocHandle.continueReading());
                 } catch (Throwable t) {
                     exception = t;
                 }
@@ -130,7 +131,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                     pipeline.fireExceptionCaught(exception);
                 }
             } finally {
-                epollInFinally(config);
+                epollInFinally(config, interrupted);
             }
         }
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -758,6 +758,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
             ByteBuf byteBuf = null;
             boolean close = false;
+            boolean interrupted = false;
             try {
                 do {
                     if (spliceQueue != null) {
@@ -810,7 +811,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                         //   was "wrapped" by this Channel implementation.
                         break;
                     }
-                } while (allocHandle.continueReading());
+                } while (!(interrupted = interrupted()) && allocHandle.continueReading());
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
@@ -821,7 +822,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             } catch (Throwable t) {
                 handleReadException(pipeline, byteBuf, t, close, allocHandle);
             } finally {
-                epollInFinally(config);
+                epollInFinally(config, interrupted);
             }
         }
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -175,11 +175,6 @@ public class EpollChannelConfig extends DefaultChannelConfig {
         }
     }
 
-    @Override
-    public void interruptReading() {
-      ((AbstractEpollChannel) channel).interruptReading();
-    }
-
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {
         this.maxBytesPerGatheringWrite = maxBytesPerGatheringWrite;
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -176,8 +176,8 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     }
 
     @Override
-    protected final void autoReadCleared() {
-        ((AbstractEpollChannel) channel).clearEpollIn();
+    public void interruptReading() {
+      ((AbstractEpollChannel) channel).interruptReading();
     }
 
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -450,6 +450,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             epollInBefore();
 
             Throwable exception = null;
+            boolean interrupted = false;
             try {
                 ByteBuf byteBuf = null;
                 try {
@@ -513,7 +514,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                         pipeline.fireChannelRead(packet);
 
                         byteBuf = null;
-                    } while (allocHandle.continueReading());
+                    } while (!(interrupted = interrupted()) && allocHandle.continueReading());
                 } catch (Throwable t) {
                     if (byteBuf != null) {
                         byteBuf.release();
@@ -528,7 +529,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                     pipeline.fireExceptionCaught(exception);
                 }
             } finally {
-                epollInFinally(config);
+                epollInFinally(config, interrupted);
             }
         }
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -158,6 +158,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
             allocHandle.reset(config);
             epollInBefore();
 
+            boolean interrupted = false;
             try {
                 readLoop: do {
                     // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
@@ -176,7 +177,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
                         pipeline.fireChannelRead(new FileDescriptor(allocHandle.lastBytesRead()));
                         break;
                     }
-                } while (allocHandle.continueReading());
+                } while (!(interrupted = interrupted()) && allocHandle.continueReading());
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
@@ -185,7 +186,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
                 pipeline.fireChannelReadComplete();
                 pipeline.fireExceptionCaught(t);
             } finally {
-                epollInFinally(config);
+                epollInFinally(config, interrupted);
             }
         }
     }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -297,7 +297,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
                 ((SocketChannelConfig) config).isAllowHalfClosure();
     }
 
-    boolean interrupted() {
+    final boolean interrupted() {
         if (interrupted) {
           interrupted = false;
           return true;

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
@@ -96,6 +96,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
             readReadyBefore();
 
             Throwable exception = null;
+            boolean interrupted = false;
             try {
                 try {
                     do {
@@ -111,7 +112,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
                         readPending = false;
                         pipeline.fireChannelRead(newChildChannel(acceptFd, acceptedAddress, 1,
                                                                  acceptedAddress[0]));
-                    } while (allocHandle.continueReading());
+                    } while (!(interrupted = interrupted()) && allocHandle.continueReading());
                 } catch (Throwable t) {
                     exception = t;
                 }
@@ -122,7 +123,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
                     pipeline.fireExceptionCaught(exception);
                 }
             } finally {
-                readReadyFinally(config);
+                readReadyFinally(config, interrupted);
             }
         }
     }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -522,6 +522,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
 
             ByteBuf byteBuf = null;
             boolean close = false;
+            boolean interrupted = false;
             try {
                 do {
                     // we use a direct buffer here as the native implementations only be able
@@ -558,7 +559,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
                         //   was "wrapped" by this Channel implementation.
                         break;
                     }
-                } while (allocHandle.continueReading());
+                } while (!(interrupted = interrupted()) && allocHandle.continueReading());
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
@@ -569,7 +570,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
             } catch (Throwable t) {
                 handleReadException(pipeline, byteBuf, t, close, allocHandle);
             } finally {
-                readReadyFinally(config);
+                readReadyFinally(config, interrupted);
             }
         }
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
@@ -150,11 +150,6 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
         return this;
     }
 
-    @Override
-    public void interruptReading() {
-        ((AbstractKQueueChannel) channel).interruptReading();
-    }
-
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {
         this.maxBytesPerGatheringWrite = min(SSIZE_MAX, maxBytesPerGatheringWrite);
     }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
@@ -151,8 +151,8 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     }
 
     @Override
-    protected final void autoReadCleared() {
-        ((AbstractKQueueChannel) channel).clearReadFilter();
+    public void interruptReading() {
+        ((AbstractKQueueChannel) channel).interruptReading();
     }
 
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -421,6 +421,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
             readReadyBefore();
 
             Throwable exception = null;
+            boolean interrupted = false;
             try {
                 ByteBuf byteBuf = null;
                 try {
@@ -484,7 +485,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
                         pipeline.fireChannelRead(packet);
 
                         byteBuf = null;
-                    } while (allocHandle.continueReading());
+                    } while (!(interrupted = interrupted()) && allocHandle.continueReading());
                 } catch (Throwable t) {
                     if (byteBuf != null) {
                         byteBuf.release();
@@ -499,7 +500,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
                     pipeline.fireExceptionCaught(exception);
                 }
             } finally {
-                readReadyFinally(config);
+                readReadyFinally(config, interrupted);
             }
         }
     }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -150,6 +150,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
             allocHandle.reset(config);
             readReadyBefore();
 
+            boolean interrupted = false;
             try {
                 readLoop: do {
                     // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
@@ -171,7 +172,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
                             pipeline.fireChannelRead(new FileDescriptor(recvFd));
                             break;
                     }
-                } while (allocHandle.continueReading());
+                } while (!(interrupted = interrupted()) && allocHandle.continueReading());
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
@@ -180,7 +181,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
                 pipeline.fireChannelReadComplete();
                 pipeline.fireExceptionCaught(t);
             } finally {
-                readReadyFinally(config);
+                readReadyFinally(config, interrupted);
             }
         }
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -392,10 +392,5 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
         private NioSctpChannelConfig(NioSctpChannel channel, SctpChannel javaChannel) {
             super(channel, javaChannel);
         }
-
-        @Override
-        public void interruptReading() {
-            ((NioSctpChannel) channel).interruptReading();
-        }
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -394,8 +394,8 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
         }
 
         @Override
-        protected void autoReadCleared() {
-            clearReadPending();
+        public void interruptReading() {
+            ((NioSctpChannel) channel).interruptReading();
         }
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -232,8 +232,8 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
         }
 
         @Override
-        protected void autoReadCleared() {
-            clearReadPending();
+        public void interruptReading() {
+            ((NioSctpServerChannel) channel).interruptReading();
         }
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -230,10 +230,5 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
         private NioSctpServerChannelConfig(NioSctpServerChannel channel, SctpServerChannel javaChannel) {
             super(channel, javaChannel);
         }
-
-        @Override
-        public void interruptReading() {
-            ((NioSctpServerChannel) channel).interruptReading();
-        }
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
@@ -34,6 +34,7 @@ import io.netty.channel.sctp.SctpChannelConfig;
 import io.netty.channel.sctp.SctpMessage;
 import io.netty.channel.sctp.SctpNotificationHandler;
 import io.netty.channel.sctp.SctpServerChannel;
+import io.netty.channel.sctp.nio.NioSctpChannel;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -467,8 +468,8 @@ public class OioSctpChannel extends AbstractOioMessageChannel
         }
 
         @Override
-        protected void autoReadCleared() {
-            clearReadPending();
+        public void interruptReading() {
+            ((OioSctpChannel) channel).interruptReading();
         }
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
@@ -466,10 +466,5 @@ public class OioSctpChannel extends AbstractOioMessageChannel
         private OioSctpChannelConfig(OioSctpChannel channel, SctpChannel javaChannel) {
             super(channel, javaChannel);
         }
-
-        @Override
-        public void interruptReading() {
-            ((OioSctpChannel) channel).interruptReading();
-        }
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -304,8 +304,8 @@ public class OioSctpServerChannel extends AbstractOioMessageChannel
         }
 
         @Override
-        protected void autoReadCleared() {
-            clearReadPending();
+        public void interruptReading() {
+            ((OioSctpServerChannel) channel).interruptReading();
         }
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -302,10 +302,5 @@ public class OioSctpServerChannel extends AbstractOioMessageChannel
         private OioSctpServerChannelConfig(OioSctpServerChannel channel, SctpServerChannel javaChannel) {
             super(channel, javaChannel);
         }
-
-        @Override
-        public void interruptReading() {
-            ((OioSctpServerChannel) channel).interruptReading();
-        }
     }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/ChannelConfig.java
@@ -198,13 +198,6 @@ public interface ChannelConfig {
     ChannelConfig setAutoRead(boolean autoRead);
 
     /**
-     * Interrupts the current {@code read()} operation and suspends further reading until
-     * the user calls {@code read()} again.
-     */
-    @UnstableApi
-    void interruptReading();
-
-    /**
      * Returns {@code true} if and only if the {@link Channel} will be closed automatically and immediately on
      * write failure. The default is {@code true}.
      */

--- a/transport/src/main/java/io/netty/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/ChannelConfig.java
@@ -17,6 +17,7 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.socket.SocketChannelConfig;
+import io.netty.util.internal.UnstableApi;
 
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
@@ -195,6 +196,13 @@ public interface ChannelConfig {
      * need to call it at all. The default value is {@code true}.
      */
     ChannelConfig setAutoRead(boolean autoRead);
+
+    /**
+     * Interrupts the current {@code read()} operation and suspends further reading until
+     * the user calls {@code read()} again.
+     */
+    @UnstableApi
+    void interruptReading();
 
     /**
      * Returns {@code true} if and only if the {@link Channel} will be closed automatically and immediately on

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -333,7 +333,13 @@ public class DefaultChannelConfig implements ChannelConfig {
      * Is called once {@link #setAutoRead(boolean)} is called with {@code false} and {@link #isAutoRead()} was
      * {@code true} before.
      */
-    protected void autoReadCleared() { }
+    protected void autoReadCleared() {
+        interruptReading();
+    }
+
+    @Override
+    public void interruptReading() {
+    }
 
     @Override
     public boolean isAutoClose() {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -324,9 +324,17 @@ public class DefaultChannelConfig implements ChannelConfig {
         if (autoRead && !oldAutoRead) {
             channel.read();
         } else if (!autoRead && oldAutoRead) {
-            autoReadCleared();
+            autoReadCleared0();
         }
         return this;
+    }
+
+    private void autoReadCleared0() {
+        if (channel instanceof Interruptible) {
+            ((Interruptible) channel).interrupt();
+        }
+
+        autoReadCleared();
     }
 
     /**
@@ -334,11 +342,6 @@ public class DefaultChannelConfig implements ChannelConfig {
      * {@code true} before.
      */
     protected void autoReadCleared() {
-        interruptReading();
-    }
-
-    @Override
-    public void interruptReading() {
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/Interruptible.java
+++ b/transport/src/main/java/io/netty/channel/Interruptible.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * An interface for {@link Channel} types that support the ability to interrupt and break out
+ * from an ongoing {@code read} operation and suspend further reading until {@link Channel#read()}
+ * is called.
+ */
+@UnstableApi
+public interface Interruptible {
+    void interrupt();
+}

--- a/transport/src/main/java/io/netty/channel/socket/SocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/SocketChannelConfig.java
@@ -185,5 +185,4 @@ public interface SocketChannelConfig extends ChannelConfig {
 
     @Override
     SocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
-
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -33,7 +33,6 @@ import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -595,10 +594,6 @@ public final class NioDatagramChannel
         super.setReadPending(readPending);
     }
 
-    void clearReadPending0() {
-        clearReadPending();
-    }
-
     @Override
     protected boolean closeOnReadError(Throwable cause) {
         // We do not want to close on SocketException when using DatagramChannel as we usually can continue receiving.
@@ -607,5 +602,9 @@ public final class NioDatagramChannel
             return false;
         }
         return super.closeOnReadError(cause);
+    }
+
+    final void interruptReading0() {
+        interruptReading();
     }
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -603,8 +603,4 @@ public final class NioDatagramChannel
         }
         return super.closeOnReadError(cause);
     }
-
-    void interruptReading0() {
-        interruptReading();
-    }
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -604,7 +604,7 @@ public final class NioDatagramChannel
         return super.closeOnReadError(cause);
     }
 
-    final void interruptReading0() {
+    void interruptReading0() {
         interruptReading();
     }
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannelConfig.java
@@ -179,11 +179,6 @@ class NioDatagramChannelConfig extends DefaultDatagramChannelConfig {
         return this;
     }
 
-    @Override
-    public void interruptReading() {
-        ((NioDatagramChannel) channel).interruptReading0();
-    }
-
     private Object getOption0(Object option) {
         if (GET_OPTION == null) {
             throw new UnsupportedOperationException();

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannelConfig.java
@@ -180,8 +180,8 @@ class NioDatagramChannelConfig extends DefaultDatagramChannelConfig {
     }
 
     @Override
-    protected void autoReadCleared() {
-        ((NioDatagramChannel) channel).clearReadPending0();
+    public void interruptReading() {
+        ((NioDatagramChannel) channel).interruptReading0();
     }
 
     private Object getOption0(Object option) {

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -200,8 +200,8 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
         }
 
         @Override
-        protected void autoReadCleared() {
-            clearReadPending();
+        public void interruptReading() {
+            NioServerSocketChannel.this.interruptReading();
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -200,11 +200,6 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
         }
 
         @Override
-        public void interruptReading() {
-            NioServerSocketChannel.this.interruptReading();
-        }
-
-        @Override
         public <T> boolean setOption(ChannelOption<T> option, T value) {
             if (PlatformDependent.javaVersion() >= 7 && option instanceof NioChannelOption) {
                 return NioChannelOption.setOption(jdkChannel(), (NioChannelOption<T>) option, value);

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -469,11 +469,6 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         }
 
         @Override
-        public void interruptReading() {
-            NioSocketChannel.this.interruptReading();
-        }
-
-        @Override
         public NioSocketChannelConfig setSendBufferSize(int sendBufferSize) {
             super.setSendBufferSize(sendBufferSize);
             calculateMaxBytesPerGatheringWrite();

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -469,8 +469,8 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         }
 
         @Override
-        protected void autoReadCleared() {
-            clearReadPending();
+        public void interruptReading() {
+            NioSocketChannel.this.interruptReading();
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
@@ -159,9 +159,9 @@ public class DefaultOioServerSocketChannelConfig extends DefaultServerSocketChan
     }
 
     @Override
-    protected void autoReadCleared() {
+    public void interruptReading() {
         if (channel instanceof OioServerSocketChannel) {
-            ((OioServerSocketChannel) channel).clearReadPending0();
+            ((OioServerSocketChannel) channel).interruptReading0();
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
@@ -159,13 +159,6 @@ public class DefaultOioServerSocketChannelConfig extends DefaultServerSocketChan
     }
 
     @Override
-    public void interruptReading() {
-        if (channel instanceof OioServerSocketChannel) {
-            ((OioServerSocketChannel) channel).interruptReading0();
-        }
-    }
-
-    @Override
     public OioServerSocketChannelConfig setAutoClose(boolean autoClose) {
         super.setAutoClose(autoClose);
         return this;

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
@@ -187,9 +187,9 @@ public class DefaultOioSocketChannelConfig extends DefaultSocketChannelConfig im
     }
 
     @Override
-    protected void autoReadCleared() {
+    public void interruptReading() {
         if (channel instanceof OioSocketChannel) {
-            ((OioSocketChannel) channel).clearReadPending0();
+            ((OioSocketChannel) channel).interruptReading0();
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
@@ -187,13 +187,6 @@ public class DefaultOioSocketChannelConfig extends DefaultSocketChannelConfig im
     }
 
     @Override
-    public void interruptReading() {
-        if (channel instanceof OioSocketChannel) {
-            ((OioSocketChannel) channel).interruptReading0();
-        }
-    }
-
-    @Override
     public OioSocketChannelConfig setAutoClose(boolean autoClose) {
         super.setAutoClose(autoClose);
         return this;

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -205,7 +205,7 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
         super.setReadPending(readPending);
     }
 
-    final void clearReadPending0() {
-        super.clearReadPending();
+    protected final void interruptReading0() {
+        interruptReading();
     }
 }

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -204,8 +204,4 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
     protected void setReadPending(boolean readPending) {
         super.setReadPending(readPending);
     }
-
-    protected final void interruptReading0() {
-        interruptReading();
-    }
 }

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
@@ -344,7 +344,7 @@ public class OioSocketChannel extends OioByteStreamChannel implements SocketChan
         super.setReadPending(readPending);
     }
 
-    final void clearReadPending0() {
-        clearReadPending();
+    protected final void interruptReading0() {
+        interruptReading();
     }
 }

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
@@ -343,8 +343,4 @@ public class OioSocketChannel extends OioByteStreamChannel implements SocketChan
     protected void setReadPending(boolean readPending) {
         super.setReadPending(readPending);
     }
-
-    protected final void interruptReading0() {
-        interruptReading();
-    }
 }


### PR DESCRIPTION
…eading

ATTENTION: This is a preliminary PR to see if it's feasible and gather some early feedback. I'll provide Unit Tests and say exploits described in #8953 in a subsequent PR if you like this idea.

Motivation

There are to aspects to this change. First: There is no way to break Netty out of an ongoing read() operation other than disabling auto reading. Second: The auto read flag is a "per connection global" mutable state. Working with it in a complex Netty application with many handlers can be awkward because anyone could re-enable it at any time and wheather a hander that disabled it is ready or not.

Modifications

Introduce an interruptReading() method which allows the user to break out of an ongoing read() operation and suspend further reading until Channel#read() is called again. Each handler in the pipeline has the opportunity to intercept and suppress attempts to produce more data if they're not ready it.

Result

Implements #8953 