### PR TITLE
Remove deprecated GraalVM native-image flags

### DIFF
--- a/codec-http/src/main/resources/META-INF/native-image/io.netty/codec-http/native-image.properties
+++ b/codec-http/src/main/resources/META-INF/native-image/io.netty/codec-http/native-image.properties
@@ -12,4 +12,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-Args = --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder
+Args = --initialize-at-build-time=io.netty \
+       --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder

--- a/codec-http2/src/main/resources/META-INF/native-image/io.netty/codec-http2/native-image.properties
+++ b/codec-http2/src/main/resources/META-INF/native-image/io.netty/codec-http2/native-image.properties
@@ -12,5 +12,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-Args = --rerun-class-initialization-at-runtime=io.netty.handler.codec.http2.Http2CodecUtil \
-       --delay-class-initialization-to-runtime=io.netty.handler.codec.http2.DefaultHttp2FrameWriter
+Args = --initialize-at-build-time=io.netty \
+       --initialize-at-run-time=io.netty.handler.codec.http2.Http2CodecUtil,io.netty.handler.codec.http2.DefaultHttp2FrameWriter

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -25,3 +25,6 @@ RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | JABBA_COMMA
 
 RUN echo 'export JAVA_HOME="/jdk"' >> ~/.bashrc
 RUN echo 'PATH=/jdk/bin:$PATH' >> ~/.bashrc
+
+# when the JDK is GraalVM install native-image
+RUN if [ -O /jdk/bin/gu ]; then /jdk/bin/gu install native-image; else echo "Not GraalVM, skip installation of native-image" ; fi

--- a/docker/docker-compose.centos-6.graalvm1.yaml
+++ b/docker/docker-compose.centos-6.graalvm1.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "graalvm@1.0.0-16"
+        java_version : "graalvm@19.0.0"
 
   test:
     image: netty:centos-6-1.8

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <argLine.java9>--illegal-access=deny --add-modules java.xml.bind ${argLine.java9.extras}</argLine.java9>
         <!-- Not use alpn agent as Java9 supports alpn out of the box -->
         <argLine.alpnAgent />
-        <!-- Skip as maven plugin not works with Java9 yet --> 
+        <!-- Skip as maven plugin not works with Java9 yet -->
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
         <enforcer.plugin.version>3.0.0-M1</enforcer.plugin.version>
@@ -315,7 +315,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <skipJapicmp>false</skipJapicmp>
-    <graalvm.version>1.0.0-rc15</graalvm.version>
+    <graalvm.version>19.0.0</graalvm.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
   </properties>
@@ -453,7 +453,7 @@
         <optional>true</optional>
       </dependency>
 
-      <!-- 
+      <!--
         Completely optional and only needed for OCSP stapling to construct and
         parse OCSP requests and responses.
       -->
@@ -814,8 +814,8 @@
             <ignore>java.nio.channels.SocketChannel</ignore>
             <ignore>java.net.StandardProtocolFamily</ignore>
             <ignore>java.nio.channels.spi.SelectorProvider</ignore>
-            <ignore>java.net.SocketOption</ignore> 
-            <ignore>java.net.StandardSocketOptions</ignore> 
+            <ignore>java.net.SocketOption</ignore>
+            <ignore>java.net.StandardSocketOptions</ignore>
             <ignore>java.nio.channels.NetworkChannel</ignore>
 
             <!-- Self-signed certificate generation -->
@@ -990,7 +990,7 @@
             </property>
           </properties>
           <jvm>${testJvm}</jvm>
-           <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 --> 
+           <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
           <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
       <activation>
         <file>
           <!-- GraalVM Component Updater should exists when using GraalVM-->
-          <exists>${java.home}/bin/native-image</exists>
+          <exists>${java.home}/bin/gu</exists>
         </file>
       </activation>
       <properties>


### PR DESCRIPTION
Removes the use of deprecated GraalVM native-image flags
Adds a flag to initialize netty at build time.

This change will be valid from the next release of GraalVM and it works on the current master.