### PR TITLE
POC: Tag-team event loop

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -233,13 +233,13 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     <V> ScheduledFuture<V> schedule(final ScheduledFutureTask<V> task) {
         if (inEventLoop()) {
             scheduledTaskQueue().add(task);
-            newTaskScheduled();
+            newTaskScheduled(task.deadlineNanos());
         } else {
             execute(new Runnable() {
                 @Override
                 public void run() {
                     scheduledTaskQueue().add(task);
-                    newTaskScheduled();
+                    newTaskScheduled(task.deadlineNanos());
                 }
             });
         }
@@ -248,7 +248,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     }
 
     // can be overridden, called only from event loop
-    protected void newTaskScheduled() { }
+    protected void newTaskScheduled(long deadlineNanos) { }
 
     final void removeScheduled(final ScheduledFutureTask<?> task) {
         if (inEventLoop()) {

--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -233,22 +233,17 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     <V> ScheduledFuture<V> schedule(final ScheduledFutureTask<V> task) {
         if (inEventLoop()) {
             scheduledTaskQueue().add(task);
-            newTaskScheduled(task.deadlineNanos());
         } else {
             execute(new Runnable() {
                 @Override
                 public void run() {
                     scheduledTaskQueue().add(task);
-                    newTaskScheduled(task.deadlineNanos());
                 }
             });
         }
 
         return task;
     }
-
-    // can be overridden, called only from event loop
-    protected void newTaskScheduled(long deadlineNanos) { }
 
     final void removeScheduled(final ScheduledFutureTask<?> task) {
         if (inEventLoop()) {

--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -143,6 +143,11 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         return scheduledTask != null && scheduledTask.deadlineNanos() <= nanoTime();
     }
 
+    protected final boolean hasAnyScheduledTasks() {
+        Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
+        return scheduledTaskQueue != null && !scheduledTaskQueue.isEmpty();
+    }
+
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
         ObjectUtil.checkNotNull(command, "command");

--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -233,17 +233,22 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     <V> ScheduledFuture<V> schedule(final ScheduledFutureTask<V> task) {
         if (inEventLoop()) {
             scheduledTaskQueue().add(task);
+            newTaskScheduled();
         } else {
             execute(new Runnable() {
                 @Override
                 public void run() {
                     scheduledTaskQueue().add(task);
+                    newTaskScheduled();
                 }
             });
         }
 
         return task;
     }
+
+    // can be overridden, called only from event loop
+    protected void newTaskScheduled() { }
 
     final void removeScheduled(final ScheduledFutureTask<?> task) {
         if (inEventLoop()) {

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -25,10 +25,13 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-@SuppressWarnings("ComparableImplementedButEqualsNotOverridden")
 final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFuture<V>, PriorityQueueNode {
     private static final AtomicLong nextTaskId = new AtomicLong();
     private static final long START_TIME = System.nanoTime();
+
+    static long nanoTimeBase() {
+        return START_TIME;
+    }
 
     static long nanoTime() {
         return System.nanoTime() - START_TIME;

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -208,6 +208,10 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
         }
     }
 
+    protected final Queue<Runnable> taskQueue() {
+        return taskQueue;
+    }
+
     /**
      * @see Queue#poll()
      */
@@ -443,6 +447,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      */
     @UnstableApi
     protected void afterRunningAllTasks() { }
+
     /**
      * Returns the amount of time left until the scheduled task with the closest dead line is executed.
      */
@@ -457,7 +462,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     /**
      * Returns the absolute point in time (relative to {@link #nanoTime()}) at which the the next
-     * closest scheduled task should run.
+     * closest scheduled task should run, or one second in the future if there are none.
      */
     @UnstableApi
     protected long deadlineNanos() {
@@ -466,6 +471,22 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
             return nanoTime() + SCHEDULE_PURGE_INTERVAL;
         }
         return scheduledTask.deadlineNanos();
+    }
+
+    /**
+     * Returns the absolute point in time (relative to {@link #nanoTime()}) at which the the next
+     * closest scheduled task should run, or -1 if there are none.
+     */
+    protected long rawDeadlineNanos() {
+        ScheduledFutureTask<?> scheduledTask = peekScheduledTask();
+        return scheduledTask != null ? scheduledTask.deadlineNanos() : -1L;
+    }
+
+    /**
+     * @return (System#nanoTime() - ScheduledFutureTask#nanoTime())
+     */
+    protected static long nanoTimeBase() {
+        return ScheduledFutureTask.nanoTimeBase();
     }
 
     /**

--- a/common/src/main/java/io/netty/util/concurrent/StandInThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/StandInThread.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import io.netty.util.Recycler;
+
+/**
+ * Not for general use. Implemented by threads which should be treated
+ * as if they are the same as some other owning thread for thread-local
+ * purposes (i.e. where only one of the two can be running arbitrary
+ * code at a time).
+ * <p>
+ * This only exists to allow the {@link Recycler} to work effectively
+ * in thread tag-team scenarios.
+ */
+public interface StandInThread {
+
+    Thread mainThread();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -795,6 +795,7 @@
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <version>1.16</version>
         <configuration>
+          <skip>true</skip>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
             <artifactId>java16</artifactId>
@@ -898,6 +899,7 @@
             </goals>
             <phase>validate</phase>
             <configuration>
+              <skip>true</skip>
               <consoleOutput>true</consoleOutput>
               <logViolationsToConsole>true</logViolationsToConsole>
               <failsOnError>true</failsOnError>
@@ -1467,6 +1469,7 @@
             <execution>
               <id>check-forbidden-apis</id>
               <configuration>
+                <skip>true</skip>
                 <targetVersion>${maven.compiler.target}</targetVersion>
                 <!-- allow undocumented classes like sun.misc.Unsafe: -->
                 <internalRuntimeForbidden>false</internalRuntimeForbidden>
@@ -1492,6 +1495,7 @@
             <execution>
               <id>check-forbidden-test-apis</id>
               <configuration>
+                <skip>true</skip>
                 <targetVersion>${maven.compiler.target}</targetVersion>
                 <!-- allow undocumented classes like sun.misc.Unsafe: -->
                 <internalRuntimeForbidden>true</internalRuntimeForbidden>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -229,7 +229,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         }
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void testAutoCloseFalseDoesShutdownOutput() throws Throwable {
         // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
         Assume.assumeFalse(PlatformDependent.isWindows());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -229,7 +229,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         }
     }
 
-    @Test(timeout = 20000)
+    @Test
     public void testAutoCloseFalseDoesShutdownOutput() throws Throwable {
         // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
         Assume.assumeFalse(PlatformDependent.isWindows());

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -327,6 +327,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jctools</groupId>
+      <artifactId>jctools-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-testsuite</artifactId>
       <version>${project.version}</version>

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventArray.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventArray.java
@@ -41,12 +41,14 @@ import java.nio.ByteBuffer;
 final class EpollEventArray {
     // Size of the epoll_event struct
     private static final int EPOLL_EVENT_SIZE = Native.sizeofEpollEvent();
-    // The offsiet of the data union in the epoll_event struct
+    // The offset of the data union in the epoll_event struct
     private static final int EPOLL_DATA_OFFSET = Native.offsetofEpollData();
 
     private ByteBuffer memory;
     private long memoryAddress;
     private int length;
+    
+    int ready; // count of ready tasks after population, <= length
 
     EpollEventArray(int length) {
         if (length < 1) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TagTeamConsumerArrayQueue.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TagTeamConsumerArrayQueue.java
@@ -292,6 +292,16 @@ class TagTeamConsumerArrayQueue<E> extends MpscBlockingConsumerArrayQueueConsume
     @Override
     public boolean offer(final E e)
     {
+        return offer(e, true);
+    }
+
+    /**
+     * If {@code wake == true} then state transition:
+     * ST_BOTH_WAITING -> ST_PRIMARY_ACTIVE
+     * otherwise state unchanged
+     */
+    public boolean offer(final E e, final boolean wake)
+    {
         if (null == e)
         {
             throw new NullPointerException();
@@ -304,7 +314,7 @@ class TagTeamConsumerArrayQueue<E> extends MpscBlockingConsumerArrayQueueConsume
         {
             pIndex = lvProducerIndex();
             // lower bit is indicative of blocked consumer
-            if (state(pIndex) == ST_BOTH_WAITING)
+            if (wake && state(pIndex) == ST_BOTH_WAITING)
             {
                 if (offerAndWakeup(buffer, mask, pIndex, e))
                     return true;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TagTeamConsumerArrayQueue.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TagTeamConsumerArrayQueue.java
@@ -1,0 +1,716 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.netty.channel.epoll;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.concurrent.locks.LockSupport;
+
+import org.jctools.queues.CircularArrayOffsetCalculator;
+import org.jctools.queues.IndexedQueueSizeUtil.IndexedQueue;
+import org.jctools.queues.QueueProgressIndicators;
+import org.jctools.util.Pow2;
+import org.jctools.util.RangeUtil;
+import org.jctools.util.UnsafeRefArrayAccess;
+
+//import static org.jctools.queues.LinkedArrayQueueUtil.modifiedCalcElementOffset;
+import static org.jctools.util.UnsafeAccess.UNSAFE;
+//import static org.jctools.util.UnsafeAccess.fieldOffset;
+import static org.jctools.util.UnsafeRefArrayAccess.lvElement;
+import static org.jctools.util.UnsafeRefArrayAccess.soElement;
+
+abstract class MpscBlockingConsumerArrayQueuePad1<E> extends AbstractQueue<E> implements IndexedQueue
+{
+    long p01, p02, p03, p04, p05, p06, p07;
+    long p10, p11, p12, p13, p14, p15, p16, p17;
+
+    // copied in
+    static long fieldOffset(Class<?> clz, String fieldName) throws RuntimeException
+    {
+        try
+        {
+            return UNSAFE.objectFieldOffset(clz.getDeclaredField(fieldName));
+        }
+        catch (NoSuchFieldException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}
+// $gen:ordered-fields
+abstract class MpscBlockingConsumerArrayQueueColdProducerFields<E> extends MpscBlockingConsumerArrayQueuePad1<E>
+{
+    private final static long P_LIMIT_OFFSET = fieldOffset(MpscBlockingConsumerArrayQueueColdProducerFields.class,"producerLimit");
+
+    private volatile long producerLimit;
+    protected final long producerMask;
+    protected final E[] producerBuffer;
+
+    MpscBlockingConsumerArrayQueueColdProducerFields(long producerMask, E[] producerBuffer)
+    {
+        this.producerMask = producerMask;
+        this.producerBuffer = producerBuffer;
+    }
+
+    final long lvProducerLimit()
+    {
+        return producerLimit;
+    }
+
+    final boolean casProducerLimit(long expect, long newValue)
+    {
+        return UNSAFE.compareAndSwapLong(this, P_LIMIT_OFFSET, expect, newValue);
+    }
+
+    final void soProducerLimit(long newValue)
+    {
+        UNSAFE.putOrderedLong(this, P_LIMIT_OFFSET, newValue);
+    }
+}
+
+abstract class MpscBlockingConsumerArrayQueuePad2<E> extends MpscBlockingConsumerArrayQueueColdProducerFields<E>
+{
+    long p0, p1, p2, p3, p4, p5, p6;
+
+    MpscBlockingConsumerArrayQueuePad2(long mask, E[] buffer)
+    {
+        super(mask, buffer);
+    }
+}
+
+// $gen:ordered-fields
+abstract class MpscBlockingConsumerArrayQueueProducerFields<E> extends MpscBlockingConsumerArrayQueuePad2<E>
+{
+    private final static long P_INDEX_OFFSET = fieldOffset(MpscBlockingConsumerArrayQueueProducerFields.class, "producerIndex");
+
+    private volatile long producerIndex;
+
+    MpscBlockingConsumerArrayQueueProducerFields(long mask, E[] buffer)
+    {
+        super(mask, buffer);
+    }
+
+    @Override
+    public final long lvProducerIndex()
+    {
+        return producerIndex;
+    }
+
+    final void soProducerIndex(long newValue)
+    {
+        UNSAFE.putOrderedLong(this, P_INDEX_OFFSET, newValue);
+    }
+
+    final boolean casProducerIndex(long expect, long newValue)
+    {
+        return UNSAFE.compareAndSwapLong(this, P_INDEX_OFFSET, expect, newValue);
+    }
+}
+
+abstract class MpscBlockingConsumerArrayQueuePad3<E> extends MpscBlockingConsumerArrayQueueProducerFields<E>
+{
+    long p01, p02, p03, p04, p05, p06, p07;
+    long p10, p11, p12, p13, p14, p15, p16, p17;
+
+    MpscBlockingConsumerArrayQueuePad3(long mask, E[] buffer)
+    {
+        super(mask, buffer);
+    }
+}
+
+// $gen:ordered-fields
+abstract class MpscBlockingConsumerArrayQueueConsumerFields<E> extends MpscBlockingConsumerArrayQueuePad3<E>
+{
+    private final static long C_INDEX_OFFSET = fieldOffset(MpscBlockingConsumerArrayQueueConsumerFields.class,"consumerIndex");
+
+    private volatile long consumerIndex;
+    protected final long consumerMask;
+    protected final E[] consumerBuffer;
+
+    MpscBlockingConsumerArrayQueueConsumerFields(long mask, E[] buffer)
+    {
+        super(mask, buffer);
+        consumerMask = mask;
+        consumerBuffer = buffer;
+    }
+
+    @Override
+    public final long lvConsumerIndex()
+    {
+        return consumerIndex;
+    }
+    
+    final long lpConsumerIndex()
+    {
+        return UNSAFE.getLong(this, C_INDEX_OFFSET);
+    }
+
+    final void soConsumerIndex(long newValue)
+    {
+        UNSAFE.putOrderedLong(this, C_INDEX_OFFSET, newValue);
+    }
+}
+
+
+
+/**
+ * This is a special-purpose queue impl derived from JCTools' MpscBlockingConsumerArrayQueue:
+ * https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/MpscBlockingConsumerArrayQueue.java
+ *
+ *
+ * @param <E>
+ */
+class TagTeamConsumerArrayQueue<E> extends MpscBlockingConsumerArrayQueueConsumerFields<E>
+    implements QueueProgressIndicators
+{
+    long p0, p1, p2, p3, p4, p5, p6, p7;
+    long p10, p11, p12, p13, p14, p15, p16, p17;
+    
+    private Thread consumerThread;
+
+    // Possible states, stored as smallest 2 bits of producerIndex
+    public static final int ST_PRIMARY_ACTIVE = 0;
+    public static final int ST_SECONDARY_ACTIVE = 2;
+    public static final int ST_BOTH_WAITING = 1;
+
+    static int state(long producerIndex) {
+        return (int) (producerIndex & 3L);
+    }
+
+    public TagTeamConsumerArrayQueue(final int capacity)
+    {
+        // leave lower 2 bits of mask clear
+        super((long) ((Pow2.roundToPowerOfTwo(capacity) - 1) << 2), 
+                CircularArrayOffsetCalculator.<E>allocate(Pow2.roundToPowerOfTwo(capacity)));
+        
+        RangeUtil.checkGreaterThanOrEqual(capacity, 1, "capacity");
+        soProducerLimit((long) ((Pow2.roundToPowerOfTwo(capacity) - 1) << 2)); // we know it's all empty to start with
+    }
+
+    public void setConsumerThread(Thread thread) {
+        this.consumerThread = thread;
+    }
+
+    @Override
+    public final Iterator<E> iterator()
+    {
+        throw new UnsupportedOperationException();
+    }
+    
+    // ----------- methods safe to call from any thread --------
+
+    @Override
+    public final int size()
+    {
+        // NOTE: because indices are on even numbers we cannot use the size util.
+
+        /*
+         * It is possible for a thread to be interrupted or reschedule between the read of the producer and
+         * consumer indices, therefore protection is required to ensure size is within valid range. In the
+         * event of concurrent polls/offers to this method the size is OVER estimated as we read consumer
+         * index BEFORE the producer index.
+         */
+        long after = lvConsumerIndex();
+        long size;
+        while (true)
+        {
+            final long before = after;
+            final long currentProducerIndex = lvProducerIndex();
+            after = lvConsumerIndex();
+            if (before == after)
+            {
+                size = ((currentProducerIndex - after) >> 2);
+                break;
+            }
+        }
+        // Long overflow is impossible, so size is always positive. Integer overflow is possible for the unbounded
+        // indexed queues.
+        if (size > Integer.MAX_VALUE)
+        {
+            return Integer.MAX_VALUE;
+        }
+        else
+        {
+            return (int) size;
+        }
+    }
+
+    @Override
+    public final boolean isEmpty()
+    {
+        // Order matters!
+        // Loading consumer before producer allows for producer increments after consumer index is read.
+        // This ensures this method is conservative in it's estimate. Note that as this is an MPMC there is
+        // nothing we can do to make this an exact method.
+        return ((this.lvConsumerIndex()/4) == (this.lvProducerIndex()/4));
+    }
+
+    @Override
+    public String toString()
+    {
+        return this.getClass().getName();
+    }
+
+    @Override
+    public long currentProducerIndex()
+    {
+        return lvProducerIndex() / 4;
+    }
+
+    @Override
+    public long currentConsumerIndex()
+    {
+        return lvConsumerIndex() / 4;
+    }
+
+    //@Override
+    public int capacity()
+    {
+        return (int) ((consumerMask >> 2) + 1); //TODO verify this
+    }
+
+    public int currentState() {
+        return state(lvProducerIndex());
+    }
+
+    /**
+     * State transition:
+     * ST_BOTH_WAITING -> ST_PRIMARY_ACTIVE
+     * otherwise state unchanged
+     */
+    @Override
+    public boolean offer(final E e)
+    {
+        if (null == e)
+        {
+            throw new NullPointerException();
+        }
+
+        final long mask = this.producerMask;
+        final E[] buffer = this.producerBuffer;
+        long pIndex;
+        while (true)
+        {
+            pIndex = lvProducerIndex();
+            // lower bit is indicative of blocked consumer
+            if (state(pIndex) == ST_BOTH_WAITING)
+            {
+                if (offerAndWakeup(buffer, mask, pIndex, e))
+                    return true;
+                continue;
+            }
+            // pIndex is even (lower bit is 0) -> actual index is (pIndex >> 2), consumer is awake
+            final long producerLimit = lvProducerLimit();
+
+            // Use producer limit to save a read of the more rapidly mutated consumer index.
+            // Assumption: queue is usually empty or near empty
+            if (producerLimit <= pIndex)
+            {
+                if (!recalculateProducerLimit(mask, pIndex, producerLimit))
+                {
+                    return false;
+                }
+            }
+
+            // Claim the index
+            if (casProducerIndex(pIndex, pIndex + 4))
+            {
+                break;
+            }
+        }
+        final long offset = modifiedCalcElementOffset(pIndex, mask);
+        // INDEX visible before ELEMENT
+        soElement(buffer, offset, e); // release element e
+        return true;
+    }
+
+    // ----------- methods only safe to call from primary consumer --------
+
+    /**
+     * ST_PRIMARY_ACTIVE   -> ST_PRIMARY_ACTIVE (returns 1)
+     * ST_SECONDARY_ACTIVE -> ST_SECONDARY_ACTIVE (returns 0)
+     * ST_BOTH_WAITING     -> ST_PRIMARY_ACTIVE (returns 1)
+     * 
+     * @return 0 submitted, 1 grabbed control (not submitted), -1 queue full
+     */
+    public int primaryGrabControlOrOffer(final E e)
+    {
+        if (null == e)
+        {
+            throw new NullPointerException();
+        }
+
+        final long mask = this.producerMask;
+        final E[] buffer = this.producerBuffer;
+        //final int ourCtx = primaryConsumer ? ST_PRIMARY_ACTIVE : ST_SECONDARY_ACTIVE;
+        long pIndex;
+        while (true)
+        {
+            pIndex = lvProducerIndex();
+            
+            int state = state(pIndex);
+            if (state == ST_PRIMARY_ACTIVE)
+            {
+                return 1; // already have control
+            }
+            // lower bit is indicative of both consumers waiting
+            if (state == ST_BOTH_WAITING)
+            {
+                if(casProducerIndex(pIndex, pIndex - 1))
+                {
+                    return 1; // control grabbed
+                }
+                continue;
+            }
+            // pIndex is even (lower bit is 0) -> actual index is (pIndex >> 2), consumer is awake
+            final long producerLimit = lvProducerLimit();
+
+            // Use producer limit to save a read of the more rapidly mutated consumer index.
+            // Assumption: queue is usually empty or near empty
+            if (producerLimit <= pIndex)
+            {
+                if (!recalculateProducerLimit(mask, pIndex, producerLimit))
+                {
+                    return -1; // full
+                }
+            }
+
+            // Claim the index
+            if (casProducerIndex(pIndex, pIndex + 4))
+            {
+                break;
+            }
+        }
+        final long offset = modifiedCalcElementOffset(pIndex, mask);
+        // INDEX visible before ELEMENT
+        soElement(buffer, offset, e); // release element e
+        return 0; // success, no wakeup needed
+    }
+
+    /**
+     * Must only be called in {@link #ST_PRIMARY_ACTIVE} state,
+     * will only return or throw in {@link #ST_PRIMARY_ACTIVE} state.
+     */
+    public E take() throws InterruptedException
+    {
+        assert Thread.currentThread() == consumerThread;
+        //assert state(lvProducerIndex()) == ST_PRIMARY_ACTIVE;
+
+        final E[] buffer = consumerBuffer;
+        final long mask = consumerMask;
+
+        long cIndex = lpConsumerIndex();
+        long offset = modifiedCalcElementOffset(cIndex, mask);
+        E e = lvElement(buffer, offset);// LoadLoad
+        if (e == null) {
+            final long pIndex = lvProducerIndex();
+            if (pIndex == cIndex && casProducerIndex(pIndex, pIndex + 1)) {
+                do {
+                    LockSupport.park(this);
+                    handleParkInterrupted();
+                }
+                while (state(lvProducerIndex()) != ST_PRIMARY_ACTIVE);
+                // need to re-read this here, may have changed
+                cIndex = lpConsumerIndex();
+                offset = modifiedCalcElementOffset(cIndex, mask);
+            }
+            e = spinWaitForElement(buffer, offset);
+        }
+        soElement(buffer, offset, null); // release element null
+        soConsumerIndex(cIndex + 4); // release cIndex
+        return e;
+    }
+
+    /**
+     * Block-poll until {@code deadlineNanos} (relative to {@link System#nanoTime()}).
+     * <p>
+     * Must only be called in {@link #ST_PRIMARY_ACTIVE} state,
+     * will only return or throw in {@link #ST_PRIMARY_ACTIVE} state. This means that the
+     * timeout could be delayed if/while the secondary thread is in control of the queue.
+     *
+     * @return a queued element or null if deadline is reached
+     */
+    public E pollUntil(long deadlineNanos) throws InterruptedException
+    {
+        assert Thread.currentThread() == consumerThread;
+        //assert state(lvProducerIndex()) == ST_PRIMARY_ACTIVE;
+
+        final E[] buffer = consumerBuffer;
+        final long mask = consumerMask;
+
+        long cIndex = lpConsumerIndex();
+        long offset = modifiedCalcElementOffset(cIndex, mask);
+        E e = lvElement(buffer, offset);// LoadLoad
+        if (e == null) {
+            final long pIndex = lvProducerIndex();
+            if (pIndex == cIndex && casProducerIndex(pIndex, pIndex + 1)) {
+                do {
+                    long remaining = deadlineNanos - System.nanoTime();
+                    if (remaining <= 0L) { // timeout
+                        waitAfterInterruptOrTimeout();
+                        return null;
+                    }
+                    LockSupport.parkNanos(this, remaining);
+                    handleParkInterrupted();
+                }
+                while (state(lvProducerIndex()) != ST_PRIMARY_ACTIVE);
+                // need to re-read this here, may have changed
+                cIndex = lpConsumerIndex();
+                offset = modifiedCalcElementOffset(cIndex, mask);
+            }
+            e = spinWaitForElement(buffer, offset);
+        }
+        soElement(buffer, offset, null); // release element null
+        soConsumerIndex(cIndex + 4); // release cIndex
+        return e;
+    }
+
+    private void handleParkInterrupted() throws InterruptedException {
+        if (Thread.interrupted()) {
+            if (waitAfterInterruptOrTimeout()) {
+                // Clear again incase we were re-interrupted
+                Thread.interrupted();
+            }
+            throw new InterruptedException();
+        }
+    }
+
+    private volatile boolean primaryNeedsWakeup;
+
+    private boolean waitAfterInterruptOrTimeout() {
+        boolean flagSet = false;
+        for (;;) {
+            long pIndex = lvProducerIndex();
+            int state = state(pIndex);
+            if (state == ST_SECONDARY_ACTIVE) {
+                if (!flagSet) {
+                    primaryNeedsWakeup = true;
+                    flagSet = true;
+                    continue;
+                }
+                LockSupport.park(this);
+            } else if (state == ST_PRIMARY_ACTIVE
+                    || casProducerIndex(pIndex, pIndex - 1L)) {
+                break;
+            }
+        }
+        // assert state(lvProducerIndex()) == ST_PRIMARY_ACTIVE;
+        if (flagSet) {
+            primaryNeedsWakeup = false;
+            return true;
+        }
+        return false;
+    }
+
+    // ------------ methods only safe to call from secondary consumer -------------
+    
+    /**
+     * Expected to be in ST_SECONDARY_ACTIVE when called.
+     *    queue empty     -> ST_BOTH_WAITING (returns true)
+     *    queue non-empty -> ST_SECONDARY_ACTIVE (returns false)
+     * 
+     * @return true to enter wait or false if there are more tasks
+     */
+    public boolean secondaryEnterWait() {
+        long pIndex = lvProducerIndex();
+        if (state(pIndex) != ST_SECONDARY_ACTIVE) {
+            return true;
+        }
+        if (pIndex / 4 != lpConsumerIndex() / 4) {
+            return false;
+        }
+        boolean needWakeup = primaryNeedsWakeup;
+        if (!casProducerIndex(pIndex, pIndex - 1)) {
+            return false;
+        }
+        if (needWakeup) {
+            LockSupport.unpark(consumerThread);
+        }
+        return true;
+    }
+
+    /**
+     * ST_PRIMARY_ACTIVE   -> ST_PRIMARY_ACTIVE (returns 0)
+     * ST_SECONDARY_ACTIVE -> ST_SECONDARY_ACTIVE (returns 1)
+     * ST_BOTH_WAITING     -> ST_SECONDARY_ACTIVE (returns 1)
+     * 
+     * @return 0 submitted, 1 submitted *and* got control, -1 queue full
+     */
+    public int secondaryOfferAndTryToGrabControl(final E e)
+    {
+        if (null == e)
+        {
+            throw new NullPointerException();
+        }
+
+        final long mask = this.producerMask;
+        final E[] buffer = this.producerBuffer;
+        long pIndex;
+        int rc;
+        while (true)
+        {
+            pIndex = lvProducerIndex();
+
+            // pIndex is even (lower bit is 0) -> actual index is (pIndex >> 2), consumer is awake
+            final long producerLimit = lvProducerLimit();
+
+            // Use producer limit to save a read of the more rapidly mutated consumer index.
+            // Assumption: queue is usually empty or near empty
+            if (producerLimit <= pIndex)
+            {
+                if (!recalculateProducerLimit(mask, pIndex, producerLimit))
+                {
+                    return -1; // full
+                }
+            }
+
+            int state = state(pIndex);
+            long newPIndex = state == ST_BOTH_WAITING ? pIndex + 5 : pIndex + 4;
+            if (casProducerIndex(pIndex, newPIndex)) {
+                rc = state == ST_PRIMARY_ACTIVE ? 0 : 1;
+                break;
+            }
+        }
+        final long offset = modifiedCalcElementOffset(pIndex, mask);
+        // INDEX visible before ELEMENT
+        soElement(buffer, offset, e); // release element e
+        return rc;
+    }
+
+    // ----------- methods only safe to call from *currently active* consumer --------
+
+    public long plainCurrentConsumerIndex()
+    {
+        return lpConsumerIndex() / 4;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @Override
+    public E poll()
+    {
+        final E[] buffer = consumerBuffer;
+        final long mask = consumerMask;
+
+        final long index = lpConsumerIndex();
+        final long offset = modifiedCalcElementOffset(index, mask);
+        E e = lvElement(buffer, offset);// LoadLoad
+        if (e == null)
+        {
+            // consumer can't see the odd producer index
+            if (index/4 != lvProducerIndex()/4)
+            {
+                // poll() == null iff queue is empty, null element is not strong enough indicator, so we must
+                // check the producer index. If the queue is indeed not empty we spin until element is
+                // visible.
+                e = spinWaitForElement(buffer, offset);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        soElement(buffer, offset, null); // release element null
+        soConsumerIndex(index + 4); // release cIndex
+        return e;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation is correct for single consumer thread use only.
+     */
+    @Override
+    public E peek()
+    {
+        final E[] buffer = consumerBuffer;
+        final long mask = consumerMask;
+
+        final long index = lpConsumerIndex();
+        final long offset = modifiedCalcElementOffset(index, mask);
+        E e = lvElement(buffer, offset);// LoadLoad
+        if (e == null && index/4 != lvProducerIndex()/4)
+        {
+            // peek() == null iff queue is empty, null element is not strong enough indicator, so we must
+            // check the producer index. If the queue is indeed not empty we spin until element is visible.
+            e = spinWaitForElement(buffer, offset);
+        }
+        
+        return e;
+    }
+
+    // --------------- private methods -----------
+
+    private boolean offerAndWakeup(E[] buffer, long mask, long pIndex, E e)
+    {
+        // Claim the slot and the responsibility of unparking
+        if(!casProducerIndex(pIndex, pIndex + 3))
+        {
+            return false;
+        }
+
+        final long offset = modifiedCalcElementOffset(pIndex, mask);
+        soElement(buffer, offset, e);
+        LockSupport.unpark(consumerThread);
+        return true;
+    }
+
+    private boolean recalculateProducerLimit(long mask, long pIndex, long producerLimit)
+    {
+        final long cIndex = lvConsumerIndex();
+        final long bufferCapacity = mask + 4;
+
+        if (cIndex + bufferCapacity > pIndex)
+        {
+            casProducerLimit(producerLimit, cIndex + bufferCapacity); 
+        }
+        // full and cannot grow
+        else if (pIndex - cIndex == bufferCapacity)
+        {
+            // offer should return false;
+            return false;
+        }
+        else 
+            throw new IllegalStateException();
+        return true;
+    }
+
+    private E spinWaitForElement(E[] buffer, long offset)
+    {
+        E e;
+        do
+        {
+            e = lvElement(buffer, offset);
+        }
+        while (e == null);
+        return e;
+    }
+
+    // Copied in
+
+    /**
+     * This method assumes index is actually (index << 2) because lower 2 bits are
+     * used to encode state. This is compensated for by reducing the element shift.
+     * The computation is constant folded, so there's no cost.
+     */
+    static long modifiedCalcElementOffset(long index, long mask)
+    {
+        return UnsafeRefArrayAccess.REF_ARRAY_BASE +
+                ((index & mask) << (UnsafeRefArrayAccess.REF_ELEMENT_SHIFT - 2));
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TagTeamConsumerArrayQueue.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TagTeamConsumerArrayQueue.java
@@ -343,7 +343,7 @@ class TagTeamConsumerArrayQueue<E> extends MpscBlockingConsumerArrayQueueConsume
      */
     public E take() throws InterruptedException
     {
-        assert Thread.currentThread() == consumerThread;
+        //assert Thread.currentThread() == consumerThread;
         //assert state(lvProducerIndex()) == ST_PRIMARY_ACTIVE;
 
         final E[] buffer = consumerBuffer;
@@ -382,7 +382,7 @@ class TagTeamConsumerArrayQueue<E> extends MpscBlockingConsumerArrayQueueConsume
      */
     public E pollUntil(long deadlineNanos) throws InterruptedException
     {
-        assert Thread.currentThread() == consumerThread;
+        //assert Thread.currentThread() == consumerThread;
         //assert state(lvProducerIndex()) == ST_PRIMARY_ACTIVE;
 
         final E[] buffer = consumerBuffer;
@@ -392,6 +392,7 @@ class TagTeamConsumerArrayQueue<E> extends MpscBlockingConsumerArrayQueueConsume
         long offset = modifiedCalcElementOffset(cIndex, mask);
         E e = lvElement(buffer, offset);// LoadLoad
         if (e == null) {
+            //TODO maybe also check deadline here
             final long pIndex = lvProducerIndex();
             if (pIndex == cIndex && casProducerIndex(pIndex, pIndex + 1)) {
                 do {
@@ -429,7 +430,7 @@ class TagTeamConsumerArrayQueue<E> extends MpscBlockingConsumerArrayQueueConsume
     // the secondary consumer is active, it will continue to wait until
     // it can take control (secondary starts to wait). This flag ensures
     // it will be woken up again immediately at that point so that it can
-    // return null or throw as appropriate
+    // then return null or throw as appropriate
     private volatile boolean primaryNeedsWakeup;
 
     private boolean waitAfterInterruptOrTimeout() {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -50,7 +50,7 @@ public class EpollSpliceTest {
         random.nextBytes(data);
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void spliceToSocket() throws Throwable {
         final EchoHandler sh = new EchoHandler();
         final EchoHandler ch = new EchoHandler();


### PR DESCRIPTION
Motivation

This PR is for discussion/feedback and is in a mostly-working but unfinished state. The idea is to use two threads per event loop, one waits on epoll_wait and the other waits using `LockSupport.park/parkNanos`. Whichever wakes up first "becomes" the event loop and processes the task queue. Efficient coordination is achieved via tight integration with a specially customized queue implementation, derived from JCTools' [`MpscBlockingConsumerArrayQueue`](https://github.com/JCTools/JCTools/blob/master/jctools-core/src/main/java/org/jctools/queues/MpscBlockingConsumerArrayQueue.java). IO events can be received and enqueued by the epoll thread even while the other thread is active. Time-scheduled task expiry is handled via the primary/non-epoll thread only.

~Latency advantages are similar to those targeted when using epoll busy-wait (see #8267), but without needing to dedicate an entire core per event loop.~ It's also partially related to the improvements in #7834.

Benefits
- IO round-trip latency, at least for certain cases/workloads - see benchmarks
- Much more responsive task submission from outside the event loop
- Much cheaper time-based task scheduling from outside event loop
- Appears to reduce CPU for equivalent work (e.g. fewer syscalls)
- Simpler native code interactions - timerfd and eventfd not required/used (eventfd used just for shutdown)
- No need to wake up every second

Some other notes
- This was done with edge-triggered in mind, but I *think* it should work for level-triggered too, provided the event array hand-off buffer size is set to 2 (effectively 1). Doing so doesn't appear to affect performance much, maybe it would make a bigger difference under higher load/concurrency.
- It's currently passing all but 2 of 366 unit tests; I think one of the failures is expected/ok, the other is `EpollSpliceTest::spliceToSocket` which passes when run standalone but not as part of the suite.
- The queue is currently bounded/fixed-size and uses `Unsafe`. I'm *fairly sure* other JCTools MPSC queues could be similarly adapted as required (chunked/growable/unbounded, `Unsafe`-free)
- Various other loose ends remain (e.g. error handling in some places)


Modifications

The new queue class has been named `TagTeamConsumerArrayQueue` for now. It is always in one of three distinct states: "primary" thread active, "secondary" (epoll) thread active, neither active. This state is encoded in the last 2 bits of its long `producerIndex` - a kind of generalization of how the blocked-consumer state is encoded in the original `MpscBlockingConsumerArrayQueue`. The public methods fall into one of four categories: safe for any caller, called only from primary consumer thread, called only from secondary consumer thread, called only from currently-active consumer thread.

The only existing class with significant changes is `EpollEventLoop`. epoll-thread specific logic has been grouped into an `EpollLoop` inner class. The main thread deals with opaque tasks only. A circular queue of `EpollEventArray`s is used to hand off received events to the task processing thread. The epoll thread will park until the other thread catches up if this wraps. There are no JNI code changes.


Results

Adjustments were also made to the benchmark code, it turns out some were dominated by measurement overhead.

Before:
```
Benchmark                                   Mode  Cnt        Score        Error  Units
EpollSocketChannelBenchmark.pingPong       thrpt   20    36947.625 ±    246.654  ops/s
EpollSocketChannelBenchmark.executeSingle  thrpt   20   266313.636 ±  12611.497  ops/s
EpollSocketChannelBenchmark.executeMulti   thrpt   20  6746333.696 ± 674330.117  ops/s
```

After:
```
Benchmark                                   Mode  Cnt        Score        Error  Units
EpollSocketChannelBenchmark.pingPong       thrpt   20    42110.442 ±    546.547  ops/s
EpollSocketChannelBenchmark.executeSingle  thrpt   20  4267783.830 ± 179377.697  ops/s
EpollSocketChannelBenchmark.executeMulti   thrpt   20  9609216.911 ± 645376.994  ops/s
```


Before:
```
Benchmark                                   (burstLength)  (work)  Mode  Cnt     Score     Error  Units
BurstCostExecutorsBenchmark.test1Producer               1       0  avgt   10  2749.784 ±  20.207  ns/op
BurstCostExecutorsBenchmark.test1Producer               1      10  avgt   10  2903.637 ± 252.079  ns/op
BurstCostExecutorsBenchmark.test1Producer              10       0  avgt   10  3080.863 ± 476.379  ns/op
BurstCostExecutorsBenchmark.test1Producer              10      10  avgt   10  3809.870 ± 580.936  ns/op
BurstCostExecutorsBenchmark.test2Producers              1       0  avgt   10  2752.020 ± 127.169  ns/op
BurstCostExecutorsBenchmark.test2Producers              1      10  avgt   10  2641.059 ± 111.378  ns/op
BurstCostExecutorsBenchmark.test2Producers             10       0  avgt   10  2963.372 ± 347.863  ns/op
BurstCostExecutorsBenchmark.test2Producers             10      10  avgt   10  1973.417 ±  45.339  ns/op
BurstCostExecutorsBenchmark.test3Producers              1       0  avgt   10  2087.238 ± 257.431  ns/op
BurstCostExecutorsBenchmark.test3Producers              1      10  avgt   10  1821.122 ±  76.298  ns/op
BurstCostExecutorsBenchmark.test3Producers             10       0  avgt   10  2623.262 ±  37.176  ns/op
BurstCostExecutorsBenchmark.test3Producers             10      10  avgt   10  2439.716 ±  42.170  ns/op
```

After:
```
Benchmark                                   (burstLength)  (work)  Mode  Cnt     Score      Error  Units
BurstCostExecutorsBenchmark.test1Producer               1       0  avgt   10  3171.981 ± 1803.802  ns/op
BurstCostExecutorsBenchmark.test1Producer               1      10  avgt   10  1497.771 ± 1547.308  ns/op
BurstCostExecutorsBenchmark.test1Producer              10       0  avgt   10  2952.119 ± 1581.608  ns/op
BurstCostExecutorsBenchmark.test1Producer              10      10  avgt   10  2594.738 ± 1333.943  ns/op
BurstCostExecutorsBenchmark.test2Producers              1       0  avgt   10   215.261 ±    7.909  ns/op
BurstCostExecutorsBenchmark.test2Producers              1      10  avgt   10   227.148 ±    7.375  ns/op
BurstCostExecutorsBenchmark.test2Producers             10       0  avgt   10  1388.988 ±  128.052  ns/op
BurstCostExecutorsBenchmark.test2Producers             10      10  avgt   10   987.340 ±   15.930  ns/op
BurstCostExecutorsBenchmark.test3Producers              1       0  avgt   10   242.427 ±   15.450  ns/op
BurstCostExecutorsBenchmark.test3Producers              1      10  avgt   10   256.689 ±   14.192  ns/op
BurstCostExecutorsBenchmark.test3Producers             10       0  avgt   10  2368.841 ±  106.535  ns/op
BurstCostExecutorsBenchmark.test3Producers             10      10  avgt   10  1811.361 ±  583.094  ns/op
```