### PR TITLE
Don't eagerly remove scheduled tasks from queue at time of cancellation

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/PromiseTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseTask.java
@@ -51,13 +51,16 @@ class PromiseTask<V> extends DefaultPromise<V> implements RunnableFuture<V> {
 
     private static class SentinelCallable<T> implements Callable<T> {
         private final String name;
+
         SentinelCallable(String name) {
             this.name = name;
         }
+
         @Override
         public T call() {
             return null;
         }
+
         @Override
         public String toString() {
             return name;
@@ -101,7 +104,7 @@ class PromiseTask<V> extends DefaultPromise<V> implements RunnableFuture<V> {
     private boolean clearTaskAfterCompletion(boolean done, Callable<?> result) {
         if (done) {
             // The only time where it might be possible for the sentinel task
-            // to be called is is in the case of a periodic ScheduledFutureTask,
+            // to be called is in the case of a periodic ScheduledFutureTask,
             // in which case it's a benign race with cancellation and the (null)
             // return value is not used.
             task = (Callable<V>) result;
@@ -126,8 +129,7 @@ class PromiseTask<V> extends DefaultPromise<V> implements RunnableFuture<V> {
     }
 
     protected final boolean tryFailureInternal(Throwable cause) {
-        boolean done = super.tryFailure(cause);
-        return clearTaskAfterCompletion(done, FAILED);
+        return clearTaskAfterCompletion(super.tryFailure(cause), FAILED);
     }
 
     @Override
@@ -147,8 +149,7 @@ class PromiseTask<V> extends DefaultPromise<V> implements RunnableFuture<V> {
     }
 
     protected final boolean trySuccessInternal(V result) {
-        boolean done = super.trySuccess(result);
-        return clearTaskAfterCompletion(done, COMPLETED);
+        return clearTaskAfterCompletion(super.trySuccess(result), COMPLETED);
     }
 
     @Override
@@ -162,8 +163,7 @@ class PromiseTask<V> extends DefaultPromise<V> implements RunnableFuture<V> {
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        boolean cancelled = super.cancel(mayInterruptIfRunning);
-        return clearTaskAfterCompletion(cancelled, CANCELLED);
+        return clearTaskAfterCompletion(super.cancel(mayInterruptIfRunning), CANCELLED);
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -159,24 +159,6 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
         }
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @param mayInterruptIfRunning this value has no effect in this implementation.
-     */
-    @Override
-    public boolean cancel(boolean mayInterruptIfRunning) {
-        boolean canceled = super.cancel(mayInterruptIfRunning);
-        if (canceled) {
-            ((AbstractScheduledEventExecutor) executor()).removeScheduled(this);
-        }
-        return canceled;
-    }
-
-    boolean cancelWithoutRemove(boolean mayInterruptIfRunning) {
-        return super.cancel(mayInterruptIfRunning);
-    }
-
     @Override
     protected StringBuilder toStringBuilder() {
         StringBuilder buf = super.toStringBuilder();

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -309,7 +309,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     private boolean fetchFromScheduledTaskQueue() {
-        if (scheduledTaskQueue == null || scheduledTaskQueue.isEmpty()) {
+        if (isNullOrEmpty(scheduledTaskQueue)) {
             return true;
         }
         long nanoTime = AbstractScheduledEventExecutor.nanoTime();
@@ -330,7 +330,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * @return {@code true} if at least one scheduled task was executed.
      */
     private boolean executeExpiredScheduledTasks() {
-        if (scheduledTaskQueue == null || scheduledTaskQueue.isEmpty()) {
+        if (isNullOrEmpty(scheduledTaskQueue)) {
             return false;
         }
         long nanoTime = AbstractScheduledEventExecutor.nanoTime();
@@ -595,19 +595,19 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     @Override
-    final void executeScheduledRunnable(final Runnable runnable, boolean isAddition, long deadlineNanos) {
-        // Don't wakeup if this is a removal task or if beforeScheduledTaskSubmitted returns false
-        if (isAddition && beforeScheduledTaskSubmitted(deadlineNanos)) {
-            super.executeScheduledRunnable(runnable, isAddition, deadlineNanos);
+    final void executeScheduledRunnable(final Runnable runnable, long deadlineNanos) {
+        // Don't wakeup if beforeScheduledTaskSubmitted returns false
+        if (beforeScheduledTaskSubmitted(deadlineNanos)) {
+            super.executeScheduledRunnable(runnable, deadlineNanos);
         } else {
             super.executeScheduledRunnable(new NonWakeupRunnable() {
                 @Override
                 public void run() {
                     runnable.run();
                 }
-            }, isAddition, deadlineNanos);
+            }, deadlineNanos);
             // Second hook after scheduling to facilitate race-avoidance
-            if (isAddition && afterScheduledTaskSubmitted(deadlineNanos)) {
+            if (afterScheduledTaskSubmitted(deadlineNanos)) {
                 wakeup(false);
             }
         }


### PR DESCRIPTION
Motivation

Currently, scheduled tasks are removed from the scheduled task `PriorityQueue` at the time that they are cancelled. There are some costs to doing this:
- Permutation of the queue's other elements to maintain ordering
- If outside the event loop, allocation of a new `Runnable` and scheduling of it via the task queue (though we now will avoid waking the EL)

Modifications

- Adjust `PromiseTask`/`ScheduledFutureTask` to clear the reference to the wrapped task upon completion/cancellation (to allow for immediate GC)
- Remove scheduled task queue removal logic from `AbstractScheduledExecutorService`
- Discard already-cancelled tasks when peeking/polling for the next entry from the `scheduledTaskQueue`

Result

Cheaper cancellation of scheduled tasks