### PR TITLE
Eliminate unnessary copy of ByteBuf on ByteToMessageDecoder removal

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -251,9 +251,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             numReads = 0;
             int readable = buf.readableBytes();
             if (readable > 0) {
-                ByteBuf bytes = buf.readBytes(readable);
-                buf.release();
-                ctx.fireChannelRead(bytes);
+                ctx.fireChannelRead(buf);
                 ctx.fireChannelReadComplete();
             } else {
                 buf.release();


### PR DESCRIPTION
Motivation:

At the moment we do a ByteBuf.readBytes(...) on removal of the ByteToMessageDecoder if there are any bytes left and forward the returned ByteBuf to the next handler in the pipeline. This is not really needed as we can just forward the cumulation buffer directly and so eliminate the extra memory copy

Modifications:

Just forward the cumulation buffer directly on removal of the ByteToMessageDecoder

Result:

Less memory copies