### PR TITLE
Upgrade various JDK flavors / version in our docker-compose files

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.11.0-4"
+        java_version : "adopt@1.11.0-5"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.13.0-0"
+        java_version : "adopt@1.13.0-1"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-6.graalvm1.yaml
+++ b/docker/docker-compose.centos-6.graalvm1.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "graalvm@19.1.1"
+        java_version : "graalvm@19.2.1"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.openj9111.yaml
+++ b/docker/docker-compose.centos-6.openj9111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt-openj9@1.11.0-4"
+        java_version : "adopt-openj9@1.11.0-5"
 
   test:
     image: netty:centos-6-openj9-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.11.0-4"
+        java_version : "adopt@1.11.0-5"
 
   test:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.13.0-0"
+        java_version : "adopt@1.13.0-1"
 
   test:
     image: netty:centos-7-1.13


### PR DESCRIPTION
Motivation:

We should always test with the latest JDK versions on our CI.

Modifications:

Update versions

Result:

Use latest JDK versions on our CI