### PR TITLE
Add testcase to prove that ET semantics for eventFD are correct

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -19,6 +19,7 @@ import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.unix.FileDescriptor;
 import io.netty.testsuite.transport.AbstractSingleThreadEventLoopTest;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
@@ -26,9 +27,12 @@ import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -73,6 +77,56 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
             assertNull(capture.get());
         } finally {
             group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testEventFDETSemantics() throws Throwable {
+        final FileDescriptor epoll = Native.newEpollCreate();
+        final FileDescriptor eventFd = Native.newEventFd();
+        final FileDescriptor timerFd = Native.newTimerFd();
+        final EpollEventArray array = new EpollEventArray(1024);
+        try {
+            Native.epollCtlAdd(epoll.intValue(), eventFd.intValue(), Native.EPOLLIN | Native.EPOLLET);
+            final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
+            final AtomicInteger integer = new AtomicInteger();
+            final Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        for (int i = 0; i < 2; i++) {
+                            int ready = Native.epollWait(epoll, array, timerFd, -1, -1);
+                            assertEquals(1, ready);
+                            assertEquals(eventFd.intValue(), array.fd(0));
+                            integer.incrementAndGet();
+                        }
+                    } catch (IOException e) {
+                        causeRef.set(e);
+                    }
+                }
+            });
+            t.start();
+            Native.eventFdWrite(eventFd.intValue(), 1);
+
+            // Spin until we was the wakeup.
+            while (integer.get() != 1) {
+                Thread.sleep(10);
+            }
+            // Sleep for a short moment to ensure there is not other wakeup.
+            Thread.sleep(1000);
+            assertEquals(1, integer.get());
+            Native.eventFdWrite(eventFd.intValue(), 1);
+            t.join();
+            Throwable cause = causeRef.get();
+            if (cause != null) {
+                throw cause;
+            }
+            assertEquals(2, integer.get());
+        } finally {
+            array.free();
+            epoll.close();
+            eventFd.close();
+            timerFd.close();
         }
     }
 }


### PR DESCRIPTION
Motivation:

We recently made a change to use ET for the eventfd and not trigger a read each time. This testcase proves everything works as expected.

Modifications:

Add testcase that verifies thqat the wakeups happen correctly

Result:

More tests