### PR TITLE
EventExecutorGroup lightweight progress metrics

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObservableTaskConsumerUtil;
+
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -28,7 +30,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Abstract base class for {@link EventExecutorGroup} implementations that handles their tasks with multiple threads at
  * the same time.
  */
-public abstract class MultithreadEventExecutorGroup extends AbstractEventExecutorGroup {
+public abstract class MultithreadEventExecutorGroup extends AbstractEventExecutorGroup
+        implements ObservableTaskConsumer {
 
     private final EventExecutor[] children;
     private final Set<EventExecutor> readonlyChildren;
@@ -128,6 +131,32 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
         readonlyChildren = Collections.unmodifiableSet(childrenSet);
     }
 
+    @Override
+    public long submittedTasks() {
+        long tasks = 0;
+        for (int i = 0, size = children.length; i < size; i++) {
+            final long t = submittedTasks(i);
+            if (t == ObservableTaskConsumer.UNSUPPORTED) {
+                return ObservableTaskConsumer.UNSUPPORTED;
+            }
+            tasks += t;
+        }
+        return tasks;
+    }
+
+    @Override
+    public long completedTasks() {
+        long tasks = 0;
+        for (int i = 0, size = children.length; i < size; i++) {
+            final long t = completedTasks(i);
+            if (t == ObservableTaskConsumer.UNSUPPORTED) {
+                return ObservableTaskConsumer.UNSUPPORTED;
+            }
+            tasks += t;
+        }
+        return tasks;
+    }
+
     protected ThreadFactory newDefaultThreadFactory() {
         return new DefaultThreadFactory(getClass());
     }
@@ -148,6 +177,24 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
      */
     public final int executorCount() {
         return children.length;
+    }
+
+    /**
+     * It allows to query the {@link #submittedTasks()} of a specific {@link EventExecutor}.<br>
+     *
+     * @throws IndexOutOfBoundsException if {@code executorIndex} is not >=0 and <{@link #executorCount()}
+     */
+    public final long submittedTasks(int executorIndex) {
+        return ObservableTaskConsumerUtil.submittedTasks(children[executorIndex]);
+    }
+
+    /**
+     * It allows to query the {@link #completedTasks()} of a specific {@link EventExecutor}.<br>
+     *
+     * @throws IndexOutOfBoundsException if {@code executorIndex} is not >=0 and <{@link #executorCount()}
+     */
+    public final long completedTasks(int executorIndex) {
+        return ObservableTaskConsumerUtil.completedTasks(children[executorIndex]);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/concurrent/ObservableTaskConsumer.java
+++ b/common/src/main/java/io/netty/util/concurrent/ObservableTaskConsumer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface ObservableTaskConsumer {
+
+    long UNSUPPORTED = -1;
+
+    /**
+     * Returns the number of submitted tasks: it's safe to be read by different threads.<br>
+     * <p>
+     * If {@code this} don't support this metrics it returns a negative value, likely {@link #UNSUPPORTED}.
+     */
+    long submittedTasks();
+
+    /**
+     * Returns the number of completed tasks: it's safe to be read by different threads.<br>
+     * <p>
+     * If {@code this} don't support this metrics it returns a negative value, likely {@link #UNSUPPORTED}.
+     */
+    long completedTasks();
+}

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -47,7 +47,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  * Abstract base class for {@link OrderedEventExecutor}'s that execute all its submitted tasks in a single thread.
  *
  */
-public abstract class SingleThreadEventExecutor extends AbstractScheduledEventExecutor implements OrderedEventExecutor {
+public abstract class SingleThreadEventExecutor extends AbstractScheduledEventExecutor
+        implements OrderedEventExecutor, ObservableTaskConsumer {
 
     static final int DEFAULT_MAX_PENDING_EXECUTOR_TASKS = Math.max(16,
             SystemPropertyUtil.getInt("io.netty.eventexecutor.maxPendingTasks", Integer.MAX_VALUE));
@@ -1070,6 +1071,16 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
             }
         }
         return numTasks;
+    }
+
+    @Override
+    public long submittedTasks() {
+        return PlatformDependent.currentProducerIndex(taskQueue);
+    }
+
+    @Override
+    public long completedTasks() {
+        return PlatformDependent.currentConsumerIndex(taskQueue);
     }
 
     private static final class DefaultThreadProperties implements ThreadProperties {

--- a/common/src/main/java/io/netty/util/internal/ObservableTaskConsumerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObservableTaskConsumerUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import io.netty.util.concurrent.ObservableTaskConsumer;
+
+public final class ObservableTaskConsumerUtil {
+
+    private ObservableTaskConsumerUtil() {
+    }
+
+    public static long completedTasks(Object obj) {
+        if (!(obj instanceof ObservableTaskConsumer)) {
+            return ObservableTaskConsumer.UNSUPPORTED;
+        }
+        final ObservableTaskConsumer consumer = (ObservableTaskConsumer) obj;
+        return consumer.completedTasks();
+    }
+
+    public static long submittedTasks(Object obj) {
+        if (!(obj instanceof ObservableTaskConsumer)) {
+            return ObservableTaskConsumer.UNSUPPORTED;
+        }
+        final ObservableTaskConsumer consumer = (ObservableTaskConsumer) obj;
+        return consumer.completedTasks();
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -16,11 +16,13 @@
 package io.netty.util.internal;
 
 import io.netty.util.CharsetUtil;
+import io.netty.util.concurrent.ObservableTaskConsumer;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jctools.queues.MpscArrayQueue;
 import org.jctools.queues.MpscChunkedArrayQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
+import org.jctools.queues.QueueProgressIndicators;
 import org.jctools.queues.SpscLinkedQueue;
 import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscGrowableAtomicArrayQueue;
@@ -906,6 +908,40 @@ public final class PlatformDependent {
             return USE_MPSC_CHUNKED_ARRAY_QUEUE ? new MpscUnboundedArrayQueue<T>(MPSC_CHUNK_SIZE)
                                                 : new MpscUnboundedAtomicArrayQueue<T>(MPSC_CHUNK_SIZE);
         }
+    }
+
+    /**
+     * This method has no concurrent visibility semantics. The value returned may be negative. Under normal
+     * circumstances 2 consecutive calls to this method can offer an idea of progress made by producer threads by
+     * subtracting the 2 results though in extreme cases (if producers have progressed by more than 2^64) this may also
+     * fail.<br/> This value will normally indicate number of elements passed into the queue, but may under some
+     * circumstances be a derivative of that figure. This method should not be used to derive size or emptiness.
+     *
+     * @return the current value of the producer progress index
+     */
+    @UnstableApi
+    public static long currentProducerIndex(Queue<?> q) {
+        if (q instanceof QueueProgressIndicators) {
+            return ((QueueProgressIndicators) q).currentProducerIndex();
+        }
+        return ObservableTaskConsumer.UNSUPPORTED;
+    }
+
+    /**
+     * This method has no concurrent visibility semantics. The value returned may be negative. Under normal
+     * circumstances 2 consecutive calls to this method can offer an idea of progress made by consumer threads by
+     * subtracting the 2 results though in extreme cases (if consumers have progressed by more than 2^64) this may also
+     * fail.<br/> This value will normally indicate number of elements taken out of the queue, but may under some
+     * circumstances be a derivative of that figure. This method should not be used to derive size or emptiness.
+     *
+     * @return the current value of the consumer progress index
+     */
+    @UnstableApi
+    public static long currentConsumerIndex(Queue<?> q) {
+        if (q instanceof QueueProgressIndicators) {
+            return ((QueueProgressIndicators) q).currentConsumerIndex();
+        }
+        return ObservableTaskConsumer.UNSUPPORTED;
     }
 
     /**


### PR DESCRIPTION
Motivation:

EventExecutorGroup doesn't allow to monitor submitted and completed
tasks.

Modifications:

JCtools QueueProgressIndicators exposes lightweight progression metrics:
if an executor is using a proper tasks queue, it will expose such
metrics for free.
MultithreadedEventExecutorGroup can expose global metrics (collected
using children metrics) or fine-grain ones (per-child).

Result:

An external observer can easily monitor executors utilization
without affecting executor performance.