### PR TITLE
DecoratingHttp2ConnectionEncoder.consumeReceivedSettings must not throw if de…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionEncoder.java
@@ -65,8 +65,9 @@ public class DecoratingHttp2ConnectionEncoder extends DecoratingHttp2FrameWriter
     public void consumeReceivedSettings(Http2Settings settings) {
         if (delegate instanceof Http2SettingsReceivedConsumer) {
             ((Http2SettingsReceivedConsumer) delegate).consumeReceivedSettings(settings);
+        } else {
+            throw new IllegalStateException("delegate " + delegate + " is not an instance of " +
+                    Http2SettingsReceivedConsumer.class);
         }
-        throw new IllegalStateException("delegate " + delegate + " is not an instance of " +
-                Http2SettingsReceivedConsumer.class);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionEncoderTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import org.junit.Test;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+public class DecoratingHttp2ConnectionEncoderTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void testConsumeReceivedSettingsThrows() {
+        Http2ConnectionEncoder encoder = mock(Http2ConnectionEncoder.class);
+        DecoratingHttp2ConnectionEncoder decoratingHttp2ConnectionEncoder =
+                new DecoratingHttp2ConnectionEncoder(encoder);
+        decoratingHttp2ConnectionEncoder.consumeReceivedSettings(Http2Settings.defaultSettings());
+    }
+
+    @Test
+    public void testConsumeReceivedSettingsDelegate() {
+        TestHttp2ConnectionEncoder encoder = mock(TestHttp2ConnectionEncoder.class);
+        DecoratingHttp2ConnectionEncoder decoratingHttp2ConnectionEncoder =
+                new DecoratingHttp2ConnectionEncoder(encoder);
+
+        Http2Settings settings = Http2Settings.defaultSettings();
+        decoratingHttp2ConnectionEncoder.consumeReceivedSettings(Http2Settings.defaultSettings());
+        verify(encoder, times(1)).consumeReceivedSettings(eq(settings));
+    }
+
+    private interface TestHttp2ConnectionEncoder extends Http2ConnectionEncoder, Http2SettingsReceivedConsumer { }
+}


### PR DESCRIPTION
…legate is instance of Http2SettingsReceivedConsumer

Motivation:

b3dba317d797e21cc253bb6ad6776307297f612e introduced the concept of Http2SettingsReceivedConsumer but did not correctly inplement DecoratingHttp2ConnectionEncoder.consumeReceivedSettings(...).

Modifications:

- Add missing `else` around the throws
- Add unit tests

Result:

Correctly implement DecoratingHttp2ConnectionEncoder.consumeReceivedSettings(...)
