### PR TITLE
Batch RandomAccessFile reads by 8192 bytes for ChunkedFile

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpChunkedInputTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpChunkedInputTest.java
@@ -80,6 +80,11 @@ public class HttpChunkedInputTest {
     }
 
     @Test
+    public void testChunkedFileWithBiggerChunkSize() throws IOException {
+        check(new HttpChunkedInput(new ChunkedFile(TMP, 8192 * 2)));
+    }
+
+    @Test
     public void testChunkedNioFile() throws IOException {
         check(new HttpChunkedInput(new ChunkedNioFile(TMP)));
     }


### PR DESCRIPTION
Motivation:

RandomAccessFile JNI code allocates on stack the native buffer used
to perform the read operation on the file for buffer size <= 8192,
using malloc/free otherwise: this change aims to make JNI to always use
stack allocation.

Modifications:

Batch reads by 8192 bytes while preserving the readFully semantic

Result:

Faster and more scalable reads, because system allocator is not stressed