### PR TITLE
Let Channel return directly to pendingWriteBytes.

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -333,6 +333,15 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      */
     protected abstract AbstractUnsafe newUnsafe();
 
+    @Override
+    public long pendingWriteBytes() {
+        ChannelOutboundBuffer buf = unsafe.outboundBuffer();
+        if (buf != null) {
+            return buf.totalPendingWriteBytes();
+        }
+        return -1;
+    }
+
     /**
      * Returns the ID of this channel.
      */

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -187,6 +187,11 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      */
     ByteBufAllocator alloc();
 
+    /**
+     * Return the {@link ChannelOutboundBuffer#totalPendingWriteBytes()} of this channel.
+     */
+    long pendingWriteBytes();
+
     @Override
     Channel read();
 


### PR DESCRIPTION
Motivation:
We have some monitoring systems that we want to be able to monitor some data from the Netty layer, such as the `pendingWriteBytes` for each channel. Adding this method will make this more convenient for getting `pendingWriteByte`.

Result:
Directly get `pendingWriteBytes` of a channel. This makes it easier to monitor the channel.
