### PR TITLE
Remove judging for inFlush0 when taking deregister

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -741,15 +741,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                         outboundBuffer.failFlushed(cause, notify);
                         outboundBuffer.close(closeCause);
                     }
-                }
-                if (inFlush0) {
-                    invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            fireChannelInactiveAndDeregister(wasActive);
-                        }
-                    });
-                } else {
                     fireChannelInactiveAndDeregister(wasActive);
                 }
             }


### PR DESCRIPTION
Motivation:
(1) The channel had been closed and flushed entrys also be set failed before judging for inFlush0. So it is useless to protected the flushing operation.
(2) io.netty.channel.AbstractChannel.AbstractUnsafe#fireChannelInactiveAndDeregister's implement is also calling invokeLater(). 

Modification:
Remove the judging for inFlush0.

Result:
The logic will be more clear and simpler.