### PR TITLE
Defer eventFd / timerFd reads until end of loop.

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -35,6 +35,11 @@ import org.openjdk.jmh.annotations.TearDown;
 
 public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
 
+    private static final Runnable runnable = new Runnable() {
+        @Override
+        public void run() { }
+    };
+
     private EpollEventLoopGroup group;
     private Channel serverChan;
     private Channel chan;
@@ -51,7 +56,7 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
             public void run() {
                 throw new AssertionError();
             }
-        }, 5, TimeUnit.MINUTES);
+        }, 30, TimeUnit.MINUTES);
         serverChan = new ServerBootstrap()
             .channel(EpollServerSocketChannel.class)
             .group(group)
@@ -135,5 +140,10 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
     @Benchmark
     public Object pingPong() throws Exception {
         return chan.pipeline().writeAndFlush(abyte.retainedSlice()).sync();
+    }
+
+    @Benchmark
+    public Object execute() throws Exception {
+        return chan.eventLoop().submit(runnable).get();
     }
 }


### PR DESCRIPTION
Motivation:

When submitting a task an epoll event loop, the submitter notifies the
loop of the new task by writing to an event fd.  If the loop is waiting
in epoll_wait, it wakes up, reads the eventFd, and processes the tasks.
Similarly when a timer fires, the loop wakes up, reads the timerFd, and
processes the tasks.

This is a slight latency hit, because the submitter (and timer) want
their tasks to be processed first, rather than reading from the fds.
The reads cost a JNI hop and a syscall, which my unscientific
measurements put at around 500ns-1000ns.

Modification:

Change the epoll loop to defer reading of the eventFd and timerFd.  The
fds are read after all tasks have been processed.

Result:

More timely handling of tasks.

Notes:

This only really helps if the event loop has less than 1 active network
tasks.  The benefit is lost as the event loop is more active, because it
naturally is awake more avoiding the need for the eventFd read at wake.
The behavior was discovered in a gRPC Benchmark, where there is only
ever one active RPC at a time, which is started from off the event loop.

Some benchmark results from my slightly noisy Skylake:

```
Before
Benchmark                              Mode  Cnt       Score     Error  Units
EpollSocketChannelBenchmark.execute   thrpt   20  158927.397 ± 952.091  ops/s
EpollSocketChannelBenchmark.pingPong  thrpt   20   59628.285 ± 292.004  ops/s

After
Benchmark                              Mode  Cnt       Score      Error  Units
EpollSocketChannelBenchmark.execute   thrpt   20  170651.174 ± 1225.152  ops/s
EpollSocketChannelBenchmark.pingPong  thrpt   20   60961.310 ±  473.759  ops/s
```
