### PR TITLE
Use adopt@1.13.0-0 when building with Java 13

### DIFF
--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "openjdk@1.13.0"
+        java_version : "adopt@1.13.0-0"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "openjdk@1.13.0"
+        java_version : "adopt@1.13.0-0"
 
   test:
     image: netty:centos-7-1.13


### PR DESCRIPTION
Motivation:

We should use adaptjdk 13 and not oracle openjdk 13 when building with Java 13

Modifications:

Use adopt@1.13.0-0

Result:

More consistent java vendor usage