### PR TITLE
Correctly respect mask parameters in all WebSocketClientHandshakerFac…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerFactory.java
@@ -108,7 +108,7 @@ public final class WebSocketClientHandshakerFactory {
             boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength,
             boolean performMasking, boolean allowMaskMismatch) {
         return newHandshaker(webSocketURL, version, subprotocol, allowExtensions, customHeaders,
-                maxFramePayloadLength, true, false, -1);
+                maxFramePayloadLength, performMasking, allowMaskMismatch, -1);
     }
 
     /**


### PR DESCRIPTION
…tory#newHandshaker(...) methods

Motivation:

We did not correctly pass the mask parameters in all cases.

Modifications:

Correctly pass on parameters

Result:

Fixes https://github.com/netty/netty/issues/9463.