### PR TITLE
Correctly detect exeception cause when using BoringSSL in SslErrorTest

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -289,7 +289,7 @@ public class SslErrorTest {
                 // When the error is produced on the client side and the client side uses JDK as provider it will always
                 // use "certificate unknown".
                 !serverProduceError && clientProvider == SslProvider.JDK &&
-                        message.toLowerCase(Locale.UK).contains("certificate unknown")) {
+                        message.toLowerCase(Locale.UK).contains("unknown")) {
             promise.setSuccess(null);
         } else {
             Throwable error = new AssertionError("message not contains '" + messagePart + "': " + message);


### PR DESCRIPTION
Motivation:

e9ce5048dfdfed32df28e46fae6e766d8fd6d734 added a testcase to ensure we correctly send the alert in all cases but did use a too strict message matching which did not work for BoringSSL as it not uses whitespaces but underscores.

Modifications:

Make the message matching less strict.

Result:

Test pass also when using BoringSSL.