### PR TITLE
Use overridable allocateArray method in UnpooledHeapByteBuf#copy(...)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -536,9 +536,9 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuf copy(int index, int length) {
         checkIndex(index, length);
-        byte[] copiedArray = PlatformDependent.allocateUninitializedArray(length);
-        System.arraycopy(array, index, copiedArray, 0, length);
-        return new UnpooledHeapByteBuf(alloc(), copiedArray, maxCapacity());
+        UnpooledHeapByteBuf copy = new UnpooledHeapByteBuf(alloc(), length, maxCapacity());
+        System.arraycopy(array, index, copy.array, 0, length);
+        return copy.writerIndex(length);
     }
 
     private ByteBuffer internalNioBuffer() {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -536,9 +536,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuf copy(int index, int length) {
         checkIndex(index, length);
-        UnpooledHeapByteBuf copy = new UnpooledHeapByteBuf(alloc(), length, maxCapacity());
-        System.arraycopy(array, index, copy.array, 0, length);
-        return copy.writerIndex(length);
+        return alloc().heapBuffer(length, maxCapacity()).writeBytes(array, index, length);
     }
 
     private ByteBuffer internalNioBuffer() {


### PR DESCRIPTION
Motivation

Underlying array allocations in `UnpooledHeapByteBuf` are intended be done via the protected `allocateArray(int)` method, so that they can be tracked and/or overridden by subclasses, for example `UnpooledByteBufAllocator$InstrumentedUnpooledHeapByteBuf` or #8015. But it looks like an explicit allocation was missed in the `copy(int,int)` method.

Modification

Have the copied buffer's array be initialized via it's length-parameter constructor instead of explicit allocation beforehand.

Result

No possibility of "missing" array allocations when `ByteBuf#copy` is used.