### PR TITLE
Avoid unnecessary compareAndSet in EventLoop.wakeup implementations

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -162,7 +162,7 @@ class EpollEventLoop extends SingleThreadEventLoop {
 
     @Override
     protected void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && WAKEN_UP_UPDATER.compareAndSet(this, 0, 1)) {
+        if (!inEventLoop && wakenUp == 0 && WAKEN_UP_UPDATER.compareAndSet(this, 0, 1)) {
             // write to the evfd which will then wake-up epoll_wait(...)
             Native.eventFdWrite(eventFd.intValue(), 1L);
         }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -114,7 +114,7 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
 
     @Override
     protected void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && WAKEN_UP_UPDATER.compareAndSet(this, 0, 1)) {
+        if (!inEventLoop && wakenUp == 0 && WAKEN_UP_UPDATER.compareAndSet(this, 0, 1)) {
             wakeup();
         }
     }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -741,7 +741,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
 
     @Override
     protected void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && wakenUp.compareAndSet(false, true)) {
+        if (!inEventLoop && !wakenUp.get() && wakenUp.compareAndSet(false, true)) {
             selector.wakeup();
         }
     }


### PR DESCRIPTION
Motivation: Unnecessary costly CAS operations
Modification: Test condition with a volatile read before issuing compareAndSet
Result: Fewer unnecessarily costly CAS operations

FWIW, I considered two further extensions to this:
1) updating NioEventLoop to use a volatile int like EPoll and KQueue
2) updating the `select` invocations of CAS to avoid them

I decided not to proceed with either, mostly because I didn't want to tangle too closely with the logic in select, which isn't very intuitive to me, but also because the change is going to be most valuable on `offer` since these calls should dominate by far.  I decided it was better to keep the change simple, focused and safe.