### PR TITLE
Avoid redundant volatile read in DefaultPromise#get()

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractFuture.java
@@ -30,18 +30,7 @@ public abstract class AbstractFuture<V> implements Future<V> {
     @Override
     public V get() throws InterruptedException, ExecutionException {
         await();
-        return getOrThrowNow();
-    }
 
-    @Override
-    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        if (await(timeout, unit)) {
-            return getOrThrowNow();
-        }
-        throw new TimeoutException();
-    }
-
-    protected V getOrThrowNow() throws ExecutionException {
         Throwable cause = cause();
         if (cause == null) {
             return getNow();
@@ -50,5 +39,20 @@ public abstract class AbstractFuture<V> implements Future<V> {
             throw (CancellationException) cause;
         }
         throw new ExecutionException(cause);
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        if (await(timeout, unit)) {
+            Throwable cause = cause();
+            if (cause == null) {
+                return getNow();
+            }
+            if (cause instanceof CancellationException) {
+                throw (CancellationException) cause;
+            }
+            throw new ExecutionException(cause);
+        }
+        throw new TimeoutException();
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/AbstractFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractFuture.java
@@ -30,7 +30,18 @@ public abstract class AbstractFuture<V> implements Future<V> {
     @Override
     public V get() throws InterruptedException, ExecutionException {
         await();
+        return getOrThrowNow();
+    }
 
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        if (await(timeout, unit)) {
+            return getOrThrowNow();
+        }
+        throw new TimeoutException();
+    }
+
+    protected V getOrThrowNow() throws ExecutionException {
         Throwable cause = cause();
         if (cause == null) {
             return getNow();
@@ -39,20 +50,5 @@ public abstract class AbstractFuture<V> implements Future<V> {
             throw (CancellationException) cause;
         }
         throw new ExecutionException(cause);
-    }
-
-    @Override
-    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        if (await(timeout, unit)) {
-            Throwable cause = cause();
-            if (cause == null) {
-                return getNow();
-            }
-            if (cause instanceof CancellationException) {
-                throw (CancellationException) cause;
-            }
-            throw new ExecutionException(cause);
-        }
-        throw new TimeoutException();
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -331,14 +331,14 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     @SuppressWarnings("unchecked")
     @Override
     public V get() throws InterruptedException, ExecutionException {
-         Object result = this.result;
-         if (!isDone0(result)) {
-             await();
-             result = this.result;
-         }
-         if (result == SUCCESS || result == UNCANCELLABLE) {
-             return null;
-         }
+        Object result = this.result;
+        if (!isDone0(result)) {
+            await();
+            result = this.result;
+        }
+        if (result == SUCCESS || result == UNCANCELLABLE) {
+            return null;
+        }
         Throwable cause = cause0(result);
         if (cause == null) {
             return (V) result;

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -26,6 +26,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -153,10 +154,10 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
 
     @Override
     public Throwable cause() {
-        return cause(result);
+        return cause0(result);
     }
 
-    private Throwable cause(Object result) {
+    private Throwable cause0(Object result) {
         if (!(result instanceof CauseHolder)) {
             return null;
         }
@@ -329,12 +330,39 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected V getOrThrowNow() throws ExecutionException {
+    public V get() throws InterruptedException, ExecutionException {
+         Object result = this.result;
+         if (!isDone0(result)) {
+             await();
+             result = this.result;
+         }
+         if (result == SUCCESS || result == UNCANCELLABLE) {
+             return null;
+         }
+        Throwable cause = cause0(result);
+        if (cause == null) {
+            return (V) result;
+        }
+        if (cause instanceof CancellationException) {
+            throw (CancellationException) cause;
+        }
+        throw new ExecutionException(cause);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         Object result = this.result;
+        if (!isDone0(result)) {
+            if (!await(timeout, unit)) {
+                throw new TimeoutException();
+            }
+            result = this.result;
+        }
         if (result == SUCCESS || result == UNCANCELLABLE) {
             return null;
         }
-        Throwable cause = cause(result);
+        Throwable cause = cause0(result);
         if (cause == null) {
             return (V) result;
         }


### PR DESCRIPTION
Motivation

Currently every call to `get()` on a promise results in two reads of the volatile result field when one would suffice. Maybe this is optimized away but it seems sensible not to rely on that.

Modification

Add protected `getOrThrowNow(`) method to `AbstractFuture` and override in `DefaultPromise`.

Result

Fewer volatile reads.