### PR TITLE
Correctly handle overflow in Native.kevent(...) when EINTR is detected

### DIFF
--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -139,15 +139,11 @@ static jint netty_kqueue_native_keventWait(JNIEnv* env, jclass clazz, jint kqueu
         }
 
         netty_unix_util_clock_gettime(waitClockId, &nowTs);
-        // beforeTs will store the time difference to check for overflow
-        beforeTs.tv_sec = nowTs.tv_sec - beforeTs.tv_sec;
-        beforeTs.tv_nsec = nowTs.tv_nsec - beforeTs.tv_nsec;
-        // Now subtract the time difference
-        timeoutTs.tv_sec -= beforeTs.tv_sec;
-        timeoutTs.tv_nsec -= beforeTs.tv_nsec;
-        if (beforeTs.tv_sec < 0 || beforeTs.tv_nsec < 0 || (timeoutTs.tv_sec <= 0 && timeoutTs.tv_nsec <= 0)) {
+        if (netty_unix_util_timespec_subtract_ns(&timeoutTs,
+              netty_unix_util_timespec_elapsed_ns(&beforeTs, &nowTs))) {
             return 0;
         }
+
         beforeTs = nowTs;
         // https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
         // When kevent() call fails with EINTR error, all changes in the changelist have been applied.

--- a/transport-native-unix-common/src/main/c/netty_unix_util.h
+++ b/transport-native-unix-common/src/main/c/netty_unix_util.h
@@ -18,6 +18,7 @@
 #define NETTY_UNIX_UTIL_H_
 
 #include <jni.h>
+#include <stdint.h>
 #include <time.h>
 
 #if defined(__MACH__) && !defined(CLOCK_REALTIME)
@@ -63,6 +64,20 @@ jboolean netty_unix_util_initialize_wait_clock(clockid_t* clockId);
  * MacOS does not support clock_gettime.
  */
 int netty_unix_util_clock_gettime(clockid_t clockId, struct timespec* tp);
+
+/**
+ * Calculate the number of nano seconds elapsed between begin and end.
+ *
+ * Returns the number of nano seconds.
+ */
+uint64_t netty_unix_util_timespec_elapsed_ns(const struct timespec* begin, const struct timespec* end);
+
+/**
+ * Subtract <pre>nanos</pre> nano seconds from a <pre>timespec</pre>.
+ *
+ * Returns true if there is underflow.
+ */
+jboolean netty_unix_util_timespec_subtract_ns(struct timespec* ts, uint64_t nanos);
 
 /**
  * Return type is as defined in http://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#wp5833.


### PR DESCRIPTION
Motivation:
When kevent(...) returns with EINTR we do not correctly decrement the timespec
structure contents to account for the time duration. This may lead to negative
values for tv_nsec which will result in an EINVAL and raise an IOException to
the event loop selection loop.

Modifications:
Correctly calculate new timeoutTs when EINTR is detected

Result:
Fixes #9013.