### PR TITLE
Externalize lazy execution semantic for EventExecutors

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -173,7 +174,8 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
      * This is equivalent to submitting a {@link EventExecutor.LazyRunnable} to
      * {@link #execute(Runnable)} but for an arbitrary {@link Runnable}.
      */
-    protected void lazyExecute(Runnable task) {
+    @UnstableApi
+    public void lazyExecute(Runnable task) {
         execute(task);
     }
 
@@ -181,5 +183,6 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
      * Marker interface for {@link Runnable} to indicate that it should be queued for execution
      * but does not need to run immediately.
      */
-    protected interface LazyRunnable extends Runnable { }
+    @UnstableApi
+    public interface LazyRunnable extends Runnable { }
 }

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -165,4 +165,15 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
             logger.warn("A task raised an exception. Task: {}", task, t);
         }
     }
+
+    /**
+     * Like {@link #execute(Runnable)} but does not guarantee the task will be run until either
+     * a non-lazy task is executed or the executor is shut down.
+     *
+     * This is equivalent to submitting a {@link EventExecutor.LazyRunnable} to
+     * {@link #execute(Runnable)} but for an arbitrary {@link Runnable}.
+     */
+    public void lazyExecute(Runnable task) {
+        execute(task);
+    }
 }

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -173,7 +173,13 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
      * This is equivalent to submitting a {@link EventExecutor.LazyRunnable} to
      * {@link #execute(Runnable)} but for an arbitrary {@link Runnable}.
      */
-    public void lazyExecute(Runnable task) {
+    protected void lazyExecute(Runnable task) {
         execute(task);
     }
+
+    /**
+     * Marker interface for {@link Runnable} to indicate that it should be queued for execution
+     * but does not need to run immediately.
+     */
+    protected interface LazyRunnable extends Runnable { }
 }

--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -38,6 +38,11 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
                 }
             };
 
+   static final Runnable WAKEUP_TASK = new Runnable() {
+       @Override
+       public void run() { } // Do nothing
+    };
+
     PriorityQueue<ScheduledFutureTask<?>> scheduledTaskQueue;
 
     long nextTaskId;
@@ -243,12 +248,22 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (inEventLoop()) {
             scheduledTaskQueue().add(task.setId(nextTaskId++));
         } else {
-            executeScheduledRunnable(new Runnable() {
+            final long deadlineNanos = task.deadlineNanos();
+            final Runnable addToQueue = new Runnable() {
                 @Override
                 public void run() {
                     scheduledTaskQueue().add(task.setId(nextTaskId++));
                 }
-            }, true, task.deadlineNanos());
+            };
+            if (beforeScheduledTaskSubmitted(deadlineNanos)) {
+                execute(addToQueue);
+            } else {
+                lazyExecute(addToQueue);
+                // Second hook after scheduling to facilitate race-avoidance
+                if (afterScheduledTaskSubmitted(deadlineNanos)) {
+                    execute(WAKEUP_TASK);
+                }
+            }
         }
 
         return task;
@@ -258,27 +273,39 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (inEventLoop()) {
             scheduledTaskQueue().removeTyped(task);
         } else {
-            executeScheduledRunnable(new Runnable() {
+            lazyExecute(new Runnable() {
                 @Override
                 public void run() {
                     scheduledTaskQueue().removeTyped(task);
                 }
-            }, false, task.deadlineNanos());
+            });
         }
     }
 
     /**
-     * Execute a {@link Runnable} from outside the event loop thread that is responsible for adding or removing
-     * a scheduled action. Note that schedule events which occur on the event loop thread do not interact with this
-     * method.
-     * @param runnable The {@link Runnable} to execute which will add or remove a scheduled action
-     * @param isAddition {@code true} if the {@link Runnable} will add an action, {@code false} if it will remove an
-     *                   action
-     * @param deadlineNanos the deadline in nanos of the scheduled task that will be added or removed.
+     * Called from arbitrary non-{@link EventExecutor} threads prior to scheduled task submission.
+     * Returns {@code true} if the {@link EventExecutor} thread should be woken immediately to
+     * process the scheduled task (if not already awake).
+     * <p>
+     * If {@code false} is returned, {@link #afterScheduledTaskSubmitted(long)} will be called with
+     * the same value <i>after</i> the scheduled task is enqueued, providing another opportunity
+     * to wake the {@link EventExecutor} thread if required.
+     *
+     * @param deadlineNanos deadline of the to-be-scheduled task
+     *     relative to {@link AbstractScheduledEventExecutor#nanoTime()}
+     * @return {@code true} if the {@link EventExecutor} thread should be woken, {@code false} otherwise
      */
-    void executeScheduledRunnable(Runnable runnable,
-                                            @SuppressWarnings("unused") boolean isAddition,
-                                            @SuppressWarnings("unused") long deadlineNanos) {
-        execute(runnable);
+    protected boolean beforeScheduledTaskSubmitted(long deadlineNanos) {
+        return true;
+    }
+
+    /**
+     * See {@link #beforeScheduledTaskSubmitted(long)}. Called only after that method returns false.
+     *
+     * @param deadlineNanos relative to {@link AbstractScheduledEventExecutor#nanoTime()}
+     * @return  {@code true} if the {@link EventExecutor} thread should be woken, {@code false} otherwise
+     */
+    protected boolean afterScheduledTaskSubmitted(long deadlineNanos) {
+        return true;
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
@@ -69,10 +69,4 @@ public interface EventExecutor extends EventExecutorGroup {
      * every call of blocking methods will just return without blocking.
      */
     <V> Future<V> newFailedFuture(Throwable cause);
-
-    /**
-     * Marker interface for {@link Runnable} to indicate that it should be queued for execution
-     * but does not need to run immediately.
-     */
-    public interface LazyRunnable extends Runnable { }
 }

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
@@ -69,4 +69,10 @@ public interface EventExecutor extends EventExecutorGroup {
      * every call of blocking methods will just return without blocking.
      */
     <V> Future<V> newFailedFuture(Throwable cause);
+
+    /**
+     * Marker interface for {@link Runnable} to indicate that it should be queued for execution
+     * but does not need to run immediately.
+     */
+    public interface LazyRunnable extends Runnable { }
 }

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -16,6 +16,7 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.SingleThreadEventLoop.LazyRunnable;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.Recycler;
@@ -1104,7 +1105,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         }
     }
 
-    static final class WriteTask extends AbstractWriteTask implements AbstractEventExecutor.LazyRunnable {
+    static final class WriteTask extends AbstractWriteTask implements LazyRunnable {
 
         private static final Recycler<WriteTask> RECYCLER = new Recycler<WriteTask>() {
             @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -16,7 +16,6 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.SingleThreadEventLoop.LazyRunnable;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.Recycler;
@@ -1105,7 +1104,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         }
     }
 
-    static final class WriteTask extends AbstractWriteTask implements LazyRunnable {
+    static final class WriteTask extends AbstractWriteTask implements AbstractEventExecutor.LazyRunnable {
 
         private static final Recycler<WriteTask> RECYCLER = new Recycler<WriteTask>() {
             @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -21,6 +21,7 @@ import io.netty.util.AttributeKey;
 import io.netty.util.Recycler;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ResourceLeakHint;
+import io.netty.util.concurrent.AbstractEventExecutor;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.OrderedEventExecutor;
 import io.netty.util.internal.PromiseNotificationUtil;
@@ -1103,7 +1104,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         }
     }
 
-    static final class WriteTask extends AbstractWriteTask implements SingleThreadEventLoop.NonWakeupRunnable {
+    static final class WriteTask extends AbstractWriteTask implements AbstractEventExecutor.LazyRunnable {
 
         private static final Recycler<WriteTask> RECYCLER = new Recycler<WriteTask>() {
             @Override

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -118,7 +118,7 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
             reject(task);
         }
 
-        if (wakesUpForTask(task)) {
+        if (!(task instanceof LazyRunnable) && wakesUpForTask(task)) {
             wakeup(inEventLoop());
         }
     }
@@ -159,9 +159,4 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     public int registeredChannels() {
         return -1;
     }
-
-    /**
-     * Marker interface for {@link Runnable} that will not trigger an {@link #wakeup(boolean)} in all cases.
-     */
-    interface NonWakeupRunnable extends SingleThreadEventExecutor.NonWakeupRunnable { }
 }

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.AbstractEventExecutor;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
@@ -159,4 +160,9 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     public int registeredChannels() {
         return -1;
     }
+
+    /**
+     * Marker interface for {@link Runnable} that will not trigger a {@link #wakeup(boolean)} in all cases.
+     */
+    interface LazyRunnable extends AbstractEventExecutor.LazyRunnable { }
 }

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -15,7 +15,6 @@
  */
 package io.netty.channel;
 
-import io.netty.util.concurrent.AbstractEventExecutor;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
@@ -160,9 +159,4 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     public int registeredChannels() {
         return -1;
     }
-
-    /**
-     * Marker interface for {@link Runnable} that will not trigger a {@link #wakeup(boolean)} in all cases.
-     */
-    interface LazyRunnable extends AbstractEventExecutor.LazyRunnable { }
 }


### PR DESCRIPTION
Motivation

This is already done internally for various reasons but it would make sense i.m.o. as a top level concept: submitting a task to be run on the event loop which doesn't need to run immediately but must still be executed in FIFO order relative all other submitted tasks (be those "lazy" or otherwise).

It's nice to separate this abstract "relaxed" semantic from concrete implementations - the simplest is to just delegate to existing `execute`, but for the main EL impls translates to whether a wakeup is required after enqueuing.

Having a "global" abstraction also allows for simplification of our internal use - for example encapsulating more of the common scheduled future logic within `AbstractScheduledEventExecutor`.

Modifications

- Introduce public `LazyRunnable` interface and `AbstractEventExecutor#lazyExecute` method (would be nice for this to be added to `EventExecutor` interface in netty 5)
- Tweak existing `SingleThreadEventExecutor` mechanics to support these
- Replace internal use of `NonWakeupRunnable` (such as for pre-flush channel writes)
- Uplift scheduling-related hooks into `AbstractScheduledEventExecutor`, eliminating intermediate `executeScheduledRunnable` method

Result

Simpler code, cleaner and more useful/flexible abstractions - cleaner in that they fully communicate the intent in a more general way, without implying/exposing/restricting implementation details