### PR TITLE
Fix GraalVM native image build error

### DIFF
--- a/codec-http2/src/main/resources/META-INF/native-image/io.netty/codec-http2/native-image.properties
+++ b/codec-http2/src/main/resources/META-INF/native-image/io.netty/codec-http2/native-image.properties
@@ -13,4 +13,4 @@
 # under the License.
 
 Args = --initialize-at-build-time=io.netty \
-       --initialize-at-run-time=io.netty.handler.codec.http2.Http2CodecUtil,io.netty.handler.codec.http2.DefaultHttp2FrameWriter
+       --initialize-at-run-time=io.netty.handler.codec.http2.Http2CodecUtil,io.netty.handler.codec.http2.Http2ClientUpgradeCodec,io.netty.handler.codec.http2.DefaultHttp2FrameWriter


### PR DESCRIPTION
Motivation:
```
Error: Class that is marked for delaying initialization to run time got initialized during image building: io.netty.handler.codec.http2.Http2CodecUtil. Try marking this class for build-time initialization with --initialize-at-build-time=io.netty.handler.codec.http2.Http2CodecUtil
Error: Use -H:+ReportExceptionStackTraces to print stacktrace of underlying exception
Error: Image build request failed with exit status 1
```

Modification:

After debugging, it seems the culprit is `io.netty.handler.codec.http2.Http2ClientUpgradeCodec`, which also needs runtime initialisation.

Result:

Fixes #https://github.com/micronaut-projects/micronaut-grpc/issues/8
