### PR TITLE
Remove an unnecessary expression in NioEventLoop

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -666,11 +666,10 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             // and thus the SelectionKey could be cancelled as part of the deregistration process, but the channel is
             // still healthy and should not be closed.
             // See https://github.com/netty/netty/issues/5125
-            if (eventLoop != this || eventLoop == null) {
-                return;
+            if (eventLoop == this) {
+                // close the channel if the key is not valid anymore
+                unsafe.close(unsafe.voidPromise());
             }
-            // close the channel if the key is not valid anymore
-            unsafe.close(unsafe.voidPromise());
             return;
         }
 


### PR DESCRIPTION
Motivation:

Remove an unnecessary expression to make the code more readable

Modification:

Remove `eventLoop == null`

Result:

Fixes #9725 
