### PR TITLE
FIX : Unpacking causes socks5proxy init failure

### DIFF
--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
@@ -56,9 +56,6 @@ public class Socks5InitialRequestDecoder extends ReplayingDecoder<State> {
                 }
 
                 final int authMethodCnt = in.readUnsignedByte();
-                if (actualReadableBytes() < authMethodCnt) {
-                    break;
-                }
 
                 final Socks5AuthMethod[] authMethods = new Socks5AuthMethod[authMethodCnt];
                 for (int i = 0; i < authMethodCnt; i++) {

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.socksx.v5;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.socksx.SocksPortUnificationServerHandler;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class Socks5InitialRequestDecoderTest {
+    @Test
+    public void testSocks5InitialRequestDecoder() {
+        EmbeddedChannel e = new EmbeddedChannel(new SocksPortUnificationServerHandler());
+        e.writeInbound(Unpooled.wrappedBuffer(new byte[]{5, 2, 0}));
+        e.writeInbound(Unpooled.wrappedBuffer(new byte[]{1}));
+        Object o = e.readInbound();
+
+        assertTrue(o instanceof DefaultSocks5InitialRequest);
+        DefaultSocks5InitialRequest req = (DefaultSocks5InitialRequest) o;
+        assertSame(req.decoderResult(), DecoderResult.SUCCESS);
+    }
+}

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2019 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,19 +20,19 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import org.junit.Test;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class Socks5InitialRequestDecoderTest {
     @Test
     public void testUnpackingCausesDecodeFail() {
         EmbeddedChannel e = new EmbeddedChannel(new Socks5InitialRequestDecoder());
-        e.writeInbound(Unpooled.wrappedBuffer(new byte[]{5, 2, 0}));
-        e.writeInbound(Unpooled.wrappedBuffer(new byte[]{1}));
+        assertFalse(e.writeInbound(Unpooled.wrappedBuffer(new byte[]{5, 2, 0})));
+        assertTrue(e.writeInbound(Unpooled.wrappedBuffer(new byte[]{1})));
         Object o = e.readInbound();
 
         assertTrue(o instanceof DefaultSocks5InitialRequest);
         DefaultSocks5InitialRequest req = (DefaultSocks5InitialRequest) o;
         assertSame(req.decoderResult(), DecoderResult.SUCCESS);
+        assertFalse(e.finish());
     }
 }

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.socksx.v5;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
-import io.netty.handler.codec.socksx.SocksPortUnificationServerHandler;
 import org.junit.Test;
 
 import static org.junit.Assert.assertSame;
@@ -26,8 +25,8 @@ import static org.junit.Assert.assertTrue;
 
 public class Socks5InitialRequestDecoderTest {
     @Test
-    public void testSocks5InitialRequestDecoder() {
-        EmbeddedChannel e = new EmbeddedChannel(new SocksPortUnificationServerHandler());
+    public void testUnpackingCausesDecodeFail() {
+        EmbeddedChannel e = new EmbeddedChannel(new Socks5InitialRequestDecoder());
         e.writeInbound(Unpooled.wrappedBuffer(new byte[]{5, 2, 0}));
         e.writeInbound(Unpooled.wrappedBuffer(new byte[]{1}));
         Object o = e.readInbound();


### PR DESCRIPTION
Motivation:
### FIX : Unpacking causes socks5proxy init failure 

## Modification:
	delete Socks5InitialRequestDecoder.java：59-61
```
if actualReadableBytes() < authMethodCnt 
	break
```

### because:
`Socks5InitialRequestDecoder` extends `ReplayingDecoder` can retry `encode`,so we not need break here.
	
### Result:
	In case of Unpacking， method `encode` will retry.

Fixes #9574. 

