### PR TITLE
Remove static wildcard imports in EpollDomainSocketChannelConfig

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -26,8 +26,8 @@ import io.netty.channel.unix.DomainSocketReadMode;
 
 import java.util.Map;
 
-import static io.netty.channel.ChannelOption.*;
-import static io.netty.channel.unix.UnixChannelOption.*;
+import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
+import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 
 public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         implements DomainSocketChannelConfig {


### PR DESCRIPTION
Motivation

These aren't needed, only one field from each class is used. It also showed as an ambiguous identifier compilation error in my IDE even though javac is obviously fine with it.

Modifications

Static-import explicit `ChannelOption` fields in `EpollDomainSocketChannelConfig` instead of using `.*` wildcard.

Result

Cleaner / more consistent code.