### PR TITLE
Allow domain sockets to configure SO_SNDBUF and SO_RCVBUF

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -27,7 +27,9 @@ import io.netty.channel.unix.DomainSocketReadMode;
 import java.io.IOException;
 import java.util.Map;
 
-import static io.netty.channel.ChannelOption.*;
+import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
+import static io.netty.channel.ChannelOption.SO_RCVBUF;
+import static io.netty.channel.ChannelOption.SO_SNDBUF;
 import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 
 public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
@@ -70,6 +72,10 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
             setReadMode((DomainSocketReadMode) value);
         } else if (option == ALLOW_HALF_CLOSURE) {
             setAllowHalfClosure((Boolean) value);
+        } else if (option == SO_SNDBUF) {
+            setSendBufferSize((Integer) value);
+        } else if (option == SO_RCVBUF) {
+            setReceiveBufferSize((Integer) value);
         } else {
             return super.setOption(option, value);
         }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -24,9 +24,10 @@ import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
 
+import java.io.IOException;
 import java.util.Map;
 
-import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
+import static io.netty.channel.ChannelOption.*;
 import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 
 public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
@@ -40,7 +41,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), DOMAIN_SOCKET_READ_MODE, ALLOW_HALF_CLOSURE);
+        return getOptions(super.getOptions(), DOMAIN_SOCKET_READ_MODE, ALLOW_HALF_CLOSURE, SO_SNDBUF, SO_RCVBUF);
     }
 
     @SuppressWarnings("unchecked")
@@ -51,6 +52,12 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         }
         if (option == ALLOW_HALF_CLOSURE) {
             return (T) Boolean.valueOf(isAllowHalfClosure());
+        }
+        if (option == SO_SNDBUF) {
+            return (T) Integer.valueOf(getSendBufferSize());
+        }
+        if (option == SO_RCVBUF) {
+            return (T) Integer.valueOf(getReceiveBufferSize());
         }
         return super.getOption(option);
     }
@@ -172,5 +179,43 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
     public EpollDomainSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
         this.allowHalfClosure = allowHalfClosure;
         return this;
+    }
+
+    @Override
+    public int getSendBufferSize() {
+        try {
+            return ((EpollDomainSocketChannel) channel).socket.getSendBufferSize();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setSendBufferSize(int sendBufferSize) {
+        try {
+            ((EpollDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public int getReceiveBufferSize() {
+        try {
+            return ((EpollDomainSocketChannel) channel).socket.getReceiveBufferSize();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+        try {
+            ((EpollDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -187,7 +187,6 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         return this;
     }
 
-    @Override
     public int getSendBufferSize() {
         try {
             return ((EpollDomainSocketChannel) channel).socket.getSendBufferSize();
@@ -196,7 +195,6 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         }
     }
 
-    @Override
     public EpollDomainSocketChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
             ((EpollDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
@@ -206,7 +204,6 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         }
     }
 
-    @Override
     public int getReceiveBufferSize() {
         try {
             return ((EpollDomainSocketChannel) channel).socket.getReceiveBufferSize();
@@ -215,7 +212,6 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         }
     }
 
-    @Override
     public EpollDomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((EpollDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -28,7 +28,10 @@ import io.netty.util.internal.UnstableApi;
 import java.io.IOException;
 import java.util.Map;
 
-import static io.netty.channel.unix.UnixChannelOption.*;
+import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
+import static io.netty.channel.ChannelOption.SO_RCVBUF;
+import static io.netty.channel.ChannelOption.SO_SNDBUF;
+import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 
 @UnstableApi
 public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig implements DomainSocketChannelConfig {
@@ -70,6 +73,10 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
             setReadMode((DomainSocketReadMode) value);
         } else if (option == ALLOW_HALF_CLOSURE) {
             setAllowHalfClosure((Boolean) value);
+        } else if (option == SO_SNDBUF) {
+            setSendBufferSize((Integer) value);
+        } else if (option == SO_RCVBUF) {
+            setReceiveBufferSize((Integer) value);
         } else {
             return super.setOption(option, value);
         }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -25,6 +25,7 @@ import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.util.internal.UnstableApi;
 
+import java.io.IOException;
 import java.util.Map;
 
 import static io.netty.channel.unix.UnixChannelOption.*;
@@ -40,7 +41,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), DOMAIN_SOCKET_READ_MODE, ALLOW_HALF_CLOSURE);
+        return getOptions(super.getOptions(), DOMAIN_SOCKET_READ_MODE, ALLOW_HALF_CLOSURE, SO_SNDBUF, SO_RCVBUF);
     }
 
     @SuppressWarnings("unchecked")
@@ -51,6 +52,12 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
         if (option == ALLOW_HALF_CLOSURE) {
             return (T) Boolean.valueOf(isAllowHalfClosure());
+        }
+        if (option == SO_SNDBUF) {
+            return (T) Integer.valueOf(getSendBufferSize());
+        }
+        if (option == SO_RCVBUF) {
+            return (T) Integer.valueOf(getReceiveBufferSize());
         }
         return super.getOption(option);
     }
@@ -157,6 +164,44 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
     @Override
     public DomainSocketReadMode getReadMode() {
         return mode;
+    }
+
+    @Override
+    public int getSendBufferSize() {
+        try {
+            return ((KQueueDomainSocketChannel) channel).socket.getSendBufferSize();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public KQueueDomainSocketChannelConfig setSendBufferSize(int sendBufferSize) {
+        try {
+            ((KQueueDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public int getReceiveBufferSize() {
+        try {
+            return ((KQueueDomainSocketChannel) channel).socket.getReceiveBufferSize();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public KQueueDomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+        try {
+            ((KQueueDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -173,7 +173,6 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         return mode;
     }
 
-    @Override
     public int getSendBufferSize() {
         try {
             return ((KQueueDomainSocketChannel) channel).socket.getSendBufferSize();
@@ -182,7 +181,6 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
     }
 
-    @Override
     public KQueueDomainSocketChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
             ((KQueueDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
@@ -192,7 +190,6 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
     }
 
-    @Override
     public int getReceiveBufferSize() {
         try {
             return ((KQueueDomainSocketChannel) channel).socket.getReceiveBufferSize();
@@ -201,7 +198,6 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
     }
 
-    @Override
     public KQueueDomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((KQueueDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
@@ -21,6 +21,8 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
+import java.net.StandardSocketOptions;
+
 /**
  * Special {@link ChannelConfig} for {@link DomainSocketChannel}s.
  */
@@ -77,4 +79,24 @@ public interface DomainSocketChannelConfig extends ChannelConfig {
      * Return the {@link DomainSocketReadMode} for the channel.
      */
     DomainSocketReadMode getReadMode();
+
+    /**
+     * Gets the {@link StandardSocketOptions#SO_SNDBUF} option.
+     */
+    int getSendBufferSize();
+
+    /**
+     * Sets the {@link StandardSocketOptions#SO_SNDBUF} option.
+     */
+    DomainSocketChannelConfig setSendBufferSize(int sendBufferSize);
+
+    /**
+     * Gets the {@link StandardSocketOptions#SO_RCVBUF} option.
+     */
+    int getReceiveBufferSize();
+
+    /**
+     * Sets the {@link StandardSocketOptions#SO_RCVBUF} option.
+     */
+    DomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize);
 }

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
@@ -21,8 +21,6 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
-import java.net.StandardSocketOptions;
-
 /**
  * Special {@link ChannelConfig} for {@link DomainSocketChannel}s.
  */
@@ -79,24 +77,4 @@ public interface DomainSocketChannelConfig extends ChannelConfig {
      * Return the {@link DomainSocketReadMode} for the channel.
      */
     DomainSocketReadMode getReadMode();
-
-    /**
-     * Gets the {@link StandardSocketOptions#SO_SNDBUF} option.
-     */
-    int getSendBufferSize();
-
-    /**
-     * Sets the {@link StandardSocketOptions#SO_SNDBUF} option.
-     */
-    DomainSocketChannelConfig setSendBufferSize(int sendBufferSize);
-
-    /**
-     * Gets the {@link StandardSocketOptions#SO_RCVBUF} option.
-     */
-    int getReceiveBufferSize();
-
-    /**
-     * Sets the {@link StandardSocketOptions#SO_RCVBUF} option.
-     */
-    DomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize);
 }


### PR DESCRIPTION
Motivation:

Running tests with a `KQueueDomainSocketChannel` showed worse performance than an `NioSocketChannel`. It turns out that the default send buffer size for Nio sockets is 64k while for KQueue sockets it's 8k. I verified that manually setting the socket's send buffer size improved perf to expected levels.

Modification:

Plumb the `SO_SNDBUF` and `SO_RCVBUF` options into the `DomainSocketChannelConfig`.

Result:

Can now configure send and receive buffer sizes for domain sockets.
