### PR TITLE
Introduce MIXED SSL Provider

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/MixedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/MixedOpenSslClientContext.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.internal.tcnative.SSL;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+
+import static io.netty.handler.ssl.ReferenceCountedOpenSslClientContext.newSessionContext;
+
+/**
+ * A client-side {@link SslContext} which uses OpenSSL's SSL/TLS implementation.
+ *
+ * This class implements a MIXED mode for OpenSSL engines and contexts. It will use a finalizer to
+ * ensure native resources backing this context are automatically cleaned up, but it will rely on
+ * manual release for its produced {@link ReferenceCountedOpenSslEngine} instances.
+ */
+public final class MixedOpenSslClientContext extends MixedOpenSslContext {
+  private final OpenSslSessionContext sessionContext;
+
+  MixedOpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+                       X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
+                       KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                       CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+                       long sessionCacheSize, long sessionTimeout, boolean enableOcsp, String keyStore)
+      throws SSLException {
+    super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_CLIENT, keyCertChain,
+        ClientAuth.NONE, protocols, false, enableOcsp);
+    boolean success = false;
+    try {
+      OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);
+      sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
+          keyCertChain, key, keyPassword, keyManagerFactory, keyStore);
+      success = true;
+    } finally {
+      if (!success) {
+        release();
+      }
+    }
+  }
+
+  @Override
+  public OpenSslSessionContext sessionContext() {
+    return sessionContext;
+  }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/MixedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/MixedOpenSslContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBufAllocator;
+
+import java.security.cert.Certificate;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+
+/**
+ * This class implements a MIXED mode for OpenSSL engines and contexts. It will use a finalizer to
+ * ensure native resources backing this context are automatically cleaned up, but it will rely on
+ * manual release for its produced {@link ReferenceCountedOpenSslEngine} instances.
+ */
+public abstract class MixedOpenSslContext extends ReferenceCountedOpenSslContext {
+  MixedOpenSslContext(Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apnCfg,
+                 long sessionCacheSize, long sessionTimeout, int mode, Certificate[] keyCertChain,
+                 ClientAuth clientAuth, String[] protocols, boolean startTls, boolean enableOcsp)
+      throws SSLException {
+    super(ciphers, cipherFilter, apnCfg, sessionCacheSize, sessionTimeout, mode, keyCertChain,
+        clientAuth, protocols, startTls, enableOcsp, false);
+  }
+
+  @Override
+  final SSLEngine newEngine0(ByteBufAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
+    return new ReferenceCountedOpenSslEngine(this, alloc, peerHost, peerPort, jdkCompatibilityMode, true);
+  }
+
+  @Override
+  @SuppressWarnings("FinalizeDeclaration")
+  protected final void finalize() throws Throwable {
+    super.finalize();
+    OpenSsl.releaseIfNeeded(this);
+  }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/MixedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/MixedOpenSslServerContext.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.internal.tcnative.SSL;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+
+import static io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.newSessionContext;
+
+/**
+ * A server-side {@link SslContext} which uses OpenSSL's SSL/TLS implementation.
+ *
+ * This class implements a MIXED mode for OpenSSL engines and contexts. It will use a finalizer to
+ * ensure native resources backing this context are automatically cleaned up, but it will rely on
+ * manual release for its produced {@link ReferenceCountedOpenSslEngine} instances.
+ */
+public final class MixedOpenSslServerContext extends OpenSslContext {
+  private final OpenSslServerSessionContext sessionContext;
+
+  MixedOpenSslServerContext(
+      X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+      X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+      Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+      long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
+      boolean enableOcsp, String keyStore) throws SSLException {
+    super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER, keyCertChain,
+        clientAuth, protocols, startTls, enableOcsp);
+
+    boolean success = false;
+    try {
+      OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);
+      sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
+          keyCertChain, key, keyPassword, keyManagerFactory, keyStore);
+      success = true;
+    } finally {
+      if (!success) {
+        release();
+      }
+    }
+  }
+
+  @Override
+  public OpenSslServerSessionContext sessionContext() {
+    return sessionContext;
+  }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -475,6 +475,14 @@ public abstract class SslContext {
                     trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
                     keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
                     clientAuth, protocols, startTls, enableOcsp, keyStoreType);
+
+        case OPENSSL_MIXED:
+            verifyNullSslContextProvider(provider, sslContextProvider);
+            return new MixedOpenSslServerContext(
+                trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                clientAuth, protocols, startTls, enableOcsp, keyStoreType);
+
         default:
             throw new Error(provider.toString());
         }
@@ -831,6 +839,14 @@ public abstract class SslContext {
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
                         enableOcsp, keyStoreType);
+
+            case OPENSSL_MIXED:
+                verifyNullSslContextProvider(provider, sslContextProvider);
+                return new MixedOpenSslClientContext(
+                    trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
+                    keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
+                    enableOcsp, keyStoreType);
+
             default:
                 throw new Error(provider.toString());
         }

--- a/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
@@ -35,5 +35,10 @@ public enum SslProvider {
      * OpenSSL-based implementation which does not have finalizers and instead implements {@link ReferenceCounted}.
      */
     @UnstableApi
-    OPENSSL_REFCNT
+    OPENSSL_REFCNT,
+    /**
+     * OpenSSL-based implementation which mixes {@link ReferenceCounted} engines with finalizer-based contexts.
+     */
+    @UnstableApi
+    OPENSSL_MIXED
 }


### PR DESCRIPTION
This is an exploratory PR (WIP) and I'm curious to hear what people think about this new feature.

This was a hack week at Twitter and my (very boring) project was to see what we can gain by dropping them finalizers on `SslEgines`. One of the long-standing problems we had with services churning connections is their GC times are suffering from very long finalizer queues. One workaround we applied was to use parallel ref processing. This mitigated the problem but didn't solve the problem entirely.

You'd ask why we're not using RefCounted OpenSSL engines - this is exactly what they exist for. Well, we want but we can't due to how we instantiate SSL contexts in Finagle (we can properly release engines but not contexts).

I tried to implement a MIXIED SSL provider that suites our needs - it uses finalizers for contexts but relies on manual release for engines. I vendored a Netty internally and tried the branch against a couple of services.

The results are promising. Here is an example of a "remark" GC phase BEFORE and AFTER (we used to see a lot of slowdown during remark):

BEFORE:
```
                                   num  min/ms  p50/ms  p90/ms  p99/ms  max/ms  tot/sec
GC_Remark_Post                       1   29.70   29.70   29.70   29.70   29.70     0.03  100.00%
  GC_RefProc                         1   28.72   28.72   28.72   28.72   28.72     0.03   96.70%
    GC_RefProc_ProcessSoftRefs       1    0.94    0.94    0.94    0.94    0.94     0.00    3.16%
    GC_RefProc_ProcessWeakRefs       1    2.28    2.28    2.28    2.28    2.28     0.00    7.68%
    GC_RefProc_ProcessFinalRefs      1   24.13   24.13   24.13   24.13   24.13     0.02   81.25%
    GC_RefProc_ProcessPhantomRefs    1    0.46    0.46    0.46    0.46    0.46     0.00    1.55%
    GC_RefProc_ProcessCleaners       1    0.55    0.55    0.55    0.55    0.55     0.00    1.85%
    GC_RefProc_ProcessJNIWeakRefs    1    0.28    0.28    0.28    0.28    0.28     0.00    0.94%
```

AFTER:

```
                                   num  min/ms  p50/ms  p90/ms  p99/ms  max/ms  tot/sec
GC_Remark_Post                       1    7.29    7.29    7.29    7.29    7.29     0.01  100.00%
  GC_RefProc                         1    6.84    6.84    6.84    6.84    6.84     0.01   93.83%
    GC_RefProc_ProcessSoftRefs       1    0.64    0.64    0.64    0.64    0.64     0.00    8.78%
    GC_RefProc_ProcessWeakRefs       1    4.54    4.54    4.54    4.54    4.54     0.00   62.28%
    GC_RefProc_ProcessFinalRefs      1    0.51    0.51    0.51    0.51    0.51     0.00    7.00%
    GC_RefProc_ProcessPhantomRefs    1    0.46    0.46    0.46    0.46    0.46     0.00    6.31%
    GC_RefProc_ProcessCleaners       1    0.46    0.46    0.46    0.46    0.46     0.00    6.31%
    GC_RefProc_ProcessJNIWeakRefs    1    0.17    0.17    0.17    0.17    0.17     0.00    2.33%
```

You can see that ProcessFinalRefs now takes 0.5ms as opposed to 25ms before as the number of objects in the finalizer queue is substantially down.

What do people think about having a MIXED SSL provider in Netty? We're obviously going to benefit from it, but I wasn't sure how other adopters find it useful.

UPDATE: Bryce's #9626 would make it possible to hack this on our end, within Finagle by defaulting to the ref-counted SSL provider and manually wrapping SslContext with a class that implements a finalizer.