### PR TITLE
Optimize the way we handle ctx.read() in the read loop when AUTO_READ…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -119,7 +119,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                         readPending = false;
                         pipeline.fireChannelRead(newChildChannel(allocHandle.lastBytesRead(), acceptedAddress, 1,
                                                                  acceptedAddress[0]));
-                    } while (allocHandle.continueReading());
+                    } while (allocHandle.continueReading(readPending));
                 } catch (Throwable t) {
                     exception = t;
                 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -810,7 +810,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                         //   was "wrapped" by this Channel implementation.
                         break;
                     }
-                } while (allocHandle.continueReading());
+                } while (allocHandle.continueReading(readPending));
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -513,7 +513,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                         pipeline.fireChannelRead(packet);
 
                         byteBuf = null;
-                    } while (allocHandle.continueReading());
+                    } while (allocHandle.continueReading(readPending));
                 } catch (Throwable t) {
                     if (byteBuf != null) {
                         byteBuf.release();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -176,7 +176,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
                         pipeline.fireChannelRead(new FileDescriptor(allocHandle.lastBytesRead()));
                         break;
                     }
-                } while (allocHandle.continueReading());
+                } while (allocHandle.continueReading(readPending));
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
@@ -111,7 +111,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
                         readPending = false;
                         pipeline.fireChannelRead(newChildChannel(acceptFd, acceptedAddress, 1,
                                                                  acceptedAddress[0]));
-                    } while (allocHandle.continueReading());
+                    } while (allocHandle.continueReading(readPending));
                 } catch (Throwable t) {
                     exception = t;
                 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -558,7 +558,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
                         //   was "wrapped" by this Channel implementation.
                         break;
                     }
-                } while (allocHandle.continueReading());
+                } while (allocHandle.continueReading(readPending));
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -484,7 +484,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
                         pipeline.fireChannelRead(packet);
 
                         byteBuf = null;
-                    } while (allocHandle.continueReading());
+                    } while (allocHandle.continueReading(readPending));
                 } catch (Throwable t) {
                     if (byteBuf != null) {
                         byteBuf.release();

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -171,7 +171,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
                             pipeline.fireChannelRead(new FileDescriptor(recvFd));
                             break;
                     }
-                } while (allocHandle.continueReading());
+                } while (allocHandle.continueReading(readPending));
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/UnixChannelUtil.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/UnixChannelUtil.java
@@ -16,6 +16,11 @@
 package io.netty.channel.unix;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.util.UncheckedBooleanSupplier;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.net.InetAddress;
@@ -58,5 +63,79 @@ public final class UnixChannelUtil {
             return osRemoteAddr;
         }
         return remoteAddr;
+    }
+
+    public static RecvByteBufAllocator.ReadPendingAwareHandle adaptHandleIfNeeded(
+            final RecvByteBufAllocator.ExtendedHandle handle) {
+        ObjectUtil.checkNotNull(handle, "handle");
+        if (handle instanceof RecvByteBufAllocator.ReadPendingAwareHandle) {
+            return (RecvByteBufAllocator.ReadPendingAwareHandle) handle;
+        }
+        return new RecvByteBufAllocator.ReadPendingAwareHandle() {
+            @Override
+            public boolean continueReading(boolean readPending) {
+                return handle.continueReading();
+            }
+
+            @Override
+            public boolean continueReading(boolean readPending, UncheckedBooleanSupplier maybeMoreDataSupplier) {
+                return handle.continueReading(maybeMoreDataSupplier);
+            }
+
+            @Override
+            public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
+                return handle.continueReading(maybeMoreDataSupplier);
+            }
+
+            @Override
+            public ByteBuf allocate(ByteBufAllocator alloc) {
+                return handle.allocate(alloc);
+            }
+
+            @Override
+            public int guess() {
+                return handle.guess();
+            }
+
+            @Override
+            public void reset(ChannelConfig config) {
+                handle.reset(config);
+            }
+
+            @Override
+            public void incMessagesRead(int numMessages) {
+                handle.incMessagesRead(numMessages);
+            }
+
+            @Override
+            public void lastBytesRead(int bytes) {
+                handle.lastBytesRead(bytes);
+            }
+
+            @Override
+            public int lastBytesRead() {
+                return handle.lastBytesRead();
+            }
+
+            @Override
+            public void attemptedBytesRead(int bytes) {
+                handle.attemptedBytesRead(bytes);
+            }
+
+            @Override
+            public int attemptedBytesRead() {
+                return handle.attemptedBytesRead();
+            }
+
+            @Override
+            public boolean continueReading() {
+                return handle.continueReading();
+            }
+
+            @Override
+            public void readComplete() {
+                handle.readComplete();
+            }
+        };
     }
 }

--- a/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
@@ -117,6 +117,20 @@ public interface RecvByteBufAllocator {
         boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier);
     }
 
+    @UnstableApi
+    interface ReadPendingAwareHandle extends ExtendedHandle {
+        /**
+         * Same as {@link ExtendedHandle#continueReading()} except that the transport can give some hint if another
+         * read is pending.
+         */
+        boolean continueReading(boolean readPending);
+        /**
+         * Same as {@link ExtendedHandle#continueReading()} except that the transport can give some hint if another
+         *  read is pending.
+         */
+        boolean continueReading(boolean readPending, UncheckedBooleanSupplier maybeMoreDataSupplier);
+    }
+
     /**
      * A {@link Handle} which delegates all call to some other {@link Handle}.
      */


### PR DESCRIPTION
… is false in the native transports

Motivation:

We currently only continue reading when AUTO_READ is true and not correctly respect the ctx.read() that may be done during the read-loop. In this case we can just continue reading and not need to go back to the kqueue / epoll and pay for the wakeup.

Modifications:

- Adjust code to correctly take readPending into account by moving it to the RecvHandle implementations of the native transports.
- Adjust testcase to correctly take into account that multiple reads may happen during one read loop.

Result:

Less overhead if user manages reads directly and set AUTO_READ to false.