### PR TITLE
Use correct object to synchronize on in DefaultChannelPipeline

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -164,7 +164,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         DefaultChannelHandlerContext newCtx = newContext(name, handler);
         EventExecutor executor = executor();
         boolean inEventLoop = executor.inEventLoop();
-        synchronized (this) {
+        synchronized (handlers) {
             if (context(name) != null) {
                 throw new IllegalArgumentException("Duplicate handler name: " + name);
             }


### PR DESCRIPTION
Motivation:

8e72071d7648df705fc2372dc63b4840d33846f1 did adjust how synchronization is done but missed to update one block and so used synchronized (this) while it should be synchronized (handlers) .

Modifications:

Use synchronized (handlers)

Result:

Correctly synchronize