### PR TITLE
RFC: Unsafe construction/reuse of NIO ByteBuffer objects

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -21,6 +21,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.internal.NioBufferRecycler;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -1231,7 +1232,9 @@ public final class ByteBufUtil {
             CharsetDecoder decoder = CharsetUtil.decoder(charset, CodingErrorAction.REPORT, CodingErrorAction.REPORT);
             try {
                 if (buf.nioBufferCount() == 1) {
-                    decoder.decode(buf.nioBuffer(index, length));
+                    ByteBuffer nioBuffer = buf.nioBuffer(index, length);
+                    decoder.decode(nioBuffer);
+                    NioBufferRecycler.recycle(nioBuffer);
                 } else {
                     ByteBuf heapBuffer = buf.alloc().heapBuffer(length);
                     try {

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -173,7 +173,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         }
 
         subpages = newSubpageArray(maxSubpageAllocs);
-        cachedNioBuffers = new ArrayDeque<ByteBuffer>(8);
+        cachedNioBuffers = arena.cacheNioBuffers() ? new ArrayDeque<ByteBuffer>(8) : null;
     }
 
     /** Creates a special chunk that is not pooled. */

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -17,6 +17,7 @@
 package io.netty.buffer;
 
 import io.netty.util.Recycler;
+import io.netty.util.internal.NioBufferRecycler;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -116,6 +117,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
             for (ByteBuffer bb: dst.nioBuffers(dstIndex, length)) {
                 int bbLen = bb.remaining();
                 getBytes(index, bb);
+                NioBufferRecycler.recycle(bb);
                 index += bbLen;
             }
         } else {
@@ -313,9 +315,10 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         if (src.hasArray()) {
             setBytes(index, src.array(), src.arrayOffset() + srcIndex, length);
         } else if (src.nioBufferCount() > 0) {
-            for (ByteBuffer bb: src.nioBuffers(srcIndex, length)) {
+            for (ByteBuffer bb : src.nioBuffers(srcIndex, length)) {
                 int bbLen = bb.remaining();
                 setBytes(index, bb);
+                NioBufferRecycler.recycle(bb);
                 index += bbLen;
             }
         } else {
@@ -339,7 +342,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         checkIndex(index, src.remaining());
         ByteBuffer tmpBuf = internalNioBuffer();
         if (src == tmpBuf) {
-            src = src.duplicate();
+            src = NioBufferRecycler.duplicate(src);
         }
 
         index = idx(index);

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -15,6 +15,7 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.internal.NioBufferRecycler;
 import io.netty.util.internal.StringUtil;
 
 import java.io.IOException;
@@ -183,6 +184,7 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
             for (ByteBuffer bb: dst.nioBuffers(dstIndex, length)) {
                 int bbLen = bb.remaining();
                 getBytes(index, bb);
+                NioBufferRecycler.recycle(bb);
                 index += bbLen;
             }
         } else {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -17,6 +17,7 @@ package io.netty.buffer;
 
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
+import io.netty.util.internal.NioBufferRecycler;
 import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
@@ -294,6 +295,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
             for (ByteBuffer bb: dst.nioBuffers(dstIndex, length)) {
                 int bbLen = bb.remaining();
                 getBytes(index, bb);
+                NioBufferRecycler.recycle(bb);
                 index += bbLen;
             }
         } else {
@@ -445,9 +447,10 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         checkSrcIndex(index, length, srcIndex, src.capacity());
         if (src.nioBufferCount() > 0) {
-            for (ByteBuffer bb: src.nioBuffers(srcIndex, length)) {
+            for (ByteBuffer bb : src.nioBuffers(srcIndex, length)) {
                 int bbLen = bb.remaining();
                 setBytes(index, bb);
+                NioBufferRecycler.recycle(bb);
                 index += bbLen;
             }
         } else {

--- a/common/src/main/java/io/netty/util/internal/NioBufferRecycler.java
+++ b/common/src/main/java/io/netty/util/internal/NioBufferRecycler.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty.util.internal.PlatformDependent0.directBufferAddress;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+
+import io.netty.util.concurrent.FastThreadLocal;
+
+public final class NioBufferRecycler {
+
+    private static final int MAX_CACHE_SIZE = 128;
+
+    private static final FastThreadLocal<ArrayDeque<ByteBuffer>> TL_NIO_BUFFER_CACHE;
+
+    static {
+        TL_NIO_BUFFER_CACHE = MAX_CACHE_SIZE > 0 && PlatformDependent0.hasUnsafeDirectBufferFields()
+                ? new FastThreadLocal<ArrayDeque<ByteBuffer>>() {
+            @Override
+            protected ArrayDeque<ByteBuffer> initialValue() throws Exception {
+                return new ArrayDeque<ByteBuffer>(4);
+            }
+        } : null;
+    }
+
+    private NioBufferRecycler() { }
+
+    public static ByteBuffer duplicate(ByteBuffer buffer) {
+        return duplicateDirectBuffer0(buffer, pollFromCacheForDerived(buffer));
+    }
+
+    public static ByteBuffer slice(ByteBuffer buffer) {
+        ByteBuffer toReuse = pollFromCacheForDerived(buffer);
+        return toReuse == null ? buffer.slice()
+                : sliceDirectBuffer0(buffer, buffer.position(), buffer.remaining(), toReuse);
+    }
+
+    public static ByteBuffer slice(ByteBuffer buffer, int index, int length) {
+        if (!PlatformDependent0.isReusableType(buffer)) {
+            ByteBuffer duplicate = buffer.duplicate();
+            duplicate.limit(index + length).position(index);
+            return duplicate.slice();
+        }
+        if (checkPositiveOrZero(index, "index") + checkPositiveOrZero(length, "length") > buffer.limit()) {
+            throw new IndexOutOfBoundsException();
+        }
+        return sliceDirectBuffer0(buffer, index, length, pollFromCacheForDerived(buffer));
+    }
+
+    static ByteBuffer pollFromCacheForNew() {
+        return TL_NIO_BUFFER_CACHE != null ? pollFromCache0() : null;
+    }
+
+    private static ByteBuffer pollFromCacheForDerived(ByteBuffer source) {
+        return TL_NIO_BUFFER_CACHE != null && PlatformDependent0.isReusableType(source) ? pollFromCache0() : null;
+    }
+
+    private static ByteBuffer pollFromCache0() {
+        ArrayDeque<ByteBuffer> cache = TL_NIO_BUFFER_CACHE.getIfExists();
+        return cache != null ? cache.poll() : null;
+    }
+
+    public static void recycle(ByteBuffer buffer) {
+        recycle(buffer, false);
+    }
+
+    public static void recycle(ByteBuffer... buffers) {
+        for (ByteBuffer buffer : buffers) {
+            recycle(buffer);
+        }
+    }
+
+    // must only be used on derived buffers or after explicit deallocation
+    static void recycle(ByteBuffer buffer, boolean afterDeallocate) {
+        if (TL_NIO_BUFFER_CACHE != null && buffer != null && buffer.isDirect()) {
+            if (afterDeallocate || PlatformDependent0.isDerivedDirectBuffer(buffer)) {
+                ArrayDeque<ByteBuffer> cache = TL_NIO_BUFFER_CACHE.get();
+                if (cache.size() < MAX_CACHE_SIZE) {
+                    cache.push(PlatformDependent0.resetDirectBuffer(buffer));
+                }
+            }
+        }
+    }
+
+    private static ByteBuffer sliceDirectBuffer0(ByteBuffer parent, int index, int length, ByteBuffer toRecycle) {
+        final long newAddress = directBufferAddress(parent) + index;
+        return toRecycle == null ? PlatformDependent0.newDirectBufferUnsafe(newAddress, length, parent)
+                : PlatformDependent0.initDirectBuffer(toRecycle, newAddress, parent, length, length);
+    }
+
+    private static ByteBuffer duplicateDirectBuffer0(ByteBuffer parent, ByteBuffer toRecycle) {
+        if (toRecycle == null) {
+            return parent.duplicate();
+        }
+        PlatformDependent0.initDirectBuffer(toRecycle,
+                directBufferAddress(parent), parent, parent.capacity(), parent.limit());
+        // We don't bother to set the mark like ByteBuffer.duplicate() does
+        toRecycle.position(parent.position());
+        return toRecycle;
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/NioBufferRecycler.java
+++ b/common/src/main/java/io/netty/util/internal/NioBufferRecycler.java
@@ -82,18 +82,17 @@ public final class NioBufferRecycler {
 
     public static void recycle(ByteBuffer... buffers) {
         for (ByteBuffer buffer : buffers) {
-            recycle(buffer);
+            recycle(buffer, false);
         }
     }
 
     // must only be used on derived buffers or after explicit deallocation
     static void recycle(ByteBuffer buffer, boolean afterDeallocate) {
-        if (TL_NIO_BUFFER_CACHE != null && buffer != null && buffer.isDirect()) {
-            if (afterDeallocate || PlatformDependent0.isDerivedDirectBuffer(buffer)) {
-                ArrayDeque<ByteBuffer> cache = TL_NIO_BUFFER_CACHE.get();
-                if (cache.size() < MAX_CACHE_SIZE) {
-                    cache.push(PlatformDependent0.resetDirectBuffer(buffer));
-                }
+        if (TL_NIO_BUFFER_CACHE != null && (afterDeallocate ? PlatformDependent0.isReusableType(buffer)
+                : PlatformDependent0.isDerivedDirectBuffer(buffer))) {
+            ArrayDeque<ByteBuffer> cache = TL_NIO_BUFFER_CACHE.get();
+            if (cache.size() < MAX_CACHE_SIZE) {
+                cache.push(PlatformDependent0.resetDirectBuffer(buffer));
             }
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.base64.Base64;
 import io.netty.handler.codec.base64.Base64Dialect;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.NioBufferRecycler;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
@@ -276,11 +277,12 @@ final class SslUtils {
         ByteBuffer tmp = ByteBuffer.allocate(5);
 
         do {
-            buffer = buffers[offset++].duplicate();
+            buffer = NioBufferRecycler.duplicate(buffers[offset++]);
             if (buffer.remaining() > tmp.remaining()) {
                 buffer.limit(buffer.position() + tmp.remaining());
             }
             tmp.put(buffer);
+            NioBufferRecycler.recycle(buffer);
         } while (tmp.hasRemaining());
 
         // Done, flip the buffer so we can read from it.


### PR DESCRIPTION
Motivation

This is a possibly-crazy experiment for feedback and not a fully-complete/polished PR.

`ByteBuffer` objects can be constructed and re-purposed via `Unsafe` surgery to avoid temporary allocations (with blatant disregard for `final`) . This has various benefits:
- Basic non-`Cleaner` direct buffer creation is cheaper than the current reflection approach which requires varargs and primitive boxing allocs, though the significance of this is questionable given that new `ByteBuffer` allocation is already a heavyweight operation.
- Threadsafe absolute slicing as performed by `ByteBuf#nioBuffer(int,int)` can be done without involving an intermediate (duplicate) `ByteBuffer` allocation
- Caching/recycling so that the common transient allocations can be avoided. The scope of this reuse is quite wide - any duplicate or slice of any nio buffer of the same type but not necessarily the same backing memory

Modifications

- Add appropriate primitives to `PlatformDependent0` and `PlatformDepdendent` for Unsafe allocation/manipulation
- Use this in preference to the existing caching when available - once a `PooledByteBuf` is assigned a `tmpNioBuf` this persists for the life of the PBB object rather than being invalidated when it moves between chunks
- Add an `NioBufferRecycler` util class for lightweight no-commitment `ThreadLocal` recycling (I did not consider the existing `Recycler` a good fit for this for various reasons)
- Exploit this class from appropriate places including various `ByteBuf` method impls and in `SslHandler` logic. Any known-to-be-exclusive `ByteBuffer` can be passed to the recycler, including those returned from `ByteBuf#nioBuffer(int,int)` (which themselves likely came from the recycler)

Changes are confined to non-readonly direct buffers. They could be extended to cover heap and/or readonly buffers if deemed worthwhile.

This will not work on all JDK impls, only a subset of those that support `Unsafe` + reflective non-`Cleaner` buffer allocs. In particular it won't work on Android. But should do for all OpenJDK variants/versions and likely most others, and it should degrade gracefully when not supported (i.e. when the "parent" `DirectByteBuffer` field isn't found)

Results

TBD, would like initial feedback before spending more time on this