### PR TITLE
Check both whether IPv4 is only stack or IPv4 is preferred when setti…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -109,7 +109,7 @@ public class DnsNameResolver extends InetNameResolver {
     private static final int DEFAULT_NDOTS;
 
     static {
-        if (NetUtil.isIpV4StackPreferred()) {
+        if (NetUtil.LOCALHOST == NetUtil.LOCALHOST4 || NetUtil.isIpV4StackPreferred()) {
             DEFAULT_RESOLVE_ADDRESS_TYPES = ResolvedAddressTypes.IPV4_ONLY;
             LOCALHOST_ADDRESS = NetUtil.LOCALHOST4;
         } else {


### PR DESCRIPTION
…ng up DnsNameResolver.

This is a straw-man's proposal related to #9044. The javadoc seems to indicate checking `LOCALHOST` is `LOCALHOST6` or 4 is the way to determine whether IPv6 stack is available.

Motivation:

DNS resolution should not return IPv6 addresses in the following cases

- IPv4 is preferred
- IPv4 is the only available stack

Otherwise, client code may end up trying to connect to addresses that it is not possible to do so.

Modification:

Check both whether IPv6 stack is available or not in addition to IPv4 preference when setting up DNS resolver.

Result:

Fixes https://github.com/line/armeria/issues/1146 in a better way than #7875
