### PR TITLE
Remove code that accounts for changing EventExecutors in DefaultPromise

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 import junit.framework.AssertionFailedError;
 import org.junit.Before;
 import org.junit.Test;
@@ -122,7 +123,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        promise = new DefaultChannelPromise(channel);
+        promise = new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
 
         final AtomicInteger headersReceivedState = new AtomicInteger();
         when(channel.isActive()).thenReturn(true);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -599,7 +599,7 @@ public class Http2ConnectionHandlerTest {
         verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID + 2), eq(errorCode), eq(data),
                 eq(promise));
         verify(connection).goAwaySent(eq(STREAM_ID + 2), eq(errorCode), eq(data));
-        promise = new DefaultChannelPromise(channel);
+        promise = new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
         handler.goAway(ctx, STREAM_ID, errorCode, data, promise);
         verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data), eq(promise));
         verify(connection).goAwaySent(eq(STREAM_ID), eq(errorCode), eq(data));

--- a/common/src/main/java/io/netty/util/concurrent/DefaultProgressivePromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultProgressivePromise.java
@@ -30,8 +30,6 @@ public class DefaultProgressivePromise<V> extends DefaultPromise<V> implements P
         super(executor);
     }
 
-    protected DefaultProgressivePromise() { /* only for subclasses */ }
-
     @Override
     public ProgressivePromise<V> setProgress(long progress, long total) {
         if (total < 0) {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelProgressivePromise.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelProgressivePromise.java
@@ -21,6 +21,8 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
+import java.util.Objects;
+
 /**
  * The default {@link ChannelProgressivePromise} implementation.  It is recommended to use
  * {@link Channel#newProgressivePromise()} to create a new {@link ChannelProgressivePromise} rather than calling the
@@ -39,7 +41,7 @@ public class DefaultChannelProgressivePromise
      *        the {@link Channel} associated with this future
      */
     public DefaultChannelProgressivePromise(Channel channel) {
-        this.channel = channel;
+        this(channel, channel.eventLoop());
     }
 
     /**
@@ -50,17 +52,7 @@ public class DefaultChannelProgressivePromise
      */
     public DefaultChannelProgressivePromise(Channel channel, EventExecutor executor) {
         super(executor);
-        this.channel = channel;
-    }
-
-    @Override
-    protected EventExecutor executor() {
-        EventExecutor e = super.executor();
-        if (e == null) {
-            return channel().eventLoop();
-        } else {
-            return e;
-        }
+        this.channel = Objects.requireNonNull(channel, "channel");
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPromise.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPromise.java
@@ -39,7 +39,7 @@ public class DefaultChannelPromise extends DefaultPromise<Void> implements Chann
      *        the {@link Channel} associated with this future
      */
     public DefaultChannelPromise(Channel channel) {
-        this.channel = requireNonNull(channel, "channel");
+        this(channel, channel.eventLoop());
     }
 
     /**
@@ -51,16 +51,6 @@ public class DefaultChannelPromise extends DefaultPromise<Void> implements Chann
     public DefaultChannelPromise(Channel channel, EventExecutor executor) {
         super(executor);
         this.channel = requireNonNull(channel, "channel");
-    }
-
-    @Override
-    protected EventExecutor executor() {
-        EventExecutor e = super.executor();
-        if (e == null) {
-            return channel().eventLoop();
-        } else {
-            return e;
-        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

DefaultPromise requires an EventExecutor which provides the thread to notify listeners on and this EventExecutor can never change. We can remove the code that supported the possibility of a changing the executor as this is not possible anymore.

Modifications:

- Remove constructor which allowed to construct a *Promise without an EventExecutor
- Remove extra state
- Adjusted SslHandler and ProxyHandler for new code

Result:

Fixes https://github.com/netty/netty/issues/8517.