### PR TITLE
Correctly calculate ttl for AuthoritativeNameServer when update exist…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -1232,7 +1232,7 @@ abstract class DnsResolveContext<T> {
         void update(InetSocketAddress address, long ttl) {
             assert this.address == null || this.address.isUnresolved();
             this.address = address;
-            this.ttl = min(ttl, ttl);
+            this.ttl = min(this.ttl, ttl);
         }
 
         void update(InetSocketAddress address) {


### PR DESCRIPTION
…ing records

Motivation:

We did not correctly calculate the new ttl as we did forget to add `this.`

Modifications:

Add .this and so correctly calculate the TTL

Result:

Use correct TTL for authoritative nameservers when updating these.