### PR TITLE
Remove duplicated calculation for calculateMaxBytesPerGatheringWrite() 

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -517,7 +517,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
             // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
             int newSendBufferSize = getSendBufferSize() << 1;
             if (newSendBufferSize > 0) {
-                setMaxBytesPerGatheringWrite(getSendBufferSize() << 1);
+                setMaxBytesPerGatheringWrite(newSendBufferSize);
             }
         }
 


### PR DESCRIPTION
Motivation:

calculateMaxBytesPerGatheringWrite() contains duplicated calculation:  getSendBufferSize() << 1

Modifications:

Remove the duplicated calculation

Result:

The method will be clear and better
