### PR TITLE
Fix a bug introduced by 79706357c73ded02615d0445db7503b646ff9547 whic…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
@@ -274,7 +274,7 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
                         //
                         // The above cases can be distinguished by performing a
                         // compareAndSet(NONE, RUNNING). If it returns "false", it is case 1; otherwise it is case 2.
-                        if (tasks.peek() == null || !state.compareAndSet(NONE, RUNNING)) {
+                        if (tasks.isEmpty() || !state.compareAndSet(NONE, RUNNING)) {
                             return; // done
                         }
                     }


### PR DESCRIPTION
Motivation:
Fix a bug where a thread can get stuck in spinning on an infinite while loop.
The bug was introduced in 79706357c73ded02615d0445db7503b646ff9547

Modification:
Use isEmpty() instead of peek() to check if task queue is empty

Bug: 
peek() is implemented in a similar way to poll() for the MPSC queue, thus it is more like a consumer call, so it is possible that we could have multiple thread call peek() and maybe one thread calls poll() at at the same time. This lead to multiple consumer scenario, which violates the multiple producer single consumer condition and could lead to a thread spinning in an infinite loop inside peek().
