### PR TITLE
Change semantics of EmbeddedChannel to match other transports more cl…

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
@@ -75,8 +75,11 @@ public class Http2ServerUpgradeCodecTest {
         } else {
             codec = new Http2ServerUpgradeCodec((Http2FrameCodec) handler, multiplexer);
         }
-        assertTrue(codec.prepareUpgradeResponse(ctx, request, new DefaultHttpHeaders()));
-        codec.upgradeTo(ctx, request);
+        channel.eventLoop().execute(() -> {
+            assertTrue(codec.prepareUpgradeResponse(ctx, request, new DefaultHttpHeaders()));
+            codec.upgradeTo(ctx, request);
+        });
+
         // Flush the channel to ensure we write out all buffered data
         channel.flush();
 

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -414,7 +414,9 @@ public class DefaultPromiseTest {
         try {
             final AtomicInteger state = new AtomicInteger();
             final CountDownLatch latch1 = new CountDownLatch(1);
-            final CountDownLatch latch2 = new CountDownLatch(2);
+            final CountDownLatch latch2 = new CountDownLatch(1);
+            final CountDownLatch latch3 = new CountDownLatch(1);
+
             final Promise<Void> promise = new DefaultPromise<>(executor);
 
             // Add a listener before completion so "lateListener" is used next time we add a listener.
@@ -443,15 +445,16 @@ public class DefaultPromiseTest {
                 assertTrue(state.compareAndSet(2, 3));
                 latch2.countDown();
             }));
+            latch2.await();
 
             // Simulate a read operation being queued up in the executor.
             executor.execute(() -> {
                 // This is the key, we depend upon the state being set in the next listener.
                 assertEquals(3, state.get());
-                latch2.countDown();
+                latch3.countDown();
             });
 
-            latch2.await();
+            latch3.await();
         } finally {
             executor.shutdownGracefully(0, 0, TimeUnit.SECONDS).sync();
         }

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -32,13 +32,13 @@ public class FlushConsolidationHandlerTest {
     public void testFlushViaScheduledTask() {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount,  true);
-        // Flushes should not go through immediately, as they're scheduled as an async task
-        channel.flush();
-        assertEquals(0, flushCount.get());
-        channel.flush();
-        assertEquals(0, flushCount.get());
-        // Trigger the execution of the async task
-        channel.runPendingTasks();
+        channel.eventLoop().execute(() -> {
+            // Flushes should not go through immediately, as they're scheduled as an async task
+            channel.flush();
+            assertEquals(0, flushCount.get());
+            channel.flush();
+            assertEquals(0, flushCount.get());
+        });
         assertEquals(1, flushCount.get());
         assertFalse(channel.finish());
     }
@@ -47,11 +47,14 @@ public class FlushConsolidationHandlerTest {
     public void testFlushViaThresholdOutsideOfReadLoop() {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount, true);
-        // After a given threshold, the async task should be bypassed and a flush should be triggered immediately
-        for (int i = 0; i < EXPLICIT_FLUSH_AFTER_FLUSHES; i++) {
-            channel.flush();
-        }
-        assertEquals(1, flushCount.get());
+        channel.eventLoop().execute(() -> {
+            // After a given threshold, the async task should be bypassed and a flush should be triggered immediately
+            for (int i = 0; i < EXPLICIT_FLUSH_AFTER_FLUSHES; i++) {
+                channel.flush();
+            }
+            assertEquals(1, flushCount.get());
+        });
+
         assertFalse(channel.finish());
     }
 

--- a/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
@@ -119,7 +119,11 @@ public class LoggingHandlerTest {
         channel.config().setWriteBufferHighWaterMark(10);
         channel.write("hello", channel.newPromise());
 
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+WRITABILITY CHANGED$")));
+        // This is expected to be called 3 times:
+        // - Mark the channel unwritable when schedule the write on the EventLoop.
+        // - Mark writable when dequeue task
+        // - Mark unwritable when the write is actual be fired through the pipeline and hit the ChannelOutboundBuffer.
+        verify(appender, times(3)).doAppend(argThat(new RegexLogMatcher(".+WRITABILITY CHANGED$")));
     }
 
     @Test

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -599,11 +599,7 @@ public class EmbeddedChannel extends AbstractChannel {
             recordException(e);
         }
 
-        try {
-            embeddedEventLoop.runScheduledTasks();
-        } catch (Exception e) {
-            recordException(e);
-        }
+        runScheduledPendingTasks();
     }
 
     /**
@@ -619,6 +615,9 @@ public class EmbeddedChannel extends AbstractChannel {
         } catch (Exception e) {
             recordException(e);
             return embeddedEventLoop.nextScheduledTask();
+        } finally {
+            // A scheduled task may put something on the taskQueue so lets run it.
+            embeddedEventLoop.runTasks();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.SocketAddress;
@@ -359,25 +360,27 @@ public class ChannelOutboundBufferTest {
 
         ChannelOutboundBuffer cob = ch.unsafe().outboundBuffer();
 
-        // Trigger channelWritabilityChanged() by writing a lot.
-        ch.write(buffer().writeZero(257));
-        assertThat(buf.toString(), is("false "));
+        ch.eventLoop().execute(() -> {
+            // Trigger channelWritabilityChanged() by writing a lot.
+            ch.write(buffer().writeZero(257));
+            assertThat(buf.toString(), is("false "));
 
-        // Ensure that setting a user-defined writability flag to false does not trigger channelWritabilityChanged()
-        cob.setUserDefinedWritability(1, false);
-        ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+            // Ensure that setting a user-defined writability flag to false does not trigger channelWritabilityChanged()
+            cob.setUserDefinedWritability(1, false);
+            ch.runPendingTasks();
+            assertThat(buf.toString(), is("false "));
 
-        // Ensure reducing the totalPendingWriteBytes down to zero does not trigger channelWritabilityChanged()
-        // because of the user-defined writability flag.
-        ch.flush();
-        assertThat(cob.totalPendingWriteBytes(), is(0L));
-        assertThat(buf.toString(), is("false "));
+            // Ensure reducing the totalPendingWriteBytes down to zero does not trigger channelWritabilityChanged()
+            // because of the user-defined writability flag.
+            ch.flush();
+            assertThat(cob.totalPendingWriteBytes(), is(0L));
+            assertThat(buf.toString(), is("false "));
 
-        // Ensure that setting the user-defined writability flag to true triggers channelWritabilityChanged()
-        cob.setUserDefinedWritability(1, true);
-        ch.runPendingTasks();
-        assertThat(buf.toString(), is("false true "));
+            // Ensure that setting the user-defined writability flag to true triggers channelWritabilityChanged()
+            cob.setUserDefinedWritability(1, true);
+            ch.runPendingTasks();
+            assertThat(buf.toString(), is("false true "));
+        });
 
         safeClose(ch);
     }


### PR DESCRIPTION
…osely.

Motiviation:

EmbeddedChannel currently is quite differently in terms of semantics to other Channel implementations. We should better change it to be more closely aligned and so have the testing code be more robust.

Modifications:

- Change EmbeddedEventLoop.inEventLoop() to only return true if we currenlty run pending / scheduled tasks
- Change EmbeddedEventLoop.execute(...) to automatically process pending tasks if not already doing so
- Adjust a few tests for the new semantics (which is closer to other Channel implementations)

Result:

EmbeddedChannel works more like other Channel implementations