### PR TITLE
Try to mark child channel writable again once the parent channel beco…

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -704,18 +703,36 @@ public class Http2MultiplexCodecTest {
         long bytesBeforeUnwritable = childChannel.bytesBeforeUnwritable();
         assertNotEquals(0, bytesBeforeUnwritable);
         // Add something to the ChannelOutboundBuffer of the parent to simulate queuing in the parents channel buffer
-        // and verify that this also effects the child channel in terms of writability.
+        // and verify that this only affect the writability of the parent channel while the child stays writable
+        // until it used all of its credits.
         parentChannel.unsafe().outboundBuffer().addMessage(
                 Unpooled.buffer().writeZero(800), 800, parentChannel.voidPromise());
         assertFalse(parentChannel.isWritable());
-        assertFalse(childChannel.isWritable());
-        assertEquals(0, childChannel.bytesBeforeUnwritable());
+
+        assertTrue(childChannel.isWritable());
+        assertEquals(4096, childChannel.bytesBeforeUnwritable());
 
         // Flush everything which simulate writing everything to the socket.
         parentChannel.flush();
         assertTrue(parentChannel.isWritable());
         assertTrue(childChannel.isWritable());
         assertEquals(bytesBeforeUnwritable, childChannel.bytesBeforeUnwritable());
+
+        ChannelFuture future = childChannel.writeAndFlush(new DefaultHttp2DataFrame(
+                Unpooled.buffer().writeZero((int) bytesBeforeUnwritable)));
+        assertFalse(childChannel.isWritable());
+        assertTrue(parentChannel.isWritable());
+
+        parentChannel.flush();
+        assertFalse(future.isDone());
+        assertTrue(parentChannel.isWritable());
+        assertFalse(childChannel.isWritable());
+
+        // Now write an window update frame for the stream which then should ensure we will flush the bytes that were
+        // queued in the RemoteFlowController before for the stream.
+        frameInboundWriter.writeInboundWindowUpdate(childChannel.stream().id(), (int) bytesBeforeUnwritable);
+        assertTrue(childChannel.isWritable());
+        assertTrue(future.isDone());
     }
 
     @Test


### PR DESCRIPTION
…mes writable

Motivation:

f945a071db4d499d21142d3aa321ce8070616665 decoupled the writability state from the flow controller but could lead to the situation of a lot of writability updates events were propagated to the child channels. This change ensure we only take into account if the parent channel becomes writable again before we try to set the child channels to writable.

Modifications:

Only listen for channel writability changes for if the parent channel becomes writable again.

Result:

Less writability updates.