### PR TITLE
Changed Netty JDK SSL to use default protocols instead of hardcoded supported protocols, to respect jvm flags(eg. jdk.tls.client.protocols)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -79,7 +79,7 @@ public class JdkSslContext extends SslContext {
         DEFAULT_PROVIDER = context.getProvider();
 
         SSLEngine engine = context.createSSLEngine();
-        DEFAULT_PROTOCOLS = defaultProtocols(engine);
+        DEFAULT_PROTOCOLS = defaultProtocols(context, engine);
 
         SUPPORTED_CIPHERS = Collections.unmodifiableSet(supportedCiphers(engine));
         DEFAULT_CIPHERS = Collections.unmodifiableList(defaultCiphers(engine, SUPPORTED_CIPHERS));
@@ -98,9 +98,9 @@ public class JdkSslContext extends SslContext {
         }
     }
 
-    private static String[] defaultProtocols(SSLEngine engine) {
-        // Choose the sensible default list of protocols.
-        final String[] supportedProtocols = engine.getSupportedProtocols();
+    private static String[] defaultProtocols(SSLContext context, SSLEngine engine) {
+        // Choose the sensible default list of protocols that respects JDK flags, eg. jdk.tls.client.protocols
+        final String[] supportedProtocols = context.getDefaultSSLParameters().getProtocols();
         Set<String> supportedProtocolsSet = new HashSet<String>(supportedProtocols.length);
         Collections.addAll(supportedProtocolsSet, supportedProtocols);
         List<String> protocols = new ArrayList<String>();
@@ -261,7 +261,7 @@ public class JdkSslContext extends SslContext {
             SSLEngine engine = sslContext.createSSLEngine();
             try {
                 if (protocols == null) {
-                    this.protocols = defaultProtocols(engine);
+                    this.protocols = defaultProtocols(sslContext, engine);
                 } else {
                     this.protocols = protocols;
                 }


### PR DESCRIPTION
Motivation:

Netty should respect JVM flags to control SSL protocols, eg. `-Djdk.tls.client.protocols`


Modification: 

Changed `JdkSslContext` to use `SSLContext.getDefaultSSLParameters().getProtocols()` instead of `engine.getSupportedProtocols()` which is hardcoded as `SSLv2Hello, SSLv3, TLSv1, TLSv1.1, TLSv1.2`.

Result:

Without `-Djdk.tls.client.protocols`, `SSLContext.getDefaultSSLParameters().getProtocols()` returns `TLSv1, TLSv1.1, TLSv1.2`.

With `-Djdk.tls.client.protocols=TLSv1.2`, `SSLContext.getDefaultSSLParameters().getProtocols()` returns `TLSv1.2`.

Fixes #9706 
