### PR TITLE
Correctly detect InternetProtocolFamily when EpollDatagramChannel is …

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -59,7 +59,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             StringUtil.simpleClassName(InetSocketAddress.class) + ">, " +
             StringUtil.simpleClassName(ByteBuf.class) + ')';
 
-    final InternetProtocolFamily family;
     private final EpollDatagramChannelConfig config;
     private volatile boolean connected;
 
@@ -68,7 +67,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      * on the Operation Systems default which will be chosen.
      */
     public EpollDatagramChannel() {
-        this(null);
+        this((InternetProtocolFamily) null);
     }
 
     /**
@@ -76,17 +75,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      * on the Operation Systems default which will be chosen.
      */
     public EpollDatagramChannel(InternetProtocolFamily family) {
-        super(family == null ?
+        this(family == null ?
                 newSocketDgram(Socket.isIPv6Preferred()) : newSocketDgram(family == InternetProtocolFamily.IPv6));
-        this.family = internetProtocolFamily(family);
-        config = new EpollDatagramChannelConfig(this);
-    }
-
-    private static InternetProtocolFamily internetProtocolFamily(InternetProtocolFamily family) {
-        if (family == null) {
-            return Socket.isIPv6Preferred() ? InternetProtocolFamily.IPv6 : InternetProtocolFamily.IPv4;
-        }
-        return family;
     }
 
     /**
@@ -94,12 +84,11 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      * on the Operation Systems default which will be chosen.
      */
     public EpollDatagramChannel(int fd) {
-        this(new LinuxSocket(fd), null);
+        this(new LinuxSocket(fd));
     }
 
-    private EpollDatagramChannel(LinuxSocket fd, InternetProtocolFamily family) {
+    private EpollDatagramChannel(LinuxSocket fd) {
         super(null, fd, true);
-        this.family = internetProtocolFamily(family);
         config = new EpollDatagramChannelConfig(this);
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -367,7 +367,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     public EpollDatagramChannelConfig setNetworkInterface(NetworkInterface networkInterface) {
         try {
             EpollDatagramChannel datagramChannel = (EpollDatagramChannel) channel;
-            datagramChannel.socket.setNetworkInterface(networkInterface, datagramChannel.family);
+            datagramChannel.socket.setNetworkInterface(networkInterface);
             return this;
         } catch (IOException e) {
             throw new ChannelException(e);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -44,6 +44,10 @@ final class LinuxSocket extends Socket {
         super(fd);
     }
 
+    private InternetProtocolFamily family() {
+        return ipv6 ? InternetProtocolFamily.IPv6 : InternetProtocolFamily.IPv4;
+    }
+
     int sendmmsg(NativeDatagramPacketArray.NativeDatagramPacket[] msgs,
                                int offset, int len) throws IOException {
         return Native.sendmmsg(intValue(), ipv6, msgs, offset, len);
@@ -58,10 +62,10 @@ final class LinuxSocket extends Socket {
         setInterface(intValue(), ipv6, a.address(), a.scopeId(), interfaceIndex(address));
     }
 
-    void setNetworkInterface(NetworkInterface netInterface, InternetProtocolFamily family) throws IOException {
-        InetAddress address = deriveInetAddress(netInterface, family == InternetProtocolFamily.IPv6);
-        if (address.equals(family == InternetProtocolFamily.IPv4 ? INET_ANY : INET6_ANY)) {
-            throw new IOException("NetworkInterface does not support " + family);
+    void setNetworkInterface(NetworkInterface netInterface) throws IOException {
+        InetAddress address = deriveInetAddress(netInterface, family() == InternetProtocolFamily.IPv6);
+        if (address.equals(family() == InternetProtocolFamily.IPv4 ? INET_ANY : INET6_ANY)) {
+            throw new IOException("NetworkInterface does not support " + family());
         }
         final NativeInetAddress nativeAddress = NativeInetAddress.newInstance(address);
         setInterface(intValue(), ipv6, nativeAddress.address(), nativeAddress.scopeId(), interfaceIndex(netInterface));


### PR DESCRIPTION
…created with existing FileDescriptor

Motivation:

When EpollDatagramChannel is created with an existing FileDescriptor we should detect the correct InternetProtocolFamily.

Modifications:

Obtain the InternetProtocolFamily from the given FD

Result:

Use correct InternetProtocolFamily when EpollDatagramChannel is created via existing FileDescriptor
