### PR TITLE
Update os-maven-plugin version to match netty-tcnative

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,7 @@
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
+    <osmaven.version>1.6.2</osmaven.version>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <tcnative.version>2.0.25.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
@@ -695,7 +696,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>${osmaven.version}</version>
       </extension>
     </extensions>
 


### PR DESCRIPTION
Motivation:

Since both projects (to some extend) rely on classifier parsing via the os-maven-plugin, they should ideally use the same version (ref https://github.com/netty/netty-tcnative/pull/480) in case the parsing changed.

Modifications:

Upgrade os-maven-plugin from 1.6.0 to 1.6.2

Result:

Same os-maven-plugin with same parsing logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netty/netty/9409)
<!-- Reviewable:end -->
