### PR TITLE
Simplify expandNioBufferArray Implementation

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -484,17 +484,9 @@ public final class ChannelOutboundBuffer {
     }
 
     private static ByteBuffer[] expandNioBufferArray(ByteBuffer[] array, int neededSpace, int size) {
-        int newCapacity = array.length;
-        do {
-            // double capacity until it is big enough
-            // See https://github.com/netty/netty/issues/1890
-            newCapacity <<= 1;
-
-            if (newCapacity < 0) {
-                throw new IllegalStateException();
-            }
-
-        } while (neededSpace > newCapacity);
+        int oldCapacity = array.length;
+        int newCapacity = oldCapacity + (oldCapacity >> 1);
+        newCapacity = Math.max(newCapacity, neededSpace);
 
         ByteBuffer[] newArray = new ByteBuffer[newCapacity];
         System.arraycopy(array, 0, newArray, 0, size);


### PR DESCRIPTION
Motivation:

Simplify code by removing a looping mechanism.  Make the code procedural.

Modification:

Remove looping structure and grow the array by 1.5x instead of 2x for a less more conservative growth.  Also, when doubling the size, it can quickly get larger than the largest signed Integer size.