### PR TITLE
Fixed incorrect Sec-WebSocket-Origin header for v13, see #9134

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -189,7 +189,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * Upgrade: websocket
      * Connection: Upgrade
      * Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-     * Sec-WebSocket-Origin: http://example.com
+     * Origin: http://example.com
      * Sec-WebSocket-Protocol: chat, superchat
      * Sec-WebSocket-Version: 13
      * </pre>
@@ -225,7 +225,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, key)
                .set(HttpHeaderNames.HOST, websocketHostValue(wsURL))
-               .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, websocketOriginValue(wsURL));
+               .set(HttpHeaderNames.ORIGIN, websocketOriginValue(wsURL));
 
         String expectedSubprotocol = expectedSubprotocol();
         if (expectedSubprotocol != null && !expectedSubprotocol.isEmpty()) {
@@ -251,7 +251,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      *
      * @param response
      *            HTTP response returned from the server for the request sent by beginOpeningHandshake00().
-     * @throws WebSocketHandshakeException
+     * @throws WebSocketHandshakeException if handshake response is invalid.
      */
     @Override
     protected void verify(FullHttpResponse response) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -115,7 +115,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
      * Upgrade: websocket
      * Connection: Upgrade
      * Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-     * Sec-WebSocket-Origin: http://example.com
+     * Origin: http://example.com
      * Sec-WebSocket-Protocol: chat, superchat
      * Sec-WebSocket-Version: 13
      * </pre>

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07Test.java
@@ -46,7 +46,7 @@ public class WebSocketClientHandshaker07Test extends WebSocketClientHandshakerTe
                 HttpHeaderNames.CONNECTION,
                 HttpHeaderNames.SEC_WEBSOCKET_KEY,
                 HttpHeaderNames.HOST,
-                HttpHeaderNames.SEC_WEBSOCKET_ORIGIN,
+                getOriginHeaderName(),
                 HttpHeaderNames.SEC_WEBSOCKET_VERSION,
         };
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13Test.java
@@ -15,11 +15,13 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 
 import java.net.URI;
 
 public class WebSocketClientHandshaker13Test extends WebSocketClientHandshaker07Test {
+
     @Override
     protected WebSocketClientHandshaker newHandshaker(URI uri, String subprotocol, HttpHeaders headers,
                                                       boolean absoluteUpgradeUrl) {
@@ -27,4 +29,10 @@ public class WebSocketClientHandshaker13Test extends WebSocketClientHandshaker07
           1024, true, true, 10000,
           absoluteUpgradeUrl);
     }
+
+    @Override
+    protected CharSequence getOriginHeaderName() {
+        return HttpHeaderNames.ORIGIN;
+    }
+
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketRequestBuilder.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketRequestBuilder.java
@@ -138,7 +138,11 @@ public class WebSocketRequestBuilder {
             headers.set(HttpHeaderNames.SEC_WEBSOCKET_KEY, key);
         }
         if (origin != null) {
-            headers.set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, origin);
+            if (version == WebSocketVersion.V13 || version == WebSocketVersion.V00) {
+                headers.set(HttpHeaderNames.ORIGIN, origin);
+            } else {
+                headers.set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, origin);
+            }
         }
         if (version != null) {
             headers.set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, version.toHttpHeaderValue());


### PR DESCRIPTION
Motivation:

Based on https://tools.ietf.org/html/rfc6455#section-1.3 - for non-browser
clients, `Origin` header field may be sent if it makes sense in the  context of those clients.

Modification:

Replace `Sec-WebSocket-Origin` to `Origin`

Result:

Fixes #9134 . 