### PR TITLE
DefaultHttp2RemoteFlowController should always write to the underlyin…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -420,7 +420,12 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
         FlowControlledData(Http2Stream stream, ByteBuf buf, int padding, boolean endOfStream,
                                    ChannelPromise promise) {
             super(stream, padding, endOfStream, promise);
-            queue = new CoalescingBufferQueue(promise.channel());
+            // Construct the CoalescingBufferQueue in a way that will notify the Channel about the amount of queued
+            // data and so update the writablity state of the Channel.
+            //
+            // This way Channel.isWritable() will also take things into account that are currently queued in the
+            // Http2RemoteFlowController.
+            queue = new CoalescingBufferQueue(promise.channel(), 4, true);
             queue.add(buf, promise);
             dataSize = queue.readableBytes();
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -246,12 +246,8 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     }
 
     private int maxUsableChannelBytes() {
-        // If the channel isWritable, allow at least minUsableChannelBytes.
-        int channelWritableBytes = (int) min(Integer.MAX_VALUE, ctx.channel().bytesBeforeUnwritable());
-        int usableBytes = channelWritableBytes > 0 ? max(channelWritableBytes, minUsableChannelBytes()) : 0;
-
         // Clip the usable bytes by the connection window.
-        return min(connectionState.windowSize(), usableBytes);
+        return min(connectionState.windowSize(), minUsableChannelBytes());
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -140,7 +140,6 @@ public class StreamBufferingEncoderTest {
         when(channel.isActive()).thenReturn(false);
         when(channel.config()).thenReturn(config);
         when(channel.isWritable()).thenReturn(true);
-        when(channel.bytesBeforeUnwritable()).thenReturn(Long.MAX_VALUE);
         when(config.getWriteBufferHighWaterMark()).thenReturn(Integer.MAX_VALUE);
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         ChannelMetadata metadata = new ChannelMetadata(false, 16);


### PR DESCRIPTION
…g Channel even if its not Writable

Motivation:

At the moment we never produce an data to the underlying Channel if isWritable() is returning false. This is a bit unfortunate as all this buys us is basically have them sit in "just another queue" until the Channel becomes writable again in which case we then will drain them. The biggest issue with this is that other parts of the ChannelPipeline will not be able to really see the queuing as the queing is not reflected in Channel.isWritable() at all.

Modifications:

- Always write FlowControlled frames to the underyling Channel even if the Channel is not Writable. This way the data will eventually hit the ChannelOutboundBuffer and so be taked into account when Channel.isWritable() is called.
- FlowControlledData now uses overload of CoalescingBufferQueue which will update the Channel writability state when data is enqueued and so Channel.isWritable() will also take the data into account that is currently queued in the Http2RemoteFlowController.

Result:

More correct and conistent Channel writability state when flow controlled data is used with HTTP/2.