### PR TITLE
Ignore IP filter rule which is null instead of all others after the null rule

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
@@ -47,7 +47,7 @@ public class RuleBasedIpFilter extends AbstractRemoteAddressFilter<InetSocketAdd
     protected boolean accept(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) throws Exception {
         for (IpFilterRule rule : rules) {
             if (rule == null) {
-                break;
+                continue;
             }
 
             if (rule.matches(remoteAddress)) {

--- a/handler/src/test/java/io/netty/handler/ipfilter/RuleBasedIpFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/RuleBasedIpFilterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ipfilter;
+
+import io.netty.util.internal.SocketUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+
+public class RuleBasedIpFilterTest {
+    @Test
+    public void testMultiRulesContainNull() throws Exception {
+        final String rejectIp = "192.168.57.1";
+        IpFilterRule rejectRule = new IpFilterRule() {
+            @Override
+            public boolean matches(InetSocketAddress remoteAddress) {
+                return rejectIp.equals(remoteAddress.getHostName());
+            }
+
+            @Override
+            public IpFilterRuleType ruleType() {
+                return IpFilterRuleType.REJECT;
+            }
+        };
+        IpFilterRule nullRule = null;
+        RuleBasedIpFilter ruleBasedIpFilter = new RuleBasedIpFilter(nullRule, rejectRule);
+        boolean accept = ruleBasedIpFilter.accept(null, SocketUtils.socketAddress(rejectIp, 1234));
+        Assert.assertFalse("should reject", accept);
+    }
+
+}


### PR DESCRIPTION
Motivation:
If one of the rules is null, all others after the rule in the array will be ignored.

Modification:
Change 'break' to 'continue';

Result:
Ignore rule which is null instead of others after the rule which aren't null.
