### PR TITLE
Improve java doc  for MINIMAL_WAIT

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -67,7 +67,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     static final long DEFAULT_MAX_SIZE = 4 * 1024 * 1024L;
 
     /**
-     * Default minimal time to wait
+     * Default minimal time to wait: 10ms
      */
     static final long MINIMAL_WAIT = 10;
 


### PR DESCRIPTION
Motivation:

MINIMAL_WAIT is the key constant. Thus, When we see it we must read more code logic to see if it is ms or ns due to it is named "MINIMAL".  So improving java doc will be better and will keep same style with other constants' java doc.

Modifications:
Improve java doc by add "10ms"  such as DEFAULT_CHECK_INTERVAL with "1s".

Result:

Easier to know it is ms and keep same java doc style with other constants such as DEFAULT_CHECK_INTERVAL.