### PR TITLE
#9345 always prefer default byte buf allocator in websockets flow

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 
 /**
  * Web Socket frame containing binary data.
@@ -27,7 +27,7 @@ public class BinaryWebSocketFrame extends WebSocketFrame {
      * Creates a new empty binary frame.
      */
     public BinaryWebSocketFrame() {
-        super(Unpooled.buffer(0));
+        super(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 
@@ -29,7 +29,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      * Creates a new empty close frame.
      */
     public CloseWebSocketFrame() {
-        super(Unpooled.buffer(0));
+        super(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**
@@ -78,7 +78,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      *            reserved bits used for protocol extensions.
      */
     public CloseWebSocketFrame(boolean finalFragment, int rsv) {
-        this(finalFragment, rsv, Unpooled.buffer(0));
+        this(finalFragment, rsv, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**
@@ -103,7 +103,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
             reasonText = StringUtil.EMPTY_STRING;
         }
 
-        ByteBuf binaryData = Unpooled.buffer(2 + reasonText.length());
+        ByteBuf binaryData = ByteBufAllocator.DEFAULT.buffer(2 + reasonText.length());
         binaryData.writeShort(statusCode);
         if (!reasonText.isEmpty()) {
             binaryData.writeCharSequence(reasonText, CharsetUtil.UTF_8);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
@@ -16,8 +16,12 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
+
+import java.nio.CharBuffer;
 
 /**
  * Web Socket continuation frame containing continuation text or binary data. This is used for
@@ -29,7 +33,7 @@ public class ContinuationWebSocketFrame extends WebSocketFrame {
      * Creates a new empty continuation frame.
      */
     public ContinuationWebSocketFrame() {
-        this(Unpooled.buffer(0));
+        this(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**
@@ -87,7 +91,7 @@ public class ContinuationWebSocketFrame extends WebSocketFrame {
         if (text == null || text.isEmpty()) {
             return Unpooled.EMPTY_BUFFER;
         } else {
-            return Unpooled.copiedBuffer(text, CharsetUtil.UTF_8);
+            return ByteBufUtil.encodeString(ByteBufAllocator.DEFAULT, CharBuffer.wrap(text), CharsetUtil.UTF_8);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 
 /**
  * Web Socket frame containing binary data.
@@ -27,7 +27,7 @@ public class PingWebSocketFrame extends WebSocketFrame {
      * Creates a new empty ping frame.
      */
     public PingWebSocketFrame() {
-        super(true, 0, Unpooled.buffer(0));
+        super(true, 0, ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.ByteBufAllocator;
 
 /**
  * Web Socket frame containing binary data.
@@ -27,7 +27,7 @@ public class PongWebSocketFrame extends WebSocketFrame {
      * Creates a new empty pong frame.
      */
     public PongWebSocketFrame() {
-        super(Unpooled.buffer(0));
+        super(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
@@ -16,8 +16,12 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
+
+import java.nio.CharBuffer;
 
 /**
  * Web Socket text frame.
@@ -28,7 +32,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
      * Creates a new empty text frame.
      */
     public TextWebSocketFrame() {
-        super(Unpooled.buffer(0));
+        super(ByteBufAllocator.DEFAULT.buffer(0));
     }
 
     /**
@@ -69,7 +73,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
         if (text == null || text.isEmpty()) {
             return Unpooled.EMPTY_BUFFER;
         } else {
-            return Unpooled.copiedBuffer(text, CharsetUtil.UTF_8);
+            return ByteBufUtil.encodeString(ByteBufAllocator.DEFAULT, CharBuffer.wrap(text), CharsetUtil.UTF_8);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -248,8 +248,6 @@ public abstract class WebSocketClientHandshaker {
      *            the {@link ChannelPromise} to be notified when the opening handshake is sent
      */
     public final ChannelFuture handshake(Channel channel, final ChannelPromise promise) {
-        FullHttpRequest request =  newHandshakeRequest();
-
         HttpResponseDecoder decoder = channel.pipeline().get(HttpResponseDecoder.class);
         if (decoder == null) {
             HttpClientCodec codec = channel.pipeline().get(HttpClientCodec.class);
@@ -260,6 +258,7 @@ public abstract class WebSocketClientHandshaker {
             }
         }
 
+        FullHttpRequest request =  newHandshakeRequest();
         channel.writeAndFlush(request).addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -214,7 +215,8 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         }
 
         // Format request
-        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, upgradeUrl(wsURL));
+        FullHttpRequest request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, upgradeUrl(wsURL), ByteBufAllocator.DEFAULT.buffer(0));
         HttpHeaders headers = request.headers();
 
         if (customHeaders != null) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -133,6 +133,13 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
         boolean isHixie76 = req.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_KEY1) &&
                             req.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_KEY2);
 
+        String origin = req.headers().get(HttpHeaderNames.ORIGIN);
+
+        //throw before DefaultFullHttpResponse allocation
+        if (origin == null && !isHixie76) {
+            throw new WebSocketHandshakeException("Missing origin header, got only " + req.headers().names());
+        }
+
         // Create the WebSocket handshake response.
         FullHttpResponse res = new DefaultFullHttpResponse(HTTP_1_1, new HttpResponseStatus(101,
                 isHixie76 ? "WebSocket Protocol Handshake" : "Web Socket Protocol Handshake"));
@@ -146,7 +153,7 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
         // Fill in the headers and contents depending on handshake getMethod.
         if (isHixie76) {
             // New handshake getMethod with a challenge:
-            res.headers().add(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, req.headers().get(HttpHeaderNames.ORIGIN));
+            res.headers().add(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, origin);
             res.headers().add(HttpHeaderNames.SEC_WEBSOCKET_LOCATION, uri());
 
             String subprotocols = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL);
@@ -176,10 +183,6 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
             res.content().writeBytes(WebSocketUtil.md5(input.array()));
         } else {
             // Old Hixie 75 handshake getMethod with no challenge:
-            String origin = req.headers().get(HttpHeaderNames.ORIGIN);
-            if (origin == null) {
-                throw new WebSocketHandshakeException("Missing origin header, got only " + req.headers().names());
-            }
             res.headers().add(HttpHeaderNames.WEBSOCKET_ORIGIN, origin);
             res.headers().add(HttpHeaderNames.WEBSOCKET_LOCATION, uri());
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker07.java
@@ -128,6 +128,10 @@ public class WebSocketServerHandshaker07 extends WebSocketServerHandshaker {
      */
     @Override
     protected FullHttpResponse newHandshakeResponse(FullHttpRequest req, HttpHeaders headers) {
+        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        if (key == null) {
+            throw new WebSocketHandshakeException("not a WebSocket request: missing key");
+        }
 
         FullHttpResponse res =
                 new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
@@ -136,10 +140,6 @@ public class WebSocketServerHandshaker07 extends WebSocketServerHandshaker {
             res.headers().add(headers);
         }
 
-        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
-        if (key == null) {
-            throw new WebSocketHandshakeException("not a WebSocket request: missing key");
-        }
         String acceptSeed = key + WEBSOCKET_07_ACCEPT_GUID;
         byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
         String accept = WebSocketUtil.base64(sha1);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
@@ -135,16 +135,17 @@ public class WebSocketServerHandshaker08 extends WebSocketServerHandshaker {
      */
     @Override
     protected FullHttpResponse newHandshakeResponse(FullHttpRequest req, HttpHeaders headers) {
+        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        if (key == null) {
+            throw new WebSocketHandshakeException("not a WebSocket request: missing key");
+        }
+
         FullHttpResponse res = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
 
         if (headers != null) {
             res.headers().add(headers);
         }
 
-        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
-        if (key == null) {
-            throw new WebSocketHandshakeException("not a WebSocket request: missing key");
-        }
         String acceptSeed = key + WEBSOCKET_08_ACCEPT_GUID;
         byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
         String accept = WebSocketUtil.base64(sha1);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -172,7 +172,8 @@ public class WebSocketServerHandshakerFactory {
     public static ChannelFuture sendUnsupportedVersionResponse(Channel channel, ChannelPromise promise) {
         HttpResponse res = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1,
-                HttpResponseStatus.UPGRADE_REQUIRED);
+                HttpResponseStatus.UPGRADE_REQUIRED,
+                channel.alloc().buffer(0));
         res.headers().set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, WebSocketVersion.V13.toHttpHeaderValue());
         HttpUtil.setContentLength(res, 0);
         return channel.writeAndFlush(res, promise);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -242,8 +242,10 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (cause instanceof WebSocketHandshakeException) {
+            byte[] messageBytes = cause.getMessage().getBytes();
             FullHttpResponse response = new DefaultFullHttpResponse(
-                    HTTP_1_1, HttpResponseStatus.BAD_REQUEST, Unpooled.wrappedBuffer(cause.getMessage().getBytes()));
+                    HTTP_1_1, HttpResponseStatus.BAD_REQUEST,
+                    ctx.alloc().buffer(messageBytes.length).writeBytes(messageBytes));
             ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
         } else {
             ctx.fireExceptionCaught(cause);
@@ -266,7 +268,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
                 if (msg instanceof FullHttpRequest) {
                     ((FullHttpRequest) msg).release();
                     FullHttpResponse response =
-                            new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.FORBIDDEN);
+                            new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.FORBIDDEN, ctx.alloc().buffer(0));
                     ctx.channel().writeAndFlush(response);
                 } else {
                     ctx.fireChannelRead(msg);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -79,7 +79,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
 
         try {
             if (!GET.equals(req.method())) {
-                sendHttpResponse(ctx, req, new DefaultFullHttpResponse(HTTP_1_1, FORBIDDEN));
+                sendHttpResponse(ctx, req, new DefaultFullHttpResponse(HTTP_1_1, FORBIDDEN, ctx.alloc().buffer(0)));
                 return;
             }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
@@ -18,8 +18,13 @@ package io.netty.handler.codec.http.websocketx;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests the WebSocket08FrameEncoder and Decoder implementation.<br>
@@ -73,9 +78,10 @@ public class WebSocket08EncoderDecoderTest {
         executeProtocolViolationTest(outChannel, inChannel, maxPayloadLength + 1, expectedStatus, errorMessage);
 
         CloseWebSocketFrame response = inChannel.readOutbound();
-        Assert.assertNotNull(response);
-        Assert.assertEquals(expectedStatus.code(), response.statusCode());
-        Assert.assertEquals(errorMessage, response.reasonText());
+        assertNotNull(response);
+        assertEquals(expectedStatus.code(), response.statusCode());
+        assertEquals(errorMessage, response.reasonText());
+        response.release();
 
         // Without auto-close
         config = WebSocketDecoderConfig.newBuilder()
@@ -88,12 +94,12 @@ public class WebSocket08EncoderDecoderTest {
         executeProtocolViolationTest(outChannel, inChannel, maxPayloadLength + 1, expectedStatus, errorMessage);
 
         response = inChannel.readOutbound();
-        Assert.assertNull(response);
+        assertNull(response);
 
         // Release test data
         binTestData.release();
-        Assert.assertFalse(inChannel.finish());
-        Assert.assertFalse(outChannel.finish());
+        assertFalse(inChannel.finish());
+        assertFalse(outChannel.finish());
     }
 
     private void executeProtocolViolationTest(EmbeddedChannel outChannel, EmbeddedChannel inChannel,
@@ -107,11 +113,11 @@ public class WebSocket08EncoderDecoderTest {
         }
 
         BinaryWebSocketFrame exceedingFrame = inChannel.readInbound();
-        Assert.assertNull(exceedingFrame);
+        assertNull(exceedingFrame);
 
-        Assert.assertNotNull(corrupted);
-        Assert.assertEquals(expectedStatus, corrupted.closeStatus());
-        Assert.assertEquals(errorMessage, corrupted.getMessage());
+        assertNotNull(corrupted);
+        assertEquals(expectedStatus, corrupted.closeStatus());
+        assertEquals(errorMessage, corrupted.getMessage());
     }
 
     @Test
@@ -172,10 +178,10 @@ public class WebSocket08EncoderDecoderTest {
         transfer(outChannel, inChannel);
 
         Object decoded = inChannel.readInbound();
-        Assert.assertNotNull(decoded);
-        Assert.assertTrue(decoded instanceof TextWebSocketFrame);
+        assertNotNull(decoded);
+        assertTrue(decoded instanceof TextWebSocketFrame);
         TextWebSocketFrame txt = (TextWebSocketFrame) decoded;
-        Assert.assertEquals(txt.text(), testStr);
+        assertEquals(txt.text(), testStr);
         txt.release();
     }
 
@@ -187,13 +193,13 @@ public class WebSocket08EncoderDecoderTest {
         transfer(outChannel, inChannel);
 
         Object decoded = inChannel.readInbound();
-        Assert.assertNotNull(decoded);
-        Assert.assertTrue(decoded instanceof BinaryWebSocketFrame);
+        assertNotNull(decoded);
+        assertTrue(decoded instanceof BinaryWebSocketFrame);
         BinaryWebSocketFrame binFrame = (BinaryWebSocketFrame) decoded;
         int readable = binFrame.content().readableBytes();
-        Assert.assertEquals(readable, testDataLength);
+        assertEquals(readable, testDataLength);
         for (int i = 0; i < testDataLength; i++) {
-            Assert.assertEquals(binTestData.getByte(i), binFrame.content().getByte(i));
+            assertEquals(binTestData.getByte(i), binFrame.content().getByte(i));
         }
         binFrame.release();
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -36,7 +36,9 @@ import org.junit.Test;
 
 import java.net.URI;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public abstract class WebSocketClientHandshakerTest {
     protected abstract WebSocketClientHandshaker newHandshaker(URI uri, String subprotocol, HttpHeaders headers,
@@ -258,7 +260,9 @@ public abstract class WebSocketClientHandshakerTest {
         // Create a EmbeddedChannel which we will use to encode a BinaryWebsocketFrame to bytes and so use these
         // to test the actual handshaker.
         WebSocketServerHandshakerFactory factory = new WebSocketServerHandshakerFactory(url, null, false);
-        WebSocketServerHandshaker socketServerHandshaker = factory.newHandshaker(shaker.newHandshakeRequest());
+        FullHttpRequest handShakeRequest = shaker.newHandshakeRequest();
+        WebSocketServerHandshaker socketServerHandshaker = factory.newHandshaker(handShakeRequest);
+        handShakeRequest.release();
         EmbeddedChannel websocketChannel = new EmbeddedChannel(socketServerHandshaker.newWebSocketEncoder(),
                 socketServerHandshaker.newWebsocketDecoder());
         assertTrue(websocketChannel.writeOutbound(new BinaryWebSocketFrame(Unpooled.wrappedBuffer(data))));
@@ -278,7 +282,7 @@ public abstract class WebSocketClientHandshakerTest {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpObjectAggregator(Integer.MAX_VALUE),
                 new SimpleChannelInboundHandler<FullHttpResponse>() {
                     @Override
-                    protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
+                    protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) {
                         handshaker.finishHandshake(ctx.channel(), msg);
                         ctx.pipeline().remove(this);
                     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testHttpUpgradeRequest() throws Exception {
+    public void testHttpUpgradeRequest() {
         EmbeddedChannel ch = createChannel(new MockOutboundHandler());
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
         writeUpgradeRequest(ch);
@@ -62,7 +63,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testSubsequentHttpRequestsAfterUpgradeShouldReturn403() throws Exception {
+    public void testSubsequentHttpRequestsAfterUpgradeShouldReturn403() {
         EmbeddedChannel ch = createChannel();
 
         writeUpgradeRequest(ch);
@@ -151,19 +152,19 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     private static String getResponseMessage(FullHttpResponse response) {
-        return new String(response.content().array());
+        return response.content().toString(CharsetUtil.UTF_8);
     }
 
     private class MockOutboundHandler extends ChannelOutboundHandlerAdapter {
 
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             responses.add((FullHttpResponse) msg);
             promise.setSuccess();
         }
 
         @Override
-        public void flush(ChannelHandlerContext ctx) throws Exception {
+        public void flush(ChannelHandlerContext ctx) {
         }
     }
 
@@ -171,7 +172,7 @@ public class WebSocketServerProtocolHandlerTest {
         private String content;
 
         @Override
-        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
             assertNull(content);
             content = "processed: " + ((TextWebSocketFrame) msg).text();
             ReferenceCountUtil.release(msg);


### PR DESCRIPTION
Motivation:

In many places Netty uses `Unpooled.buffer(0)` while should use `EMPTY_BUFFER`. We can't change this due to back compatibility, however we can at least replace `Unpooled.buffer(0)` with `ByteBufAllocator.DEFAULT.buffer(0)` so in evns. with preferDirect=true heap will not be used.

Modification:

- Repalced `Unpooled.buffer(0)` with `ByteBufAllocator.DEFAULT.buffer(0)` for web sockets frames and HttpRequest, HttpResponse;
- `Unpooled.copiedBuffer(text, CharsetUtil.UTF_8)` ->
`ByteBufUtil.encodeString(ByteBufAllocator.DEFAULT, CharBuffer.wrap(text), CharsetUtil.UTF_8)`;
- `Unpooled.wrappedBuffer(bytes)` -> `ctx.alloc().buffer(bytes.length).writeBytes(bytes)`

Result:
Fixes #9345 for websockets package.