### PR TITLE
EmptyByteBuf.getCharSequence(0,...) must return empty String

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -684,7 +684,7 @@ public final class EmptyByteBuf extends ByteBuf {
     @Override
     public CharSequence readCharSequence(int length, Charset charset) {
         checkLength(length);
-        return null;
+        return StringUtil.EMPTY_STRING;
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -14,6 +14,7 @@
  * under the License.
  */package io.netty.buffer;
 
+import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
@@ -93,4 +94,11 @@ public class EmptyByteBufTest {
         assertTrue(emptyAbstract.release());
         assertFalse(empty.release());
     }
+
+    @Test
+    public void testGetCharSequence() {
+        EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
+        assertEquals("", empty.readCharSequence(0, CharsetUtil.US_ASCII));
+    }
+
 }


### PR DESCRIPTION
Motivation:

At the moment EmptyByteBuf.getCharSequence(0,...) will return null while it must return a "".

Modifications:

- Let EmptyByteBuf.getCharSequence(0,...) return ""
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/9271.