### PR TITLE
Let the DefaultChannelHandlerContext ensure that reads will happen if…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -18,7 +18,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.AsciiString;
 
-import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -122,42 +121,6 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator {
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
-        ctx.bind(localAddress, promise);
-    }
-
-    @Override
-    public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        ChannelPromise promise) throws Exception {
-        ctx.connect(remoteAddress, localAddress, promise);
-    }
-
-    @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-        ctx.disconnect(promise);
-    }
-
-    @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-        ctx.close(promise);
-    }
-
-    @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-        ctx.register(promise);
-    }
-
-    @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-        ctx.deregister(promise);
-    }
-
-    @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
-        ctx.read();
-    }
-
-    @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
             throws Exception {
         if (!(msg instanceof HttpRequest)) {
@@ -180,11 +143,6 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator {
         // Notify that the upgrade request was issued.
         ctx.fireUserEventTriggered(UpgradeEvent.UPGRADE_ISSUED);
         // Now we wait for the next HTTP response to see if we switch protocols.
-    }
-
-    @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
-        ctx.flush();
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
@@ -51,107 +51,102 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
     protected ChannelHandlerContext ctx;
     private EmbeddedChannel decoder;
     private boolean continueResponse;
-    private boolean needRead = true;
 
     @Override
     protected void decode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
-        try {
-            if (msg instanceof HttpResponse && ((HttpResponse) msg).status().code() == 100) {
+        if (msg instanceof HttpResponse && ((HttpResponse) msg).status().code() == 100) {
 
-                if (!(msg instanceof LastHttpContent)) {
-                    continueResponse = true;
-                }
-                // 100-continue response must be passed through.
-                out.add(ReferenceCountUtil.retain(msg));
-                return;
+            if (!(msg instanceof LastHttpContent)) {
+                continueResponse = true;
             }
+            // 100-continue response must be passed through.
+            out.add(ReferenceCountUtil.retain(msg));
+            return;
+        }
 
-            if (continueResponse) {
-                if (msg instanceof LastHttpContent) {
-                    continueResponse = false;
-                }
-                // 100-continue response must be passed through.
-                out.add(ReferenceCountUtil.retain(msg));
-                return;
+        if (continueResponse) {
+            if (msg instanceof LastHttpContent) {
+                continueResponse = false;
             }
+            // 100-continue response must be passed through.
+            out.add(ReferenceCountUtil.retain(msg));
+            return;
+        }
 
-            if (msg instanceof HttpMessage) {
-                cleanup();
-                final HttpMessage message = (HttpMessage) msg;
-                final HttpHeaders headers = message.headers();
+        if (msg instanceof HttpMessage) {
+            cleanup();
+            final HttpMessage message = (HttpMessage) msg;
+            final HttpHeaders headers = message.headers();
 
-                // Determine the content encoding.
-                String contentEncoding = headers.get(HttpHeaderNames.CONTENT_ENCODING);
-                if (contentEncoding != null) {
-                    contentEncoding = contentEncoding.trim();
-                } else {
-                    contentEncoding = IDENTITY;
-                }
-                decoder = newContentDecoder(contentEncoding);
+            // Determine the content encoding.
+            String contentEncoding = headers.get(HttpHeaderNames.CONTENT_ENCODING);
+            if (contentEncoding != null) {
+                contentEncoding = contentEncoding.trim();
+            } else {
+                contentEncoding = IDENTITY;
+            }
+            decoder = newContentDecoder(contentEncoding);
 
-                if (decoder == null) {
-                    if (message instanceof HttpContent) {
-                        ((HttpContent) message).retain();
-                    }
-                    out.add(message);
-                    return;
-                }
-
-                // Remove content-length header:
-                // the correct value can be set only after all chunks are processed/decoded.
-                // If buffering is not an issue, add HttpObjectAggregator down the chain, it will set the header.
-                // Otherwise, rely on LastHttpContent message.
-                if (headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
-                    headers.remove(HttpHeaderNames.CONTENT_LENGTH);
-                    headers.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-                }
-                // Either it is already chunked or EOF terminated.
-                // See https://github.com/netty/netty/issues/5892
-
-                // set new content encoding,
-                CharSequence targetContentEncoding = getTargetContentEncoding(contentEncoding);
-                if (HttpHeaderValues.IDENTITY.contentEquals(targetContentEncoding)) {
-                    // Do NOT set the 'Content-Encoding' header if the target encoding is 'identity'
-                    // as per: http://tools.ietf.org/html/rfc2616#section-14.11
-                    headers.remove(HttpHeaderNames.CONTENT_ENCODING);
-                } else {
-                    headers.set(HttpHeaderNames.CONTENT_ENCODING, targetContentEncoding);
-                }
-
+            if (decoder == null) {
                 if (message instanceof HttpContent) {
-                    // If message is a full request or response object (headers + data), don't copy data part into out.
-                    // Output headers only; data part will be decoded below.
-                    // Note: "copy" object must not be an instance of LastHttpContent class,
-                    // as this would (erroneously) indicate the end of the HttpMessage to other handlers.
-                    HttpMessage copy;
-                    if (message instanceof HttpRequest) {
-                        HttpRequest r = (HttpRequest) message; // HttpRequest or FullHttpRequest
-                        copy = new DefaultHttpRequest(r.protocolVersion(), r.method(), r.uri());
-                    } else if (message instanceof HttpResponse) {
-                        HttpResponse r = (HttpResponse) message; // HttpResponse or FullHttpResponse
-                        copy = new DefaultHttpResponse(r.protocolVersion(), r.status());
-                    } else {
-                        throw new CodecException("Object of class " + message.getClass().getName() +
-                                                 " is not a HttpRequest or HttpResponse");
-                    }
-                    copy.headers().set(message.headers());
-                    copy.setDecoderResult(message.decoderResult());
-                    out.add(copy);
-                } else {
-                    out.add(message);
+                    ((HttpContent) message).retain();
                 }
+                out.add(message);
+                return;
             }
 
-            if (msg instanceof HttpContent) {
-                final HttpContent c = (HttpContent) msg;
-                if (decoder == null) {
-                    out.add(c.retain());
-                } else {
-                    decodeContent(c, out);
-                }
+            // Remove content-length header:
+            // the correct value can be set only after all chunks are processed/decoded.
+            // If buffering is not an issue, add HttpObjectAggregator down the chain, it will set the header.
+            // Otherwise, rely on LastHttpContent message.
+            if (headers.contains(HttpHeaderNames.CONTENT_LENGTH)) {
+                headers.remove(HttpHeaderNames.CONTENT_LENGTH);
+                headers.set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
             }
-        } finally {
-            needRead = out.isEmpty();
+            // Either it is already chunked or EOF terminated.
+            // See https://github.com/netty/netty/issues/5892
+
+            // set new content encoding,
+            CharSequence targetContentEncoding = getTargetContentEncoding(contentEncoding);
+            if (HttpHeaderValues.IDENTITY.contentEquals(targetContentEncoding)) {
+                // Do NOT set the 'Content-Encoding' header if the target encoding is 'identity'
+                // as per: http://tools.ietf.org/html/rfc2616#section-14.11
+                headers.remove(HttpHeaderNames.CONTENT_ENCODING);
+            } else {
+                headers.set(HttpHeaderNames.CONTENT_ENCODING, targetContentEncoding);
+            }
+
+            if (message instanceof HttpContent) {
+                // If message is a full request or response object (headers + data), don't copy data part into out.
+                // Output headers only; data part will be decoded below.
+                // Note: "copy" object must not be an instance of LastHttpContent class,
+                // as this would (erroneously) indicate the end of the HttpMessage to other handlers.
+                HttpMessage copy;
+                if (message instanceof HttpRequest) {
+                    HttpRequest r = (HttpRequest) message; // HttpRequest or FullHttpRequest
+                    copy = new DefaultHttpRequest(r.protocolVersion(), r.method(), r.uri());
+                } else if (message instanceof HttpResponse) {
+                    HttpResponse r = (HttpResponse) message; // HttpResponse or FullHttpResponse
+                    copy = new DefaultHttpResponse(r.protocolVersion(), r.status());
+                } else {
+                    throw new CodecException("Object of class " + message.getClass().getName() +
+                            " is not a HttpRequest or HttpResponse");
+                }
+                copy.headers().set(message.headers());
+                copy.setDecoderResult(message.decoderResult());
+                out.add(copy);
+            } else {
+                out.add(message);
+            }
+        }
+
+        if (msg instanceof HttpContent) {
+            final HttpContent c = (HttpContent) msg;
+            if (decoder == null) {
+                out.add(c.retain());
+            } else {
+                decodeContent(c, out);
+            }
         }
     }
 
@@ -171,20 +166,6 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
                 out.add(LastHttpContent.EMPTY_LAST_CONTENT);
             } else {
                 out.add(new ComposedLastHttpContent(headers, DecoderResult.SUCCESS));
-            }
-        }
-    }
-
-    @Override
-    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-        boolean needRead = this.needRead;
-        this.needRead = true;
-
-        try {
-            ctx.fireChannelReadComplete();
-        } finally {
-            if (needRead && !ctx.channel().config().isAutoRead()) {
-                ctx.read();
             }
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -48,21 +48,13 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
         if (frame instanceof PingWebSocketFrame) {
             frame.content().retain();
             ctx.channel().writeAndFlush(new PongWebSocketFrame(frame.content()));
-            readIfNeeded(ctx);
             return;
         }
         if (frame instanceof PongWebSocketFrame && dropPongFrames) {
-            readIfNeeded(ctx);
             return;
         }
 
         out.add(frame.retain());
-    }
-
-    private static void readIfNeeded(ChannelHandlerContext ctx) {
-        if (!ctx.channel().config().isAutoRead()) {
-            ctx.read();
-        }
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -418,17 +418,6 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
     }
 
     @Override
-    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-        // We might need keep reading the channel until the full message is aggregated.
-        //
-        // See https://github.com/netty/netty/issues/6583
-        if (currentMessage != null && !ctx.channel().config().isAutoRead()) {
-            ctx.read();
-        }
-        ctx.fireChannelReadComplete();
-    }
-
-    @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         try {
             // release current message if it is not null as it may be a left-over

--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageDecoder.java
@@ -105,6 +105,11 @@ public abstract class MessageToMessageDecoder<I> extends ChannelHandlerAdapter i
         }
     }
 
+    @Override
+    public final boolean isBufferingInbound() {
+        return true;
+    }
+
     /**
      * Decode from one message to an other. This method will be called for each written message that can be handled
      * by this decoder.

--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -191,12 +191,11 @@ public class FlowControlHandler implements ChannelHandler {
         if (queue != null && queue.isEmpty()) {
             queue.recycle();
             queue = null;
-
-            if (consumed > 0) {
-                ctx.fireChannelReadComplete();
-            }
         }
 
+        if (consumed > 0) {
+            ctx.fireChannelReadComplete();
+        }
         return consumed;
     }
 

--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -383,4 +383,8 @@ public interface ChannelHandler {
     default void flush(ChannelHandlerContext ctx) throws Exception {
         ctx.flush();
     }
+
+    default boolean isBufferingInbound() {
+        return false;
+    }
 }


### PR DESCRIPTION
… the handlers buffers data

Motivation:

As of today the user needs to be very careful to request more data if the auto read is disable and the decoder / handler does buffer data or consume it. This is kind of error-prone and so it may be a good idea to automatically take care of this for the user.

Modifications:

- Introduce ChannelHandler.isBufferingInbound() which the user can implement to return true.
- Add logic to DefaultChannelHandlerContext to respect isBufferInbound() and keep track of if a read() needs to be triggered automatically
- Remove logic in handler implementations which is not needed anymore because of the mentioned changes

Result:

Automatically request more data if needed.