### PR TITLE
Change the netty.io homepage scheme(http -> https)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please review the [guidelines for contributing](http://netty.io/wiki/developer-guide.html) for this repository.
+Please review the [guidelines for contributing](https://netty.io/wiki/developer-guide.html) for this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,5 +42,5 @@ My system has IPv6 disabled.
 
 ## How to contribute your work
 
-Before submitting a pull request or push a commit, please read [our developer guide](http://netty.io/wiki/developer-guide.html).
+Before submitting a pull request or push a commit, please read [our developer guide](https://netty.io/wiki/developer-guide.html).
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,7 +4,7 @@
 
 Please visit the Netty web site for more information:
 
-  * http://netty.io/
+  * https://netty.io/
 
 Copyright 2014 The Netty Project
 

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Netty is an asynchronous event-driven network application framework for rapid de
 
 ## Links
 
-* [Web Site](http://netty.io/)
-* [Downloads](http://netty.io/downloads.html)
-* [Documentation](http://netty.io/wiki/)
+* [Web Site](https://netty.io/)
+* [Downloads](https://netty.io/downloads.html)
+* [Documentation](https://netty.io/wiki/)
 * [@netty_project](https://twitter.com/netty_project)
 
 ## How to build
 
-For the detailed information about building and developing Netty, please visit [the developer guide](http://netty.io/wiki/developer-guide.html).  This page only gives very basic information.
+For the detailed information about building and developing Netty, please visit [the developer guide](https://netty.io/wiki/developer-guide.html).  This page only gives very basic information.
 
 You require the following to build Netty:
 
 * Latest stable [Oracle JDK 7](http://www.oracle.com/technetwork/java/)
 * Latest stable [Apache Maven](http://maven.apache.org/)
-* If you are on Linux, you need [additional development packages](http://netty.io/wiki/native-transports.html) installed on your system, because you'll build the native transport.
+* If you are on Linux, you need [additional development packages](https://netty.io/wiki/native-transports.html) installed on your system, because you'll build the native transport.
 
 Note that this is build-time requirement.  JDK 5 (for 3.x) or 6 (for 4.0+) is enough to run your Netty-based application.
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,11 +30,11 @@
 
   <name>Netty/BOM</name>
   <description>Netty (Bill of Materials)</description>
-  <url>http://netty.io/</url>
+  <url>https://netty.io/</url>
 
   <organization>
     <name>The Netty Project</name>
-    <url>http://netty.io/</url>
+    <url>https://netty.io/</url>
   </organization>
 
   <licenses>
@@ -57,9 +57,9 @@
       <id>netty.io</id>
       <name>The Netty Project Contributors</name>
       <email>netty@googlegroups.com</email>
-      <url>http://netty.io/</url>
+      <url>https://netty.io/</url>
       <organization>The Netty Project</organization>
-      <organizationUrl>http://netty.io/</organizationUrl>
+      <organizationUrl>https://netty.io/</organizationUrl>
     </developer>
   </developers>
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
@@ -54,7 +54,7 @@ import static io.netty.util.internal.StringUtil.*;
  *
  * <h3>HashDOS vulnerability fix</h3>
  *
- * As a workaround to the <a href="http://netty.io/s/hashdos">HashDOS</a> vulnerability, the decoder
+ * As a workaround to the <a href="https://netty.io/s/hashdos">HashDOS</a> vulnerability, the decoder
  * limits the maximum number of decoded key-value parameter pairs, up to {@literal 1024} by
  * default, and you can configure it when you construct the decoder by passing an additional
  * integer parameter.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -28,8 +28,8 @@ import static io.netty.handler.codec.http.HttpVersion.*;
 
 /**
  * <p>
- * Performs server side opening and closing handshakes for <a href="http://netty.io/s/rfc6455">RFC 6455</a>
- * (originally web socket specification <a href="http://netty.io/s/ws-17">draft-ietf-hybi-thewebsocketprotocol-17</a>).
+ * Performs server side opening and closing handshakes for <a href="https://netty.io/s/rfc6455">RFC 6455</a>
+ * (originally web socket specification <a href="https://netty.io/s/ws-17">draft-ietf-hybi-thewebsocketprotocol-17</a>).
  * </p>
  */
 public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/package-info.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/package-info.java
@@ -21,11 +21,11 @@
  * This package supports different web socket specification versions (hence the X suffix).
  * The specification current supported are:
  * <ul>
- * <li><a href="http://netty.io/s/ws-00">draft-ietf-hybi-thewebsocketprotocol-00</a></li>
- * <li><a href="http://netty.io/s/ws-07">draft-ietf-hybi-thewebsocketprotocol-07</a></li>
- * <li><a href="http://netty.io/s/ws-10">draft-ietf-hybi-thewebsocketprotocol-10</a></li>
- * <li><a href="http://netty.io/s/rfc6455">RFC 6455</a>
- *     (originally <a href="http://netty.io/s/ws-17">draft-ietf-hybi-thewebsocketprotocol-17</a>)</li>
+ * <li><a href="https://netty.io/s/ws-00">draft-ietf-hybi-thewebsocketprotocol-00</a></li>
+ * <li><a href="https://netty.io/s/ws-07">draft-ietf-hybi-thewebsocketprotocol-07</a></li>
+ * <li><a href="https://netty.io/s/ws-10">draft-ietf-hybi-thewebsocketprotocol-10</a></li>
+ * <li><a href="https://netty.io/s/rfc6455">RFC 6455</a>
+ *     (originally <a href="https://netty.io/s/ws-17">draft-ietf-hybi-thewebsocketprotocol-17</a>)</li>
 
  * </ul>
  * </p>

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -136,7 +136,7 @@ import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
  * reference counted objects (e.g. {@link ByteBuf}s). The frame codec will call {@link ReferenceCounted#retain()} before
  * propagating a reference counted object through the pipeline, and thus an application handler needs to release such
  * an object after having consumed it. For more information on reference counting take a look at
- * http://netty.io/wiki/reference-counted-objects.html
+ * https://netty.io/wiki/reference-counted-objects.html
  *
  * <h3>HTTP Upgrade</h3>
  *

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -61,7 +61,7 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * reference counted objects (e.g. {@link ByteBuf}s). The multiplex codec will call {@link ReferenceCounted#retain()}
  * before propagating a reference counted object through the pipeline, and thus an application handler needs to release
  * such an object after having consumed it. For more information on reference counting take a look at
- * http://netty.io/wiki/reference-counted-objects.html
+ * https://netty.io/wiki/reference-counted-objects.html
  *
  * <h3>Channel Events</h3>
  *

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -64,7 +64,7 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * reference counted objects (e.g. {@link ByteBuf}s). The multiplex codec will call {@link ReferenceCounted#retain()}
  * before propagating a reference counted object through the pipeline, and thus an application handler needs to release
  * such an object after having consumed it. For more information on reference counting take a look at
- * http://netty.io/wiki/reference-counted-objects.html
+ * https://netty.io/wiki/reference-counted-objects.html
  *
  * <h3>Channel Events</h3>
  *

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlDecoderTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlDecoderTest.java
@@ -37,12 +37,12 @@ public class XmlDecoderTest {
             "<!DOCTYPE employee SYSTEM \"employee.dtd\">" +
             "<?xml-stylesheet type=\"text/css\" href=\"netty.css\"?>" +
             "<?xml-test ?>" +
-            "<employee xmlns:nettya=\"http://netty.io/netty/a\">" +
+            "<employee xmlns:nettya=\"https://netty.io/netty/a\">" +
             "<nettya:id>&plusmn;1</nettya:id>\n" +
             "<name ";
 
     private static final String XML2 = "type=\"given\">Alba</name><![CDATA[ <some data &gt;/> ]]>" +
-            "   <!-- namespaced --><nettyb:salary xmlns:nettyb=\"http://netty.io/netty/b\" nettyb:period=\"weekly\">" +
+            "   <!-- namespaced --><nettyb:salary xmlns:nettyb=\"https://netty.io/netty/b\" nettyb:period=\"weekly\">" +
             "100</nettyb:salary><last/></employee>";
 
     private static final String XML3 = "<?xml version=\"1.1\" encoding=\"UTf-8\" standalone=\"yes\"?><netty></netty>";
@@ -99,13 +99,13 @@ public class XmlDecoderTest {
         assertThat(((XmlElementStart) temp).attributes().size(), is(0));
         assertThat(((XmlElementStart) temp).namespaces().size(), is(1));
         assertThat(((XmlElementStart) temp).namespaces().get(0).prefix(), is("nettya"));
-        assertThat(((XmlElementStart) temp).namespaces().get(0).uri(), is("http://netty.io/netty/a"));
+        assertThat(((XmlElementStart) temp).namespaces().get(0).uri(), is("https://netty.io/netty/a"));
 
         temp = channel.readInbound();
         assertThat(temp, instanceOf(XmlElementStart.class));
         assertThat(((XmlElementStart) temp).name(), is("id"));
         assertThat(((XmlElementStart) temp).prefix(), is("nettya"));
-        assertThat(((XmlElementStart) temp).namespace(), is("http://netty.io/netty/a"));
+        assertThat(((XmlElementStart) temp).namespace(), is("https://netty.io/netty/a"));
         assertThat(((XmlElementStart) temp).attributes().size(), is(0));
         assertThat(((XmlElementStart) temp).namespaces().size(), is(0));
 
@@ -122,7 +122,7 @@ public class XmlDecoderTest {
         assertThat(temp, instanceOf(XmlElementEnd.class));
         assertThat(((XmlElementEnd) temp).name(), is("id"));
         assertThat(((XmlElementEnd) temp).prefix(), is("nettya"));
-        assertThat(((XmlElementEnd) temp).namespace(), is("http://netty.io/netty/a"));
+        assertThat(((XmlElementEnd) temp).namespace(), is("https://netty.io/netty/a"));
 
         temp = channel.readInbound();
         assertThat(temp, instanceOf(XmlCharacters.class));
@@ -171,15 +171,15 @@ public class XmlDecoderTest {
         assertThat(temp, instanceOf(XmlElementStart.class));
         assertThat(((XmlElementStart) temp).name(), is("salary"));
         assertThat(((XmlElementStart) temp).prefix(), is("nettyb"));
-        assertThat(((XmlElementStart) temp).namespace(), is("http://netty.io/netty/b"));
+        assertThat(((XmlElementStart) temp).namespace(), is("https://netty.io/netty/b"));
         assertThat(((XmlElementStart) temp).attributes().size(), is(1));
         assertThat(((XmlElementStart) temp).attributes().get(0).name(), is("period"));
         assertThat(((XmlElementStart) temp).attributes().get(0).value(), is("weekly"));
         assertThat(((XmlElementStart) temp).attributes().get(0).prefix(), is("nettyb"));
-        assertThat(((XmlElementStart) temp).attributes().get(0).namespace(), is("http://netty.io/netty/b"));
+        assertThat(((XmlElementStart) temp).attributes().get(0).namespace(), is("https://netty.io/netty/b"));
         assertThat(((XmlElementStart) temp).namespaces().size(), is(1));
         assertThat(((XmlElementStart) temp).namespaces().get(0).prefix(), is("nettyb"));
-        assertThat(((XmlElementStart) temp).namespaces().get(0).uri(), is("http://netty.io/netty/b"));
+        assertThat(((XmlElementStart) temp).namespaces().get(0).uri(), is("https://netty.io/netty/b"));
 
         temp = channel.readInbound();
         assertThat(temp, instanceOf(XmlCharacters.class));
@@ -189,10 +189,10 @@ public class XmlDecoderTest {
         assertThat(temp, instanceOf(XmlElementEnd.class));
         assertThat(((XmlElementEnd) temp).name(), is("salary"));
         assertThat(((XmlElementEnd) temp).prefix(), is("nettyb"));
-        assertThat(((XmlElementEnd) temp).namespace(), is("http://netty.io/netty/b"));
+        assertThat(((XmlElementEnd) temp).namespace(), is("https://netty.io/netty/b"));
         assertThat(((XmlElementEnd) temp).namespaces().size(), is(1));
         assertThat(((XmlElementEnd) temp).namespaces().get(0).prefix(), is("nettyb"));
-        assertThat(((XmlElementEnd) temp).namespaces().get(0).uri(), is("http://netty.io/netty/b"));
+        assertThat(((XmlElementEnd) temp).namespaces().get(0).uri(), is("https://netty.io/netty/b"));
 
         temp = channel.readInbound();
         assertThat(temp, instanceOf(XmlElementStart.class));
@@ -216,7 +216,7 @@ public class XmlDecoderTest {
         assertThat(((XmlElementEnd) temp).namespace(), is(""));
         assertThat(((XmlElementEnd) temp).namespaces().size(), is(1));
         assertThat(((XmlElementEnd) temp).namespaces().get(0).prefix(), is("nettya"));
-        assertThat(((XmlElementEnd) temp).namespaces().get(0).uri(), is("http://netty.io/netty/a"));
+        assertThat(((XmlElementEnd) temp).namespaces().get(0).uri(), is("https://netty.io/netty/a"));
 
         temp = channel.readInbound();
         assertThat(temp, nullValue());

--- a/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
+++ b/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
@@ -29,7 +29,7 @@
   <version>4.0.14.Final-SNAPSHOT</version>
 
   <name>Netty</name>
-  <url>http://netty.io/</url>
+  <url>https://netty.io/</url>
   <description>
     Netty is an asynchronous event-driven network application framework for 
     rapid development of maintainable high performance protocol servers and
@@ -38,7 +38,7 @@
 
   <organization>
     <name>The Netty Project</name>
-    <url>http://netty.io/</url>
+    <url>https://netty.io/</url>
   </organization>
 
   <licenses>
@@ -61,9 +61,9 @@
       <id>netty.io</id>
       <name>The Netty Project Contributors</name>
       <email>netty@googlegroups.com</email>
-      <url>http://netty.io/</url>
+      <url>https://netty.io/</url>
       <organization>The Netty Project</organization>
-      <organizationUrl>http://netty.io/</organizationUrl>
+      <organizationUrl>https://netty.io/</organizationUrl>
     </developer>
   </developers>
 

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -316,7 +316,7 @@ public class ResourceLeakDetector<T> {
     protected void reportTracedLeak(String resourceType, String records) {
         logger.error(
                 "LEAK: {}.release() was not called before it's garbage-collected. " +
-                "See http://netty.io/wiki/reference-counted-objects.html for more information.{}",
+                "See https://netty.io/wiki/reference-counted-objects.html for more information.{}",
                 resourceType, records);
     }
 
@@ -329,7 +329,7 @@ public class ResourceLeakDetector<T> {
                 "Enable advanced leak reporting to find out where the leak occurred. " +
                 "To enable advanced leak reporting, " +
                 "specify the JVM option '-D{}={}' or call {}.setLevel() " +
-                "See http://netty.io/wiki/reference-counted-objects.html for more information.",
+                "See https://netty.io/wiki/reference-counted-objects.html for more information.",
                 resourceType, PROP_LEVEL, Level.ADVANCED.name().toLowerCase(), simpleClassName(this));
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -44,7 +44,7 @@ import java.util.Set;
 import static io.netty.handler.ssl.SslUtils.*;
 
 /**
- * Tells if <a href="http://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and its OpenSSL support
+ * Tells if <a href="https://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and its OpenSSL support
  * are available.
  */
 public final class OpenSsl {
@@ -137,7 +137,7 @@ public final class OpenSsl {
                             "Failed to load netty-tcnative; " +
                                     OpenSslEngine.class.getSimpleName() + " will be unavailable, unless the " +
                                     "application has already loaded the symbols by some other means. " +
-                                    "See http://netty.io/wiki/forked-tomcat-native.html for more information.", t);
+                                    "See https://netty.io/wiki/forked-tomcat-native.html for more information.", t);
                 }
 
                 try {
@@ -160,7 +160,7 @@ public final class OpenSsl {
                     logger.debug(
                             "Failed to initialize netty-tcnative; " +
                                     OpenSslEngine.class.getSimpleName() + " will be unavailable. " +
-                                    "See http://netty.io/wiki/forked-tomcat-native.html for more information.", t);
+                                    "See https://netty.io/wiki/forked-tomcat-native.html for more information.", t);
                 }
             }
         }
@@ -422,7 +422,7 @@ public final class OpenSsl {
 
     /**
      * Returns {@code true} if and only if
-     * <a href="http://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and its OpenSSL support
+     * <a href="https://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and its OpenSSL support
      * are available.
      */
     public static boolean isAvailable() {
@@ -461,7 +461,7 @@ public final class OpenSsl {
     }
 
     /**
-     * Ensure that <a href="http://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and
+     * Ensure that <a href="https://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and
      * its OpenSSL support are available.
      *
      * @throws UnsatisfiedLinkError if unavailable
@@ -475,7 +475,7 @@ public final class OpenSsl {
 
     /**
      * Returns the cause of unavailability of
-     * <a href="http://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and its OpenSSL support.
+     * <a href="https://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and its OpenSSL support.
      *
      * @return the cause if unavailable. {@code null} if available.
      */

--- a/handler/src/main/java/io/netty/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemReader.java
@@ -126,7 +126,7 @@ final class PemReader {
         Matcher m = KEY_PATTERN.matcher(content);
         if (!m.find()) {
             throw new KeyException("could not find a PKCS #8 private key in input stream" +
-                    " (see http://netty.io/wiki/sslcontextbuilder-and-private-key.html for more information)");
+                    " (see https://netty.io/wiki/sslcontextbuilder-and-private-key.html for more information)");
         }
 
         ByteBuf base64 = Unpooled.copiedBuffer(m.group(1), CharsetUtil.US_ASCII);

--- a/microbench/README.md
+++ b/microbench/README.md
@@ -1,4 +1,4 @@
 ## Microbenchmark tests
 
-See [our wiki page](http://netty.io/wiki/microbenchmarks.html).
+See [our wiki page](https://netty.io/wiki/microbenchmarks.html).
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <version>4.1.38.Final-SNAPSHOT</version>
 
   <name>Netty</name>
-  <url>http://netty.io/</url>
+  <url>https://netty.io/</url>
   <description>
     Netty is an asynchronous event-driven network application framework for
     rapid development of maintainable high performance protocol servers and
@@ -38,7 +38,7 @@
 
   <organization>
     <name>The Netty Project</name>
-    <url>http://netty.io/</url>
+    <url>https://netty.io/</url>
   </organization>
 
   <licenses>
@@ -61,9 +61,9 @@
       <id>netty.io</id>
       <name>The Netty Project Contributors</name>
       <email>netty@googlegroups.com</email>
-      <url>http://netty.io/</url>
+      <url>https://netty.io/</url>
       <organization>The Netty Project</organization>
-      <organizationUrl>http://netty.io/</organizationUrl>
+      <organizationUrl>https://netty.io/</organizationUrl>
     </developer>
   </developers>
 

--- a/transport-native-epoll/README.md
+++ b/transport-native-epoll/README.md
@@ -1,3 +1,3 @@
 # Native transport for Linux
 
-See [our wiki page](http://netty.io/wiki/native-transports.html).
+See [our wiki page](https://netty.io/wiki/native-transports.html).

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
@@ -19,13 +19,14 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.internal.SystemPropertyUtil;
 
 /**
- * Tells if <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is supported.
+ * Tells if <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is
+ * supported.
  */
 public final class Epoll {
 
     private static final Throwable UNAVAILABILITY_CAUSE;
 
-    static  {
+    static {
         Throwable cause = null;
 
         if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
@@ -61,8 +62,8 @@ public final class Epoll {
     }
 
     /**
-     * Returns {@code true} if and only if the
-     * <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is available.
+     * Returns {@code true} if and only if the <a href="https://netty.io/wiki/native-transports.html">{@code
+     * netty-transport-native-epoll}</a> is available.
      */
     public static boolean isAvailable() {
         return UNAVAILABILITY_CAUSE == null;
@@ -82,8 +83,8 @@ public final class Epoll {
     }
 
     /**
-     * Returns the cause of unavailability of
-     * <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a>.
+     * Returns the cause of unavailability of <a href="https://netty.io/wiki/native-transports.html">
+     * {@code netty-transport-native-epoll}</a>.
      *
      * @return the cause if unavailable. {@code null} if available.
      */
@@ -91,5 +92,6 @@ public final class Epoll {
         return UNAVAILABILITY_CAUSE;
     }
 
-    private Epoll() { }
+    private Epoll() {
+    }
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
@@ -19,7 +19,7 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.internal.SystemPropertyUtil;
 
 /**
- * Tells if <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is supported.
+ * Tells if <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is supported.
  */
 public final class Epoll {
 
@@ -62,14 +62,14 @@ public final class Epoll {
 
     /**
      * Returns {@code true} if and only if the
-     * <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is available.
+     * <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is available.
      */
     public static boolean isAvailable() {
         return UNAVAILABILITY_CAUSE == null;
     }
 
     /**
-     * Ensure that <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is
+     * Ensure that <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is
      * available.
      *
      * @throws UnsatisfiedLinkError if unavailable
@@ -83,7 +83,7 @@ public final class Epoll {
 
     /**
      * Returns the cause of unavailability of
-     * <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a>.
+     * <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a>.
      *
      * @return the cause if unavailable. {@code null} if available.
      */

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
@@ -25,7 +25,8 @@ import io.netty.util.internal.UnstableApi;
 @UnstableApi
 public final class KQueue {
     private static final Throwable UNAVAILABILITY_CAUSE;
-    static  {
+
+    static {
         Throwable cause = null;
         if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
             cause = new UnsupportedOperationException(
@@ -51,8 +52,8 @@ public final class KQueue {
     }
 
     /**
-     * Returns {@code true} if and only if the
-     * <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a> is available.
+     * Returns {@code true} if and only if the <a href="https://netty.io/wiki/native-transports.html">{@code
+     * netty-transport-native-kqueue}</a> is available.
      */
     public static boolean isAvailable() {
         return UNAVAILABILITY_CAUSE == null;
@@ -72,8 +73,8 @@ public final class KQueue {
     }
 
     /**
-     * Returns the cause of unavailability of
-     * <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a>.
+     * Returns the cause of unavailability of <a href="https://netty.io/wiki/native-transports.html">{@code
+     * netty-transport-native-kqueue}</a>.
      *
      * @return the cause if unavailable. {@code null} if available.
      */
@@ -81,5 +82,6 @@ public final class KQueue {
         return UNAVAILABILITY_CAUSE;
     }
 
-    private KQueue() { }
+    private KQueue() {
+    }
 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
@@ -52,14 +52,14 @@ public final class KQueue {
 
     /**
      * Returns {@code true} if and only if the
-     * <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a> is available.
+     * <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a> is available.
      */
     public static boolean isAvailable() {
         return UNAVAILABILITY_CAUSE == null;
     }
 
     /**
-     * Ensure that <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a> is
+     * Ensure that <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a> is
      * available.
      *
      * @throws UnsatisfiedLinkError if unavailable
@@ -73,7 +73,7 @@ public final class KQueue {
 
     /**
      * Returns the cause of unavailability of
-     * <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a>.
+     * <a href="https://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a>.
      *
      * @return the cause if unavailable. {@code null} if available.
      */


### PR DESCRIPTION
### Motivation:
* Netty homepage(```netty.io```) serves both "http" and "https".
* It's recommended to use https than http.

### Modification:
* I changed from "http://netty.io" to "https://netty.io"

### Result:
* No effects.