### PR TITLE
Removes Sec-WebSocket-Origin From Websocket HS

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -151,7 +151,6 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * Upgrade: websocket
      * Connection: Upgrade
      * Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-     * Sec-WebSocket-Origin: http://example.com
      * Sec-WebSocket-Protocol: chat, superchat
      * Sec-WebSocket-Version: 13
      * </pre>
@@ -188,8 +187,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         headers.set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, key)
-               .set(HttpHeaderNames.HOST, websocketHostValue(wsURL))
-               .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, websocketOriginValue(wsURL));
+               .set(HttpHeaderNames.HOST, websocketHostValue(wsURL));
 
         String expectedSubprotocol = expectedSubprotocol();
         if (expectedSubprotocol != null && !expectedSubprotocol.isEmpty()) {


### PR DESCRIPTION
Sec-WebSocket-Origin is a Server to Client handshake not a Client to Server handshake header per the websocket RFC specification. 

This removes the header from the specification. This has been changed because some websocket proxy servers are very picky. There exists other areas that need adjusted for example this client should send "Connection: Upgrade" but instead sends "connection: upgrade"... Some Proxy WS Clients are not adhering properly to case insensitivity specifications and require the proper casing for the keys and values being sent.

Fixes Issue #9134
