### PR TITLE
Fix flaky GlobalEventExecutorTest.*

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/GlobalEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/GlobalEventExecutorTest.java
@@ -46,7 +46,7 @@ public class GlobalEventExecutorTest {
         }
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testAutomaticStartStop() throws Exception {
         final TestRunnable task = new TestRunnable(500);
         e.execute(task);
@@ -56,10 +56,7 @@ public class GlobalEventExecutorTest {
         assertThat(thread, is(not(nullValue())));
         assertThat(thread.isAlive(), is(true));
 
-        Thread.sleep(1500);
-
-        // Ensure the thread stopped itself after running the task.
-        assertThat(thread.isAlive(), is(false));
+        thread.join();
         assertThat(task.ran.get(), is(true));
 
         // Ensure another new thread starts again.
@@ -68,14 +65,12 @@ public class GlobalEventExecutorTest {
         assertThat(e.thread, not(sameInstance(thread)));
         thread = e.thread;
 
-        Thread.sleep(1500);
+        thread.join();
 
-        // Ensure the thread stopped itself after running the task.
-        assertThat(thread.isAlive(), is(false));
         assertThat(task.ran.get(), is(true));
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void testScheduledTasks() throws Exception {
         TestRunnable task = new TestRunnable(0);
         ScheduledFuture<?> f = e.schedule(task, 1500, TimeUnit.MILLISECONDS);
@@ -87,10 +82,7 @@ public class GlobalEventExecutorTest {
         assertThat(thread, is(not(nullValue())));
         assertThat(thread.isAlive(), is(true));
 
-        Thread.sleep(1500);
-
-        // Now it should be stopped.
-        assertThat(thread.isAlive(), is(false));
+        thread.join();
     }
 
     // ensure that when a task submission causes a new thread to be created, the thread inherits the thread group of the


### PR DESCRIPTION
Motivation:

In GlobalEventExecutorTest we used Thread.sleep(...) which can produce flaky results (as seen on the CI). We should use another alternative during tests.

Modifications:

Replace Thread.sleep(...) with join()

Result:

No more flaky GlobalEventExecutor tests.