### PR TITLE
Update to latest JDK releases in our CI

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.11.0-2"
+        java_version : "adopt@1.11.0-2"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.112.yaml
+++ b/docker/docker-compose.centos-6.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.12.0"
+        java_version : "zulu@1.12.0"
 
   test:
     image: netty:centos-6-1.12

--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.13.0-9"
+        java_version : "openjdk@1.13.0-13"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.8.202"
+        java_version : "adopt@1.8.202-08"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.19.yaml
+++ b/docker/docker-compose.centos-6.19.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.9.0-4"
+        java_version : "zulu@1.9.0-7"
 
   test:
     image: netty:centos-6-1.9

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.11.0-2"
+        java_version : "adopt@1.11.0-2"
 
   test:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.112.yaml
+++ b/docker/docker-compose.centos-7.112.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.12.0"
+        java_version : "zulu@1.12.0"
 
   test:
     image: netty:centos-7-1.12

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.13.0-9"
+        java_version : "openjdk@1.13.0-13"
 
   test:
     image: netty:centos-7-1.13

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.8.202"
+        java_version : "adopt@1.8.202-08"
 
   test:
     image: netty:centos-7-1.8

--- a/docker/docker-compose.centos-7.19.yaml
+++ b/docker/docker-compose.centos-7.19.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.9.0-4"
+        java_version : "openjdk@1.9.0-7"
 
   test:
     image: netty:centos-7-1.9


### PR DESCRIPTION
Motivation:

We should use the latest JDK release on our CI

Modifications:

Update all versions.

Result:

Test on latest JDK versions on our CI