### PR TITLE
Use ArrayDeque instead of LinkedList

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpResponseStreamIdHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpResponseStreamIdHandler.java
@@ -21,7 +21,7 @@ import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.spdy.SpdyHttpHeaders.Names;
 import io.netty.util.ReferenceCountUtil;
 
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 
@@ -33,7 +33,7 @@ import java.util.Queue;
 public class SpdyHttpResponseStreamIdHandler extends
         MessageToMessageCodec<Object, HttpMessage> {
     private static final Integer NO_ID = -1;
-    private final Queue<Integer> ids = new LinkedList<Integer>();
+    private final Queue<Integer> ids = new ArrayDeque<Integer>();
 
     @Override
     public boolean acceptInboundMessage(Object msg) throws Exception {


### PR DESCRIPTION
Motivation:
Prefer ArrayDeque to LinkedList because later will produce more GC.

https://github.com/netty/netty/blob/4c64c98f348131e0792ba4a92ce3d0003237d56a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java#L45

Modification:

Use ArrayDeque instead of LinkedList

