### PR TITLE
Constants for fixed-header only MQTT messages

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessage.java
@@ -29,6 +29,17 @@ public class MqttMessage {
     private final Object payload;
     private final DecoderResult decoderResult;
 
+    // Constants for fixed-header only message types with all flags set to 0 (see
+    // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_2.2_-)
+    public static final MqttMessage PINGREQ = new MqttMessage(new MqttFixedHeader(MqttMessageType.PINGREQ, false,
+            MqttQoS.AT_MOST_ONCE, false, 0));
+
+    public static final MqttMessage PINGRESP = new MqttMessage(new MqttFixedHeader(MqttMessageType.PINGRESP, false,
+            MqttQoS.AT_MOST_ONCE, false, 0));
+
+    public static final MqttMessage DISCONNECT = new MqttMessage(new MqttFixedHeader(MqttMessageType.DISCONNECT, false,
+            MqttQoS.AT_MOST_ONCE, false, 0));
+
     public MqttMessage(MqttFixedHeader mqttFixedHeader) {
         this(mqttFixedHeader, null, null);
     }

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -266,17 +266,17 @@ public class MqttCodecTest {
 
     @Test
     public void testPingReqMessage() throws Exception {
-        testMessageWithOnlyFixedHeader(MqttMessageType.PINGREQ);
+        testMessageWithOnlyFixedHeader(MqttMessage.PINGREQ);
     }
 
     @Test
     public void testPingRespMessage() throws Exception {
-        testMessageWithOnlyFixedHeader(MqttMessageType.PINGRESP);
+        testMessageWithOnlyFixedHeader(MqttMessage.PINGRESP);
     }
 
     @Test
     public void testDisconnectMessage() throws Exception {
-        testMessageWithOnlyFixedHeader(MqttMessageType.DISCONNECT);
+        testMessageWithOnlyFixedHeader(MqttMessage.DISCONNECT);
     }
 
     @Test
@@ -450,8 +450,7 @@ public class MqttCodecTest {
         }
     }
 
-    private void testMessageWithOnlyFixedHeader(MqttMessageType messageType) throws Exception {
-        MqttMessage message = createMessageWithFixedHeader(messageType);
+    private void testMessageWithOnlyFixedHeader(MqttMessage message) throws Exception {
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
 
         final List<Object> out = new LinkedList<Object>();


### PR DESCRIPTION
Motivation:

Currently, the only way to create fixed-header only messages PINGREQ,
PINGRESP and DISCONNECT is to explicitly instantiate a `MqttFixedHeader` like:
```
MqttFixedHeader disconnectFixedHeader = new MqttFixedHeader(MqttMessageType.DISCONNECT,
    false, MqttQoS.AT_MOST_ONCE, false, 0);
MqttMessage disconnectMessage = new MqttMessage(disconnectFixedHeader);
```

According to the MQTT spec
(http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718077),
the fixed-header flags for these messages are reserved and  must be set to zero, otherwise
the receiver must close the connection. It's easy to mess this up when
you're creating the header explicitly, for e.g by setting the QoS bit to
`AT_LEAST_ONCE`.

As such, provide static constants for PINGREQ, PINGRESP and
DISCONNECT messages that will set the flags correctly for the developer.

Modification:

Add static constants to MqttMessage class to construct PINGREQ, PINGRESP and
DISCONNECT messages that will set the fixed-header flags correctly to 0.