### PR TITLE
Correctly handle http2 upgrades when Http2FrameCodec is used together…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -143,9 +143,21 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
 
     @Override
     public void upgradeTo(final ChannelHandlerContext ctx, FullHttpRequest upgradeRequest) {
+        int firstHandlerIdx = 0;
         try {
             // Add the HTTP/2 connection handler to the pipeline immediately following the current handler.
             ctx.pipeline().addAfter(ctx.name(), handlerName, connectionHandler);
+
+            // As we will re-act on the created streams in the Http2MultiplexHandler we need to ensure we special
+            // handle it and put it into the pipeline before we all onHttp2ServerUpgrade(...) is called. Otherwise
+            // we will not correctly create the Http2StreamChannel for the upgrade request and so will produce an
+            // NPE.
+            //
+            // See https://github.com/netty/netty/issues/9314
+            if (handlers != null && handlers.length > 0 && handlers[firstHandlerIdx] instanceof Http2MultiplexHandler) {
+                ChannelHandlerContext connectionHandlerCtx = ctx.pipeline().context(connectionHandler);
+                ctx.pipeline().addAfter(connectionHandlerCtx.name(), null, handlers[firstHandlerIdx++]);
+            }
             connectionHandler.onHttpServerUpgrade(settings);
 
         } catch (Http2Exception e) {
@@ -156,7 +168,7 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
 
         if (handlers != null) {
             final String name = ctx.pipeline().context(connectionHandler).name();
-            for (int i = handlers.length - 1; i >= 0; i--) {
+            for (int i = handlers.length - 1; i >= firstHandlerIdx; i--) {
                 ctx.pipeline().addAfter(name, null, handlers[i]);
             }
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
@@ -76,6 +76,11 @@ public class Http2ServerUpgradeCodecTest {
         // Flush the channel to ensure we write out all buffered data
         channel.flush();
 
+        channel.writeInbound(Http2CodecUtil.connectionPrefaceBuf());
+        Http2FrameInboundWriter writer = new Http2FrameInboundWriter(channel);
+        writer.writeInboundSettings(new Http2Settings());
+        writer.writeInboundRstStream(Http2CodecUtil.HTTP_UPGRADE_STREAM_ID, Http2Error.CANCEL.code());
+
         assertSame(handler, channel.pipeline().remove(handler.getClass()));
         assertNull(channel.pipeline().get(handler.getClass()));
         assertTrue(channel.finish());
@@ -84,6 +89,10 @@ public class Http2ServerUpgradeCodecTest {
         ByteBuf settingsBuffer = channel.readOutbound();
         assertNotNull(settingsBuffer);
         settingsBuffer.release();
+
+        ByteBuf buf = channel.readOutbound();
+        assertNotNull(buf);
+        buf.release();
 
         assertNull(channel.readOutbound());
     }


### PR DESCRIPTION
… with Http2MultiplexHandler

Motivation:

In the latest release we introduced Http2MultiplexHandler as a replacement of Http2MultiplexCodec. This did split the frame parsing from the multiplexing to allow a more flexible way to handle frames and to make the code cleaner. Unfortunally we did miss to special handle this in Http2ServerUpgradeCodec and so did not correctly add Http2MultiplexHandler to the pipeline before calling Http2FrameCodec.onHttpServerUpgrade(...). This did lead to the situation that we did not correctly receive the event on the Http2MultiplexHandler and so did not correctly created the Http2StreamChannel for the upgrade stream. Because of this we ended up with an NPE if a frame was dispatched to the upgrade stream later on.

Modifications:

- Correctly add Http2MultiplexHandler to the pipeline before calling Http2FrameCodec.onHttpServerUpgrade(...)
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/9314.