### PR TITLE
Support cancellation in the Http2StreamChannelBootstrap

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -166,6 +166,9 @@ public final class Http2StreamChannelBootstrap {
     @Deprecated
     public void open0(ChannelHandlerContext ctx, final Promise<Http2StreamChannel> promise) {
         assert ctx.executor().inEventLoop();
+        if (!promise.setUncancellable()) {
+            return;
+        }
         final Http2StreamChannel streamChannel;
         if (ctx.handler() instanceof Http2MultiplexCodec) {
             streamChannel = ((Http2MultiplexCodec) ctx.handler()).newOutboundStream();


### PR DESCRIPTION
Motivation:

Right now you can cancel the `Future` returned by
`Http2StreamChannelBootstrap.open()` and that will race with the
registration of the stream channel with the event loop, potentially
culminating in an `IllegalStateException` and potential resource leak.

Modification:

Ensure that the returned promise is uncancellable.

Result:

Should no longer see `IllegalStateException`s.