### PR TITLE
Update to latest openjdk13 EA release

### DIFF
--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.13.0-13"
+        java_version : "openjdk@1.13.0-14"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.13.0-13"
+        java_version : "openjdk@1.13.0-14"
 
   test:
     image: netty:centos-7-1.13


### PR DESCRIPTION
Motivation:

A new openjdk13 EA release is out.

Modifications:

Update openjdk13 version.

Result:

Run build on CI with latest openjdk13 EA build