### PR TITLE
Simplify detection of major version

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -858,9 +858,10 @@ final class PlatformDependent0 {
     private static int majorVersionFromSystemClass() {
         InputStream in = ClassLoader.getSystemResourceAsStream("java/lang/ClassLoader.class");
         assert in != null;
+        int version;
         try {
             in.skip(6L);
-            return (in.read() << 8) + in.read() - 44;
+            version =  (in.read() << 8) + in.read() - 44;
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         } finally {
@@ -870,6 +871,8 @@ final class PlatformDependent0 {
                 // Should not probably ignore this, but will leave it now as it is
             }
         }
+        assert version >= 6;
+        return version;
     }
 
     private PlatformDependent0() {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -857,7 +857,10 @@ final class PlatformDependent0 {
 
     private static int majorVersionFromSystemClass() {
         InputStream in = ClassLoader.getSystemResourceAsStream("java/lang/ClassLoader.class");
-        assert in != null;
+        if (in == null) {
+            // Probably will never happen, but ok
+            return majorVersionFromJavaSpecificationVersion();
+        }
         int version;
         try {
             in.skip(6L);
@@ -873,6 +876,27 @@ final class PlatformDependent0 {
         }
         assert version >= 6;
         return version;
+    }
+
+    // Package-private for testing only
+    static int majorVersionFromJavaSpecificationVersion() {
+        return majorVersion(SystemPropertyUtil.get("java.specification.version", "1.6"));
+    }
+
+    // Package-private for testing only
+    static int majorVersion(final String javaSpecVersion) {
+        final String[] components = javaSpecVersion.split("\\.");
+        final int[] version = new int[components.length];
+        for (int i = 0; i < components.length; i++) {
+            version[i] = Integer.parseInt(components[i]);
+        }
+
+        if (version[0] == 1) {
+            assert version[1] >= 6;
+            return version[1];
+        } else {
+            return version[0];
+        }
     }
 
     private PlatformDependent0() {

--- a/common/src/test/java/io/netty/util/internal/PlatformDependent0Test.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependent0Test.java
@@ -19,6 +19,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.security.Permission;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
@@ -53,5 +54,41 @@ public class PlatformDependent0Test {
         ByteBuffer buffer = PlatformDependent0.newDirectBuffer(address, capacity);
         assertEquals(address, PlatformDependent0.directBufferAddress(buffer));
         assertEquals(capacity, buffer.capacity());
+    }
+
+    @Test
+    public void testMajorVersionFromJavaSpecificationVersion() {
+        final SecurityManager current = System.getSecurityManager();
+
+        try {
+            System.setSecurityManager(new SecurityManager() {
+                @Override
+                public void checkPropertyAccess(String key) {
+                    if (key.equals("java.specification.version")) {
+                        // deny
+                        throw new SecurityException(key);
+                    }
+                }
+
+                // so we can restore the security manager
+                @Override
+                public void checkPermission(Permission perm) {
+                }
+            });
+
+            assertEquals(6, PlatformDependent0.majorVersionFromJavaSpecificationVersion());
+        } finally {
+            System.setSecurityManager(current);
+        }
+    }
+
+    @Test
+    public void testMajorVersion() {
+        assertEquals(6, PlatformDependent0.majorVersion("1.6"));
+        assertEquals(7, PlatformDependent0.majorVersion("1.7"));
+        assertEquals(8, PlatformDependent0.majorVersion("1.8"));
+        assertEquals(8, PlatformDependent0.majorVersion("8"));
+        assertEquals(9, PlatformDependent0.majorVersion("1.9")); // early version of JDK 9 before Project Verona
+        assertEquals(9, PlatformDependent0.majorVersion("9"));
     }
 }

--- a/common/src/test/java/io/netty/util/internal/PlatformDependent0Test.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependent0Test.java
@@ -19,7 +19,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
-import java.security.Permission;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
@@ -54,41 +53,5 @@ public class PlatformDependent0Test {
         ByteBuffer buffer = PlatformDependent0.newDirectBuffer(address, capacity);
         assertEquals(address, PlatformDependent0.directBufferAddress(buffer));
         assertEquals(capacity, buffer.capacity());
-    }
-
-    @Test
-    public void testMajorVersionFromJavaSpecificationVersion() {
-        final SecurityManager current = System.getSecurityManager();
-
-        try {
-            System.setSecurityManager(new SecurityManager() {
-                @Override
-                public void checkPropertyAccess(String key) {
-                    if (key.equals("java.specification.version")) {
-                        // deny
-                        throw new SecurityException(key);
-                    }
-                }
-
-                // so we can restore the security manager
-                @Override
-                public void checkPermission(Permission perm) {
-                }
-            });
-
-            assertEquals(6, PlatformDependent0.majorVersionFromJavaSpecificationVersion());
-        } finally {
-            System.setSecurityManager(current);
-        }
-    }
-
-    @Test
-    public void testMajorVersion() {
-        assertEquals(6, PlatformDependent0.majorVersion("1.6"));
-        assertEquals(7, PlatformDependent0.majorVersion("1.7"));
-        assertEquals(8, PlatformDependent0.majorVersion("1.8"));
-        assertEquals(8, PlatformDependent0.majorVersion("8"));
-        assertEquals(9, PlatformDependent0.majorVersion("1.9")); // early version of JDK 9 before Project Verona
-        assertEquals(9, PlatformDependent0.majorVersion("9"));
     }
 }


### PR DESCRIPTION
Motivation:

Currently because of how Oracle broke version system property, version detection became a bit 'harder'

Modification:

A way how major version is detected changed.

Result:

Detection is done by reading major class version of java.lang.ClassLoader class