### PR TITLE
Fix native-build/target/lib wanted but build in native-build/target/lib64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,7 @@
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
+    <osmaven.version>1.6.2</osmaven.version>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <tcnative.version>2.0.25.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
@@ -695,7 +696,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>${osmaven.version}</version>
       </extension>
     </extensions>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -155,6 +155,7 @@
                   <configureArgs>
                     <arg>${jni.compiler.args.ldflags}</arg>
                     <arg>${jni.compiler.args.cflags}</arg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                   </configureArgs>
                 </configuration>
                 <goals>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -84,6 +84,7 @@
                          explicitly set the target platform. Otherwise we may get fatal link errors due to weakly linked
                          methods which are not expected to be present on MacOS (e.g. accept4). -->
                     <arg>MACOSX_DEPLOYMENT_TARGET=10.6</arg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                   </configureArgs>
                 </configuration>
                 <goals>


### PR DESCRIPTION
Motivation:

On openSUSE (probably more), 64 bit builds use `lib64`, e.g. `/usr/lib64`, and configure picks this up and builds the native library in `native-build/target/lib64` where maven is not looking.

Modifications:

Based on #9409, this explicitly specifies `--libdir=${project.build.directory}/native-build/target/lib` during configuration.

Result:

Maven uses the correct lib directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netty/netty/9410)
<!-- Reviewable:end -->
