### PR TITLE
Only use static Exception instances when we can ensure addSuppressed …

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -47,8 +47,6 @@ import java.util.Set;
  */
 public abstract class WebSocketServerHandshaker {
     protected static final InternalLogger logger = InternalLoggerFactory.getInstance(WebSocketServerHandshaker.class);
-    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), WebSocketServerHandshaker.class, "handshake(...)");
 
     private final String uri;
 
@@ -282,7 +280,9 @@ public abstract class WebSocketServerHandshaker {
             @Override
             public void channelInactive(ChannelHandlerContext ctx) throws Exception {
                 // Fail promise if Channel was closed
-                promise.tryFailure(CLOSED_CHANNEL_EXCEPTION);
+                if (!promise.isDone()) {
+                    promise.tryFailure(new ClosedChannelException());
+                }
                 ctx.fireChannelInactive();
             }
         });

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyProtocolException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyProtocolException.java
@@ -15,6 +15,9 @@
  */
 package io.netty.handler.codec.spdy;
 
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SuppressJava6Requirement;
+
 public class SpdyProtocolException extends Exception {
 
     private static final long serialVersionUID = 7870000537743847264L;
@@ -43,5 +46,20 @@ public class SpdyProtocolException extends Exception {
      */
     public SpdyProtocolException(Throwable cause) {
         super(cause);
+    }
+
+
+    static SpdyProtocolException newStatic(String message) {
+        if (PlatformDependent.javaVersion() >= 7) {
+            return new SpdyProtocolException(message, true);
+        }
+        return new SpdyProtocolException(message);
+    }
+
+    @SuppressJava6Requirement(reason = "uses Java 7+ Exception.<init>(String, Throwable, boolean, boolean)" +
+            " but is guarded by version checks")
+    private SpdyProtocolException(String message, boolean shared) {
+        super(message, null, false, true);
+        assert shared;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyProtocolException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyProtocolException.java
@@ -48,7 +48,6 @@ public class SpdyProtocolException extends Exception {
         super(cause);
     }
 
-
     static SpdyProtocolException newStatic(String message) {
         if (PlatformDependent.javaVersion() >= 7) {
             return new SpdyProtocolException(message, true);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -53,24 +53,31 @@ import static io.netty.util.internal.ThrowableUtil.unknownStackTrace;
 
 final class HpackDecoder {
     private static final Http2Exception DECODE_ULE_128_DECOMPRESSION_EXCEPTION = unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - decompression failure"), HpackDecoder.class,
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - decompression failure",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackDecoder.class,
             "decodeULE128(..)");
     private static final Http2Exception DECODE_ULE_128_TO_LONG_DECOMPRESSION_EXCEPTION = unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - long overflow"), HpackDecoder.class, "decodeULE128(..)");
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - long overflow",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackDecoder.class, "decodeULE128(..)");
     private static final Http2Exception DECODE_ULE_128_TO_INT_DECOMPRESSION_EXCEPTION = unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - int overflow"), HpackDecoder.class, "decodeULE128ToInt(..)");
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - int overflow",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackDecoder.class, "decodeULE128ToInt(..)");
     private static final Http2Exception DECODE_ILLEGAL_INDEX_VALUE = unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - illegal index value"), HpackDecoder.class, "decode(..)");
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - illegal index value",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackDecoder.class, "decode(..)");
     private static final Http2Exception INDEX_HEADER_ILLEGAL_INDEX_VALUE = unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - illegal index value"), HpackDecoder.class, "indexHeader(..)");
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - illegal index value",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackDecoder.class, "indexHeader(..)");
     private static final Http2Exception READ_NAME_ILLEGAL_INDEX_VALUE = unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - illegal index value"), HpackDecoder.class, "readName(..)");
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - illegal index value",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackDecoder.class, "readName(..)");
     private static final Http2Exception INVALID_MAX_DYNAMIC_TABLE_SIZE = unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - invalid max dynamic table size"), HpackDecoder.class,
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - invalid max dynamic table size",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackDecoder.class,
             "setDynamicTableSize(..)");
     private static final Http2Exception MAX_DYNAMIC_TABLE_SIZE_CHANGE_REQUIRED = unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - max dynamic table size change required"), HpackDecoder.class,
-            "decode(..)");
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - max dynamic table size change required",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackDecoder.class, "decode(..)");
     private static final byte READ_HEADER_REPRESENTATION = 0;
     private static final byte READ_MAX_DYNAMIC_TABLE_SIZE = 1;
     private static final byte READ_INDEXED_HEADER = 2;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanDecoder.java
@@ -43,9 +43,11 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 final class HpackHuffmanDecoder {
 
     private static final Http2Exception EOS_DECODED = ThrowableUtil.unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - EOS Decoded"), HpackHuffmanDecoder.class, "decode(..)");
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - EOS Decoded",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackHuffmanDecoder.class, "decode(..)");
     private static final Http2Exception INVALID_PADDING = ThrowableUtil.unknownStackTrace(
-            connectionError(COMPRESSION_ERROR, "HPACK - Invalid Padding"), HpackHuffmanDecoder.class, "decode(..)");
+            Http2Exception.newStatic(COMPRESSION_ERROR, "HPACK - Invalid Padding",
+                    Http2Exception.ShutdownHint.HARD_SHUTDOWN), HpackHuffmanDecoder.class, "decode(..)");
 
     private static final Node ROOT = buildTree(HpackUtil.HUFFMAN_CODES, HpackUtil.HUFFMAN_CODE_LENGTHS);
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
@@ -15,6 +15,8 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayList;
@@ -58,6 +60,22 @@ public class Http2Exception extends Exception {
 
     public Http2Exception(Http2Error error, String message, Throwable cause, ShutdownHint shutdownHint) {
         super(message, cause);
+        this.error = checkNotNull(error, "error");
+        this.shutdownHint = checkNotNull(shutdownHint, "shutdownHint");
+    }
+
+    static Http2Exception newStatic(Http2Error error, String message, ShutdownHint shutdownHint) {
+        if (PlatformDependent.javaVersion() >= 7) {
+            return new Http2Exception(error, message, shutdownHint, true);
+        }
+        return new Http2Exception(error, message, shutdownHint);
+    }
+
+    @SuppressJava6Requirement(reason = "uses Java 7+ Exception.<init>(String, Throwable, boolean, boolean)" +
+            " but is guarded by version checks")
+    private Http2Exception(Http2Error error, String message, ShutdownHint shutdownHint, boolean shared) {
+        super(message, null, false, true);
+        assert shared;
         this.error = checkNotNull(error, "error");
         this.shutdownHint = checkNotNull(shutdownHint, "shutdownHint");
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -117,8 +117,6 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
     };
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
-    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), DefaultHttp2StreamChannel.Http2ChannelUnsafe.class, "write(...)");
     /**
      * Number of bytes to consider non-payload messages. 9 is arbitrary, but also the minimum size of an HTTP/2 frame.
      * Primarily is non-zero.
@@ -1091,7 +1089,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                         // Once the outbound side was closed we should not allow header / data frames
                         outboundClosed && (msg instanceof Http2HeadersFrame || msg instanceof Http2DataFrame)) {
                     ReferenceCountUtil.release(msg);
-                    promise.setFailure(CLOSED_CHANNEL_EXCEPTION);
+                    promise.setFailure(new ClosedChannelException());
                     return;
                 }
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -50,7 +50,6 @@ import static io.netty.handler.codec.compression.Lz4Constants.MAGIC_NUMBER;
 import static io.netty.handler.codec.compression.Lz4Constants.MAX_BLOCK_SIZE;
 import static io.netty.handler.codec.compression.Lz4Constants.MIN_BLOCK_SIZE;
 import static io.netty.handler.codec.compression.Lz4Constants.TOKEN_OFFSET;
-import static io.netty.util.internal.ThrowableUtil.unknownStackTrace;
 
 /**
  * Compresses a {@link ByteBuf} using the LZ4 format.
@@ -69,9 +68,6 @@ import static io.netty.util.internal.ThrowableUtil.unknownStackTrace;
  *  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *     * * * * * * * * * *
  */
 public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
-    private static final EncoderException ENCODE_FINSHED_EXCEPTION = unknownStackTrace(new EncoderException(
-                    new IllegalStateException("encode finished and not enough space to write remaining data")),
-                    Lz4FrameEncoder.class, "encode");
     static final int DEFAULT_MAX_ENCODE_SIZE = Integer.MAX_VALUE;
 
     private final int blockSize;
@@ -246,7 +242,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
         if (finished) {
             if (!out.isWritable(in.readableBytes())) {
                 // out should be EMPTY_BUFFER because we should have allocated enough space above in allocateBuffer.
-                throw ENCODE_FINSHED_EXCEPTION;
+                throw new IllegalStateException("encode finished and not enough space to write remaining data");
             }
             out.writeBytes(in);
             return;

--- a/common/src/main/java/io/netty/util/internal/SuppressJava6Requirement.java
+++ b/common/src/main/java/io/netty/util/internal/SuppressJava6Requirement.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * Annotation to suppress the Java 6 source code requirement checks for a method.
  */
 @Retention(RetentionPolicy.CLASS)
-@Target({ ElementType.METHOD })
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR })
 public @interface SuppressJava6Requirement {
 
     String reason();

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -28,7 +28,6 @@ import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -98,12 +97,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ReferenceCountedOpenSslEngine.class);
 
-    private static final SSLException BEGIN_HANDSHAKE_ENGINE_CLOSED = ThrowableUtil.unknownStackTrace(
-            new SSLException("engine closed"), ReferenceCountedOpenSslEngine.class, "beginHandshake()");
-    private static final SSLException HANDSHAKE_ENGINE_CLOSED = ThrowableUtil.unknownStackTrace(
-            new SSLException("engine closed"), ReferenceCountedOpenSslEngine.class, "handshake()");
-    private static final SSLException RENEGOTIATION_UNSUPPORTED =  ThrowableUtil.unknownStackTrace(
-            new SSLException("renegotiation unsupported"), ReferenceCountedOpenSslEngine.class, "beginHandshake()");
     private static final ResourceLeakDetector<ReferenceCountedOpenSslEngine> leakDetector =
             ResourceLeakDetectorFactory.instance().newResourceLeakDetector(ReferenceCountedOpenSslEngine.class);
     private static final int OPENSSL_OP_NO_PROTOCOL_INDEX_SSLV2 = 0;
@@ -1637,7 +1630,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     public final synchronized void beginHandshake() throws SSLException {
         switch (handshakeState) {
             case STARTED_IMPLICITLY:
-                checkEngineClosed(BEGIN_HANDSHAKE_ENGINE_CLOSED);
+                checkEngineClosed();
 
                 // A user did not start handshake by calling this method by him/herself,
                 // but handshake has been started already by wrap() or unwrap() implicitly.
@@ -1653,7 +1646,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 // Nothing to do as the handshake is not done yet.
                 break;
             case FINISHED:
-                throw RENEGOTIATION_UNSUPPORTED;
+                throw new SSLException("renegotiation unsupported");
             case NOT_STARTED:
                 handshakeState = HandshakeState.STARTED_EXPLICITLY;
                 if (handshake() == NEED_TASK) {
@@ -1667,9 +1660,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         }
     }
 
-    private void checkEngineClosed(SSLException cause) throws SSLException {
+    private void checkEngineClosed() throws SSLException {
         if (isDestroyed()) {
-            throw cause;
+            throw new SSLException("engine closed");
         }
     }
 
@@ -1721,7 +1714,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             return FINISHED;
         }
 
-        checkEngineClosed(HANDSHAKE_ENGINE_CLOSED);
+        checkEngineClosed();
 
         if (handshakeException != null) {
             return handshakeException();

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -45,7 +45,6 @@ import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -172,18 +171,6 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             "^.*(?:Socket|Datagram|Sctp|Udt)Channel.*$");
     private static final Pattern IGNORABLE_ERROR_MESSAGE = Pattern.compile(
             "^.*(?:connection.*(?:reset|closed|abort|broken)|broken.*pipe).*$", Pattern.CASE_INSENSITIVE);
-
-    /**
-     * Used in {@link #unwrapNonAppData(ChannelHandlerContext)} as input for
-     * {@link #unwrap(ChannelHandlerContext, ByteBuf, int,  int)}.  Using this static instance reduce object
-     * creation as {@link Unpooled#EMPTY_BUFFER#nioBuffer()} creates a new {@link ByteBuffer} everytime.
-     */
-    private static final SSLException SSLENGINE_CLOSED = ThrowableUtil.unknownStackTrace(
-            new SSLException("SSLEngine closed already"), SslHandler.class, "wrap(...)");
-    private static final SSLException HANDSHAKE_TIMED_OUT = ThrowableUtil.unknownStackTrace(
-            new SSLException("handshake timed out"), SslHandler.class, "handshake(...)");
-    private static final ClosedChannelException CHANNEL_CLOSED = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), SslHandler.class, "channelInactive(...)");
 
     /**
      * <a href="https://tools.ietf.org/html/rfc5246#section-6.2">2^14</a> which is the maximum sized plaintext chunk
@@ -844,11 +831,12 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 if (result.getStatus() == Status.CLOSED) {
                     buf.release();
                     buf = null;
-                    promise.tryFailure(SSLENGINE_CLOSED);
+                    SSLException exception = new SSLException("SSLEngine closed already");
+                    promise.tryFailure(exception);
                     promise = null;
                     // SSLEngine has been closed already.
                     // Any further write attempts should be denied.
-                    pendingUnencryptedWrites.releaseAndFailAll(ctx, SSLENGINE_CLOSED);
+                    pendingUnencryptedWrites.releaseAndFailAll(ctx, exception);
                     return;
                 } else {
                     if (buf.isReadable()) {
@@ -1068,12 +1056,13 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        ClosedChannelException exception = new ClosedChannelException();
         // Make sure to release SSLEngine,
         // and notify the handshake future if the connection has been closed during handshake.
-        setHandshakeFailure(ctx, CHANNEL_CLOSED, !outboundClosed, handshakeStarted, false);
+        setHandshakeFailure(ctx, exception, !outboundClosed, handshakeStarted, false);
 
         // Ensure we always notify the sslClosePromise as well
-        notifyClosePromise(CHANNEL_CLOSED);
+        notifyClosePromise(exception);
 
         super.channelInactive(ctx);
     }
@@ -1988,12 +1977,13 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 if (localHandshakePromise.isDone()) {
                     return;
                 }
+                SSLException exception = new SSLException("handshake timed out");
                 try {
-                    if (localHandshakePromise.tryFailure(HANDSHAKE_TIMED_OUT)) {
-                        SslUtils.handleHandshakeFailure(ctx, HANDSHAKE_TIMED_OUT, true);
+                    if (localHandshakePromise.tryFailure(exception)) {
+                        SslUtils.handleHandshakeFailure(ctx, exception, true);
                     }
                 } finally {
-                    releaseAndFailAll(HANDSHAKE_TIMED_OUT);
+                    releaseAndFailAll(exception);
                 }
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/handler/src/main/java/io/netty/handler/ssl/ocsp/OcspClientHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ocsp/OcspClientHandler.java
@@ -21,7 +21,6 @@ import io.netty.handler.ssl.ReferenceCountedOpenSslContext;
 import io.netty.handler.ssl.ReferenceCountedOpenSslEngine;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.UnstableApi;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -34,9 +33,6 @@ import javax.net.ssl.SSLHandshakeException;
  */
 @UnstableApi
 public abstract class OcspClientHandler extends ChannelInboundHandlerAdapter {
-
-    private static final SSLHandshakeException OCSP_VERIFICATION_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new SSLHandshakeException("Bad OCSP response"), OcspClientHandler.class, "verify(...)");
 
     private final ReferenceCountedOpenSslEngine engine;
 
@@ -56,7 +52,7 @@ public abstract class OcspClientHandler extends ChannelInboundHandlerAdapter {
 
             SslHandshakeCompletionEvent event = (SslHandshakeCompletionEvent) evt;
             if (event.isSuccess() && !verify(ctx, engine)) {
-                throw OCSP_VERIFICATION_EXCEPTION;
+                throw new SSLHandshakeException("Bad OCSP response");
             }
         }
 

--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutException.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.timeout;
 
+import io.netty.util.internal.PlatformDependent;
+
 /**
  * A {@link TimeoutException} raised by {@link ReadTimeoutHandler} when no data
  * was read within a certain period of time.
@@ -23,7 +25,12 @@ public final class ReadTimeoutException extends TimeoutException {
 
     private static final long serialVersionUID = 169287984113283421L;
 
-    public static final ReadTimeoutException INSTANCE = new ReadTimeoutException();
+    public static final ReadTimeoutException INSTANCE = PlatformDependent.javaVersion() >= 7 ?
+            new ReadTimeoutException(true) : new ReadTimeoutException();
 
-    private ReadTimeoutException() { }
+    ReadTimeoutException() { }
+
+    private ReadTimeoutException(boolean shared) {
+        super(shared);
+    }
 }

--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
@@ -95,7 +95,7 @@ public class ReadTimeoutHandler extends IdleStateHandler {
      */
     protected void readTimedOut(ChannelHandlerContext ctx) throws Exception {
         if (!closed) {
-            ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+            ctx.fireExceptionCaught(new ReadTimeoutException());
             ctx.close();
             closed = true;
         }

--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
@@ -95,7 +95,7 @@ public class ReadTimeoutHandler extends IdleStateHandler {
      */
     protected void readTimedOut(ChannelHandlerContext ctx) throws Exception {
         if (!closed) {
-            ctx.fireExceptionCaught(new ReadTimeoutException());
+            ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
             ctx.close();
             closed = true;
         }

--- a/handler/src/main/java/io/netty/handler/timeout/TimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/TimeoutException.java
@@ -25,7 +25,12 @@ public class TimeoutException extends ChannelException {
 
     private static final long serialVersionUID = 4673641882869672533L;
 
-    TimeoutException() { }
+    TimeoutException() {
+    }
+
+    TimeoutException(boolean shared) {
+        super(null, null, shared);
+    }
 
     @Override
     public Throwable fillInStackTrace() {

--- a/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutException.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.timeout;
 
+import io.netty.util.internal.PlatformDependent;
+
 /**
  * A {@link TimeoutException} raised by {@link WriteTimeoutHandler} when no data
  * was written within a certain period of time.
@@ -23,7 +25,12 @@ public final class WriteTimeoutException extends TimeoutException {
 
     private static final long serialVersionUID = -144786655770296065L;
 
-    public static final WriteTimeoutException INSTANCE = new WriteTimeoutException();
+    public static final WriteTimeoutException INSTANCE = PlatformDependent.javaVersion() >= 7 ?
+            new WriteTimeoutException(true) : new WriteTimeoutException();
 
     private WriteTimeoutException() { }
+
+    private WriteTimeoutException(boolean shared) {
+        super(shared);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -873,7 +873,6 @@
             <ignore>java.nio.file.LinkOption</ignore>
             <ignore>java.nio.file.Path</ignore>
             <ignore>java.io.File</ignore>
-
           </ignores>
           <annotations>
             <annotation>io.netty.util.internal.SuppressJava6Requirement</annotation>

--- a/pom.xml
+++ b/pom.xml
@@ -873,6 +873,7 @@
             <ignore>java.nio.file.LinkOption</ignore>
             <ignore>java.nio.file.Path</ignore>
             <ignore>java.io.File</ignore>
+
           </ignores>
           <annotations>
             <annotation>io.netty.util.internal.SuppressJava6Requirement</annotation>

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -57,8 +57,6 @@ import static io.netty.channel.unix.UnixChannelUtil.computeRemoteAddr;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 abstract class AbstractEpollChannel extends AbstractChannel implements UnixChannel {
-    private static final ClosedChannelException DO_CLOSE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), AbstractEpollChannel.class, "doClose()");
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     final LinuxSocket socket;
     /**
@@ -158,7 +156,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             ChannelPromise promise = connectPromise;
             if (promise != null) {
                 // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-                promise.tryFailure(DO_CLOSE_CLOSED_CHANNEL_EXCEPTION);
+                promise.tryFailure(new ClosedChannelException());
                 connectPromise = null;
             }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -16,29 +16,20 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.DefaultFileRegion;
-import io.netty.channel.unix.Errors.NativeIoException;
 import io.netty.channel.unix.NativeInetAddress;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Socket;
-import io.netty.util.internal.ThrowableUtil;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.nio.channels.ClosedChannelException;
 
-import static io.netty.channel.unix.Errors.ERRNO_EPIPE_NEGATIVE;
 import static io.netty.channel.unix.Errors.ioResult;
-import static io.netty.channel.unix.Errors.newConnectionResetException;
 
 /**
  * A socket which provides access Linux native methods.
  */
 final class LinuxSocket extends Socket {
     private static final long MAX_UINT32_T = 0xFFFFFFFFL;
-    private static final NativeIoException SENDFILE_CONNECTION_RESET_EXCEPTION =
-            newConnectionResetException("syscall:sendfile(...)", ERRNO_EPIPE_NEGATIVE);
-    private static final ClosedChannelException SENDFILE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), Native.class, "sendfile(...)");
 
     LinuxSocket(int fd) {
         super(fd);
@@ -177,7 +168,7 @@ final class LinuxSocket extends Socket {
         if (res >= 0) {
             return res;
         }
-        return ioResult("sendfile", (int) res, SENDFILE_CONNECTION_RESET_EXCEPTION, SENDFILE_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("sendfile", (int) res);
     }
 
     public static LinuxSocket newSocketStream() {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -15,7 +15,6 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.channel.unix.Errors.NativeIoException;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.Socket;
 import io.netty.util.internal.NativeLibraryLoader;
@@ -26,7 +25,6 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
-import java.nio.channels.ClosedChannelException;
 import java.util.Locale;
 
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.epollerr;
@@ -38,9 +36,7 @@ import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.isSupp
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.isSupportingTcpFastopen;
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.kernelVersion;
 import static io.netty.channel.epoll.NativeStaticallyReferencedJniMethods.tcpMd5SigMaxKeyLen;
-import static io.netty.channel.unix.Errors.ERRNO_EPIPE_NEGATIVE;
 import static io.netty.channel.unix.Errors.ioResult;
-import static io.netty.channel.unix.Errors.newConnectionResetException;
 import static io.netty.channel.unix.Errors.newIOException;
 
 /**
@@ -74,20 +70,6 @@ public final class Native {
     public static final boolean IS_SUPPORTING_TCP_FASTOPEN = isSupportingTcpFastopen();
     public static final int TCP_MD5SIG_MAXKEYLEN = tcpMd5SigMaxKeyLen();
     public static final String KERNEL_VERSION = kernelVersion();
-
-    private static final NativeIoException SENDMMSG_CONNECTION_RESET_EXCEPTION;
-    private static final NativeIoException SPLICE_CONNECTION_RESET_EXCEPTION;
-    private static final ClosedChannelException SENDMMSG_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), Native.class, "sendmmsg(...)");
-    private static final ClosedChannelException SPLICE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), Native.class, "splice(...)");
-
-    static {
-        SENDMMSG_CONNECTION_RESET_EXCEPTION = newConnectionResetException("syscall:sendmmsg(...)",
-                ERRNO_EPIPE_NEGATIVE);
-        SPLICE_CONNECTION_RESET_EXCEPTION = newConnectionResetException("syscall:splice(...)",
-                ERRNO_EPIPE_NEGATIVE);
-    }
 
     public static FileDescriptor newEventFd() {
         return new FileDescriptor(eventFd());
@@ -165,7 +147,7 @@ public final class Native {
         if (res >= 0) {
             return res;
         }
-        return ioResult("splice", res, SPLICE_CONNECTION_RESET_EXCEPTION, SPLICE_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("splice", res);
     }
 
     private static native int splice0(int fd, long offIn, int fdOut, long offOut, long len);
@@ -176,7 +158,7 @@ public final class Native {
         if (res >= 0) {
             return res;
         }
-        return ioResult("sendmmsg", res, SENDMMSG_CONNECTION_RESET_EXCEPTION, SENDMMSG_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("sendmmsg", res);
     }
 
     private static native int sendmmsg0(

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -16,37 +16,24 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.DefaultFileRegion;
-import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Socket;
-import io.netty.util.internal.ThrowableUtil;
 
 import java.io.IOException;
-import java.nio.channels.ClosedChannelException;
 
 import static io.netty.channel.kqueue.AcceptFilter.PLATFORM_UNSUPPORTED;
-import static io.netty.channel.unix.Errors.ERRNO_EPIPE_NEGATIVE;
 import static io.netty.channel.unix.Errors.ioResult;
-import static io.netty.channel.unix.Errors.newConnectionResetException;
 
 /**
  * A socket which provides access BSD native methods.
  */
 final class BsdSocket extends Socket {
-    private static final Errors.NativeIoException SENDFILE_CONNECTION_RESET_EXCEPTION;
-    private static final ClosedChannelException SENDFILE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), Native.class, "sendfile(..)");
 
     // These limits are just based on observations. I couldn't find anything in header files which formally
     // define these limits.
     private static final int APPLE_SND_LOW_AT_MAX = 1 << 17;
     private static final int FREEBSD_SND_LOW_AT_MAX = 1 << 15;
     static final int BSD_SND_LOW_AT_MAX = Math.min(APPLE_SND_LOW_AT_MAX, FREEBSD_SND_LOW_AT_MAX);
-
-    static {
-        SENDFILE_CONNECTION_RESET_EXCEPTION = newConnectionResetException("syscall:sendfile",
-                ERRNO_EPIPE_NEGATIVE);
-    }
 
     BsdSocket(int fd) {
         super(fd);
@@ -90,7 +77,7 @@ final class BsdSocket extends Socket {
         if (res >= 0) {
             return res;
         }
-        return ioResult("sendfile", (int) res, SENDFILE_CONNECTION_RESET_EXCEPTION, SENDFILE_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("sendfile", (int) res);
     }
 
     public static BsdSocket newSocketStream() {

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
@@ -15,12 +15,10 @@
  */
 package io.netty.channel.unix;
 
-import io.netty.util.internal.ThrowableUtil;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.netty.channel.unix.Errors.ioResult;
@@ -35,36 +33,6 @@ import static java.lang.Math.min;
  * {@link FileDescriptor} for it.
  */
 public class FileDescriptor {
-    private static final ClosedChannelException WRITE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), FileDescriptor.class, "write(..)");
-    private static final ClosedChannelException WRITE_ADDRESS_CLOSED_CHANNEL_EXCEPTION =
-            ThrowableUtil.unknownStackTrace(new ClosedChannelException(), FileDescriptor.class, "writeAddress(..)");
-    private static final ClosedChannelException WRITEV_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), FileDescriptor.class, "writev(..)");
-    private static final ClosedChannelException WRITEV_ADDRESSES_CLOSED_CHANNEL_EXCEPTION =
-            ThrowableUtil.unknownStackTrace(new ClosedChannelException(), FileDescriptor.class, "writevAddresses(..)");
-    private static final ClosedChannelException READ_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), FileDescriptor.class, "read(..)");
-    private static final ClosedChannelException READ_ADDRESS_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), FileDescriptor.class, "readAddress(..)");
-    private static final Errors.NativeIoException WRITE_CONNECTION_RESET_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            Errors.newConnectionResetException("syscall:write", Errors.ERRNO_EPIPE_NEGATIVE),
-            FileDescriptor.class, "write(..)");
-    private static final Errors.NativeIoException WRITE_ADDRESS_CONNECTION_RESET_EXCEPTION =
-            ThrowableUtil.unknownStackTrace(Errors.newConnectionResetException("syscall:write",
-                    Errors.ERRNO_EPIPE_NEGATIVE), FileDescriptor.class, "writeAddress(..)");
-    private static final Errors.NativeIoException WRITEV_CONNECTION_RESET_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            Errors.newConnectionResetException("syscall:writev", Errors.ERRNO_EPIPE_NEGATIVE),
-            FileDescriptor.class, "writev(..)");
-    private static final Errors.NativeIoException WRITEV_ADDRESSES_CONNECTION_RESET_EXCEPTION =
-            ThrowableUtil.unknownStackTrace(Errors.newConnectionResetException("syscall:writev",
-                    Errors.ERRNO_EPIPE_NEGATIVE), FileDescriptor.class, "writeAddresses(..)");
-    private static final Errors.NativeIoException READ_CONNECTION_RESET_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            Errors.newConnectionResetException("syscall:read", Errors.ERRNO_ECONNRESET_NEGATIVE),
-            FileDescriptor.class, "read(..)");
-    private static final Errors.NativeIoException READ_ADDRESS_CONNECTION_RESET_EXCEPTION =
-            ThrowableUtil.unknownStackTrace(Errors.newConnectionResetException("syscall:read",
-                    Errors.ERRNO_ECONNRESET_NEGATIVE), FileDescriptor.class, "readAddress(..)");
 
     private static final AtomicIntegerFieldUpdater<FileDescriptor> stateUpdater =
             AtomicIntegerFieldUpdater.newUpdater(FileDescriptor.class, "state");
@@ -126,7 +94,7 @@ public class FileDescriptor {
         if (res >= 0) {
             return res;
         }
-        return ioResult("write", res, WRITE_CONNECTION_RESET_EXCEPTION, WRITE_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("write", res);
     }
 
     public final int writeAddress(long address, int pos, int limit) throws IOException {
@@ -134,8 +102,7 @@ public class FileDescriptor {
         if (res >= 0) {
             return res;
         }
-        return ioResult("writeAddress", res,
-                WRITE_ADDRESS_CONNECTION_RESET_EXCEPTION, WRITE_ADDRESS_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("writeAddress", res);
     }
 
     public final long writev(ByteBuffer[] buffers, int offset, int length, long maxBytesToWrite) throws IOException {
@@ -143,7 +110,7 @@ public class FileDescriptor {
         if (res >= 0) {
             return res;
         }
-        return ioResult("writev", (int) res, WRITEV_CONNECTION_RESET_EXCEPTION, WRITEV_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("writev", (int) res);
     }
 
     public final long writevAddresses(long memoryAddress, int length) throws IOException {
@@ -151,8 +118,7 @@ public class FileDescriptor {
         if (res >= 0) {
             return res;
         }
-        return ioResult("writevAddresses", (int) res,
-                WRITEV_ADDRESSES_CONNECTION_RESET_EXCEPTION, WRITEV_ADDRESSES_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("writevAddresses", (int) res);
     }
 
     public final int read(ByteBuffer buf, int pos, int limit) throws IOException {
@@ -163,7 +129,7 @@ public class FileDescriptor {
         if (res == 0) {
             return -1;
         }
-        return ioResult("read", res, READ_CONNECTION_RESET_EXCEPTION, READ_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("read", res);
     }
 
     public final int readAddress(long address, int pos, int limit) throws IOException {
@@ -174,8 +140,7 @@ public class FileDescriptor {
         if (res == 0) {
             return -1;
         }
-        return ioResult("readAddress", res,
-                READ_ADDRESS_CONNECTION_RESET_EXCEPTION, READ_ADDRESS_CLOSED_CHANNEL_EXCEPTION);
+        return ioResult("readAddress", res);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -21,7 +21,6 @@ import io.netty.channel.socket.ChannelOutputShutdownException;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -43,17 +42,6 @@ import java.util.concurrent.RejectedExecutionException;
 public abstract class AbstractChannel extends DefaultAttributeMap implements Channel {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractChannel.class);
-
-    private static final ClosedChannelException ENSURE_OPEN_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ExtendedClosedChannelException(null), AbstractUnsafe.class, "ensureOpen(...)");
-    private static final ClosedChannelException CLOSE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), AbstractUnsafe.class, "close(...)");
-    private static final ClosedChannelException WRITE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ExtendedClosedChannelException(null), AbstractUnsafe.class, "write(...)");
-    private static final ClosedChannelException FLUSH0_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ExtendedClosedChannelException(null), AbstractUnsafe.class, "flush0()");
-    private static final NotYetConnectedException FLUSH0_NOT_YET_CONNECTED_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new NotYetConnectedException(), AbstractUnsafe.class, "flush0()");
 
     private final Channel parent;
     private final ChannelId id;
@@ -613,7 +601,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         public final void close(final ChannelPromise promise) {
             assertEventLoop();
 
-            close(promise, CLOSE_CLOSED_CHANNEL_EXCEPTION, CLOSE_CLOSED_CHANNEL_EXCEPTION, false);
+            ClosedChannelException closedChannelException = new ClosedChannelException();
+            close(promise, closedChannelException, closedChannelException, false);
         }
 
         /**
@@ -638,7 +627,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
             final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
             if (outboundBuffer == null) {
-                promise.setFailure(CLOSE_CLOSED_CHANNEL_EXCEPTION);
+                promise.setFailure(new ClosedChannelException());
                 return;
             }
             this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
@@ -871,7 +860,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 // need to fail the future right away. If it is not null the handling of the rest
                 // will be done in flush0()
                 // See https://github.com/netty/netty/issues/2362
-                safeSetFailure(promise, newWriteException(initialCloseCause));
+                safeSetFailure(promise, newClosedChannelException(initialCloseCause));
                 // release message now to prevent resource-leak
                 ReferenceCountUtil.release(msg);
                 return;
@@ -924,10 +913,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             if (!isActive()) {
                 try {
                     if (isOpen()) {
-                        outboundBuffer.failFlushed(FLUSH0_NOT_YET_CONNECTED_EXCEPTION, true);
+                        outboundBuffer.failFlushed(new NotYetConnectedException(), true);
                     } else {
                         // Do not trigger channelWritabilityChanged because the channel is closed already.
-                        outboundBuffer.failFlushed(newFlush0Exception(initialCloseCause), false);
+                        outboundBuffer.failFlushed(newClosedChannelException(initialCloseCause), false);
                     }
                 } finally {
                     inFlush0 = false;
@@ -948,13 +937,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                      * may still return {@code true} even if the channel should be closed as result of the exception.
                      */
                     initialCloseCause = t;
-                    close(voidPromise(), t, newFlush0Exception(t), false);
+                    close(voidPromise(), t, newClosedChannelException(t), false);
                 } else {
                     try {
                         shutdownOutput(voidPromise(), t);
                     } catch (Throwable t2) {
                         initialCloseCause = t;
-                        close(voidPromise(), t2, newFlush0Exception(t), false);
+                        close(voidPromise(), t2, newClosedChannelException(t), false);
                     }
                 }
             } finally {
@@ -962,28 +951,12 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             }
         }
 
-        private ClosedChannelException newWriteException(Throwable cause) {
-            if (cause == null) {
-                return WRITE_CLOSED_CHANNEL_EXCEPTION;
+        private ClosedChannelException newClosedChannelException(Throwable cause) {
+            ClosedChannelException exception = new ClosedChannelException();
+            if (cause != null) {
+                exception.initCause(cause);
             }
-            return ThrowableUtil.unknownStackTrace(
-                    new ExtendedClosedChannelException(cause), AbstractUnsafe.class, "write(...)");
-        }
-
-        private ClosedChannelException newFlush0Exception(Throwable cause) {
-            if (cause == null) {
-                return FLUSH0_CLOSED_CHANNEL_EXCEPTION;
-            }
-            return ThrowableUtil.unknownStackTrace(
-                    new ExtendedClosedChannelException(cause), AbstractUnsafe.class, "flush0()");
-        }
-
-        private ClosedChannelException newEnsureOpenException(Throwable cause) {
-            if (cause == null) {
-                return ENSURE_OPEN_CLOSED_CHANNEL_EXCEPTION;
-            }
-            return ThrowableUtil.unknownStackTrace(
-                    new ExtendedClosedChannelException(cause), AbstractUnsafe.class, "ensureOpen(...)");
+            return exception;
         }
 
         @Override
@@ -998,7 +971,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return true;
             }
 
-            safeSetFailure(promise, newEnsureOpenException(initialCloseCause));
+            safeSetFailure(promise, newClosedChannelException(initialCloseCause));
             return false;
         }
 

--- a/transport/src/main/java/io/netty/channel/ChannelException.java
+++ b/transport/src/main/java/io/netty/channel/ChannelException.java
@@ -15,6 +15,10 @@
  */
 package io.netty.channel;
 
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SuppressJava6Requirement;
+import io.netty.util.internal.UnstableApi;
+
 /**
  * A {@link RuntimeException} which is thrown when an I/O operation fails.
  */
@@ -47,5 +51,20 @@ public class ChannelException extends RuntimeException {
      */
     public ChannelException(Throwable cause) {
         super(cause);
+    }
+
+    @UnstableApi
+    @SuppressJava6Requirement(reason = "uses Java 7+ RuntimeException.<init>(String, Throwable, boolean, boolean)" +
+            " but is guarded by version checks")
+    protected ChannelException(String message, Throwable cause, boolean shared) {
+        super(message, cause, false, true);
+        assert shared;
+    }
+
+    static ChannelException newStatic(String message, Throwable cause) {
+        if (PlatformDependent.javaVersion() >= 7) {
+            return new ChannelException(message, cause, true);
+        }
+        return new ChannelException(message, cause);
     }
 }

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
@@ -135,7 +135,7 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
         this.executor = executor;
 
         tooManyChannels = ThrowableUtil.unknownStackTrace(
-                new ChannelException("too many channels (max: " + maxChannels + ')'),
+                ChannelException.newStatic("too many channels (max: " + maxChannels + ')', null),
                 ThreadPerChannelEventLoopGroup.class, "nextChild()");
     }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -32,7 +32,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -55,10 +54,6 @@ public class LocalChannel extends AbstractChannel {
             AtomicReferenceFieldUpdater.newUpdater(LocalChannel.class, Future.class, "finishReadFuture");
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     private static final int MAX_READER_STACK_DEPTH = 8;
-    private static final ClosedChannelException DO_WRITE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), LocalChannel.class, "doWrite(...)");
-    private static final ClosedChannelException DO_CLOSE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), LocalChannel.class, "doClose()");
 
     private enum State { OPEN, BOUND, CONNECTED, CLOSED }
 
@@ -234,7 +229,7 @@ public class LocalChannel extends AbstractChannel {
                 ChannelPromise promise = connectPromise;
                 if (promise != null) {
                     // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-                    promise.tryFailure(DO_CLOSE_CLOSED_CHANNEL_EXCEPTION);
+                    promise.tryFailure(new ClosedChannelException());
                     connectPromise = null;
                 }
             }
@@ -347,7 +342,7 @@ public class LocalChannel extends AbstractChannel {
         case BOUND:
             throw new NotYetConnectedException();
         case CLOSED:
-            throw DO_WRITE_CLOSED_CHANNEL_EXCEPTION;
+            throw new ClosedChannelException();
         case CONNECTED:
             break;
         }
@@ -356,6 +351,7 @@ public class LocalChannel extends AbstractChannel {
 
         writeInProgress = true;
         try {
+            ClosedChannelException exception = null;
             for (;;) {
                 Object msg = in.current();
                 if (msg == null) {
@@ -368,7 +364,10 @@ public class LocalChannel extends AbstractChannel {
                         peer.inboundBuffer.add(ReferenceCountUtil.retain(msg));
                         in.remove();
                     } else {
-                        in.remove(DO_WRITE_CLOSED_CHANNEL_EXCEPTION);
+                        if (exception == null) {
+                            exception = new ClosedChannelException();
+                        }
+                        in.remove(exception);
                     }
                 } catch (Throwable cause) {
                     in.remove(cause);

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -29,7 +29,6 @@ import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -50,9 +49,6 @@ public abstract class AbstractNioChannel extends AbstractChannel {
 
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(AbstractNioChannel.class);
-
-    private static final ClosedChannelException DO_CLOSE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new ClosedChannelException(), AbstractNioChannel.class, "doClose()");
 
     private final SelectableChannel ch;
     protected final int readInterestOp;
@@ -505,7 +501,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         ChannelPromise promise = connectPromise;
         if (promise != null) {
             // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            promise.tryFailure(DO_CLOSE_CLOSED_CHANNEL_EXCEPTION);
+            promise.tryFailure(new ClosedChannelException());
             connectPromise = null;
         }
 

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -26,7 +26,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.ThrowableUtil;
 
 import java.util.Deque;
 
@@ -41,9 +40,6 @@ import static io.netty.util.internal.ObjectUtil.*;
  */
 public class SimpleChannelPool implements ChannelPool {
     private static final AttributeKey<SimpleChannelPool> POOL_KEY = AttributeKey.newInstance("channelPool");
-    private static final IllegalStateException FULL_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new IllegalStateException("ChannelPool full"), SimpleChannelPool.class, "releaseAndOffer(...)");
-
     private final Deque<Channel> deque = PlatformDependent.newConcurrentDeque();
     private final ChannelPoolHandler handler;
     private final ChannelHealthChecker healthCheck;
@@ -352,7 +348,12 @@ public class SimpleChannelPool implements ChannelPool {
             handler.channelReleased(channel);
             promise.setSuccess(null);
         } else {
-            closeAndFail(channel, FULL_EXCEPTION, promise);
+            closeAndFail(channel, new IllegalStateException("ChannelPool full") {
+                @Override
+                public synchronized Throwable fillInStackTrace() {
+                    return this;
+                }
+            }, promise);
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -310,7 +310,7 @@ public class FixedChannelPoolTest {
             pool.release(channel).syncUninterruptibly();
             fail();
         } catch (IllegalStateException e) {
-            assertSame(FixedChannelPool.POOL_CLOSED_ON_RELEASE_EXCEPTION, e);
+            // expected
         }
         // Since the pool is closed, the Channel should have been closed as well.
         channel.closeFuture().syncUninterruptibly();


### PR DESCRIPTION
…can not be used.

Motivation:

OOME is occurred by increasing suppressedExceptions because other libraries call Throwable#addSuppressed. As we have no control over what other libraries do we need to ensure this can not lead to OOME.

Modifications:

Only use static instances of the Exceptions if we can either dissable addSuppressed or we run on java6.

Result:

Not possible to OOME because of addSuppressed. Fixes https://github.com/netty/netty/issues/9151.