### PR TITLE
DefaultHeaders#valueIterator to support removal

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -1019,6 +1019,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             entries[i] = entry.next;
         }
         entry.remove();
+        --size;
     }
 
     @SuppressWarnings("unchecked")

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -1012,6 +1012,15 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         return value;
     }
 
+    private void remove0(HeaderEntry<K, V> entry) {
+        int i = index(entry.hash);
+        HeaderEntry<K, V> e = entries[i];
+        if (e == entry) {
+            entries[i] = entry.next;
+        }
+        entry.remove();
+    }
+
     @SuppressWarnings("unchecked")
     private T thisT() {
         return (T) this;
@@ -1055,6 +1064,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     private final class ValueIterator implements Iterator<V> {
         private final K name;
         private final int hash;
+        private HeaderEntry<K, V> previous;
         private HeaderEntry<K, V> next;
 
         ValueIterator(K name) {
@@ -1073,14 +1083,18 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             if (!hasNext()) {
                 throw new NoSuchElementException();
             }
-            HeaderEntry<K, V> current = next;
+            previous = next;
             calculateNext(next.next);
-            return current.value;
+            return previous.value;
         }
 
         @Override
         public void remove() {
-            throw new UnsupportedOperationException("read only");
+            if (previous == null) {
+                throw new IllegalStateException();
+            }
+            remove0(previous);
+            previous = null;
         }
 
         private void calculateNext(HeaderEntry<K, V> entry) {

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -121,9 +121,12 @@ public class DefaultHeadersTest {
         Iterator<CharSequence> itr = headers.valueIterator(of("name"));
         while (itr.hasNext()) {
             values.add(itr.next());
+            itr.remove();
         }
         assertEquals(3, values.size());
         assertTrue(values.containsAll(asList(of("value1"), of("value2"), of("value3"))));
+        itr = headers.valueIterator(of("name"));
+        assertFalse(itr.hasNext());
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -129,6 +129,35 @@ public class DefaultHeadersTest {
         assertFalse(itr.hasNext());
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void valuesItrRemoveThrowsWhenEmpty() {
+        TestDefaultHeaders headers = newInstance();
+        Iterator<CharSequence> itr = headers.valueIterator(of("name"));
+        itr.remove();
+    }
+
+    @Test
+    public void valuesItrRemoveThrowsAfterLastElement() {
+        TestDefaultHeaders headers = newInstance();
+        headers.add(of("name"), of("value1"));
+        assertEquals(1, headers.size());
+
+        List<CharSequence> values = new ArrayList<CharSequence>();
+        Iterator<CharSequence> itr = headers.valueIterator(of("name"));
+        while (itr.hasNext()) {
+            values.add(itr.next());
+            itr.remove();
+        }
+        assertEquals(1, values.size());
+        assertTrue(values.contains(of("value1")));
+        try {
+            itr.remove();
+            fail();
+        } catch (IllegalStateException ignored) {
+            // ignored
+        }
+    }
+
     @Test
     public void multipleValuesPerNameIteratorEmpty() {
         TestDefaultHeaders headers = newInstance();

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -124,6 +124,8 @@ public class DefaultHeadersTest {
             itr.remove();
         }
         assertEquals(3, values.size());
+        assertEquals(0, headers.size());
+        assertTrue(headers.isEmpty());
         assertTrue(values.containsAll(asList(of("value1"), of("value2"), of("value3"))));
         itr = headers.valueIterator(of("name"));
         assertFalse(itr.hasNext());
@@ -132,6 +134,8 @@ public class DefaultHeadersTest {
     @Test(expected = IllegalStateException.class)
     public void valuesItrRemoveThrowsWhenEmpty() {
         TestDefaultHeaders headers = newInstance();
+        assertEquals(0, headers.size());
+        assertTrue(headers.isEmpty());
         Iterator<CharSequence> itr = headers.valueIterator(of("name"));
         itr.remove();
     }
@@ -149,6 +153,8 @@ public class DefaultHeadersTest {
             itr.remove();
         }
         assertEquals(1, values.size());
+        assertEquals(0, headers.size());
+        assertTrue(headers.isEmpty());
         assertTrue(values.contains(of("value1")));
         try {
             itr.remove();


### PR DESCRIPTION
Motivation:
While iterating values it is often desirable to be able to remove individual
entries. The existing mechanism to do this involves removal of all entries and
conditional re-insertion which is heavy weight in order to remove a single
value.

Modifications:
- DefaultHeaders$ValueIterator supports removal

Result:
It is possible to remove entries while iterating the values in DefaultHeaders.