### PR TITLE
Implement Http2StreamChannel.bytesBeforeWritable() and bytesBeforeUnw…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -173,6 +173,13 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         return monitor.isWritable(state(stream));
     }
 
+    /**
+     * Get the amount of bytes this stream has pending to send.
+     */
+    public long pendingBytes(Http2Stream stream) {
+        return state(stream).pendingBytes();
+    }
+
     @Override
     public void channelWritabilityChanged() throws Http2Exception {
         monitor.channelWritabilityChange();


### PR DESCRIPTION
…ritable()

Motivation:

Our Http2StreamChannel implementation did not implement bytesBeforeWritable() and bytesBeforeUnwritable(). We should implement these to make the channel implementation more feature complete.

Modifications:

- Implement both methods
- Update tests to cover the implementations.

Result:

Fixes https://github.com/netty/netty/issues/8148.