### PR TITLE
Prefer Log4J2 over Log4J1 for default InternalLoggerFactory

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -43,12 +43,12 @@ public abstract class InternalLoggerFactory {
             f.newInstance(name).debug("Using SLF4J as the default logging framework");
         } catch (Throwable ignore1) {
             try {
-                f = Log4JLoggerFactory.INSTANCE;
-                f.newInstance(name).debug("Using Log4J as the default logging framework");
+                f = Log4J2LoggerFactory.INSTANCE;
+                f.newInstance(name).debug("Using Log4J2 as the default logging framework");
             } catch (Throwable ignore2) {
                 try {
-                    f = Log4J2LoggerFactory.INSTANCE;
-                    f.newInstance(name).debug("Using Log4J2 as the default logging framework");
+                    f = Log4JLoggerFactory.INSTANCE;
+                    f.newInstance(name).debug("Using Log4J as the default logging framework");
                 } catch (Throwable ignore3) {
                     f = JdkLoggerFactory.INSTANCE;
                     f.newInstance(name).debug("Using java.util.logging as the default logging framework");


### PR DESCRIPTION
**Motivation:**

The InternalLoggerFactory attempts to instantiate different logger
implementations to discover what is available on the class path,
accepting the first implementation that does not throw an exception.

Currently, the default ordering will attempt to instantiate a Log4j1
logger before Log4j2. For environments where both Log4j1 and Log4j2 are
available, this will result in using the older version. It seems that it
would be more intuitive to prefer the newer version, when possible.

**Modification:**

Change the default ordering to attempt to use the Log4J2LoggerFactory
before the Log4JLoggerFactory.

**Result:**

For environments where both Log4j1 and Log4j2 are available on the class
path (but Slf4J is not available), Netty will now use Log4j2 instead of
Log4j1.