### PR TITLE
Compute system property names taking into account that Netty can be repackaged

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -59,8 +59,8 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
         checkBounds = SystemPropertyUtil.getBoolean(PROP_CHECK_BOUNDS, true);
         if (logger.isDebugEnabled()) {
-            logger.debug("-D{}: {}", PROP_CHECK_ACCESSIBLE, checkAccessible);
-            logger.debug("-D{}: {}", PROP_CHECK_BOUNDS, checkBounds);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName(PROP_CHECK_ACCESSIBLE), checkAccessible);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName(PROP_CHECK_BOUNDS), checkBounds);
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -44,7 +44,8 @@ final class AdvancedLeakAwareByteBuf extends SimpleLeakAwareByteBuf {
         ACQUIRE_AND_RELEASE_ONLY = SystemPropertyUtil.getBoolean(PROP_ACQUIRE_AND_RELEASE_ONLY, false);
 
         if (logger.isDebugEnabled()) {
-            logger.debug("-D{}: {}", PROP_ACQUIRE_AND_RELEASE_ONLY, ACQUIRE_AND_RELEASE_ONLY);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName(PROP_ACQUIRE_AND_RELEASE_ONLY),
+                    ACQUIRE_AND_RELEASE_ONLY);
         }
 
         ResourceLeakDetector.addExclusions(

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -79,22 +79,25 @@ public final class ByteBufUtil {
         ByteBufAllocator alloc;
         if ("unpooled".equals(allocType)) {
             alloc = UnpooledByteBufAllocator.DEFAULT;
-            logger.debug("-Dio.netty.allocator.type: {}", allocType);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.allocator.type"), allocType);
         } else if ("pooled".equals(allocType)) {
             alloc = PooledByteBufAllocator.DEFAULT;
-            logger.debug("-Dio.netty.allocator.type: {}", allocType);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.allocator.type"), allocType);
         } else {
             alloc = PooledByteBufAllocator.DEFAULT;
-            logger.debug("-Dio.netty.allocator.type: pooled (unknown: {})", allocType);
+            logger.debug("-D{}: pooled (unknown: {})",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.type"), allocType);
         }
 
         DEFAULT_ALLOCATOR = alloc;
 
         THREAD_LOCAL_BUFFER_SIZE = SystemPropertyUtil.getInt("io.netty.threadLocalDirectBufferSize", 0);
-        logger.debug("-Dio.netty.threadLocalDirectBufferSize: {}", THREAD_LOCAL_BUFFER_SIZE);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.threadLocalDirectBufferSize"),
+                THREAD_LOCAL_BUFFER_SIZE);
 
         MAX_CHAR_BUFFER_SIZE = SystemPropertyUtil.getInt("io.netty.maxThreadLocalCharBufferSize", 16 * 1024);
-        logger.debug("-Dio.netty.maxThreadLocalCharBufferSize: {}", MAX_CHAR_BUFFER_SIZE);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.maxThreadLocalCharBufferSize"),
+                MAX_CHAR_BUFFER_SIZE);
     }
 
     static final int MAX_TL_ARRAY_LEN = 1024;

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -139,27 +139,52 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                 "io.netty.allocator.maxCachedByteBuffersPerChunk", 1023);
 
         if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty.allocator.numHeapArenas: {}", DEFAULT_NUM_HEAP_ARENA);
-            logger.debug("-Dio.netty.allocator.numDirectArenas: {}", DEFAULT_NUM_DIRECT_ARENA);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.numHeapArenas"), DEFAULT_NUM_HEAP_ARENA);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.numDirectArena"), DEFAULT_NUM_DIRECT_ARENA);
             if (pageSizeFallbackCause == null) {
-                logger.debug("-Dio.netty.allocator.pageSize: {}", DEFAULT_PAGE_SIZE);
+                logger.debug("-D{}: {}",
+                        SystemPropertyUtil.propertyName("io.netty.allocator.pageSize"), DEFAULT_PAGE_SIZE);
             } else {
-                logger.debug("-Dio.netty.allocator.pageSize: {}", DEFAULT_PAGE_SIZE, pageSizeFallbackCause);
+                logger.debug("-D{}: {}",
+                        SystemPropertyUtil.propertyName("io.netty.allocator.pageSize"), DEFAULT_PAGE_SIZE,
+                        pageSizeFallbackCause);
             }
             if (maxOrderFallbackCause == null) {
-                logger.debug("-Dio.netty.allocator.maxOrder: {}", DEFAULT_MAX_ORDER);
+                logger.debug("-D{}: {}",
+                        SystemPropertyUtil.propertyName("io.netty.allocator.maxOrder"), DEFAULT_MAX_ORDER);
             } else {
-                logger.debug("-Dio.netty.allocator.maxOrder: {}", DEFAULT_MAX_ORDER, maxOrderFallbackCause);
+                logger.debug("-D{}: {}",
+                        SystemPropertyUtil.propertyName("io.netty.allocator.maxOrder"), DEFAULT_MAX_ORDER,
+                        maxOrderFallbackCause);
             }
-            logger.debug("-Dio.netty.allocator.chunkSize: {}", DEFAULT_PAGE_SIZE << DEFAULT_MAX_ORDER);
-            logger.debug("-Dio.netty.allocator.tinyCacheSize: {}", DEFAULT_TINY_CACHE_SIZE);
-            logger.debug("-Dio.netty.allocator.smallCacheSize: {}", DEFAULT_SMALL_CACHE_SIZE);
-            logger.debug("-Dio.netty.allocator.normalCacheSize: {}", DEFAULT_NORMAL_CACHE_SIZE);
-            logger.debug("-Dio.netty.allocator.maxCachedBufferCapacity: {}", DEFAULT_MAX_CACHED_BUFFER_CAPACITY);
-            logger.debug("-Dio.netty.allocator.cacheTrimInterval: {}", DEFAULT_CACHE_TRIM_INTERVAL);
-            logger.debug("-Dio.netty.allocator.cacheTrimIntervalMillis: {}", DEFAULT_CACHE_TRIM_INTERVAL_MILLIS);
-            logger.debug("-Dio.netty.allocator.useCacheForAllThreads: {}", DEFAULT_USE_CACHE_FOR_ALL_THREADS);
-            logger.debug("-Dio.netty.allocator.maxCachedByteBuffersPerChunk: {}",
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.chunkSize"),
+                    DEFAULT_PAGE_SIZE << DEFAULT_MAX_ORDER);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.tinyCacheSize"),
+                    DEFAULT_TINY_CACHE_SIZE);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.smallCacheSize"),
+                    DEFAULT_SMALL_CACHE_SIZE);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.normalCacheSize"),
+                    DEFAULT_NORMAL_CACHE_SIZE);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.maxCachedBufferCapacity"),
+                    DEFAULT_MAX_CACHED_BUFFER_CAPACITY);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.cacheTrimInterval"),
+                    DEFAULT_CACHE_TRIM_INTERVAL);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.cacheTrimIntervalMillis"),
+                    DEFAULT_CACHE_TRIM_INTERVAL_MILLIS);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.useCacheForAllThreads"),
+                    DEFAULT_USE_CACHE_FOR_ALL_THREADS);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.allocator.maxCachedByteBuffersPerChunk"),
                     DEFAULT_MAX_CACHED_BYTEBUFFERS_PER_CHUNK);
         }
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
@@ -36,10 +36,10 @@ public final class ZlibCodecFactory {
     static {
         noJdkZlibDecoder = SystemPropertyUtil.getBoolean("io.netty.noJdkZlibDecoder",
                 PlatformDependent.javaVersion() < 7);
-        logger.debug("-Dio.netty.noJdkZlibDecoder: {}", noJdkZlibDecoder);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.noJdkZlibDecoder"), noJdkZlibDecoder);
 
         noJdkZlibEncoder = SystemPropertyUtil.getBoolean("io.netty.noJdkZlibEncoder", false);
-        logger.debug("-Dio.netty.noJdkZlibEncoder: {}", noJdkZlibEncoder);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.noJdkZlibEncoder"), noJdkZlibEncoder);
 
         supportsWindowSizeAndMemLevel = noJdkZlibDecoder || PlatformDependent.javaVersion() >= 7;
     }

--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -88,15 +88,27 @@ public abstract class Recycler<T> {
 
         if (logger.isDebugEnabled()) {
             if (DEFAULT_MAX_CAPACITY_PER_THREAD == 0) {
-                logger.debug("-Dio.netty.recycler.maxCapacityPerThread: disabled");
-                logger.debug("-Dio.netty.recycler.maxSharedCapacityFactor: disabled");
-                logger.debug("-Dio.netty.recycler.linkCapacity: disabled");
-                logger.debug("-Dio.netty.recycler.ratio: disabled");
+                logger.debug("-D{}: disabled",
+                        SystemPropertyUtil.propertyName("io.netty.recycler.maxCapacityPerThread"));
+                logger.debug("-D{}: disabled",
+                        SystemPropertyUtil.propertyName("io.netty.recycler.maxSharedCapacityFactor"));
+                logger.debug("-D{}: disabled",
+                        SystemPropertyUtil.propertyName("io.netty.recycler.linkCapacity"));
+                logger.debug("-D{}: disabled",
+                        SystemPropertyUtil.propertyName("io.netty.recycler.ratio"));
             } else {
-                logger.debug("-Dio.netty.recycler.maxCapacityPerThread: {}", DEFAULT_MAX_CAPACITY_PER_THREAD);
-                logger.debug("-Dio.netty.recycler.maxSharedCapacityFactor: {}", MAX_SHARED_CAPACITY_FACTOR);
-                logger.debug("-Dio.netty.recycler.linkCapacity: {}", LINK_CAPACITY);
-                logger.debug("-Dio.netty.recycler.ratio: {}", RATIO);
+                logger.debug("-D{}: {}",
+                        SystemPropertyUtil.propertyName("io.netty.recycler.maxCapacityPerThread"),
+                        DEFAULT_MAX_CAPACITY_PER_THREAD);
+                logger.debug("-D{}: {}",
+                        SystemPropertyUtil.propertyName("io.netty.recycler.maxSharedCapacityFactor"),
+                        MAX_SHARED_CAPACITY_FACTOR);
+                logger.debug("-D{}: {}",
+                        SystemPropertyUtil.propertyName("io.netty.recycler.linkCapacity"),
+                        LINK_CAPACITY);
+                logger.debug("-D{}: {}",
+                        SystemPropertyUtil.propertyName("io.netty.recycler.ratio"),
+                        RATIO);
             }
         }
 

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -104,10 +104,11 @@ public class ResourceLeakDetector<T> {
         final boolean disabled;
         if (SystemPropertyUtil.get("io.netty.noResourceLeakDetection") != null) {
             disabled = SystemPropertyUtil.getBoolean("io.netty.noResourceLeakDetection", false);
-            logger.debug("-Dio.netty.noResourceLeakDetection: {}", disabled);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.noResourceLeakDetection"), disabled);
             logger.warn(
-                    "-Dio.netty.noResourceLeakDetection is deprecated. Use '-D{}={}' instead.",
-                    PROP_LEVEL, DEFAULT_LEVEL.name().toLowerCase());
+                    "-D{} is deprecated. Use '-D{}={}' instead.",
+                    SystemPropertyUtil.propertyName("io.netty.noResourceLeakDetection"),
+                    SystemPropertyUtil.propertyName(PROP_LEVEL), DEFAULT_LEVEL.name().toLowerCase());
         } else {
             disabled = false;
         }
@@ -126,8 +127,8 @@ public class ResourceLeakDetector<T> {
 
         ResourceLeakDetector.level = level;
         if (logger.isDebugEnabled()) {
-            logger.debug("-D{}: {}", PROP_LEVEL, level.name().toLowerCase());
-            logger.debug("-D{}: {}", PROP_TARGET_RECORDS, TARGET_RECORDS);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName(PROP_LEVEL), level.name().toLowerCase());
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName(PROP_TARGET_RECORDS), TARGET_RECORDS);
         }
     }
 

--- a/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
@@ -110,7 +110,8 @@ public abstract class ResourceLeakDetectorFactory {
                     }
                 });
             } catch (Throwable cause) {
-                logger.error("Could not access System property: io.netty.customResourceLeakDetector", cause);
+                logger.error("Could not access System property: {}",
+                        SystemPropertyUtil.propertyName("io.netty.customResourceLeakDetector"), cause);
                 customLeakDetector = null;
             }
             if (customLeakDetector == null) {

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -51,10 +51,14 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     static {
         STRING_BUILDER_INITIAL_SIZE =
                 SystemPropertyUtil.getInt("io.netty.threadLocalMap.stringBuilder.initialSize", 1024);
-        logger.debug("-Dio.netty.threadLocalMap.stringBuilder.initialSize: {}", STRING_BUILDER_INITIAL_SIZE);
+        logger.debug("-D{}: {}",
+                SystemPropertyUtil.propertyName("io.netty.threadLocalMap.stringBuilder.initialSize"),
+                STRING_BUILDER_INITIAL_SIZE);
 
         STRING_BUILDER_MAX_SIZE = SystemPropertyUtil.getInt("io.netty.threadLocalMap.stringBuilder.maxSize", 1024 * 4);
-        logger.debug("-Dio.netty.threadLocalMap.stringBuilder.maxSize: {}", STRING_BUILDER_MAX_SIZE);
+        logger.debug("-D{}: {}",
+                SystemPropertyUtil.propertyName("io.netty.threadLocalMap.stringBuilder.maxSize"),
+                STRING_BUILDER_MAX_SIZE);
     }
 
     public static InternalThreadLocalMap getIfSet() {

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -67,19 +67,23 @@ public final class NativeLibraryLoader {
             }
 
             WORKDIR = f;
-            logger.debug("-Dio.netty.native.workdir: " + WORKDIR);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.native.workdir"), WORKDIR);
         } else {
             WORKDIR = PlatformDependent.tmpdir();
-            logger.debug("-Dio.netty.native.workdir: " + WORKDIR + " (io.netty.tmpdir)");
+            logger.debug("-D{}: {} ({})",
+                    SystemPropertyUtil.propertyName("io.netty.native.workdir"), WORKDIR,
+                    SystemPropertyUtil.propertyName("io.netty.tmpdir"));
         }
 
         DELETE_NATIVE_LIB_AFTER_LOADING = SystemPropertyUtil.getBoolean(
                 "io.netty.native.deleteLibAfterLoading", true);
-        logger.debug("-Dio.netty.native.deleteLibAfterLoading: {}", DELETE_NATIVE_LIB_AFTER_LOADING);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.native.deleteLibAfterLoading"),
+                DELETE_NATIVE_LIB_AFTER_LOADING);
 
         TRY_TO_PATCH_SHADED_ID = SystemPropertyUtil.getBoolean(
                 "io.netty.native.tryPatchShadedId", true);
-        logger.debug("-Dio.netty.native.tryPatchShadedId: {}", TRY_TO_PATCH_SHADED_ID);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.native.tryPatchShadedId"),
+                TRY_TO_PATCH_SHADED_ID);
     }
 
     /**
@@ -139,7 +143,8 @@ public final class NativeLibraryLoader {
             suppressed.add(ex);
             logger.debug(
                     "{} cannot be loaded from java.library.path, "
-                    + "now trying export to -Dio.netty.native.workdir: {}", name, WORKDIR, ex);
+                    + "now trying export to -D{}: {}", name,
+                    SystemPropertyUtil.propertyName("io.netty.native.workdir"), WORKDIR, ex);
         }
 
         String libname = System.mapLibraryName(name);

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -156,14 +156,16 @@ public final class PlatformDependent {
                 DIRECT_MEMORY_COUNTER = new AtomicLong();
             }
         }
-        logger.debug("-Dio.netty.maxDirectMemory: {} bytes", maxDirectMemory);
+        logger.debug("-D{}: {} bytes", SystemPropertyUtil.propertyName("io.netty.maxDirectMemory"), maxDirectMemory);
         DIRECT_MEMORY_LIMIT = maxDirectMemory >= 1 ? maxDirectMemory : MAX_DIRECT_MEMORY;
 
         int tryAllocateUninitializedArray =
                 SystemPropertyUtil.getInt("io.netty.uninitializedArrayAllocationThreshold", 1024);
         UNINITIALIZED_ARRAY_ALLOCATION_THRESHOLD = javaVersion() >= 9 && PlatformDependent0.hasAllocateArrayMethod() ?
                 tryAllocateUninitializedArray : -1;
-        logger.debug("-Dio.netty.uninitializedArrayAllocationThreshold: {}", UNINITIALIZED_ARRAY_ALLOCATION_THRESHOLD);
+        logger.debug("-D{}: {}",
+                SystemPropertyUtil.propertyName("io.netty.uninitializedArrayAllocationThreshold"),
+                UNINITIALIZED_ARRAY_ALLOCATION_THRESHOLD);
 
         MAYBE_SUPER_USER = maybeSuperUser0();
 
@@ -183,7 +185,8 @@ public final class PlatformDependent {
         DIRECT_BUFFER_PREFERRED = CLEANER != NOOP
                                   && !SystemPropertyUtil.getBoolean("io.netty.noPreferDirect", false);
         if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty.noPreferDirect: {}", !DIRECT_BUFFER_PREFERRED);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.noPreferDirect"), !DIRECT_BUFFER_PREFERRED);
         }
 
         /*
@@ -1080,13 +1083,14 @@ public final class PlatformDependent {
         try {
             f = toDirectory(SystemPropertyUtil.get("io.netty.tmpdir"));
             if (f != null) {
-                logger.debug("-Dio.netty.tmpdir: {}", f);
+                logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.tmpdir"), f);
                 return f;
             }
 
             f = toDirectory(SystemPropertyUtil.get("java.io.tmpdir"));
             if (f != null) {
-                logger.debug("-Dio.netty.tmpdir: {} (java.io.tmpdir)", f);
+                logger.debug("-D{}: {} (java.io.tmpdir)",
+                        SystemPropertyUtil.propertyName("io.netty.tmpdir"), f);
                 return f;
             }
 
@@ -1094,7 +1098,7 @@ public final class PlatformDependent {
             if (isWindows()) {
                 f = toDirectory(System.getenv("TEMP"));
                 if (f != null) {
-                    logger.debug("-Dio.netty.tmpdir: {} (%TEMP%)", f);
+                    logger.debug("-D{}: {} (%TEMP%)", SystemPropertyUtil.propertyName("io.netty.tmpdir"), f);
                     return f;
                 }
 
@@ -1102,20 +1106,22 @@ public final class PlatformDependent {
                 if (userprofile != null) {
                     f = toDirectory(userprofile + "\\AppData\\Local\\Temp");
                     if (f != null) {
-                        logger.debug("-Dio.netty.tmpdir: {} (%USERPROFILE%\\AppData\\Local\\Temp)", f);
+                        logger.debug("-D{}: {} (%USERPROFILE%\\AppData\\Local\\Temp)",
+                                SystemPropertyUtil.propertyName("io.netty.tmpdir"), f);
                         return f;
                     }
 
                     f = toDirectory(userprofile + "\\Local Settings\\Temp");
                     if (f != null) {
-                        logger.debug("-Dio.netty.tmpdir: {} (%USERPROFILE%\\Local Settings\\Temp)", f);
+                        logger.debug("-D{}: {} (%USERPROFILE%\\Local Settings\\Temp)",
+                                SystemPropertyUtil.propertyName("io.netty.tmpdir"), f);
                         return f;
                     }
                 }
             } else {
                 f = toDirectory(System.getenv("TMPDIR"));
                 if (f != null) {
-                    logger.debug("-Dio.netty.tmpdir: {} ($TMPDIR)", f);
+                    logger.debug("-D{}: {} ($TMPDIR)", SystemPropertyUtil.propertyName("io.netty.tmpdir"), f);
                     return f;
                 }
             }
@@ -1158,19 +1164,21 @@ public final class PlatformDependent {
         // Check user-specified bit mode first.
         int bitMode = SystemPropertyUtil.getInt("io.netty.bitMode", 0);
         if (bitMode > 0) {
-            logger.debug("-Dio.netty.bitMode: {}", bitMode);
+            logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.bitMode"), bitMode);
             return bitMode;
         }
 
         // And then the vendor specific ones which is probably most reliable.
         bitMode = SystemPropertyUtil.getInt("sun.arch.data.model", 0);
         if (bitMode > 0) {
-            logger.debug("-Dio.netty.bitMode: {} (sun.arch.data.model)", bitMode);
+            logger.debug("-D{}: {} (sun.arch.data.model)",
+                    SystemPropertyUtil.propertyName("io.netty.bitMode"), bitMode);
             return bitMode;
         }
         bitMode = SystemPropertyUtil.getInt("com.ibm.vm.bitmode", 0);
         if (bitMode > 0) {
-            logger.debug("-Dio.netty.bitMode: {} (com.ibm.vm.bitmode)", bitMode);
+            logger.debug("-D{}: {} (com.ibm.vm.bitmode)",
+                    SystemPropertyUtil.propertyName("io.netty.bitMode"), bitMode);
             return bitMode;
         }
 
@@ -1183,7 +1191,8 @@ public final class PlatformDependent {
         }
 
         if (bitMode > 0) {
-            logger.debug("-Dio.netty.bitMode: {} (os.arch: {})", bitMode, arch);
+            logger.debug("-D{}: {} (os.arch: {})",
+                    SystemPropertyUtil.propertyName("io.netty.bitMode"), bitMode, arch);
         }
 
         // Last resort: guess from VM name and then fall back to most common 64-bit mode.

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -392,11 +392,12 @@ final class PlatformDependent0 {
 
     private static Throwable explicitNoUnsafeCause0() {
         final boolean noUnsafe = SystemPropertyUtil.getBoolean("io.netty.noUnsafe", false);
-        logger.debug("-Dio.netty.noUnsafe: {}", noUnsafe);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.noUnsafe"), noUnsafe);
 
         if (noUnsafe) {
-            logger.debug("sun.misc.Unsafe: unavailable (io.netty.noUnsafe)");
-            return new UnsupportedOperationException("sun.misc.Unsafe: unavailable (io.netty.noUnsafe)");
+            logger.debug("sun.misc.Unsafe: unavailable ({})", SystemPropertyUtil.propertyName("io.netty.noUnsafe"));
+            return new UnsupportedOperationException("sun.misc.Unsafe: unavailable ("
+                    + SystemPropertyUtil.propertyName("io.netty.noUnsafe") + ")");
         }
 
         // Legacy properties
@@ -408,7 +409,7 @@ final class PlatformDependent0 {
         }
 
         if (!SystemPropertyUtil.getBoolean(unsafePropName, true)) {
-            String msg = "sun.misc.Unsafe: unavailable (" + unsafePropName + ")";
+            String msg = "sun.misc.Unsafe: unavailable (" + SystemPropertyUtil.propertyName(unsafePropName) + ")";
             logger.debug(msg);
             return new UnsupportedOperationException(msg);
         }

--- a/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
+++ b/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
@@ -23,10 +23,68 @@ import java.security.PrivilegedAction;
 
 /**
  * A collection of utility methods to retrieve and parse the values of the Java system properties.
+ * This library takes into account the fact that Netty classes are usually repackaged and relocated.
  */
 public final class SystemPropertyUtil {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SystemPropertyUtil.class);
+
+    private static final String SYSTEM_PROPERTIES_PREFIX =
+            computePrefix("io.netty.util.internal.SystemPropertyUtil", SystemPropertyUtil.class.getName());
+
+    /**
+     * Try to detect that Netty has been relocated to a different package name.
+     * In that case we compute a prefix to prepend to every Netty system property.
+     * When you are relocating Netty classes you want an isolated version of Netty
+     * with its own set of settings. As Netty is configurable with System properties
+     * we have to provide a way to shield the relocated version of Netty by system wide settings.
+     *
+     * @param originalName the original name of the class inside Netty codebase.
+     * @param currentName the actual name of this class, that could have been repackaged with a different package name.
+     * @return the prefix, empty string in case we are running the original version of Netty.
+     */
+    static String computePrefix(final String originalName, final String currentName) {
+        if (originalName.equals(currentName)) {
+            return "";
+        }
+        boolean usePrefix = Boolean.parseBoolean(get0("", "io.netty.internal.detectRelocation", "true"));
+        if (!usePrefix) {
+            logger.warn("Detected a relocated version of Netty ({}), "
+                    + "but io.netty.internal.detectRelocation is disabled" , currentName);
+            return "";
+        }
+        // strip the original name, and try to keep the prefix injected by the relocation
+        // "io.netty.util.internal.SystemPropertyUtil" -> ""
+        // "mylib.io.netty.util.internal.SystemPropertyUtil" -> "mylib."
+        // "mylib.nettyshaded.util.internal.SystemPropertyUtil" -> "mylib.nettyshaded."
+        String result = currentName
+                .replace(originalName, "") // common case
+                .replace("io.netty.", "")
+                .replace("util.internal.", "")
+                .replace("SystemPropertyUtil", "");
+        if (!result.isEmpty()) {
+            logger.warn("Detected a relocated version of netty, "
+                    + "prefix '{}' will be prepended to every system property for this instance of Netty", result);
+        }
+        return result;
+    }
+
+    /**
+     * Compute the actual name of a system property that is in use.
+     * This method is used while logging system property values.
+     *
+     * @param key
+     *
+     * @return the key prepended by {@link #SYSTEM_PROPERTIES_PREFIX}
+     * @see #computePrefix(java.lang.String, java.lang.String)
+     */
+    public static String propertyName(String key) {
+        if (isNettyProperty(key)) {
+            return SYSTEM_PROPERTIES_PREFIX + key;
+        } else {
+            return key;
+        }
+    }
 
     /**
      * Returns {@code true} if and only if the system property with the specified {@code key}
@@ -50,33 +108,47 @@ public final class SystemPropertyUtil {
      * Returns the value of the Java system property with the specified
      * {@code key}, while falling back to the specified default value if
      * the property access fails.
-     *
+     * @param key the name of the property.
+     * @param def the default value.
      * @return the property value.
      *         {@code def} if there's no such property or if an access to the
      *         specified property is not allowed.
      */
-    public static String get(final String key, String def) {
+    public static String get(final String key, final String def) {
+        return get0(SYSTEM_PROPERTIES_PREFIX, key, def);
+    }
+
+    private static boolean isNettyProperty(String key) {
+        // we have to handle only Netty properties, not stuff like "java.net.preferIPv4Stack" or "os.name"
+        return key.startsWith("io.netty");
+    }
+
+    private static String get0(final String prefix, final String key, String def) {
         if (key == null) {
             throw new NullPointerException("key");
+        }
+        if (prefix == null) {
+            throw new NullPointerException("prefix");
         }
         if (key.isEmpty()) {
             throw new IllegalArgumentException("key must not be empty.");
         }
-
+        boolean isNettyProperty = isNettyProperty(key);
+        final String prefixedKey = isNettyProperty ? prefix + key : key;
         String value = null;
         try {
             if (System.getSecurityManager() == null) {
-                value = System.getProperty(key);
+                value = System.getProperty(prefixedKey);
             } else {
                 value = AccessController.doPrivileged(new PrivilegedAction<String>() {
                     @Override
                     public String run() {
-                        return System.getProperty(key);
+                        return System.getProperty(prefixedKey);
                     }
                 });
             }
         } catch (SecurityException e) {
-            logger.warn("Unable to retrieve a system property '{}'; default values will be used.", key, e);
+            logger.warn("Unable to retrieve a system property '{}'; default values will be used.", prefixedKey, e);
         }
 
         if (value == null) {

--- a/common/src/main/java/io/netty/util/internal/ThreadLocalRandom.java
+++ b/common/src/main/java/io/netty/util/internal/ThreadLocalRandom.java
@@ -209,7 +209,9 @@ public final class ThreadLocalRandom extends Random {
                                 actualCurrent,
                                 TimeUnit.NANOSECONDS.toMillis(seedGeneratorEndTime - seedGeneratorStartTime)));
                     } else {
-                        logger.debug(String.format("-Dio.netty.initialSeedUniquifier: 0x%016x", actualCurrent));
+                        logger.debug(String.format("-D{}: 0x%016x",
+                                SystemPropertyUtil.propertyName("io.netty.initialSeedUniquifier"),
+                                actualCurrent));
                     }
                 }
                 return next ^ System.nanoTime();

--- a/common/src/test/java/io/netty/util/internal/SystemPropertyUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/SystemPropertyUtilTest.java
@@ -125,4 +125,20 @@ public class SystemPropertyUtilTest {
         assertEquals(1, SystemPropertyUtil.getLong("key", 1));
     }
 
+    @Test
+    public void computePrefix() {
+        // not relocated
+        assertEquals("", SystemPropertyUtil
+                .computePrefix("io.netty.util.internal.SystemPropertyUtil",
+                               "io.netty.util.internal.SystemPropertyUtil"));
+        // prepended suffix
+        assertEquals("shaded.", SystemPropertyUtil
+                .computePrefix("io.netty.util.internal.SystemPropertyUtil",
+                               "shaded.io.netty.util.internal.SystemPropertyUtil"));
+        // prepended suffix and changed root package name io.netty
+        assertEquals("shadednetty.", SystemPropertyUtil
+                .computePrefix("io.netty.util.internal.SystemPropertyUtil",
+                               "shadednetty.util.internal.SystemPropertyUtil"));
+    }
+
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -110,7 +110,8 @@ public final class OpenSsl {
 
         if (SystemPropertyUtil.getBoolean("io.netty.handler.ssl.noOpenSsl", false)) {
             cause = new UnsupportedOperationException(
-                    "OpenSSL was explicit disabled with -Dio.netty.handler.ssl.noOpenSsl=true");
+                    "OpenSSL was explicit disabled with -D" +
+                            SystemPropertyUtil.propertyName("io.netty.handler.ssl.noOpenSsl") + "=true");
 
             logger.debug(
                     "netty-tcnative explicit disabled; " +
@@ -256,15 +257,19 @@ public final class OpenSsl {
 
                                     if (propertySet) {
                                         logger.info("System property " +
-                                                "'io.netty.handler.ssl.openssl.useKeyManagerFactory'" +
-                                                " is deprecated and so will be ignored in the future");
+                                                "'{}'" +
+                                                " is deprecated and so will be ignored in the future",
+                                                SystemPropertyUtil.propertyName(
+                                                        "io.netty.handler.ssl.openssl.useKeyManagerFactory"));
                                     }
                                 } else {
                                     useKeyManagerFactory = true;
                                     if (propertySet) {
                                         logger.info("System property " +
-                                                "'io.netty.handler.ssl.openssl.useKeyManagerFactory'" +
-                                                " is deprecated and will be ignored when using BoringSSL");
+                                                "'{}'" +
+                                                " is deprecated and will be ignored when using BoringSSL",
+                                                SystemPropertyUtil.propertyName(
+                                                        "io.netty.handler.ssl.openssl.useKeyManagerFactory"));
                                     }
                                 }
                             } catch (Throwable ignore) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -49,8 +49,8 @@ public class SocketTestPermutation {
 
     static {
         InternalLogger logger = InternalLoggerFactory.getInstance(SocketConnectionAttemptTest.class);
-        logger.debug("-Dio.netty.testsuite.badHost: {}", BAD_HOST);
-        logger.debug("-Dio.netty.testsuite.badPort: {}", BAD_PORT);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.testsuite.badHost"), BAD_HOST);
+        logger.debug("-D{}: {}", SystemPropertyUtil.propertyName("io.netty.testsuite.badPort"), BAD_PORT);
     }
 
     static final SocketTestPermutation INSTANCE = new SocketTestPermutation();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
@@ -31,7 +31,8 @@ public final class Epoll {
 
         if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
             cause = new UnsupportedOperationException(
-                    "Native transport was explicit disabled with -Dio.netty.transport.noNative=true");
+                    "Native transport was explicit disabled with -D" +
+                            SystemPropertyUtil.propertyName("io.netty.transport.noNative") + "=true");
         } else {
             FileDescriptor epollFd = null;
             FileDescriptor eventFd = null;

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
@@ -30,7 +30,8 @@ public final class KQueue {
         Throwable cause = null;
         if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
             cause = new UnsupportedOperationException(
-                    "Native transport was explicit disabled with -Dio.netty.transport.noNative=true");
+                    "Native transport was explicit disabled with -D"
+                            + SystemPropertyUtil.propertyName("io.netty.transport.noNative") + "=true");
         } else {
             FileDescriptor kqueueFd = null;
             try {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -67,16 +67,19 @@ public final class DefaultChannelId implements ChannelId {
 
             if (processId < 0) {
                 processId = -1;
-                logger.warn("-Dio.netty.processId: {} (malformed)", customProcessId);
+                logger.warn("-D{}: {} (malformed)",
+                        SystemPropertyUtil.propertyName("io.netty.processId"), customProcessId);
             } else if (logger.isDebugEnabled()) {
-                logger.debug("-Dio.netty.processId: {} (user-set)", processId);
+                logger.debug("-D{}: {} (user-set)",
+                        SystemPropertyUtil.propertyName("io.netty.processId"), processId);
             }
         }
 
         if (processId < 0) {
             processId = defaultProcessId();
             if (logger.isDebugEnabled()) {
-                logger.debug("-Dio.netty.processId: {} (auto-detected)", processId);
+                logger.debug("-D{}: {} (auto-detected)",
+                        SystemPropertyUtil.propertyName("io.netty.processId"), processId);
             }
         }
 
@@ -88,17 +91,20 @@ public final class DefaultChannelId implements ChannelId {
             try {
                 machineId = parseMAC(customMachineId);
             } catch (Exception e) {
-                logger.warn("-Dio.netty.machineId: {} (malformed)", customMachineId, e);
+                logger.warn("-D{}: {} (malformed)",
+                        SystemPropertyUtil.propertyName("io.netty.machineId"), customMachineId, e);
             }
             if (machineId != null) {
-                logger.debug("-Dio.netty.machineId: {} (user-set)", customMachineId);
+                logger.debug("-D{}: {} (user-set)",
+                        SystemPropertyUtil.propertyName("io.netty.machineId"), customMachineId);
             }
         }
 
         if (machineId == null) {
             machineId = defaultMachineId();
             if (logger.isDebugEnabled()) {
-                logger.debug("-Dio.netty.machineId: {} (auto-detected)", MacAddressUtil.formatAddress(machineId));
+                logger.debug("-D{}: {} (auto-detected)",
+                        SystemPropertyUtil.propertyName("io.netty.machineId"), MacAddressUtil.formatAddress(machineId));
             }
         }
 

--- a/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
@@ -41,7 +41,8 @@ public abstract class MultithreadEventLoopGroup extends MultithreadEventExecutor
                 "io.netty.eventLoopThreads", NettyRuntime.availableProcessors() * 2));
 
         if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty.eventLoopThreads: {}", DEFAULT_EVENT_LOOP_THREADS);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.eventLoopThreads"), DEFAULT_EVENT_LOOP_THREADS);
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -103,8 +103,12 @@ public final class NioEventLoop extends SingleThreadEventLoop {
         SELECTOR_AUTO_REBUILD_THRESHOLD = selectorAutoRebuildThreshold;
 
         if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty.noKeySetOptimization: {}", DISABLE_KEY_SET_OPTIMIZATION);
-            logger.debug("-Dio.netty.selectorAutoRebuildThreshold: {}", SELECTOR_AUTO_REBUILD_THRESHOLD);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.noKeySetOptimization"),
+                    DISABLE_KEY_SET_OPTIMIZATION);
+            logger.debug("-D{}: {}",
+                    SystemPropertyUtil.propertyName("io.netty.selectorAutoRebuildThreshold"),
+                    SELECTOR_AUTO_REBUILD_THRESHOLD);
         }
     }
 


### PR DESCRIPTION
Compute system property names taking into account that Netty can be repackaged and io.netty package can be renamed.

Motivation:
When you are working with different copies of Netty on the classpath (imported by repackaging Netty classes and relocating package names) you have the problem that you cannot tune Netty parameters for a specific copy and if you change one parameter because one library needs it it will clash with the needs of the other library that imported Netty.


Modification:

Compute system property names taking into account that Netty can be repackaged and io.netty package can be renamed.

- Detect that Netty classes have been relocated (based on the actual name of SystemPropertyUtil class)
- Access system properties by adding a prefix
- Ensure that every log message report the exact name of the system property that is in use

With this change repackaged versions of Netty will use its own namespace of system
properties.

Add system property to disable this feature
-Dio.netty.internal.detectRelocation=false

Result:

Now downstream application can reliably configure separate version of Netty on the same classpath.