### PR TITLE
NioServerSocketChannel.isActive() must return false after close() com…

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -106,7 +106,9 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
 
     @Override
     public boolean isActive() {
-        return javaChannel().socket().isBound();
+        // As java.nio.ServerSocketChannel.isBound() will continue to return true even after the channel was closed
+        // we will also need to check if it is open.
+        return isOpen() && javaChannel().socket().isBound();
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioServerSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioServerSocketChannelTest.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel.socket.nio;
 
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import org.junit.Assert;
@@ -40,6 +42,23 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
             Assert.assertFalse(serverSocketChannel.closeOnReadError(new IOException()));
             Assert.assertTrue(serverSocketChannel.closeOnReadError(new IllegalArgumentException()));
             serverSocketChannel.close().syncUninterruptibly();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testIsActiveFalseAfterClose()  {
+        NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel();
+        EventLoopGroup group = new NioEventLoopGroup(1);
+        try {
+            group.register(serverSocketChannel).syncUninterruptibly();
+            Channel channel = serverSocketChannel.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+            Assert.assertTrue(channel.isActive());
+            Assert.assertTrue(channel.isOpen());
+            channel.close().syncUninterruptibly();
+            Assert.assertFalse(channel.isOpen());
+            Assert.assertFalse(channel.isActive());
         } finally {
             group.shutdownGracefully();
         }


### PR DESCRIPTION
…pletes.

Motivation:

When a Channel was closed its isActive() method must return false.

Modifications:

First check for isOpen() before isBound() as isBound() will continue to return true even after the underyling fd was closed.

Result:

Fixes https://github.com/netty/netty/issues/9026.