### PR TITLE
[WIP]: ChannelOutboundInvoker method variants that take ChannelPromise shoul…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -308,7 +308,9 @@ public abstract class WebSocketServerHandshaker {
      */
     public ChannelFuture close(Channel channel, CloseWebSocketFrame frame) {
         requireNonNull(channel, "channel");
-        return close(channel, frame, channel.newPromise());
+        ChannelPromise promise = channel.newPromise();
+        close(channel, frame, promise);
+        return promise;
     }
 
     /**
@@ -321,9 +323,10 @@ public abstract class WebSocketServerHandshaker {
      * @param promise
      *            the {@link ChannelPromise} to be notified when the closing handshake is done
      */
-    public ChannelFuture close(Channel channel, CloseWebSocketFrame frame, ChannelPromise promise) {
+    public WebSocketServerHandshaker close(Channel channel, CloseWebSocketFrame frame, ChannelPromise promise) {
         requireNonNull(channel, "channel");
-        return channel.writeAndFlush(frame, promise).addListener(ChannelFutureListener.CLOSE);
+        channel.writeAndFlush(frame, promise.addListener(ChannelFutureListener.CLOSE));
+        return this;
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -183,8 +183,9 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
      *            Web Socket frame that was received
      */
     @Override
-    public ChannelFuture close(Channel channel, CloseWebSocketFrame frame, ChannelPromise promise) {
-        return channel.writeAndFlush(frame, promise);
+    public WebSocketServerHandshaker close(Channel channel, CloseWebSocketFrame frame, ChannelPromise promise) {
+        channel.writeAndFlush(frame, promise);
+        return this;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -148,18 +148,23 @@ public class WebSocketServerHandshakerFactory {
      * Return that we need cannot not support the web socket version
      */
     public static ChannelFuture sendUnsupportedVersionResponse(Channel channel) {
-        return sendUnsupportedVersionResponse(channel, channel.newPromise());
-    }
-
-    /**
-     * Return that we need cannot not support the web socket version
-     */
-    public static ChannelFuture sendUnsupportedVersionResponse(Channel channel, ChannelPromise promise) {
         HttpResponse res = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1,
                 HttpResponseStatus.UPGRADE_REQUIRED);
         res.headers().set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, WebSocketVersion.V13.toHttpHeaderValue());
         HttpUtil.setContentLength(res, 0);
-        return channel.writeAndFlush(res, promise);
+        return channel.writeAndFlush(res);
+    }
+
+    /**
+     * Return that we need cannot not support the web socket version
+     */
+    public static void sendUnsupportedVersionResponse(Channel channel, ChannelPromise promise) {
+        HttpResponse res = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                HttpResponseStatus.UPGRADE_REQUIRED);
+        res.headers().set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, WebSocketVersion.V13.toHttpHeaderValue());
+        HttpUtil.setContentLength(res, 0);
+        channel.writeAndFlush(res, promise);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -282,7 +282,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             buf.writeInt(exclusive ? (int) (0x80000000L | streamDependency) : streamDependency);
             // Adjust the weight so that it fits into a single byte on the wire.
             buf.writeByte(weight - 1);
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
+            return promise;
         } catch (Throwable t) {
             return promise.setFailure(t);
         }
@@ -298,7 +299,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             ByteBuf buf = ctx.alloc().buffer(RST_STREAM_FRAME_LENGTH);
             writeFrameHeaderInternal(buf, INT_FIELD_LENGTH, RST_STREAM, new Http2Flags(), streamId);
             buf.writeInt((int) errorCode);
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
+            return promise;
         } catch (Throwable t) {
             return promise.setFailure(t);
         }
@@ -316,7 +318,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 buf.writeChar(entry.key());
                 buf.writeInt(entry.value().intValue());
             }
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
+            return promise;
         } catch (Throwable t) {
             return promise.setFailure(t);
         }
@@ -327,7 +330,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
         try {
             ByteBuf buf = ctx.alloc().buffer(FRAME_HEADER_LENGTH);
             writeFrameHeaderInternal(buf, 0, SETTINGS, new Http2Flags().ack(true), 0);
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
+            return promise;
         } catch (Throwable t) {
             return promise.setFailure(t);
         }
@@ -341,7 +345,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
         // in the catch block.
         writeFrameHeaderInternal(buf, PING_FRAME_PAYLOAD_LENGTH, PING, flags, 0);
         buf.writeLong(data);
-        return ctx.write(buf, promise);
+        ctx.write(buf, promise);
+        return promise;
     }
 
     @Override
@@ -447,7 +452,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             ByteBuf buf = ctx.alloc().buffer(WINDOW_UPDATE_FRAME_LENGTH);
             writeFrameHeaderInternal(buf, INT_FIELD_LENGTH, WINDOW_UPDATE, new Http2Flags(), streamId);
             buf.writeInt(windowSizeIncrement);
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
+            return promise;
         } catch (Throwable t) {
             return promise.setFailure(t);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -41,7 +41,6 @@ import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -629,7 +628,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
         @Override
         public ChannelFuture register() {
-            return register(newPromise());
+            return pipeline().register();
         }
 
         @Override
@@ -638,38 +637,45 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
         }
 
         @Override
-        public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
-            return pipeline().bind(localAddress, promise);
+        public Channel bind(SocketAddress localAddress, ChannelPromise promise) {
+            pipeline().bind(localAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
-            return pipeline().connect(remoteAddress, promise);
+        public Channel connect(SocketAddress remoteAddress, ChannelPromise promise) {
+            pipeline().connect(remoteAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            return pipeline().connect(remoteAddress, localAddress, promise);
+        public Channel connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            pipeline().connect(remoteAddress, localAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture disconnect(ChannelPromise promise) {
-            return pipeline().disconnect(promise);
+        public Channel disconnect(ChannelPromise promise) {
+            pipeline().disconnect(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture close(ChannelPromise promise) {
-            return pipeline().close(promise);
+        public Channel close(ChannelPromise promise) {
+            pipeline().close(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture register(ChannelPromise promise) {
-            return pipeline().register(promise);
+        public Channel register(ChannelPromise promise) {
+            pipeline().register(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture deregister(ChannelPromise promise) {
-            return pipeline().deregister(promise);
+        public Channel deregister(ChannelPromise promise) {
+            pipeline().deregister(promise);
+            return this;
         }
 
         @Override
@@ -678,13 +684,15 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
         }
 
         @Override
-        public ChannelFuture write(Object msg, ChannelPromise promise) {
-            return pipeline().write(msg, promise);
+        public Channel write(Object msg, ChannelPromise promise) {
+            pipeline().write(msg, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-            return pipeline().writeAndFlush(msg, promise);
+        public Channel writeAndFlush(Object msg, ChannelPromise promise) {
+            pipeline().writeAndFlush(msg, promise);
+            return this;
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -76,16 +76,22 @@ public class DefaultHttp2FrameWriterTest {
 
         http2HeadersEncoder = new DefaultHttp2HeadersEncoder();
 
-        Answer<Object> answer = var1 -> {
+        when(ctx.write(any())).then(var1 -> {
             Object msg = var1.getArgument(0);
             if (msg instanceof ByteBuf) {
                 outbound.writeBytes((ByteBuf) msg);
             }
             ReferenceCountUtil.release(msg);
             return future;
-        };
-        when(ctx.write(any())).then(answer);
-        when(ctx.write(any(), any(ChannelPromise.class))).then(answer);
+        });
+        when(ctx.write(any(), any(ChannelPromise.class))).then(var1 -> {
+            Object msg = var1.getArgument(0);
+            if (msg instanceof ByteBuf) {
+                outbound.writeBytes((ByteBuf) msg);
+            }
+            ReferenceCountUtil.release(msg);
+            return ctx;
+        });
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(ctx.channel()).thenReturn(channel);
         when(ctx.executor()).thenReturn(ImmediateEventExecutor.INSTANCE);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -260,52 +260,63 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
-            return channel.bind(localAddress, promise);
+        public ChannelHandlerContext bind(SocketAddress localAddress, ChannelPromise promise) {
+            channel.bind(localAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
-            return channel.connect(remoteAddress, promise);
+        public ChannelHandlerContext connect(SocketAddress remoteAddress, ChannelPromise promise) {
+            channel.connect(remoteAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            return channel.connect(remoteAddress, localAddress, promise);
+        public ChannelHandlerContext connect(
+                SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            channel.connect(remoteAddress, localAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture disconnect(ChannelPromise promise) {
-            return channel.disconnect(promise);
+        public ChannelHandlerContext disconnect(ChannelPromise promise) {
+            channel.disconnect(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture close(ChannelPromise promise) {
-            return channel.close(promise);
+        public ChannelHandlerContext close(ChannelPromise promise) {
+            channel.close(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture register(ChannelPromise promise) {
-            return channel.register(promise);
+        public ChannelHandlerContext register(ChannelPromise promise) {
+            channel.register(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture deregister(ChannelPromise promise) {
-            return channel.deregister(promise);
+        public ChannelHandlerContext deregister(ChannelPromise promise) {
+            channel.deregister(promise);
+            return this;
         }
 
         @Override
         public ChannelFuture write(Object msg) {
-            return write(msg, newPromise());
+            ChannelPromise promise = newPromise();
+             write(msg, promise);
+            return promise;
         }
 
         @Override
-        public ChannelFuture write(Object msg, ChannelPromise promise) {
-            return writeAndFlush(msg, promise);
+        public ChannelHandlerContext write(Object msg, ChannelPromise promise) {
+            writeAndFlush(msg, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        public ChannelHandlerContext writeAndFlush(Object msg, ChannelPromise promise) {
             try {
                 channel.writeInbound(msg);
                 channel.runPendingTasks();
@@ -313,12 +324,14 @@ final class Http2FrameInboundWriter {
             } catch (Throwable cause) {
                 promise.setFailure(cause);
             }
-            return promise;
+            return this;
         }
 
         @Override
         public ChannelFuture writeAndFlush(Object msg) {
-            return writeAndFlush(msg, newPromise());
+            ChannelPromise promise = newPromise();
+            writeAndFlush(msg, promise);
+            return promise;
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -553,7 +553,8 @@ public class Http2MultiplexCodecTest {
             channelOpen.set(future.channel().isOpen());
             channelActive.set(future.channel().isActive());
         });
-        childChannel.close(p).syncUninterruptibly();
+        childChannel.close(p);
+        p.syncUninterruptibly();
 
         assertFalse(channelOpen.get());
         assertFalse(channelActive.get());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -22,7 +22,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
@@ -48,7 +47,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
@@ -145,8 +143,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .add(new AsciiString("foo"), new AsciiString("goo2"))
                 .add(new AsciiString("foo2"), new AsciiString("goo2"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -166,8 +163,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .add(HttpHeaderNames.COOKIE, "c=d")
                 .add(HttpHeaderNames.COOKIE, "e=f");
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -182,8 +178,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .path(new AsciiString("/where?q=now&f=then#section1"))
                 .scheme(new AsciiString("http"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -199,8 +194,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                                          .path(new AsciiString("/where%2B0?q=now%2B0&f=then%2B0#section1%2B0"))
                                          .scheme(new AsciiString("http"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -217,8 +211,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .path(new AsciiString("/pub/WWW/TheProject.html"))
                 .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("https"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -233,8 +226,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .path(new AsciiString("/pub/WWW/TheProject.html"))
                 .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("http"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -247,8 +239,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 new DefaultHttp2Headers().method(new AsciiString("CONNECT")).path(new AsciiString("/"))
                 .scheme(new AsciiString("http")).authority(new AsciiString("www.example.com:80"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -263,8 +254,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 new DefaultHttp2Headers().method(new AsciiString("OPTIONS")).path(new AsciiString("*"))
                 .scheme(new AsciiString("http")).authority(new AsciiString("www.example.com:80"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -281,8 +271,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 new DefaultHttp2Headers().method(new AsciiString("GET")).path(new AsciiString("/"))
                 .scheme(new AsciiString("http")).authority(new AsciiString("[::1]:80"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -297,8 +286,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 new DefaultHttp2Headers().method(new AsciiString("GET")).path(new AsciiString("/"))
                 .scheme(new AsciiString("http")).authority(new AsciiString("localhost:80"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -313,8 +301,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                 new DefaultHttp2Headers().method(new AsciiString("GET")).path(new AsciiString("/"))
                 .scheme(new AsciiString("http")).authority(new AsciiString("1.2.3.4:80"));
 
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        verifyHeadersOnly(http2Headers, clientChannel.writeAndFlush(request));
     }
 
     @Test
@@ -324,12 +311,9 @@ public class HttpToHttp2ConnectionHandlerTest {
         final HttpHeaders httpHeaders = request.headers();
         httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
         httpHeaders.set(HttpHeaderNames.HOST, "localhost");
-        ChannelPromise writePromise = newPromise();
-        ChannelFuture writeFuture = clientChannel.writeAndFlush(request, writePromise);
+        ChannelFuture writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writePromise.isDone());
-        assertFalse(writePromise.isSuccess());
+        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isDone());
         assertFalse(writeFuture.isSuccess());
     }
@@ -358,11 +342,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .add(new AsciiString("foo"), new AsciiString("goo"))
                 .add(new AsciiString("foo"), new AsciiString("goo2"))
                 .add(new AsciiString("foo2"), new AsciiString("goo2"));
-        ChannelPromise writePromise = newPromise();
-        ChannelFuture writeFuture = clientChannel.writeAndFlush(request, writePromise);
+        ChannelFuture writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writePromise.isSuccess());
         assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();
@@ -404,11 +385,8 @@ public class HttpToHttp2ConnectionHandlerTest {
         final Http2Headers http2TrailingHeaders = new DefaultHttp2Headers()
                 .add(new AsciiString("trailing"), new AsciiString("bar"));
 
-        ChannelPromise writePromise = newPromise();
-        ChannelFuture writeFuture = clientChannel.writeAndFlush(request, writePromise);
+        ChannelFuture writeFuture = clientChannel.writeAndFlush(request);
 
-        assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writePromise.isSuccess());
         assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();
@@ -456,27 +434,18 @@ public class HttpToHttp2ConnectionHandlerTest {
         final Http2Headers http2TrailingHeaders = new DefaultHttp2Headers()
                 .add(new AsciiString("trailing"), new AsciiString("bar"));
 
-        ChannelPromise writePromise = newPromise();
-        ChannelFuture writeFuture = clientChannel.write(request, writePromise);
-        ChannelPromise contentPromise = newPromise();
-        ChannelFuture contentFuture = clientChannel.write(httpContent, contentPromise);
-        ChannelPromise lastContentPromise = newPromise();
-        ChannelFuture lastContentFuture = clientChannel.write(lastHttpContent, lastContentPromise);
+        ChannelFuture writeFuture = clientChannel.write(request);
+        ChannelFuture contentFuture = clientChannel.write(httpContent);
+        ChannelFuture lastContentFuture = clientChannel.write(lastHttpContent);
 
         clientChannel.flush();
 
-        assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writePromise.isSuccess());
         assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
 
-        assertTrue(contentPromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(contentPromise.isSuccess());
         assertTrue(contentFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(contentFuture.isSuccess());
 
-        assertTrue(lastContentPromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(lastContentPromise.isSuccess());
         assertTrue(lastContentFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(lastContentFuture.isSuccess());
 
@@ -551,10 +520,8 @@ public class HttpToHttp2ConnectionHandlerTest {
         assertTrue(serverChannelLatch.await(WAIT_TIME_SECONDS, SECONDS));
     }
 
-    private void verifyHeadersOnly(Http2Headers expected, ChannelPromise writePromise, ChannelFuture writeFuture)
+    private void verifyHeadersOnly(Http2Headers expected, ChannelFuture writeFuture)
             throws Exception {
-        assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writePromise.isSuccess());
         assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writeFuture.isSuccess());
         awaitRequests();

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibEncoder.java
@@ -45,9 +45,9 @@ public abstract class ZlibEncoder extends MessageToByteEncoder<ByteBuf> {
 
     /**
      * Close this {@link ZlibEncoder} and so finish the encoding.
-     * The given {@link ChannelFuture} will be notified once the operation
-     * completes and will also be returned.
+     * The given {@link ChannelPromise} will be notified once the operation
+     * completes.
      */
-    public abstract ChannelFuture close(ChannelPromise promise);
+    public abstract ZlibEncoder close(ChannelPromise promise);
 
 }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
@@ -245,7 +245,7 @@ public class HttpProxyHandlerTest {
         verifyNoMoreInteractions(promise);
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        when(ctx.connect(same(proxyAddress), isNull(InetSocketAddress.class), same(promise))).thenReturn(promise);
+        when(ctx.connect(same(proxyAddress), isNull(InetSocketAddress.class), same(promise))).thenReturn(ctx);
 
         HttpProxyHandler handler = new HttpProxyHandler(
                 new InetSocketAddress(NetUtil.LOCALHOST, 8080),

--- a/handler/src/main/java/io/netty/handler/address/DynamicAddressConnectHandler.java
+++ b/handler/src/main/java/io/netty/handler/address/DynamicAddressConnectHandler.java
@@ -43,13 +43,13 @@ public abstract class DynamicAddressConnectHandler implements ChannelHandler {
             promise.setFailure(e);
             return;
         }
-        ctx.connect(remote, local, promise).addListener(future -> {
+        ctx.connect(remote, local, promise.addListener(future -> {
             if (future.isSuccess()) {
                 // We only remove this handler from the pipeline once the connect was successful as otherwise
                 // the user may try to connect again.
                 ctx.pipeline().remove(DynamicAddressConnectHandler.this);
             }
-        });
+        }));
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1998,7 +1998,7 @@ public class SslHandler extends ByteToMessageDecoder {
                     if (!flushFuture.isDone()) {
                         logger.warn("{} Last write attempt timed out; force-closing the connection.",
                                 ctx.channel());
-                        addCloseListener(ctx.close(ctx.newPromise()), promise);
+                        addCloseListener(ctx.close(), promise);
                     }
                 }, closeNotifyTimeout, TimeUnit.MILLISECONDS);
             } else {
@@ -2017,7 +2017,7 @@ public class SslHandler extends ByteToMessageDecoder {
             if (closeNotifyReadTimeout <= 0) {
                 // Trigger the close in all cases to make sure the promise is notified
                 // See https://github.com/netty/netty/issues/2358
-                addCloseListener(ctx.close(ctx.newPromise()), promise);
+                addCloseListener(ctx.close(), promise);
             } else {
                 final ScheduledFuture<?> closeNotifyReadTimeoutFuture;
 
@@ -2029,7 +2029,7 @@ public class SslHandler extends ByteToMessageDecoder {
                                     ctx.channel(), closeNotifyReadTimeout);
 
                             // Do the close now...
-                            addCloseListener(ctx.close(ctx.newPromise()), promise);
+                            addCloseListener(ctx.close(), promise);
                         }
                     }, closeNotifyReadTimeout, TimeUnit.MILLISECONDS);
                 } else {
@@ -2041,7 +2041,7 @@ public class SslHandler extends ByteToMessageDecoder {
                     if (closeNotifyReadTimeoutFuture != null) {
                         closeNotifyReadTimeoutFuture.cancel(false);
                     }
-                    addCloseListener(ctx.close(ctx.newPromise()), promise);
+                    addCloseListener(ctx.close(), promise);
                 });
             }
         });

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -300,7 +300,7 @@ public class IdleStateHandler implements ChannelHandler {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         // Allow writing with void promise if handler is only configured for read timeout events.
         if (writerIdleTimeNanos > 0 || allIdleTimeNanos > 0) {
-            ctx.write(msg, promise.unvoid()).addListener(writeListener);
+            ctx.write(msg, (promise == null ? ctx.newPromise() : promise).addListener(writeListener));
         } else {
             ctx.write(msg, promise);
         }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -139,52 +139,66 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
 
     @Override
     public final ChannelFuture bind(SocketAddress localAddress) {
-        return bind(localAddress, newPromise());
+        ChannelPromise promise = newPromise();
+        bind(localAddress, promise);
+        return promise;
     }
 
     @Override
     public final ChannelFuture connect(SocketAddress remoteAddress) {
-        return connect(remoteAddress, newPromise());
+        ChannelPromise promise = newPromise();
+        connect(remoteAddress, promise);
+        return promise;
     }
 
     @Override
     public final ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return connect(remoteAddress, localAddress, newPromise());
+        ChannelPromise promise = newPromise();
+        connect(remoteAddress, localAddress, promise);
+        return promise;
     }
 
     @Override
     public final ChannelFuture disconnect() {
-        return disconnect(newPromise());
+        ChannelPromise promise = newPromise();
+        disconnect(promise);
+        return promise;
     }
 
     @Override
     public final ChannelFuture close() {
-        return close(newPromise());
+        ChannelPromise promise = newPromise();
+        close(promise);
+        return promise;
     }
 
     @Override
     public ChannelFuture register() {
-        return register(newPromise());
+        ChannelPromise promise = newPromise();
+        register(promise);
+        return promise;
     }
 
     @Override
-    public ChannelFuture register(ChannelPromise promise) {
+    public ChannelHandlerContext register(ChannelPromise promise) {
         try {
             channel().register(promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
     public final ChannelFuture deregister() {
-        return deregister(newPromise());
+        ChannelPromise promise = newPromise();
+        deregister(promise);
+        return promise;
     }
 
     @Override
-    public final ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+    public final ChannelHandlerContext bind(SocketAddress localAddress, ChannelPromise promise) {
         try {
             channel().bind(localAddress, promise);
             this.localAddress = localAddress;
@@ -192,22 +206,22 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
-    public final ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+    public final ChannelHandlerContext connect(SocketAddress remoteAddress, ChannelPromise promise) {
         try {
             channel().connect(remoteAddress, localAddress, promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
-    public final ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress,
+    public final ChannelHandlerContext connect(SocketAddress remoteAddress, SocketAddress localAddress,
                                  ChannelPromise promise) {
         try {
             channel().connect(remoteAddress, localAddress, promise);
@@ -215,40 +229,40 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
-    public final ChannelFuture disconnect(ChannelPromise promise) {
+    public final ChannelHandlerContext disconnect(ChannelPromise promise) {
         try {
             channel().disconnect(promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
-    public final ChannelFuture close(ChannelPromise promise) {
+    public final ChannelHandlerContext close(ChannelPromise promise) {
         try {
             channel().close(promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
-    public final ChannelFuture deregister(ChannelPromise promise) {
+    public final ChannelHandlerContext deregister(ChannelPromise promise) {
         try {
             channel().deregister(promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
@@ -267,8 +281,9 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public ChannelFuture write(Object msg, ChannelPromise promise) {
-        return channel().write(msg, promise);
+    public ChannelHandlerContext write(Object msg, ChannelPromise promise) {
+        channel().write(msg, promise);
+        return this;
     }
 
     @Override
@@ -278,13 +293,16 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-        return channel().writeAndFlush(msg, promise);
+    public ChannelHandlerContext writeAndFlush(Object msg, ChannelPromise promise) {
+        channel().writeAndFlush(msg, promise);
+        return this;
     }
 
     @Override
     public ChannelFuture writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
+        ChannelPromise promise = newPromise();
+        writeAndFlush(msg, newPromise());
+        return promise;
     }
 
     @Override

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteAccumulatingHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteAccumulatingHandlerContext.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -53,11 +54,13 @@ public abstract class EmbeddedChannelWriteAccumulatingHandlerContext extends Emb
 
     @Override
     public final ChannelFuture write(Object msg) {
-        return write(msg, newPromise());
+        ChannelPromise promise = newPromise();
+        write(msg, promise);
+        return promise;
     }
 
     @Override
-    public final ChannelFuture write(Object msg, ChannelPromise promise) {
+    public final ChannelHandlerContext write(Object msg, ChannelPromise promise) {
         try {
             if (msg instanceof ByteBuf) {
                 if (cumulation == null) {
@@ -73,11 +76,11 @@ public abstract class EmbeddedChannelWriteAccumulatingHandlerContext extends Emb
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
-    public final ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+    public final ChannelHandlerContext writeAndFlush(Object msg, ChannelPromise promise) {
         try {
             if (msg instanceof ByteBuf) {
                 ByteBuf buf = (ByteBuf) msg;
@@ -94,11 +97,13 @@ public abstract class EmbeddedChannelWriteAccumulatingHandlerContext extends Emb
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
     public final ChannelFuture writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
+        ChannelPromise promise = newPromise();
+        writeAndFlush(msg, promise);
+        return promise;
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
@@ -17,6 +17,7 @@ package io.netty.microbench.channel;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.ReferenceCounted;
@@ -35,11 +36,13 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext extends Embedded
 
     @Override
     public final ChannelFuture write(Object msg) {
-        return write(msg, newPromise());
+        ChannelPromise promise = newPromise();
+        write(msg, promise);
+        return promise;
     }
 
     @Override
-    public final ChannelFuture write(Object msg, ChannelPromise promise) {
+    public final ChannelHandlerContext write(Object msg, ChannelPromise promise) {
         try {
             if (msg instanceof ReferenceCounted) {
                 ((ReferenceCounted) msg).release();
@@ -51,11 +54,11 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext extends Embedded
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
-    public final ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+    public final ChannelHandlerContext writeAndFlush(Object msg, ChannelPromise promise) {
         try {
             if (msg instanceof ReferenceCounted) {
                 ((ReferenceCounted) msg).release();
@@ -67,11 +70,13 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext extends Embedded
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
+        return this;
     }
 
     @Override
     public final ChannelFuture writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
+        ChannelPromise promise = newPromise();
+        writeAndFlush(msg, promise);
+        return promise;
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -139,12 +139,15 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
     }
 
     private void writeQuery(final DnsQuery query, final boolean flush, final ChannelPromise writePromise) {
-        final ChannelFuture writeFuture = flush ? channel().writeAndFlush(query, writePromise) :
-                channel().write(query, writePromise);
-        if (writeFuture.isDone()) {
-            onQueryWriteCompletion(writeFuture);
+        if (flush) {
+            channel().writeAndFlush(query, writePromise);
         } else {
-            writeFuture.addListener((ChannelFutureListener) future -> onQueryWriteCompletion(writeFuture));
+            channel().write(query, writePromise);
+        }
+        if (writePromise.isDone()) {
+            onQueryWriteCompletion(writePromise);
+        } else {
+            writePromise.addListener((ChannelFutureListener) future -> onQueryWriteCompletion(future));
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -102,7 +102,7 @@ public class SocketEchoTest extends AbstractSocketTest {
             int length = Math.min(random.nextInt(1024 * 64), data.length - i);
             ByteBuf buf = Unpooled.wrappedBuffer(data, i, length);
             if (voidPromise) {
-                assertEquals(cc.voidPromise(), cc.writeAndFlush(buf, cc.voidPromise()));
+                cc.writeAndFlush(buf, cc.voidPromise());
             } else {
                 assertNotEquals(cc.voidPromise(), cc.writeAndFlush(buf));
             }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -195,9 +195,9 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         // See https://github.com/netty/netty/issues/2769
         //     https://github.com/netty/netty/issues/2964
         if (voidPromise) {
-            assertEquals(cc.voidPromise(), cc.write(Unpooled.wrappedBuffer(data, 0, bufferSize), cc.voidPromise()));
-            assertEquals(cc.voidPromise(), cc.write(emptyRegion, cc.voidPromise()));
-            assertEquals(cc.voidPromise(), cc.writeAndFlush(region, cc.voidPromise()));
+            cc.write(Unpooled.wrappedBuffer(data, 0, bufferSize), cc.voidPromise());
+            cc.write(emptyRegion, cc.voidPromise());
+            cc.writeAndFlush(region, cc.voidPromise());
         } else {
             assertNotEquals(cc.voidPromise(), cc.write(Unpooled.wrappedBuffer(data, 0, bufferSize)));
             assertNotEquals(cc.voidPromise(), cc.write(emptyRegion));

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -286,7 +286,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
         // the pipeline in its channelRegistered() implementation.
         channel.eventLoop().execute(() -> {
             if (regFuture.isSuccess()) {
-                channel.bind(localAddress, promise).addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+                channel.bind(localAddress, promise.addListener(ChannelFutureListener.CLOSE_ON_FAILURE));
             } else {
                 promise.setFailure(regFuture.cause());
             }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -259,38 +259,45 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     }
 
     @Override
-    public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
-        return pipeline.bind(localAddress, promise);
+    public Channel bind(SocketAddress localAddress, ChannelPromise promise) {
+        pipeline.bind(localAddress, promise);
+        return this;
     }
 
     @Override
-    public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
-        return pipeline.connect(remoteAddress, promise);
+    public Channel connect(SocketAddress remoteAddress, ChannelPromise promise) {
+        pipeline.connect(remoteAddress, promise);
+        return this;
     }
 
     @Override
-    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-        return pipeline.connect(remoteAddress, localAddress, promise);
+    public Channel connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        pipeline.connect(remoteAddress, localAddress, promise);
+        return this;
     }
 
     @Override
-    public ChannelFuture disconnect(ChannelPromise promise) {
-        return pipeline.disconnect(promise);
+    public Channel disconnect(ChannelPromise promise) {
+        pipeline.disconnect(promise);
+        return this;
     }
 
     @Override
-    public ChannelFuture close(ChannelPromise promise) {
-        return pipeline.close(promise);
+    public Channel close(ChannelPromise promise) {
+        pipeline.close(promise);
+        return this;
     }
 
     @Override
-    public ChannelFuture register(ChannelPromise promise) {
-        return pipeline.register(promise);
+    public Channel register(ChannelPromise promise) {
+        pipeline.register(promise);
+        return this;
     }
 
     @Override
-    public ChannelFuture deregister(ChannelPromise promise) {
-        return pipeline.deregister(promise);
+    public Channel deregister(ChannelPromise promise) {
+        pipeline.deregister(promise);
+        return this;
     }
 
     @Override
@@ -305,8 +312,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     }
 
     @Override
-    public ChannelFuture write(Object msg, ChannelPromise promise) {
-        return pipeline.write(msg, promise);
+    public Channel write(Object msg, ChannelPromise promise) {
+        pipeline.write(msg, promise);
+        return this;
     }
 
     @Override
@@ -315,8 +323,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     }
 
     @Override
-    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-        return pipeline.writeAndFlush(msg, promise);
+    public Channel writeAndFlush(Object msg, ChannelPromise promise) {
+        pipeline.writeAndFlush(msg, promise);
+        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -193,6 +193,33 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     @Override
     Channel flush();
 
+    @Override
+    Channel bind(SocketAddress localAddress, ChannelPromise promise);
+
+    @Override
+    Channel connect(SocketAddress remoteAddress, ChannelPromise promise);
+
+    @Override
+    Channel connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise);
+
+    @Override
+    Channel disconnect(ChannelPromise promise);
+
+    @Override
+    Channel close(ChannelPromise promise);
+
+    @Override
+    Channel register(ChannelPromise promise);
+
+    @Override
+    Channel deregister(ChannelPromise promise);
+
+    @Override
+    Channel write(Object msg, ChannelPromise promise);
+
+    @Override
+    Channel writeAndFlush(Object msg, ChannelPromise promise);
+
     /**
      * <em>Unsafe</em> operations that should <em>never</em> be called from user-code. These methods
      * are only provided to implement the actual transport, and must be invoked from an I/O thread except for the

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -22,6 +22,7 @@ import io.netty.util.AttributeKey;
 import io.netty.util.AttributeMap;
 import io.netty.util.concurrent.EventExecutor;
 
+import java.net.SocketAddress;
 import java.nio.channels.Channels;
 
 /**
@@ -185,6 +186,33 @@ public interface ChannelHandlerContext extends AttributeMap, ChannelInboundInvok
 
     @Override
     ChannelHandlerContext flush();
+
+    @Override
+    ChannelHandlerContext bind(SocketAddress localAddress, ChannelPromise promise);
+
+    @Override
+    ChannelHandlerContext connect(SocketAddress remoteAddress, ChannelPromise promise);
+
+    @Override
+    ChannelHandlerContext connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise);
+
+    @Override
+    ChannelHandlerContext disconnect(ChannelPromise promise);
+
+    @Override
+    ChannelHandlerContext close(ChannelPromise promise);
+
+    @Override
+    ChannelHandlerContext register(ChannelPromise promise);
+
+    @Override
+    ChannelHandlerContext deregister(ChannelPromise promise);
+
+    @Override
+    ChannelHandlerContext write(Object msg, ChannelPromise promise);
+
+    @Override
+    ChannelHandlerContext writeAndFlush(Object msg, ChannelPromise promise);
 
     /**
      * Return the assigned {@link ChannelPipeline}

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
@@ -123,7 +123,7 @@ public interface ChannelOutboundInvoker {
      * called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise);
+    ChannelOutboundInvoker bind(SocketAddress localAddress, ChannelPromise promise);
 
     /**
      * Request to connect to the given {@link SocketAddress} and notify the {@link ChannelFuture} once the operation
@@ -141,7 +141,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise);
+    ChannelOutboundInvoker connect(SocketAddress remoteAddress, ChannelPromise promise);
 
     /**
      * Request to connect to the given {@link SocketAddress} while bind to the localAddress and notify the
@@ -155,7 +155,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise);
+    ChannelOutboundInvoker connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise);
 
     /**
      * Request to disconnect from the remote peer and notify the {@link ChannelFuture} once the operation completes,
@@ -168,7 +168,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelFuture disconnect(ChannelPromise promise);
+    ChannelOutboundInvoker disconnect(ChannelPromise promise);
 
     /**
      * Request to close the {@link Channel} and notify the {@link ChannelFuture} once the operation completes,
@@ -183,7 +183,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelFuture close(ChannelPromise promise);
+    ChannelOutboundInvoker close(ChannelPromise promise);
 
     /**
      * Request to register on the {@link EventExecutor} for I/O processing.
@@ -197,7 +197,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelFuture register(ChannelPromise promise);
+    ChannelOutboundInvoker register(ChannelPromise promise);
 
     /**
      * Request to deregister from the previous assigned {@link EventExecutor} and notify the
@@ -211,7 +211,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelFuture deregister(ChannelPromise promise);
+    ChannelOutboundInvoker deregister(ChannelPromise promise);
 
     /**
      * Request to Read data from the {@link Channel} into the first inbound buffer, triggers an
@@ -239,7 +239,7 @@ public interface ChannelOutboundInvoker {
      * This method will not request to actual flush, so be sure to call {@link #flush()}
      * once you want to request to flush all pending data to the actual transport.
      */
-    ChannelFuture write(Object msg, ChannelPromise promise);
+    ChannelOutboundInvoker write(Object msg, ChannelPromise promise);
 
     /**
      * Request to flush all pending messages via this ChannelOutboundInvoker.
@@ -249,7 +249,7 @@ public interface ChannelOutboundInvoker {
     /**
      * Shortcut for call {@link #write(Object, ChannelPromise)} and {@link #flush()}.
      */
-    ChannelFuture writeAndFlush(Object msg, ChannelPromise promise);
+    ChannelOutboundInvoker writeAndFlush(Object msg, ChannelPromise promise);
 
     /**
      * Shortcut for call {@link #write(Object)} and {@link #flush()}.

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -530,6 +530,36 @@ public interface ChannelPipeline
     @Override
     ChannelPipeline flush();
 
+    @Override
+    ChannelPipeline bind(SocketAddress localAddress, ChannelPromise promise);
+
+    @Override
+    ChannelPipeline connect(SocketAddress remoteAddress, ChannelPromise promise);
+
+    @Override
+    ChannelPipeline connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise);
+
+    @Override
+    ChannelPipeline disconnect(ChannelPromise promise);
+
+    @Override
+    ChannelPipeline close(ChannelPromise promise);
+
+    @Override
+    ChannelPipeline register(ChannelPromise promise);
+
+    @Override
+    ChannelPipeline deregister(ChannelPromise promise);
+
+    @Override
+    ChannelPipeline read();
+
+    @Override
+    ChannelPipeline write(Object msg, ChannelPromise promise);
+
+    @Override
+    ChannelPipeline writeAndFlush(Object msg, ChannelPromise promise);
+
     /**
      * Returns the {@link EventExecutor} which is used by all {@link ChannelHandler}s in the pipeline.
      */

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -461,39 +461,46 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
         }
 
         @Override
-        public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
-            return ctx.bind(localAddress, promise);
+        public ChannelHandlerContext bind(SocketAddress localAddress, ChannelPromise promise) {
+            ctx.bind(localAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
-            return ctx.connect(remoteAddress, promise);
+        public ChannelHandlerContext connect(SocketAddress remoteAddress, ChannelPromise promise) {
+            ctx.connect(remoteAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture connect(
+        public ChannelHandlerContext connect(
                 SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            return ctx.connect(remoteAddress, localAddress, promise);
+            ctx.connect(remoteAddress, localAddress, promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture disconnect(ChannelPromise promise) {
-            return ctx.disconnect(promise);
+        public ChannelHandlerContext disconnect(ChannelPromise promise) {
+            ctx.disconnect(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture close(ChannelPromise promise) {
-            return ctx.close(promise);
+        public ChannelHandlerContext close(ChannelPromise promise) {
+            ctx.close(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture register(ChannelPromise promise) {
-            return ctx.register(promise);
+        public ChannelHandlerContext register(ChannelPromise promise) {
+            ctx.register(promise);
+            return this;
         }
 
         @Override
-        public ChannelFuture deregister(ChannelPromise promise) {
-            return ctx.deregister(promise);
+        public ChannelHandlerContext deregister(ChannelPromise promise) {
+            ctx.deregister(promise);
+            return this;
         }
 
         @Override
@@ -508,8 +515,9 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
         }
 
         @Override
-        public ChannelFuture write(Object msg, ChannelPromise promise) {
-            return ctx.write(msg, promise);
+        public ChannelHandlerContext write(Object msg, ChannelPromise promise) {
+            ctx.write(msg, promise);
+            return this;
         }
 
         @Override
@@ -519,8 +527,9 @@ public class CombinedChannelDuplexHandler<I extends ChannelHandler, O extends Ch
         }
 
         @Override
-        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-            return ctx.writeAndFlush(msg, promise);
+        public ChannelHandlerContext writeAndFlush(Object msg, ChannelPromise promise) {
+            ctx.writeAndFlush(msg, promise);
+            return this;
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
@@ -356,45 +356,59 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
 
     @Override
     public ChannelFuture bind(SocketAddress localAddress) {
-        return bind(localAddress, newPromise());
+        ChannelPromise promise = newPromise();
+        bind(localAddress, promise);
+        return promise;
     }
 
     @Override
     public ChannelFuture connect(SocketAddress remoteAddress) {
-        return connect(remoteAddress, newPromise());
+        ChannelPromise promise = newPromise();
+        connect(remoteAddress, promise);
+        return promise;
     }
 
     @Override
     public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return connect(remoteAddress, localAddress, newPromise());
+        ChannelPromise promise = newPromise();
+        connect(remoteAddress, localAddress, promise);
+        return promise;
     }
 
     @Override
     public ChannelFuture disconnect() {
-        return disconnect(newPromise());
+        ChannelPromise promise = newPromise();
+        disconnect(promise);
+        return promise;
     }
 
     @Override
     public ChannelFuture close() {
-        return close(newPromise());
+        ChannelPromise promise = newPromise();
+        close(promise);
+        return promise;
     }
 
     @Override
     public ChannelFuture register() {
-        return register(newPromise());
+        ChannelPromise promise = newPromise();
+        register(promise);
+        return promise;
     }
 
     @Override
     public ChannelFuture deregister() {
-        return deregister(newPromise());
+        ChannelPromise promise = newPromise();
+        deregister(promise);
+        return promise;
     }
 
     @Override
-    public ChannelFuture bind(final SocketAddress localAddress, final ChannelPromise promise) {
+    public ChannelHandlerContext bind(final SocketAddress localAddress, final ChannelPromise promise) {
         requireNonNull(localAddress, "localAddress");
         if (isNotValidPromise(promise, false)) {
             // cancelled
-            return promise;
+            return this;
         }
 
         EventExecutor executor = executor();
@@ -403,7 +417,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         } else {
             safeExecute(executor, () -> findAndInvokeBind(localAddress, promise), promise, null);
         }
-        return promise;
+        return this;
     }
 
     private void findAndInvokeBind(SocketAddress localAddress, ChannelPromise promise) {
@@ -419,17 +433,17 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     }
 
     @Override
-    public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+    public ChannelHandlerContext connect(SocketAddress remoteAddress, ChannelPromise promise) {
         return connect(remoteAddress, null, promise);
     }
 
     @Override
-    public ChannelFuture connect(
+    public ChannelHandlerContext connect(
             final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
         requireNonNull(remoteAddress, "remoteAddress");
         if (isNotValidPromise(promise, false)) {
             // cancelled
-            return promise;
+            return this;
         }
 
         EventExecutor executor = executor();
@@ -438,7 +452,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         } else {
             safeExecute(executor, () -> findAndInvokeConnect(remoteAddress, localAddress, promise), promise, null);
         }
-        return promise;
+        return this;
     }
 
     private void findAndInvokeConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
@@ -454,7 +468,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     }
 
     @Override
-    public ChannelFuture disconnect(final ChannelPromise promise) {
+    public ChannelHandlerContext disconnect(final ChannelPromise promise) {
         if (!channel().metadata().hasDisconnect()) {
             // Translate disconnect to close if the channel has no notion of disconnect-reconnect.
             // So far, UDP/IP is the only transport that has such behavior.
@@ -463,7 +477,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
 
         if (isNotValidPromise(promise, false)) {
             // cancelled
-            return promise;
+            return this;
         }
 
         EventExecutor executor = executor();
@@ -472,7 +486,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         } else {
             safeExecute(executor, () -> findAndInvokeDisconnect(promise), promise, null);
         }
-        return promise;
+        return this;
     }
 
     private void findAndInvokeDisconnect(ChannelPromise promise) {
@@ -488,10 +502,10 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     }
 
     @Override
-    public ChannelFuture close(final ChannelPromise promise) {
+    public ChannelHandlerContext close(final ChannelPromise promise) {
         if (isNotValidPromise(promise, false)) {
             // cancelled
-            return promise;
+            return this;
         }
 
         EventExecutor executor = executor();
@@ -500,7 +514,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         } else {
             safeExecute(executor, () -> findAndInvokeClose(promise), promise, null);
         }
-        return promise;
+        return this;
     }
 
     private void findAndInvokeClose(ChannelPromise promise) {
@@ -516,10 +530,10 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     }
 
     @Override
-    public ChannelFuture register(final ChannelPromise promise) {
+    public ChannelHandlerContext register(final ChannelPromise promise) {
         if (isNotValidPromise(promise, false)) {
             // cancelled
-            return promise;
+            return this;
         }
 
         EventExecutor executor = executor();
@@ -528,7 +542,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         } else {
             safeExecute(executor, () -> findAndInvokeRegister(promise), promise, null);
         }
-        return promise;
+        return this;
     }
 
     private void findAndInvokeRegister(ChannelPromise promise) {
@@ -544,10 +558,10 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     }
 
     @Override
-    public ChannelFuture deregister(final ChannelPromise promise) {
+    public ChannelHandlerContext deregister(final ChannelPromise promise) {
         if (isNotValidPromise(promise, false)) {
             // cancelled
-            return promise;
+            return this;
         }
 
         EventExecutor executor = executor();
@@ -556,7 +570,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
         } else {
             safeExecute(executor, () -> findAndInvokeDeregister(promise), promise, null);
         }
-        return promise;
+        return this;
     }
 
     private void findAndInvokeDeregister(ChannelPromise promise) {
@@ -605,14 +619,16 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
 
     @Override
     public ChannelFuture write(Object msg) {
-        return write(msg, newPromise());
+        ChannelPromise promise = newPromise();
+        write(msg, promise);
+        return promise;
     }
 
     @Override
-    public ChannelFuture write(final Object msg, final ChannelPromise promise) {
+    public ChannelHandlerContext write(final Object msg, final ChannelPromise promise) {
         write(msg, false, promise);
 
-        return promise;
+        return this;
     }
 
     private void invokeWrite(Object msg, ChannelPromise promise) {
@@ -650,9 +666,9 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
     }
 
     @Override
-    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+    public ChannelHandlerContext writeAndFlush(Object msg, ChannelPromise promise) {
         write(msg, true, promise);
-        return promise;
+        return this;
     }
 
     private void invokeWriteAndFlush(Object msg, ChannelPromise promise) {
@@ -701,7 +717,9 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
 
     @Override
     public ChannelFuture writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
+        ChannelPromise promise = newPromise();
+        writeAndFlush(msg, promise);
+        return promise;
     }
 
     private static void notifyOutboundHandlerException(Throwable cause, ChannelPromise promise) {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -923,39 +923,46 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
-        return tail.bind(localAddress, promise);
+    public final ChannelPipeline bind(SocketAddress localAddress, ChannelPromise promise) {
+        tail.bind(localAddress, promise);
+        return this;
     }
 
     @Override
-    public final ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
-        return tail.connect(remoteAddress, promise);
+    public final ChannelPipeline connect(SocketAddress remoteAddress, ChannelPromise promise) {
+        tail.connect(remoteAddress, promise);
+        return this;
     }
 
     @Override
-    public final ChannelFuture connect(
+    public final ChannelPipeline connect(
             SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-        return tail.connect(remoteAddress, localAddress, promise);
+        tail.connect(remoteAddress, localAddress, promise);
+        return this;
     }
 
     @Override
-    public final ChannelFuture disconnect(ChannelPromise promise) {
-        return tail.disconnect(promise);
+    public final ChannelPipeline disconnect(ChannelPromise promise) {
+        tail.disconnect(promise);
+        return this;
     }
 
     @Override
-    public final ChannelFuture close(ChannelPromise promise) {
-        return tail.close(promise);
+    public final ChannelPipeline close(ChannelPromise promise) {
+        tail.close(promise);
+        return this;
     }
 
     @Override
-    public final ChannelFuture register(final ChannelPromise promise) {
-        return tail.register(promise);
+    public final ChannelPipeline register(final ChannelPromise promise) {
+        tail.register(promise);
+        return this;
     }
 
     @Override
-    public final ChannelFuture deregister(final ChannelPromise promise) {
-        return tail.deregister(promise);
+    public final ChannelPipeline deregister(final ChannelPromise promise) {
+        tail.deregister(promise);
+        return this;
     }
 
     @Override
@@ -970,13 +977,15 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final ChannelFuture write(Object msg, ChannelPromise promise) {
-        return tail.write(msg, promise);
+    public final ChannelPipeline write(Object msg, ChannelPromise promise) {
+        tail.write(msg, promise);
+        return this;
     }
 
     @Override
-    public final ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
-        return tail.writeAndFlush(msg, promise);
+    public final ChannelPipeline writeAndFlush(Object msg, ChannelPromise promise) {
+        tail.writeAndFlush(msg, promise);
+        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -219,7 +219,8 @@ public final class PendingWriteQueue {
         Object msg = write.msg;
         ChannelPromise promise = write.promise;
         recycle(write, true);
-        return ctx.write(msg, promise);
+        ctx.write(msg, promise);
+        return promise;
     }
 
     /**

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -16,6 +16,7 @@
 
 package io.netty.bootstrap;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
@@ -177,11 +178,12 @@ public class BootstrapTest {
                         }
 
                         @Override
-                        public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+                        public Channel bind(SocketAddress localAddress, ChannelPromise promise) {
                             // Close the Channel to emulate what NIO and others impl do on bind failure
                             // See https://github.com/netty/netty/issues/2586
                             close();
-                            return promise.setFailure(new SocketException());
+                            promise.setFailure(new SocketException());
+                            return this;
                         }
                     });
             bootstrap.childHandler(new DummyHandler());

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -41,6 +41,7 @@ public class AbstractChannelTest {
 
         registerChannel(channel);
 
+        Thread.sleep(1000);
         verify(handler).handlerAdded(any(ChannelHandlerContext.class));
         verify(handler).channelRegistered(any(ChannelHandlerContext.class));
         verify(handler).channelActive(any(ChannelHandlerContext.class));

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -503,8 +503,8 @@ public class DefaultChannelPipelineTest {
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        ChannelFuture future = pipeline.bind(new LocalAddress("test"), promise);
-        assertTrue(future.isCancelled());
+        pipeline.bind(new LocalAddress("test"), promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -514,8 +514,8 @@ public class DefaultChannelPipelineTest {
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        ChannelFuture future = pipeline.connect(new LocalAddress("test"), promise);
-        assertTrue(future.isCancelled());
+        pipeline.connect(new LocalAddress("test"), promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -525,8 +525,8 @@ public class DefaultChannelPipelineTest {
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        ChannelFuture future = pipeline.disconnect(promise);
-        assertTrue(future.isCancelled());
+        pipeline.disconnect(promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -536,8 +536,8 @@ public class DefaultChannelPipelineTest {
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        ChannelFuture future = pipeline.close(promise);
-        assertTrue(future.isCancelled());
+        pipeline.close(promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -590,8 +590,8 @@ public class DefaultChannelPipelineTest {
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        ChannelFuture future = pipeline.deregister(promise);
-        assertTrue(future.isCancelled());
+        pipeline.deregister(promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -603,8 +603,8 @@ public class DefaultChannelPipelineTest {
         assertTrue(promise.cancel(false));
         ByteBuf buffer = Unpooled.buffer();
         assertEquals(1, buffer.refCnt());
-        ChannelFuture future = pipeline.write(buffer, promise);
-        assertTrue(future.isCancelled());
+        pipeline.write(buffer, promise);
+        assertTrue(promise.isCancelled());
         assertEquals(0, buffer.refCnt());
     }
 
@@ -617,8 +617,8 @@ public class DefaultChannelPipelineTest {
         assertTrue(promise.cancel(false));
         ByteBuf buffer = Unpooled.buffer();
         assertEquals(1, buffer.refCnt());
-        ChannelFuture future = pipeline.writeAndFlush(buffer, promise);
-        assertTrue(future.isCancelled());
+        pipeline.writeAndFlush(buffer, promise);
+        assertTrue(promise.isCancelled());
         assertEquals(0, buffer.refCnt());
     }
 

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -367,10 +367,10 @@ public class SingleThreadEventLoopTest {
         }
 
         try {
-            ChannelFuture f = ch.register(promise);
-            f.awaitUninterruptibly();
-            assertFalse(f.isSuccess());
-            assertThat(f.cause(), is(instanceOf(RejectedExecutionException.class)));
+            ch.register(promise);
+            promise.awaitUninterruptibly();
+            assertFalse(promise.isSuccess());
+            assertThat(promise.cause(), is(instanceOf(RejectedExecutionException.class)));
 
             // Ensure the listener was notified.
             assertFalse(latch.await(1, TimeUnit.SECONDS));

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -181,14 +181,22 @@ public class EmbeddedChannelTest {
     @Test(timeout = 2000)
     public void testFireChannelInactiveAndUnregisteredOnClose() throws InterruptedException {
         testFireChannelInactiveAndUnregistered(ChannelOutboundInvoker::close);
-        testFireChannelInactiveAndUnregistered(channel -> channel.close(channel.newPromise()));
+        testFireChannelInactiveAndUnregistered(channel -> {
+            ChannelPromise promise = channel.newPromise();
+            channel.close(promise);
+            return promise;
+        });
     }
 
     @Test(timeout = 2000)
     public void testFireChannelInactiveAndUnregisteredOnDisconnect() throws InterruptedException {
         testFireChannelInactiveAndUnregistered(ChannelOutboundInvoker::disconnect);
 
-        testFireChannelInactiveAndUnregistered(channel -> channel.disconnect(channel.newPromise()));
+        testFireChannelInactiveAndUnregistered(channel -> {
+            ChannelPromise promise = channel.newPromise();
+            channel.disconnect(promise);
+            return promise;
+        });
     }
 
     private static void testFireChannelInactiveAndUnregistered(Action action) throws InterruptedException {

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -720,7 +720,7 @@ public class LocalChannelTest {
 
                 // Make sure a write operation is executed in the eventloop
                 cc.pipeline().lastContext().executor().execute(() ->
-                        ccCpy.writeAndFlush(data.retainedDuplicate(), ccCpy.newPromise())
+                        ccCpy.writeAndFlush(data.retainedDuplicate(), ccCpy.newPromise()
                 .addListener((ChannelFutureListener) future -> {
                     serverChannelCpy.eventLoop().execute(() -> {
                         // The point of this test is to write while the peer is closed, so we should
@@ -737,16 +737,16 @@ public class LocalChannelTest {
                             }
                         }
                         serverChannelCpy.writeAndFlush(data2.retainedDuplicate(),
-                            serverChannelCpy.newPromise())
+                            serverChannelCpy.newPromise()
                             .addListener((ChannelFutureListener) future1 -> {
                                 if (!future1.isSuccess() &&
                                     future1.cause() instanceof ClosedChannelException) {
                                     writeFailLatch.countDown();
                                 }
-                            });
+                            }));
                     });
                     ccCpy.close();
-                }));
+                })));
 
                 assertTrue(serverMessageLatch.await(5, SECONDS));
                 assertTrue(writeFailLatch.await(5, SECONDS));
@@ -805,7 +805,8 @@ public class LocalChannelTest {
                 }
             });
             // Connect to the server
-            cc.connect(sc.localAddress(), promise).sync();
+            cc.connect(sc.localAddress(), promise);
+            promise.sync();
 
             assertPromise.syncUninterruptibly();
             assertTrue(promise.isSuccess());


### PR DESCRIPTION
…d not return ChannelFuture.

Motivation:

At the moment we most of the times offer two different variants for outbound operations. One which takes no ChannelPromise as an argument and the other one that takes ChannelPromise as last parameter, both return ChannelFuture at the end.

We should change the method that takes ChannelPromise to NOT return ChannelFuture but just "itself". This way it is more clear which instance will receive the notification at the end and it also does allow us to do futher changes that will help to remove the VoidPromise / VoidChannelPromise all together and so make the contract and handling more clear.

Modifications:

Change ChannelOutboundInvoker methods that take ChannelPromise as an argument to not return ChannelFuture

Result:

More clear API which allows to futher optimizations.