### PR TITLE
Introduce HttpServerCodec.resetDecoder() and use it in HttpObjectAggr…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -277,6 +277,11 @@ public class HttpObjectAggregator
             HttpObjectDecoder decoder = ctx.pipeline().get(HttpObjectDecoder.class);
             if (decoder != null) {
                 decoder.reset();
+            } else {
+                HttpServerCodec codec = ctx.pipeline().get(HttpServerCodec.class);
+                if (codec != null) {
+                    codec.resetDecoder();
+                }
             }
         } else if (oversized instanceof HttpResponse) {
             ctx.close();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -72,6 +72,14 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
     }
 
     /**
+     * Resets the state of the decoder so that it is ready to decode a new message.
+     * This method is useful for handling a rejected request with {@code Expect: 100-continue} header.
+     */
+    public void resetDecoder() {
+        inboundHandler().reset();
+    }
+
+    /**
      * Upgrades to another protocol from HTTP. Removes the {@link HttpRequestDecoder} and
      * {@link HttpResponseEncoder} from the pipeline.
      */

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
@@ -115,6 +115,60 @@ public class HttpServerCodecTest {
     }
 
     @Test
+    public void test100ContinueReject() {
+        HttpServerCodec decoder = new HttpServerCodec();
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+        String oversized =
+                "PUT /file HTTP/1.1\r\n" +
+                        "Expect: 100-continue\r\n" +
+                        "Content-Length: 1048576000\r\n\r\n";
+
+        channel.writeInbound(Unpooled.copiedBuffer(oversized, CharsetUtil.US_ASCII));
+        assertThat(channel.readInbound(), is(instanceOf(HttpRequest.class)));
+
+        // At this point, we assume that we sent '413 Entity Too Large' to the peer without closing the connection
+        // so that the client can try again.
+        decoder.resetDecoder();
+
+        String query = "GET /max-file-size HTTP/1.1\r\n\r\n";
+        channel.writeInbound(Unpooled.copiedBuffer(query, CharsetUtil.US_ASCII));
+        assertThat(channel.readInbound(), is(instanceOf(HttpRequest.class)));
+        assertThat(channel.readInbound(), is(instanceOf(LastHttpContent.class)));
+
+        assertThat(channel.finish(), is(false));
+    }
+
+    @Test
+    public void test100ContinueWithBadClient() {
+        HttpServerCodec decoder = new HttpServerCodec();
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+        String oversized =
+                "PUT /file HTTP/1.1\r\n" +
+                        "Expect: 100-continue\r\n" +
+                        "Content-Length: 1048576000\r\n\r\n" +
+                        "WAY_TOO_LARGE_DATA_BEGINS";
+
+        channel.writeInbound(Unpooled.copiedBuffer(oversized, CharsetUtil.US_ASCII));
+        assertThat(channel.readInbound(), is(instanceOf(HttpRequest.class)));
+
+        HttpContent prematureData = channel.readInbound();
+        prematureData.release();
+
+        assertThat(channel.readInbound(), is(nullValue()));
+
+        // At this point, we assume that we sent '413 Entity Too Large' to the peer without closing the connection
+        // so that the client can try again.
+        decoder.resetDecoder();
+
+        String query = "GET /max-file-size HTTP/1.1\r\n\r\n";
+        channel.writeInbound(Unpooled.copiedBuffer(query, CharsetUtil.US_ASCII));
+        assertThat(channel.readInbound(), is(instanceOf(HttpRequest.class)));
+        assertThat(channel.readInbound(), is(instanceOf(LastHttpContent.class)));
+
+        assertThat(channel.finish(), is(false));
+    }
+
+    @Test
     public void testChunkedHeadResponse() {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
 


### PR DESCRIPTION
…egator

Motivation:

To correctly handle reject of 100-Continue responses we expose HttpObjectDecoder.reset(), this method is also used in HttpObjectAggregator. Unfortunaly we do not expose something similar in HttpServerCodec and so not correctly reset the decoder when it is used with HttpObjectAggregator.

Modifications:

- Add HttpServerCodec.resetDecoder() which calls HttpRequestDecoder.reset()
- Add unit tests
- Correctly call HttpServerCodec.resetDecoder() from HttpObjectAggregator when 100-Continue is rejected

Result:

Correctly handle reject of 100-Continue when HttpServerCodec is used.