### PR TITLE
Allow filtering to direct buffers before nio write

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -34,6 +34,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ConnectionPendingException;
@@ -494,6 +495,23 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         }
 
         return buf;
+    }
+
+    /**
+     * Invoked when a {@link ByteBuffer} is about to be written to a {@link java.nio.channels.GatheringByteChannel},
+     * so that the {@link Channel} implementation can optionally copy the bytes to a direct buffer.
+     */
+    protected ByteBuffer filterOutboundByteBuffer(ByteBuffer buffer) throws Exception {
+        return buffer;
+    }
+
+    /**
+     * Invoked when an array of {@link ByteBuffer} is about to be written to a
+     * {@link java.nio.channels.GatheringByteChannel}, so that the {@link Channel} implementation can optionally copy
+     * the bytes to a direct buffer.
+     */
+    protected ByteBuffer[] filterOutboundByteBuffers(ByteBuffer[] buffers) throws Exception {
+        return buffers;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -288,11 +288,12 @@ public final class NioDatagramChannel
 
         final ByteBuffer nioData = data.nioBufferCount() == 1 ? data.internalNioBuffer(data.readerIndex(), dataLen)
                                                               : data.nioBuffer(data.readerIndex(), dataLen);
+        final ByteBuffer filteredNioData = filterOutboundByteBuffer(nioData);
         final int writtenBytes;
         if (remoteAddress != null) {
-            writtenBytes = javaChannel().send(nioData, remoteAddress);
+            writtenBytes = javaChannel().send(filteredNioData, remoteAddress);
         } else {
-            writtenBytes = javaChannel().write(nioData);
+            writtenBytes = javaChannel().write(filteredNioData);
         }
         return writtenBytes > 0;
     }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -386,7 +386,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
             // Ensure the pending writes are made of ByteBufs only.
             int maxBytesPerGatheringWrite = ((NioSocketChannelConfig) config).getMaxBytesPerGatheringWrite();
-            ByteBuffer[] nioBuffers = in.nioBuffers(1024, maxBytesPerGatheringWrite);
+            ByteBuffer[] nioBuffers = filterOutboundByteBuffers(in.nioBuffers(1024, maxBytesPerGatheringWrite));
             int nioBufferCnt = in.nioBufferCount();
 
             // Always us nioBuffers() to workaround data-corruption.


### PR DESCRIPTION
Motivation:

Currently in netty heap bytes will be copied to direct bytes when the
messages are placed in the channel outbound buffer. This requires direct
buffer pooling to be enabled which may not be ideal in lower memory
environments.

Modification:

This commit adds `filterOutboundByteBuffer` methods to the
`AbstractNioChannel`. This method will be called by the
`NioSocketChannel` and `NioDatagramChannel` immeidately before writing
to a java nio channel. This gives one last chance for an implementation
to implement some type of slimmer direct buffer pooling before relying
on the JDK's (unideal) direct buffer pooling.
