### PR TITLE
Correctly clean up memory attributes and file uploads

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
@@ -130,7 +130,7 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
 
     @Override
     public Attribute createAttribute(HttpRequest request, String name) {
-        Attribute attribute;
+        final Attribute attribute;
         if (useDisk) {
             attribute = new DiskAttribute(name, charset);
         } else if (checkSize) {
@@ -146,7 +146,7 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
 
     @Override
     public Attribute createAttribute(HttpRequest request, String name, long definedSize) {
-        Attribute attribute;
+        final Attribute attribute;
         if (useDisk) {
             attribute = new DiskAttribute(name, definedSize, charset);
         } else if (checkSize) {
@@ -201,7 +201,7 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
     public FileUpload createFileUpload(HttpRequest request, String name, String filename,
             String contentType, String contentTransferEncoding, Charset charset,
             long size) {
-        FileUpload fileUpload;
+        final FileUpload fileUpload;
         if (useDisk) {
             fileUpload = new DiskFileUpload(name, filename, contentType,
                     contentTransferEncoding, charset, size);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
@@ -115,23 +115,22 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
     long definedLength();
 
     /**
-     * Deletes the underlying storage for a file item, including deleting any
-     * associated temporary disk file.
+     * Deletes the content of the HttpData.
      */
     void delete();
 
     /**
-     * Returns the contents of the file item as an array of bytes.
+     * Returns the contents of the HttpData as an array of bytes.
      *
-     * @return the contents of the file item as an array of bytes.
+     * @return the contents of the HttpData as an array of bytes.
      * @throws IOException
      */
     byte[] get() throws IOException;
 
     /**
-     * Returns the content of the file item as a ByteBuf
+     * Returns the content of the HttpData as a ByteBuf
      *
-     * @return the content of the file item as a ByteBuf
+     * @return the content of the HttpData as a ByteBuf
      * @throws IOException
      */
     ByteBuf getByteBuf() throws IOException;
@@ -148,22 +147,22 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
     ByteBuf getChunk(int length) throws IOException;
 
     /**
-     * Returns the contents of the file item as a String, using the default
+     * Returns the contents of the HttpData as a String, using the default
      * character encoding.
      *
-     * @return the contents of the file item as a String, using the default
+     * @return the contents of the HttpData as a String, using the default
      *         character encoding.
      * @throws IOException
      */
     String getString() throws IOException;
 
     /**
-     * Returns the contents of the file item as a String, using the specified
+     * Returns the contents of the HttpData as a String, using the specified
      * charset.
      *
      * @param encoding
      *            the charset to use
-     * @return the contents of the file item as a String, using the specified
+     * @return the contents of the HttpData as a String, using the specified
      *         charset.
      * @throws IOException
      */

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpDataFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpDataFactory.java
@@ -68,14 +68,14 @@ public interface HttpDataFactory {
     void removeHttpDataFromClean(HttpRequest request, InterfaceHttpData data);
 
     /**
-     * Remove all InterfaceHttpData from virtual File storage from clean list for the request
+     * Clean up all attributes and file uploads for the given request
      *
      * @param request associated request
      */
     void cleanRequestHttpData(HttpRequest request);
 
     /**
-     * Remove all InterfaceHttpData from virtual File storage from clean list for all requests
+     * Clean up all attributes and file uploads for all requests
      */
     void cleanAllHttpData();
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -943,7 +943,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
     }
 
     /**
-     * Clean all HttpDatas (on Disk) for the current request.
+     * Clean all {@link HttpData}s for the current request.
      */
     @Override
     public void cleanFiles() {
@@ -953,7 +953,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
     }
 
     /**
-     * Remove the given FileUpload from the list of FileUploads to clean
+     * Remove the given FileUpload from the list of {@link HttpData}s to clean
      */
     @Override
     public void removeHttpDataFromClean(InterfaceHttpData data) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -664,7 +664,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
     }
 
     /**
-     * Remove the given FileUpload from the list of FileUploads to clean
+     * Remove the given FileUpload from the list of {@link HttpData}s to clean
      */
     @Override
     public void removeHttpDataFromClean(InterfaceHttpData data) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/InterfaceHttpPostRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/InterfaceHttpPostRequestDecoder.java
@@ -137,12 +137,12 @@ public interface InterfaceHttpPostRequestDecoder {
     void destroy();
 
     /**
-     * Clean all HttpDatas (on Disk) for the current request.
+     * Clean all {@link HttpData}s for the current request.
      */
     void cleanFiles();
 
     /**
-     * Remove the given FileUpload from the list of FileUploads to clean
+     * Remove the given FileUpload from the list of {@link HttpData}s to clean
      */
     void removeHttpDataFromClean(InterfaceHttpData data);
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -100,7 +100,6 @@ public class HttpPostRequestDecoderTest {
             // Validate data has been parsed correctly as it was passed into request.
             assertEquals("Invalid decoded data [data=" + data.replaceAll("\r", "\\\\r") + ", upload=" + upload + ']',
                 data, upload.getString(CharsetUtil.UTF_8));
-            upload.release();
             decoder.destroy();
         }
     }
@@ -271,7 +270,6 @@ public class HttpPostRequestDecoderTest {
         Attribute aAttr = (Attribute) aDecodedData;
         assertEquals(aData, aAttr.getValue());
 
-        aDecodedData.release();
         aDecoder.destroy();
     }
 


### PR DESCRIPTION
Motivation:

To ensure memory attributes and file uploads are cleaned up properly

Modification:

Modified the data factory to correctly clean up memory uploads and attributes, as well as refactored the methods to ensure something like this is less likely to happen again.

Result:

Fixes #8640. 