### PR TITLE
Issue #8025. Ignoring HEADER and DATA frames for streams that may have existed in the past.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -771,7 +771,9 @@ public class DefaultHttp2Connection implements Http2Connection {
         @Override
         public DefaultStream reservePushStream(int streamId, Http2Stream parent) throws Http2Exception {
             if (parent == null) {
-                throw connectionError(PROTOCOL_ERROR, "Parent stream missing");
+                incrementExpectedStreamId(streamId);
+                throw streamError(streamId, Http2Error.REFUSED_STREAM, "PUSH_PROMISE sent on unknown stream, "
+                                                                       + "likely discarded due to a RST_STREAM.");
             }
             if (isLocal() ? !parent.state().localSideOpen() : !parent.state().remoteSideOpen()) {
                 throw connectionError(PROTOCOL_ERROR, "Stream %d is not open for sending push promise", parent.id());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamRingBuffer.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamRingBuffer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.util.internal.MathUtil;
+
+import java.util.Arrays;
+
+/**
+ * Fixed size ring-buffer for {@code HTTP2} streams.
+ */
+final class Http2StreamRingBuffer {
+
+    private final int[] elements;
+    private int oldestIdx;
+
+    Http2StreamRingBuffer() {
+        this(32);
+    }
+
+    Http2StreamRingBuffer(int capacity) {
+        elements = new int[MathUtil.findNextPositivePowerOfTwo(capacity)];
+        Arrays.fill(elements, -1);
+    }
+
+    int capacity() {
+        return elements.length;
+    }
+
+    /**
+     * Add the given {@code streamId}
+     * @param streamId the ID
+     * @return {@code true} if could be added, false if it was not added as this ring-buffer already contained it.
+     */
+    boolean add(int streamId) {
+        assert streamId >= 0;
+        // We expect elements to be very small and also to have the latest streamId at the beginning, so just scan the
+        // array.
+        for (int i = 0; i < elements.length; i++) {
+            int id = elements[i];
+            if (id == streamId) {
+                return false;
+            }
+            if (id == -1) {
+                // Still some space left
+                elements[i] = streamId;
+                return true;
+            }
+        }
+
+        // Just override the oldest entry.
+        elements[oldestIdx++] = streamId;
+        if (oldestIdx == elements.length) {
+            // We need to start from 0 again.
+            oldestIdx = 0;
+        }
+
+        return true;
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
 import junit.framework.AssertionFailedError;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -47,6 +48,7 @@ import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_REMOTE;
 import static io.netty.handler.codec.http2.Http2TestUtil.newHttp2HeadersWithRequestPseudoHeaders;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
@@ -277,13 +279,16 @@ public class DefaultHttp2ConnectionDecoderTest {
         }
     }
 
-    @Test(expected = Http2Exception.class)
+    @Test
     public void dataReadForUnknownStreamThatNeverExistedShouldThrow() throws Exception {
         when(connection.streamMayHaveExisted(STREAM_ID)).thenReturn(false);
         when(connection.stream(STREAM_ID)).thenReturn(null);
         final ByteBuf data = dummyData();
         try {
             decode().onDataRead(ctx, STREAM_ID, data, 0, true);
+            fail();
+        } catch (Http2Exception expected) {
+            assertThat(expected, CoreMatchers.not(CoreMatchers.instanceOf(Http2Exception.StreamException.class)));
         } finally {
             data.release();
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -321,6 +321,18 @@ public class DefaultHttp2ConnectionTest {
     }
 
     @Test
+    public void reservePushStreamForUnknownParentStreamIncrementsExpectedStreamIdAndThrows() throws Http2Exception {
+        try {
+            assertEquals(0, server.local().lastStreamCreated());
+            server.local().reservePushStream(2, null);
+            fail("Expected StreamException");
+        } catch (Http2Exception.StreamException expected) {
+            // Next expected stream id should still be incremented.
+            assertEquals(2, server.local().lastStreamCreated());
+        }
+    }
+
+    @Test
     public void clientReservePushStreamShouldSucceed() throws Http2Exception {
         Http2Stream stream = server.remote().createStream(3, true);
         Http2Stream pushStream = server.local().reservePushStream(4, stream);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamRingBufferTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamRingBufferTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class Http2StreamRingBufferTest {
+
+    @Test
+    public void testOverride() {
+        Http2StreamRingBuffer streams = new Http2StreamRingBuffer();
+        assertAdd(true, streams, 0);
+        assertAdd(false, streams, 0);
+        assertAdd(true, streams, streams.capacity());
+        assertAdd(false, streams, streams.capacity());
+    }
+
+    private static void assertAdd(boolean expected, Http2StreamRingBuffer streams, int increment) {
+        for (int i = 0; i < streams.capacity(); i++) {
+            assertEquals(expected, streams.add(i + increment));
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Correctly ignore frames that come in after a RST_STREAM is sent.

Modification:

Ignoring frames that are for a stream that may have existed in the past instead of throwing an exception.

Result:

Fixes #8025.