### PR TITLE
#8575 fix the unexpected IllegalReferenceCountException produced by HttpPostRequestDecoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -933,18 +933,14 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
      */
     @Override
     public void destroy() {
-        checkDestroyed();
+        // Release all data items, including those not yet pulled
         cleanFiles();
+
         destroyed = true;
 
         if (undecodedChunk != null && undecodedChunk.refCnt() > 0) {
             undecodedChunk.release();
             undecodedChunk = null;
-        }
-
-        // release all data which was not yet pulled
-        for (int i = bodyListHttpDataRank; i < bodyListHttpData.size(); i++) {
-            bodyListHttpData.get(i).release();
         }
     }
 


### PR DESCRIPTION
Motivation:

HttpPostRequestDecoder will produce IllegalReferenceCountException when try to call `destroy()`.
The problem might be introduced by the commit 2b4f667.

Modification:

Remove the for-loop since all data has been released in `cleanFiles()`. And there is no need to call `checkDestroyed()` because it will be called in `cleanFiles()`

Result:

Fixes #8575.