### PR TITLE
Add SubChannel implementation

### DIFF
--- a/transport/src/main/java/io/netty/channel/PromiseRelay.java
+++ b/transport/src/main/java/io/netty/channel/PromiseRelay.java
@@ -1,0 +1,29 @@
+package io.netty.channel;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelPromise;
+
+public class PromiseRelay implements ChannelFutureListener {
+	private ChannelPromise promise;
+
+	public PromiseRelay(ChannelPromise promise) {
+		this.promise = promise;
+	}
+
+	@Override
+	public void operationComplete(final ChannelFuture future) throws Exception {
+		promise.channel().eventLoop().execute(new Runnable() {
+			@Override
+			public void run() {
+				if (future.isSuccess()) {
+					promise.setSuccess();
+				} else if (future.isCancelled()) {
+					promise.cancel(true);
+				} else {
+					promise.setFailure(future.cause());
+				}
+			}
+		});
+	}
+}

--- a/transport/src/main/java/io/netty/channel/SubChannel.java
+++ b/transport/src/main/java/io/netty/channel/SubChannel.java
@@ -1,0 +1,520 @@
+package io.netty.channel;
+
+import java.net.SocketAddress;
+import java.util.concurrent.RejectedExecutionException;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.RecvByteBufAllocator.Handle;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+public class SubChannel implements Channel {
+
+	private static final InternalLogger logger = InternalLoggerFactory.getInstance(SubChannel.class);
+
+	private final class SubChannelId implements ChannelId {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public int compareTo(ChannelId o) {
+			return parent().id().compareTo(o);
+		}
+
+		@Override
+		public String asShortText() {
+			return parent().id().asShortText();
+		}
+
+		@Override
+		public String asLongText() {
+			return parent().id().asLongText();
+		}
+
+	}
+
+	private final SubChannelUnsafe unsafe = new SubChannelUnsafe();
+	private final ChannelId channelId;
+	private final ChannelPipeline pipeline;
+
+	protected final ChannelHandlerContext ctx;
+
+	private volatile boolean registered;
+
+	public SubChannel(final ChannelHandlerContext ctx) {
+		this.ctx = ctx;
+		pipeline = new DefaultChannelPipeline(this) {
+			@Override
+			protected void incrementPendingOutboundBytes(long size) {
+				// Do nothing for now
+			}
+
+			@Override
+			protected void decrementPendingOutboundBytes(long size) {
+				// Do nothing for now
+			}
+
+			@Override
+			protected void onUnhandledInboundException(Throwable cause) {
+				ctx.fireExceptionCaught(cause);
+			}
+
+			@Override
+			protected void onUnhandledInboundChannelActive() {
+				ctx.fireChannelActive();
+			}
+
+			@Override
+			protected void onUnhandledInboundChannelInactive() {
+				ctx.fireChannelInactive();
+			}
+
+			@Override
+			protected void onUnhandledInboundMessage(Object msg) {
+				ctx.fireChannelRead(msg);
+			}
+
+			@Override
+			protected void onUnhandledInboundChannelReadComplete() {
+				ctx.fireChannelReadComplete();
+			}
+
+			@Override
+			protected void onUnhandledInboundUserEventTriggered(Object evt) {
+				ctx.fireUserEventTriggered(evt);
+			}
+
+			@Override
+			protected void onUnhandledChannelWritabilityChanged() {
+				ctx.fireChannelWritabilityChanged();
+			}
+		};
+		channelId = new SubChannelId();
+	}
+
+	@Override
+	public ChannelMetadata metadata() {
+		return parent().metadata();
+	}
+
+	@Override
+	public ChannelConfig config() {
+		return parent().config();
+	}
+
+	@Override
+	public boolean isOpen() {
+		return parent().isOpen();
+	}
+
+	@Override
+	public boolean isActive() {
+		return parent().isActive();
+	}
+
+	@Override
+	public boolean isWritable() {
+		return parent().isWritable();
+	}
+
+	@Override
+	public ChannelId id() {
+		return channelId;
+	}
+
+	@Override
+	public EventLoop eventLoop() {
+		return parent().eventLoop();
+	}
+
+	@Override
+	public Channel parent() {
+		return ctx.channel();
+	}
+
+	@Override
+	public boolean isRegistered() {
+		return registered;
+	}
+
+	@Override
+	public SocketAddress localAddress() {
+		return parent().localAddress();
+	}
+
+	@Override
+	public SocketAddress remoteAddress() {
+		return parent().remoteAddress();
+	}
+
+	@Override
+	public ChannelFuture closeFuture() {
+		return parent().closeFuture();
+	}
+
+	@Override
+	public long bytesBeforeUnwritable() {
+		return parent().bytesBeforeUnwritable();
+	}
+
+	@Override
+	public long bytesBeforeWritable() {
+		return parent().bytesBeforeWritable();
+	}
+
+	@Override
+	public Unsafe unsafe() {
+		return unsafe;
+	}
+
+	@Override
+	public ChannelPipeline pipeline() {
+		return pipeline;
+	}
+
+	@Override
+	public ByteBufAllocator alloc() {
+		return config().getAllocator();
+	}
+
+	@Override
+	public Channel read() {
+		pipeline().read();
+		return this;
+	}
+
+	@Override
+	public Channel flush() {
+		pipeline().flush();
+		return this;
+	}
+
+	@Override
+	public ChannelFuture bind(SocketAddress localAddress) {
+		return pipeline().bind(localAddress);
+	}
+
+	@Override
+	public ChannelFuture connect(SocketAddress remoteAddress) {
+		return pipeline().connect(remoteAddress);
+	}
+
+	@Override
+	public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+		return pipeline().connect(remoteAddress, localAddress);
+	}
+
+	@Override
+	public ChannelFuture disconnect() {
+		return pipeline().disconnect();
+	}
+
+	@Override
+	public ChannelFuture close() {
+		return pipeline().close();
+	}
+
+	@Override
+	public ChannelFuture deregister() {
+		return pipeline().deregister();
+	}
+
+	@Override
+	public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+		return pipeline().bind(localAddress, promise);
+	}
+
+	@Override
+	public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+		return pipeline().connect(remoteAddress, promise);
+	}
+
+	@Override
+	public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+		return pipeline().connect(remoteAddress, localAddress, promise);
+	}
+
+	@Override
+	public ChannelFuture disconnect(ChannelPromise promise) {
+		return pipeline().disconnect(promise);
+	}
+
+	@Override
+	public ChannelFuture close(ChannelPromise promise) {
+		return pipeline().close(promise);
+	}
+
+	@Override
+	public ChannelFuture deregister(ChannelPromise promise) {
+		return pipeline().deregister(promise);
+	}
+
+	@Override
+	public ChannelFuture write(Object msg) {
+		return pipeline().write(msg);
+	}
+
+	@Override
+	public ChannelFuture write(Object msg, ChannelPromise promise) {
+		return pipeline().write(msg, promise);
+	}
+
+	@Override
+	public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+		return pipeline().writeAndFlush(msg, promise);
+	}
+
+	@Override
+	public ChannelFuture writeAndFlush(Object msg) {
+		return pipeline().writeAndFlush(msg);
+	}
+
+	@Override
+	public ChannelPromise newPromise() {
+		return pipeline().newPromise();
+	}
+
+	@Override
+	public ChannelProgressivePromise newProgressivePromise() {
+		return pipeline().newProgressivePromise();
+	}
+
+	@Override
+	public ChannelFuture newSucceededFuture() {
+		return pipeline().newSucceededFuture();
+	}
+
+	@Override
+	public ChannelFuture newFailedFuture(Throwable cause) {
+		return pipeline().newFailedFuture(cause);
+	}
+
+	@Override
+	public ChannelPromise voidPromise() {
+		return pipeline().voidPromise();
+	}
+
+	@Override
+	public int hashCode() {
+		return id().hashCode();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return this == o;
+	}
+
+	@Override
+	public int compareTo(Channel o) {
+		if (this == o) {
+			return 0;
+		}
+
+		return id().compareTo(o.id());
+	}
+
+	@Override
+	public String toString() {
+		return parent().toString() + "(subchannel)";
+	}
+
+	private final class SubChannelUnsafe implements Unsafe {
+		private final VoidChannelPromise unsafeVoidPromise = new VoidChannelPromise(SubChannel.this, false);
+		private boolean closeInitiated;
+
+		@Override
+		public void connect(final SocketAddress remoteAddress, SocketAddress localAddress,
+				final ChannelPromise promise) {
+			ctx.connect(remoteAddress, localAddress).addListener(new PromiseRelay(promise));
+		}
+
+		@Override
+		@SuppressWarnings("deprecation")
+		public Handle recvBufAllocHandle() {
+			return parent().unsafe().recvBufAllocHandle();
+		}
+
+		@Override
+		public SocketAddress localAddress() {
+			return parent().unsafe().localAddress();
+		}
+
+		@Override
+		public SocketAddress remoteAddress() {
+			return parent().unsafe().remoteAddress();
+		}
+
+		@Override
+		public void register(EventLoop eventLoop, ChannelPromise promise) {
+			if (!promise.setUncancellable()) {
+				return;
+			}
+			if (registered) {
+				throw new UnsupportedOperationException("Re-register is not supported");
+			}
+
+			registered = true;
+
+			promise.setSuccess();
+
+			pipeline().fireChannelRegistered();
+		}
+
+		@Override
+		public void bind(SocketAddress localAddress, ChannelPromise promise) {
+			ctx.bind(localAddress).addListener(new PromiseRelay(promise));
+		}
+
+		@Override
+		public void disconnect(ChannelPromise promise) {
+			ctx.disconnect().addListener(new PromiseRelay(promise));
+		}
+
+		@Override
+		public void close(final ChannelPromise promise) {
+			if (!promise.setUncancellable()) {
+				return;
+			}
+			if (closeInitiated) {
+				if (closeFuture().isDone()) {
+					// Closed already.
+					promise.setSuccess();
+				} else if (!(promise instanceof VoidChannelPromise)) { // Only needed if no VoidChannelPromise.
+					// This means close() was called before so we just register a listener and
+					// return
+					closeFuture().addListener(new ChannelFutureListener() {
+						@Override
+						public void operationComplete(ChannelFuture future) {
+							promise.setSuccess();
+						}
+					});
+				}
+				return;
+			}
+			closeInitiated = true;
+
+			fireChannelInactiveAndDeregister(voidPromise(), isActive());
+			ctx.close().addListener(new PromiseRelay(promise));
+		}
+
+		@Override
+		public void closeForcibly() {
+			close(unsafe().voidPromise());
+		}
+
+		@Override
+		public void deregister(ChannelPromise promise) {
+			fireChannelInactiveAndDeregister(promise, false);
+		}
+
+		private void fireChannelInactiveAndDeregister(final ChannelPromise promise,
+				final boolean fireChannelInactive) {
+			if (!promise.setUncancellable()) {
+				return;
+			}
+
+			if (!registered) {
+				promise.setSuccess();
+				return;
+			}
+
+			// As a user may call deregister() from within any method while doing processing
+			// in the ChannelPipeline,
+			// we need to ensure we do the actual deregister operation later. This is
+			// necessary to preserve the
+			// behavior of the AbstractChannel, which always invokes channelUnregistered and
+			// channelInactive
+			// events 'later' to ensure the current events in the handler are completed
+			// before these events.
+			//
+			// See:
+			// https://github.com/netty/netty/issues/4435
+			invokeLater(new Runnable() {
+				@Override
+				public void run() {
+					if (fireChannelInactive) {
+						pipeline.fireChannelInactive();
+					}
+					// The user can fire `deregister` events multiple times but we only want to fire
+					// the pipeline event if the channel was actually registered.
+					if (registered) {
+						registered = false;
+						pipeline.fireChannelUnregistered();
+					}
+					safeSetSuccess(promise);
+				}
+			});
+		}
+
+		private void safeSetSuccess(ChannelPromise promise) {
+			if (!(promise instanceof VoidChannelPromise) && !promise.trySuccess()) {
+				logger.warn("Failed to mark a promise as success because it is done already: {}", promise);
+			}
+		}
+
+		private void invokeLater(Runnable task) {
+			try {
+				// This method is used by outbound operation implementations to trigger an
+				// inbound event later.
+				// They do not trigger an inbound event immediately because an outbound
+				// operation might have been
+				// triggered by another inbound event handler method. If fired immediately, the
+				// call stack
+				// will look like this for example:
+				//
+				// handlerA.inboundBufferUpdated() - (1) an inbound handler method closes a
+				// connection.
+				// -> handlerA.ctx.close()
+				// -> channel.unsafe.close()
+				// -> handlerA.channelInactive() - (2) another inbound handler method called
+				// while in (1) yet
+				//
+				// which means the execution of two inbound handler methods of the same handler
+				// overlap undesirably.
+				eventLoop().execute(task);
+			} catch (RejectedExecutionException e) {
+				logger.warn("Can't invoke task later as EventLoop rejected it", e);
+			}
+		}
+
+		@Override
+		public void beginRead() {
+			ctx.read();
+		}
+
+		@Override
+		public void write(Object msg, final ChannelPromise promise) {
+			ctx.write(msg).addListener(new PromiseRelay(promise));
+		}
+
+		@Override
+		public void flush() {
+			ctx.flush();
+		}
+
+		@Override
+		public ChannelPromise voidPromise() {
+			return unsafeVoidPromise;
+		}
+
+		@Override
+		public ChannelOutboundBuffer outboundBuffer() {
+			// Always return null as we not use the ChannelOutboundBuffer and not even
+			// support it.
+			return null;
+		}
+	}
+
+	@Override
+	public <T> Attribute<T> attr(AttributeKey<T> key) {
+		return parent().attr(key);
+	}
+
+	@Override
+	public <T> boolean hasAttr(AttributeKey<T> key) {
+		return parent().hasAttr(key);
+	}
+
+}

--- a/transport/src/main/java/io/netty/channel/SubChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/SubChannelHandler.java
@@ -1,0 +1,138 @@
+package io.netty.channel;
+
+import java.net.SocketAddress;
+
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.DatagramSubChannel;
+import io.netty.channel.socket.DuplexChannel;
+import io.netty.channel.socket.DuplexSubChannel;
+
+public class SubChannelHandler extends ChannelDuplexHandler {
+
+	private ChannelHandler[] handlers;
+	private Channel sc;
+
+	public SubChannelHandler(ChannelHandler... handlers) {
+		this.handlers = handlers;
+	}
+
+	public Channel subChannel() {
+		return sc;
+	}
+
+	@Override
+	public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+		sc.bind(localAddress).addListener(new PromiseRelay(promise));
+	}
+
+	@Override
+	public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
+			ChannelPromise promise) throws Exception {
+		sc.connect(remoteAddress, localAddress).addListener(new PromiseRelay(promise));
+	}
+
+	@Override
+	public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+		sc.disconnect().addListener(new PromiseRelay(promise));
+	}
+
+	@Override
+	public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+		sc.close().addListener(new PromiseRelay(promise));
+	}
+
+	@Override
+	public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+		sc.deregister().addListener(new PromiseRelay(promise));
+	}
+
+	@Override
+	public void read(ChannelHandlerContext ctx) throws Exception {
+		sc.pipeline().read();
+	}
+
+	@Override
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+		sc.write(msg).addListener(new PromiseRelay(promise));
+	}
+
+	@Override
+	public void flush(ChannelHandlerContext ctx) throws Exception {
+		sc.flush();
+	}
+
+	@Override
+	public void channelRegistered(final ChannelHandlerContext ctx) throws Exception {
+		ChannelPromise promise = ctx.channel().newPromise();
+		sc.unsafe().register(ctx.channel().eventLoop(), promise);
+	}
+
+	@Override
+	public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+		sc.deregister();
+	}
+
+	@Override
+	public void channelActive(ChannelHandlerContext ctx) throws Exception {
+		sc.pipeline().fireChannelActive();
+	}
+
+	@Override
+	public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+		sc.pipeline().fireChannelInactive();
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+		sc.pipeline().fireChannelRead(msg);
+	}
+
+	@Override
+	public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+		sc.pipeline().fireChannelReadComplete();
+	}
+
+	@Override
+	public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+		sc.pipeline().fireUserEventTriggered(evt);
+	}
+
+	@Override
+	public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+		sc.pipeline().fireChannelWritabilityChanged();
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+		sc.pipeline().fireExceptionCaught(cause);
+	}
+
+	@Override
+	public boolean isSharable() {
+		return false;
+	}
+
+	protected Channel createSubChannel(ChannelHandlerContext ctx) {
+		if (ctx.channel() instanceof DatagramChannel)
+			return new DatagramSubChannel(ctx);
+		else if (ctx.channel() instanceof DuplexChannel)
+			return new DuplexSubChannel(ctx);
+		else return new SubChannel(ctx);
+	}
+	
+	@Override
+	public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+		sc = createSubChannel(ctx);
+		if (handlers != null)
+			sc.pipeline().addFirst(handlers);
+	}
+
+	@Override
+	public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+		ChannelHandler first;
+		while ((first = sc.pipeline().first()) != null) {
+			sc.pipeline().remove(first);
+		}
+	}
+
+}

--- a/transport/src/main/java/io/netty/channel/socket/DatagramSubChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramSubChannel.java
@@ -1,0 +1,131 @@
+package io.netty.channel.socket;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.SubChannel;
+
+public class DatagramSubChannel extends SubChannel implements DatagramChannel {
+
+	public DatagramSubChannel(ChannelHandlerContext ctx) {
+		super(ctx);
+	}
+
+	@Override
+	public DatagramChannel parent() {
+		return (DatagramChannel) super.parent();
+	}
+
+	@Override
+	public DatagramChannelConfig config() {
+		return parent().config();
+	}
+
+	@Override
+	public InetSocketAddress localAddress() {
+		return parent().localAddress();
+	}
+
+	@Override
+	public InetSocketAddress remoteAddress() {
+		return parent().remoteAddress();
+	}
+
+	@Override
+	public boolean isConnected() {
+		return parent().isConnected();
+	}
+
+	@Override
+	public ChannelFuture joinGroup(InetAddress multicastAddress) {
+		return parent().joinGroup(multicastAddress);
+	}
+
+	@Override
+	public ChannelFuture joinGroup(InetAddress multicastAddress, ChannelPromise future) {
+		return parent().joinGroup(multicastAddress, future);
+	}
+
+	@Override
+	public ChannelFuture joinGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
+		return parent().joinGroup(multicastAddress, networkInterface);
+	}
+
+	@Override
+	public ChannelFuture joinGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface,
+			ChannelPromise future) {
+		return parent().joinGroup(multicastAddress, networkInterface, future);
+	}
+
+	@Override
+	public ChannelFuture joinGroup(InetAddress multicastAddress, NetworkInterface networkInterface,
+			InetAddress source) {
+		return parent().joinGroup(multicastAddress, networkInterface, source);
+	}
+
+	@Override
+	public ChannelFuture joinGroup(InetAddress multicastAddress, NetworkInterface networkInterface,
+			InetAddress source, ChannelPromise future) {
+		return parent().joinGroup(multicastAddress, networkInterface, source, future);
+	}
+
+	@Override
+	public ChannelFuture leaveGroup(InetAddress multicastAddress) {
+		return parent().leaveGroup(multicastAddress);
+	}
+
+	@Override
+	public ChannelFuture leaveGroup(InetAddress multicastAddress, ChannelPromise future) {
+		return parent().leaveGroup(multicastAddress, future);
+	}
+
+	@Override
+	public ChannelFuture leaveGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
+		return parent().leaveGroup(multicastAddress, networkInterface);
+	}
+
+	@Override
+	public ChannelFuture leaveGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface,
+			ChannelPromise future) {
+		return parent().leaveGroup(multicastAddress, networkInterface, future);
+	}
+
+	@Override
+	public ChannelFuture leaveGroup(InetAddress multicastAddress, NetworkInterface networkInterface,
+			InetAddress source) {
+		return parent().leaveGroup(multicastAddress, networkInterface, source);
+	}
+
+	@Override
+	public ChannelFuture leaveGroup(InetAddress multicastAddress, NetworkInterface networkInterface,
+			InetAddress source, ChannelPromise future) {
+		return parent().leaveGroup(multicastAddress, networkInterface, source, future);
+	}
+
+	@Override
+	public ChannelFuture block(InetAddress multicastAddress, NetworkInterface networkInterface,
+			InetAddress sourceToBlock) {
+		return parent().block(multicastAddress, networkInterface, sourceToBlock);
+	}
+
+	@Override
+	public ChannelFuture block(InetAddress multicastAddress, NetworkInterface networkInterface,
+			InetAddress sourceToBlock, ChannelPromise future) {
+		return parent().block(multicastAddress, networkInterface, sourceToBlock, future);
+	}
+
+	@Override
+	public ChannelFuture block(InetAddress multicastAddress, InetAddress sourceToBlock) {
+		return parent().block(multicastAddress, sourceToBlock);
+	}
+
+	@Override
+	public ChannelFuture block(InetAddress multicastAddress, InetAddress sourceToBlock, ChannelPromise future) {
+		return parent().block(multicastAddress, sourceToBlock, future);
+	}
+
+}

--- a/transport/src/main/java/io/netty/channel/socket/DuplexSubChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/DuplexSubChannel.java
@@ -1,0 +1,69 @@
+package io.netty.channel.socket;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.SubChannel;
+
+public class DuplexSubChannel extends SubChannel implements DuplexChannel {
+
+	public DuplexSubChannel(ChannelHandlerContext ctx) {
+		super(ctx);
+	}
+
+	@Override
+	public DuplexChannel parent() {
+		return (DuplexChannel) super.parent();
+	}
+
+	@Override
+	public boolean isInputShutdown() {
+		return parent().isInputShutdown();
+	}
+
+	@Override
+	public ChannelFuture shutdownInput() {
+		return parent().shutdownInput();
+	}
+
+	@Override
+	public ChannelFuture shutdownInput(ChannelPromise promise) {
+		ChannelFuture cf = parent().shutdownInput();
+		cf.addListener(new PromiseRelay(promise));
+		return cf;
+	}
+
+	@Override
+	public boolean isOutputShutdown() {
+		return parent().isOutputShutdown();
+	}
+
+	@Override
+	public ChannelFuture shutdownOutput() {
+		return parent().shutdownOutput();
+	}
+
+	@Override
+	public ChannelFuture shutdownOutput(ChannelPromise promise) {
+		ChannelFuture cf = parent().shutdownOutput();
+		cf.addListener(new PromiseRelay(promise));
+		return cf;
+	}
+
+	@Override
+	public boolean isShutdown() {
+		return parent().isShutdown();
+	}
+
+	@Override
+	public ChannelFuture shutdown() {
+		return parent().shutdown();
+	}
+
+	@Override
+	public ChannelFuture shutdown(ChannelPromise promise) {
+		ChannelFuture cf = parent().shutdown();
+		cf.addListener(new PromiseRelay(promise));
+		return cf;
+	}
+}

--- a/transport/src/main/java/io/netty/channel/socket/PromiseRelay.java
+++ b/transport/src/main/java/io/netty/channel/socket/PromiseRelay.java
@@ -1,0 +1,41 @@
+package io.netty.channel.socket;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelPromise;
+
+public class PromiseRelay implements ChannelFutureListener {
+	private ChannelPromise promise;
+	private Exception caller = new Exception();
+
+	public PromiseRelay(ChannelPromise promise) {
+		this.promise = promise;
+//		System.err.println("Called by " + caller() + " on a " + promise.channel().getClass());
+//		caller.printStackTrace();
+	}
+
+	private String caller() {
+		return caller.getStackTrace()[2].toString();
+	}
+
+	@Override
+	public void operationComplete(final ChannelFuture future) throws Exception {
+		promise.channel().eventLoop().execute(new Runnable() {
+			@Override
+			public void run() {
+				if (future.isSuccess()) {
+//					System.out.println("Success! " + caller());
+					promise.setSuccess();
+				} else if (future.isCancelled()) {
+//					System.out.println("Cancelled! " + caller());
+					promise.cancel(true);
+				} else {
+//					System.out.println("Failure! " + caller());
+//					promise.setFailure(future.cause());
+//					caller.printStackTrace();
+//					future.cause().printStackTrace();
+				}
+			}
+		});
+	}
+}


### PR DESCRIPTION
Motivation:

A SubChannel is a useful construct for cases where the pipeline
is exposed to a framework user, but the framework needs certain
handlers to remain undisturbed by pipeline manipulation.

Those handlers can be added to the primary pipeline, and user
handlers can be added to a separate pipeline within a SubChannel,
which is entirely under the control of the user.

Events flow in the primary channel until they reach the
SubChannelHandler, at which point they are diverted into the
SubChannel. Any events that reach the end of the SubChannel are
then propagated back into the primary channel.

Modification:

Implemented SubChannelHandler (the primary interface to SubChannel), a SubChannel which handles the bulk of the work, DuplexSubChannel and DatagramSubChannel implementations that mirror the functionality of DuplexChannel and DatagramChannel for any added handlers.
Also implemented PromiseRelay, which is required to handle e.g. write() events that cross from one Channel to another.

Result:

Fixes #8894. 
