### PR TITLE
Register sun.nio.ch.SelectorImpl fields for unsafe access.

### DIFF
--- a/transport/src/main/resources/META-INF/native-image/io.netty/transport/reflection-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/transport/reflection-config.json
@@ -4,5 +4,12 @@
       "methods": [
         { "name": "<init>", "parameterTypes": [] }
       ]
+    },
+    {
+      "name": "sun.nio.ch.SelectorImpl",
+      "fields": [
+        { "name": "selectedKeys",  "allowUnsafeAccess" : true},
+        { "name": "publicSelectedKeys",  "allowUnsafeAccess" : true}
+      ]
     }
 ]


### PR DESCRIPTION
Motivation:

On JDK > 9 Netty uses Unsafe to write two internal JDK fields: `sun.nio.ch.SelectorImp.selectedKeys` and `sun.nio.ch.SelectorImpl.publicSelectedKeys`. This is done in [`transport/src/main/java/io/netty/channel/nio/NioEventLoop.java:225`](https://github.com/netty/netty/blob/a22d4ba859b115d353b4cea1af581b987249adf6/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java#L225), in `openSelector()` method. The GraalVM analysis cannot do the Unsafe registration automatically because the object field offset computation is hidden behind two layers of calls.

Modifications:

This PR updates the Netty GraalVM configuration by registering those fields for unsafe access.
 
Result:

Improved support for Netty on GraalVM with JDK > 9.