### PR TITLE
Update to netty-tcnative 2.0.25.Final to fix possible segfault when o…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.24.Final</tcnative.version>
+    <tcnative.version>2.0.25.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
…penssl < 1.0.2 and gcc is used.

Motivation:

We should update to netty-tcnative 2.0.25.Final as it fixes a possible segfault on systems that use openssl < 1.0.2 and for which we compiled with gcc.

See https://github.com/netty/netty-tcnative/pull/457

Modifications:

Update netty-tcnative

Result:

No more segfault possible.