### PR TITLE
DnsNameResolver should log in trace level if notification of the prom…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -861,13 +861,19 @@ public class DnsNameResolver extends InetNameResolver {
 
     static <T> void trySuccess(Promise<T> promise, T result) {
         if (!promise.trySuccess(result)) {
-            logger.warn("Failed to notify success ({}) to a promise: {}", result, promise);
+            // There is nothing really wrong with not be able to notify the promise as we may have raced here because
+            // of multiple queries that have been executed. Log it with trace level anyway just in case the user
+            // wants to better understand what happened.
+            logger.trace("Failed to notify success ({}) to a promise: {}", result, promise);
         }
     }
 
     private static void tryFailure(Promise<?> promise, Throwable cause) {
         if (!promise.tryFailure(cause)) {
-            logger.warn("Failed to notify failure to a promise: {}", promise, cause);
+            // There is nothing really wrong with not be able to notify the promise as we may have raced here because
+            // of multiple queries that have been executed. Log it with trace level anyway just in case the user
+            // wants to better understand what happened.
+            logger.trace("Failed to notify failure to a promise: {}", promise, cause);
         }
     }
 


### PR DESCRIPTION
…ise fails

Motivation:

During investigating some other bug I noticed that we log with warn level if we fail to notify the promise due the fact that it is already full-filled. This is not correct and missleading as there is nothing wrong with it in general. A promise may already been fullfilled because we did multiple queries and one of these was successful.

Modifications:

- Change log level to trace
- Add unit test which before did log with warn level but now does with trace level.

Result:

Less missleading noise in the log.