### PR TITLE
Correctly discard messages after oversized message is detected.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -399,7 +399,6 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
 
     private void invokeHandleOversizedMessage(ChannelHandlerContext ctx, S oversized) throws Exception {
         handlingOversizedMessage = true;
-        aggregating = false;
         currentMessage = null;
         try {
             handleOversizedMessage(ctx, oversized);


### PR DESCRIPTION
Motivation:

32563bfcc129ef9332f175c277e4f6b59fd37d8c introduced a regression in which we did now not longer discard the messages after we handled an oversized message.

Modifications:

- Do not set aggregating to false after handleOversizedMessage is called
- Adjust unit tests to verify the behaviour is correct again.

Result:

Fixes https://github.com/netty/netty/issues/9007.