### PR TITLE
Http2FrameCodec to simulate GOAWAY received when stream IDs are exhausted

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -39,7 +39,6 @@ import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_STREAM_ID;
 import static io.netty.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
 import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
-import static java.lang.Integer.MAX_VALUE;
 
 /**
  * <p><em>This API is very immature.</em> The Http2Connection-based API is currently preferred over this API.
@@ -346,8 +345,8 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
         int lastStreamCreated = connection().remote().lastStreamCreated();
         long lastStreamId = lastStreamCreated + ((long) frame.extraStreamIds()) * 2;
         // Check if the computation overflowed.
-        if (lastStreamId > MAX_VALUE) {
-            lastStreamId = MAX_VALUE;
+        if (lastStreamId > Integer.MAX_VALUE) {
+            lastStreamId = Integer.MAX_VALUE;
         }
         goAway(ctx, (int) lastStreamId, frame.errorCode(), frame.content(), promise);
     }
@@ -367,8 +366,9 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
 
                 // Simulate a GOAWAY being received due to stream exhaustion on this connection. We use the maximum
                 // valid stream ID for the current peer.
-                onHttp2Frame(ctx, new DefaultHttp2GoAwayFrame(connection.isServer() ? MAX_VALUE : MAX_VALUE - 1,
-                        NO_ERROR.code(), writeAscii(ctx.alloc(), "Stream IDs exhausted on local stream creation")));
+                onHttp2Frame(ctx, new DefaultHttp2GoAwayFrame(connection.isServer() ? Integer.MAX_VALUE :
+                        Integer.MAX_VALUE - 1, NO_ERROR.code(),
+                        writeAscii(ctx.alloc(), "Stream IDs exhausted on local stream creation")));
                 return;
             }
             stream.id = streamId;


### PR DESCRIPTION
Motivation:
Http2FrameCodec currently fails the write promise associated with creating a
stream with a Http2NoMoreStreamIdsException. However this means the user code
will have to listen to all write futures in order to catch this scenario which
is the same as receiving a GOAWAY frame. We can also simulate receiving a GOAWAY
frame from our remote peer and that allows users to consolidate graceful close
logic in the GOAWAY processing.

Modifications:
- Http2FrameCodec should simulate a DefaultHttp2GoAwayFrame when trying to
create a stream but the stream IDs have been exhausted.