### PR TITLE
Include native-image properties in the netty-all jar

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -585,7 +585,7 @@
             </goals>
             <configuration>
               <excludes>io/netty/internal/tcnative/**,io/netty/example/**,META-INF/native/libnetty_tcnative*,META-INF/native/include/**,META-INF/native/**/*.a</excludes>
-              <includes>io/netty/**,META-INF/native/**</includes>
+              <includes>io/netty/**,META-INF/native/**,META-INF/native-image/**</includes>
               <includeScope>runtime</includeScope>
               <includeGroupIds>${project.groupId}</includeGroupIds>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>


### PR DESCRIPTION
Motivation:

We need to also include the native-image configuration files in the netty all jar to be able to use it with GraalVM native.

Modifications:

Add files in META-INF/native-image as well

Result:

Fixes https://github.com/netty/netty/issues/9514