### PR TITLE
Do not use static exceptions for websocket handshake timeout

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -24,18 +24,12 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
-import io.netty.util.concurrent.ScheduledFuture;
-import io.netty.util.internal.ThrowableUtil;
 
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.util.internal.ObjectUtil.*;
 
 class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapter {
-    private static final WebSocketHandshakeException HANDSHAKE_TIMED_OUT_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new WebSocketHandshakeException("handshake timed out"),
-            WebSocketClientProtocolHandshakeHandler.class,
-            "channelActive(...)");
     private static final long DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000L;
 
     private final WebSocketClientHandshaker handshaker;
@@ -112,7 +106,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
                     return;
                 }
 
-                if (localHandshakePromise.tryFailure(HANDSHAKE_TIMED_OUT_EXCEPTION)) {
+                if (localHandshakePromise.tryFailure(new WebSocketHandshakeException("handshake timed out"))) {
                     ctx.flush()
                        .fireUserEventTriggered(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT)
                        .close();


### PR DESCRIPTION
Motivation:

f17bfd0f64189d91302fbdd15103788bf9eabaa2 removed the usage of static exception instances to reduce the risk of OOME due addSupressed calls. We should do the same for exceptions used to signal handshake timeouts.

Modifications:

Do not use static instances

Result:

No risk of OOME due addSuppressed calls