### PR TITLE
fix remove handler cause ByteToMessageDecoder out disorder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -507,7 +507,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             boolean removePending = decodeState == STATE_HANDLER_REMOVED_PENDING;
             decodeState = STATE_INIT;
             if (removePending) {
-                fireChannelRead(ctx,out,out.size());
+                fireChannelRead(ctx, out, out.size());
                 out.clear();
                 handlerRemoved(ctx);
             }

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -81,7 +81,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             try {
                 final ByteBuf buffer;
                 if (cumulation.writerIndex() > cumulation.maxCapacity() - in.readableBytes()
-                    || cumulation.refCnt() > 1 || cumulation.isReadOnly()) {
+                        || cumulation.refCnt() > 1 || cumulation.isReadOnly()) {
                     // Expand cumulation (by replace it) when either there is not more room in the buffer
                     // or if the refCnt is greater then 1 which may happen when the user use slice().retain() or
                     // duplicate().retain() or if its read-only.
@@ -507,6 +507,8 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             boolean removePending = decodeState == STATE_HANDLER_REMOVED_PENDING;
             decodeState = STATE_INIT;
             if (removePending) {
+                fireChannelRead(ctx,out,out.size());
+                out.clear();
                 handlerRemoved(ctx);
             }
         }

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -401,9 +401,9 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testDisorder(){
+    public void testDisorder() {
         ByteToMessageDecoder decoder = new ByteToMessageDecoder() {
-            int count = 0;
+            int count;
 
             //read 4 byte then remove this decoder
             @Override
@@ -416,12 +416,12 @@ public class ByteToMessageDecoderTest {
         };
         EmbeddedChannel channel = new EmbeddedChannel(decoder);
         assertTrue(channel.writeInbound(Unpooled.wrappedBuffer(new byte[]{1, 2, 3, 4, 5})));
-        assertEquals((byte)1, (byte) channel.readInbound());
-        assertEquals((byte)2, (byte) channel.readInbound());
-        assertEquals((byte)3, (byte) channel.readInbound());
-        assertEquals((byte)4, (byte) channel.readInbound());
+        assertEquals((byte) 1, (byte) channel.readInbound());
+        assertEquals((byte) 2, (byte) channel.readInbound());
+        assertEquals((byte) 3, (byte) channel.readInbound());
+        assertEquals((byte) 4, (byte) channel.readInbound());
         ByteBuf buffer5 = channel.readInbound();
-        assertEquals((byte)5, buffer5.readByte());
+        assertEquals((byte) 5, buffer5.readByte());
         assertTrue(buffer5.release());
         assertFalse(channel.finish());
     }

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -416,10 +416,10 @@ public class ByteToMessageDecoderTest {
         };
         EmbeddedChannel channel = new EmbeddedChannel(decoder);
         assertTrue(channel.writeInbound(Unpooled.wrappedBuffer(new byte[]{1, 2, 3, 4, 5})));
-        assertEquals((byte) 1, (byte) channel.readInbound());
-        assertEquals((byte) 2, (byte) channel.readInbound());
-        assertEquals((byte) 3, (byte) channel.readInbound());
-        assertEquals((byte) 4, (byte) channel.readInbound());
+        assertEquals((byte) 1,  channel.readInbound());
+        assertEquals((byte) 2,  channel.readInbound());
+        assertEquals((byte) 3,  channel.readInbound());
+        assertEquals((byte) 4,  channel.readInbound());
         ByteBuf buffer5 = channel.readInbound();
         assertEquals((byte) 5, buffer5.readByte());
         assertTrue(buffer5.release());

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -422,6 +422,7 @@ public class ByteToMessageDecoderTest {
         assertEquals((byte) 4,  channel.readInbound());
         ByteBuf buffer5 = channel.readInbound();
         assertEquals((byte) 5, buffer5.readByte());
+        assertFalse(buffer5.isReadable());
         assertTrue(buffer5.release());
         assertFalse(channel.finish());
     }

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -408,20 +408,21 @@ public class ByteToMessageDecoderTest {
             //read 4 byte then remove this decoder
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
-                out.add(in.readBytes(1));
+                out.add(in.readByte());
                 if (++count >= 4) {
                     ctx.pipeline().remove(this);
                 }
             }
         };
-
         EmbeddedChannel channel = new EmbeddedChannel(decoder);
         assertTrue(channel.writeInbound(Unpooled.wrappedBuffer(new byte[]{1, 2, 3, 4, 5})));
-        assertEquals(1, ((ByteBuf) channel.readInbound()).readByte());
-        assertEquals(2, ((ByteBuf) channel.readInbound()).readByte());
-        assertEquals(3, ((ByteBuf) channel.readInbound()).readByte());
-        assertEquals(4, ((ByteBuf) channel.readInbound()).readByte());
-        assertEquals(5, ((ByteBuf) channel.readInbound()).readByte());
+        assertEquals((byte)1, (byte) channel.readInbound());
+        assertEquals((byte)2, (byte) channel.readInbound());
+        assertEquals((byte)3, (byte) channel.readInbound());
+        assertEquals((byte)4, (byte) channel.readInbound());
+        ByteBuf buffer5 = channel.readInbound();
+        assertEquals((byte)5, buffer5.readByte());
+        assertTrue(buffer5.release());
         assertFalse(channel.finish());
     }
 }


### PR DESCRIPTION
Motivation:

Data flowing in from the decoder flows out in sequence，Whether decoder removed or not.

Modification:

fire data in out and clear out when hander removed
before call method handlerRemoved(ctx)

Result:

Fixes #9668 . 

