### PR TITLE
SmtpRequestEncoderTest ByteBuf leak

### DIFF
--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpRequestEncoderTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpRequestEncoderTest.java
@@ -22,7 +22,9 @@ import io.netty.handler.codec.EncoderException;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SmtpRequestEncoderTest {
 
@@ -92,8 +94,12 @@ public class SmtpRequestEncoderTest {
     @Test(expected = EncoderException.class)
     public void testThrowsIfContentExpected() {
         EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
-        assertTrue(channel.writeOutbound(SmtpRequests.data()));
-        channel.writeOutbound(SmtpRequests.noop());
+        try {
+            assertTrue(channel.writeOutbound(SmtpRequests.data()));
+            channel.writeOutbound(SmtpRequests.noop());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:
SmtpRequestEncoderTest#testThrowsIfContentExpected has a ByteBuf leak.

Modifications:
- SmtpRequestEncoderTest#testThrowsIfContentExpected should release buffers in a finally block

Result:
No more leaks in SmtpRequestEncoderTest#testThrowsIfContentExpected.