### PR TITLE
Use eventfd_read to close EpollEventLoop shutdown/wakeup race

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -718,6 +718,7 @@
             </ignoreMissingClassesByRegularExpressions>
             <excludes>
               <exclude>@io.netty.util.internal.UnstableApi</exclude>
+              <exclude>io.netty.channel.epoll.Native</exclude>
             </excludes>
           </parameter>
           <skip>${skipJapicmp}</skip>

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -145,6 +145,7 @@ static jlong netty_epoll_native_eventFdRead(JNIEnv* env, jclass clazz, jint fd) 
 
     if (eventfd_read(fd, &val) != 0) {
         if (errno == EAGAIN) {
+            // EAGAIN means counter value is 0 (see http://man7.org/linux/man-pages/man2/eventfd.2.html)
             return (jlong) 0;
         }
         // something is serious wrong

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -140,13 +140,17 @@ static void netty_epoll_native_eventFdWrite(JNIEnv* env, jclass clazz, jint fd, 
     }
 }
 
-static void netty_epoll_native_eventFdRead(JNIEnv* env, jclass clazz, jint fd) {
-    uint64_t eventfd_t;
+static jlong netty_epoll_native_eventFdRead(JNIEnv* env, jclass clazz, jint fd) {
+    uint64_t val;
 
-    if (eventfd_read(fd, &eventfd_t) != 0) {
+    if (eventfd_read(fd, &val) != 0) {
+        if (errno == EAGAIN) {
+            return (jlong) 0;
+        }
         // something is serious wrong
         netty_unix_errors_throwRuntimeException(env, "eventfd_read() failed");
     }
+    return (jlong) val;
 }
 
 static void netty_epoll_native_timerFdRead(JNIEnv* env, jclass clazz, jint fd) {
@@ -452,7 +456,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "eventFd", "()I", (void *) netty_epoll_native_eventFd },
   { "timerFd", "()I", (void *) netty_epoll_native_timerFd },
   { "eventFdWrite", "(IJ)V", (void *) netty_epoll_native_eventFdWrite },
-  { "eventFdRead", "(I)V", (void *) netty_epoll_native_eventFdRead },
+  { "eventFdRead", "(I)J", (void *) netty_epoll_native_eventFdRead },
   { "timerFdRead", "(I)V", (void *) netty_epoll_native_timerFdRead },
   { "timerFdSetTime", "(III)V", (void *) netty_epoll_native_timerFdSetTime },
   { "epollCreate", "()I", (void *) netty_epoll_native_epollCreate },

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -398,6 +398,8 @@ class EpollEventLoop extends SingleThreadEventLoop {
                                 strategy = epollWait();
                             }
                         } finally {
+                            // Try get() first to avoid much more expensive CAS in the case we
+                            // were woken via the wakeup() method (submitted task)
                             if (wakenUp.get() == 1 || wakenUp.getAndSet(1) == 1) {
                                 eventFdWriteCount++;
                             }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -386,6 +386,8 @@ class EpollEventLoop extends SingleThreadEventLoop {
                         break;
 
                     case SelectStrategy.SELECT:
+                        // Ordered store is sufficient here since the only access outside this
+                        // thread is a getAndSet in the wakeup() method
                         wakenUp.lazySet(0);
                         try {
                             if (!hasTasks()) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThrowableUtil;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -44,6 +45,7 @@ import static io.netty.channel.unix.Errors.newIOException;
  * <p><strong>Internal usage only!</strong>
  * <p>Static members which call JNI methods must be defined in {@link NativeStaticallyReferencedJniMethods}.
  */
+@UnstableApi
 public final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
 
@@ -82,7 +84,7 @@ public final class Native {
     private static native int eventFd();
     private static native int timerFd();
     public static native void eventFdWrite(int fd, long value);
-    public static native void eventFdRead(int fd);
+    public static native long eventFdRead(int fd);
     static native void timerFdRead(int fd);
     static native void timerFdSetTime(int fd, int sec, int nsec) throws IOException;
 


### PR DESCRIPTION
Motivation

@carl-mastrangelo discovered a non-hypothetical race condition during `EpollEventLoop` shutdown where wakeup writes can complete after the eventfd has been closed and subsequently reassigned by the kernel.

This fix is an alternative to #9388, using `eventfd_read` to hopefully close the gap completely, and without involving an additional CAS during wakeup.

Modification

After waking from `epollWait`, CAS the `wakenUp` atomic from 0 to 1. The times that a value of 1 is encountered here (CAS fail) correspond 1-1 with prior CAS wins by other threads in the `wakeup(...)` method, which correspond 1-1 with `eventfd_write(1)` calls (even if the most recent write is yet to happen).

Thus we can locally maintain a precise total count of those writes (`eventFdWriteCount`) which will be constant while the EL is awake - no further writes can happen until we reset `wakenUp` back to 0.

Since eventfd is a counter, when shutting down we just need to read from it until the sum of read values equals the known total write count. At this point all the writes must have completed and no more can happen.

Result

Race condition eliminated. Fixes #9362