### PR TITLE
In order to avoid the LengthFieldPrepender memory copy

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
@@ -174,7 +174,7 @@ public class LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
                     "writeLengthIndex (" + writeLengthIndex + ") can't greater than readableBytes + lengthFieldLength");
             }
             out.markWriterIndex();
-			out.writerIndex(writeLengthIndex);
+	    out.writerIndex(writeLengthIndex);
         }
         switch (lengthFieldLength) {
         case 1:

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
@@ -174,7 +174,7 @@ public class LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
                     "writeLengthIndex (" + writeLengthIndex + ") can't greater than readableBytes + lengthFieldLength");
             }
             out.markWriterIndex();
-	    out.writerIndex(writeLengthIndex);
+            out.writerIndex(writeLengthIndex);
         }
         switch (lengthFieldLength) {
         case 1:

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
@@ -98,7 +98,7 @@ public class LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
      * @throws IllegalArgumentException
      *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
      */
-    public LengthFieldPrepender(int lengthFieldLength, int lengthAdjustment, int writeLengthIndex)) {
+    public LengthFieldPrepender(int lengthFieldLength, int lengthAdjustment, int writeLengthIndex) {
         this(lengthFieldLength, lengthAdjustment, false, writeLengthIndex);
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/MessageToByteEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToByteEncoder.java
@@ -106,7 +106,7 @@ public abstract class MessageToByteEncoder<I> extends ChannelOutboundHandlerAdap
                 try {
                     encode(ctx, cast, buf);
                 } finally {
-                    ReferenceCountUtil.release(cast);
+                    if (cast != buf) ReferenceCountUtil.release(cast);
                 }
 
                 if (buf.isReadable()) {


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.
In order to avoid the LengthFieldPrepender memory copy.

Modification:
Describe the modifications you've done.
Added writeLengthIndex, if writeLengthIndex < 0, write with new bytebuf, otherwise write to old bytebuf

Result:

Fixes #<GitHub issue number>. 
#9422 
If there is no issue then describe the changes introduced by this PR.
