### PR TITLE
fix java doc description

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutException.java
@@ -18,8 +18,8 @@ package io.netty.handler.timeout;
 import io.netty.util.internal.PlatformDependent;
 
 /**
- * A {@link TimeoutException} raised by {@link WriteTimeoutHandler} when no data
- * was written within a certain period of time.
+ * A {@link TimeoutException} raised by {@link WriteTimeoutHandler} when a write operation
+ * cannot finish in a certain period of time.
  */
 public final class WriteTimeoutException extends TimeoutException {
 


### PR DESCRIPTION
Motivation:

The java doc doesn't match the real case: The exception only happen when a write operation
 cannot finish in a certain period of time instead of write idle happen.

Modification:

Correct java doc

Result:
Java doc matched the real case
