### PR TITLE
AsciiString contentEqualsIgnoreCase fails when arrayOffset is non-zero

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -532,7 +532,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
 
         if (string instanceof AsciiString) {
             AsciiString rhs = (AsciiString) string;
-            for (int i = arrayOffset(), j = rhs.arrayOffset(); i < length(); ++i, ++j) {
+            for (int i = arrayOffset(), j = rhs.arrayOffset(), end = i + length(); i < end; ++i, ++j) {
                 if (!equalsIgnoreCase(value[i], rhs.value[j])) {
                     return false;
                 }
@@ -540,7 +540,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
             return true;
         }
 
-        for (int i = arrayOffset(), j = 0; i < length(); ++i, ++j) {
+        for (int i = arrayOffset(), j = 0, end = length(); j < end; ++i, ++j) {
             if (!equalsIgnoreCase(b2c(value[i]), string.charAt(j))) {
                 return false;
             }

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -38,6 +38,15 @@ public class AsciiStringCharacterTest {
     private static final Random r = new Random();
 
     @Test
+    public void testContentEqualsIgnoreCase() {
+        byte[] bytes = { 32, 'a' };
+        AsciiString asciiString = new AsciiString(bytes, 1, 1, false);
+        // https://github.com/netty/netty/issues/9475
+        assertFalse(asciiString.contentEqualsIgnoreCase("b"));
+        assertFalse(asciiString.contentEqualsIgnoreCase(AsciiString.of("b")));
+    }
+
+    @Test
     public void testGetBytesStringBuilder() {
         final StringBuilder b = new StringBuilder();
         for (int i = 0; i < 1 << 16; ++i) {


### PR DESCRIPTION
Fix bug where AsciiString.contentEqualsIgnoreCase may return true for non-matching strings of equal length.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #9475 . 

If there is no issue then describe the changes introduced by this PR.
