### PR TITLE
Enable generation of test JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1033,6 +1033,12 @@
               <goal>jar-no-fork</goal>
             </goals>
           </execution>
+          <execution>
+            <id>attach-test-sources</id>
+            <goals>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -1234,6 +1240,11 @@
                   <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                 </archive>
               </configuration>
+            </execution>
+            <execution>
+              <goals>
+                <goal>test-jar</goal>
+              </goals>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
Motivation:

Netty currently doesn't build and distribute the test JARs. Having easy access to the test JARs would enable downstream projects (such as GraalVM) to integrate the Netty unit tests in their CI pipeline to ensure continuous compatibility with Netty features. The alternative would be to build Netty from source every time to obtain the test jars, however, depending on the CI setup, that may not always be possible.
 
Modifications:

Modify `pom.xml` to enable generation of test JARs and corresponding source JARs.
 
Result:

Running the Maven build will create the test JARs and corresponding source JARs. This change was tested locally via `mvn install` and the test JARs are correctly copied under the Maven cache. The expectation is that running `mvn deploy` will also copy the additional JARs to the maven repository.
