### PR TITLE
Use byte[] to create DatagramSocketAddress and so reduce overhead

### DIFF
--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DatagramSocketAddress.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DatagramSocketAddress.java
@@ -15,7 +15,10 @@
  */
 package io.netty.channel.unix;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 
 /**
  * Act as special {@link InetSocketAddress} to be able to easily pass all needed data from JNI without the need
@@ -30,8 +33,9 @@ public final class DatagramSocketAddress extends InetSocketAddress {
     private final int receivedAmount;
     private final DatagramSocketAddress localAddress;
 
-    DatagramSocketAddress(String addr, int port, int receivedAmount, DatagramSocketAddress local) {
-        super(addr, port);
+    DatagramSocketAddress(byte[] addr, int scopeId, int port, int receivedAmount, DatagramSocketAddress local)
+            throws UnknownHostException {
+        super(newAddress(addr, scopeId), port);
         this.receivedAmount = receivedAmount;
         localAddress = local;
     }
@@ -42,5 +46,12 @@ public final class DatagramSocketAddress extends InetSocketAddress {
 
     public int receivedAmount() {
         return receivedAmount;
+    }
+
+    private static InetAddress newAddress(byte[] bytes, int scopeId) throws UnknownHostException {
+        if (bytes.length == 4) {
+            return InetAddress.getByAddress(bytes);
+        }
+        return Inet6Address.getByAddress(null, bytes, scopeId);
     }
 }


### PR DESCRIPTION
Motivation:

At the moment we use the String representation of the IP to create the DatagramSocketAddress. This is not for free and we should better use the byte[] directly to reduce the overhead of parsing the String (and creating it in the first place)

Modifications:

Directly use byte[] as input for the DatagramSocketAddress

Result:

Less overhead when using Datagrams with native transports