### PR TITLE
Fixed toString() exception in MqttSubscribePayload and MqttUnsubscribePayload

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribePayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribePayload.java
@@ -39,11 +39,12 @@ public final class MqttSubscribePayload {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(StringUtil.simpleClassName(this)).append('[');
-        for (int i = 0; i < topicSubscriptions.size() - 1; i++) {
-            builder.append(topicSubscriptions.get(i)).append(", ");
+        for (MqttTopicSubscription subscription : topicSubscriptions) {
+            builder.append(subscription).append(", ");
         }
-        builder.append(topicSubscriptions.get(topicSubscriptions.size() - 1));
-        builder.append(']');
-        return builder.toString();
+        if (!topicSubscriptions.isEmpty()) {
+            builder.setLength(builder.length() - 2);
+        }
+        return builder.append(']').toString();
     }
 }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribePayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribePayload.java
@@ -39,8 +39,8 @@ public final class MqttSubscribePayload {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(StringUtil.simpleClassName(this)).append('[');
-        for (MqttTopicSubscription subscription : topicSubscriptions) {
-            builder.append(subscription).append(", ");
+        for (int i = 0; i < topicSubscriptions.size(); i++) {
+            builder.append(topicSubscriptions.get(i)).append(", ");
         }
         if (!topicSubscriptions.isEmpty()) {
             builder.setLength(builder.length() - 2);

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribePayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribePayload.java
@@ -39,8 +39,8 @@ public final class MqttUnsubscribePayload {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(StringUtil.simpleClassName(this)).append('[');
-        for (String subscription : topics) {
-            builder.append("topicName = ").append(subscription).append(", ");
+        for (int i = 0; i < topics.size(); i++) {
+            builder.append("topicName = ").append(topics.get(i)).append(", ");
         }
         if (!topics.isEmpty()) {
             builder.setLength(builder.length() - 2);

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribePayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribePayload.java
@@ -39,11 +39,12 @@ public final class MqttUnsubscribePayload {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(StringUtil.simpleClassName(this)).append('[');
-        for (int i = 0; i < topics.size() - 1; i++) {
-            builder.append("topicName = ").append(topics.get(i)).append(", ");
+        for (String subscription : topics) {
+            builder.append("topicName = ").append(subscription).append(", ");
         }
-        builder.append("topicName = ").append(topics.get(topics.size() - 1))
-               .append(']');
-        return builder.toString();
+        if (!topics.isEmpty()) {
+            builder.setLength(builder.length() - 2);
+        }
+        return builder.append("]").toString();
     }
 }

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttConnectPayloadTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttConnectPayloadTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertNull;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
+import java.util.Collections;
+
 public class MqttConnectPayloadTest {
 
     @Test
@@ -87,5 +89,12 @@ public class MqttConnectPayloadTest {
 
         assertNull(mqttConnectPayload.willMessageInBytes());
         assertNull(mqttConnectPayload.willMessage());
+    }
+
+    /* See https://github.com/netty/netty/pull/9202 */
+    @Test
+    public void testEmptyTopicsToString() {
+        new MqttSubscribePayload(Collections.<MqttTopicSubscription>emptyList()).toString();
+        new MqttUnsubscribePayload(Collections.<String>emptyList()).toString();
     }
 }


### PR DESCRIPTION
Motivation:
The toString() methods of MqttSubscribePayload and MqttUnsubscribePayload are causing excpetions when no topics are set.

Modification:
The toString() methods will not throw Excpetions anymore.

Fixes #9197
