### PR TITLE
Update to adopt@1.8.212-04

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.212-03"
+        java_version : "adopt@1.8.212-04"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.8.212-03"
+        java_version : "adopt@1.8.212-04"
 
   test:
     image: netty:centos-7-1.8

--- a/docker/docker-sync-compose.centos-6.18.yaml
+++ b/docker/docker-sync-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.212-03"
+        java_version : "adopt@1.8.212-04"
 
   test:
     image: netty:centos-6-1.8


### PR DESCRIPTION
Motivation:

We should use latest jdk 1.8 release

Modifications:

Update to adopt@1.8.212-04

Result:

Use latest jdk 1.8 on ci