### PR TITLE
Adds DeflateDecoder to native-image.properties of codec-http

### DIFF
--- a/codec-http/src/main/resources/META-INF/native-image/io.netty/codec-http/native-image.properties
+++ b/codec-http/src/main/resources/META-INF/native-image/io.netty/codec-http/native-image.properties
@@ -13,4 +13,4 @@
 # under the License.
 
 Args = --initialize-at-build-time=io.netty \
-       --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder
+       --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder


### PR DESCRIPTION
Motivation:
DeflateDecoder was found to be needed when building spring examples app
with graalvm's native image: https://github.com/spring-projects-experimental/spring-graal-native

Modification:
Adds extra native-image.properties to code-http package

Result:
Both:
https://github.com/spring-projects-experimental/spring-graal-native/tree/master/spring-graal-native-samples/spring-petclinic-jpa
and 
https://github.com/spring-projects-experimental/spring-graal-native/tree/master/spring-graal-native-samples/webflux-netty
Build and run
