### PR TITLE
Http2FrameCodec / Http2MultiplexCodec should forward Http2WindowUpdat…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -542,11 +542,11 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
 
         @Override
         public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) {
-            if (streamId == 0) {
-                // Ignore connection window updates.
-                return;
+            DefaultHttp2WindowUpdateFrame frame = new DefaultHttp2WindowUpdateFrame(windowSizeIncrement);
+            if (streamId != 0) {
+                frame.stream(requireStream(streamId));
             }
-            onHttp2Frame(ctx, new DefaultHttp2WindowUpdateFrame(windowSizeIncrement).stream(requireStream(streamId)));
+            onHttp2Frame(ctx, frame);
         }
 
         @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -231,7 +231,12 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
     final void onHttp2Frame(ChannelHandlerContext ctx, Http2Frame frame) {
         if (frame instanceof Http2StreamFrame) {
             Http2StreamFrame streamFrame = (Http2StreamFrame) frame;
-            ((Http2MultiplexCodecStream) streamFrame.stream()).channel.fireChildRead(streamFrame);
+            if (streamFrame.stream() == null) {
+                // A frame that is for the connection itself.
+                ctx.fireChannelRead(frame);
+            } else {
+                ((Http2MultiplexCodecStream) streamFrame.stream()).channel.fireChildRead(streamFrame);
+            }
         } else if (frame instanceof Http2GoAwayFrame) {
             onHttp2GoAwayFrame(ctx, (Http2GoAwayFrame) frame);
             // Allow other handlers to act on GOAWAY frame

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -505,7 +505,10 @@ public class Http2FrameCodecTest {
         assertEquals(3, windowUpdateFrame.stream().id());
         assertEquals(100, windowUpdateFrame.windowSizeIncrement());
 
-        // Window update for the connection should not be forwarded.
+        windowUpdateFrame = inboundHandler.readInbound();
+        assertNull(windowUpdateFrame.stream());
+        assertEquals(100, windowUpdateFrame.windowSizeIncrement());
+
         assertNull(inboundHandler.readInbound());
     }
 


### PR DESCRIPTION
…eFrame even when applied to the whole connection.

Motivation:

At the moment we just not forward Http2WindowUpdateFrame when it is for the whole connection. This put some limits on the following handlers to act on these frames. We should just also forward these.

Modifications:

- Correctly forward all Http2WindowUpdateFrame (these that are for a stream and these that are for a connection)
- Adjust test to cover the behaviour

Result:

More correct and consistent behaviour for Http2WindowUpdateFrames.