### PR TITLE
Do not cache local/remote address when creating EpollDatagramChannel with InternetProtocolFamily

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -67,7 +67,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      * on the Operation Systems default which will be chosen.
      */
     public EpollDatagramChannel() {
-        this((InternetProtocolFamily) null);
+        this(null);
     }
 
     /**
@@ -76,7 +76,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      */
     public EpollDatagramChannel(InternetProtocolFamily family) {
         this(family == null ?
-                newSocketDgram(Socket.isIPv6Preferred()) : newSocketDgram(family == InternetProtocolFamily.IPv6));
+                newSocketDgram(Socket.isIPv6Preferred()) : newSocketDgram(family == InternetProtocolFamily.IPv6),
+                false);
     }
 
     /**
@@ -84,11 +85,11 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      * on the Operation Systems default which will be chosen.
      */
     public EpollDatagramChannel(int fd) {
-        this(new LinuxSocket(fd));
+        this(new LinuxSocket(fd), true);
     }
 
-    private EpollDatagramChannel(LinuxSocket fd) {
-        super(null, fd, true);
+    private EpollDatagramChannel(LinuxSocket fd, boolean active) {
+        super(null, fd, active);
         config = new EpollDatagramChannelConfig(this);
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.channel.unix.Socket;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import static io.netty.util.NetUtil.LOCALHOST;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class EpollDatagramChannelTest {
+
+    @Before
+    public void setUp() {
+        Epoll.ensureAvailability();
+    }
+
+    @Test
+    public void testNotActiveNoLocalRemoteAddress() throws IOException {
+        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel());
+        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel(InternetProtocolFamily.IPv4));
+        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel(InternetProtocolFamily.IPv6));
+    }
+
+    @Test
+    public void testActiveHasLocalAddress() throws IOException {
+        Socket socket = Socket.newSocketDgram();
+        EpollDatagramChannel channel = new EpollDatagramChannel(socket.intValue());
+        InetSocketAddress localAddress = channel.localAddress();
+        assertTrue(channel.active);
+        assertNotNull(localAddress);
+        assertEquals(socket.localAddress(), localAddress);
+        channel.fd().close();
+    }
+
+    @Test
+    public void testLocalAddressBeforeAndAfterBind() {
+        EventLoopGroup group = new EpollEventLoopGroup(1);
+        try {
+            TestHandler handler = new TestHandler();
+            InetSocketAddress localAddressBeforeBind = new InetSocketAddress(LOCALHOST, 0);
+
+            Bootstrap bootstrap = new Bootstrap();
+            bootstrap.group(group)
+                    .channel(EpollDatagramChannel.class)
+                    .localAddress(localAddressBeforeBind)
+                    .handler(handler);
+
+            ChannelFuture future = bootstrap.bind().syncUninterruptibly();
+
+            assertNull(handler.localAddress);
+
+            SocketAddress localAddressAfterBind = future.channel().localAddress();
+            assertNotNull(localAddressAfterBind);
+            assertTrue(localAddressAfterBind instanceof InetSocketAddress);
+            assertTrue(((InetSocketAddress) localAddressAfterBind).getPort() != 0);
+
+            future.channel().close().syncUninterruptibly();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private static void checkNotActiveNoLocalRemoteAddress(EpollDatagramChannel channel) throws IOException {
+        assertFalse(channel.active);
+        assertNull(channel.localAddress());
+        assertNull(channel.remoteAddress());
+        channel.fd().close();
+    }
+
+    private static final class TestHandler extends ChannelInboundHandlerAdapter {
+        private volatile SocketAddress localAddress;
+
+        @Override
+        public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+            this.localAddress = ctx.channel().localAddress();
+            super.channelRegistered(ctx);
+        }
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
@@ -23,6 +23,8 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ResourceLeakDetector;
@@ -78,7 +80,7 @@ public class EpollReuseAddrTest {
     }
 
     private static void testMultipleBindDatagramChannelWithoutReusePortFails0(AbstractBootstrap<?, ?> bootstrap) {
-        bootstrap.handler(new DummyHandler());
+        bootstrap.handler(new LoggingHandler(LogLevel.ERROR));
         ChannelFuture future = bootstrap.bind().syncUninterruptibly();
         try {
             bootstrap.bind(future.channel().localAddress()).syncUninterruptibly();


### PR DESCRIPTION
Motivation:

EpollDatagramChannel#localAddress returns wrong information when
EpollDatagramChannel is created with InternetProtocolFamily,
and EpollDatagramChannel#localAddress is invoked BEFORE the actual binding.

This is a regression caused by change
https://github.com/netty/netty/commit/e17ce934da501788c3737631a02d02ee89ebf9df

Modifications:

EpollDatagramChannel() and EpollDatagramChannel(InternetProtocolFamily family)
do not cache local/remote address

Result:

Rebinding on the same address without "reuse port" works
EpollDatagramChannel#localAddress returns correct address
