### PR TITLE
Cleanup example to use local variable.

### DIFF
--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadServerHandler.java
@@ -69,8 +69,6 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
 
     private HttpRequest request;
 
-    private boolean readingChunks;
-
     private HttpData partialContent;
 
     private final StringBuilder responseContent = new StringBuilder();
@@ -162,13 +160,12 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
                 return;
             }
 
-            readingChunks = HttpUtil.isTransferEncodingChunked(request);
+            boolean readingChunks = HttpUtil.isTransferEncodingChunked(request);
             responseContent.append("Is Chunked: " + readingChunks + "\r\n");
             responseContent.append("IsMultipart: " + decoder.isMultipart() + "\r\n");
             if (readingChunks) {
                 // Chunk version
                 responseContent.append("Chunks: ");
-                readingChunks = true;
             }
         }
 
@@ -194,7 +191,6 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
                 // example of reading only if at the end
                 if (chunk instanceof LastHttpContent) {
                     writeResponse(ctx.channel());
-                    readingChunks = false;
 
                     reset();
                 }


### PR DESCRIPTION
Motivation:

We can just use a local variable in HttpUploadServerHandler and so make the example code a bit cleaner.

Modifications:

Use local variable.

Result:

Fixes https://github.com/netty/netty/issues/8892.
