### PR TITLE
Move ChannelHandler.Skip to ChannelHandlerMask.Skip and make it packa…

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -195,35 +195,9 @@ public interface ChannelHandler {
     }
 
     /**
-     * Indicates that the annotated event handler method in {@link ChannelHandler} will not be invoked by
-     * {@link ChannelPipeline}. This annotation is only useful when your handler method implementation
-     * only passes the event through to the next handler, like the following:
-     *
-     * <pre>
-     * {@code @Skip}
-     * {@code @Override}
-     * public void channelActive({@link ChannelHandlerContext} ctx) {
-     *     ctx.fireChannelActive(); // do nothing but passing through to the next handler
-     * }
-     * </pre>
-     *
-     * <p>
-     * Note that this annotation is not {@linkplain Inherited inherited}.  If you override a method annotated with
-     * {@link Skip}, it will not be skipped anymore.  Similarly, you can override a method not annotated with
-     * {@link Skip} and simply pass the event through to the next handler, which reverses the behavior of the
-     * supertype.
-     * </p>
-     */
-    @Target(ElementType.METHOD)
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface Skip {
-        // no value
-    }
-
-    /**
      * The {@link Channel} of the {@link ChannelHandlerContext} was registered with its {@link EventLoop}
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void channelRegistered(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelRegistered();
     }
@@ -231,7 +205,7 @@ public interface ChannelHandler {
     /**
      * The {@link Channel} of the {@link ChannelHandlerContext} was unregistered from its {@link EventLoop}
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelUnregistered();
     }
@@ -239,7 +213,7 @@ public interface ChannelHandler {
     /**
      * The {@link Channel} of the {@link ChannelHandlerContext} is now active
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void channelActive(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelActive();
     }
@@ -248,7 +222,7 @@ public interface ChannelHandler {
      * The {@link Channel} of the {@link ChannelHandlerContext} was registered is now inactive and reached its
      * end of lifetime.
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void channelInactive(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelInactive();
     }
@@ -256,7 +230,7 @@ public interface ChannelHandler {
     /**
      * Invoked when the current {@link Channel} has read a message from the peer.
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         ctx.fireChannelRead(msg);
     }
@@ -267,7 +241,7 @@ public interface ChannelHandler {
      * attempt to read an inbound data from the current {@link Channel} will be made until
      * {@link ChannelHandlerContext#read()} is called.
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelReadComplete();
     }
@@ -275,7 +249,7 @@ public interface ChannelHandler {
     /**
      * Gets called if an user event was triggered.
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         ctx.fireUserEventTriggered(evt);
     }
@@ -284,7 +258,7 @@ public interface ChannelHandler {
      * Gets called once the writable state of a {@link Channel} changed. You can check the state with
      * {@link Channel#isWritable()}.
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelWritabilityChanged();
     }
@@ -292,7 +266,7 @@ public interface ChannelHandler {
     /**
      * Gets called if a {@link Throwable} was thrown.
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         ctx.fireExceptionCaught(cause);
     }
@@ -305,7 +279,7 @@ public interface ChannelHandler {
      * @param promise       the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception    thrown if an error occurs
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
         ctx.bind(localAddress, promise);
     }
@@ -319,7 +293,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void connect(
             ChannelHandlerContext ctx, SocketAddress remoteAddress,
             SocketAddress localAddress, ChannelPromise promise) throws Exception {
@@ -333,7 +307,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         ctx.disconnect(promise);
     }
@@ -345,7 +319,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         ctx.close(promise);
     }
@@ -357,7 +331,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         ctx.register(promise);
     }
@@ -369,7 +343,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         ctx.deregister(promise);
     }
@@ -377,7 +351,7 @@ public interface ChannelHandler {
     /**
      * Intercepts {@link ChannelHandlerContext#read()}.
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void read(ChannelHandlerContext ctx) throws Exception {
         ctx.read();
     }
@@ -392,7 +366,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         ctx.write(msg, promise);
     }
@@ -404,7 +378,7 @@ public interface ChannelHandler {
      * @param ctx               the {@link ChannelHandlerContext} for which the flush operation is made
      * @throws Exception        thrown if an error occurs
      */
-    @Skip
+    @ChannelHandlerMask.Skip
     default void flush(ChannelHandlerContext ctx) throws Exception {
         ctx.flush();
     }

--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -17,6 +17,7 @@ package io.netty.channel;
 
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import io.netty.channel.ChannelHandlerMask.Skip;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -197,7 +198,7 @@ public interface ChannelHandler {
     /**
      * The {@link Channel} of the {@link ChannelHandlerContext} was registered with its {@link EventLoop}
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void channelRegistered(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelRegistered();
     }
@@ -205,7 +206,7 @@ public interface ChannelHandler {
     /**
      * The {@link Channel} of the {@link ChannelHandlerContext} was unregistered from its {@link EventLoop}
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelUnregistered();
     }
@@ -213,7 +214,7 @@ public interface ChannelHandler {
     /**
      * The {@link Channel} of the {@link ChannelHandlerContext} is now active
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void channelActive(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelActive();
     }
@@ -222,7 +223,7 @@ public interface ChannelHandler {
      * The {@link Channel} of the {@link ChannelHandlerContext} was registered is now inactive and reached its
      * end of lifetime.
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void channelInactive(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelInactive();
     }
@@ -230,7 +231,7 @@ public interface ChannelHandler {
     /**
      * Invoked when the current {@link Channel} has read a message from the peer.
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         ctx.fireChannelRead(msg);
     }
@@ -241,7 +242,7 @@ public interface ChannelHandler {
      * attempt to read an inbound data from the current {@link Channel} will be made until
      * {@link ChannelHandlerContext#read()} is called.
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelReadComplete();
     }
@@ -249,7 +250,7 @@ public interface ChannelHandler {
     /**
      * Gets called if an user event was triggered.
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         ctx.fireUserEventTriggered(evt);
     }
@@ -258,7 +259,7 @@ public interface ChannelHandler {
      * Gets called once the writable state of a {@link Channel} changed. You can check the state with
      * {@link Channel#isWritable()}.
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelWritabilityChanged();
     }
@@ -266,7 +267,7 @@ public interface ChannelHandler {
     /**
      * Gets called if a {@link Throwable} was thrown.
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         ctx.fireExceptionCaught(cause);
     }
@@ -279,7 +280,7 @@ public interface ChannelHandler {
      * @param promise       the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception    thrown if an error occurs
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
         ctx.bind(localAddress, promise);
     }
@@ -293,7 +294,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void connect(
             ChannelHandlerContext ctx, SocketAddress remoteAddress,
             SocketAddress localAddress, ChannelPromise promise) throws Exception {
@@ -307,7 +308,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         ctx.disconnect(promise);
     }
@@ -319,7 +320,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         ctx.close(promise);
     }
@@ -331,7 +332,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         ctx.register(promise);
     }
@@ -343,7 +344,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         ctx.deregister(promise);
     }
@@ -351,7 +352,7 @@ public interface ChannelHandler {
     /**
      * Intercepts {@link ChannelHandlerContext#read()}.
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void read(ChannelHandlerContext ctx) throws Exception {
         ctx.read();
     }
@@ -366,7 +367,7 @@ public interface ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         ctx.write(msg, promise);
     }
@@ -378,7 +379,7 @@ public interface ChannelHandler {
      * @param ctx               the {@link ChannelHandlerContext} for which the flush operation is made
      * @throws Exception        thrown if an error occurs
      */
-    @ChannelHandlerMask.Skip
+    @Skip
     default void flush(ChannelHandlerContext ctx) throws Exception {
         ctx.flush();
     }

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
@@ -18,6 +18,11 @@ package io.netty.channel;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.PlatformDependent;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.net.SocketAddress;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
@@ -163,8 +168,34 @@ final class ChannelHandlerMask {
             final Class<?> handlerType, final String methodName, final Class<?>... paramTypes) throws Exception {
 
         return AccessController.doPrivileged((PrivilegedExceptionAction<Boolean>) () ->
-                handlerType.getMethod(methodName, paramTypes).isAnnotationPresent(ChannelHandler.Skip.class));
+                handlerType.getMethod(methodName, paramTypes).isAnnotationPresent(Skip.class));
     }
 
     private ChannelHandlerMask() { }
+
+    /**
+     * Indicates that the annotated event handler method in {@link ChannelHandler} will not be invoked by
+     * {@link ChannelPipeline}. This annotation is only useful when your handler method implementation
+     * only passes the event through to the next handler, like the following:
+     *
+     * <pre>
+     * {@code @Skip}
+     * {@code @Override}
+     * public void channelActive({@link ChannelHandlerContext} ctx) {
+     *     ctx.fireChannelActive(); // do nothing but passing through to the next handler
+     * }
+     * </pre>
+     *
+     * <p>
+     * Note that this annotation is not {@linkplain Inherited inherited}.  If you override a method annotated with
+     * {@link Skip}, it will not be skipped anymore.  Similarly, you can override a method not annotated with
+     * {@link Skip} and simply pass the event through to the next handler, which reverses the behavior of the
+     * supertype.
+     * </p>
+     */
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Skip {
+        // no value
+    }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
@@ -175,20 +175,11 @@ final class ChannelHandlerMask {
 
     /**
      * Indicates that the annotated event handler method in {@link ChannelHandler} will not be invoked by
-     * {@link ChannelPipeline}. This annotation is only useful when your handler method implementation
-     * only passes the event through to the next handler, like the following:
-     *
-     * <pre>
-     * {@code @Skip}
-     * {@code @Override}
-     * public void channelActive({@link ChannelHandlerContext} ctx) {
-     *     ctx.fireChannelActive(); // do nothing but passing through to the next handler
-     * }
-     * </pre>
-     *
+     * {@link ChannelPipeline} and so <strong>MUST</strong> only be used when the {@link ChannelHandler}
+     * method does nothing except forward to the next {@link ChannelHandler} in the pipeline.
      * <p>
-     * Note that this annotation is not {@linkplain Inherited inherited}.  If you override a method annotated with
-     * {@link Skip}, it will not be skipped anymore.  Similarly, you can override a method not annotated with
+     * Note that this annotation is not {@linkplain Inherited inherited}. If a user overrides a method annotated with
+     * {@link Skip}, it will not be skipped anymore. Similarly, the user can override a method not annotated with
      * {@link Skip} and simply pass the event through to the next handler, which reverses the behavior of the
      * supertype.
      * </p>

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -21,6 +21,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerMask.Skip;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
@@ -953,14 +954,14 @@ public class DefaultChannelPipelineTest {
                 errorRef = new AssertionError("Method should never been called");
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
                 fail();
                 ctx.bind(localAddress, promise);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
                                 SocketAddress localAddress, ChannelPromise promise) {
@@ -968,112 +969,112 @@ public class DefaultChannelPipelineTest {
                 ctx.connect(remoteAddress, localAddress, promise);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
                 fail();
                 ctx.disconnect(promise);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
                 fail();
                 ctx.close(promise);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
                 fail();
                 ctx.register(promise);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
                 fail();
                 ctx.deregister(promise);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void read(ChannelHandlerContext ctx) {
                 fail();
                 ctx.read();
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                 fail();
                 ctx.write(msg, promise);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void flush(ChannelHandlerContext ctx) {
                 fail();
                 ctx.flush();
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void channelRegistered(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelRegistered();
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void channelUnregistered(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelUnregistered();
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelActive();
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void channelInactive(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelInactive();
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                 fail();
                 ctx.fireChannelRead(msg);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void channelReadComplete(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelReadComplete();
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 fail();
                 ctx.fireUserEventTriggered(evt);
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void channelWritabilityChanged(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelWritabilityChanged();
             }
 
-            @ChannelHandlerMask.Skip
+            @Skip
             @Override
             public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 fail();

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -953,14 +953,14 @@ public class DefaultChannelPipelineTest {
                 errorRef = new AssertionError("Method should never been called");
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
                 fail();
                 ctx.bind(localAddress, promise);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
                                 SocketAddress localAddress, ChannelPromise promise) {
@@ -968,112 +968,112 @@ public class DefaultChannelPipelineTest {
                 ctx.connect(remoteAddress, localAddress, promise);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
                 fail();
                 ctx.disconnect(promise);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
                 fail();
                 ctx.close(promise);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
                 fail();
                 ctx.register(promise);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
                 fail();
                 ctx.deregister(promise);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void read(ChannelHandlerContext ctx) {
                 fail();
                 ctx.read();
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                 fail();
                 ctx.write(msg, promise);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void flush(ChannelHandlerContext ctx) {
                 fail();
                 ctx.flush();
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void channelRegistered(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelRegistered();
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void channelUnregistered(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelUnregistered();
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelActive();
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void channelInactive(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelInactive();
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                 fail();
                 ctx.fireChannelRead(msg);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void channelReadComplete(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelReadComplete();
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 fail();
                 ctx.fireUserEventTriggered(evt);
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void channelWritabilityChanged(ChannelHandlerContext ctx) {
                 fail();
                 ctx.fireChannelWritabilityChanged();
             }
 
-            @Skip
+            @ChannelHandlerMask.Skip
             @Override
             public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                 fail();


### PR DESCRIPTION
…ge-private

Motivation:

8fdf373557622aa74a9bdf513ac9a92c28ec83cf introduced the @Skip annotation which allows to optimize the way we invoke ChannelHandlers when traversing the pipeline. Now that we moved all the "default" code to the ChannelHandler interface we can make the annotation package-private to guard the user to make any mistakes which will lead to hard to debug issues.

Modifications:

Move ChannelHandler.Skip to ChannelHandlerMask.Skip and make it package-private

Result:

Guard users from introduce hard to debug issues.