### PR TITLE
 Fix the issue of incorrectly calculating the number of buffer pretty hex dump rows

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -1095,7 +1095,7 @@ public final class ByteBufUtil {
             if (length == 0) {
               return StringUtil.EMPTY_STRING;
             } else {
-                int rows = length / 16 + (length % 15 == 0? 0 : 1) + 4;
+                int rows = length / 16 + ((length & 15) == 0? 0 : 1) + 4;
                 StringBuilder buf = new StringBuilder(rows * 80);
                 appendPrettyHexDump(buf, buffer, offset, length);
                 return buf.toString();


### PR DESCRIPTION
Motivation:

Fix the issue of incorrectly calculating the number of dump rows when using `prettyHexDump`method in `ByteBufUtil`. The way to find the remainder is either `length % 16` or `length & 15`

Modification:

Fixed the way to calculate the remainder

Result:

Fixed #9301

