### PR TITLE
Update commons-compress dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -640,7 +640,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.18</version>
+        <version>1.19</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Motivation:

We should use the latest commons-compress release to fix CVE-2019-12402 (even it is only a test dependency)

Modifications:

Update commons-compress to 1.19

Result:

Fix security alert
