### PR TITLE
Clean up expired docs.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -495,14 +495,6 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
 
     /**
      * Extract the sub-region of the specified buffer.
-     * <p>
-     * If you are sure that the frame and its content are not accessed after
-     * the current {@link #decode(ChannelHandlerContext, ByteBuf)}
-     * call returns, you can even avoid memory copy by returning the sliced
-     * sub-region (i.e. <tt>return buffer.slice(index, length)</tt>).
-     * It's often useful when you convert the extracted frame into an object.
-     * Refer to the source code of {@link ObjectDecoder} to see how this method
-     * is overridden to avoid memory copy.
      */
     protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
         return buffer.retainedSlice(index, length);


### PR DESCRIPTION

Motivation:
Since the `extractFrame` has used `retainedSlice` to avoid memory copy, we should clean this doc that was expired.

Result:
Better doc.
