### PR TITLE
Use same JDK SSL test workaround when using ACCP as when just using t…

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/AmazonCorrettoSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/AmazonCorrettoSslEngineTest.java
@@ -109,4 +109,10 @@ public class AmazonCorrettoSslEngineTest extends SSLEngineTest {
     @Override
     public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() {
     }
+
+    @Override
+    protected boolean mySetupMutualAuthServerIsValidException(Throwable cause) {
+        // TODO(scott): work around for a JDK issue. The exception should be SSLHandshakeException.
+        return super.mySetupMutualAuthServerIsValidException(cause) || causedBySSLException(cause);
+    }
 }


### PR DESCRIPTION
…he JDK SSL implementation

Motivation:

14607979f6db074247d764cc4583461bcd298719 added tests for using ACCP but did miss to use the same unwrapping technique of exceptions as JdkSslEngineTest. This can lead to test-failures on specific JDK versions

Modifications:

Add the same unwrapping code

Result:

No more test failures