### PR TITLE
Use OpenJDK13 RC

### DIFF
--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.13.0-28"
+        java_version : "openjdk@1.13.0"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.13.0-28"
+        java_version : "openjdk@1.13.0"
 
   test:
     image: netty:centos-7-1.13


### PR DESCRIPTION
Motivation:

The first release canidate for OpenJDK13 was released.

Modifications:

Update version.

Result:

Use latest OpenJDK13 release