### PR TITLE
Fix HttpContentEncoder does not handle multiple Accept-Encoding 

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -74,27 +74,30 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, HttpRequest msg, List<Object> out)
-            throws Exception {
-        CharSequence acceptedEncoding;
+    protected void decode(ChannelHandlerContext ctx, HttpRequest msg, List<Object> out) throws Exception {
+        CharSequence acceptEncoding;
         List<String> acceptEncodingHeaders = msg.headers().getAll(ACCEPT_ENCODING);
-        if (acceptEncodingHeaders.isEmpty()) {
-            acceptedEncoding = HttpContentDecoder.IDENTITY;
-        } else if (acceptEncodingHeaders.size() == 1) {
-            acceptedEncoding = acceptEncodingHeaders.get(0);
-        } else {
+        switch (acceptEncodingHeaders.size()) {
+        case 0:
+            acceptEncoding = HttpContentDecoder.IDENTITY;
+            break;
+        case 1:
+            acceptEncoding = acceptEncodingHeaders.get(0);
+            break;
+        default:
             // Multiple message-header fields https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-            acceptedEncoding = StringUtil.join(",", acceptEncodingHeaders.iterator());
+            acceptEncoding = StringUtil.join(",", acceptEncodingHeaders);
+            break;
         }
 
         HttpMethod method = msg.method();
         if (HttpMethod.HEAD.equals(method)) {
-            acceptedEncoding = ZERO_LENGTH_HEAD;
+            acceptEncoding = ZERO_LENGTH_HEAD;
         } else if (HttpMethod.CONNECT.equals(method)) {
-            acceptedEncoding = ZERO_LENGTH_CONNECT;
+            acceptEncoding = ZERO_LENGTH_CONNECT;
         }
 
-        acceptEncodingQueue.add(acceptedEncoding);
+        acceptEncodingQueue.add(acceptEncoding);
         out.add(ReferenceCountUtil.retain(msg));
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -503,18 +503,18 @@ public class HttpContentCompressorTest {
     @Test
     public void testMultipleAcceptEncodingHeaders() {
         FullHttpRequest request = newRequest();
-        request.headers().set(HttpHeaderNames.ACCEPT_ENCODING, "unknown")
-               .add(HttpHeaderNames.ACCEPT_ENCODING, "gzip")
-               .add(HttpHeaderNames.ACCEPT_ENCODING, "deflate");
+        request.headers().set(HttpHeaderNames.ACCEPT_ENCODING, "unknown; q=1.0")
+               .add(HttpHeaderNames.ACCEPT_ENCODING, "gzip; q=0.5")
+               .add(HttpHeaderNames.ACCEPT_ENCODING, "deflate; q=0");
 
         EmbeddedChannel ch = new EmbeddedChannel(new HttpContentCompressor());
 
-        ch.writeInbound(request);
+        assertTrue(ch.writeInbound(request));
 
         FullHttpResponse res = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer("Gzip Win", CharsetUtil.US_ASCII));
-        ch.writeOutbound(res);
+        assertTrue(ch.writeOutbound(res));
 
         assertEncodedResponse(ch);
         HttpContent c = ch.readOutbound();

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -599,27 +599,33 @@ public final class StringUtil {
     }
 
     /**
-     * Returns a new string that contains all {@code elements} joined by a given separator.
+     * Returns a char sequence that contains all {@code elements} joined by a given separator.
      *
      * @param separator for each element
      * @param elements to join together
      *
-     * @return a string joined by a given separator.
+     * @return a char sequence joined by a given separator.
      */
-    public static CharSequence join(CharSequence separator, Iterator<? extends CharSequence> elements) {
+    public static CharSequence join(CharSequence separator, Iterable<? extends CharSequence> elements) {
         ObjectUtil.checkNotNull(separator, "separator");
         ObjectUtil.checkNotNull(elements, "elements");
 
-        if (!elements.hasNext()) {
+        Iterator<? extends CharSequence> iterator = elements.iterator();
+        if (!iterator.hasNext()) {
             return EMPTY_STRING;
         }
 
-        StringBuilder builder = new StringBuilder().append(elements.next());
-        while (elements.hasNext()) {
-            builder.append(separator).append(elements.next());
+        CharSequence firstElement = iterator.next();
+        if (!iterator.hasNext()) {
+            return firstElement;
         }
 
-        return builder.toString();
+        StringBuilder builder = new StringBuilder(firstElement);
+        do {
+            builder.append(separator).append(iterator.next());
+        } while (iterator.hasNext());
+
+        return builder;
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -17,6 +17,7 @@ package io.netty.util.internal;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import static io.netty.util.internal.ObjectUtil.*;
@@ -598,6 +599,30 @@ public final class StringUtil {
     }
 
     /**
+     * Returns a new string that contains all {@code elements} joined by a given separator.
+     *
+     * @param separator for each element
+     * @param elements to join together
+     *
+     * @return a string joined by a given separator.
+     */
+    public static CharSequence join(CharSequence separator, Iterator<? extends CharSequence> elements) {
+        ObjectUtil.checkNotNull(separator, "separator");
+        ObjectUtil.checkNotNull(elements, "elements");
+
+        if (!elements.hasNext()) {
+            return EMPTY_STRING;
+        }
+
+        StringBuilder builder = new StringBuilder().append(elements.next());
+        while (elements.hasNext()) {
+            builder.append(separator).append(elements.next());
+        }
+
+        return builder.toString();
+    }
+
+    /**
      * @return {@code length} if no OWS is found.
      */
     private static int indexOfFirstNonOwsChar(CharSequence value, int length) {
@@ -622,4 +647,5 @@ public final class StringUtil {
     private static boolean isOws(char c) {
         return c == SPACE || c == TAB;
     }
+
 }

--- a/common/src/test/java/io/netty/util/internal/StringUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/StringUtilTest.java
@@ -534,4 +534,13 @@ public class StringUtilTest {
         assertEquals("", StringUtil.trimOws("\t ").toString());
         assertEquals("a b", StringUtil.trimOws("\ta b \t").toString());
     }
+
+    @Test
+    public void testJoin() {
+        assertEquals("", StringUtil.join(",", Collections.<CharSequence>emptyList().iterator()));
+        assertEquals("a", StringUtil.join(",", Collections.singletonList("a").iterator()));
+        assertEquals("a,b,c", StringUtil.join(",", Arrays.asList("a", "b", "c").iterator()));
+        assertEquals("a,b,c,null,d", StringUtil.join(",", Arrays.asList("a", "b", "c", null, "d").iterator()));
+    }
+
 }

--- a/common/src/test/java/io/netty/util/internal/StringUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/StringUtilTest.java
@@ -537,10 +537,16 @@ public class StringUtilTest {
 
     @Test
     public void testJoin() {
-        assertEquals("", StringUtil.join(",", Collections.<CharSequence>emptyList().iterator()));
-        assertEquals("a", StringUtil.join(",", Collections.singletonList("a").iterator()));
-        assertEquals("a,b,c", StringUtil.join(",", Arrays.asList("a", "b", "c").iterator()));
-        assertEquals("a,b,c,null,d", StringUtil.join(",", Arrays.asList("a", "b", "c", null, "d").iterator()));
+        assertEquals("",
+                     StringUtil.join(",", Collections.<CharSequence>emptyList()).toString());
+        assertEquals("a",
+                     StringUtil.join(",", Collections.singletonList("a")).toString());
+        assertEquals("a,b",
+                     StringUtil.join(",", Arrays.asList("a", "b")).toString());
+        assertEquals("a,b,c",
+                     StringUtil.join(",", Arrays.asList("a", "b", "c")).toString());
+        assertEquals("a,b,c,null,d",
+                     StringUtil.join(",", Arrays.asList("a", "b", "c", null, "d")).toString());
     }
 
 }


### PR DESCRIPTION
Motivation:
At the current moment `HttpContentEncoder` handle only first value of multiple `accept-encoding` headers.

Modification:

Join multiple `accept-encoding` headers to one separated by comma.

Result:

Fixes #9553 
