### PR TITLE
Fix broken pipe due to /usr/bin/ldd

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -208,7 +208,7 @@
                   <tasks>
                     <exec executable="sh" outputproperty="ldd_version">
                       <arg value="-c" />
-                      <arg value="ldd --version | head -1" />
+                      <arg value="ldd --version | tail | head -1" />
                     </exec>
                     <exec executable="uname" outputproperty="uname_os_version">
                       <arg value="-r" />


### PR DESCRIPTION
Motivation:

The build script for the module Netty Transport Native Epoll can cause
intermittent build break due to broken pipe by /usr/bin/ldd. This issue
likely to occur on a build environment with multiple processors.

Modifications:

The root cause is that the consumer head command finishes earlier the
producer ldd command. Buffering the outputs of the ldd command by an
intermediate tail command avoids the broken pipe.

Result:

A build on multiple processors can finish successfully.

Signed-off-by: Tatsushi Inagaki <e29253@jp.ibm.com>
