### PR TITLE
Use fast HPACK comparisons when not checking sensitive headers

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHeaderField.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHeaderField.java
@@ -31,6 +31,7 @@
  */
 package io.netty.handler.codec.http2;
 
+import static io.netty.handler.codec.http2.HpackUtil.equalsVariableTime;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 class HpackHeaderField {
@@ -57,23 +58,8 @@ class HpackHeaderField {
         return name.length() + value.length() + HEADER_ENTRY_OVERHEAD;
     }
 
-    @Override
-    public final int hashCode() {
-        // TODO(nmittler): Netty's build rules require this. Probably need a better implementation.
-        return super.hashCode();
-    }
-
-    @Override
-    public final boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
-        if (!(obj instanceof HpackHeaderField)) {
-            return false;
-        }
-        HpackHeaderField other = (HpackHeaderField) obj;
-        // To avoid short circuit behavior a bitwise operator is used instead of a boolean operator.
-        return (HpackUtil.equalsConstantTime(name, other.name) & HpackUtil.equalsConstantTime(value, other.value)) != 0;
+    public final boolean equalsForTest(HpackHeaderField other) {
+        return equalsVariableTime(name, other.name) && equalsVariableTime(value, other.value);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.netty.handler.codec.http2.HpackUtil.equalsConstantTime;
+import static io.netty.handler.codec.http2.HpackUtil.equalsVariableTime;
 
 final class HpackStaticTable {
 
@@ -145,7 +146,7 @@ final class HpackStaticTable {
      * Returns the index value for the given header field in the static table. Returns -1 if the
      * header field is not in the static table.
      */
-    static int getIndex(CharSequence name, CharSequence value) {
+    static int getIndexInsensitive(CharSequence name, CharSequence value) {
         int index = getIndex(name);
         if (index == -1) {
             return -1;
@@ -154,10 +155,7 @@ final class HpackStaticTable {
         // Note this assumes all entries for a given header field are sequential.
         while (index <= length) {
             HpackHeaderField entry = getEntry(index);
-            if (equalsConstantTime(name, entry.name) == 0) {
-                break;
-            }
-            if (equalsConstantTime(value, entry.value) != 0) {
+            if (equalsVariableTime(name, entry.name) && equalsVariableTime(value, entry.value)) {
                 return index;
             }
             index++;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackUtil.java
@@ -65,6 +65,16 @@ final class HpackUtil {
         return ConstantTimeUtils.equalsConstantTime(s1, s2);
     }
 
+    /**
+     * Compare two {@link CharSequence}s.
+     * @param s1 the first value.
+     * @param s2 the second value.
+     * @return {@code false} if not equal. {@code true} if equal.
+     */
+    static boolean equalsVariableTime(CharSequence s1, CharSequence s2) {
+        return AsciiString.contentEquals(s1, s2);
+    }
+
     // Section 6.2. Literal Header Field Representation
     enum IndexType {
         INCREMENTAL, // Section 6.2.1. Literal Header Field with Incremental Indexing

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
@@ -102,7 +102,7 @@ final class HpackTestCase {
 
             List<HpackHeaderField> expectedDynamicTable = headerBlock.getDynamicTable();
 
-            if (!expectedDynamicTable.equals(actualDynamicTable)) {
+            if (!headersEqual(expectedDynamicTable, actualDynamicTable)) {
                 throw new AssertionError(
                         "\nEXPECTED DYNAMIC TABLE:\n" + expectedDynamicTable +
                                 "\nACTUAL DYNAMIC TABLE:\n" + actualDynamicTable);
@@ -128,7 +128,7 @@ final class HpackTestCase {
                 expectedHeaders.add(new HpackHeaderField(h.name, h.value));
             }
 
-            if (!expectedHeaders.equals(actualHeaders)) {
+            if (!headersEqual(expectedHeaders, actualHeaders)) {
                 throw new AssertionError(
                         "\nEXPECTED:\n" + expectedHeaders +
                                 "\nACTUAL:\n" + actualHeaders);
@@ -141,7 +141,7 @@ final class HpackTestCase {
 
             List<HpackHeaderField> expectedDynamicTable = headerBlock.getDynamicTable();
 
-            if (!expectedDynamicTable.equals(actualDynamicTable)) {
+            if (!headersEqual(expectedDynamicTable, actualDynamicTable)) {
                 throw new AssertionError(
                         "\nEXPECTED DYNAMIC TABLE:\n" + expectedDynamicTable +
                                 "\nACTUAL DYNAMIC TABLE:\n" + actualDynamicTable);
@@ -227,6 +227,18 @@ final class HpackTestCase {
             ret.append(s);
         }
         return ret.toString();
+    }
+
+    private static boolean headersEqual(List<HpackHeaderField> expected, List<HpackHeaderField> actual) {
+        if (expected.size() != actual.size()) {
+            return false;
+        }
+        for (int i = 0; i < expected.size(); i++) {
+            if (!expected.get(i).equalsForTest(actual.get(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     static class HeaderBlock {


### PR DESCRIPTION
Motivation:
Constant time comparison functions are used to compare HTTP/2 header
values, even if they are not sensitive.

Modification:
After checking for sensitivity, use fast comparison.

Result: Faster HPACK table reads/writes
