### PR TITLE
Expose epoll errno on eventfd read and write failure

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -128,7 +128,7 @@ static void netty_epoll_native_eventFdRead(JNIEnv* env, jclass clazz, jint fd) {
 
     if (eventfd_read(fd, &eventfd_t) != 0) {
         // something is serious wrong
-        netty_unix_errors_throwRuntimeException(env, "eventfd_read() failed");
+        netty_unix_errors_throwChannelExceptionErrorNo(env, "eventfd_read() failed", errno);
     }
 }
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.unix;
 
+import io.netty.channel.ChannelException;
 import io.netty.util.internal.EmptyArrays;
 
 import java.io.FileNotFoundException;
@@ -97,6 +98,23 @@ public final class Errors {
 
         int expectedErr() {
             return expectedErr;
+        }
+    }
+
+    /**
+     * <strong>Internal usage only!</strong>
+     */
+    public static final class NativeChannelException extends ChannelException {
+        private static final long serialVersionUID = 8222160204268655523L;
+        private final int expectedErr;
+
+        public NativeChannelException(String message, int expectedErr) {
+            super(message);
+            this.expectedErr = expectedErr;
+        }
+
+        public int expectedErr() {
+          return expectedErr;
         }
     }
 


### PR DESCRIPTION
Motivation:
Exposing the errno let's Java code handle the errors more precisely

Modification:
- Make eventFDRead throw a ChannelException rather then RuntimeException
- Make eventFD writes also throw with the errno
- Add a NativeChannelException, to keep the exception type for reads and
writes

Result:

Better handling of native errors
