### PR TITLE
ByteBufHolder: support slice and retainedSlice

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufHolder.java
@@ -33,6 +33,20 @@ public interface ByteBufHolder extends ReferenceCounted {
     ByteBufHolder copy();
 
     /**
+     * Slices this {@link ByteBufHolder}. Be aware that this will not automatically call {@link #retain()}.
+     *
+     * @see ByteBuf#slice()
+     */
+    ByteBufHolder slice();
+
+    /**
+     * Slices this {@link ByteBufHolder}. This method returns a retained slice unlike {@link #slice()}.
+     *
+     * @see ByteBuf#retainedSlice()
+     */
+    ByteBufHolder retainedSlice();
+
+    /**
      * Duplicates this {@link ByteBufHolder}. Be aware that this will not automatically call {@link #retain()}.
      */
     ByteBufHolder duplicate();

--- a/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
@@ -54,6 +54,26 @@ public class DefaultByteBufHolder implements ByteBufHolder {
     /**
      * {@inheritDoc}
      * <p>
+     * This method calls {@code replace(content().slice())} by default.
+     */
+    @Override
+    public ByteBufHolder slice() {
+        return replace(data.slice());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method calls {@code replace(content().retainedSlice())} by default.
+     */
+    @Override
+    public ByteBufHolder retainedSlice() {
+        return replace(data.retainedSlice());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
      * This method calls {@code replace(content().duplicate())} by default.
      */
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRawRecord.java
@@ -73,6 +73,16 @@ public class DefaultDnsRawRecord extends AbstractDnsRecord implements DnsRawReco
     }
 
     @Override
+    public DnsRawRecord slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public DnsRawRecord retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public DnsRawRecord duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRawRecord.java
@@ -28,6 +28,12 @@ public interface DnsRawRecord extends DnsRecord, ByteBufHolder {
     DnsRawRecord copy();
 
     @Override
+    DnsRawRecord slice();
+
+    @Override
+    DnsRawRecord retainedSlice();
+
+    @Override
     DnsRawRecord duplicate();
 
     @Override

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
@@ -111,6 +111,16 @@ public class HAProxyTLV extends DefaultByteBufHolder {
     }
 
     @Override
+    public HAProxyTLV slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public HAProxyTLV retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public HAProxyTLV duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/ComposedLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ComposedLastHttpContent.java
@@ -46,6 +46,16 @@ final class ComposedLastHttpContent implements LastHttpContent {
     }
 
     @Override
+    public LastHttpContent slice() {
+        return copy();
+    }
+
+    @Override
+    public LastHttpContent retainedSlice() {
+        return copy();
+    }
+
+    @Override
     public LastHttpContent duplicate() {
         return copy();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -131,6 +131,16 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
     }
 
     @Override
+    public FullHttpRequest slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public FullHttpRequest retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public FullHttpRequest duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -138,6 +138,16 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     }
 
     @Override
+    public FullHttpResponse slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public FullHttpResponse retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public FullHttpResponse duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpContent.java
@@ -46,6 +46,16 @@ public class DefaultHttpContent extends DefaultHttpObject implements HttpContent
     }
 
     @Override
+    public HttpContent slice() {
+        return replace(content.slice());
+    }
+
+    @Override
+    public HttpContent retainedSlice() {
+        return replace(content.retainedSlice());
+    }
+
+    @Override
     public HttpContent duplicate() {
         return replace(content.duplicate());
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
@@ -49,6 +49,16 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
     }
 
     @Override
+    public LastHttpContent slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public LastHttpContent retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public LastHttpContent duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpMessage.java
@@ -26,6 +26,12 @@ public interface FullHttpMessage extends HttpMessage, LastHttpContent {
     FullHttpMessage copy();
 
     @Override
+    FullHttpMessage slice();
+
+    @Override
+    FullHttpMessage retainedSlice();
+
+    @Override
     FullHttpMessage duplicate();
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpRequest.java
@@ -26,6 +26,12 @@ public interface FullHttpRequest extends HttpRequest, FullHttpMessage {
     FullHttpRequest copy();
 
     @Override
+    FullHttpRequest slice();
+
+    @Override
+    FullHttpRequest retainedSlice();
+
+    @Override
     FullHttpRequest duplicate();
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpResponse.java
@@ -26,6 +26,12 @@ public interface FullHttpResponse extends HttpResponse, FullHttpMessage {
     FullHttpResponse copy();
 
     @Override
+    FullHttpResponse slice();
+
+    @Override
+    FullHttpResponse retainedSlice();
+
+    @Override
     FullHttpResponse duplicate();
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContent.java
@@ -32,6 +32,12 @@ public interface HttpContent extends HttpObject, ByteBufHolder {
     HttpContent copy();
 
     @Override
+    HttpContent slice();
+
+    @Override
+    HttpContent retainedSlice();
+
+    @Override
     HttpContent duplicate();
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -382,6 +382,12 @@ public class HttpObjectAggregator
         public abstract FullHttpMessage copy();
 
         @Override
+        public abstract FullHttpMessage slice();
+
+        @Override
+        public abstract FullHttpMessage retainedSlice();
+
+        @Override
         public abstract FullHttpMessage duplicate();
 
         @Override
@@ -397,6 +403,16 @@ public class HttpObjectAggregator
         @Override
         public FullHttpRequest copy() {
             return replace(content().copy());
+        }
+
+        @Override
+        public FullHttpRequest slice() {
+            return replace(content().slice());
+        }
+
+        @Override
+        public FullHttpRequest retainedSlice() {
+            return replace(content().retainedSlice());
         }
 
         @Override
@@ -495,6 +511,16 @@ public class HttpObjectAggregator
         @Override
         public FullHttpResponse copy() {
             return replace(content().copy());
+        }
+
+        @Override
+        public FullHttpResponse slice() {
+            return replace(content().slice());
+        }
+
+        @Override
+        public FullHttpResponse retainedSlice() {
+            return replace(content().retainedSlice());
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/LastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/LastHttpContent.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.DecoderResult;
 
@@ -37,6 +38,16 @@ public interface LastHttpContent extends HttpContent {
         @Override
         public LastHttpContent copy() {
             return EMPTY_LAST_CONTENT;
+        }
+
+        @Override
+        public LastHttpContent slice() {
+            return this;
+        }
+
+        @Override
+        public LastHttpContent retainedSlice() {
+            return this;
         }
 
         @Override
@@ -120,6 +131,12 @@ public interface LastHttpContent extends HttpContent {
 
     @Override
     LastHttpContent copy();
+
+    @Override
+    LastHttpContent slice();
+
+    @Override
+    LastHttpContent retainedSlice();
 
     @Override
     LastHttpContent duplicate();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/Attribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/Attribute.java
@@ -37,6 +37,12 @@ public interface Attribute extends HttpData {
     Attribute copy();
 
     @Override
+    Attribute slice();
+
+    @Override
+    Attribute retainedSlice();
+
+    @Override
     Attribute duplicate();
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskAttribute.java
@@ -166,6 +166,32 @@ public class DiskAttribute extends AbstractDiskHttpData implements Attribute {
     }
 
     @Override
+    public Attribute slice() {
+        final ByteBuf content = content();
+        return replace(content != null ? content.slice() : null);
+    }
+
+    @Override
+    public Attribute retainedSlice() {
+        ByteBuf content = content();
+        if (content != null) {
+            content = content.retainedSlice();
+            boolean success = false;
+            try {
+                Attribute slice = replace(content);
+                success = true;
+                return slice;
+            } finally {
+                if (!success) {
+                    content.release();
+                }
+            }
+        }
+
+        return replace(null);
+    }
+
+    @Override
     public Attribute duplicate() {
         final ByteBuf content = content();
         return replace(content != null ? content.duplicate() : null);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
@@ -165,6 +165,32 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
     }
 
     @Override
+    public FileUpload slice() {
+        final ByteBuf content = content();
+        return replace(content != null ? content.slice() : null);
+    }
+
+    @Override
+    public FileUpload retainedSlice() {
+        ByteBuf content = content();
+        if (content != null) {
+            content = content.retainedSlice();
+            boolean success = false;
+            try {
+                FileUpload slice = replace(content);
+                success = true;
+                return slice;
+            } finally {
+                if (!success) {
+                    content.release();
+                }
+            }
+        }
+
+        return replace(null);
+    }
+
+    @Override
     public FileUpload duplicate() {
         final ByteBuf content = content();
         return replace(content != null ? content.duplicate() : null);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/FileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/FileUpload.java
@@ -62,6 +62,12 @@ public interface FileUpload extends HttpData {
     FileUpload copy();
 
     @Override
+    FileUpload slice();
+
+    @Override
+    FileUpload retainedSlice();
+
+    @Override
     FileUpload duplicate();
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
@@ -217,6 +217,12 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
     HttpData copy();
 
     @Override
+    HttpData slice();
+
+    @Override
+    HttpData retainedSlice();
+
+    @Override
     HttpData duplicate();
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -1269,6 +1269,16 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         }
 
         @Override
+        public FullHttpRequest slice() {
+            return replace(content().slice());
+        }
+
+        @Override
+        public FullHttpRequest retainedSlice() {
+            return replace(content().retainedSlice());
+        }
+
+        @Override
         public FullHttpRequest duplicate() {
             return replace(content().duplicate());
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryAttribute.java
@@ -126,6 +126,32 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
     }
 
     @Override
+    public Attribute slice() {
+        final ByteBuf content = content();
+        return replace(content != null ? content.slice() : null);
+    }
+
+    @Override
+    public Attribute retainedSlice() {
+        ByteBuf content = content();
+        if (content != null) {
+            content = content.retainedSlice();
+            boolean success = false;
+            try {
+                Attribute slice = replace(content);
+                success = true;
+                return slice;
+            } finally {
+                if (!success) {
+                    content.release();
+                }
+            }
+        }
+
+        return replace(null);
+    }
+
+    @Override
     public Attribute duplicate() {
         final ByteBuf content = content();
         return replace(content != null ? content.duplicate() : null);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
@@ -125,6 +125,32 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
     }
 
     @Override
+    public FileUpload slice() {
+        final ByteBuf content = content();
+        return replace(content != null ? content.slice() : content);
+    }
+
+    @Override
+    public FileUpload retainedSlice() {
+        ByteBuf content = content();
+        if (content != null) {
+            content = content.retainedSlice();
+            boolean success = false;
+            try {
+                FileUpload slice = replace(content);
+                success = true;
+                return slice;
+            } finally {
+                if (!success) {
+                    content.release();
+                }
+            }
+        }
+
+        return replace(null);
+    }
+
+    @Override
     public FileUpload duplicate() {
         final ByteBuf content = content();
         return replace(content != null ? content.duplicate() : content);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedAttribute.java
@@ -267,6 +267,16 @@ public class MixedAttribute implements Attribute {
     }
 
     @Override
+    public Attribute slice() {
+        return attribute.slice();
+    }
+
+    @Override
+    public Attribute retainedSlice() {
+        return attribute.retainedSlice();
+    }
+
+    @Override
     public Attribute duplicate() {
         return attribute.duplicate();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedFileUpload.java
@@ -289,6 +289,16 @@ public class MixedFileUpload implements FileUpload {
     }
 
     @Override
+    public FileUpload slice() {
+        return fileUpload.slice();
+    }
+
+    @Override
+    public FileUpload retainedSlice() {
+        return fileUpload.retainedSlice();
+    }
+
+    @Override
     public FileUpload duplicate() {
         return fileUpload.duplicate();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
@@ -60,6 +60,16 @@ public class BinaryWebSocketFrame extends WebSocketFrame {
     }
 
     @Override
+    public BinaryWebSocketFrame slice() {
+        return (BinaryWebSocketFrame) super.slice();
+    }
+
+    @Override
+    public BinaryWebSocketFrame retainedSlice() {
+        return (BinaryWebSocketFrame) super.retainedSlice();
+    }
+
+    @Override
     public BinaryWebSocketFrame duplicate() {
         return (BinaryWebSocketFrame) super.duplicate();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -143,6 +143,16 @@ public class CloseWebSocketFrame extends WebSocketFrame {
     }
 
     @Override
+    public CloseWebSocketFrame slice() {
+        return (CloseWebSocketFrame) super.slice();
+    }
+
+    @Override
+    public CloseWebSocketFrame retainedSlice() {
+        return (CloseWebSocketFrame) super.retainedSlice();
+    }
+
+    @Override
     public CloseWebSocketFrame duplicate() {
         return (CloseWebSocketFrame) super.duplicate();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
@@ -97,6 +97,16 @@ public class ContinuationWebSocketFrame extends WebSocketFrame {
     }
 
     @Override
+    public ContinuationWebSocketFrame slice() {
+        return (ContinuationWebSocketFrame) super.slice();
+    }
+
+    @Override
+    public ContinuationWebSocketFrame retainedSlice() {
+        return (ContinuationWebSocketFrame) super.retainedSlice();
+    }
+
+    @Override
     public ContinuationWebSocketFrame duplicate() {
         return (ContinuationWebSocketFrame) super.duplicate();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
@@ -60,6 +60,16 @@ public class PingWebSocketFrame extends WebSocketFrame {
     }
 
     @Override
+    public PingWebSocketFrame slice() {
+        return (PingWebSocketFrame) super.slice();
+    }
+
+    @Override
+    public PingWebSocketFrame retainedSlice() {
+        return (PingWebSocketFrame) super.retainedSlice();
+    }
+
+    @Override
     public PingWebSocketFrame duplicate() {
         return (PingWebSocketFrame) super.duplicate();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
@@ -60,6 +60,16 @@ public class PongWebSocketFrame extends WebSocketFrame {
     }
 
     @Override
+    public PongWebSocketFrame slice() {
+        return (PongWebSocketFrame) super.slice();
+    }
+
+    @Override
+    public PongWebSocketFrame retainedSlice() {
+        return (PongWebSocketFrame) super.retainedSlice();
+    }
+
+    @Override
     public PongWebSocketFrame duplicate() {
         return (PongWebSocketFrame) super.duplicate();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
@@ -100,6 +100,16 @@ public class TextWebSocketFrame extends WebSocketFrame {
     }
 
     @Override
+    public TextWebSocketFrame slice() {
+        return (TextWebSocketFrame) super.slice();
+    }
+
+    @Override
+    public TextWebSocketFrame retainedSlice() {
+        return (TextWebSocketFrame) super.retainedSlice();
+    }
+
+    @Override
     public TextWebSocketFrame duplicate() {
         return (TextWebSocketFrame) super.duplicate();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrame.java
@@ -66,6 +66,16 @@ public abstract class WebSocketFrame extends DefaultByteBufHolder {
     }
 
     @Override
+    public WebSocketFrame slice() {
+        return (WebSocketFrame) super.slice();
+    }
+
+    @Override
+    public WebSocketFrame retainedSlice() {
+        return (WebSocketFrame) super.retainedSlice();
+    }
+
+    @Override
     public WebSocketFrame duplicate() {
         return (WebSocketFrame) super.duplicate();
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
@@ -83,6 +83,16 @@ public class AbstractMemoryHttpDataTest {
         }
 
         @Override
+        public HttpData slice() {
+            throw reject();
+        }
+
+        @Override
+        public HttpData retainedSlice() {
+            throw reject();
+        }
+
+        @Override
         public HttpData duplicate() {
             throw reject();
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
@@ -121,6 +121,16 @@ public final class DefaultHttp2DataFrame extends AbstractHttp2StreamFrame implem
     }
 
     @Override
+    public DefaultHttp2DataFrame slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public DefaultHttp2DataFrame retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public DefaultHttp2DataFrame duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -116,6 +116,16 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
     }
 
     @Override
+    public Http2GoAwayFrame slice() {
+        return (Http2GoAwayFrame) super.slice();
+    }
+
+    @Override
+    public Http2GoAwayFrame retainedSlice() {
+        return (Http2GoAwayFrame) super.retainedSlice();
+    }
+
+    @Override
     public Http2GoAwayFrame duplicate() {
         return (Http2GoAwayFrame) super.duplicate();
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
@@ -69,6 +69,16 @@ public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder impleme
     }
 
     @Override
+    public DefaultHttp2UnknownFrame slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public DefaultHttp2UnknownFrame retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public DefaultHttp2UnknownFrame duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataFrame.java
@@ -51,6 +51,12 @@ public interface Http2DataFrame extends Http2StreamFrame, ByteBufHolder {
     Http2DataFrame copy();
 
     @Override
+    Http2DataFrame slice();
+
+    @Override
+    Http2DataFrame retainedSlice();
+
+    @Override
     Http2DataFrame duplicate();
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2GoAwayFrame.java
@@ -67,6 +67,12 @@ public interface Http2GoAwayFrame extends Http2Frame, ByteBufHolder {
     Http2GoAwayFrame copy();
 
     @Override
+    Http2GoAwayFrame slice();
+
+    @Override
+    Http2GoAwayFrame retainedSlice();
+
+    @Override
     Http2GoAwayFrame duplicate();
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
@@ -36,6 +36,12 @@ public interface Http2UnknownFrame extends Http2StreamFrame, ByteBufHolder {
     Http2UnknownFrame copy();
 
     @Override
+    Http2UnknownFrame slice();
+
+    @Override
+    Http2UnknownFrame retainedSlice();
+
+    @Override
     Http2UnknownFrame duplicate();
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
@@ -64,6 +64,16 @@ public class DefaultLastMemcacheContent extends DefaultMemcacheContent implement
     }
 
     @Override
+    public LastMemcacheContent slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public LastMemcacheContent retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public LastMemcacheContent duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -48,6 +48,16 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
+    public MemcacheContent slice() {
+        return replace(content.slice());
+    }
+
+    @Override
+    public MemcacheContent retainedSlice() {
+        return replace(content.retainedSlice());
+    }
+
+    @Override
     public MemcacheContent duplicate() {
         return replace(content.duplicate());
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
@@ -29,6 +29,12 @@ public interface FullMemcacheMessage extends MemcacheMessage, LastMemcacheConten
     FullMemcacheMessage copy();
 
     @Override
+    FullMemcacheMessage slice();
+
+    @Override
+    FullMemcacheMessage retainedSlice();
+
+    @Override
     FullMemcacheMessage duplicate();
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
@@ -38,6 +38,16 @@ public interface LastMemcacheContent extends MemcacheContent {
         }
 
         @Override
+        public LastMemcacheContent slice() {
+            return this;
+        }
+
+        @Override
+        public LastMemcacheContent retainedSlice() {
+            return this;
+        }
+
+        @Override
         public LastMemcacheContent duplicate() {
             return this;
         }
@@ -105,6 +115,12 @@ public interface LastMemcacheContent extends MemcacheContent {
 
     @Override
     LastMemcacheContent copy();
+
+    @Override
+    LastMemcacheContent slice();
+
+    @Override
+    LastMemcacheContent retainedSlice();
 
     @Override
     LastMemcacheContent duplicate();

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
@@ -21,9 +21,9 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.util.internal.UnstableApi;
 
 /**
- * An Memcache content chunk.
+ * A Memcache content chunk.
  * <p/>
- * A implementation of a {@link AbstractMemcacheObjectDecoder} generates {@link MemcacheContent} after
+ * An implementation of a {@link AbstractMemcacheObjectDecoder} generates {@link MemcacheContent} after
  * {@link MemcacheMessage} when the content is large. If you prefer not to receive {@link MemcacheContent}
  * in your handler, place a aggregator after an implementation of the {@link AbstractMemcacheObjectDecoder}
  * in the {@link ChannelPipeline}.
@@ -33,6 +33,12 @@ public interface MemcacheContent extends MemcacheObject, ByteBufHolder {
 
     @Override
     MemcacheContent copy();
+
+    @Override
+    MemcacheContent slice();
+
+    @Override
+    MemcacheContent retainedSlice();
 
     @Override
     MemcacheContent duplicate();

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -106,6 +106,32 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
+    public FullBinaryMemcacheRequest slice() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.slice();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.slice();
+        }
+        return newInstance(key, extras, content().slice());
+    }
+
+    @Override
+    public FullBinaryMemcacheRequest retainedSlice() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.retainedSlice();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.retainedSlice();
+        }
+        return newInstance(key, extras, content().retainedSlice());
+    }
+
+    @Override
     public FullBinaryMemcacheRequest duplicate() {
         ByteBuf key = key();
         if (key != null) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -106,6 +106,32 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
+    public FullBinaryMemcacheResponse slice() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.slice();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.slice();
+        }
+        return newInstance(key, extras, content().slice());
+    }
+
+    @Override
+    public FullBinaryMemcacheResponse retainedSlice() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.retainedSlice();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.retainedSlice();
+        }
+        return newInstance(key, extras, content().retainedSlice());
+    }
+
+    @Override
     public FullBinaryMemcacheResponse duplicate() {
         ByteBuf key = key();
         if (key != null) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
@@ -29,6 +29,12 @@ public interface FullBinaryMemcacheRequest extends BinaryMemcacheRequest, FullMe
     FullBinaryMemcacheRequest copy();
 
     @Override
+    FullBinaryMemcacheRequest slice();
+
+    @Override
+    FullBinaryMemcacheRequest retainedSlice();
+
+    @Override
     FullBinaryMemcacheRequest duplicate();
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
@@ -29,6 +29,12 @@ public interface FullBinaryMemcacheResponse extends BinaryMemcacheResponse, Full
     FullBinaryMemcacheResponse copy();
 
     @Override
+    FullBinaryMemcacheResponse slice();
+
+    @Override
+    FullBinaryMemcacheResponse retainedSlice();
+
+    @Override
     FullBinaryMemcacheResponse duplicate();
 
     @Override

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequestTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequestTest.java
@@ -57,6 +57,27 @@ public class DefaultFullBinaryMemcacheRequestTest {
     }
 
     @Test
+    public void fullSlice() {
+        FullBinaryMemcacheRequest newInstance = request.slice();
+        try {
+            assertCopy(request, request.content(), newInstance);
+        } finally {
+            request.release();
+        }
+    }
+
+    @Test
+    public void fullRetainedSlice() {
+        FullBinaryMemcacheRequest newInstance = request.retainedSlice();
+        try {
+            assertCopy(request, request.content(), newInstance);
+        } finally {
+            request.release();
+            newInstance.release();
+        }
+    }
+
+    @Test
     public void fullDuplicate() {
         FullBinaryMemcacheRequest newInstance = request.duplicate();
         try {

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponseTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponseTest.java
@@ -57,6 +57,27 @@ public class DefaultFullBinaryMemcacheResponseTest {
     }
 
     @Test
+    public void fullSlice() {
+        FullBinaryMemcacheResponse newInstance = response.slice();
+        try {
+            assertResponseEquals(response, response.content(), newInstance);
+        } finally {
+            response.release();
+        }
+    }
+
+    @Test
+    public void fullRetainedSlice() {
+        FullBinaryMemcacheResponse newInstance = response.retainedSlice();
+        try {
+            assertResponseEquals(response, response.content(), newInstance);
+        } finally {
+            response.release();
+            newInstance.release();
+        }
+    }
+
+    @Test
     public void fullDuplicate() {
         try {
             assertResponseEquals(response, response.content(), response.duplicate());

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishMessage.java
@@ -57,6 +57,16 @@ public class MqttPublishMessage extends MqttMessage implements ByteBufHolder {
     }
 
     @Override
+    public MqttPublishMessage slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public MqttPublishMessage retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public MqttPublishMessage duplicate() {
         return replace(content().duplicate());
     }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/BulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/BulkStringRedisContent.java
@@ -34,6 +34,12 @@ public interface BulkStringRedisContent extends RedisMessage, ByteBufHolder {
     BulkStringRedisContent copy();
 
     @Override
+    BulkStringRedisContent slice();
+
+    @Override
+    BulkStringRedisContent retainedSlice();
+
+    @Override
     BulkStringRedisContent duplicate();
 
     @Override

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/DefaultBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/DefaultBulkStringRedisContent.java
@@ -41,6 +41,16 @@ public class DefaultBulkStringRedisContent extends DefaultByteBufHolder implemen
     }
 
     @Override
+    public BulkStringRedisContent slice() {
+        return (BulkStringRedisContent) super.slice();
+    }
+
+    @Override
+    public BulkStringRedisContent retainedSlice() {
+        return (BulkStringRedisContent) super.retainedSlice();
+    }
+
+    @Override
     public BulkStringRedisContent duplicate() {
         return (BulkStringRedisContent) super.duplicate();
     }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/DefaultLastBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/DefaultLastBulkStringRedisContent.java
@@ -39,6 +39,16 @@ public final class DefaultLastBulkStringRedisContent extends DefaultBulkStringRe
     }
 
     @Override
+    public LastBulkStringRedisContent slice() {
+        return (LastBulkStringRedisContent) super.slice();
+    }
+
+    @Override
+    public LastBulkStringRedisContent retainedSlice() {
+        return (LastBulkStringRedisContent) super.retainedSlice();
+    }
+
+    @Override
     public LastBulkStringRedisContent duplicate() {
         return (LastBulkStringRedisContent) super.duplicate();
     }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/FullBulkStringRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/FullBulkStringRedisMessage.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
@@ -140,6 +141,16 @@ public class FullBulkStringRedisMessage extends DefaultByteBufHolder implements 
         }
 
         @Override
+        public FullBulkStringRedisMessage slice() {
+            return this;
+        }
+
+        @Override
+        public FullBulkStringRedisMessage retainedSlice() {
+            return this;
+        }
+
+        @Override
         public FullBulkStringRedisMessage duplicate() {
             return this;
         }
@@ -188,6 +199,16 @@ public class FullBulkStringRedisMessage extends DefaultByteBufHolder implements 
     @Override
     public FullBulkStringRedisMessage copy() {
         return (FullBulkStringRedisMessage) super.copy();
+    }
+
+    @Override
+    public FullBulkStringRedisMessage slice() {
+        return (FullBulkStringRedisMessage) super.slice();
+    }
+
+    @Override
+    public FullBulkStringRedisMessage retainedSlice() {
+        return (FullBulkStringRedisMessage) super.retainedSlice();
     }
 
     @Override

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/LastBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/LastBulkStringRedisContent.java
@@ -41,6 +41,16 @@ public interface LastBulkStringRedisContent extends BulkStringRedisContent {
         }
 
         @Override
+        public LastBulkStringRedisContent slice() {
+            return this;
+        }
+
+        @Override
+        public LastBulkStringRedisContent retainedSlice() {
+            return this;
+        }
+
+        @Override
         public LastBulkStringRedisContent duplicate() {
             return this;
         }
@@ -93,6 +103,12 @@ public interface LastBulkStringRedisContent extends BulkStringRedisContent {
 
     @Override
     LastBulkStringRedisContent copy();
+
+    @Override
+    LastBulkStringRedisContent slice();
+
+    @Override
+    LastBulkStringRedisContent retainedSlice();
 
     @Override
     LastBulkStringRedisContent duplicate();

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultLastSmtpContent.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultLastSmtpContent.java
@@ -37,6 +37,16 @@ public final class DefaultLastSmtpContent extends DefaultSmtpContent implements 
     }
 
     @Override
+    public LastSmtpContent slice() {
+        return (LastSmtpContent) super.slice();
+    }
+
+    @Override
+    public LastSmtpContent retainedSlice() {
+        return (LastSmtpContent) super.retainedSlice();
+    }
+
+    @Override
     public LastSmtpContent duplicate() {
         return (LastSmtpContent) super.duplicate();
     }

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpContent.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpContent.java
@@ -38,6 +38,16 @@ public class DefaultSmtpContent extends DefaultByteBufHolder implements SmtpCont
     }
 
     @Override
+    public SmtpContent slice() {
+        return (SmtpContent) super.slice();
+    }
+
+    @Override
+    public SmtpContent retainedSlice() {
+        return (SmtpContent) super.retainedSlice();
+    }
+
+    @Override
     public SmtpContent duplicate() {
         return (SmtpContent) super.duplicate();
     }

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/LastSmtpContent.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/LastSmtpContent.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.smtp;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.UnstableApi;
 
@@ -34,6 +35,16 @@ public interface LastSmtpContent extends SmtpContent {
     LastSmtpContent EMPTY_LAST_CONTENT = new LastSmtpContent() {
         @Override
         public LastSmtpContent copy() {
+            return this;
+        }
+
+        @Override
+        public LastSmtpContent slice() {
+            return this;
+        }
+
+        @Override
+        public LastSmtpContent retainedSlice() {
             return this;
         }
 

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpContent.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpContent.java
@@ -31,6 +31,12 @@ public interface SmtpContent extends ByteBufHolder {
     SmtpContent copy();
 
     @Override
+    SmtpContent slice();
+
+    @Override
+    SmtpContent retainedSlice();
+
+    @Override
     SmtpContent duplicate();
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultLastStompContentSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultLastStompContentSubframe.java
@@ -32,6 +32,16 @@ public class DefaultLastStompContentSubframe extends DefaultStompContentSubframe
     }
 
     @Override
+    public LastStompContentSubframe slice() {
+        return (LastStompContentSubframe) super.slice();
+    }
+
+    @Override
+    public LastStompContentSubframe retainedSlice() {
+        return (LastStompContentSubframe) super.retainedSlice();
+    }
+
+    @Override
     public LastStompContentSubframe duplicate() {
         return (LastStompContentSubframe) super.duplicate();
     }

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompContentSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompContentSubframe.java
@@ -36,6 +36,16 @@ public class DefaultStompContentSubframe extends DefaultByteBufHolder implements
     }
 
     @Override
+    public StompContentSubframe slice() {
+        return (StompContentSubframe) super.slice();
+    }
+
+    @Override
+    public StompContentSubframe retainedSlice() {
+        return (StompContentSubframe) super.retainedSlice();
+    }
+
+    @Override
     public StompContentSubframe duplicate() {
         return (StompContentSubframe) super.duplicate();
     }

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
@@ -54,6 +54,16 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
     }
 
     @Override
+    public StompFrame slice() {
+        return replace(content.slice());
+    }
+
+    @Override
+    public StompFrame retainedSlice() {
+        return replace(content.retainedSlice());
+    }
+
+    @Override
     public StompFrame duplicate() {
         return replace(content.duplicate());
     }

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/LastStompContentSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/LastStompContentSubframe.java
@@ -40,6 +40,16 @@ public interface LastStompContentSubframe extends StompContentSubframe {
         }
 
         @Override
+        public LastStompContentSubframe slice() {
+            return this;
+        }
+
+        @Override
+        public LastStompContentSubframe retainedSlice() {
+            return this;
+        }
+
+        @Override
         public LastStompContentSubframe duplicate() {
             return this;
         }
@@ -102,6 +112,12 @@ public interface LastStompContentSubframe extends StompContentSubframe {
 
     @Override
     LastStompContentSubframe copy();
+
+    @Override
+    LastStompContentSubframe slice();
+
+    @Override
+    LastStompContentSubframe retainedSlice();
 
     @Override
     LastStompContentSubframe duplicate();

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompContentSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompContentSubframe.java
@@ -31,6 +31,12 @@ public interface StompContentSubframe extends ByteBufHolder, StompSubframe {
     StompContentSubframe copy();
 
     @Override
+    StompContentSubframe slice();
+
+    @Override
+    StompContentSubframe retainedSlice();
+
+    @Override
     StompContentSubframe duplicate();
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompFrame.java
@@ -26,6 +26,12 @@ public interface StompFrame extends StompHeadersSubframe, LastStompContentSubfra
     StompFrame copy();
 
     @Override
+    StompFrame slice();
+
+    @Override
+    StompFrame retainedSlice();
+
+    @Override
     StompFrame duplicate();
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/PemEncoded.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemEncoded.java
@@ -33,6 +33,12 @@ interface PemEncoded extends ByteBufHolder {
     PemEncoded copy();
 
     @Override
+    PemEncoded slice();
+
+    @Override
+    PemEncoded retainedSlice();
+
+    @Override
     PemEncoded duplicate();
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/PemPrivateKey.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemPrivateKey.java
@@ -147,6 +147,16 @@ public final class PemPrivateKey extends AbstractReferenceCounted implements Pri
     }
 
     @Override
+    public PemPrivateKey slice() {
+        return replace(content.slice());
+    }
+
+    @Override
+    public PemPrivateKey retainedSlice() {
+        return replace(content.retainedSlice());
+    }
+
+    @Override
     public PemPrivateKey duplicate() {
         return replace(content.duplicate());
     }

--- a/handler/src/main/java/io/netty/handler/ssl/PemValue.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemValue.java
@@ -61,6 +61,16 @@ class PemValue extends AbstractReferenceCounted implements PemEncoded {
     }
 
     @Override
+    public PemValue slice() {
+        return replace(content.slice());
+    }
+
+    @Override
+    public PemValue retainedSlice() {
+        return replace(content.retainedSlice());
+    }
+
+    @Override
     public PemValue duplicate() {
         return replace(content.duplicate());
     }

--- a/handler/src/main/java/io/netty/handler/ssl/PemX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemX509Certificate.java
@@ -206,6 +206,16 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
     }
 
     @Override
+    public PemX509Certificate slice() {
+        return replace(content.slice());
+    }
+
+    @Override
+    public PemX509Certificate retainedSlice() {
+        return replace(content.retainedSlice());
+    }
+
+    @Override
     public PemX509Certificate duplicate() {
         return replace(content.duplicate());
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -154,6 +154,16 @@ public final class SctpMessage extends DefaultByteBufHolder {
     }
 
     @Override
+    public SctpMessage slice() {
+        return (SctpMessage) super.slice();
+    }
+
+    @Override
+    public SctpMessage retainedSlice() {
+        return (SctpMessage) super.retainedSlice();
+    }
+
+    @Override
     public SctpMessage duplicate() {
         return (SctpMessage) super.duplicate();
     }

--- a/transport/src/main/java/io/netty/channel/socket/DatagramPacket.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramPacket.java
@@ -48,6 +48,16 @@ public final class DatagramPacket
     }
 
     @Override
+    public DatagramPacket slice() {
+        return replace(content().slice());
+    }
+
+    @Override
+    public DatagramPacket retainedSlice() {
+        return replace(content().retainedSlice());
+    }
+
+    @Override
     public DatagramPacket duplicate() {
         return replace(content().duplicate());
     }


### PR DESCRIPTION
Motivations
-----------
ByteBufHolder interface provides a copy method but not the copy-free
equivalent slice. Slice and retainedSlice should be supported.

Modifications
-------------
Added slice and retainedSlice methods to ByteBufHolder interface and
implemented methods in class implementing said interface.

Result
------
Implementations of ByteBufHolder can be sliced.

Fixes #9173


Note: `mvn test` passes up to a point but I can't get past building `kqueue` (even without making any changes) due to missing `io.netty:netty-transport-native-kqueue:zip:5.0.0.Final-SNAPSHOT`. Not sure how to address this (I tried various combinations of mvn package and skipping tests, but none helped). Tests that got skipped:
```
[INFO] Netty/Transport/Native/KQueue ...................... FAILURE [  2.356 s]
^ because jar io.netty:netty-transport-native-kqueue:zip:5.0.0.Final-SNAPSHOT is missing 

[INFO] Netty/Transport/Native/Epoll ....................... SKIPPED
[INFO] Netty/All-in-One ................................... SKIPPED
[INFO] Netty/Tarball ...................................... SKIPPED
[INFO] Netty/Testsuite/Autobahn ........................... SKIPPED
[INFO] Netty/Testsuite/Http2 .............................. SKIPPED
[INFO] Netty/Testsuite/OSGI ............................... SKIPPED
[INFO] Netty/Testsuite/Shading ............................ SKIPPED
[INFO] Netty/Testsuite/NativeImage ........................ SKIPPED
[INFO] Netty/Microbench ................................... SKIPPED
[INFO] Netty/BOM .......................................... SKIPPED
```
Everything else compiled successfully.