### PR TITLE
delete Other "Content-" MIME Header Fields exception

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -764,9 +764,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                         }
                     }
                 }
-            } else {
-                throw new ErrorDataDecoderException("Unknown Params: " + newline);
-            }
+            } 
         }
         // Is it a FileUpload
         Attribute filenameAttribute = currentFieldAttributes.get(HttpHeaderValues.FILENAME);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -764,7 +764,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                         }
                     }
                 }
-            } 
+            }
         }
         // Is it a FileUpload
         Attribute filenameAttribute = currentFieldAttributes.get(HttpHeaderValues.FILENAME);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -412,7 +412,40 @@ public class HttpPostRequestDecoderTest {
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
     }
+    
+    @Test
+    public void testDecodeOtherMimeHeaderFields() throws Exception {
+        final String boundary = "74e78d11b0214bdcbc2f86491eeb4902";
+        String filecontent = "123456";
 
+        final String body = "--" + boundary + "\r\n" +
+                            "Content-Disposition: form-data; name=\"file\"; filename=" + "\""+"attached.txt"+"\"" + "\r\n"+
+                            "Content-Type: application/octet-stream"+"\r\n"+
+                            "Content-Encoding: gzip"+"\r\n"+
+                            "\r\n" +
+                            filecontent +
+                            "\r\n" +
+                            "--" + boundary + "--";
+
+        final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
+                                                                      HttpMethod.POST,
+                                                                      "http://localhost",
+                                                                      Unpooled.wrappedBuffer(body.getBytes()));
+        req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+        req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+        final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
+        final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        assertFalse(decoder.getBodyHttpDatas().isEmpty());
+        InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
+        assertTrue("the item should be a FileUpload", part1 instanceof FileUpload);
+        FileUpload fileUpload = (FileUpload) part1;
+        byte[] fileBytes = fileUpload.get();
+        assertTrue("the filecontent should not be decoded", filecontent.equals(new String(fileBytes)));
+        decoder.destroy();
+        req.release();
+    }
+
+    
     @Test
     public void testMultipartRequestWithFileInvalidCharset() throws Exception {
         final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -412,16 +412,17 @@ public class HttpPostRequestDecoderTest {
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
     }
-    
+
     @Test
     public void testDecodeOtherMimeHeaderFields() throws Exception {
         final String boundary = "74e78d11b0214bdcbc2f86491eeb4902";
         String filecontent = "123456";
 
         final String body = "--" + boundary + "\r\n" +
-                            "Content-Disposition: form-data; name=\"file\"; filename=" + "\""+"attached.txt"+"\"" + "\r\n"+
-                            "Content-Type: application/octet-stream"+"\r\n"+
-                            "Content-Encoding: gzip"+"\r\n"+
+                            "Content-Disposition: form-data; name=\"file\"; filename=" + "\"" + "attached.txt" + "\"" +
+                            "\r\n" +
+                            "Content-Type: application/octet-stream" + "\r\n" +
+                            "Content-Encoding: gzip" + "\r\n" +
                             "\r\n" +
                             filecontent +
                             "\r\n" +
@@ -445,7 +446,6 @@ public class HttpPostRequestDecoderTest {
         req.release();
     }
 
-    
     @Test
     public void testMultipartRequestWithFileInvalidCharset() throws Exception {
         final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";


### PR DESCRIPTION
delete Other "Content-" MIME   Header Fields exception

Motivation:

RFC7578 4.8. Other "Content-" Header Fields

The multipart/form-data media type does not support any MIME header
fields in parts other than Content-Type, Content-Disposition, and (in
limited circumstances) Content-Transfer-Encoding. Other header
fields MUST NOT be included and MUST be ignored.

Other "Content-" Header Fields should be ignored no ecxeption