### PR TITLE
DnsNameResolver.resolveAll(...) should not include duplicates

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -695,10 +695,17 @@ abstract class DnsResolveContext<T> {
                 continue;
             }
 
+            // We want to ensure we do not have duplicates in finalResult as this may be unexpected.
+            //
+            // While using a LinkedHashSet or HashSet may sound like the perfect fit for this we will use an
+            // ArrayList here as duplicates should be found quite unfrequently in the wild and we dont want to pay
+            // for the extra memory copy and allocations in this cases later on.
             if (finalResult == null) {
                 finalResult = new ArrayList<T>(8);
+                finalResult.add(converted);
+            } else if (!finalResult.contains(converted)) {
+                finalResult.add(converted);
             }
-            finalResult.add(converted);
 
             cache(hostname, additionals, r, converted);
             found = true;


### PR DESCRIPTION
Motivation:

DnsNameResolver#resolveAll(String) may return duplicate results in the event that the original hostname DNS response includes an IP address X and a CNAME that ends up resolving the same IP address X. This behavior is inconsistent with the JDK’s resolver and is unexpected to retrun a List with duplicate entries from a resolveAll(..) call.

Modifications:

- Filter out duplicates
- Add unit test

Result:

More consistent and less suprising behavior