### PR TITLE
Minimize task queue access in epoll event loop

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -400,8 +400,8 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * Poll all tasks from the task queue and run them via {@link Runnable#run()} method.  This method stops running
      * the tasks in the task queue and returns if it ran longer than {@code timeoutNanos}.
      *
-     * @return if {@code returnTrueIfTasksRemain} is true returns whether any tasks from the main queue were run,
-     *     otherwise whether any tasks remain due to timeout
+     * @return if {@code returnTrueIfTasksRemain} is true returns whether any any tasks remain due to timeout,
+     *     otherwise returns whether any tasks from the main queue were run
      */
     protected boolean runAllTasks(long timeoutNanos, boolean returnTrueIfTasksRemain) {
         fetchFromScheduledTaskQueue();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -284,11 +284,12 @@ class EpollEventLoop extends SingleThreadEventLoop {
                         break;
 
                     case SelectStrategy.SELECT:
-                        if (wakenUp == 1) {
-                            wakenUp = 0;
-                        }
-                        if (!hasTasks && !hasTasks()) {
+                        wakenUp = 0;
+                        if (!hasTasks()) {
                             strategy = epollWait();
+                        }
+                        if (strategy > 0 || wakenUp == 0) {
+                            wakenUp = 1;
                         }
                         // fallthrough
                     default:


### PR DESCRIPTION
Motivation

This is a follow-on change to #9191 which simplified the event loop task wakeup coordination. There are still redundant checks for task existence, which aren't free since they each involve 4 separate volatile reads, at least one of which is possibly contended.

Modifications
Add a variant of `SingleThreadEventExecutor#runAllTasks(long)` whose return value indicates whether any tasks still remain, rather than whether any were run. This is used to avoid immediately re-checking the queue after it's just been processed. Add a local `hasTasks` variable in the event loop run() method to keep track of whether or not outstanding tasks are known to be in the queue.

Result

Less coordination overhead in epoll event loop