### PR TITLE
Fix log format in HashedWheelTimer

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -271,8 +271,8 @@ public class HashedWheelTimer implements Timer {
 
         if (duration < MILLISECOND_NANOS) {
             if (logger.isWarnEnabled()) {
-                logger.warn("Configured tickDuration %d smaller then %d, using 1ms.",
-                            tickDuration, MILLISECOND_NANOS);
+                logger.warn(String.format("Configured tickDuration %d smaller then %d, using 1ms.",
+                        tickDuration, MILLISECOND_NANOS));
             }
             this.tickDuration = MILLISECOND_NANOS;
         } else {

--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -271,8 +271,8 @@ public class HashedWheelTimer implements Timer {
 
         if (duration < MILLISECOND_NANOS) {
             if (logger.isWarnEnabled()) {
-                logger.warn(String.format("Configured tickDuration %d smaller then %d, using 1ms.",
-                        tickDuration, MILLISECOND_NANOS));
+                logger.warn("Configured tickDuration {} smaller then {}, using 1ms.",
+                        tickDuration, MILLISECOND_NANOS);
             }
             this.tickDuration = MILLISECOND_NANOS;
         } else {


### PR DESCRIPTION
Motivation:

A warn log missed String.format in HashedWheelTimer

Modification:

Add String.format

Result:

The log is correct.