### PR TITLE
Allow null sender when using DatagramPacketEncoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DatagramPacketEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DatagramPacketEncoder.java
@@ -63,7 +63,7 @@ public class DatagramPacketEncoder<M> extends MessageToMessageEncoder<AddressedE
             @SuppressWarnings("rawtypes")
             AddressedEnvelope envelope = (AddressedEnvelope) msg;
             return encoder.acceptOutboundMessage(envelope.content())
-                    && envelope.sender() instanceof InetSocketAddress
+                    && (envelope.sender() instanceof InetSocketAddress || envelope.sender() == null)
                     && envelope.recipient() instanceof InetSocketAddress;
         }
         return false;

--- a/codec/src/test/java/io/netty/handler/codec/DatagramPacketEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DatagramPacketEncoderTest.java
@@ -51,8 +51,17 @@ public class DatagramPacketEncoderTest {
 
     @Test
     public void testEncode() {
+        testEncode(false);
+    }
+
+    @Test
+    public void testEncodeWithSenderIsNull() {
+        testEncode(true);
+    }
+
+    private void testEncode(boolean senderIsNull) {
         InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
-        InetSocketAddress sender = SocketUtils.socketAddress("127.0.0.1", 20000);
+        InetSocketAddress sender = senderIsNull ? null : SocketUtils.socketAddress("127.0.0.1", 20000);
         assertTrue(channel.writeOutbound(
                 new DefaultAddressedEnvelope<String, InetSocketAddress>("netty", recipient, sender)));
         DatagramPacket packet = channel.readOutbound();


### PR DESCRIPTION
Motivation:

It is valid to use null as sender so we should support it when DatagramPacketEncoder checks if it supports the message.

Modifications:

- Add null check
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/9199.