### PR TITLE
Return the result of the list.recycle() call

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/internal/RecyclableArrayListBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/internal/RecyclableArrayListBenchmark.java
@@ -36,8 +36,8 @@ public class RecyclableArrayListBenchmark extends AbstractMicrobenchmark {
     public int size;
 
     @Benchmark
-    public void recycleSameThread() {
+    public boolean recycleSameThread() {
         RecyclableArrayList list = RecyclableArrayList.newInstance(size);
-        list.recycle();
+        return list.recycle();
     }
 }


### PR DESCRIPTION
Motivation:

Resolve the issue highlighted by SpotJMHBugs that the creation of the RecyclableArrayList may be elided by the JIT since the result isn't consumed or returned.

Modifications:

Return the result of `list.recycle()` so that the list isn't elided.

Result:

The JMH benchmark shows a change in performance indicating that the prior results of this may be unsound.
