### PR TITLE
Add *ReceiveBufferSize / *SendBufferSize methods to DomainSocketChann…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -187,6 +187,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         return this;
     }
 
+    @Override
     public int getSendBufferSize() {
         try {
             return ((EpollDomainSocketChannel) channel).socket.getSendBufferSize();
@@ -195,6 +196,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         }
     }
 
+    @Override
     public EpollDomainSocketChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
             ((EpollDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
@@ -204,6 +206,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         }
     }
 
+    @Override
     public int getReceiveBufferSize() {
         try {
             return ((EpollDomainSocketChannel) channel).socket.getReceiveBufferSize();
@@ -212,6 +215,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         }
     }
 
+    @Override
     public EpollDomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((EpollDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -172,6 +172,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         return mode;
     }
 
+    @Override
     public int getSendBufferSize() {
         try {
             return ((KQueueDomainSocketChannel) channel).socket.getSendBufferSize();
@@ -180,6 +181,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
     }
 
+    @Override
     public KQueueDomainSocketChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
             ((KQueueDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
@@ -189,6 +191,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
     }
 
+    @Override
     public int getReceiveBufferSize() {
         try {
             return ((KQueueDomainSocketChannel) channel).socket.getReceiveBufferSize();
@@ -197,6 +200,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
     }
 
+    @Override
     public KQueueDomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((KQueueDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
@@ -20,6 +20,9 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.socket.SocketChannelConfig;
+
+import java.net.StandardSocketOptions;
 
 /**
  * Special {@link ChannelConfig} for {@link DomainSocketChannel}s.
@@ -61,6 +64,26 @@ public interface DomainSocketChannelConfig extends ChannelConfig {
 
     @Override
     DomainSocketChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
+
+    /**
+     * Gets the {@link StandardSocketOptions#SO_SNDBUF} option.
+     */
+    int getSendBufferSize();
+
+    /**
+     * Sets the {@link StandardSocketOptions#SO_SNDBUF} option.
+     */
+    DomainSocketChannelConfig setSendBufferSize(int sendBufferSize);
+
+    /**
+     * Gets the {@link StandardSocketOptions#SO_RCVBUF} option.
+     */
+    int getReceiveBufferSize();
+
+    /**
+     * Sets the {@link StandardSocketOptions#SO_RCVBUF} option.
+     */
+    DomainSocketChannelConfig setReceiveBufferSize(int receiveBufferSize);
 
     /**
      * Change the {@link DomainSocketReadMode} for the channel. The default is


### PR DESCRIPTION
…elConfig interface

Motivation:

aebe206 added support for using a ChannelOption to set / get Buffer sizes but did not add the methods to the DomainSocketChannelConfig interface itself (due not be able to break the API)

Modifications:

Add methods to interface (as this is a next major release)

Result:

Easier access to configure these buffer sizes