### PR TITLE
Reduce event loop volatile field access overhead

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -757,7 +757,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
         synchronized (threadLock) {
             long remainingNanos;
             while (!isTerminated() && (remainingNanos = deadline - System.nanoTime()) > 0L) {
-                threadLock.wait(remainingNanos / 1000000L, (int) (remainingNanos % 1000000L));
+                TimeUnit.NANOSECONDS.timedWait(threadLock, remainingNanos);
             }
         }
 
@@ -965,8 +965,8 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
                             thread = nonVolatileThread = null;
 
+                            STATE_UPDATER.set(SingleThreadEventExecutor.this, ST_TERMINATED);
                             synchronized (threadLock) {
-                                STATE_UPDATER.set(SingleThreadEventExecutor.this, ST_TERMINATED);
                                 threadLock.notifyAll();
                             }
                             if (logger.isWarnEnabled() && !taskQueue.isEmpty()) {

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -495,6 +495,14 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     @Override
     public boolean inEventLoop() {
+        // This may appear to be racy at first glance but is safe. We might not read the "correct"
+        // thread from the non-volatile field, but we will see its value as == current thread
+        // if and only if we are the thread currently executing the event loop:
+        // - If we are the event loop thread then it will be set to us since it is set at the
+        //   beginning of the run() method
+        // - If we are not the event loop thread then no other thread can have set the value to
+        //   be our thread, and if we had set it previously we would have subsequently set
+        //   it to null prior to exiting the run() method
         return Thread.currentThread() == nonVolatileThread;
     }
 


### PR DESCRIPTION
Motivation

Right now there's various volatile reads performed on every call to each of `executor.inEventLoop()` and `executor.execute(Runnable)` which are avoidable. These methods are called very often.

Also use of a `Semaphore` just for awaiting termination is kind of overkill.

Modifications

- Add a non-volatile `SingleThreadEventExecutor.nonVolatileThread` field
- null out both thread fields upon event loop termination
- Use the new non-volatile field in `inEventLoop()` and `startThread()` methods
- Change `awaitTermination`'s use of `Semaphore` to a regular monitor

Result

Less volatile access overhead, slightly reduced event loop object footprint.