### PR TITLE
Make validation tools more happy by not have TrustManager impl just a…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509TrustManagerWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509TrustManagerWrapper.java
@@ -71,11 +71,13 @@ final class OpenSslX509TrustManagerWrapper {
                             @Override
                             public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
                                     throws CertificateException {
+                                throw new CertificateException();
                             }
 
                             @Override
                             public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
                                     throws CertificateException {
+                                throw new CertificateException();
                             }
 
                             @Override


### PR DESCRIPTION
…ccept

Motivation:

Seems like some analyzer / validation tools scan code to detect if it may produce some security risk because of just blindly accept certificates. Such a tool did tag our code because we have such an implementation (which then is actually never be used). We should just change the impl to not do this as it does not matter for us and it makes such tools happier.

Modifications:

Throw CertificateException

Result:

Fixes https://github.com/netty/netty/issues/9032