### PR TITLE
Decouple WebSocket server extension handshaker from read I/O

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandler.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http.websocketx.extensions.compression;
 
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
+import io.netty.handler.codec.http.HttpRequest;
 
 /**
  * Extends <tt>io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerExtensionHandler</tt>
@@ -30,6 +31,18 @@ public class WebSocketServerCompressionHandler extends WebSocketServerExtensionH
      */
     public WebSocketServerCompressionHandler() {
         super(new PerMessageDeflateServerExtensionHandshaker(),
+                new DeflateFrameServerExtensionHandshaker());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param request
+     *      The instance of WebSocket upgrade HTTP request.
+     */
+    public WebSocketServerCompressionHandler(HttpRequest request) {
+        super(request,
+                new PerMessageDeflateServerExtensionHandshaker(),
                 new DeflateFrameServerExtensionHandshaker());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandlerTest.java
@@ -55,6 +55,24 @@ public class WebSocketServerCompressionHandlerTest {
     }
 
     @Test
+    public void testPredefinedReuqestSuccess() {
+        HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION);
+        EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler(req));
+
+        HttpResponse res = newUpgradeResponse(null);
+        ch.writeOutbound(res);
+
+        HttpResponse res2 = ch.readOutbound();
+        List<WebSocketExtensionData> exts = WebSocketExtensionUtil.extractExtensions(
+                res2.headers().get(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS));
+
+        Assert.assertEquals(PERMESSAGE_DEFLATE_EXTENSION, exts.get(0).name());
+        Assert.assertTrue(exts.get(0).parameters().isEmpty());
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
+    }
+
+    @Test
     public void testClientWindowSizeSuccess() {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
                 new PerMessageDeflateServerExtensionHandshaker(6, false, 10, false, false)));


### PR DESCRIPTION
Motivation:

`WebSocketServerExtensionHandler` turns extensions on by examining the `channelRead` event for a `HttpRequest` message. It means that the instance of a handler should be present in the pipeline **before** the request comes in.

But let's assume I have a server that covers a lot of different requests, e.g. I have a routing mechanism that decides what should be invoked based on URI provided. If I want to perform WebSocket upgrade only at "/websocket/*", I don't what to pay the price of the handler sitting in the pipeline all the time. It's better to include it only when I know exactly this should be a WebSocket connection. In such a case I've already read and decoded the request from the channel and I need a way to provide this request to the handler not through firing I/O events.

Modifications:

Added a new contructor with additional HTTP request argument to `WebSocketServerExtensionHandler` and `WebSocketServerCompressionHandler`.

Ideally, the implementation should also prevent reading 2 pipelined requests consequently. But it was not covered explicitly before, so I didn't change the details (this should not be a problem as the connection would be closed anyway because of a decoder exception).

Result:

More flexible `WebSocketServerExtensionHandler` API.