### PR TITLE
Make BlockHound tests run on Java 13

### DIFF
--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -31,6 +31,18 @@
 
   <name>Netty/Transport/BlockHound/Tests</name>
 
+  <profiles>
+    <profile>
+      <id>java13</id>
+      <activation>
+        <jdk>13</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
+  </profiles>
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
## Motivation:
Java 13 requires special flags to be set to make BlockHound work

## Modifications:
- Added jdk13 profile to `transport-blockhound-tests`
- Enabled `-XX:+AllowRedefinitionToAddDeleteMethods` on jdk13

## Result:
The tests work on Java 13, #9738 is fixed
