### PR TITLE
Increase default bits for SelfSignedCertificate

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -67,6 +67,14 @@ public final class SelfSignedCertificate {
     private static final Date DEFAULT_NOT_AFTER = new Date(SystemPropertyUtil.getLong(
             "io.netty.selfSignedCertificate.defaultNotAfter", 253402300799000L));
 
+    /**
+     * FIPS 140-2 encryption requires the key length to be 2048 bits or greater.
+     * Let's use that as a sane default but allow the default to be set dynamically
+     * for those that need more stringent security requirements.
+     */
+    private static final int DEFAULT_KEY_LENGTH_BITS =
+            SystemPropertyUtil.getInt("io.netty.handler.ssl.util.selfSignedKeyStrength", 2048);
+
     private final File certificate;
     private final File privateKey;
     private final X509Certificate cert;
@@ -107,7 +115,7 @@ public final class SelfSignedCertificate {
     public SelfSignedCertificate(String fqdn, Date notBefore, Date notAfter) throws CertificateException {
         // Bypass entropy collection by using insecure random generator.
         // We just want to generate it without any delay because it's for testing purposes only.
-        this(fqdn, ThreadLocalInsecureRandom.current(), 1024, notBefore, notAfter);
+        this(fqdn, ThreadLocalInsecureRandom.current(), DEFAULT_KEY_LENGTH_BITS, notBefore, notAfter);
     }
 
     /**


### PR DESCRIPTION
Motivation:
During OpenSsl.java initialization, a SelfSignedCertificate is created
during the static initialization block to determine if OpenSsl
can be used.

The default key strength for SelfSignedCertificate was too low if FIPS
mode is used and BouncyCastle-FIPS is the only available provider
(necessary for compliance). A simple fix is to just augment the key
strength to the minimum required about by FIPS.

Modification:
Set default key bit length to 2048 but also allow it to be dynamically set via a system property for future proofing to more stricter security compliance.

Result:
Fixes #9018 

Signed-off-by: Farid Zakaria <farid.m.zakaria@gmail.com>