### PR TITLE
Allow to build on s390_64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -749,10 +749,10 @@
                 </requireMavenVersion>
                 <requireProperty>
                   <regexMessage>
-                    x86_64/AARCH64/PPCLE64 JDK must be used.
+		     x86_64/AARCH64/PPCLE64/s390x_64 JDK must be used.
                   </regexMessage>
                   <property>os.detected.arch</property>
-                  <regex>^(x86_64|aarch_64|ppcle_64)$</regex>
+                  <regex>^(x86_64|aarch_64|ppcle_64|s390_64)$</regex>
                 </requireProperty>
               </rules>
             </configuration>

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -540,6 +540,7 @@ static jint netty_unix_socket_disconnect(JNIEnv* env, jclass clazz, jint fd, jbo
 static jint netty_unix_socket_accept(JNIEnv* env, jclass clazz, jint fd, jbyteArray acceptedAddress) {
     jint socketFd;
     jsize len;
+    jbyte len_b;
     int err;
     struct sockaddr_storage addr;
     socklen_t address_len = sizeof(addr);
@@ -564,9 +565,10 @@ static jint netty_unix_socket_accept(JNIEnv* env, jclass clazz, jint fd, jbyteAr
     }
 
     len = addressLength(&addr);
+    len_b = (jbyte) len;
 
     // Fill in remote address details
-    (*env)->SetByteArrayRegion(env, acceptedAddress, 0, 4, (jbyte*) &len);
+    (*env)->SetByteArrayRegion(env, acceptedAddress, 0, 1, (jbyte*) &len_b);
     initInetSocketAddressArray(env, &addr, acceptedAddress, 1, len);
 
     if (accept4)  {


### PR DESCRIPTION
Motivation:

We would like to enable Netty also on a big endian platform such as s390_64. We need to a function in the Netty Transport Native Unix Common module, which currently assumes that the target platform is little endian.

Modifications:

Modify `netty_unix_socket_accept()` to write an address length as `jbyte` instead of `jsize`.

Result:

Netty can be enabled on a big endian platform.

Signed-off-by: Tatsushi Inagaki <e29253@jp.ibm.com>