### PR TITLE
Send close frame on channel close, when this frame was not send manually

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -30,8 +30,8 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
 public final class WebSocketClientProtocolConfig {
 
     static final WebSocketClientProtocolConfig DEFAULT = new WebSocketClientProtocolConfig(
-        URI.create("https://localhost/"), null, WebSocketVersion.V13, false,
-        EmptyHttpHeaders.INSTANCE, 65536, true, false, true, true, 10000L, -1, false);
+        URI.create("https://localhost/"), null, WebSocketVersion.V13, false, EmptyHttpHeaders.INSTANCE,
+        65536, true, false, true, WebSocketCloseStatus.NORMAL_CLOSURE, true, 10000L, -1, false);
 
     private final URI webSocketUri;
     private final String subprotocol;
@@ -42,6 +42,7 @@ public final class WebSocketClientProtocolConfig {
     private final boolean performMasking;
     private final boolean allowMaskMismatch;
     private final boolean handleCloseFrames;
+    private final WebSocketCloseStatus sendCloseFrame;
     private final boolean dropPongFrames;
     private final long handshakeTimeoutMillis;
     private final long forceCloseTimeoutMillis;
@@ -57,6 +58,7 @@ public final class WebSocketClientProtocolConfig {
         boolean performMasking,
         boolean allowMaskMismatch,
         boolean handleCloseFrames,
+        WebSocketCloseStatus sendCloseFrame,
         boolean dropPongFrames,
         long handshakeTimeoutMillis,
         long forceCloseTimeoutMillis,
@@ -72,6 +74,7 @@ public final class WebSocketClientProtocolConfig {
         this.allowMaskMismatch = allowMaskMismatch;
         this.forceCloseTimeoutMillis = forceCloseTimeoutMillis;
         this.handleCloseFrames = handleCloseFrames;
+        this.sendCloseFrame = sendCloseFrame;
         this.dropPongFrames = dropPongFrames;
         this.handshakeTimeoutMillis = checkPositive(handshakeTimeoutMillis, "handshakeTimeoutMillis");
         this.absoluteUpgradeUrl = absoluteUpgradeUrl;
@@ -113,6 +116,10 @@ public final class WebSocketClientProtocolConfig {
         return handleCloseFrames;
     }
 
+    public WebSocketCloseStatus sendCloseFrame() {
+        return sendCloseFrame;
+    }
+
     public boolean dropPongFrames() {
         return dropPongFrames;
     }
@@ -141,6 +148,7 @@ public final class WebSocketClientProtocolConfig {
             ", performMasking=" + performMasking +
             ", allowMaskMismatch=" + allowMaskMismatch +
             ", handleCloseFrames=" + handleCloseFrames +
+            ", sendCloseFrame=" + sendCloseFrame +
             ", dropPongFrames=" + dropPongFrames +
             ", handshakeTimeoutMillis=" + handshakeTimeoutMillis +
             ", forceCloseTimeoutMillis=" + forceCloseTimeoutMillis +
@@ -166,6 +174,7 @@ public final class WebSocketClientProtocolConfig {
         private boolean performMasking;
         private boolean allowMaskMismatch;
         private boolean handleCloseFrames;
+        private WebSocketCloseStatus sendCloseFrame;
         private boolean dropPongFrames;
         private long handshakeTimeoutMillis;
         private long forceCloseTimeoutMillis;
@@ -174,19 +183,20 @@ public final class WebSocketClientProtocolConfig {
         private Builder(WebSocketClientProtocolConfig clientConfig) {
             ObjectUtil.checkNotNull(clientConfig, "clientConfig");
 
-            this.webSocketUri = clientConfig.webSocketUri();
-            this.subprotocol = clientConfig.subprotocol();
-            this.version = clientConfig.version();
-            this.allowExtensions = clientConfig.allowExtensions();
-            this.customHeaders = clientConfig.customHeaders();
-            this.maxFramePayloadLength = clientConfig.maxFramePayloadLength();
-            this.performMasking = clientConfig.performMasking();
-            this.allowMaskMismatch = clientConfig.allowMaskMismatch();
-            this.handleCloseFrames = clientConfig.handleCloseFrames();
-            this.dropPongFrames = clientConfig.dropPongFrames();
-            this.handshakeTimeoutMillis = clientConfig.handshakeTimeoutMillis();
-            this.forceCloseTimeoutMillis = clientConfig.forceCloseTimeoutMillis();
-            this.absoluteUpgradeUrl = clientConfig.absoluteUpgradeUrl();
+            webSocketUri = clientConfig.webSocketUri();
+            subprotocol = clientConfig.subprotocol();
+            version = clientConfig.version();
+            allowExtensions = clientConfig.allowExtensions();
+            customHeaders = clientConfig.customHeaders();
+            maxFramePayloadLength = clientConfig.maxFramePayloadLength();
+            performMasking = clientConfig.performMasking();
+            allowMaskMismatch = clientConfig.allowMaskMismatch();
+            handleCloseFrames = clientConfig.handleCloseFrames();
+            sendCloseFrame = clientConfig.sendCloseFrame();
+            dropPongFrames = clientConfig.dropPongFrames();
+            handshakeTimeoutMillis = clientConfig.handshakeTimeoutMillis();
+            forceCloseTimeoutMillis = clientConfig.forceCloseTimeoutMillis();
+            absoluteUpgradeUrl = clientConfig.absoluteUpgradeUrl();
         }
 
         /**
@@ -273,6 +283,14 @@ public final class WebSocketClientProtocolConfig {
         }
 
         /**
+         * Close frame to send, when close frame was not send manually. Or {@code null} to disable proper close.
+         */
+        public Builder sendCloseFrame(WebSocketCloseStatus sendCloseFrame) {
+            this.sendCloseFrame = sendCloseFrame;
+            return this;
+        }
+
+        /**
          * {@code true} if pong frames should not be forwarded
          */
         public Builder dropPongFrames(boolean dropPongFrames) {
@@ -319,6 +337,7 @@ public final class WebSocketClientProtocolConfig {
                 performMasking,
                 allowMaskMismatch,
                 handleCloseFrames,
+                sendCloseFrame,
                 dropPongFrames,
                 handshakeTimeoutMillis,
                 forceCloseTimeoutMillis,

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseFrameHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseFrameHandler.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.ObjectUtil;
 
@@ -61,6 +62,7 @@ final class WebSocketCloseFrameHandler extends ChannelOutboundHandlerAdapter {
     @Override
     public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (closeSent != null) {
+            ReferenceCountUtil.release(msg);
             promise.setFailure(new ClosedChannelException());
             return;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseFrameHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseFrameHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.websocketx;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.concurrent.ScheduledFuture;
+import io.netty.util.internal.ObjectUtil;
+
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Send {@link CloseWebSocketFrame} message on channel close, if close frame was not sent before.
+ */
+final class WebSocketCloseFrameHandler extends ChannelOutboundHandlerAdapter {
+    private final WebSocketCloseStatus closeStatus;
+    private final long forceCloseTimeoutMillis;
+    private ChannelPromise closeSent;
+
+    WebSocketCloseFrameHandler(WebSocketCloseStatus closeStatus, long forceCloseTimeoutMillis) {
+        this.closeStatus = ObjectUtil.checkNotNull(closeStatus, "closeStatus");
+        this.forceCloseTimeoutMillis = forceCloseTimeoutMillis;
+    }
+
+    @Override
+    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
+        if (!ctx.channel().isActive()) {
+            ctx.close(promise);
+            return;
+        }
+        if (closeSent == null) {
+            write(ctx, new CloseWebSocketFrame(closeStatus), ctx.newPromise());
+        }
+        flush(ctx);
+        applyCloseSentTimeout(ctx);
+        closeSent.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) {
+                ctx.close(promise);
+            }
+        });
+    }
+
+    @Override
+    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (closeSent != null) {
+            promise.setFailure(new ClosedChannelException());
+            return;
+        }
+        if (msg instanceof CloseWebSocketFrame) {
+            promise = promise.unvoid();
+            closeSent = promise;
+        }
+        super.write(ctx, msg, promise);
+    }
+
+    private void applyCloseSentTimeout(ChannelHandlerContext ctx) {
+        if (closeSent.isDone() || forceCloseTimeoutMillis < 0) {
+            return;
+        }
+
+        final ScheduledFuture<?> timeoutTask = ctx.executor().schedule(new Runnable() {
+            @Override
+            public void run() {
+                if (!closeSent.isDone()) {
+                    closeSent.tryFailure(new WebSocketHandshakeException("send close frame timed out"));
+                }
+            }
+        }, forceCloseTimeoutMillis, TimeUnit.MILLISECONDS);
+
+        closeSent.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) {
+                timeoutTask.cancel(false);
+            }
+        });
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -229,6 +229,10 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
             cp.addBefore(ctx.name(), Utf8FrameValidator.class.getName(),
                     new Utf8FrameValidator());
         }
+        if (serverConfig.sendCloseFrame() != null) {
+            cp.addBefore(ctx.name(), WebSocketCloseFrameHandler.class.getName(),
+                new WebSocketCloseFrameHandler(serverConfig.sendCloseFrame(), serverConfig.forceCloseTimeoutMillis()));
+        }
     }
 
     @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
@@ -78,6 +78,9 @@ public class WebSocket08EncoderDecoderTest {
         Assert.assertEquals(errorMessage, response.reasonText());
         response.release();
 
+        Assert.assertFalse(inChannel.finish());
+        Assert.assertFalse(outChannel.finish());
+
         // Without auto-close
         config = WebSocketDecoderConfig.newBuilder()
             .maxFramePayloadLength(maxPayloadLength)
@@ -91,10 +94,11 @@ public class WebSocket08EncoderDecoderTest {
         response = inChannel.readOutbound();
         Assert.assertNull(response);
 
-        // Release test data
-        binTestData.release();
         Assert.assertFalse(inChannel.finish());
         Assert.assertFalse(outChannel.finish());
+
+        // Release test data
+        binTestData.release();
     }
 
     private void executeProtocolViolationTest(EmbeddedChannel outChannel, EmbeddedChannel inChannel,

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -49,7 +49,11 @@ public class WebSocketHandshakeHandOverTest {
 
     private final class CloseNoOpServerProtocolHandler extends WebSocketServerProtocolHandler {
         CloseNoOpServerProtocolHandler(String websocketPath) {
-            super(websocketPath, null, false);
+            super(WebSocketServerProtocolConfig.newBuilder()
+                .websocketPath(websocketPath)
+                .allowExtensions(false)
+                .sendCloseFrame(null)
+                .build());
         }
 
         @Override


### PR DESCRIPTION
### Motivation:

By default ```CloseWebSocketFrame```s  are handled automatically.
However I need manually manage their sending both on client- and on server-sides.

### Modification:

Send close frame on channel close automatically, when it was not send before explicitly.

### Result:

No more messages like "Connection closed by remote peer" for normal close flows.
