### PR TITLE
Deprecate ChannelOption.newInstance(...)

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -65,7 +65,10 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     /**
      * Creates a new {@link ChannelOption} for the given {@code name} or fail with an
      * {@link IllegalArgumentException} if a {@link ChannelOption} for the given {@code name} exists.
+     *
+     * @deprecated use {@link #valueOf(String)}.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public static <T> ChannelOption<T> newInstance(String name) {
         return (ChannelOption<T>) pool.newInstance(name);


### PR DESCRIPTION
Motivation:

Deprecate ChannelOption.newInstance(...) as it is not used.

Modifications:

Deprecate ChannelOption.newInstance(...) as valueOf(...) should be used as a replacement.

Result:

Fixes https://github.com/netty/netty/issues/8983.