### PR TITLE
codec-memcache: support slice and retainedSlice

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
@@ -64,6 +64,16 @@ public class DefaultLastMemcacheContent extends DefaultMemcacheContent implement
     }
 
     @Override
+    public LastMemcacheContent slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public LastMemcacheContent retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public LastMemcacheContent duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -48,6 +48,16 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
+    public MemcacheContent slice() {
+        return replace(content.slice());
+    }
+
+    @Override
+    public MemcacheContent retainedSlice() {
+        return replace(content.retainedSlice());
+    }
+
+    @Override
     public MemcacheContent duplicate() {
         return replace(content.duplicate());
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
@@ -29,6 +29,12 @@ public interface FullMemcacheMessage extends MemcacheMessage, LastMemcacheConten
     FullMemcacheMessage copy();
 
     @Override
+    FullMemcacheMessage slice();
+
+    @Override
+    FullMemcacheMessage retainedSlice();
+
+    @Override
     FullMemcacheMessage duplicate();
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
@@ -38,6 +38,16 @@ public interface LastMemcacheContent extends MemcacheContent {
         }
 
         @Override
+        public LastMemcacheContent slice() {
+            return this;
+        }
+
+        @Override
+        public LastMemcacheContent retainedSlice() {
+            return this;
+        }
+
+        @Override
         public LastMemcacheContent duplicate() {
             return this;
         }
@@ -105,6 +115,12 @@ public interface LastMemcacheContent extends MemcacheContent {
 
     @Override
     LastMemcacheContent copy();
+
+    @Override
+    LastMemcacheContent slice();
+
+    @Override
+    LastMemcacheContent retainedSlice();
 
     @Override
     LastMemcacheContent duplicate();

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
@@ -21,9 +21,9 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.util.internal.UnstableApi;
 
 /**
- * An Memcache content chunk.
+ * A Memcache content chunk.
  * <p/>
- * A implementation of a {@link AbstractMemcacheObjectDecoder} generates {@link MemcacheContent} after
+ * An implementation of a {@link AbstractMemcacheObjectDecoder} generates {@link MemcacheContent} after
  * {@link MemcacheMessage} when the content is large. If you prefer not to receive {@link MemcacheContent}
  * in your handler, place a aggregator after an implementation of the {@link AbstractMemcacheObjectDecoder}
  * in the {@link ChannelPipeline}.
@@ -33,6 +33,20 @@ public interface MemcacheContent extends MemcacheObject, ByteBufHolder {
 
     @Override
     MemcacheContent copy();
+
+    /**
+     * Slices this {@link ByteBufHolder}. Be aware that this will not automatically call {@link #retain()}.
+     *
+     * @see ByteBuf#slice()
+     */
+    MemcacheContent slice();
+
+    /**
+     * Slices this {@link ByteBufHolder}. This method returns a retained slice unlike {@link #slice()}.
+     *
+     * @see ByteBuf#retainedSlice()
+     */
+    MemcacheContent retainedSlice();
 
     @Override
     MemcacheContent duplicate();

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -106,6 +106,32 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
+    public FullBinaryMemcacheRequest slice() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.slice();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.slice();
+        }
+        return newInstance(key, extras, content().slice());
+    }
+
+    @Override
+    public FullBinaryMemcacheRequest retainedSlice() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.retainedSlice();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.retainedSlice();
+        }
+        return newInstance(key, extras, content().retainedSlice());
+    }
+
+    @Override
     public FullBinaryMemcacheRequest duplicate() {
         ByteBuf key = key();
         if (key != null) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -106,6 +106,32 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
+    public FullBinaryMemcacheResponse slice() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.slice();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.slice();
+        }
+        return newInstance(key, extras, content().slice());
+    }
+
+    @Override
+    public FullBinaryMemcacheResponse retainedSlice() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.retainedSlice();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.retainedSlice();
+        }
+        return newInstance(key, extras, content().retainedSlice());
+    }
+
+    @Override
     public FullBinaryMemcacheResponse duplicate() {
         ByteBuf key = key();
         if (key != null) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
@@ -29,6 +29,12 @@ public interface FullBinaryMemcacheRequest extends BinaryMemcacheRequest, FullMe
     FullBinaryMemcacheRequest copy();
 
     @Override
+    FullBinaryMemcacheRequest slice();
+
+    @Override
+    FullBinaryMemcacheRequest retainedSlice();
+
+    @Override
     FullBinaryMemcacheRequest duplicate();
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
@@ -29,6 +29,12 @@ public interface FullBinaryMemcacheResponse extends BinaryMemcacheResponse, Full
     FullBinaryMemcacheResponse copy();
 
     @Override
+    FullBinaryMemcacheResponse slice();
+
+    @Override
+    FullBinaryMemcacheResponse retainedSlice();
+
+    @Override
     FullBinaryMemcacheResponse duplicate();
 
     @Override

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequestTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequestTest.java
@@ -57,6 +57,27 @@ public class DefaultFullBinaryMemcacheRequestTest {
     }
 
     @Test
+    public void fullSlice() {
+        FullBinaryMemcacheRequest newInstance = request.slice();
+        try {
+            assertCopy(request, request.content(), newInstance);
+        } finally {
+            request.release();
+        }
+    }
+
+    @Test
+    public void fullRetainedSlice() {
+        FullBinaryMemcacheRequest newInstance = request.retainedSlice();
+        try {
+            assertCopy(request, request.content(), newInstance);
+        } finally {
+            request.release();
+            newInstance.release();
+        }
+    }
+
+    @Test
     public void fullDuplicate() {
         FullBinaryMemcacheRequest newInstance = request.duplicate();
         try {

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponseTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponseTest.java
@@ -57,6 +57,27 @@ public class DefaultFullBinaryMemcacheResponseTest {
     }
 
     @Test
+    public void fullSlice() {
+        FullBinaryMemcacheResponse newInstance = response.slice();
+        try {
+            assertResponseEquals(response, response.content(), newInstance);
+        } finally {
+            response.release();
+        }
+    }
+
+    @Test
+    public void fullRetainedSlice() {
+        FullBinaryMemcacheResponse newInstance = response.retainedSlice();
+        try {
+            assertResponseEquals(response, response.content(), newInstance);
+        } finally {
+            response.release();
+            newInstance.release();
+        }
+    }
+
+    @Test
     public void fullDuplicate() {
         try {
             assertResponseEquals(response, response.content(), response.duplicate());


### PR DESCRIPTION
Motivations
-----------
MemcacheContent interface provides a copy method but not the copy-free
equivalent slice. Slice and retainedSlice should be supported.

Modifications
-------------
Added slice and retainedSlice methods to MemcacheContent interface and
implemented methods in class implementing said interface.

Result
------
Memcache content, requests and responses can be sliced.