### PR TITLE
Guard against busy spinning in HashedWheelTimer when using windows an…

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -571,6 +571,9 @@ public class HashedWheelTimer implements Timer {
                 // See https://github.com/netty/netty/issues/356
                 if (PlatformDependent.isWindows()) {
                     sleepTimeMs = sleepTimeMs / 10 * 10;
+                    if (sleepTimeMs == 0) {
+                        sleepTimeMs = 1;
+                    }
                 }
 
                 try {


### PR DESCRIPTION
…d a tickDuration of 1

Motivation:

We do not correct guard against the gact that when applying our workaround for windows we may end up with a 0 sleep period. In this case we should just sleep for 1 ms.

Modifications:

Guard agains the case when our calculation will produce 0 as sleep time on windows

Result:

Fixes https://github.com/netty/netty/issues/9710.