### PR TITLE
Don't pollute FastThreadLocal for Threads with WeakHashMap if maxDela…

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -622,6 +622,10 @@ public abstract class Recycler<T> {
         }
 
         private void pushLater(DefaultHandle<?> item, Thread thread) {
+            if (maxDelayedQueues == 0) {
+                // We don't support recycling across threads and should just drop the item on the floor.
+                return;
+            }
             // we don't want to have a ref to the queue as the value in our weak map
             // so we null it out; to ensure there are no races with restoring it later
             // we impose a memory ordering here (no-op on x86)


### PR DESCRIPTION
…yedQueues == 0

Motivation:

If maxDelayedQueues == 0 we should never put any WeakHashMap into the FastThreadLocal for a Thread.

Modifications:

Check if maxDelayedQueues == 0 and if so return directly. This will ensure we never call FastThreadLocal.initialValue() in this case

Result:

Less overhead / memory usage when maxDelayedQueues == 0