### PR TITLE
Http2MultiplexHandler / Http2MultiplexCodec should not force the user…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
@@ -55,6 +56,29 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
 import static java.lang.Math.min;
 
 abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements Http2StreamChannel {
+
+    static final ChannelHandler NOOP_UPGRADE_HANDLER = new ChannelInboundHandlerAdapter() {
+
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            ReferenceCountUtil.release(msg);
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+            ReferenceCountUtil.release(evt);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            // Just ignore
+        }
+    };
 
     static final Http2FrameStreamVisitor WRITABLE_VISITOR = new Http2FrameStreamVisitor() {
         @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -49,9 +49,20 @@ public class Http2ClientUpgradeCodecTest {
     }
 
     @Test
+    public void testUpgradeToHttp2MultiplexCodecAndNoUpgradeHandler() throws Exception {
+        testUpgrade(Http2MultiplexCodecBuilder.forClient(new HttpInboundHandler()).build(), null);
+    }
+
+    @Test
     public void testUpgradeToHttp2FrameCodecWithMultiplexer() throws Exception {
         testUpgrade(Http2FrameCodecBuilder.forClient().build(),
             new Http2MultiplexHandler(new HttpInboundHandler(), new HttpInboundHandler()));
+    }
+
+    @Test
+    public void testUpgradeToHttp2FrameCodecWithMultiplexerAndNoUpgradeHandler() throws Exception {
+        testUpgrade(Http2FrameCodecBuilder.forClient().build(),
+                new Http2MultiplexHandler(new HttpInboundHandler()));
     }
 
     private static void testUpgrade(Http2ConnectionHandler handler, Http2MultiplexHandler multiplexer)

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
@@ -76,7 +76,7 @@ public abstract class Http2MultiplexClientUpgradeTest<C extends Http2FrameCodec>
         assertTrue(upgradeHandler.channelInactiveCalled);
     }
 
-    @Test(expected = Http2Exception.class)
+    @Test
     public void clientUpgradeWithoutUpgradeHandlerThrowsHttp2Exception() throws Http2Exception {
         C codec = newCodec(null);
         EmbeddedChannel ch = new EmbeddedChannel(codec, newMultiplexer(null));


### PR DESCRIPTION
… to provide an upgradeStreamHandler during client side cleartext upgrade

Motivation:

When we use Http2MultiplexHandler along with a clear tex upgrade in client side using Http2ClientUpgradeCodec, it throws an exception when a ChannelHandler is not provided for upgradeStreamHandler. This may be to strict as the user user can chose to create the outbound channel using Http2StreamChannelBootstrap later on.

Modifications:

- Just ensure we use a dummy handler that will release all received frames / events when the user does not supply one
- Adjust unit tests

Result:

Fixes https://github.com/netty/netty/issues/9508.