### PR TITLE
Update to latest JDK13 EA release

### DIFF
--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.13.0-14"
+        java_version : "openjdk@1.13.0-21"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.13.0-14"
+        java_version : "openjdk@1.13.0-21"
 
   test:
     image: netty:centos-7-1.13


### PR DESCRIPTION
Motivation:

We should use the latest EA release when trying to compile with JDK13.

Modifications:

Update to latest release

Result:

Test with latest release on the CI