### PR TITLE
Only close eventFD in EpollEventLoop when it cannot be written to.

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -77,8 +77,6 @@ class EpollEventLoop extends SingleThreadEventLoop {
             return epollWaitNow();
         }
     };
-    // wakenUp is a packed field, where the bottom bit indicates if the loop is trying to exit
-    // The high bits indicate if there are multiple non-loop threads trying to wake up the loop.
     private volatile int wakenUp = WAKEUP_NOT_ALLOWED;
     private volatile int ioRatio = 50;
 
@@ -469,7 +467,7 @@ class EpollEventLoop extends SingleThreadEventLoop {
                     // Busy loop until the last wakeup() is out of the critical section.
                     while (wakenUp != WAKEUP_NOT_ALLOWED) { /* spin */ }
                 }
-                
+
                 eventFd.close();
             } catch (IOException e) {
                 logger.warn("Failed to close the event fd.", e);


### PR DESCRIPTION
Motivation:
Writing to the eventFD is racy with close.   If the event loop is shutdown
and the fd closed, the fd number could be reused.   An in progress call to wakeup()
may write to the newly allocated fd, causing corruption.

Modification:
Make wakeup() indicate if a write is in progress or has completed.  The normal
loop will clear this indicator.  A shutdown now waits for the pending fd write to
finish.

Result:
No TSAN races reported.

Fixes #9362