### PR TITLE
HTTP/2 multiplex: Correctly process buffered inbound data even if aut…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -770,24 +770,31 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             }
         }
 
+        private Object pollQueuedMessage() {
+            return inboundBuffer == null ? null : inboundBuffer.poll();
+        }
+
         void doBeginRead() {
-            Object message;
-            if (inboundBuffer == null || (message = inboundBuffer.poll()) == null) {
-                if (readEOS) {
-                    unsafe.closeForcibly();
+            // Process messages until there are none left (or the user stopped requesting) and also handle EOS.
+            while (readStatus != ReadStatus.IDLE) {
+                Object message = pollQueuedMessage();
+                if (message == null) {
+                    if (readEOS) {
+                        unsafe.closeForcibly();
+                    }
+                    break;
                 }
-            } else {
                 final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
                 allocHandle.reset(config());
                 boolean continueReading = false;
                 do {
                     flowControlledBytes += doRead0((Http2Frame) message, allocHandle);
-                } while ((readEOS || (continueReading = allocHandle.continueReading())) &&
-                        inboundBuffer != null && (message = inboundBuffer.poll()) != null);
+                } while ((readEOS || (continueReading = allocHandle.continueReading()))
+                        && (message = pollQueuedMessage()) != null);
 
                 if (continueReading && isParentReadInProgress() && !readEOS) {
                     // Currently the parent and child channel are on the same EventLoop thread. If the parent is
-                    // currently reading it is possile that more frames will be delivered to this child channel. In
+                    // currently reading it is possible that more frames will be delivered to this child channel. In
                     // the case that this child channel still wants to read we delay the channelReadComplete on this
                     // child channel until the parent is done reading.
                     if (!readCompletePending) {


### PR DESCRIPTION
…oRead is false

Motivation:

When using the HTTP/2 multiplex implementation we need to ensure we correctly drain the buffered inbound data even if the RecvByteBufallocator.Handle tells us to stop reading in between.

Modifications:

Correctly loop through the buffered inbound data until the user does stop to request from it.

Result:

Fixes https://github.com/netty/netty/issues/9387.

Co-authored-by: Bryce Anderson <banderson@twitter.com>