### PR TITLE
Implement tracking for event loop group load

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -35,6 +35,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     private final AtomicInteger terminatedChildren = new AtomicInteger();
     private final Promise<?> terminationFuture = new DefaultPromise(GlobalEventExecutor.INSTANCE);
     private final EventExecutorChooserFactory.EventExecutorChooser chooser;
+    private final SaturationHistogram saturationHistogram;
 
     /**
      * Create a new instance.
@@ -76,6 +77,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
             executor = new ThreadPerTaskExecutor(newDefaultThreadFactory());
         }
 
+        saturationHistogram = new SaturationHistogram(nThreads);
         children = new EventExecutor[nThreads];
 
         for (int i = 0; i < nThreads; i ++) {
@@ -130,6 +132,10 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
 
     protected ThreadFactory newDefaultThreadFactory() {
         return new DefaultThreadFactory(getClass());
+    }
+
+    protected final SaturationHistogram getSaturationHistogram() {
+        return saturationHistogram;
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/SaturationHistogram.java
+++ b/common/src/main/java/io/netty/util/concurrent/SaturationHistogram.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+public class SaturationHistogram {
+  private final AtomicLongArray histogram;
+  private final AtomicInteger count;
+  private final AtomicLong fullySaturatedTimeNanos;
+  private final AtomicLong fullySaturatedStart;
+  private final int nThreads;
+
+  public SaturationHistogram(int nThreads) {
+      this.nThreads = nThreads;
+      this.count = new AtomicInteger();
+      this.fullySaturatedTimeNanos = new AtomicLong();
+      this.fullySaturatedStart = new AtomicLong();
+      this.histogram = new AtomicLongArray(nThreads);
+  }
+
+  public long[] snapshot() {
+      long[] snap = new long[histogram.length()];
+      for (int i = 0; i < histogram.length(); i++) {
+          snap[i] = histogram.get(i);
+      }
+      return snap;
+  }
+
+  public long getFullySaturatedTimeNanos() {
+      return fullySaturatedTimeNanos.get();
+  }
+
+  public void enter() {
+      int currentCount = count.incrementAndGet();
+      if (currentCount <= nThreads) {
+          histogram.incrementAndGet(currentCount - 1);
+          if (currentCount == nThreads) {
+              fullySaturatedStart.set(System.nanoTime());
+          }
+      }
+  }
+
+  public void exit() {
+      long currentFullySaturatedStart = fullySaturatedStart.getAndSet(0L);
+      int oldCount = count.getAndDecrement();
+      if (oldCount == nThreads && currentFullySaturatedStart != 0) {
+          fullySaturatedTimeNanos.addAndGet(System.nanoTime() - currentFullySaturatedStart);
+      }
+  }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.epoll;
 
+import io.netty.util.concurrent.SaturationHistogram;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -129,9 +130,18 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
         }
     }
 
+    public long[] getSaturationHistogramSnapshot() {
+        return getSaturationHistogram().snapshot();
+    }
+
+    public long getFullySaturatedTimeNanos() {
+        return getSaturationHistogram().getFullySaturatedTimeNanos();
+    }
+
     @Override
     protected EventLoop newChild(Executor executor, Object... args) throws Exception {
         return new EpollEventLoop(this, executor, (Integer) args[0],
-                ((SelectStrategyFactory) args[1]).newSelectStrategy(), (RejectedExecutionHandler) args[2]);
+                ((SelectStrategyFactory) args[1]).newSelectStrategy(), (RejectedExecutionHandler) args[2],
+                getSaturationHistogram());
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.epoll;
 
+import io.netty.util.concurrent.SaturationHistogram;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -51,7 +52,8 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
 
         final EventLoopGroup group = new EpollEventLoop(null,
                 new ThreadPerTaskExecutor(new DefaultThreadFactory(getClass())), 0,
-                DefaultSelectStrategyFactory.INSTANCE.newSelectStrategy(), RejectedExecutionHandlers.reject()) {
+                DefaultSelectStrategyFactory.INSTANCE.newSelectStrategy(), RejectedExecutionHandlers.reject(),
+                new SaturationHistogram(1)) {
             @Override
             void handleLoopException(Throwable t) {
                 capture.set(t);

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -16,6 +16,7 @@
 package io.netty.channel.nio;
 
 import io.netty.channel.Channel;
+import io.netty.util.concurrent.SaturationHistogram;
 import io.netty.channel.EventLoop;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.MultithreadEventLoopGroup;
@@ -91,7 +92,7 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
                              final SelectorProvider selectorProvider,
                              final SelectStrategyFactory selectStrategyFactory) {
         super(nThreads, executor, chooserFactory, selectorProvider, selectStrategyFactory,
-                RejectedExecutionHandlers.reject());
+              RejectedExecutionHandlers.reject());
     }
 
     public NioEventLoopGroup(int nThreads, Executor executor, EventExecutorChooserFactory chooserFactory,
@@ -121,9 +122,18 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
         }
     }
 
+    public long[] getSaturationHistogramSnapshot() {
+        return getSaturationHistogram().snapshot();
+    }
+
+    public long getFullySaturatedTimeNanos() {
+        return getSaturationHistogram().getFullySaturatedTimeNanos();
+    }
+
     @Override
     protected EventLoop newChild(Executor executor, Object... args) throws Exception {
         return new NioEventLoop(this, executor, (SelectorProvider) args[0],
-            ((SelectStrategyFactory) args[1]).newSelectStrategy(), (RejectedExecutionHandler) args[2]);
+            ((SelectStrategyFactory) args[1]).newSelectStrategy(), (RejectedExecutionHandler) args[2],
+            getSaturationHistogram());
     }
 }


### PR DESCRIPTION
Motivation:

One of the difficult questions (at least in my opinion) to answer when debugging applications using netty is "how busy is the netty event loop group".  All workers being busy can cause difficult-to-debug hangs, but too many workers can cause unneeded context switching.  To complicate things, simply exposing a gauge of "how many threads are currently busy" is insufficient to answer questions like this, because it's simply a point-in-time snapshot.  eg, if at time T, all threads are busy, but then all go idle at time T+1, depending on when the gauge is read, we'll either think the ELG is completely idle, or completely full.

Modification:

This PR introduces a saturation histogram that is used to track how many event loops are busy at any given time.  Each time an event loop "wakes up", it checks how many other event loops are also busy, and increments the corresponding bucket in the histogram.  This histogram can be observed via snapshotting it, and various information derived from that snapshot (percentiles, etc).  Additionally, we also track a counter of how many nanoseconds all event loops were busy for.

Result:

This has proven extremely useful for finding ELG starvation, as well as tuning the number of worker threads a given group needs in a service.  I've implemented tracking for both epoll and NIO, simply because those are the two transport types we use, however, it would be trivial to extend this to the other transports as well.  I'd love to get feedback on this, and happy to hear any suggestions!
