### PR TITLE
Remove uncessary synchronized keyword in PolledByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -449,7 +449,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         }
 
         @Override
-        protected synchronized PoolThreadCache initialValue() {
+        protected PoolThreadCache initialValue() {
             final PoolArena<byte[]> heapArena = leastUsedArena(heapArenas);
             final PoolArena<ByteBuffer> directArena = leastUsedArena(directArenas);
 


### PR DESCRIPTION
Motivation:

The extra thread-safety by synchronized is not needed

Modifications:

Remove synchronized

Result:

Fixes https://github.com/netty/netty/issues/9356