### PR TITLE
Close eventfd shutdown/wakeup race by closely tracking epoll edges (#9586)

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollHandler.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollHandler.java
@@ -37,6 +37,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.util.BitSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -48,8 +49,6 @@ import static java.util.Objects.requireNonNull;
  */
 public class EpollHandler implements IoHandler {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollHandler.class);
-    private static final AtomicIntegerFieldUpdater<EpollHandler> WAKEN_UP_UPDATER =
-            AtomicIntegerFieldUpdater.newUpdater(EpollHandler.class, "wakenUp");
 
     static {
         // Ensure JNI is initialized by the time this class is loaded by this time!
@@ -73,8 +72,8 @@ public class EpollHandler implements IoHandler {
 
     private final SelectStrategy selectStrategy;
     private final IntSupplier selectNowSupplier = this::epollWaitNow;
-    @SuppressWarnings("unused") // AtomicIntegerFieldUpdater
-    private volatile int wakenUp;
+    private final AtomicInteger wakenUp = new AtomicInteger(1);
+    private boolean pendingWakeup;
 
     // See http://man7.org/linux/man-pages/man2/timerfd_create.2.html.
     private static final long MAX_SCHEDULED_TIMERFD_NS = 999999999;
@@ -219,7 +218,7 @@ public class EpollHandler implements IoHandler {
 
     @Override
     public final void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && WAKEN_UP_UPDATER.getAndSet(this, 1) == 0) {
+        if (!inEventLoop && wakenUp.getAndSet(1) == 0) {
             // write to the evfd which will then wake-up epoll_wait(...)
             Native.eventFdWrite(eventFd.intValue(), 1L);
         }
@@ -309,11 +308,16 @@ public class EpollHandler implements IoHandler {
     }
 
     private int epollWaitNow() throws IOException {
-        return Native.epollWait(epollFd, events, timerFd, 0, 0);
+        return Native.epollWait(epollFd, events, true);
     }
 
     private int epollBusyWait() throws IOException {
         return Native.epollBusyWait(epollFd, events);
+    }
+
+    private int epollWaitTimeboxed() throws IOException {
+        // Wait with 1 second "safeguard" timeout
+        return Native.epollWait(epollFd, events, 1000);
     }
 
     @Override
@@ -331,15 +335,36 @@ public class EpollHandler implements IoHandler {
                     break;
 
                 case SelectStrategy.SELECT:
-                    if (wakenUp == 1) {
-                        Native.eventFdWrite(eventFd.intValue(), 1L);
-                        wakenUp = 0;
-                    }
-                    if (context.canBlock()) {
-                        strategy = epollWait(context);
+                    if (pendingWakeup) {
+                        // We are going to be immediately woken so no need to reset wakenUp
+                        // or check for timerfd adjustment.
+                        strategy = epollWaitTimeboxed();
+                        if (strategy != 0) {
+                            break;
+                        }
+                        // We timed out so assume that we missed the write event due to an
+                        // abnormally failed syscall (the write itself or a prior epoll_wait)
+                        logger.warn("Missed eventfd write (not seen after > 1 second)");
+                        pendingWakeup = false;
+                        if (!context.canBlock()) {
+                            break;
+                        }
+                        // fall-through
                     }
 
-                    // fallthrough
+                    wakenUp.set(0);
+                    try {
+                        if (context.canBlock()) {
+                            strategy = epollWait(context);
+                        }
+                    } finally {
+                        // Try get() first to avoid much more expensive CAS in the case we
+                        // were woken via the wakeup() method (submitted task)
+                        if (wakenUp.get() == 1 || wakenUp.getAndSet(1) == 1) {
+                            pendingWakeup = true;
+                        }
+                    }
+                    // fall-through
                 default:
             }
             if (strategy > 0) {
@@ -391,7 +416,9 @@ public class EpollHandler implements IoHandler {
     private void processReady(EpollEventArray events, int ready) {
         for (int i = 0; i < ready; i ++) {
             final int fd = events.fd(i);
-            if (fd == eventFd.intValue() || fd == timerFd.intValue()) {
+            if (fd == eventFd.intValue()) {
+                pendingWakeup = false;
+            } else if (fd == timerFd.intValue()) {
                 // Just ignore as we use ET mode for the eventfd and timerfd.
                 //
                 // See also https://stackoverflow.com/a/12492308/1074097
@@ -453,10 +480,23 @@ public class EpollHandler implements IoHandler {
     @Override
     public final void destroy() {
         try {
-            try {
-                epollFd.close();
-            } catch (IOException e) {
-                logger.warn("Failed to close the epoll fd.", e);
+            // Ensure any in-flight wakeup writes have been performed prior to closing eventFd.
+            while (pendingWakeup) {
+                try {
+                    int count = epollWaitTimeboxed();
+                    if (count == 0) {
+                        // We timed-out so assume that the write we're expecting isn't coming
+                        break;
+                    }
+                    for (int i = 0; i < count; i++) {
+                        if (events.fd(i) == eventFd.intValue()) {
+                            pendingWakeup = false;
+                            break;
+                        }
+                    }
+                } catch (IOException ignore) {
+                    // ignore
+                }
             }
             try {
                 eventFd.close();
@@ -467,6 +507,11 @@ public class EpollHandler implements IoHandler {
                 timerFd.close();
             } catch (IOException e) {
                 logger.warn("Failed to close the timer fd.", e);
+            }
+            try {
+                epollFd.close();
+            } catch (IOException e) {
+                logger.warn("Failed to close the epoll fd.", e);
             }
         } finally {
             // release native memory

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollHandler.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollHandler.java
@@ -398,12 +398,6 @@ public class EpollHandler implements IoHandler {
 
     @Override
     public void prepareToDestroy() {
-        try {
-            epollWaitNow();
-        } catch (IOException ignore) {
-            // ignore on close
-        }
-
         // Using the intermediate collection to prevent ConcurrentModificationException.
         // In the `close()` method, the channel is deleted from `channels` map.
         AbstractEpollChannel[] localChannels = channels.values().toArray(new AbstractEpollChannel[0]);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -91,6 +91,10 @@ public final class Native {
 
     private static native int epollCreate();
 
+    /**
+     * @deprecated this method is no longer supported. This functionality is internal to this package.
+     */
+    @Deprecated
     public static int epollWait(FileDescriptor epollFd, EpollEventArray events, FileDescriptor timerFd,
                                 int timeoutSec, int timeoutNs) throws IOException {
         int ready = epollWait0(epollFd.intValue(), events.memoryAddress(), events.length(), timerFd.intValue(),
@@ -100,7 +104,21 @@ public final class Native {
         }
         return ready;
     }
-    private static native int epollWait0(int efd, long address, int len, int timerFd, int timeoutSec, int timeoutNs);
+
+    static int epollWait(FileDescriptor epollFd, EpollEventArray events, boolean immediatePoll) throws IOException {
+        return epollWait(epollFd, events, immediatePoll ? 0 : -1);
+    }
+
+    /**
+     * This uses epoll's own timeout and does not reset/re-arm any timerfd
+     */
+    static int epollWait(FileDescriptor epollFd, EpollEventArray events, int timeoutMillis) throws IOException {
+        int ready = epollWait(epollFd.intValue(), events.memoryAddress(), events.length(), timeoutMillis);
+        if (ready < 0) {
+            throw newIOException("epoll_wait", ready);
+        }
+        return ready;
+    }
 
     /**
      * Non-blocking variant of
@@ -115,6 +133,8 @@ public final class Native {
         return ready;
     }
 
+    private static native int epollWait0(int efd, long address, int len, int timerFd, int timeoutSec, int timeoutNs);
+    private static native int epollWait(int efd, long address, int len, int timeout);
     private static native int epollBusyWait0(int efd, long address, int len);
 
     public static void epollCtlAdd(int efd, final int fd, final int flags) throws IOException {


### PR DESCRIPTION
Motivation

This is another iteration of #9476.

Modifications

Instead of maintaining a count of all writes performed and then using
reads during shutdown to ensure all are accounted for, just set a flag
after each write and don't reset it until the corresponding event has
been returned from epoll_wait.

This requires that while a write is still pending we don't reset
wakenUp, i.e. continue to block writes from the wakeup() method.

Result

Race condition eliminated. Fixes #9362


Co-authored-by: Norman Maurer <norman_maurer@apple.com>
