### PR TITLE
OpenSsl.USE_KEYMANAGER_FACTORY incorrectly set to false with BoringSSL

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -260,6 +260,7 @@ public final class OpenSsl {
                                                 " is deprecated and so will be ignored in the future");
                                     }
                                 } else {
+                                    useKeyManagerFactory = true;
                                     if (propertySet) {
                                         logger.info("System property " +
                                                 "'io.netty.handler.ssl.openssl.useKeyManagerFactory'" +


### PR DESCRIPTION
Motivation

SSL unit tests started failing for me (RHEL 7.6) after #9162. It looks like the intention was to prevent use of the `io.netty.handler.ssl.openssl.useKeyManagerFactory` property when using BoringSSL, but it now gets set to false in that case rather than the prior/non-BoringSSL default of true.

Modification

Set `useKeyManagerFactory` to true rather than false in BoringSSL case during static init of `OpenSsl` class.

Result

Tests pass again.