### PR TITLE
Make UnpooledUnsafeHeapByteBuf class public

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
@@ -17,7 +17,12 @@ package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
 
-class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
+/**
+ * Big endian Java heap buffer implementation. It is recommended to use
+ * {@link UnpooledByteBufAllocator#heapBuffer(int, int)}, {@link Unpooled#buffer(int)} and
+ * {@link Unpooled#wrappedBuffer(byte[])} instead of calling the constructor explicitly.
+ */
+public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     /**
      * Creates a new heap buffer with a newly allocated byte array.
@@ -25,7 +30,7 @@ class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
      * @param initialCapacity the initial capacity of the underlying byte array
      * @param maxCapacity the max capacity of the underlying byte array
      */
-    UnpooledUnsafeHeapByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
+    public UnpooledUnsafeHeapByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
         super(alloc, initialCapacity, maxCapacity);
     }
 


### PR DESCRIPTION
Motivation:

1. Users will be able to use an optimized version of `UnpooledHeapByteBuf` and
override behavior of methods if required.
2. Consistency with `UnpooledDirectByteBuf`, `UnpooledHeapByteBuf`, and
`UnpooledUnsafeDirectByteBuf`.

Modifications:

- Add `public` access modifier to `UnpooledUnsafeHeapByteBuf` class and ctor;

Result:

Public access for an optimized version of `UnpooledHeapByteBuf`.