### PR TITLE
Upgrade to new netty-build and com.puppycrawl.tools 8.18

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -593,7 +593,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 if (paddingBytes(padding) > 0) {
                     ctx.write(ZERO_BUFFER.slice(0, paddingBytes(padding)), promiseAggregator.newPromise());
                 }
-            } while(headerBlock.isReadable());
+            } while (headerBlock.isReadable());
         }
         return promiseAggregator;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
     <netty.dev.tools.directory>${project.build.directory}/dev-tools</netty.dev.tools.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <netty.build.version>24</netty.build.version>
+    <netty.build.version>25</netty.build.version>
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.8</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
@@ -891,6 +891,11 @@
           </execution>
         </executions>
         <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.18</version>
+          </dependency>
           <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>netty-build</artifactId>

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -141,7 +141,7 @@ public final class Native {
             throw newIOException("epoll_ctl", res);
         }
     }
-    private static native int epollCtlAdd0(int efd, final int fd, final int flags);
+    private static native int epollCtlAdd0(int efd, int fd, int flags);
 
     public static void epollCtlMod(int efd, final int fd, final int flags) throws IOException {
         int res = epollCtlMod0(efd, fd, flags);
@@ -149,7 +149,7 @@ public final class Native {
             throw newIOException("epoll_ctl", res);
         }
     }
-    private static native int epollCtlMod0(int efd, final int fd, final int flags);
+    private static native int epollCtlMod0(int efd, int fd, int flags);
 
     public static void epollCtlDel(int efd, final int fd) throws IOException {
         int res = epollCtlDel0(efd, fd);
@@ -157,7 +157,7 @@ public final class Native {
             throw newIOException("epoll_ctl", res);
         }
     }
-    private static native int epollCtlDel0(int efd, final int fd);
+    private static native int epollCtlDel0(int efd, int fd);
 
     // File-descriptor operations
     public static int splice(int fd, long offIn, int fdOut, long offOut, long len) throws IOException {


### PR DESCRIPTION
Motivation:

com.puppycrawl.tools checkstyle < 8.18 was reported to contain a possible security flaw. We should upgrade.

Modifications:

- Upgrade netty-build and checkstyle.
- Fix checkstyle errors

Result:

Fixes https://github.com/netty/netty/issues/8968.