### PR TITLE
Close delegate resolver from RoundRobinInetAddressResolver

### DIFF
--- a/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
@@ -100,4 +100,9 @@ public class RoundRobinInetAddressResolver extends InetNameResolver {
     private static int randomIndex(int numAddresses) {
         return numAddresses == 1 ? 0 : PlatformDependent.threadLocalRandom().nextInt(numAddresses);
     }
+
+    @Override
+    public void close() {
+        nameResolver.close();
+    }
 }


### PR DESCRIPTION
Motivation:

`RoundRobinDnsAddressResolverGroup` ultimately opens UDP ports for DNS resolution. Callers likely expect that [`RoundRobinDnsAddressResolverGroup#close()`](https://netty.io/4.1/api/io/netty/resolver/AddressResolverGroup.html#close--) will close those ports, but that is not currently true (see #9212).

Modifications:

Overrode `RoundRobinInetAddressResolver#close()` to close the delegate name resolver, which in turn closes any UDP ports used for name resolution.

Result:

`RoundRobinDnsAddressResolverGroup#close()` closes UDP ports as expected. This fixes #9212.