### PR TITLE
We should fail fast if the given PrivateKey or X509Certificate chain …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -189,6 +189,7 @@ public final class OpenSslClientContext extends OpenSslContext {
                 ClientAuth.NONE, protocols, false, enableOcsp);
         boolean success = false;
         try {
+            OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
                                                keyCertChain, key, keyPassword, keyManagerFactory);
             success = true;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialProvider.java
@@ -16,8 +16,10 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.internal.tcnative.SSL;
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.X509KeyManager;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
@@ -35,6 +37,58 @@ class OpenSslKeyMaterialProvider {
     OpenSslKeyMaterialProvider(X509KeyManager keyManager, String password) {
         this.keyManager = keyManager;
         this.password = password;
+    }
+
+    static void validateKeyMaterialSupported(X509Certificate[] keyCertChain, PrivateKey key, String keyPassword)
+            throws SSLException {
+        validateSupported(keyCertChain);
+        validateSupported(key, keyPassword);
+    }
+
+    private static void validateSupported(PrivateKey key, String password) throws SSLException {
+        if (key == null) {
+            return;
+        }
+
+        long pkeyBio = 0;
+        long pkey = 0;
+
+        try {
+            pkeyBio = toBIO(UnpooledByteBufAllocator.DEFAULT, key);
+            pkey = SSL.parsePrivateKey(pkeyBio, password);
+        } catch (Exception e) {
+            throw new SSLException("PrivateKey type not supported " + key.getFormat(), e);
+        } finally {
+            SSL.freeBIO(pkeyBio);
+            if (pkey != 0) {
+                SSL.freePrivateKey(pkey);
+            }
+        }
+    }
+
+    private static void validateSupported(X509Certificate[] certificates) throws SSLException {
+        if (certificates == null || certificates.length == 0) {
+            return;
+        }
+
+        long chainBio = 0;
+        long chain = 0;
+        PemEncoded encoded = null;
+        try {
+            encoded = PemX509Certificate.toPEM(UnpooledByteBufAllocator.DEFAULT, true, certificates);
+            chainBio = toBIO(UnpooledByteBufAllocator.DEFAULT, encoded.retain());
+            chain = SSL.parseX509Chain(chainBio);
+        } catch (Exception e) {
+            throw new SSLException("Certificate type not supported", e);
+        } finally {
+            SSL.freeBIO(chainBio);
+            if (chain != 0) {
+                SSL.freeX509Chain(chain);
+            }
+            if (encoded != null) {
+                encoded.release();
+            }
+        }
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -344,9 +344,11 @@ public final class OpenSslServerContext extends OpenSslContext {
             boolean enableOcsp) throws SSLException {
         super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER, keyCertChain,
                 clientAuth, protocols, startTls, enableOcsp);
+
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {
+            OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
                                                keyCertChain, key, keyPassword, keyManagerFactory);
             success = true;


### PR DESCRIPTION
…is not supported by the used SslProvider.

Motivation:

Some SslProvider do support different types of keys and chains. We should fail fast if we can not support the type.

Related to https://github.com/netty/netty-tcnative/issues/455.

Modifications:

- Try to parse key / chain first and if if this fails throw and SslException
- Add tests.

Result:

Fail fast.