### PR TITLE
Only try to use reflection to access default nameservers when using J…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
@@ -55,7 +55,9 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
             DirContextUtils.addNameServers(defaultNameServers, DNS_PORT);
         }
 
-        if (defaultNameServers.isEmpty()) {
+        // Only try when using Java8 and lower as otherwise it will produce:
+        // WARNING: Illegal reflective access by io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider
+        if (PlatformDependent.javaVersion() < 9 && defaultNameServers.isEmpty()) {
             try {
                 Class<?> configClass = Class.forName("sun.net.dns.ResolverConfiguration");
                 Method open = configClass.getMethod("open");


### PR DESCRIPTION
…ava8 and lower

Motivation:

We should only try to use  reflection to access default nameservers when using Java8 and lower as otherwise we will produce an Illegal reflective access warning like:

WARNING: Illegal reflective access by io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider

Modifications:

Add Java version check before try to use reflective access.

Result:

No more warning when Java9+ is used.