### PR TITLE
Add @SupressWarnings("deprecation") to ChannelInboundHandlerAdapter a…

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -191,7 +191,8 @@ public interface ChannelHandler {
     /**
      * Gets called if a {@link Throwable} was thrown.
      *
-     * @deprecated is part of {@link ChannelInboundHandler}
+     * @deprecated if you want to handle this event you should implement {@link ChannelInboundHandler} and
+     * implement the method there.
      */
     @Deprecated
     void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception;

--- a/transport/src/main/java/io/netty/channel/ChannelInboundHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInboundHandlerAdapter.java
@@ -126,6 +126,7 @@ public class ChannelInboundHandlerAdapter extends ChannelHandlerAdapter implemen
      * Sub-classes may override this method to change behavior.
      */
     @Override
+    @SuppressWarnings("deprecation")
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
             throws Exception {
         ctx.fireExceptionCaught(cause);


### PR DESCRIPTION
…nd clarify deprecation in ChannelHandler

Motivation:

https://github.com/netty/netty/pull/8826 added @Deprecated to the exceptionCaught(...) method but we missed to add @SupressWarnings(...) to it's sub-types. Beside this we can make the deprecated docs a bit more clear.

Modifications:

- Add @SupressWarnings("deprecated")
- Clarify docs.

Result:

Less warnings and more clear deprecated docs.