### PR TITLE
#9345 use default allocator when possible to avoid heap allocations

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.IllegalReferenceCountException;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -33,7 +33,7 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
     private int hash;
 
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
-        this(httpVersion, method, uri, Unpooled.buffer(0));
+        this(httpVersion, method, uri, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, ByteBuf content) {
@@ -41,7 +41,7 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
     }
 
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, boolean validateHeaders) {
-        this(httpVersion, method, uri, Unpooled.buffer(0), validateHeaders);
+        this(httpVersion, method, uri, ByteBufAllocator.DEFAULT.buffer(0), validateHeaders);
     }
 
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.IllegalReferenceCountException;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -35,7 +35,7 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     private int hash;
 
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status) {
-        this(version, status, Unpooled.buffer(0));
+        this(version, status, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, ByteBuf content) {
@@ -43,12 +43,12 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     }
 
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
-        this(version, status, Unpooled.buffer(0), validateHeaders, false);
+        this(version, status, ByteBufAllocator.DEFAULT.buffer(0), validateHeaders, false);
     }
 
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders,
                                    boolean singleFieldHeaders) {
-        this(version, status, Unpooled.buffer(0), validateHeaders, singleFieldHeaders);
+        this(version, status, ByteBufAllocator.DEFAULT.buffer(0), validateHeaders, singleFieldHeaders);
     }
 
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.DefaultHeaders.NameValidator;
 import io.netty.util.internal.StringUtil;
 
@@ -30,7 +30,7 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
     private final boolean validateHeaders;
 
     public DefaultLastHttpContent() {
-        this(Unpooled.buffer(0));
+        this(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     public DefaultLastHttpContent(ByteBuf content) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 
 /**
  * Web Socket frame containing binary data.
@@ -27,7 +27,7 @@ public class BinaryWebSocketFrame extends WebSocketFrame {
      * Creates a new empty binary frame.
      */
     public BinaryWebSocketFrame() {
-        super(Unpooled.buffer(0));
+        super(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 
@@ -29,7 +29,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      * Creates a new empty close frame.
      */
     public CloseWebSocketFrame() {
-        super(Unpooled.buffer(0));
+        super(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**
@@ -78,7 +78,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      *            reserved bits used for protocol extensions.
      */
     public CloseWebSocketFrame(boolean finalFragment, int rsv) {
-        this(finalFragment, rsv, Unpooled.buffer(0));
+        this(finalFragment, rsv, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**
@@ -103,7 +103,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
             reasonText = StringUtil.EMPTY_STRING;
         }
 
-        ByteBuf binaryData = Unpooled.buffer(2 + reasonText.length());
+        ByteBuf binaryData = ByteBufAllocator.DEFAULT.buffer(2 + reasonText.length());
         binaryData.writeShort(statusCode);
         if (!reasonText.isEmpty()) {
             binaryData.writeCharSequence(reasonText, CharsetUtil.UTF_8);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
@@ -16,8 +16,12 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
+
+import java.nio.CharBuffer;
 
 /**
  * Web Socket continuation frame containing continuation text or binary data. This is used for
@@ -29,7 +33,7 @@ public class ContinuationWebSocketFrame extends WebSocketFrame {
      * Creates a new empty continuation frame.
      */
     public ContinuationWebSocketFrame() {
-        this(Unpooled.buffer(0));
+        this(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**
@@ -87,7 +91,7 @@ public class ContinuationWebSocketFrame extends WebSocketFrame {
         if (text == null || text.isEmpty()) {
             return Unpooled.EMPTY_BUFFER;
         } else {
-            return Unpooled.copiedBuffer(text, CharsetUtil.UTF_8);
+            return ByteBufUtil.encodeString(ByteBufAllocator.DEFAULT, CharBuffer.wrap(text), CharsetUtil.UTF_8);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 
 /**
  * Web Socket frame containing binary data.
@@ -27,7 +27,7 @@ public class PingWebSocketFrame extends WebSocketFrame {
      * Creates a new empty ping frame.
      */
     public PingWebSocketFrame() {
-        super(true, 0, Unpooled.buffer(0));
+        super(true, 0, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 
 /**
  * Web Socket frame containing binary data.
@@ -27,7 +27,7 @@ public class PongWebSocketFrame extends WebSocketFrame {
      * Creates a new empty pong frame.
      */
     public PongWebSocketFrame() {
-        super(Unpooled.buffer(0));
+        super(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
@@ -16,8 +16,12 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
+
+import java.nio.CharBuffer;
 
 /**
  * Web Socket text frame.
@@ -28,7 +32,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
      * Creates a new empty text frame.
      */
     public TextWebSocketFrame() {
-        super(Unpooled.buffer(0));
+        super(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**
@@ -69,7 +73,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
         if (text == null || text.isEmpty()) {
             return Unpooled.EMPTY_BUFFER;
         } else {
-            return Unpooled.copiedBuffer(text, CharsetUtil.UTF_8);
+            return ByteBufUtil.encodeString(ByteBufAllocator.DEFAULT, CharBuffer.wrap(text), CharsetUtil.UTF_8);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -133,6 +133,13 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
         boolean isHixie76 = req.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_KEY1) &&
                             req.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_KEY2);
 
+        String origin = req.headers().get(HttpHeaderNames.ORIGIN);
+
+        //throw before DefaultFullHttpResponse allocation
+        if (origin == null && !isHixie76) {
+            throw new WebSocketHandshakeException("Missing origin header, got only " + req.headers().names());
+        }
+
         // Create the WebSocket handshake response.
         FullHttpResponse res = new DefaultFullHttpResponse(HTTP_1_1, new HttpResponseStatus(101,
                 isHixie76 ? "WebSocket Protocol Handshake" : "Web Socket Protocol Handshake"));
@@ -146,7 +153,7 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
         // Fill in the headers and contents depending on handshake getMethod.
         if (isHixie76) {
             // New handshake getMethod with a challenge:
-            res.headers().add(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, req.headers().get(HttpHeaderNames.ORIGIN));
+            res.headers().add(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, origin);
             res.headers().add(HttpHeaderNames.SEC_WEBSOCKET_LOCATION, uri());
 
             String subprotocols = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL);
@@ -175,11 +182,6 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
             input.writeLong(c);
             res.content().writeBytes(WebSocketUtil.md5(input.array()));
         } else {
-            // Old Hixie 75 handshake getMethod with no challenge:
-            String origin = req.headers().get(HttpHeaderNames.ORIGIN);
-            if (origin == null) {
-                throw new WebSocketHandshakeException("Missing origin header, got only " + req.headers().names());
-            }
             res.headers().add(HttpHeaderNames.WEBSOCKET_ORIGIN, origin);
             res.headers().add(HttpHeaderNames.WEBSOCKET_LOCATION, uri());
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -134,15 +134,16 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
      */
     @Override
     protected FullHttpResponse newHandshakeResponse(FullHttpRequest req, HttpHeaders headers) {
+        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        if (key == null) {
+            throw new WebSocketHandshakeException("not a WebSocket request: missing key");
+        }
+
         FullHttpResponse res = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
         if (headers != null) {
             res.headers().add(headers);
         }
 
-        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
-        if (key == null) {
-            throw new WebSocketHandshakeException("not a WebSocket request: missing key");
-        }
         String acceptSeed = key + WEBSOCKET_13_ACCEPT_GUID;
         byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
         String accept = WebSocketUtil.base64(sha1);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -242,8 +242,10 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (cause instanceof WebSocketHandshakeException) {
+            byte[] messageBytes = cause.getMessage().getBytes();
             FullHttpResponse response = new DefaultFullHttpResponse(
-                    HTTP_1_1, HttpResponseStatus.BAD_REQUEST, Unpooled.wrappedBuffer(cause.getMessage().getBytes()));
+                    HTTP_1_1, HttpResponseStatus.BAD_REQUEST,
+                    ctx.alloc().buffer(messageBytes.length).writeBytes(messageBytes));
             ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
         } else {
             ctx.fireExceptionCaught(cause);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.internal.StringUtil;
 
@@ -33,7 +33,7 @@ public class DefaultSpdyDataFrame extends DefaultSpdyStreamFrame implements Spdy
      * @param streamId the Stream-ID of this frame
      */
     public DefaultSpdyDataFrame(int streamId) {
-        this(streamId, Unpooled.buffer(0));
+        this(streamId, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -15,6 +15,9 @@
  */
 package io.netty.handler.codec.spdy;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_DATA_FLAG_FIN;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_DATA_FRAME;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_FLAG_FIN;
@@ -39,9 +42,6 @@ import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedInt;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedMedium;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedShort;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 
 /**
  * Decodes {@link ByteBuf}s into SPDY Frames.
@@ -154,7 +154,8 @@ public class SpdyFrameDecoder {
                 case READ_DATA_FRAME:
                     if (length == 0) {
                         state = State.READ_COMMON_HEADER;
-                        delegate.readDataFrame(streamId, hasFlag(flags, SPDY_DATA_FLAG_FIN), Unpooled.buffer(0));
+                        delegate.readDataFrame(
+                                streamId, hasFlag(flags, SPDY_DATA_FLAG_FIN), ByteBufAllocator.DEFAULT.buffer(0));
                         break;
                     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -501,7 +501,7 @@ public class HttpContentCompressorTest {
     }
 
     private static FullHttpRequest newRequest() {
-        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/", Unpooled.buffer(0));
         req.headers().set(HttpHeaderNames.ACCEPT_ENCODING, "gzip");
         return req;
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.Test;
 
 import java.util.Random;
@@ -43,6 +44,7 @@ public class HttpInvalidMessageTest {
         assertFalse(dr.isSuccess());
         assertTrue(dr.isFailure());
         ensureInboundTrafficDiscarded(ch);
+        ReferenceCountUtil.release(req);
     }
 
     @Test
@@ -59,6 +61,7 @@ public class HttpInvalidMessageTest {
         assertEquals("Good Value", req.headers().get(of("Good_Name")));
         assertEquals("/maybe-something", req.uri());
         ensureInboundTrafficDiscarded(ch);
+        ReferenceCountUtil.release(req);
     }
 
     @Test
@@ -103,6 +106,7 @@ public class HttpInvalidMessageTest {
         assertFalse(dr.isSuccess());
         assertTrue(dr.isFailure());
         ensureInboundTrafficDiscarded(ch);
+        ReferenceCountUtil.release(req);
     }
 
     private void ensureInboundTrafficDiscarded(EmbeddedChannel ch) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -26,7 +26,6 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -41,10 +40,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assert.assertSame;
 
 public class HttpObjectAggregatorTest {
 
@@ -356,6 +355,7 @@ public class HttpObjectAggregatorTest {
         assertThat(inbound, is(instanceOf(FullHttpRequest.class)));
         assertTrue(((DecoderResultProvider) inbound).decoderResult().isFailure());
         assertNull(ch.readInbound());
+        assertThat(ReferenceCountUtil.release(inbound), is(true));
         ch.finish();
     }
 
@@ -367,6 +367,7 @@ public class HttpObjectAggregatorTest {
         assertThat(inbound, is(instanceOf(FullHttpResponse.class)));
         assertTrue(((DecoderResultProvider) inbound).decoderResult().isFailure());
         assertNull(ch.readInbound());
+        assertThat(ReferenceCountUtil.release(inbound), is(true));
         ch.finish();
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.Test;
 
 import java.util.List;
@@ -306,6 +307,7 @@ public class HttpRequestDecoderTest {
         assertTrue(request.decoderResult().isFailure());
         assertTrue(request.decoderResult().cause() instanceof TooLongFrameException);
         assertFalse(channel.finish());
+        ReferenceCountUtil.release(request);
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -642,6 +643,8 @@ public class HttpResponseDecoderTest {
         // Closing the connection should not generate anything since the protocol has been violated.
         ch.finish();
         assertThat(ch.readInbound(), is(nullValue()));
+
+        ReferenceCountUtil.release(res);
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -53,6 +53,7 @@ public class CorsHandlerTest {
     public void nonCorsRequest() {
         final HttpResponse response = simpleRequest(forAnyOrigin().build(), null);
         assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_ORIGIN), is(false));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -60,6 +61,7 @@ public class CorsHandlerTest {
         final HttpResponse response = simpleRequest(forAnyOrigin().build(), "http://localhost:7777");
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is("*"));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -70,6 +72,7 @@ public class CorsHandlerTest {
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is("null"));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(equalTo("true")));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -78,6 +81,7 @@ public class CorsHandlerTest {
         final HttpResponse response = simpleRequest(forOrigin(origin).build(), origin);
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(origin));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -88,9 +92,11 @@ public class CorsHandlerTest {
         final HttpResponse response1 = simpleRequest(forOrigins(origins).build(), origin1);
         assertThat(response1.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(origin1));
         assertThat(response1.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(response1), is(true));
         final HttpResponse response2 = simpleRequest(forOrigins(origins).build(), origin2);
         assertThat(response2.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(origin2));
         assertThat(response2.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(response2), is(true));
     }
 
     @Test
@@ -100,6 +106,7 @@ public class CorsHandlerTest {
                 forOrigins("https://localhost:8888").build(), origin);
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(nullValue()));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -112,6 +119,7 @@ public class CorsHandlerTest {
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS), containsString("GET"));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS), containsString("DELETE"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -127,6 +135,7 @@ public class CorsHandlerTest {
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), containsString("content-type"));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), containsString("xheader1"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -136,6 +145,7 @@ public class CorsHandlerTest {
         assertThat(response.headers().get(CONTENT_LENGTH), is("0"));
         assertThat(response.headers().get(DATE), is(notNullValue()));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -147,6 +157,7 @@ public class CorsHandlerTest {
         assertThat(response.headers().get(of("CustomHeader")), equalTo("somevalue"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
         assertThat(response.headers().get(CONTENT_LENGTH), is("0"));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -155,6 +166,7 @@ public class CorsHandlerTest {
         final CorsConfig config = forOrigin("http://localhost").build();
         final HttpResponse response = preflightRequest(config, origin, "xheader1");
         assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_ORIGIN), is(false));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -168,6 +180,7 @@ public class CorsHandlerTest {
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
         assertValues(response, headerName, value1, value2);
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -181,6 +194,7 @@ public class CorsHandlerTest {
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
         assertValues(response, headerName, value1, value2);
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -195,6 +209,7 @@ public class CorsHandlerTest {
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
         assertThat(response.headers().get(of("GenHeader")), equalTo("generatedValue"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -207,6 +222,7 @@ public class CorsHandlerTest {
         final HttpResponse response = preflightRequest(config, origin, "content-type, xheader1");
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(equalTo("null")));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(equalTo("true")));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -215,6 +231,7 @@ public class CorsHandlerTest {
         final CorsConfig config = forOrigin(origin).allowCredentials().build();
         final HttpResponse response = preflightRequest(config, origin, "content-type, xheader1");
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(equalTo("true")));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -223,6 +240,7 @@ public class CorsHandlerTest {
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "");
         // the only valid value for Access-Control-Allow-Credentials is true.
         assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(false));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -232,6 +250,7 @@ public class CorsHandlerTest {
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("*"));
         assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS), containsString("custom1"));
         assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS), containsString("custom2"));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -239,6 +258,7 @@ public class CorsHandlerTest {
         final CorsConfig config = forAnyOrigin().allowCredentials().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo("true"));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -246,6 +266,7 @@ public class CorsHandlerTest {
         final CorsConfig config = forAnyOrigin().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(false));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -255,6 +276,7 @@ public class CorsHandlerTest {
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo("true"));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("http://localhost:7777"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -263,6 +285,7 @@ public class CorsHandlerTest {
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS), containsString("one"));
         assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS), containsString("two"));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -271,6 +294,7 @@ public class CorsHandlerTest {
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertThat(response.status(), is(FORBIDDEN));
         assertThat(response.headers().get(CONTENT_LENGTH), is("0"));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -279,6 +303,7 @@ public class CorsHandlerTest {
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertThat(response.status(), is(OK));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -287,6 +312,7 @@ public class CorsHandlerTest {
         final HttpResponse response = simpleRequest(config, null);
         assertThat(response.status(), is(OK));
         assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(response), is(true));
     }
 
     @Test
@@ -428,10 +454,12 @@ public class CorsHandlerTest {
         final HttpResponse preFlightHost1 = preflightRequest(corsConfigs, host1, "", false);
         assertThat(preFlightHost1.headers().get(ACCESS_CONTROL_ALLOW_METHODS), is("GET"));
         assertThat(preFlightHost1.headers().getAsString(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(nullValue()));
+        assertThat(ReferenceCountUtil.release(preFlightHost1), is(true));
 
         final HttpResponse preFlightHost2 = preflightRequest(corsConfigs, host2, "", false);
         assertValues(preFlightHost2, ACCESS_CONTROL_ALLOW_METHODS.toString(), "GET", "POST");
         assertThat(preFlightHost2.headers().getAsString(ACCESS_CONTROL_ALLOW_CREDENTIALS), IsEqual.equalTo("true"));
+        assertThat(ReferenceCountUtil.release(preFlightHost2), is(true));
     }
 
     @Test
@@ -448,11 +476,13 @@ public class CorsHandlerTest {
         final HttpResponse host1Response = preflightRequest(rules, host1, "", false);
         assertThat(host1Response.headers().get(ACCESS_CONTROL_ALLOW_METHODS), is("GET"));
         assertThat(host1Response.headers().getAsString(ACCESS_CONTROL_MAX_AGE), equalTo("3600"));
+        assertThat(ReferenceCountUtil.release(host1Response), is(true));
 
         final HttpResponse host2Response = preflightRequest(rules, host2, "", false);
         assertValues(host2Response, ACCESS_CONTROL_ALLOW_METHODS.toString(), "POST", "GET", "OPTIONS");
         assertThat(host2Response.headers().getAsString(ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("*"));
         assertThat(host2Response.headers().getAsString(ACCESS_CONTROL_MAX_AGE), equalTo("1800"));
+        assertThat(ReferenceCountUtil.release(host2Response), is(true));
     }
 
     private static HttpResponse simpleRequest(final CorsConfig config, final String origin) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -107,9 +107,9 @@ public class HttpPostRequestDecoderTest {
     // See https://github.com/netty/netty/issues/1089
     @Test
     public void testFullHttpRequestUpload() throws Exception {
-        final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+        String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
 
-        final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
                 "http://localhost");
 
         req.setDecoderResult(DecoderResult.SUCCESS);
@@ -117,10 +117,10 @@ public class HttpPostRequestDecoderTest {
         req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
 
         // Force to use memory-based data.
-        final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
+        DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
 
         for (String data : Arrays.asList("", "\r", "\r\r", "\r\r\r")) {
-            final String body =
+            String body =
                     "--" + boundary + "\r\n" +
                             "Content-Disposition: form-data; name=\"file\"; filename=\"tmp-0.txt\"\r\n" +
                             "Content-Type: image/gif\r\n" +
@@ -131,9 +131,10 @@ public class HttpPostRequestDecoderTest {
             req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         }
         // Create decoder instance to test.
-        final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
+        req.release();
     }
 
     // See https://github.com/netty/netty/issues/2544
@@ -180,15 +181,16 @@ public class HttpPostRequestDecoderTest {
             assertEquals(datas[i].getBytes(CharsetUtil.UTF_8).length, datar.length);
 
             decoder.destroy();
+            req.release();
         }
     }
 
     // See https://github.com/netty/netty/issues/2542
     @Test
     public void testQuotedBoundary() throws Exception {
-        final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+        String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
 
-        final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
                 "http://localhost");
 
         req.setDecoderResult(DecoderResult.SUCCESS);
@@ -196,7 +198,7 @@ public class HttpPostRequestDecoderTest {
         req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
 
         // Force to use memory-based data.
-        final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
+        DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
 
         for (String data : Arrays.asList("", "\r", "\r\r", "\r\r\r")) {
             final String body =
@@ -213,6 +215,7 @@ public class HttpPostRequestDecoderTest {
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
+        req.release();
     }
 
     // See https://github.com/netty/netty/issues/1848
@@ -352,6 +355,7 @@ public class HttpPostRequestDecoderTest {
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
+        req.release();
     }
 
     @Test
@@ -385,9 +389,9 @@ public class HttpPostRequestDecoderTest {
 
     @Test
     public void testMultipartRequestWithoutContentTypeBody() {
-        final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+        String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
 
-        final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
                 "http://localhost");
 
         req.setDecoderResult(DecoderResult.SUCCESS);
@@ -395,10 +399,10 @@ public class HttpPostRequestDecoderTest {
         req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
 
         // Force to use memory-based data.
-        final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
+        DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
 
         for (String data : Arrays.asList("", "\r", "\r\r", "\r\r\r")) {
-            final String body =
+            String body =
                     "--" + boundary + "\r\n" +
                             "Content-Disposition: form-data; name=\"file\"; filename=\"tmp-0.txt\"\r\n" +
                             "\r\n" +
@@ -408,9 +412,10 @@ public class HttpPostRequestDecoderTest {
             req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         }
         // Create decoder instance to test without any exception.
-        final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
+        req.release();
     }
 
     @Test
@@ -478,17 +483,17 @@ public class HttpPostRequestDecoderTest {
 
     @Test
     public void testMultipartRequestWithFieldInvalidCharset() throws Exception {
-        final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
-        final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+        String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
             "http://localhost");
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         // Force to use memory-based data.
-        final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
-        final String aData = "some data would be here. the data should be long enough that it " +
+        DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
+        String aData = "some data would be here. the data should be long enough that it " +
             "will be longer than the original buffer length of 256 bytes in " +
             "the HttpPostRequestDecoder in order to trigger the issue. Some more " +
             "data just to be on the safe side.";
-        final String body =
+        String body =
             "--" + boundary + "\r\n" +
                 "Content-Disposition: form-data; name=\"root\"\r\n" +
                 "Content-Type: text/plain; charset=ABCD\r\n" +
@@ -506,6 +511,7 @@ public class HttpPostRequestDecoderTest {
             assertTrue(e.getCause() instanceof UnsupportedCharsetException);
         } finally {
             req.release();
+            inMemoryFactory.cleanAllHttpData();
         }
     }
 
@@ -663,15 +669,15 @@ public class HttpPostRequestDecoderTest {
     // https://github.com/netty/netty/issues/7620
     @Test
     public void testDecodeMalformedEmptyContentTypeFieldParameters() throws Exception {
-        final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
-        final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+        String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
                                                                       "http://localhost");
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         // Force to use memory-based data.
-        final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
-        final String data = "asdf";
-        final String filename = "tmp-0.txt";
-        final String body =
+        DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
+        String data = "asdf";
+        String filename = "tmp-0.txt";
+        String body =
                 "--" + boundary + "\r\n" +
                 "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
                 "Content-Type: \r\n" +
@@ -681,12 +687,13 @@ public class HttpPostRequestDecoderTest {
 
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
         // Create decoder instance to test.
-        final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
         assertTrue(part1 instanceof FileUpload);
         FileUpload fileUpload = (FileUpload) part1;
         assertEquals("tmp-0.txt", fileUpload.getFilename());
         decoder.destroy();
+        req.release();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
@@ -95,6 +95,7 @@ public class HttpPostRequestEncoderTest {
                 "--" + multipartDataBoundary + "--" + "\r\n";
 
         assertEquals(expected, content);
+        request.release();
     }
 
     @Test
@@ -128,6 +129,7 @@ public class HttpPostRequestEncoderTest {
                 "--" + multipartDataBoundary + "--" + "\r\n";
 
         assertEquals(expected, content);
+        request.release();
     }
 
     @Test
@@ -188,6 +190,7 @@ public class HttpPostRequestEncoderTest {
                 "--" + multipartDataBoundary + "--" + "\r\n";
 
         assertEquals(expected, content);
+        request.release();
     }
 
     @Test
@@ -238,6 +241,7 @@ public class HttpPostRequestEncoderTest {
                 "--" + multipartDataBoundary + "--" + "\r\n";
 
         assertEquals(expected, content);
+        request.release();
     }
 
     @Test
@@ -282,6 +286,7 @@ public class HttpPostRequestEncoderTest {
                 "--" + multipartDataBoundary + "--" + "\r\n";
 
         assertEquals(expected, content);
+        request.release();
     }
 
     @Test
@@ -318,6 +323,7 @@ public class HttpPostRequestEncoderTest {
                 "--" + multipartDataBoundary + "--" + "\r\n";
 
         assertEquals(expected, content);
+        request.release();
     }
 
     @Test
@@ -350,6 +356,7 @@ public class HttpPostRequestEncoderTest {
         }
         encoder.cleanFiles();
         encoder.close();
+        request.release();
     }
 
     private static String getRequestBody(HttpPostRequestEncoder encoder) throws Exception {
@@ -401,8 +408,8 @@ public class HttpPostRequestEncoderTest {
         HttpContent httpContent = encoder.readChunk((ByteBufAllocator) null);
         assertTrue("Expected LastHttpContent is not received", httpContent instanceof LastHttpContent);
         httpContent.release();
-
-           assertTrue("Expected end of input is not receive", encoder.isEndOfInput());
+        assertTrue("Expected end of input is not receive", encoder.isEndOfInput());
+        request.release();
     }
 
     @Test
@@ -425,6 +432,7 @@ public class HttpPostRequestEncoderTest {
         httpContent.release();
 
         assertTrue("Expected end of input is not receive", encoder.isEndOfInput());
+        request.release();
     }
 
     private static void checkNextChunkSize(HttpPostRequestEncoder encoder, int sizeWithoutDelimiter) throws Exception {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
@@ -21,6 +21,12 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
 /**
  * Tests the WebSocket08FrameEncoder and Decoder implementation.<br>
  * Checks whether the combination of encoding and decoding yields the original data.<br>
@@ -73,9 +79,10 @@ public class WebSocket08EncoderDecoderTest {
         executeProtocolViolationTest(outChannel, inChannel, maxPayloadLength + 1, expectedStatus, errorMessage);
 
         CloseWebSocketFrame response = inChannel.readOutbound();
-        Assert.assertNotNull(response);
-        Assert.assertEquals(expectedStatus.code(), response.statusCode());
-        Assert.assertEquals(errorMessage, response.reasonText());
+        assertNotNull(response);
+        assertEquals(expectedStatus.code(), response.statusCode());
+        assertEquals(errorMessage, response.reasonText());
+        response.release();
 
         // Without auto-close
         config = WebSocketDecoderConfig.newBuilder()
@@ -88,12 +95,12 @@ public class WebSocket08EncoderDecoderTest {
         executeProtocolViolationTest(outChannel, inChannel, maxPayloadLength + 1, expectedStatus, errorMessage);
 
         response = inChannel.readOutbound();
-        Assert.assertNull(response);
+        assertNull(response);
 
         // Release test data
         binTestData.release();
-        Assert.assertFalse(inChannel.finish());
-        Assert.assertFalse(outChannel.finish());
+        assertFalse(inChannel.finish());
+        assertFalse(outChannel.finish());
     }
 
     private void executeProtocolViolationTest(EmbeddedChannel outChannel, EmbeddedChannel inChannel,
@@ -107,11 +114,11 @@ public class WebSocket08EncoderDecoderTest {
         }
 
         BinaryWebSocketFrame exceedingFrame = inChannel.readInbound();
-        Assert.assertNull(exceedingFrame);
+        assertNull(exceedingFrame);
 
-        Assert.assertNotNull(corrupted);
-        Assert.assertEquals(expectedStatus, corrupted.closeStatus());
-        Assert.assertEquals(errorMessage, corrupted.getMessage());
+        assertNotNull(corrupted);
+        assertEquals(expectedStatus, corrupted.closeStatus());
+        assertEquals(errorMessage, corrupted.getMessage());
     }
 
     @Test
@@ -172,10 +179,10 @@ public class WebSocket08EncoderDecoderTest {
         transfer(outChannel, inChannel);
 
         Object decoded = inChannel.readInbound();
-        Assert.assertNotNull(decoded);
-        Assert.assertTrue(decoded instanceof TextWebSocketFrame);
+        assertNotNull(decoded);
+        assertTrue(decoded instanceof TextWebSocketFrame);
         TextWebSocketFrame txt = (TextWebSocketFrame) decoded;
-        Assert.assertEquals(txt.text(), testStr);
+        assertEquals(txt.text(), testStr);
         txt.release();
     }
 
@@ -187,13 +194,13 @@ public class WebSocket08EncoderDecoderTest {
         transfer(outChannel, inChannel);
 
         Object decoded = inChannel.readInbound();
-        Assert.assertNotNull(decoded);
-        Assert.assertTrue(decoded instanceof BinaryWebSocketFrame);
+        assertNotNull(decoded);
+        assertTrue(decoded instanceof BinaryWebSocketFrame);
         BinaryWebSocketFrame binFrame = (BinaryWebSocketFrame) decoded;
         int readable = binFrame.content().readableBytes();
-        Assert.assertEquals(readable, testDataLength);
+        assertEquals(readable, testDataLength);
         for (int i = 0; i < testDataLength; i++) {
-            Assert.assertEquals(binTestData.getByte(i), binFrame.content().getByte(i));
+            assertEquals(binTestData.getByte(i), binFrame.content().getByte(i));
         }
         binFrame.release();
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -36,7 +36,9 @@ import org.junit.Test;
 
 import java.net.URI;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public abstract class WebSocketClientHandshakerTest {
     protected abstract WebSocketClientHandshaker newHandshaker(URI uri, String subprotocol, HttpHeaders headers,
@@ -258,7 +260,9 @@ public abstract class WebSocketClientHandshakerTest {
         // Create a EmbeddedChannel which we will use to encode a BinaryWebsocketFrame to bytes and so use these
         // to test the actual handshaker.
         WebSocketServerHandshakerFactory factory = new WebSocketServerHandshakerFactory(url, null, false);
-        WebSocketServerHandshaker socketServerHandshaker = factory.newHandshaker(shaker.newHandshakeRequest());
+        FullHttpRequest handShakeRequest = shaker.newHandshakeRequest();
+        WebSocketServerHandshaker socketServerHandshaker = factory.newHandshaker(handShakeRequest);
+        handShakeRequest.release();
         EmbeddedChannel websocketChannel = new EmbeddedChannel(socketServerHandshaker.newWebSocketEncoder(),
                 socketServerHandshaker.newWebsocketDecoder());
         assertTrue(websocketChannel.writeOutbound(new BinaryWebSocketFrame(Unpooled.wrappedBuffer(data))));

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
@@ -203,6 +203,7 @@ public class SpdySessionHandlerTest {
         sessionHandler.writeInbound(spdyHeadersFrame);
         assertRstStream(sessionHandler.readOutbound(), localStreamId, SpdyStreamStatus.PROTOCOL_ERROR);
         assertNull(sessionHandler.readOutbound());
+        spdyDataFrame.release();
 
         sessionHandler.finish();
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -16,7 +16,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -26,10 +25,10 @@ import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.util.internal.UnstableApi;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -55,7 +54,8 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         @Override
         public FullHttpMessage copyIfNeeded(FullHttpMessage msg) {
             if (msg instanceof FullHttpRequest) {
-                FullHttpRequest copy = ((FullHttpRequest) msg).replace(Unpooled.buffer(0));
+                FullHttpRequest req = (FullHttpRequest) msg;
+                FullHttpRequest copy = req.replace(req.content().alloc().buffer(0));
                 copy.headers().remove(HttpHeaderNames.EXPECT);
                 return copy;
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -19,15 +19,12 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
-import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-
-import org.junit.Test;
 
 public class Http2ClientUpgradeCodecTest {
 
@@ -48,7 +45,7 @@ public class Http2ClientUpgradeCodecTest {
     }
 
     private static void testUpgrade(Http2ConnectionHandler handler) throws Exception {
-        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "*");
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "*");
 
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
         ChannelHandlerContext ctx = channel.pipeline().firstContext();
@@ -61,6 +58,7 @@ public class Http2ClientUpgradeCodecTest {
         assertNotNull(channel.pipeline().get("connectionHandler"));
 
         assertTrue(channel.finishAndReleaseAll());
+        request.release();
     }
 
     @ChannelHandler.Sharable

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
@@ -57,7 +57,7 @@ public class Http2ServerUpgradeCodecTest {
     }
 
     private static void testUpgrade(Http2ConnectionHandler handler, ChannelHandler multiplexer) {
-        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "*");
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "*");
         request.headers().set(HttpHeaderNames.HOST, "netty.io");
         request.headers().set(HttpHeaderNames.CONNECTION, "Upgrade, HTTP2-Settings");
         request.headers().set(HttpHeaderNames.UPGRADE, "h2c");
@@ -93,6 +93,7 @@ public class Http2ServerUpgradeCodecTest {
         ByteBuf buf = channel.readOutbound();
         assertNotNull(buf);
         buf.release();
+        request.release();
 
         assertNull(channel.readOutbound());
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.memcache.binary;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -35,7 +35,7 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
      * @param extras the extras to use.
      */
     public DefaultFullBinaryMemcacheRequest(ByteBuf key, ByteBuf extras) {
-        this(key, extras, Unpooled.buffer(0));
+        this(key, extras, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.memcache.binary;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -35,7 +35,7 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
      * @param extras the extras to use.
      */
     public DefaultFullBinaryMemcacheResponse(ByteBuf key, ByteBuf extras) {
-        this(key, extras, Unpooled.buffer(0));
+        this(key, extras, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.stomp;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.CharsetUtil;
 
 /**
@@ -27,7 +27,7 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
     private final ByteBuf content;
 
     public DefaultStompFrame(StompCommand command) {
-        this(command, Unpooled.buffer(0));
+        this(command, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     public DefaultStompFrame(StompCommand command, ByteBuf content) {


### PR DESCRIPTION
Motivation:

In many places Netty uses `Unpooled.buffer(0)` while should use `EMPTY_BUFFER`. We can't change this due to back compatibility, however we can at least replace `Unpooled.buffer(0)` with `ByteBufAllocator.DEFAULT.buffer(0)` so in evns. with `preferDirect=true` heap will not be used.
This change affects mostly http and websockets users.

Modification:

- Repalced `Unpooled.buffer(0)` with `ByteBufAllocator.DEFAULT.buffer(0)`;
- Replaced  `Unpooled.copiedBuffer(text, CharsetUtil.UTF_8)` with 
`ByteBufUtil.encodeString(ByteBufAllocator.DEFAULT, CharBuffer.wrap(text), CharsetUtil.UTF_8)`;

Result:

Fixes https://github.com/netty/netty/issues/9345
