### PR TITLE
codec-http2: Lazily translate cookies for HTTP/1

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
+import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.URI;
@@ -647,8 +648,7 @@ public final class HttpConversionUtil {
                     // combine the cookie values into 1 header entry.
                     // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
                     if (cookies == null) {
-                        // sized to leave space for further growth.
-                        cookies = new StringBuilder(value.length() + 512);
+                        cookies = InternalThreadLocalMap.get().stringBuilder();
                     } else if (cookies.length() > 0) {
                         cookies.append("; ");
                     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -17,10 +17,12 @@ package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
 import org.junit.Test;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.COOKIE;
 import static io.netty.handler.codec.http.HttpHeaderNames.TE;
 import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
 import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
@@ -142,5 +144,19 @@ public class HttpConversionUtilTest {
         HttpConversionUtil.toHttp2Headers(inHeaders, out);
         assertEquals(1, out.size());
         assertSame("world", out.get("hello"));
+    }
+
+    @Test
+    public void addHttp2ToHttpHeadersCombinesCookies() throws Http2Exception {
+        Http2Headers inHeaders = new DefaultHttp2Headers();
+        inHeaders.add("yes", "no");
+        inHeaders.add(COOKIE, "foo=bar");
+        inHeaders.add(COOKIE, "bax=baz");
+
+        HttpHeaders outHeaders = new DefaultHttpHeaders();
+
+        HttpConversionUtil.addHttp2ToHttpHeaders(5, inHeaders, outHeaders, HttpVersion.HTTP_1_1, false, false);
+        assertEquals("no", outHeaders.get("yes"));
+        assertEquals("foo=bar; bax=baz", outHeaders.get(COOKIE.toString()));
     }
 }


### PR DESCRIPTION
Motivation:

For HTTP/2 messages with multiple cookies `HttpConversionUtil.addHttp2ToHttpHeaders` spends a good portion of time creating throwaway StringBuilders.

Modification:

Handle cookies lazily by building up a single StringBuilder and then converting it to the H1 header at the end.

Result:

Less allocations.