### PR TITLE
Reuse Http2FrameStreamEvent instances to reduce GC pressure

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -613,11 +613,11 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
 
     private void onHttp2StreamWritabilityChanged(ChannelHandlerContext ctx, Http2FrameStream stream,
                                          @SuppressWarnings("unused") boolean writable) {
-        ctx.fireUserEventTriggered(Http2FrameStreamEvent.writabilityChanged(stream));
+        ctx.fireUserEventTriggered(((DefaultHttp2FrameStream) stream).writabilityChanged);
     }
 
     void onHttp2StreamStateChanged(ChannelHandlerContext ctx, Http2FrameStream stream) {
-        ctx.fireUserEventTriggered(Http2FrameStreamEvent.stateChanged(stream));
+        ctx.fireUserEventTriggered(((DefaultHttp2FrameStream) stream).stateChanged);
     }
 
     void onHttp2Frame(ChannelHandlerContext ctx, Http2Frame frame) {
@@ -648,6 +648,9 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
 
         private volatile int id = -1;
         volatile Http2Stream stream;
+
+        final Http2FrameStreamEvent stateChanged = Http2FrameStreamEvent.stateChanged(this);
+        final Http2FrameStreamEvent writabilityChanged = Http2FrameStreamEvent.writabilityChanged(this);
 
         Channel attachment;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -423,7 +423,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
             return;
         }
 
-        Http2FrameStream stream2 = newStream().setStreamAndProperty(streamKey, stream);
+        DefaultHttp2FrameStream stream2 = newStream().setStreamAndProperty(streamKey, stream);
         onHttp2StreamStateChanged(ctx, stream2);
     }
 
@@ -454,7 +454,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
         }
 
         private void onHttp2StreamStateChanged0(Http2Stream stream) {
-            Http2FrameStream stream2 = stream.getProperty(streamKey);
+            DefaultHttp2FrameStream stream2 = stream.getProperty(streamKey);
             if (stream2 != null) {
                 onHttp2StreamStateChanged(ctx, stream2);
             }
@@ -611,13 +611,13 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
         ctx.fireUserEventTriggered(evt);
     }
 
-    private void onHttp2StreamWritabilityChanged(ChannelHandlerContext ctx, Http2FrameStream stream,
+    private void onHttp2StreamWritabilityChanged(ChannelHandlerContext ctx, DefaultHttp2FrameStream stream,
                                          @SuppressWarnings("unused") boolean writable) {
-        ctx.fireUserEventTriggered(((DefaultHttp2FrameStream) stream).writabilityChanged);
+        ctx.fireUserEventTriggered(stream.writabilityChanged);
     }
 
-    void onHttp2StreamStateChanged(ChannelHandlerContext ctx, Http2FrameStream stream) {
-        ctx.fireUserEventTriggered(((DefaultHttp2FrameStream) stream).stateChanged);
+    void onHttp2StreamStateChanged(ChannelHandlerContext ctx, DefaultHttp2FrameStream stream) {
+        ctx.fireUserEventTriggered(stream.stateChanged);
     }
 
     void onHttp2Frame(ChannelHandlerContext ctx, Http2Frame frame) {
@@ -631,7 +631,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
     private final class Http2RemoteFlowControllerListener implements Http2RemoteFlowController.Listener {
         @Override
         public void writabilityChanged(Http2Stream stream) {
-            Http2FrameStream frameStream = stream.getProperty(streamKey);
+            DefaultHttp2FrameStream frameStream = stream.getProperty(streamKey);
             if (frameStream == null) {
                 return;
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -166,24 +166,23 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
     }
 
     @Override
-    final void onHttp2StreamStateChanged(ChannelHandlerContext ctx, Http2FrameStream stream) {
-        DefaultHttp2FrameStream s = (DefaultHttp2FrameStream) stream;
+    final void onHttp2StreamStateChanged(ChannelHandlerContext ctx, DefaultHttp2FrameStream stream) {
 
         switch (stream.state()) {
             case HALF_CLOSED_LOCAL:
                 if (stream.id() == HTTP_UPGRADE_STREAM_ID) {
-                    onHttp2UpgradeStreamInitialized(ctx, s);
+                    onHttp2UpgradeStreamInitialized(ctx, stream);
                 }
                 break;
             case HALF_CLOSED_REMOTE:
             case OPEN:
-                if (s.attachment != null) {
+                if (stream.attachment != null) {
                     // ignore if child channel was already created.
                     break;
                 }
                 // fall-trough
                 ChannelFuture future = ctx.channel().eventLoop().register(
-                        new Http2MultiplexCodecStreamChannel(s, inboundStreamHandler));
+                        new Http2MultiplexCodecStreamChannel(stream, inboundStreamHandler));
                 if (future.isDone()) {
                     Http2MultiplexHandler.registerDone(future);
                 } else {
@@ -191,7 +190,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                 }
                 break;
             case CLOSED:
-                AbstractHttp2StreamChannel channel = (AbstractHttp2StreamChannel) s.attachment;
+                AbstractHttp2StreamChannel channel = (AbstractHttp2StreamChannel) stream.attachment;
                 if (channel != null) {
                     channel.streamClosed();
                 }


### PR DESCRIPTION
Motivation:

We can easily reuse the Http2FrameStreamEvent instances and so reduce GC pressure as there may be multiple events per streams over the life-time.

Modifications:

Reuse instances

Result:

Less allocations