### PR TITLE
Add test to check Connection-Specific headers are removed in HTTP/2 (by HttpConversionUtil.toHttp2Headers)

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -23,7 +23,12 @@ import org.junit.Test;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.COOKIE;
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static io.netty.handler.codec.http.HttpHeaderNames.KEEP_ALIVE;
+import static io.netty.handler.codec.http.HttpHeaderNames.PROXY_CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.TE;
+import static io.netty.handler.codec.http.HttpHeaderNames.TRANSFER_ENCODING;
+import static io.netty.handler.codec.http.HttpHeaderNames.UPGRADE;
 import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
 import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
 import static org.junit.Assert.assertEquals;
@@ -158,5 +163,30 @@ public class HttpConversionUtilTest {
         HttpConversionUtil.addHttp2ToHttpHeaders(5, inHeaders, outHeaders, HttpVersion.HTTP_1_1, false, false);
         assertEquals("no", outHeaders.get("yes"));
         assertEquals("foo=bar; bax=baz", outHeaders.get(COOKIE.toString()));
+    }
+
+    @Test
+    public void connectionSpecificHeadersShouldBeRemoved() {
+        HttpHeaders inHeaders = new DefaultHttpHeaders();
+        inHeaders.add(CONNECTION, "keep-alive");
+        inHeaders.add(HOST, "example.com");
+        @SuppressWarnings("deprecation")
+        AsciiString keepAlive = KEEP_ALIVE;
+        inHeaders.add(keepAlive, "timeout=5, max=1000");
+        @SuppressWarnings("deprecation")
+        AsciiString proxyConnection = PROXY_CONNECTION;
+        inHeaders.add(proxyConnection, "timeout=5, max=1000");
+        inHeaders.add(TRANSFER_ENCODING, "chunked");
+        inHeaders.add(UPGRADE, "h2c");
+
+        Http2Headers outHeaders = new DefaultHttp2Headers();
+        HttpConversionUtil.toHttp2Headers(inHeaders, outHeaders);
+
+        assertFalse(outHeaders.contains(CONNECTION));
+        assertFalse(outHeaders.contains(HOST));
+        assertFalse(outHeaders.contains(keepAlive));
+        assertFalse(outHeaders.contains(proxyConnection));
+        assertFalse(outHeaders.contains(TRANSFER_ENCODING));
+        assertFalse(outHeaders.contains(UPGRADE));
     }
 }


### PR DESCRIPTION
Motivation:
To avoid regression regarding connection-specific headers[1], we should add a test.
[1] https://tools.ietf.org/html/rfc7540#section-8.1.2.2

Modification:
Add test that checks the following headers are removed.
- Connection
- Host
- Keep-Alive
- Proxy-Connection
- Transfer-Encoding
- Upgrade

Result:
There's no functional change.