### PR TITLE
Allow configuring a custom cleaner

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -16,6 +16,7 @@
 
 package io.netty.buffer;
 
+import io.netty.util.DirectCleaner;
 import io.netty.util.internal.LongCounter;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
@@ -777,7 +778,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             if (PlatformDependent.useDirectBufferNoCleaner()) {
                 PlatformDependent.freeDirectNoCleaner(chunk.memory);
             } else {
-                PlatformDependent.freeDirectBuffer(chunk.memory);
+                DirectCleaner.freeDirectBuffer(chunk.memory);
             }
         }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
-import io.netty.util.internal.PlatformDependent;
+import io.netty.util.DirectCleaner;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -108,7 +108,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
      * Free a direct {@link ByteBuffer}
      */
     protected void freeDirect(ByteBuffer buffer) {
-        PlatformDependent.freeDirectBuffer(buffer);
+        DirectCleaner.freeDirectBuffer(buffer);
     }
 
     private void setByteBuffer(ByteBuffer buffer) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -17,6 +17,7 @@ package io.netty.buffer;
 
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
+import io.netty.util.DirectCleaner;
 import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
@@ -122,7 +123,7 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
      * Free a direct {@link ByteBuffer}
      */
     protected void freeDirect(ByteBuffer buffer) {
-        PlatformDependent.freeDirectBuffer(buffer);
+        DirectCleaner.freeDirectBuffer(buffer);
     }
 
     final void setByteBuffer(ByteBuffer buffer, boolean tryFree) {

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -16,6 +16,7 @@
 
 package io.netty.buffer;
 
+import io.netty.util.DirectCleaner;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.Assert;
 import org.junit.Test;
@@ -59,7 +60,7 @@ public class PoolArenaTest {
             long address = PlatformDependent.directBufferAddress(bb);
 
             Assert.assertEquals(0, (offset + address) & (alignment - 1));
-            PlatformDependent.freeDirectBuffer(bb);
+            DirectCleaner.freeDirectBuffer(bb);
         }
     }
 

--- a/common/src/main/java/io/netty/util/DirectCleaner.java
+++ b/common/src/main/java/io/netty/util/DirectCleaner.java
@@ -24,7 +24,8 @@ import java.nio.ByteBuffer;
 @UnstableApi
 public final class DirectCleaner {
 
-    private static final boolean ALLOW_CUSTOM_CLEANER = SystemPropertyUtil.getBoolean("io.netty.allowCustomCleaner", false);
+    private static final boolean ALLOW_CUSTOM_CLEANER =
+            SystemPropertyUtil.getBoolean("io.netty.allowCustomCleaner", false);
     private static volatile CustomCleaner customCleaner;
 
     /**

--- a/common/src/main/java/io/netty/util/DirectCleaner.java
+++ b/common/src/main/java/io/netty/util/DirectCleaner.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 @UnstableApi
 public final class DirectCleaner {
 
-    private static boolean ALLOW_CUSTOM_CLEANER = SystemPropertyUtil.getBoolean("io.netty.allowCustomCleaner", false);
+    private static final boolean ALLOW_CUSTOM_CLEANER = SystemPropertyUtil.getBoolean("io.netty.allowCustomCleaner", false);
     private static volatile CustomCleaner customCleaner;
 
     /**

--- a/common/src/main/java/io/netty/util/DirectCleaner.java
+++ b/common/src/main/java/io/netty/util/DirectCleaner.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.UnstableApi;
+
+import java.nio.ByteBuffer;
+
+@UnstableApi
+public class DirectCleaner {
+
+    private static boolean ALLOW_CUSTOM_CLEANER = SystemPropertyUtil.getBoolean("io.netty.allowCustomCleaner", false);
+    private static volatile CustomCleaner customerCleaner;
+
+    /**
+     * Try to deallocate the specified direct {@link ByteBuffer}. Please note this method does nothing if
+     * the current platform does not support this operation and no custom cleaner is provided or if the
+     * specified buffer is not a direct buffer.
+     */
+    public static void freeDirectBuffer(ByteBuffer buffer) {
+        if (!ALLOW_CUSTOM_CLEANER || customerCleaner == null) {
+            PlatformDependent.freeDirectBuffer(buffer);
+        } else {
+            customerCleaner.freeDirectMemory(buffer);
+        }
+    }
+
+    /**
+     * Set a {@link CustomCleaner} that will be used to deallocate direct byte buffers. This customer cleaner
+     * can only be used if io.netty.allowCustomCleaner is set to true and Netty is not configured to use
+     * direct byte buffers without cleaners.
+     */
+    @SuppressWarnings("unused") // this method is part of the public API
+    public static void setCustomCleaner(CustomCleaner cleaner) {
+        if (!ALLOW_CUSTOM_CLEANER) {
+            throw new UnsupportedOperationException("Cannot set CustomCleaner, io.netty.allowCustomCleaner set to false.");
+        }
+        if (PlatformDependent.useDirectBufferNoCleaner()) {
+            throw new UnsupportedOperationException("Cannot set CustomCleaner because Netty is configured to allocate direct byte " +
+                    "buffers without use of Cleaner.");
+        }
+        customerCleaner = cleaner;
+    }
+
+    private DirectCleaner() {
+    }
+
+    public interface CustomCleaner {
+
+        void freeDirectMemory(ByteBuffer byteBuffer);
+
+    }
+}

--- a/common/src/main/java/io/netty/util/DirectCleaner.java
+++ b/common/src/main/java/io/netty/util/DirectCleaner.java
@@ -34,8 +34,8 @@ public final class DirectCleaner {
      */
     public static void freeDirectBuffer(ByteBuffer buffer) {
         // Copied locally to prevent race
-        CustomCleaner localCustomCleaner = DirectCleaner.customCleaner;
-        if (!ALLOW_CUSTOM_CLEANER || localCustomCleaner == null) {
+        CustomCleaner localCustomCleaner;
+        if (!ALLOW_CUSTOM_CLEANER || (localCustomCleaner = DirectCleaner.customCleaner) == null) {
             PlatformDependent.freeDirectBuffer(buffer);
         } else {
             localCustomCleaner.freeDirectMemory(buffer);
@@ -47,7 +47,6 @@ public final class DirectCleaner {
      * can only be used if io.netty.allowCustomCleaner is set to true and Netty is not configured to use
      * direct byte buffers without cleaners.
      */
-    @SuppressWarnings("unused") // this method is part of the public API
     public static void setCustomCleaner(CustomCleaner cleaner) {
         if (!ALLOW_CUSTOM_CLEANER) {
             throw new UnsupportedOperationException("Cannot set CustomCleaner, io.netty.allowCustomCleaner set to " +

--- a/common/src/main/java/io/netty/util/DirectCleaner.java
+++ b/common/src/main/java/io/netty/util/DirectCleaner.java
@@ -62,6 +62,12 @@ public final class DirectCleaner {
     private DirectCleaner() {
     }
 
+    /**
+     * Frees direct {@link ByteBuffer}s. This interface can be implemented by users that need custom logic when freeing
+     * direct buffers. A possible use case is one where a user of Netty has disabled Netty's access Unsafe (preventing
+     * Netty from freeing direct buffers), but can provide a {@link CustomCleaner} implementation with the necessary
+     * Unsafe functionality.
+     */
     public interface CustomCleaner {
 
         void freeDirectMemory(ByteBuffer byteBuffer);

--- a/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
+import io.netty.util.DirectCleaner;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -66,7 +67,7 @@ public class ByteBufAccessBenchmark extends AbstractMicrobenchmark {
         }
         @Override
         public boolean release() {
-            PlatformDependent.freeDirectBuffer(byteBuffer);
+            DirectCleaner.freeDirectBuffer(byteBuffer);
             return true;
         }
     }

--- a/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslEngineBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/handler/ssl/AbstractSslEngineBenchmark.java
@@ -21,6 +21,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.DirectCleaner;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.PlatformDependent;
 import org.openjdk.jmh.annotations.Param;
@@ -114,7 +115,7 @@ public class AbstractSslEngineBenchmark extends AbstractMicrobenchmark {
 
             @Override
             void freeBuffer(ByteBuffer buffer) {
-                PlatformDependent.freeDirectBuffer(buffer);
+                DirectCleaner.freeDirectBuffer(buffer);
             }
         };
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Buffer.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Buffer.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.unix;
 
+import io.netty.util.DirectCleaner;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
@@ -30,7 +31,7 @@ public final class Buffer {
      * Free the direct {@link ByteBuffer}.
      */
     public static void free(ByteBuffer buffer) {
-        PlatformDependent.freeDirectBuffer(buffer);
+        DirectCleaner.freeDirectBuffer(buffer);
     }
 
     /**


### PR DESCRIPTION
Motivation:

Currently Netty can only deallocate direct byte buffers using a cleaner
if unsafe is enabled. This means that an environment without unsafe
priviledges granted to netty will have to rely on a GC in order to
deallocate large (normally 16MB) direct chunks.

Modification:

Add a class DirectCleaner that allows users to specify a custom cleaner
that will deallocate the buffers. The CustomerCleaner is only allowed if
a specific (io.netty.allowCustomCleaner) system property is set.