### PR TITLE
Fix tests failures introduced by bad cherry-pick of 7ff8cde66f14d9582…

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -216,15 +216,15 @@ public class WebSocketServerProtocolHandlerTest {
         EmbeddedChannel client = createClient();
         EmbeddedChannel server = createServer();
 
-        assertFalse(server.writeInbound(client.readOutbound()));
-        assertFalse(client.writeInbound(server.readOutbound()));
+        assertFalse(server.writeInbound((ByteBuf) client.readOutbound()));
+        assertFalse(client.writeInbound((ByteBuf) server.readOutbound()));
 
         // When server channel closed with explicit close-frame
         assertTrue(server.writeOutbound(new CloseWebSocketFrame(closeStatus)));
         server.close();
 
         // Then client receives provided close-frame
-        assertTrue(client.writeInbound(server.readOutbound()));
+        assertTrue(client.writeInbound((ByteBuf) server.readOutbound()));
         assertFalse(server.isOpen());
 
         CloseWebSocketFrame closeMessage = client.readInbound();
@@ -242,14 +242,14 @@ public class WebSocketServerProtocolHandlerTest {
         EmbeddedChannel client = createClient();
         EmbeddedChannel server = createServer();
 
-        assertFalse(server.writeInbound(client.readOutbound()));
-        assertFalse(client.writeInbound(server.readOutbound()));
+        assertFalse(server.writeInbound((ByteBuf) client.readOutbound()));
+        assertFalse(client.writeInbound((ByteBuf) server.readOutbound()));
 
         // When server channel closed without explicit close-frame
         server.close();
 
         // Then client receives NORMAL_CLOSURE close-frame
-        assertTrue(client.writeInbound(server.readOutbound()));
+        assertTrue(client.writeInbound((ByteBuf) server.readOutbound()));
         assertFalse(server.isOpen());
 
         CloseWebSocketFrame closeMessage = client.readInbound();
@@ -268,15 +268,15 @@ public class WebSocketServerProtocolHandlerTest {
         EmbeddedChannel client = createClient();
         EmbeddedChannel server = createServer();
 
-        assertFalse(server.writeInbound(client.readOutbound()));
-        assertFalse(client.writeInbound(server.readOutbound()));
+        assertFalse(server.writeInbound((ByteBuf) client.readOutbound()));
+        assertFalse(client.writeInbound((ByteBuf) server.readOutbound()));
 
         // When client channel closed with explicit close-frame
         assertTrue(client.writeOutbound(new CloseWebSocketFrame(closeStatus)));
         client.close();
 
         // Then client receives provided close-frame
-        assertFalse(server.writeInbound(client.readOutbound()));
+        assertFalse(server.writeInbound((ByteBuf) client.readOutbound()));
         assertFalse(client.isOpen());
         assertFalse(server.isOpen());
 
@@ -293,14 +293,14 @@ public class WebSocketServerProtocolHandlerTest {
         EmbeddedChannel client = createClient();
         EmbeddedChannel server = createServer();
 
-        assertFalse(server.writeInbound(client.readOutbound()));
-        assertFalse(client.writeInbound(server.readOutbound()));
+        assertFalse(server.writeInbound((ByteBuf) client.readOutbound()));
+        assertFalse(client.writeInbound((ByteBuf) server.readOutbound()));
 
         // When client channel closed without explicit close-frame
         client.close();
 
         // Then server receives NORMAL_CLOSURE close-frame
-        assertFalse(server.writeInbound(client.readOutbound()));
+        assertFalse(server.writeInbound((ByteBuf) client.readOutbound()));
         assertFalse(client.isOpen());
         assertFalse(server.isOpen());
 


### PR DESCRIPTION
…d78480c845406725b042344

Motivation:

7ff8cde66f14d9582d78480c845406725b042344 introduced some tests which needs some small adjustments for master.

Modifications:

Add explicit casts

Result:

master builds again without test failures