### PR TITLE
HTTP2: Update local flow-controller on Channel.read() if needed

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -757,6 +757,8 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             if (!isActive()) {
                 return;
             }
+            updateLocalWindowIfNeeded();
+
             switch (readStatus) {
                 case IDLE:
                     readStatus = ReadStatus.IN_PROGRESS;
@@ -832,8 +834,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             } else {
                 readStatus = ReadStatus.IDLE;
             }
-
-            updateLocalWindowIfNeeded();
 
             allocHandle.readComplete();
             pipeline().fireChannelReadComplete();


### PR DESCRIPTION
Motivation:

We should better update the flow-controller on Channel.read() to reduce overhead and memory overhead.

See https://github.com/netty/netty/pull/9390#issuecomment-513008269

Modifications:

Move updateLocalWindowIfNeeded() to doBeginRead()

Result:

Reduce memory overhead