### PR TITLE
Use interval instead of mask comparison for Recycler ratio

### DIFF
--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -185,9 +185,8 @@ public class RecyclerTest {
         thread.start();
         thread.join();
 
-        // As we use a ratioMask of 2 we should see o2 as the first object that could recycled from a different thread.
-        assertSame(recycler.get(), o2);
-        assertNotSame(recycler.get(), o);
+        assertSame(recycler.get(), o);
+        assertNotSame(recycler.get(), o2);
     }
 
     @Test


### PR DESCRIPTION
Motivation

The recycling ratio is currently implemented by comparing with a masked count. The mask operation is not free and also not necessary.

Modification

Change the count(s) to just iterate over the corresponding interval, which requires only a comparison and no mask.

Also make "first time recycle" behaviour consistent and revert change to `RecyclerTest` made in #9727.

Result

Less recycling overhead