### PR TITLE
Also use adoptjdk builds when using docker-sync

### DIFF
--- a/docker/docker-sync-compose.centos-6.18.yaml
+++ b/docker/docker-sync-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.8.202"
+        java_version : "adopt@1.8.202-08"
 
   test:
     image: netty:centos-6-1.8


### PR DESCRIPTION
Motivation:

We recently changed the docker config to use adoptjdk builds but missed to include the docker-sync related files.

Modifications:

Use adoptjdk there as well.

Result:

More consistent usage of JDK versions.