### PR TITLE
Always include classes from all native transports no matter on which …

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -112,6 +112,14 @@
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
+        <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
       </dependencies>
     </profile>
     <!-- The mac, openbsd and freebsd  profile will only include the native jar for epol to the all jar.
@@ -131,6 +139,14 @@
           <artifactId>netty-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
+        <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
@@ -154,6 +170,14 @@
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
+        <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -171,6 +195,14 @@
           <artifactId>netty-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
+        <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>


### PR DESCRIPTION
…platfrom netty-all is build

Motivation:

While building netty-all we should always include all classes for native transports no matter if the native part can be build or not. This was it is easier to test locally with a installed snapshot of netty-all when the code that uses it does enable a specific native transport depending on if the native bits can be loaded or not.

Modifications:

Always include classes of native transports no matter on which platfrom we build. When a release is done we ensure we include the native bits by using the uber-staging profile.

Result:

Easier testing with netty-all snapshots.
