### PR TITLE
Add one new constructor with threadFactory only

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -53,6 +53,14 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     /**
+     * Create a new instance using the default number of threads and the given {@link ThreadFactory}.
+     */
+    @SuppressWarnings("deprecation")
+    public EpollEventLoopGroup(ThreadFactory threadFactory) {
+        this(0, threadFactory, 0);
+    }
+
+    /**
      * Create a new instance using the specified number of threads and the default {@link ThreadFactory}.
      */
     @SuppressWarnings("deprecation")

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
@@ -50,6 +50,14 @@ public final class KQueueEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     /**
+     * Create a new instance using the default number of threads and the given {@link ThreadFactory}.
+     */
+    @SuppressWarnings("deprecation")
+    public KQueueEventLoopGroup(ThreadFactory threadFactory) {
+        this(0, threadFactory, 0);
+    }
+
+    /**
      * Create a new instance using the specified number of threads and the default {@link ThreadFactory}.
      */
     @SuppressWarnings("deprecation")

--- a/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
@@ -40,6 +40,15 @@ public class DefaultEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     /**
+     * Create a new instance with the default number of threads and the given {@link ThreadFactory}.
+     *
+     * @param threadFactory     the {@link ThreadFactory} or {@code null} to use the default
+     */
+    public DefaultEventLoopGroup(ThreadFactory threadFactory) {
+        this(0, threadFactory);
+    }
+
+    /**
      * Create a new instance
      *
      * @param nThreads          the number of threads to use

--- a/transport/src/main/java/io/netty/channel/local/LocalEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalEventLoopGroup.java
@@ -40,6 +40,15 @@ public class LocalEventLoopGroup extends DefaultEventLoopGroup {
     }
 
     /**
+     * Create a new instance with the default number of threads and the given {@link ThreadFactory}.
+     *
+     * @param threadFactory     the {@link ThreadFactory} or {@code null} to use the default
+     */
+    public LocalEventLoopGroup(ThreadFactory threadFactory) {
+        super(0, threadFactory);
+    }
+
+    /**
      * Create a new instance
      *
      * @param nThreads          the number of threads to use

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -53,6 +53,14 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     /**
+     * Create a new instance using the default number of threads, the given {@link ThreadFactory} and the
+     * {@link SelectorProvider} which is returned by {@link SelectorProvider#provider()}.
+     */
+    public NioEventLoopGroup(ThreadFactory threadFactory) {
+        this(0, threadFactory, SelectorProvider.provider());
+    }
+
+    /**
      * Create a new instance using the specified number of threads, the given {@link ThreadFactory} and the
      * {@link SelectorProvider} which is returned by {@link SelectorProvider#provider()}.
      */


### PR DESCRIPTION
Motivation:

In most cases, we want to use NioEventLoopGroup without setting thread numbers but thread name only. So we need to use followed code:
NioEventLoopGroup boss = new NioEventLoopGroup(0, new DefaultThreadFactory("boss"));
It looks a bit confuse or strange for the number 0 due to we only want to set thread name. So it will be better to add new constructor for this case.

Modifications:
Add one constructor: public NioEventLoopGroup(ThreadFactory threadFactory)

Result:
User can only set thread factory without setting the thread number to 0:
NioEventLoopGroup boss = new NioEventLoopGroup(new DefaultThreadFactory("boss"));