### PR TITLE
Add a utility that checks if SslProvider.JDK supports ALPN

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -148,4 +148,8 @@ public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicati
     static boolean jdkAlpnSupported() {
         return PlatformDependent.javaVersion() >= 9 && Java9SslUtils.supportsAlpn();
     }
+
+    static boolean isAlpnSupported() {
+        return AVAILABLE;
+    }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -432,7 +432,10 @@ public final class OpenSsl {
     /**
      * Returns {@code true} if the used version of openssl supports
      * <a href="https://tools.ietf.org/html/rfc7301">ALPN</a>.
+     *
+     * @deprecated use {@link SslProvider#isAlpnSupported(SslProvider)} with {@link SslProvider#OPENSSL}.
      */
+    @Deprecated
     public static boolean isAlpnSupported() {
         return version() >= 0x10002000L;
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
@@ -35,5 +35,21 @@ public enum SslProvider {
      * OpenSSL-based implementation which does not have finalizers and instead implements {@link ReferenceCounted}.
      */
     @UnstableApi
-    OPENSSL_REFCNT
+    OPENSSL_REFCNT;
+
+    /**
+     * Returns {@code true} if the specified {@link SslProvider} supports
+     * <a href="https://tools.ietf.org/html/rfc7301#section-6">TLS ALPN Extension</a>, {@code false} otherwise.
+     */
+    public static boolean isAlpnSupported(final SslProvider provider) {
+        switch (provider) {
+            case JDK:
+                return JdkAlpnApplicationProtocolNegotiator.isAlpnSupported();
+            case OPENSSL:
+            case OPENSSL_REFCNT:
+                return OpenSsl.isAlpnSupported();
+            default:
+                throw new Error("Unknown SslProvider: " + provider);
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

We have a public utility `OpenSsl.isAlpnSupported()` that helps users to
check if ALPN is available for `SslProvider.OPENSSL`. However, we do not
provide a similar utility for `SslProvider.JDK`. Therefore, users who
configured ALPN with `SslProvider.JDK` will get a runtime exception at
the time when a new connection will be created.

Modifications:

- Add public `SslProvider.isAlpnSupported(SslProvider)` utility method that
returns `true` if the `SslProvider` supports ALPN;
- Deprecate `OpenSsl.isAlpnSupported()`;

Result:

Users can verify if their environment supports ALPN with
`SslProvider.JDK` upfront (at bootstrap), instead of failing with runtime
exception when a new connection will be created.