### PR TITLE
Epoll: Don't wake event loop when splicing

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -70,9 +70,9 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             ((AbstractEpollUnsafe) unsafe()).flush0();
         }
     };
-    private Queue<SpliceInTask> spliceQueue;
 
     // Lazy init these if we need to splice(...)
+    private volatile Queue<SpliceInTask> spliceQueue;
     private FileDescriptor pipeIn;
     private FileDescriptor pipeOut;
 
@@ -678,13 +678,14 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     }
 
     private void clearSpliceQueue() {
-        if (spliceQueue == null) {
+        Queue<SpliceInTask> sQueue = spliceQueue;
+        if (sQueue == null) {
             return;
         }
         ClosedChannelException exception = null;
 
         for (;;) {
-            SpliceInTask task = spliceQueue.poll();
+            SpliceInTask task = sQueue.poll();
             if (task == null) {
                 break;
             }
@@ -755,15 +756,16 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             ByteBuf byteBuf = null;
             boolean close = false;
             try {
+                Queue<SpliceInTask> sQueue = null;
                 do {
-                    if (spliceQueue != null) {
-                        SpliceInTask spliceTask = spliceQueue.peek();
+                    if (sQueue != null || (sQueue = spliceQueue) != null) {
+                        SpliceInTask spliceTask = sQueue.peek();
                         if (spliceTask != null) {
                             if (spliceTask.spliceIn(allocHandle)) {
                                 // We need to check if it is still active as if not we removed all SpliceTasks in
                                 // doClose(...)
                                 if (isActive()) {
-                                    spliceQueue.remove();
+                                    sQueue.remove();
                                 }
                                 continue;
                             } else {
@@ -823,24 +825,16 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     }
 
     private void addToSpliceQueue(final SpliceInTask task) {
-        EventLoop eventLoop = eventLoop();
-        if (eventLoop.inEventLoop()) {
-            addToSpliceQueue0(task);
-        } else {
-            eventLoop.execute(new Runnable() {
-                @Override
-                public void run() {
-                    addToSpliceQueue0(task);
+        Queue<SpliceInTask> sQueue = spliceQueue;
+        if (sQueue == null) {
+            synchronized (this) {
+                sQueue = spliceQueue;
+                if (sQueue == null) {
+                    spliceQueue = sQueue = PlatformDependent.newMpscQueue();
                 }
-            });
+            }
         }
-    }
-
-    private void addToSpliceQueue0(SpliceInTask task) {
-        if (spliceQueue == null) {
-            spliceQueue = PlatformDependent.newMpscQueue();
-        }
-        spliceQueue.add(task);
+        sQueue.add(task);
     }
 
     protected abstract class SpliceInTask {


### PR DESCRIPTION
Motivation

I noticed this while looking at something else. `AbstractEpollStreamChannel::spliceQueue` is an MPSC queue but only accessed from the event loop. So it could be just changed to e.g. an `ArrayDeque`. This PR instead reverts to using is as an MPSC queue to avoid dispatching a task to the EL, as appears was the original intention.

Modification

Change `AbstractEpollStreamChannel::spliceQueue` to be volatile and lazily initialized via double-checked locking. Add tasks directly to the queue from the public methods rather than possibly waking the EL just to enqueue.

An alternative would be to change `PlatformDependent.newMpscQueue()` to `new ArrayDeque()` and be done with it :)

Result

Less disruptive channel/fd-splicing.