### PR TITLE
Add ability to set attributes on a SslContext

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -24,7 +24,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
-import io.netty.util.AttributeMap;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.internal.EmptyArrays;
 
@@ -86,7 +85,7 @@ import java.util.concurrent.Executor;
  * ...
  * </pre>
  */
-public abstract class SslContext {
+public abstract class SslContext extends DefaultAttributeMap {
     static final String ALIAS = "key";
 
     static final CertificateFactory X509_CERT_FACTORY;
@@ -98,7 +97,6 @@ public abstract class SslContext {
         }
     }
 
-    private final AttributeMap attributeMap = new DefaultAttributeMap();
     private final boolean startTls;
 
     /**
@@ -870,13 +868,6 @@ public abstract class SslContext {
      */
     public final boolean isServer() {
         return !isClient();
-    }
-
-    /**
-     * Returns the {@link AttributeMap} that is tied to this {@link SslContext} instance.
-     */
-    public final AttributeMap attributeMap() {
-        return attributeMap;
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -24,6 +24,8 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.util.AttributeMap;
+import io.netty.util.DefaultAttributeMap;
 import io.netty.util.internal.EmptyArrays;
 
 import java.security.Provider;
@@ -96,6 +98,7 @@ public abstract class SslContext {
         }
     }
 
+    private final AttributeMap attributeMap = new DefaultAttributeMap();
     private final boolean startTls;
 
     /**
@@ -867,6 +870,13 @@ public abstract class SslContext {
      */
     public final boolean isServer() {
         return !isClient();
+    }
+
+    /**
+     * Returns the {@link AttributeMap} that is tied to this {@link SslContext} instance.
+     */
+    public final AttributeMap attributeMap() {
+        return attributeMap;
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.util.AttributeMap;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.internal.EmptyArrays;
 
@@ -85,7 +86,7 @@ import java.util.concurrent.Executor;
  * ...
  * </pre>
  */
-public abstract class SslContext extends DefaultAttributeMap {
+public abstract class SslContext {
     static final String ALIAS = "key";
 
     static final CertificateFactory X509_CERT_FACTORY;
@@ -98,6 +99,7 @@ public abstract class SslContext extends DefaultAttributeMap {
     }
 
     private final boolean startTls;
+    private final AttributeMap attributes = new DefaultAttributeMap();
 
     /**
      * Returns the default server-side implementation provider currently in use.
@@ -861,6 +863,13 @@ public abstract class SslContext extends DefaultAttributeMap {
      */
     protected SslContext(boolean startTls) {
         this.startTls = startTls;
+    }
+
+    /**
+     * Returns the {@link AttributeMap} that belongs to this {@link SslContext} .
+     */
+    public final AttributeMap attributes() {
+        return attributes;
     }
 
     /**


### PR DESCRIPTION
Motivation:

Sometimes it is useful to be able to set attributes on a SslContext.

Modifications:

Add new method that will return a AttributeMap that is tied to a SslContext instance

Result:

Fixes https://github.com/netty/netty/issues/6542.