### PR TITLE
ChunkedWriteHandler::queue should account outbound pending bytes

### DIFF
--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -259,6 +259,18 @@ public final class PendingWriteQueue {
         return write.msg;
     }
 
+    /**
+     * Return the current {@link ChannelPromise} or {@code null} if empty.
+     */
+    public ChannelPromise currentPromise() {
+        assert ctx.executor().inEventLoop();
+        PendingWrite write = head;
+        if (write == null) {
+            return null;
+        }
+        return write.promise;
+    }
+
     private void recycle(PendingWrite write, boolean update) {
         final PendingWrite next = write.next;
         final long writeSize = write.size;


### PR DESCRIPTION
ChunkedWriteHandler::queue should account outbound pending bytes

Motivation:

ChunkedWriteHandler::queue can grow too much in some pathological cases
eg slow disk/network and huge backlog of write&flush tasks.
Offloading pending bytes into ChunkedWriteHandler::queue would make
less effective the back-pressure mechanism provided by
Channel::isWritable, because ChunkedWriteHandler::queue writes aren't
accounted as ChannelOutboundBuffer::pendingBytes.

Modifications:

Replace ChunkedWriteHandler::queue with a PendingWriteQueue

Result:

Channel::isWritable now correctly propagate memory (back-)pressure.
