### PR TITLE
Don't cache key material if sun.security.ssl.X509KeyManagerImpl is used

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.UnpooledByteBufAllocator;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -66,5 +67,23 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
 
         assertEquals(0, material.refCnt());
         assertEquals(0, material2.refCnt());
+    }
+
+    @Test
+    public void testCacheForSunX509() throws Exception {
+        OpenSslCachingX509KeyManagerFactory factory = new OpenSslCachingX509KeyManagerFactory(
+                super.newKeyManagerFactory("SunX509"));
+        OpenSslKeyMaterialProvider provider = factory.newProvider(PASSWORD);
+        assertThat(provider,
+                CoreMatchers.<OpenSslKeyMaterialProvider>instanceOf(OpenSslCachingKeyMaterialProvider.class));
+    }
+
+    @Test
+    public void testNotCacheForX509() throws Exception {
+        OpenSslCachingX509KeyManagerFactory factory = new OpenSslCachingX509KeyManagerFactory(
+                super.newKeyManagerFactory("PKIX"));
+        OpenSslKeyMaterialProvider provider = factory.newProvider(PASSWORD);
+        assertThat(provider, CoreMatchers.not(
+                CoreMatchers.<OpenSslKeyMaterialProvider>instanceOf(OpenSslCachingKeyMaterialProvider.class)));
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialProviderTest.java
@@ -46,12 +46,16 @@ public class OpenSslKeyMaterialProviderTest {
     }
 
     protected KeyManagerFactory newKeyManagerFactory() throws Exception {
+       return newKeyManagerFactory(KeyManagerFactory.getDefaultAlgorithm());
+    }
+
+    protected KeyManagerFactory newKeyManagerFactory(String algorithm) throws Exception {
         char[] password = PASSWORD.toCharArray();
         final KeyStore keystore = KeyStore.getInstance("PKCS12");
         keystore.load(getClass().getResourceAsStream("mutual_auth_server.p12"), password);
 
         KeyManagerFactory kmf =
-                KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                KeyManagerFactory.getInstance(algorithm);
         kmf.init(keystore, password);
         return kmf;
     }


### PR DESCRIPTION
Motivation:

sun.security.ssl.X509KeyManagerImpl will not use "stable" aliases and so aliases may be changed during invocations. This means caching is useless. Because of this we should disable the cache if its used.

Modifications:

- Disable caching if sun.security.ssl.X509KeyManagerImpl is used
- Add tests

Result:

More protection against https://github.com/netty/netty/issues/9747.