### PR TITLE
Introduce ByteBuf#isContiguous() method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
@@ -117,4 +117,9 @@ public abstract class AbstractDerivedByteBuf extends AbstractByteBuf {
     public ByteBuffer nioBuffer(int index, int length) {
         return unwrap().nioBuffer(index, length);
     }
+
+    @Override
+    public boolean isContiguous() {
+        return unwrap().isContiguous();
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -124,6 +124,11 @@ abstract class AbstractPooledDerivedByteBuf extends AbstractReferenceCountedByte
     }
 
     @Override
+    public boolean isContiguous() {
+        return unwrap().isContiguous();
+    }
+
+    @Override
     public final int nioBufferCount() {
         return unwrap().nioBufferCount();
     }

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -2384,6 +2384,19 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract long memoryAddress();
 
     /**
+     * Returns {@code true} if this {@link ByteBuf} implementation is backed by a single memory region.
+     * Composite buffer implementations must return false even if they currently hold &le; 1 components.
+     * For buffers that return {@code true}, it's guaranteed that a successful call to {@link #discardReadBytes()}
+     * will increase the value of {@link #maxFastWritableBytes()} by the current {@code readerIndex}.
+     * <p>
+     * This method will return {@code false} by default, and a {@code false} return value does not necessarily
+     * mean that the implementation is composite or that it is <i>not</i> backed by a single memory region.
+     */
+    public boolean isContiguous() {
+        return false;
+    }
+
+    /**
      * Decodes this buffer's readable bytes into a string with the specified
      * character set name.  This method is identical to
      * {@code buf.toString(buf.readerIndex(), buf.readableBytes(), charsetName)}.

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -963,6 +963,11 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isContiguous() {
+        return true;
+    }
+
+    @Override
     public String toString(Charset charset) {
         return "";
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -215,6 +215,11 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public final boolean isContiguous() {
+        return true;
+    }
+
+    @Override
     public final int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
         return out.write(duplicateInternalNioBuffer(index, length));
     }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -455,6 +455,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public final boolean isContiguous() {
+        return true;
+    }
+
+    @Override
     public boolean hasArray() {
         return buffer.hasArray();
     }

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -983,6 +983,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isContiguous() {
+        return buf.isContiguous();
+    }
+
+    @Override
     public long memoryAddress() {
         return buf.memoryAddress();
     }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -601,6 +601,11 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public final boolean isContiguous() {
+        return true;
+    }
+
+    @Override
     public ByteBuf copy(int index, int length) {
         ensureAccessible();
         ByteBuffer src;

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -321,6 +321,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public final boolean isContiguous() {
+        return true;
+    }
+
+    @Override
     public byte getByte(int index) {
         ensureAccessible();
         return _getByte(index);

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -53,6 +53,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isContiguous() {
+        return buf.isContiguous();
+    }
+
+    @Override
     public final long memoryAddress() {
         return buf.memoryAddress();
     }

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -109,6 +109,13 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         return false;
     }
 
+    @Test
+    public void testIsContiguous() {
+        ByteBuf buf = newBuffer(4);
+        assertFalse(buf.isContiguous());
+        buf.release();
+    }
+
     /**
      * Tests the "getBufferFor" method
      */

--- a/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
@@ -118,4 +118,11 @@ public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
         assertEquals(buffer.writableBytes(), buffer.maxFastWritableBytes());
         buffer.release();
     }
+
+    @Test
+    public void testIsContiguous() {
+        ByteBuf buf = newBuffer(4);
+        assertTrue(buf.isContiguous());
+        buf.release();
+    }
 }

--- a/buffer/src/test/java/io/netty/buffer/BigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianDirectByteBufTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.*;
 
 import java.nio.ByteOrder;
 
+import org.junit.Test;
+
 /**
  * Tests big-endian direct channel buffers
  */
@@ -34,5 +36,12 @@ public class BigEndianDirectByteBufTest extends AbstractByteBufTest {
 
     protected ByteBuf newDirectBuffer(int length, int maxCapacity) {
         return new UnpooledDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity);
+    }
+
+    @Test
+    public void testIsContiguous() {
+        ByteBuf buf = newBuffer(4);
+        assertTrue(buf.isContiguous());
+        buf.release();
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
@@ -33,6 +33,13 @@ public class DuplicatedByteBufTest extends AbstractByteBufTest {
         return buffer;
     }
 
+    @Test
+    public void testIsContiguous() {
+        ByteBuf buf = newBuffer(4);
+        assertEquals(buf.unwrap().isContiguous(), buf.isContiguous());
+        buf.release();
+    }
+
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullInConstructor() {
         new DuplicatedByteBuf(null);

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -23,6 +23,12 @@ import static org.junit.Assert.*;
 public class EmptyByteBufTest {
 
     @Test
+    public void testIsContiguous() {
+        EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
+        assertTrue(empty.isContiguous());
+    }
+
+    @Test
     public void testIsWritable() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
         assertFalse(empty.isWritable());

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -37,6 +37,13 @@ public class ReadOnlyDirectByteBufferBufTest {
         return ByteBuffer.allocateDirect(size);
     }
 
+    @Test
+    public void testIsContiguous() {
+        ByteBuf buf = buffer(allocate(4).asReadOnlyBuffer());
+        Assert.assertTrue(buf.isContiguous());
+        buf.release();
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testConstructWithWritable() {
         buffer(allocate(1));

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -47,6 +47,13 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         return buffer.slice(offset, length);
     }
 
+    @Test
+    public void testIsContiguous() {
+        ByteBuf buf = newBuffer(4);
+        assertEquals(buf.unwrap().isContiguous(), buf.isContiguous());
+        buf.release();
+    }
+
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullInConstructor() {
         new SlicedByteBuf(null, 0, 0);


### PR DESCRIPTION
Motivation

There's currently no way to determine whether an arbitrary `ByteBuf` behaves internally like a "singluar" buffer or a composite one, and this can be important to know when making decisions about how to manipulate it in an efficient way.

An example of this is the `ByteBuf#discardReadBytes()` method which increases the writable bytes for a contiguous buffer (by `readerIndex`) but does not for a composite one.

Unfortunately `!(buf instanceof CompositeByteBuf)` is not reliable, since for example this will be true in the case of a sliced `CompositeByteBuf` or some third-party composite implementation.

`isContiguous` was chosen over `isComposite` since we want to assume "not contiguous" in the unknown/default case - the doc will make it clear that false does not imply composite.

Modifications

- Add `ByteBuf#isContiguous()` which returns true by default
- Override the "concrete" `ByteBuf` impls to return true and ensure wrapped/derived impls delegate it appropriately
- Include some basic unit tests

Result

Better assumptions/decisions possible when manipulating arbitrary `ByteBuf`s, for example when combining/cumulating them.