### PR TITLE
Http2EmptyDataFrameConnectionDecoder.frameListener() should return un…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EmptyDataFrameConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EmptyDataFrameConnectionDecoder.java
@@ -24,7 +24,7 @@ final class Http2EmptyDataFrameConnectionDecoder extends DecoratingHttp2Connecti
 
     private final int maxConsecutiveEmptyFrames;
 
-    Http2EmptyDataFrameConnectionDecoder(Http2ConnectionDecoder delegate,  int maxConsecutiveEmptyFrames) {
+    Http2EmptyDataFrameConnectionDecoder(Http2ConnectionDecoder delegate, int maxConsecutiveEmptyFrames) {
         super(delegate);
         this.maxConsecutiveEmptyFrames = ObjectUtil.checkPositive(
                 maxConsecutiveEmptyFrames, "maxConsecutiveEmptyFrames");
@@ -37,5 +37,20 @@ final class Http2EmptyDataFrameConnectionDecoder extends DecoratingHttp2Connecti
         } else {
             super.frameListener(null);
         }
+    }
+
+    @Override
+    public Http2FrameListener frameListener() {
+        Http2FrameListener frameListener = frameListener0();
+        // Unwrap the original Http2FrameListener as we add this decoder under the hood.
+        if (frameListener instanceof Http2EmptyDataFrameListener) {
+            return ((Http2EmptyDataFrameListener) frameListener).listener;
+        }
+        return frameListener;
+    }
+
+    // Package-private for testing
+    Http2FrameListener frameListener0() {
+        return super.frameListener();
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2EmptyDataFrameConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2EmptyDataFrameConnectionDecoderTest.java
@@ -44,7 +44,9 @@ public class Http2EmptyDataFrameConnectionDecoderTest {
         decoder.frameListener(listener);
         verify(delegate).frameListener(listenerArgumentCaptor.capture());
 
-        assertThat(decoder.frameListener(), CoreMatchers.instanceOf(Http2EmptyDataFrameListener.class));
+        assertThat(decoder.frameListener(),
+                CoreMatchers.not(CoreMatchers.instanceOf(Http2EmptyDataFrameListener.class)));
+        assertThat(decoder.frameListener0(), CoreMatchers.instanceOf(Http2EmptyDataFrameListener.class));
     }
 
     @Test


### PR DESCRIPTION
…wrapped Http2FrameListener

Motivation:

As we decorate the Http2FrameListener under the covers we should ensure the user can still access the original Http2FrameListener.

Modifications:

- Unwrap the Http2FrameListener in frameListener()
- Add unit test

Result:

Less surprises for users.