### PR TITLE
Decrease the level of logging in WebSocketFrameEncoder/Decoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -179,8 +179,8 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
             frameRsv = (b & 0x70) >> 4;
             frameOpcode = b & 0x0F;
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Decoding WebSocket Frame opCode={}", frameOpcode);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Decoding WebSocket Frame opCode={}", frameOpcode);
             }
 
             state = State.READING_SECOND;
@@ -288,8 +288,8 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
                 return;
             }
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Decoding WebSocket Frame length={}", framePayloadLength);
+            if (logger.isTraceEnabled()) {
+                logger.trace("Decoding WebSocket Frame length={}", framePayloadLength);
             }
 
             state = State.MASKING_KEY;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -126,8 +126,8 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
 
         int length = data.readableBytes();
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Encoding WebSocket Frame opCode=" + opcode + " length=" + length);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Encoding WebSocket Frame opCode={} length={}", opcode, length);
         }
 
         int b0 = 0;


### PR DESCRIPTION
Motivation:

Our QA servers are spammed with this messages:

```
13:57:51.560 DEBUG- Decoding WebSocket Frame opCode=1
13:57:51.560 DEBUG- Decoding WebSocket Frame length=4
```

I think this is too much info for debug level. It is better to move it to trace level.

Modification:

`logger.debug` changed to `logger.trace` for `WebSocketFrameEncoder`/`Decoder`

Result:

Less messages in Debug mode.
