### PR TITLE
Remove extra checks to fix #9456

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -270,10 +270,8 @@ public class HashedWheelTimer implements Timer {
         }
 
         if (duration < MILLISECOND_NANOS) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Configured tickDuration {} smaller then {}, using 1ms.",
+            logger.warn("Configured tickDuration {} smaller then {}, using 1ms.",
                         tickDuration, MILLISECOND_NANOS);
-            }
             this.tickDuration = MILLISECOND_NANOS;
         } else {
             this.tickDuration = duration;

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -119,9 +119,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
         try {
             doFlush(ctx);
         } catch (Exception e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Unexpected exception while sending chunks.", e);
-            }
+            logger.warn("Unexpected exception while sending chunks.", e);
         }
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -701,9 +701,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             try {
                 fd.close();
             } catch (IOException e) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn("Error while closing a pipe", e);
-                }
+                logger.warn("Error while closing a pipe", e);
             }
         }
     }

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
@@ -79,9 +79,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
             try {
                 channelUDT.close();
             } catch (final Exception e2) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn("Failed to close channel.", e2);
-                }
+                logger.warn("Failed to close channel.", e2);
             }
             throw new ChannelException("Failed to configure channel.", e);
         }

--- a/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
@@ -161,9 +161,7 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
         try {
             file.close();
         } catch (IOException e) {
-            if (logger.isWarnEnabled()) {
-                logger.warn("Failed to close a file.", e);
-            }
+            logger.warn("Failed to close a file.", e);
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -86,10 +86,8 @@ public abstract class AbstractNioChannel extends AbstractChannel {
             try {
                 ch.close();
             } catch (IOException e2) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn(
+                logger.warn(
                             "Failed to close a partially initialized socket.", e2);
-                }
             }
 
             throw new ChannelException("Failed to enter non-blocking mode.", e);


### PR DESCRIPTION
Motivation:

There are some extra log level checks (logger.isWarnEnabled()).

Modification:

Remove log level checks (logger.isWarnEnabled()) from io.netty.channel.epoll.AbstractEpollStreamChannel, io.netty.channel.DefaultFileRegion, io.netty.channel.nio.AbstractNioChannel, io.netty.util.HashedWheelTimer, io.netty.handler.stream.ChunkedWriteHandler and io.netty.channel.udt.nio.NioUdtMessageConnectorChannel

Result:

Fixes #9456
Remove extra checks which are not necessary
