### PR TITLE
Update java versions

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.11.0-3"
+        java_version : "adopt@1.11.0-4"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.212-04"
+        java_version : "adopt@1.8.222-10"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.openj9111.yaml
+++ b/docker/docker-compose.centos-6.openj9111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt-openj9@1.11.0-3"
+        java_version : "adopt-openj9@1.11.0-4"
 
   test:
     image: netty:centos-6-openj9-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.11.0-3"
+        java_version : "adopt@1.11.0-4"
 
   test:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.8.212-04"
+        java_version : "adopt@1.8.222-10"
 
   test:
     image: netty:centos-7-1.8

--- a/docker/docker-sync-compose.centos-6.18.yaml
+++ b/docker/docker-sync-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.212-04"
+        java_version : "adopt@1.8.222-10"
 
   test:
     image: netty:centos-6-1.8


### PR DESCRIPTION
Motivation:

There were new openjdk releases

Modifications:

Update releases to latest

Result:

Use latest openjdk versions on CI