### PR TITLE
Fix ByteBufUtil.indexOf(...) and so AbstractByteBuf.indexOf(...) to a…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -470,7 +470,8 @@ public final class ByteBufUtil {
             return -1;
         }
 
-        return buffer.forEachByteDesc(toIndex, fromIndex - toIndex, new ByteProcessor.IndexOfProcessor(value));
+        // the toIndex is exclusive so we need to skip it.
+        return buffer.forEachByteDesc(toIndex + 1, fromIndex - toIndex, new ByteProcessor.IndexOfProcessor(value));
     }
 
     private static CharSequence checkCharSequenceBounds(CharSequence seq, int start, int end) {

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2131,10 +2131,13 @@ public abstract class AbstractByteBufTest {
         buffer.writeByte((byte) 2);
         buffer.writeByte((byte) 1);
 
+        assertEquals(0, buffer.indexOf(0, 4, (byte) 1));
         assertEquals(-1, buffer.indexOf(1, 4, (byte) 1));
-        assertEquals(-1, buffer.indexOf(4, 1, (byte) 1));
+        assertEquals(4, buffer.indexOf(4, 1, (byte) 1));
         assertEquals(1, buffer.indexOf(1, 4, (byte) 2));
         assertEquals(3, buffer.indexOf(4, 1, (byte) 2));
+        assertEquals(-1, buffer.indexOf(4, 3, (byte) 2));
+        assertEquals(4, buffer.indexOf(4, 3, (byte) 1));
     }
 
     @Test


### PR DESCRIPTION
…lways tread the toIndex as exclusive

Motivation:

The javadocs of indexOf(...) clearly tell that the toIndex should be handled as exclusive and so not be included in the search. This is not always respected at the moment and so we may return an index which is out of the range.

Modifications:

- Correclty handle toIndex as exclusive
- Fix testcase and also add a few more asserts to ensure we always handle inclusive / explusive for fromIndex and toIndex

Result:

AbstractByteBuf.indexOf(...) follows spec