### PR TITLE
Fixing possible NPE in DefaultHttp2UnknownFrame#equals

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
@@ -80,7 +80,7 @@ public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder impleme
 
     @Override
     public DefaultHttp2UnknownFrame replace(ByteBuf content) {
-        return new DefaultHttp2UnknownFrame(frameType, flags, content).stream(stream());
+        return new DefaultHttp2UnknownFrame(frameType, flags, content).stream(stream);
     }
 
     @Override
@@ -97,8 +97,8 @@ public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder impleme
 
     @Override
     public String toString() {
-        return StringUtil.simpleClassName(this) + "(frameType=" + frameType() + ", stream=" + stream() +
-                ", flags=" + flags() + ", content=" + contentToString() + ')';
+        return StringUtil.simpleClassName(this) + "(frameType=" + frameType + ", stream=" + stream +
+               ", flags=" + flags + ", content=" + contentToString() + ')';
     }
 
     @Override
@@ -119,18 +119,20 @@ public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder impleme
             return false;
         }
         DefaultHttp2UnknownFrame other = (DefaultHttp2UnknownFrame) o;
-        return super.equals(other) && flags().equals(other.flags())
-                && frameType() == other.frameType() && (stream() == null && other.stream() == null) ||
-                stream().equals(other.stream());
+        Http2FrameStream otherStream = other.stream();
+        return (stream == otherStream || otherStream != null && otherStream.equals(stream))
+               && flags.equals(other.flags())
+               && frameType == other.frameType()
+               && super.equals(other);
     }
 
     @Override
     public int hashCode() {
         int hash = super.hashCode();
-        hash = hash * 31 + frameType();
-        hash = hash * 31 + flags().hashCode();
-        if (stream() != null) {
-            hash = hash * 31 + stream().hashCode();
+        hash = hash * 31 + frameType;
+        hash = hash * 31 + flags.hashCode();
+        if (stream != null) {
+            hash = hash * 31 + stream.hashCode();
         }
 
         return hash;


### PR DESCRIPTION
Motivation:
`DefaultHttp2UnknownFrame#equals` may produce NPE due to an incorrect comparison of `stream` field.

Modification:
- Fix the `stream` field compare.
- Clear usage of class fields: use direct access instead of getters (because the class is final).

Result:
No NPE in `equals` method.