### PR TITLE
Update to latest JMH version

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <!-- Skip tests by default; run only if -DskipTests=false is specified -->
     <skipTests>true</skipTests>
-    <jmh.version>1.21</jmh.version>
+    <jmh.version>1.22</jmh.version>
     <!-- This only be set when run on linux as on other platforms we just want to include the jar without native
          code -->
     <epoll.classifier />


### PR DESCRIPTION
Motivation

JMH 1.22 was released recently, we might as well use the latest when running benchmarks.

Summary of changes: https://mail.openjdk.java.net/pipermail/jmh-dev/2019-November/002879.html

Modifications

Update jmh dependencies in microbench module from version 1.21 to 1.22.

Result

Benchmarks run using latest JMH