### PR TITLE
Allow to build on powerpc

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
@@ -28,6 +28,7 @@ final class Conscrypt {
     // This class exists to avoid loading other conscrypt related classes using features only available in JDK8+,
     // because we need to maintain JDK6+ runtime compatibility.
     private static final Method IS_CONSCRYPT_SSLENGINE = loadIsConscryptEngine();
+    private static final boolean CAN_INSTANCE_PROVIDER = canInstanceProvider();
 
     private static Method loadIsConscryptEngine() {
         try {
@@ -40,11 +41,22 @@ final class Conscrypt {
         }
     }
 
+    private static boolean canInstanceProvider() {
+        try {
+            Class<?> providerClass = Class.forName("org.conscrypt.OpenSSLProvider", true,
+                    ConscryptAlpnSslEngine.class.getClassLoader());
+            providerClass.newInstance();
+            return true;
+        } catch (Throwable ignore) {
+            return false;
+        }
+    }
+
     /**
      * Indicates whether or not conscrypt is available on the current system.
      */
     static boolean isAvailable() {
-        return IS_CONSCRYPT_SSLENGINE != null && PlatformDependent.javaVersion() >= 8;
+        return CAN_INSTANCE_PROVIDER && IS_CONSCRYPT_SSLENGINE != null && PlatformDependent.javaVersion() >= 8;
     }
 
     static boolean isEngineSupported(SSLEngine engine) {

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,21 @@
   </developers>
 
   <profiles>
+    <profile>
+      <id>not_x86_64</id>
+      <activation>
+        <property>
+          <name>os.detected.arch</name>
+          <value>!x86_64</value>
+        </property>
+      </activation>
+      <properties>
+        <!-- Use no classifier as we only support x86_64 atm-->
+        <tcnative.classifier />
+        <skipShadingTestsuite>true</skipShadingTestsuite>
+      </properties>
+    </profile>
+
     <!-- Detect if we use GraalVM and if so enable the native image testsuite -->
     <profile>
       <id>graal</id>
@@ -320,6 +335,7 @@
     <graalvm.version>19.0.0</graalvm.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
+    <skipShadingTestsuite>false</skipShadingTestsuite>
   </properties>
 
   <modules>
@@ -752,10 +768,10 @@
                 </requireMavenVersion>
                 <requireProperty>
                   <regexMessage>
-                    x86_64/AARCH64 JDK must be used.
+                    x86_64/AARCH64/PPCLE64 JDK must be used.
                   </regexMessage>
                   <property>os.detected.arch</property>
-                  <regex>^(x86_64|aarch_64)$</regex>
+                  <regex>^(x86_64|aarch_64|ppcle_64)$</regex>
                 </requireProperty>
               </rules>
             </configuration>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -67,6 +67,17 @@
   </dependencies>
   <profiles>
     <profile>
+      <id>skipTests</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <skipShadingTestsuite>true</skipShadingTestsuite>
+      </properties>
+    </profile>
+    <profile>
       <id>windows</id>
       <activation>
         <os>
@@ -193,6 +204,7 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
+                  <skip>${skipShadingTestsuite}</skip>
                   <target>
                     <unzip dest="${classesShadedDir}/">
                       <fileset dir="${project.build.directory}/">
@@ -222,6 +234,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
+              <skip>${skipShadingTestsuite}</skip>
               <systemPropertyVariables>
                 <shadingPrefix>${shadingPrefix}</shadingPrefix>
                 <shadingPrefix2>${shadingPrefix2}</shadingPrefix2>
@@ -337,6 +350,7 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
+                  <skip>${skipShadingTestsuite}</skip>
                   <target>
                     <unzip dest="${classesShadedDir}/">
                       <fileset dir="${project.build.directory}/">
@@ -366,6 +380,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
+              <skip>${skipShadingTestsuite}</skip>
               <systemPropertyVariables>
                 <shadingPrefix>${shadingPrefix}</shadingPrefix>
                 <shadingPrefix2>${shadingPrefix2}</shadingPrefix2>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
@@ -37,6 +37,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -335,13 +336,27 @@ public class UDTClientServerConnectionTest {
     static final int WAIT_COUNT = 50;
     static final int WAIT_SLEEP = 100;
 
+    @BeforeClass
+    public static void assumeUdt() {
+        Assume.assumeTrue("com.barchart.udt.SocketUDT can not be loaded and initialized", canLoadAndInit());
+        Assume.assumeFalse("Not supported on J9 JVM", PlatformDependent.isJ9Jvm());
+    }
+
+    private static boolean canLoadAndInit() {
+        try {
+            Class.forName("com.barchart.udt.SocketUDT", true,
+                    UDTClientServerConnectionTest.class.getClassLoader());
+            return true;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
     /**
      * Verify UDT client/server connect and disconnect.
      */
     @Test
     public void connection() throws Exception {
-        Assume.assumeFalse("Not supported on J9 JVM", PlatformDependent.isJ9Jvm());
-
         log.info("Starting server.");
         // Using LOCALHOST4 as UDT transport does not support IPV6 :(
         final Server server = new Server(new InetSocketAddress(NetUtil.LOCALHOST4, 0));


### PR DESCRIPTION
Motivation:

At the moment it is not possible to build netty on a power 8 systems.

Modifications:

- Improve detection of the possibility of using Conscrypt
- Skip testsuite-shading when not on x86_64 as this is the only platform for which we build tcnative atm
- Only include classifier if on x86_64 for tcnative as dependency as this is the only platform for which we build tcnative atm
- Better detect if UDT test can be run

Result:

Fixes https://github.com/netty/netty/issues/9479