### PR TITLE
Test that `NettyBlockHoundIntegration` can be loaded with `ServiceLoader`

### DIFF
--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -16,10 +16,13 @@
 package io.netty.util.internal;
 
 import io.netty.util.concurrent.GlobalEventExecutor;
+import io.netty.util.internal.Hidden.NettyBlockHoundIntegration;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import reactor.blockhound.BlockHound;
+import reactor.blockhound.integration.BlockHoundIntegration;
 
+import java.util.ServiceLoader;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +36,17 @@ public class NettyBlockHoundIntegrationTest {
     @BeforeClass
     public static void setUpClass() {
         BlockHound.install();
+    }
+
+    @Test
+    public void testServiceLoader() {
+        for (BlockHoundIntegration integration : ServiceLoader.load(BlockHoundIntegration.class)) {
+            if (integration instanceof NettyBlockHoundIntegration) {
+                return;
+            }
+        }
+
+        fail("NettyBlockHoundIntegration cannot be loaded with ServiceLoader");
     }
 
     @Test


### PR DESCRIPTION
## Motivation:

If something is mis-configured, the "main" test will fail but it is unclear
whether it fails because the integration does not work or it wasn't applied
at all.
Also see:
https://github.com/netty/netty/issues/9738#issuecomment-548416693

## Modifications:

This change adds a test that uses the same mechanism as BlockHound does
(`ServiceLoader`) and checks that `NettyBlockHoundIntegration` is present.

## Result:

It is now clear whether the integration is not working or it wasn't loaded at all.
