### PR TITLE
Add null check to isSkippable. Fixes #9278

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
@@ -175,7 +175,7 @@ final class ChannelHandlerMask {
                         "Class {} missing method {}, assume we can not skip execution", handlerType, methodName, e);
                     return false;
                 }
-                return m.isAnnotationPresent(Skip.class);
+                return m != null && m.isAnnotationPresent(Skip.class);
             }
         });
     }


### PR DESCRIPTION
Motivation:

Currently GraalVM substrate returns null for reflective calls if the reflection access is not declared up front.

A change introduced in Netty 4.1.35 results in needing to register every Netty handler for reflection. This complicates matters as it is difficult to know all the possible handlers that need to be registered. 

Modification:

This change adds a simple
null check such that Netty does not break on GraalVM substrate without the reflection information registration.

Result:

Fixes #9278 


