### PR TITLE
De-duplicate PooledByteBuf implementations

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1417,6 +1417,13 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
+    protected final void checkDstIndex(int length, int dstIndex, int dstCapacity) {
+        checkReadableBytes(length);
+        if (checkBounds) {
+            checkRangeBounds("dstIndex", dstIndex, length, dstCapacity);
+        }
+    }
+
     /**
      * Throws an {@link IndexOutOfBoundsException} if the current
      * {@linkplain #readableBytes() readable bytes} of this buffer is less

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -19,8 +19,13 @@ package io.netty.buffer;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ScatteringByteChannel;
 
 abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
@@ -89,34 +94,23 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
     @Override
     public final ByteBuf capacity(int newCapacity) {
+        if (newCapacity == length) {
+            ensureAccessible();
+            return this;
+        }
         checkNewCapacity(newCapacity);
-
-        // If the request capacity does not require reallocation, just update the length of the memory.
-        if (chunk.unpooled) {
-            if (newCapacity == length) {
-                return this;
-            }
-        } else {
+        if (!chunk.unpooled) {
+            // If the request capacity does not require reallocation, just update the length of the memory.
             if (newCapacity > length) {
                 if (newCapacity <= maxLength) {
                     length = newCapacity;
                     return this;
                 }
-            } else if (newCapacity < length) {
-                if (newCapacity > maxLength >>> 1) {
-                    if (maxLength <= 512) {
-                        if (newCapacity > maxLength - 16) {
-                            length = newCapacity;
-                            setIndex(Math.min(readerIndex(), newCapacity), Math.min(writerIndex(), newCapacity));
-                            return this;
-                        }
-                    } else { // > 512 (i.e. >= 1024)
-                        length = newCapacity;
-                        setIndex(Math.min(readerIndex(), newCapacity), Math.min(writerIndex(), newCapacity));
-                        return this;
-                    }
-                }
-            } else {
+            } else if (newCapacity > maxLength >>> 1 &&
+                    (maxLength > 512 || newCapacity > maxLength - 16)) {
+                // here newCapacity < length
+                length = newCapacity;
+                setIndex(Math.min(readerIndex(), newCapacity), Math.min(writerIndex(), newCapacity));
                 return this;
             }
         }
@@ -186,5 +180,82 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
     protected final int idx(int index) {
         return offset + index;
+    }
+
+    final ByteBuffer _internalNioBuffer(int index, int length, boolean duplicate) {
+        index = idx(index);
+        ByteBuffer buffer = duplicate ? newInternalNioBuffer(memory) : internalNioBuffer();
+        buffer.limit(index + length).position(index);
+        return buffer;
+    }
+
+    ByteBuffer duplicateInternalNioBuffer(int index, int length) {
+        checkIndex(index, length);
+        return _internalNioBuffer(index, length, true);
+    }
+
+    @Override
+    public final ByteBuffer internalNioBuffer(int index, int length) {
+        checkIndex(index, length);
+        return _internalNioBuffer(index, length, false);
+    }
+
+    @Override
+    public final int nioBufferCount() {
+        return 1;
+    }
+
+    @Override
+    public final ByteBuffer nioBuffer(int index, int length) {
+        return duplicateInternalNioBuffer(index, length).slice();
+    }
+
+    @Override
+    public final ByteBuffer[] nioBuffers(int index, int length) {
+        return new ByteBuffer[] { nioBuffer(index, length) };
+    }
+
+    @Override
+    public final int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
+        return out.write(duplicateInternalNioBuffer(index, length));
+    }
+
+    @Override
+    public final int readBytes(GatheringByteChannel out, int length) throws IOException {
+        checkReadableBytes(length);
+        int readBytes = out.write(_internalNioBuffer(readerIndex, length, false));
+        readerIndex += readBytes;
+        return readBytes;
+    }
+
+    @Override
+    public final int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+        return out.write(duplicateInternalNioBuffer(index, length), position);
+    }
+
+    @Override
+    public final int readBytes(FileChannel out, long position, int length) throws IOException {
+        checkReadableBytes(length);
+        int readBytes = out.write(_internalNioBuffer(readerIndex, length, false), position);
+        readerIndex += readBytes;
+        return readBytes;
+    }
+
+    @Override
+    public final int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
+        try {
+            return in.read(internalNioBuffer(index, length));
+        } catch (ClosedChannelException ignored) {
+            return -1;
+        }
+    }
+
+    @Override
+    public final int setBytes(int index, FileChannel in, long position, int length) throws IOException {
+        try {
+            return in.read(internalNioBuffer(index, length), position);
+        } catch (ClosedChannelException ignored) {
+            return -1;
+        }
     }
 }


### PR DESCRIPTION
Motivation

There's quite a lot of duplicate/equivalent logic across the various concrete `ByteBuf` implementations. We could take this even further but here I've focused on the `PooledByteBuf` sub-hierarchy.

Modifications

- Move common logic/methods into existing `PooledByteBuf` abstract superclass
- Shorten `PooledByteBuf.capacity(int)` method implementation

Result

Less code to maintain