### PR TITLE
Change javadoc of ByteBuf#indexOf(...) to match its behaviour

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -2060,11 +2060,14 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
 
     /**
      * Locates the first occurrence of the specified {@code value} in this
-     * buffer.  The search takes place from the specified {@code fromIndex}
-     * (inclusive)  to the specified {@code toIndex} (exclusive).
+     * buffer. The search takes place from the specified {@code fromIndex}
+     * (inclusive) to the specified {@code toIndex} (exclusive).
      * <p>
      * If {@code fromIndex} is greater than {@code toIndex}, the search is
-     * performed in a reversed order.
+     * performed in a reversed order from {@code fromIndex} (exclusive)
+     * down to {@code toIndex} (inclusive).
+     * <p>
+     * Note that the lower index is always included and higher always excluded.
      * <p>
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
      * this buffer.


### PR DESCRIPTION
Motivation

Currently doc != code and so one of them needs to change. Though behaviour as currently documented might be more intuitive, we don't want to break anyone so will adjust the doc instead. See #9503 for discussion.

Modifications

Correct the javadoc of `indexOf(...)` method in `ByteBuf` abstract class.

Results

Correct javadoc