### PR TITLE
Ensure channel handler close() is not skipped in !hasDisconnect case

### DIFF
--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -282,6 +282,17 @@ public class EmbeddedChannelTest {
     }
 
     @Test
+    public void testHasNoDisconnectSkipDisconnect() throws InterruptedException {
+        EmbeddedChannel channel = new EmbeddedChannel(false, new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+                promise.tryFailure(new Throwable());
+            }
+        });
+        assertFalse(channel.disconnect().isSuccess());
+    }
+
+    @Test
     public void testFinishAndReleaseAll() {
         ByteBuf in = Unpooled.buffer();
         ByteBuf out = Unpooled.buffer();


### PR DESCRIPTION
Motivation

The optimization in #8988 didn't correctly handle the specific case where the channel `hasDisconnect == false`, and a `ChannelOutboundHandlerAdapter` subclass overrides only the `close(ctx,
promise)` method without also overriding the `disconnect(ctx, promise)` method.

Modifications

Adjust `AbstractChannelHandler.disconnect(...)` method to divert to `close(...)` in `!hasDisconnect` case before computing target context for the event.

Result

Fixes #9092