### PR TITLE
DnsNameResolver.resolve(...) should notify future as soon as one pref…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -31,13 +31,16 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
 
     private final DnsCache resolveCache;
     private final AuthoritativeDnsServerCache authoritativeDnsServerCache;
+    private final boolean completeEarlyIfPossible;
 
     DnsAddressResolveContext(DnsNameResolver parent, String hostname, DnsRecord[] additionals,
                              DnsServerAddressStream nameServerAddrs, DnsCache resolveCache,
-                             AuthoritativeDnsServerCache authoritativeDnsServerCache) {
+                             AuthoritativeDnsServerCache authoritativeDnsServerCache,
+                             boolean completeEarlyIfPossible) {
         super(parent, hostname, DnsRecord.CLASS_IN, parent.resolveRecordTypes(), additionals, nameServerAddrs);
         this.resolveCache = resolveCache;
         this.authoritativeDnsServerCache = authoritativeDnsServerCache;
+        this.completeEarlyIfPossible = completeEarlyIfPossible;
     }
 
     @Override
@@ -46,7 +49,7 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
                                                       DnsRecord[] additionals,
                                                       DnsServerAddressStream nameServerAddrs) {
         return new DnsAddressResolveContext(parent, hostname, additionals, nameServerAddrs, resolveCache,
-                authoritativeDnsServerCache);
+                authoritativeDnsServerCache, completeEarlyIfPossible);
     }
 
     @Override
@@ -58,6 +61,11 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     List<InetAddress> filterResults(List<InetAddress> unfiltered) {
         Collections.sort(unfiltered, PreferredAddressTypeComparator.comparator(parent.preferredAddressType()));
         return unfiltered;
+    }
+
+    @Override
+    boolean isCompleteEarly(InetAddress resolved) {
+        return completeEarlyIfPossible && parent.preferredAddressType().addressType() == resolved.getClass();
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -59,6 +59,11 @@ final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
     }
 
     @Override
+    boolean isCompleteEarly(DnsRecord resolved) {
+        return false;
+    }
+
+    @Override
     void cache(String hostname, DnsRecord[] additionals, DnsRecord result, DnsRecord convertedResult) {
         // Do not cache.
         // XXX: When we implement cache, we would need to retain the reference count of the result record.


### PR DESCRIPTION
…erred record was resolved

Motivation:

At the moment resolve(...) does just delegate to resolveAll(...) and so will only notify the future once all records were resolved. This is wasteful as we are only interested in the first record anyway. We should notify the promise as soon as one record that matches the preferred record type is resolved.

Modifications:

- Introduce DnsResolveContext.isCompleteEarly(...) to be able to detect once we should early notify the promise.
- Make use of this early detecting if resolve(...) is called
- Remove FutureListener which could lead to IllegalReferenceCountException due double releases
- add unit test

Result:

Be able to notify about resolved host more quickly.