### PR TITLE
optimize asList

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
@@ -196,7 +196,7 @@ public class CombinedHttpHeadersTest {
     public void addIterableCsvEmpty() {
         final CombinedHttpHeaders headers = newCombinedHttpHeaders();
         headers.add(HEADER_NAME, Collections.<CharSequence>emptyList());
-        assertEquals(Arrays.asList(""), headers.getAll(HEADER_NAME));
+        assertEquals(Collections.singletonList(""), headers.getAll(HEADER_NAME));
     }
 
     @Test
@@ -294,9 +294,9 @@ public class CombinedHttpHeadersTest {
         headers.set(HEADER_NAME, Arrays.asList("\"a\"", "\"b\"", "\"c\""));
         assertEquals(Arrays.asList("a", "b", "c"), headers.getAll(HEADER_NAME));
         headers.set(HEADER_NAME, "a,b,c");
-        assertEquals(Arrays.asList("a,b,c"), headers.getAll(HEADER_NAME));
+        assertEquals(Collections.singletonList("a,b,c"), headers.getAll(HEADER_NAME));
         headers.set(HEADER_NAME, "\"a,b,c\"");
-        assertEquals(Arrays.asList("a,b,c"), headers.getAll(HEADER_NAME));
+        assertEquals(Collections.singletonList("a,b,c"), headers.getAll(HEADER_NAME));
     }
 
     @Test

--- a/common/src/test/java/io/netty/util/internal/StringUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/StringUtilTest.java
@@ -18,6 +18,7 @@ package io.netty.util.internal;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static io.netty.util.internal.StringUtil.NEWLINE;
 import static io.netty.util.internal.StringUtil.commonSuffixOfLength;
@@ -446,15 +447,15 @@ public class StringUtilTest {
 
     @Test
     public void testUnescapeCsvFields() {
-        assertEquals(Arrays.asList(""), unescapeCsvFields(""));
+        assertEquals(Collections.singletonList(""), unescapeCsvFields(""));
         assertEquals(Arrays.asList("", ""), unescapeCsvFields(","));
         assertEquals(Arrays.asList("a", ""), unescapeCsvFields("a,"));
         assertEquals(Arrays.asList("", "a"), unescapeCsvFields(",a"));
-        assertEquals(Arrays.asList("\""), unescapeCsvFields("\"\"\"\""));
+        assertEquals(Collections.singletonList("\""), unescapeCsvFields("\"\"\"\""));
         assertEquals(Arrays.asList("\"", "\""), unescapeCsvFields("\"\"\"\",\"\"\"\""));
-        assertEquals(Arrays.asList("netty"), unescapeCsvFields("netty"));
+        assertEquals(Collections.singletonList("netty"), unescapeCsvFields("netty"));
         assertEquals(Arrays.asList("hello", "netty"), unescapeCsvFields("hello,netty"));
-        assertEquals(Arrays.asList("hello,netty"), unescapeCsvFields("\"hello,netty\""));
+        assertEquals(Collections.singletonList("hello,netty"), unescapeCsvFields("\"hello,netty\""));
         assertEquals(Arrays.asList("hello", "netty"), unescapeCsvFields("\"hello\",\"netty\""));
         assertEquals(Arrays.asList("a\"b", "c\"d"), unescapeCsvFields("\"a\"\"b\",\"c\"\"d\""));
         assertEquals(Arrays.asList("a\rb", "c\nd"), unescapeCsvFields("\"a\rb\",\"c\nd\""));

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1918,13 +1918,13 @@ public abstract class SSLEngineTest {
         final String sharedCipher = "TLS_RSA_WITH_AES_128_CBC_SHA";
         clientSslCtx = SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .ciphers(Arrays.asList(sharedCipher))
+                .ciphers(Collections.singletonList(sharedCipher))
                 .protocols(PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1)
                 .sslProvider(sslClientProvider())
                 .build();
 
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .ciphers(Arrays.asList(sharedCipher))
+                .ciphers(Collections.singletonList(sharedCipher))
                 .protocols(PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1)
                 .sslProvider(sslServerProvider())
                 .build();
@@ -1949,13 +1949,13 @@ public abstract class SSLEngineTest {
         final String sharedCipher = "TLS_RSA_WITH_AES_128_CBC_SHA";
         clientSslCtx = SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
-                .ciphers(Arrays.asList(sharedCipher), SupportedCipherSuiteFilter.INSTANCE)
+                .ciphers(Collections.singletonList(sharedCipher), SupportedCipherSuiteFilter.INSTANCE)
                 .protocols(PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1)
                 .sslProvider(sslClientProvider())
                 .build();
 
         serverSslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
-                .ciphers(Arrays.asList(sharedCipher), SupportedCipherSuiteFilter.INSTANCE)
+                .ciphers(Collections.singletonList(sharedCipher), SupportedCipherSuiteFilter.INSTANCE)
                 .protocols(PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1)
                 .sslProvider(sslServerProvider())
                 .build();


### PR DESCRIPTION
…etonList’

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:


Call to `asList` with only one argument could be replaced with `singletonList` to save memory

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
