### PR TITLE
Add IPv6 multicast test to testsuite

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractDatagramTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractDatagramTest.java
@@ -18,6 +18,7 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.testsuite.transport.AbstractComboTestsuiteTest;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.util.NetUtil;
@@ -34,7 +35,7 @@ public abstract class AbstractDatagramTest extends AbstractComboTestsuiteTest<Bo
 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
-        return SocketTestPermutation.INSTANCE.datagram();
+        return SocketTestPermutation.INSTANCE.datagram(InternetProtocolFamily.IPv4);
     }
 
     @Override
@@ -44,11 +45,17 @@ public abstract class AbstractDatagramTest extends AbstractComboTestsuiteTest<Bo
     }
 
     protected SocketAddress newSocketAddress() {
-        // We use LOCALHOST4 as we use InternetProtocolFamily.IPv4 when creating the DatagramChannel and its
-        // not supported to bind to and IPV6 address in this case.
-        //
-        // See also http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/e74259b3eadc/
-        // src/share/classes/sun/nio/ch/DatagramChannelImpl.java#l684
-        return new InetSocketAddress(NetUtil.LOCALHOST4, 0);
+        switch (internetProtocolFamily()) {
+            case IPv4:
+                return new InetSocketAddress(NetUtil.LOCALHOST4, 0);
+            case IPv6:
+                return new InetSocketAddress(NetUtil.LOCALHOST6, 0);
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    protected InternetProtocolFamily internetProtocolFamily() {
+        return InternetProtocolFamily.IPv4;
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastIPv6Test.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastIPv6Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Netty Project
+ * Copyright 2019 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,18 +13,14 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel.kqueue;
+package io.netty.testsuite.transport.socket;
 
-import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.socket.InternetProtocolFamily;
-import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.DatagramUnicastTest;
 
-import java.util.List;
+public class DatagramMulticastIPv6Test extends DatagramMulticastTest {
 
-public class KQueueDatagramUnicastTest extends DatagramUnicastTest {
     @Override
-    protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
-        return KQueueSocketTestPermutation.INSTANCE.datagram(InternetProtocolFamily.IPv4);
+    protected InternetProtocolFamily internetProtocolFamily() {
+        return InternetProtocolFamily.IPv6;
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -112,7 +112,7 @@ public class SocketTestPermutation {
         return list;
     }
 
-    public List<BootstrapComboFactory<Bootstrap, Bootstrap>> datagram() {
+    public List<BootstrapComboFactory<Bootstrap, Bootstrap>> datagram(final InternetProtocolFamily family) {
         // Make the list of Bootstrap factories.
         List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
                 new BootstrapFactory<Bootstrap>() {
@@ -121,7 +121,7 @@ public class SocketTestPermutation {
                         return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
                             @Override
                             public Channel newChannel() {
-                                return new NioDatagramChannel(InternetProtocolFamily.IPv4);
+                                return new NioDatagramChannel(family);
                             }
 
                             @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramMulticastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramMulticastTest.java
@@ -16,6 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramMulticastTest;
 
@@ -24,7 +25,7 @@ import java.util.List;
 public class EpollDatagramMulticastTest extends DatagramMulticastTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
-        return EpollSocketTestPermutation.INSTANCE.datagram();
+        return EpollSocketTestPermutation.INSTANCE.datagram(InternetProtocolFamily.IPv4);
     }
 
     public void testMulticast(Bootstrap sb, Bootstrap cb) throws Throwable {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
@@ -16,6 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramUnicastTest;
 
@@ -24,7 +25,7 @@ import java.util.List;
 public class EpollDatagramUnicastTest extends DatagramUnicastTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
-        return EpollSocketTestPermutation.INSTANCE.datagram();
+        return EpollSocketTestPermutation.INSTANCE.datagram(InternetProtocolFamily.IPv4);
     }
 
     public void testSimpleSendWithConnect(Bootstrap sb, Bootstrap cb) throws Throwable {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -119,7 +119,8 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     }
 
     @Override
-    public List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> datagram() {
+    public List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> datagram(
+            final InternetProtocolFamily family) {
         // Make the list of Bootstrap factories.
         @SuppressWarnings("unchecked")
         List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
@@ -129,7 +130,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                         return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
                             @Override
                             public Channel newChannel() {
-                                return new NioDatagramChannel(InternetProtocolFamily.IPv4);
+                                return new NioDatagramChannel(family);
                             }
 
                             @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -103,7 +103,8 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     }
 
     @Override
-    public List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> datagram() {
+    public List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> datagram(
+            final InternetProtocolFamily family) {
         // Make the list of Bootstrap factories.
         @SuppressWarnings("unchecked")
         List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
@@ -113,7 +114,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                         return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
                             @Override
                             public Channel newChannel() {
-                                return new NioDatagramChannel(InternetProtocolFamily.IPv4);
+                                return new NioDatagramChannel(family);
                             }
 
                             @Override


### PR DESCRIPTION
Motivation:

We currently only cover ipv4 multicast in the testsuite but we should also have tests for ipv6.

Modifications:

- Add test for ipv6
- Ensure we only try to run multicast test for ipv4 / ipv6 if the loopback interface supports it.

Result:

Better test coverage