### PR TITLE
Add Http2GoAwayWriteEvent

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -818,6 +818,10 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             return promise;
         }
 
+        // The GO_AWAY may be the result of an internal error, or user generated (and they may not know the stream ID).
+        // We fire this event in the pipeline so the application has visibility that the connection is shutting down.
+        ctx.fireUserEventTriggered(new Http2GoAwayWriteEvent(lastStreamId, errorCode));
+
         // Need to retain before we write the buffer because if we do it after the refCnt could already be 0 and
         // result in an IllegalRefCountException.
         debugData.retain();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2GoAwayWriteEvent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2GoAwayWriteEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+/**
+ * Notification that an <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame write attempt was
+ * made. This doesn't necessarily mean the write was successful but instead is an indication that the corresponding
+ * channel is shutting down.
+ */
+public final class Http2GoAwayWriteEvent {
+    private final int lastKnownStreamId;
+    private final long errorCode;
+
+    /**
+     * Create a new instance.
+     * @param lastKnownStreamId The last known stream identifier.
+     * @param errorCode The errorCode see {@link Http2Error}.
+     */
+    Http2GoAwayWriteEvent(int lastKnownStreamId, long errorCode) {
+        this.lastKnownStreamId = lastKnownStreamId;
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Gets the last known stream identifier.
+     * @return the last known stream identifier.
+     */
+    public int lastKnownStreamId() {
+        return lastKnownStreamId;
+    }
+
+    /**
+     * Gets the errorCode (see {@link Http2Error}).
+     * @return the errorCode (see {@link Http2Error}).
+     */
+    public long errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " lastKnownStreamId: " + lastKnownStreamId + " errorCode: " + errorCode;
+    }
+}


### PR DESCRIPTION
Motivation:
A GOAWAY frame maybe initialized by the user via a close, but it maybe
initialized internally. This makes it difficult for the user to understand
when a connection is being shutdown and should no longer be used. The users
could override the FrameWriter, but this API is not something that we expect
users of the child channel API to interact with.

Modifications:
- Add a Http2GoAwayWriteEvent that is fired as a userEvent when a GOAWAY frame
is written.

Result:
HTTP/2 use cases (including child channel) can now know when a GOAWAY is sent or
received.