### PR TITLE
Add docker-compose file to compile / test with graalvm

### DIFF
--- a/docker/docker-compose.centos-6.graalvm1.yaml
+++ b/docker/docker-compose.centos-6.graalvm1.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-1.8
+    build:
+      args:
+        centos_version : "6"
+        java_version : "graalvm@1.0.0-16"
+
+  test:
+    image: netty:centos-6-1.8
+
+  test-leak:
+    image: netty:centos-6-1.8
+
+  test-boringssl-static:
+    image: netty:centos-6-1.8
+
+  shell:
+    image: netty:centos-6-1.8


### PR DESCRIPTION
Motivation:

We should try to compile / test with graalvm as well.

Modifications:

Add docker-compose file for graalvm

Result:

Be able to also compile / test with graalvm