### PR TITLE
DnsNameResolver.resolveAll(DnsQuestion) should not try to filter dupl…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -69,6 +69,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     }
 
     @Override
+    boolean isDuplicateAllowed() {
+        // We don't want include duplicates to mimic JDK behaviour.
+        return false;
+    }
+
+    @Override
     void cache(String hostname, DnsRecord[] additionals,
                DnsRecord result, InetAddress convertedResult) {
         resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(), parent.ch.eventLoop());

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -64,6 +64,11 @@ final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
     }
 
     @Override
+    boolean isDuplicateAllowed() {
+        return true;
+    }
+
+    @Override
     void cache(String hostname, DnsRecord[] additionals, DnsRecord result, DnsRecord convertedResult) {
         // Do not cache.
         // XXX: When we implement cache, we would need to retain the reference count of the result record.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -160,6 +160,12 @@ abstract class DnsResolveContext<T> {
     abstract boolean isCompleteEarly(T resolved);
 
     /**
+     * Returns {@code true} if we should allow duplicates in the result or {@code false} if no duplicates should
+     * be included.
+     */
+    abstract boolean isDuplicateAllowed();
+
+    /**
      * Caches a successful resolution.
      */
     abstract void cache(String hostname, DnsRecord[] additionals,
@@ -706,7 +712,7 @@ abstract class DnsResolveContext<T> {
             if (finalResult == null) {
                 finalResult = new ArrayList<T>(8);
                 finalResult.add(converted);
-            } else if (!finalResult.contains(converted)) {
+            } else if (isDuplicateAllowed() || !finalResult.contains(converted)) {
                 finalResult.add(converted);
             } else {
                 shouldRelease = true;


### PR DESCRIPTION
…icates

Motivation:

https://github.com/netty/netty/pull/9021 did apply some changes to filter out duplicates InetAddress when calling resolveAll(...) to mimic JDK behaviour. Unfortunally this also introduced a regression as we should not filter duplicates when the user explicit calls resolveAll(DnsQuestion).

Modifications:

- Only filter duplicates if resolveAll(String) is used
- Add unit test

Result:

Fixes regressions introduces by https://github.com/netty/netty/pull/9021
