### PR TITLE
optimize the QueryStringEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -43,8 +43,7 @@ public class QueryStringEncoder {
     private final StringBuilder uriBuilder;
     private boolean hasParams;
     private static final byte WRITE_UTF_UNKNOWN = (byte) '?';
-    private static final char[] CHAR_MAP
-            = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+    private static final char[] CHAR_MAP = "0123456789ABCDEF".toCharArray();
 
     /**
      * Creates a new encoder that encodes a URI that starts with the specified

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -32,6 +32,7 @@ import java.util.BitSet;
  * encoder.addParam("recipient", "world");
  * assert encoder.toString().equals("/hello?recipient=world");
  * </pre>
+ *
  * @see QueryStringDecoder
  */
 public class QueryStringEncoder {
@@ -40,7 +41,6 @@ public class QueryStringEncoder {
     private final StringBuilder uriBuilder;
     private boolean hasParams;
     private static final BitSet dontNeedEncoding;
-    private static final int CASE_DIFF = 'a' - 'A';
 
     static {
         dontNeedEncoding = new BitSet(256);
@@ -130,7 +130,7 @@ public class QueryStringEncoder {
         //allocate memory until needed
         char[] buf = null;
 
-        for (int i = 0; i < s.length();) {
+        for (int i = 0; i < s.length(); ) {
             int c = s.charAt(i);
             if (dontNeedEncoding.get(c)) {
                 uriBuilder.append((char) c);
@@ -152,19 +152,26 @@ public class QueryStringEncoder {
                 for (byte b : bytes) {
                     uriBuilder.append('%');
 
-                    char ch = Character.forDigit((b >> 4) & 0xF, 16);
-                    if (ch >= 'a' && ch <= 'f') {
-                        ch -= CASE_DIFF;
-                    }
+                    char ch = forDigit((b >> 4) & 0xF);
                     uriBuilder.append(ch);
 
-                    ch = Character.forDigit(b & 0xF, 16);
-                    if (ch >= 'a' && ch <= 'f') {
-                        ch -= CASE_DIFF;
-                    }
+                    ch = forDigit(b & 0xF);
                     uriBuilder.append(ch);
                 }
             }
         }
+    }
+
+    /**
+     * convert the given digit to a upper hexadecimal char.
+     * <p>
+     * the 55 in this method means {@code 'A' - 10}
+     *
+     * @param digit the number to convert to a character.
+     * @return the {@code char} representation of the specified digit
+     * in hexadecimal.
+     */
+    private char forDigit(int digit) {
+        return (char) (digit < 10 ? '0' + digit : 55 + digit);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -43,6 +43,7 @@ public class QueryStringEncoder {
     private final StringBuilder uriBuilder;
     private boolean hasParams;
     private static final byte WRITE_UTF_UNKNOWN = (byte) '?';
+    private static final char[] CHAR_MAP = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
 
     /**
      * Creates a new encoder that encodes a URI that starts with the specified
@@ -203,16 +204,13 @@ public class QueryStringEncoder {
 
     /**
      * Convert the given digit to a upper hexadecimal char.
-     * <p>
-     * the 55 in this method means {@code 'A' - 10}
      *
      * @param digit the number to convert to a character.
      * @return the {@code char} representation of the specified digit
      * in hexadecimal.
      */
     private static char forDigit(int digit) {
-        digit = digit & 0xF;
-        return (char) (digit < 10 ? '0' + digit : 55 + digit);
+        return CHAR_MAP[digit & 0xF];
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -17,12 +17,11 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.internal.ObjectUtil;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
+import java.util.BitSet;
 
 /**
  * Creates an URL-encoded URI from a path string and key-value parameter pairs.
@@ -37,9 +36,30 @@ import java.nio.charset.UnsupportedCharsetException;
  */
 public class QueryStringEncoder {
 
-    private final String charsetName;
+    private final Charset charset;
     private final StringBuilder uriBuilder;
     private boolean hasParams;
+    private static BitSet dontNeedEncoding;
+    private static final int CASE_DIFF = 'a' - 'A';
+
+    static {
+        dontNeedEncoding = new BitSet(256);
+        int i;
+        for (i = 'a'; i <= 'z'; i++) {
+            dontNeedEncoding.set(i);
+        }
+        for (i = 'A'; i <= 'Z'; i++) {
+            dontNeedEncoding.set(i);
+        }
+        for (i = '0'; i <= '9'; i++) {
+            dontNeedEncoding.set(i);
+        }
+
+        dontNeedEncoding.set('-');
+        dontNeedEncoding.set('_');
+        dontNeedEncoding.set('.');
+        dontNeedEncoding.set('*');
+    }
 
     /**
      * Creates a new encoder that encodes a URI that starts with the specified
@@ -55,7 +75,7 @@ public class QueryStringEncoder {
      */
     public QueryStringEncoder(String uri, Charset charset) {
         uriBuilder = new StringBuilder(uri);
-        charsetName = charset.name();
+        this.charset = charset;
     }
 
     /**
@@ -69,10 +89,11 @@ public class QueryStringEncoder {
             uriBuilder.append('?');
             hasParams = true;
         }
-        appendComponent(name, charsetName, uriBuilder);
+
+        encodeComponent(name);
         if (value != null) {
             uriBuilder.append('=');
-            appendComponent(value, charsetName, uriBuilder);
+            encodeComponent(value);
         }
     }
 
@@ -95,27 +116,54 @@ public class QueryStringEncoder {
         return uriBuilder.toString();
     }
 
-    private static void appendComponent(String s, String charset, StringBuilder sb) {
-        try {
-            s = URLEncoder.encode(s, charset);
-        } catch (UnsupportedEncodingException ignored) {
-            throw new UnsupportedCharsetException(charset);
-        }
-        // replace all '+' with "%20"
-        int idx = s.indexOf('+');
-        if (idx == -1) {
-            sb.append(s);
-            return;
-        }
-        sb.append(s, 0, idx).append("%20");
-        int size = s.length();
-        idx++;
-        for (; idx < size; idx++) {
-            char c = s.charAt(idx);
-            if (c != '+') {
-                sb.append(c);
+    /**
+     * encode the String as per RFC 3986, Section 2.
+     * <p>
+     * There is a little different between the JDK's encode method : {@link URLEncoder#encode(String, String)}.
+     * The JDK's encoder encode the space to {@code +} and this method directly encode the blank to {@code %20}
+     * beyond that , this method reuse the {@link #uriBuilder} in this class rather then create a new one,
+     * thus generates less garbage for the GC.
+     *
+     * @param s The String to encode
+     */
+    private void encodeComponent(String s) {
+        //allocate memory until needed
+        char[] buf = null;
+
+        for (int i = 0; i < s.length();) {
+            int c = s.charAt(i);
+            if (dontNeedEncoding.get(c)) {
+                uriBuilder.append((char) c);
+                i++;
             } else {
-                sb.append("%20");
+                int index = 0;
+                if (buf == null) {
+                    buf = new char[s.length() - i];
+                }
+
+                do {
+                    buf[index] = (char) c;
+                    index++;
+                    i++;
+                } while (i < s.length() && !dontNeedEncoding.get(c = s.charAt(i)));
+
+                byte[] bytes = new String(buf, 0, index).getBytes(charset);
+
+                for (byte b : bytes) {
+                    uriBuilder.append('%');
+
+                    char ch = Character.forDigit((b >> 4) & 0xF, 16);
+                    if (ch >= 'a' && ch <= 'f') {
+                        ch -= CASE_DIFF;
+                    }
+                    uriBuilder.append(ch);
+
+                    ch = Character.forDigit(b & 0xF, 16);
+                    if (ch >= 'a' && ch <= 'f') {
+                        ch -= CASE_DIFF;
+                    }
+                    uriBuilder.append(ch);
+                }
             }
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -39,7 +39,7 @@ public class QueryStringEncoder {
     private final Charset charset;
     private final StringBuilder uriBuilder;
     private boolean hasParams;
-    private static BitSet dontNeedEncoding;
+    private static final BitSet dontNeedEncoding;
     private static final int CASE_DIFF = 'a' - 'A';
 
     static {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -43,7 +43,8 @@ public class QueryStringEncoder {
     private final StringBuilder uriBuilder;
     private boolean hasParams;
     private static final byte WRITE_UTF_UNKNOWN = (byte) '?';
-    private static final char[] CHAR_MAP = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
+    private static final char[] CHAR_MAP
+            = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
     /**
      * Creates a new encoder that encodes a URI that starts with the specified

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -80,8 +80,8 @@ public class QueryStringEncoder {
         }
     }
 
-    private void encodeComponent(String s) {
-        if (charset == CharsetUtil.UTF_8) {
+    private void encodeComponent(CharSequence s) {
+        if (CharsetUtil.UTF_8.equals(charset)) {
             encodeUtf8Component(s);
         } else {
             encodeNonUtf8Component(s);
@@ -108,7 +108,7 @@ public class QueryStringEncoder {
     }
 
     /**
-     * encode the String as per RFC 3986, Section 2.
+     * Encode the String as per RFC 3986, Section 2.
      * <p>
      * There is a little different between the JDK's encode method : {@link URLEncoder#encode(String, String)}.
      * The JDK's encoder encode the space to {@code +} and this method directly encode the blank to {@code %20}
@@ -117,7 +117,7 @@ public class QueryStringEncoder {
      *
      * @param s The String to encode
      */
-    private void encodeNonUtf8Component(String s) {
+    private void encodeNonUtf8Component(CharSequence s) {
         //allocate memory until needed
         char[] buf = null;
 
@@ -150,7 +150,7 @@ public class QueryStringEncoder {
     /**
      * @see ByteBufUtil#writeUtf8(io.netty.buffer.ByteBuf, CharSequence, int, int)
      */
-    private void encodeUtf8Component(String s) {
+    private void encodeUtf8Component(CharSequence s) {
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);
             if (c < 0x80) {
@@ -201,7 +201,7 @@ public class QueryStringEncoder {
     }
 
     /**
-     * convert the given digit to a upper hexadecimal char.
+     * Convert the given digit to a upper hexadecimal char.
      * <p>
      * the 55 in this method means {@code 'A' - 10}
      *
@@ -209,7 +209,7 @@ public class QueryStringEncoder {
      * @return the {@code char} representation of the specified digit
      * in hexadecimal.
      */
-    private char forDigit(int digit) {
+    private static char forDigit(int digit) {
         digit = digit & 0xF;
         return (char) (digit < 10 ? '0' + digit : 55 + digit);
     }
@@ -225,7 +225,7 @@ public class QueryStringEncoder {
      * @param ch the char to be judged whether it need to be encode
      * @return true or false
      */
-    private boolean dontNeedEncoding(char ch) {
+    private static boolean dontNeedEncoding(char ch) {
         return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9'
                 || ch == '-' || ch == '_' || ch == '.' || ch == '*';
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -57,8 +57,9 @@ public class QueryStringEncoder {
      * path string in the specified charset.
      */
     public QueryStringEncoder(String uri, Charset charset) {
+        ObjectUtil.checkNotNull(charset, "charset");
         uriBuilder = new StringBuilder(uri);
-        this.charset = charset;
+        this.charset = CharsetUtil.UTF_8.equals(charset) ? null : charset;
     }
 
     /**
@@ -81,7 +82,7 @@ public class QueryStringEncoder {
     }
 
     private void encodeComponent(CharSequence s) {
-        if (CharsetUtil.UTF_8.equals(charset)) {
+        if (charset == null) {
             encodeUtf8Component(s);
         } else {
             encodeNonUtf8Component(s);
@@ -118,7 +119,7 @@ public class QueryStringEncoder {
      * @param s The String to encode
      */
     private void encodeNonUtf8Component(CharSequence s) {
-        //allocate memory until needed
+        //Don't allocate memory until needed
         char[] buf = null;
 
         for (int i = 0; i < s.length();) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -122,7 +122,7 @@ public class QueryStringEncoder {
         //Don't allocate memory until needed
         char[] buf = null;
 
-        for (int i = 0; i < s.length();) {
+        for (int i = 0, len = s.length(); i < len;) {
             char c = s.charAt(i);
             if (dontNeedEncoding(c)) {
                 uriBuilder.append(c);
@@ -152,7 +152,7 @@ public class QueryStringEncoder {
      * @see ByteBufUtil#writeUtf8(io.netty.buffer.ByteBuf, CharSequence, int, int)
      */
     private void encodeUtf8Component(CharSequence s) {
-        for (int i = 0; i < s.length(); i++) {
+        for (int i = 0, len = s.length(); i < len; i++) {
             char c = s.charAt(i);
             if (c < 0x80) {
                 if (dontNeedEncoding(c)) {


### PR DESCRIPTION
Motivation:

Optimize the `QueryStringEncoder` for lower memory overhead and higher encode speed.

Modification:

Encode the space to + directly, and reuse the `uriStringBuilder `rather then create a new one.

Result:

here is my benchmark result

if there is something to encode, such as **qwer!@#$**
```
Benchmark                                           Mode  Samples   Score  Score error  Units
b.UrlEncodeBenchmark.NettyUrlEncodeBenchmark        avgt       10  22.003        1.343  ms/op
b.UrlEncodeBenchmark.optimizedUrlEncodeBenchmark    avgt       10  14.965        0.468  ms/op
```

if there is no thing to encode, such as **qwerqwer**
```
Benchmark                                           Mode  Samples  Score  Score error  Units
b.UrlEncodeBenchmark.NettyUrlEncodeBenchmark        avgt       10  9.023        0.106  ms/op
b.UrlEncodeBenchmark.optimizedUrlEncodeBenchmark    avgt       10  4.696        0.054  ms/op
```

and here is my benchmark code : 
```
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Measurement(iterations = 10,batchSize = 100000)
@Fork(1)
@Warmup(iterations = 5)
@Threads(1)
public class UrlEncodeBenchmark {

    private static final String s = "/hello";

    @Benchmark
    public String NettyUrlEncodeBenchmark() {
        QueryStringEncoder encoder = new QueryStringEncoder(s);
        encoder.addParam("a","qwer");
        String result = encoder.toString();
        return result;
    }

    @Benchmark
    public String optimizedUrlEncodeBenchmark() {
        OptimizedQueryStringEncoder encoder = new OptimizedQueryStringEncoder(s);
        encoder.addParam("a","qwer");
        String result = encoder.toString();
        return result;
    }
}
```

**update :**
after applying the optimization from `ByteBufUtil`, the benchmark result becomes :
```
Benchmark                                           Mode  Samples   Score  Score error  Units
b.UrlEncodeBenchmark.NettyUrlEncodeBenchmark        avgt        5  21.062        0.431  ms/op
b.UrlEncodeBenchmark.optimizedUrlEncodeBenchmark    avgt        5   7.036        0.045  ms/op
```