### PR TITLE
Remove redundant epollWaitNow() call in EpollEventLoop#closeAll()

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -425,12 +425,6 @@ class EpollEventLoop extends SingleThreadEventLoop {
     }
 
     private void closeAll() {
-        try {
-            epollWaitNow();
-        } catch (IOException ignore) {
-            // ignore on close
-        }
-
         // Using the intermediate collection to prevent ConcurrentModificationException.
         // In the `close()` method, the channel is deleted from `channels` map.
         AbstractEpollChannel[] localChannels = channels.values().toArray(new AbstractEpollChannel[0]);


### PR DESCRIPTION
Motivation

This is a vestige that was removed in the original PR #9535 before it was reverted, but we missed it when re-applying in #9586.

It means there is a possible race condition because a wakeup event could be missed while shutting down, but the consequences aren't serious since there's a 1 second safeguard timeout when waiting for it.

Modification

Remove call to `epollWaitNow()` in `EpollEventLoop#closeAll()`

Result

Cleanup redundant code, avoid shutdown delay race condition