### PR TITLE
Make atomic operation on test and assign

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -76,10 +76,12 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
      */
     public B group(EventLoopGroup group) {
         requireNonNull(group, "group");
-        if (this.group != null) {
-            throw new IllegalStateException("group set already");
+        synchronized (this) {
+            if (this.group != null) {
+                throw new IllegalStateException("group set already");
+            }
+            this.group = group;
         }
-        this.group = group;
         return self();
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -131,11 +131,13 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
      */
     public Bootstrap channelFactory(ChannelFactory<? extends Channel> channelFactory) {
         requireNonNull(channelFactory, "channelFactory");
-        if (this.channelFactory != null) {
-            throw new IllegalStateException("channelFactory set already");
-        }
+        synchronized (this) {
+            if (this.channelFactory != null) {
+                throw new IllegalStateException("channelFactory set already");
+            }
 
-        this.channelFactory = channelFactory;
+            this.channelFactory = channelFactory;
+        }
         return this;
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -89,10 +89,12 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
     public ServerBootstrap group(EventLoopGroup parentGroup, EventLoopGroup childGroup) {
         super.group(parentGroup);
         requireNonNull(childGroup, "childGroup");
-        if (this.childGroup != null) {
-            throw new IllegalStateException("childGroup set already");
+        synchronized (this) {
+            if (this.childGroup != null) {
+                throw new IllegalStateException("childGroup set already");
+            }
+            this.childGroup = childGroup;
         }
-        this.childGroup = childGroup;
         return this;
     }
 
@@ -157,11 +159,13 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
      */
     public ServerBootstrap channelFactory(ServerChannelFactory<? extends ServerChannel> channelFactory) {
         requireNonNull(channelFactory, "channelFactory");
-        if (this.channelFactory != null) {
-            throw new IllegalStateException("channelFactory set already");
-        }
+        synchronized (this) {
+            if (this.channelFactory != null) {
+                throw new IllegalStateException("channelFactory set already");
+            }
 
-        this.channelFactory = channelFactory;
+            this.channelFactory = channelFactory;
+        }
         return this;
     }
 
@@ -228,9 +232,11 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         if (channelFactory == null) {
             throw new IllegalStateException("channelFactory not set");
         }
-        if (childGroup == null) {
-            logger.warn("childGroup is not set. Using parentGroup instead.");
-            childGroup = config.group();
+        synchronized (this) {
+            if (childGroup == null) {
+                logger.warn("childGroup is not set. Using parentGroup instead.");
+                childGroup = config.group();
+            }
         }
         return this;
     }


### PR DESCRIPTION
Motivation:

Within bootstrap classes some field use non atomic test and assign.

Modification:

Use synchronization to create atomic test and assign.
