### PR TITLE
Remove todo in StringEncoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/string/StringEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/string/StringEncoder.java
@@ -51,7 +51,6 @@ import java.util.List;
 @Sharable
 public class StringEncoder extends MessageToMessageEncoder<CharSequence> {
 
-    // TODO Use CharsetEncoder instead.
     private final Charset charset;
 
     /**


### PR DESCRIPTION
Motivation:

StringEncoder is marked @Shareable and CharsetEncoder is not thread-safe.

Modifications:

Remove TODO.

Result:

Less technical debt.