### PR TITLE
Epoll: Avoid modifying EPOLLIN interest when in ET mode

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -69,7 +69,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     private volatile SocketAddress local;
     private volatile SocketAddress remote;
 
-    protected int flags = Native.EPOLLET;
+    protected int flags = Native.EPOLLET | Native.EPOLLIN;
     boolean inputClosedSeenErrorOnRead;
     boolean epollInReadyRunnablePending;
 
@@ -404,7 +404,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 // to false before every read operation to prevent re-entry into epollInReady() we will not read from
                 // the underlying OS again unless the user happens to call read again.
                 executeEpollInReadyRunnable(config);
-            } else if (!readPending && !config.isAutoRead()) {
+            } else if (!readPending && !config.isAutoRead() && !isFlagSet(Native.EPOLLET)) {
                 // Check if there is a readPending which was not processed yet.
                 // This could be for two reasons:
                 // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -533,7 +533,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         protected final void clearEpollIn0() {
             assert eventLoop().inEventLoop();
             readPending = false;
-            if (!isFlagSet(Native.EPOLLET)) {
+            if (isFlagSet(Native.EPOLLET)) {
                 return;
             }
             try {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -177,10 +177,7 @@ public class EpollChannelConfig extends DefaultChannelConfig {
 
     @Override
     protected final void autoReadCleared() {
-        AbstractEpollChannel epollChannel = (AbstractEpollChannel) channel;
-        if (!epollChannel.isFlagSet(Native.EPOLLET)) {
-            epollChannel.clearEpollIn();
-        }
+        ((AbstractEpollChannel) channel).clearEpollIn();
     }
 
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -177,7 +177,10 @@ public class EpollChannelConfig extends DefaultChannelConfig {
 
     @Override
     protected final void autoReadCleared() {
-        ((AbstractEpollChannel) channel).clearEpollIn();
+        AbstractEpollChannel epollChannel = (AbstractEpollChannel) channel;
+        if (!epollChannel.isFlagSet(Native.EPOLLET)) {
+            epollChannel.clearEpollIn();
+        }
     }
 
     final void setMaxBytesPerGatheringWrite(long maxBytesPerGatheringWrite) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -428,11 +428,9 @@ class EpollEventLoop extends SingleThreadEventLoop {
                         } else {
                             // We don't want to read now, just make a record that there's data
                             unsafe.maybeMoreDataToRead = true;
-                            if (!ch.isFlagSet(Native.EPOLLET)) {
-                                // This should never happen, but clear the flag just in case since
-                                // we could enter a wait/wake spin otherwise
-                                unsafe.clearEpollIn0();
-                            }
+                            // We should never reach here in LT mode but just in case we do
+                            // then clear the flag to avoid a wait/wake spin
+                            unsafe.clearEpollIn0();
                         }
                     }
 


### PR DESCRIPTION
Motivation

An inbound analog of #9347. This is only applicable when `autoRead` is turned off. AFAIU it shouldn't be necessary to toggle the `EPOLLIN` flag via successive calls to `epoll_ctl` between reads.

Modifications

Don't clear `EPOLLIN` flag when in ET mode with `autoRead == false`. Don't process `EPOLLIN` events when there is no read pending, just set the `maybeMoreDataToRead` flag.

Result

Fewer syscalls when using epoll transport without autoRead. I have not done any performance tests but expect the saving might be significant in cases where `read()` isn't often called in `channelRead(...)` or
`channelReadComplete(...)` - i.e. two syscalls per read.