### PR TITLE
Increase maxHeaderListSize for HpackDecoderBenchmark to be able to be…

### DIFF
--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackDecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackDecoderBenchmark.java
@@ -72,7 +72,7 @@ public class HpackDecoderBenchmark extends AbstractMicrobenchmark {
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     public void decode(final Blackhole bh) throws Http2Exception {
-        HpackDecoder hpackDecoder = new HpackDecoder(DEFAULT_HEADER_LIST_SIZE);
+        HpackDecoder hpackDecoder = new HpackDecoder(Integer.MAX_VALUE);
         @SuppressWarnings("unchecked")
         Http2Headers headers =
                 new DefaultHttp2Headers() {

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackHeader.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackHeader.java
@@ -59,14 +59,14 @@ class HpackHeader {
                                            boolean limitToAscii) {
         List<HpackHeader> hpackHeaders = new ArrayList<HpackHeader>(numHeaders);
         for (int i = 0; i < numHeaders; ++i) {
-            byte[] name = randomBytes(new byte[nameLength], limitToAscii);
-            byte[] value = randomBytes(new byte[valueLength], limitToAscii);
+            byte[] name = randomBytes(new byte[nameLength], limitToAscii, true);
+            byte[] value = randomBytes(new byte[valueLength], limitToAscii, false);
             hpackHeaders.add(new HpackHeader(name, value));
         }
         return hpackHeaders;
     }
 
-    private static byte[] randomBytes(byte[] bytes, boolean limitToAscii) {
+    private static byte[] randomBytes(byte[] bytes, boolean limitToAscii, boolean removeLeadingColon) {
         Random r = new Random();
         if (limitToAscii) {
             for (int index = 0; index < bytes.length; ++index) {
@@ -75,6 +75,12 @@ class HpackHeader {
             }
         } else {
             r.nextBytes(bytes);
+
+            // Remove leading ':' as this is not allowed
+            if (removeLeadingColon && bytes[0] == ':') {
+                int charIndex = r.nextInt(ALPHABET.length());
+                bytes[0] = (byte) ALPHABET.charAt(charIndex);
+            }
         }
         return bytes;
     }

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackHeader.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackHeader.java
@@ -40,14 +40,14 @@ import java.util.Random;
 /**
  * Helper class representing a single header entry. Used by the benchmarks.
  */
-class HpackHeader {
+final class HpackHeader {
     private static final String ALPHABET =
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
 
     final CharSequence name;
     final CharSequence value;
 
-    HpackHeader(byte[] name, byte[] value) {
+    private HpackHeader(byte[] name, byte[] value) {
         this.name = new AsciiString(name, false);
         this.value = new AsciiString(value, false);
     }
@@ -59,14 +59,15 @@ class HpackHeader {
                                            boolean limitToAscii) {
         List<HpackHeader> hpackHeaders = new ArrayList<HpackHeader>(numHeaders);
         for (int i = 0; i < numHeaders; ++i) {
-            byte[] name = randomBytes(new byte[nameLength], limitToAscii, true);
-            byte[] value = randomBytes(new byte[valueLength], limitToAscii, false);
+            // Force always ascii for header names
+            byte[] name = randomBytes(new byte[nameLength], true);
+            byte[] value = randomBytes(new byte[valueLength], limitToAscii);
             hpackHeaders.add(new HpackHeader(name, value));
         }
         return hpackHeaders;
     }
 
-    private static byte[] randomBytes(byte[] bytes, boolean limitToAscii, boolean removeLeadingColon) {
+    private static byte[] randomBytes(byte[] bytes, boolean limitToAscii) {
         Random r = new Random();
         if (limitToAscii) {
             for (int index = 0; index < bytes.length; ++index) {
@@ -75,12 +76,6 @@ class HpackHeader {
             }
         } else {
             r.nextBytes(bytes);
-
-            // Remove leading ':' as this is not allowed
-            if (removeLeadingColon && bytes[0] == ':') {
-                int charIndex = r.nextInt(ALPHABET.length());
-                bytes[0] = (byte) ALPHABET.charAt(charIndex);
-            }
         }
         return bytes;
     }


### PR DESCRIPTION
…nchmark with HpackHeadersSize.LARGE

Motivation:

The previous used maxHeaderListSize was too low which resulted in exceptions during the benchmark run:

```
io.netty.handler.codec.http2.Http2Exception: Header size exceeded max allowed size (8192)
	at io.netty.handler.codec.http2.Http2Exception.connectionError(Http2Exception.java:103)
	at io.netty.handler.codec.http2.Http2Exception.headerListSizeError(Http2Exception.java:188)
	at io.netty.handler.codec.http2.Http2CodecUtil.headerListSizeExceeded(Http2CodecUtil.java:231)
	at io.netty.handler.codec.http2.HpackDecoder$Http2HeadersSink.finish(HpackDecoder.java:545)
	at io.netty.handler.codec.http2.HpackDecoder.decode(HpackDecoder.java:132)
	at io.netty.handler.codec.http2.HpackDecoderBenchmark.decode(HpackDecoderBenchmark.java:85)
	at io.netty.handler.codec.http2.generated.HpackDecoderBenchmark_decode_jmhTest.decode_thrpt_jmhStub(HpackDecoderBenchmark_decode_jmhTest.java:120)
	at io.netty.handler.codec.http2.generated.HpackDecoderBenchmark_decode_jmhTest.decode_Throughput(HpackDecoderBenchmark_decode_jmhTest.java:83)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)

```

Modifications:

Just use Integer.MAX_VALUE as limit

Result:

Be able to run benchmark without exceptions