### PR TITLE
Mark flaky test as @Ignore

### DIFF
--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -27,6 +27,7 @@ import io.netty.util.IntSupplier;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import org.hamcrest.core.IsInstanceOf;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -258,6 +259,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
         }
     }
 
+    @Ignore
     @Test
     public void testChannelsRegistered()  {
         NioEventLoopGroup group = new NioEventLoopGroup(1);


### PR DESCRIPTION
Motivation:

0a0da67f43354473af9861407749d02fe62e8f6c introduced a testcase which is flacky. We need to fix it and enable it again.

Modifications:

Mark flaky test as ignore.

Result:

No flaky build anymore.