### PR TITLE
Epoll: Avoid modifying EPOLLOUT interest when in ET mode

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -70,7 +70,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     private volatile SocketAddress remote;
 
     protected int flags = Native.EPOLLET | Native.EPOLLOUT;
-    boolean flushPending; // used only when EPOLLET is set
+    boolean flushPending; // coincides with EPOLLOUT flag when in LT mode
     boolean inputClosedSeenErrorOnRead;
     boolean epollInReadyRunnablePending;
 


### PR DESCRIPTION
Motivation

The `EPOLLOUT` event is used to indicate fd writability following write buffer exhaustion. We currently update the epoll fd per channel on the fly to change the corresponding interest flag, but based on my (possibly incomplete) understanding it shouldn't be necessary in edge-triggered mode. We could just leave it set and avoid the extra `epoll_ctl` syscalls.

Modifications

In `AbstractEpollChannel`, set the `EPOLLOUT` flag from the outset and intercept existing calls to set/clear it when in ET mode, instead using a separate boolean to indicate that a flush is pending.

This particular approach is a bit hacky imo but involves minimal changes to existing code. I mainly wanted to check the general idea is valid.

Result

Fewer syscalls on event loop when in ET mode (default).