### PR TITLE
Change Scheduled to FixedRate in Traffic Counter

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficCounter.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficCounter.java
@@ -78,8 +78,6 @@ public class GlobalChannelTrafficCounter extends TrafficCounter {
                 perChannel.channelTrafficCounter.resetAccounting(newLastTime);
             }
             trafficShapingHandler1.doAccounting(counter);
-            counter.scheduledFuture = counter.executor.schedule(this, counter.checkInterval.get(),
-                                                                TimeUnit.MILLISECONDS);
         }
     }
 
@@ -97,7 +95,7 @@ public class GlobalChannelTrafficCounter extends TrafficCounter {
             monitorActive = true;
             monitor = new MixedTrafficMonitoringTask((GlobalChannelTrafficShapingHandler) trafficShapingHandler, this);
             scheduledFuture =
-                executor.schedule(monitor, localCheckInterval, TimeUnit.MILLISECONDS);
+                executor.scheduleAtFixedRate(monitor, 0, localCheckInterval, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
+++ b/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
@@ -174,7 +174,6 @@ public class TrafficCounter {
             if (trafficShapingHandler != null) {
                 trafficShapingHandler.doAccounting(TrafficCounter.this);
             }
-            scheduledFuture = executor.schedule(this, checkInterval.get(), TimeUnit.MILLISECONDS);
         }
     }
 
@@ -192,7 +191,7 @@ public class TrafficCounter {
             monitorActive = true;
             monitor = new TrafficMonitoringTask();
             scheduledFuture =
-                executor.schedule(monitor, localCheckInterval, TimeUnit.MILLISECONDS);
+                executor.scheduleAtFixedRate(monitor, 0, localCheckInterval, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -317,7 +316,8 @@ public class TrafficCounter {
                 // No more active monitoring
                 lastTime.set(milliSecondFromNano());
             } else {
-                // Start if necessary
+                // Restart
+                stop();
                 start();
             }
         }


### PR DESCRIPTION
Motivation:

Traffic shaping needs more accurate execution than scheduled one. So the
use of FixedRate instead.

Modifications:

Change the executor.schedule to executor.scheduleAtFixedRate in the
start and remove the reschedule call from run monitor thread since it
will be restarted by the Fixed rate executor.
Also fix a minor bug where restart was only doing start() without stop()
before.

Result:

The precision of traffic shaping is enhanced.
