### PR TITLE
using No StackTrace subclass of CancellationException and ClosedChannelException for improve the performance and less gc

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -293,6 +293,11 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         }
         return (V) result;
     }
+    private static final CancellationException CANCEL_EX = new CancellationException() {
+        public Throwable fillInStackTrace() {
+            return this;
+        }
+    };
 
     /**
      * {@inheritDoc}
@@ -302,7 +307,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         if (RESULT_UPDATER.get(this) == null &&
-                RESULT_UPDATER.compareAndSet(this, null, new CauseHolder(new CancellationException()))) {
+                RESULT_UPDATER.compareAndSet(this, null, new CauseHolder(CANCEL_EX))) {
             if (checkNotifyWaiters()) {
                 notifyListeners();
             }


### PR DESCRIPTION

By jmh, noStackTrace faster over 90X, and singleton way faster over 300X
ref: https://github.com/qxo/Common-JMH-benchmark/blob/master/src/main/java/test/ExceptionPerformanceBenchmark.java
```
REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                    Mode  Cnt     Score    Error   Units  Score/min
ExceptionPerformanceBenchmark.baseline      thrpt   10     3.842 ±  0.036  ops/us      1.000
ExceptionPerformanceBenchmark.noStackTrace  thrpt   10   336.346 ±  0.692  ops/us     87.542
ExceptionPerformanceBenchmark.singleton     thrpt   10  1327.454 ± 97.471  ops/us    345.502

```

Motivation:
   jmc profiler with ab  `-n 10000 -c 400 $url ` test on vertx web app 
  found there create lots CancellationException and ClosedChannelException
  
Modification:
   Since these exception used for control flow, StackTrace is useless
   so we can override its fillInStackTrace method and Cache the exception 
   to improve the performance and less gc

Result:
   1. cache control flow exception if it's cloud
   2. override its fillInStackTrace method
   finally to  improve the performance and less gc