### PR TITLE
Add epoll aarch64 maven config and Dockerfile

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -59,6 +59,14 @@
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-aarch_64</classifier>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <classifier>osx-x86_64</classifier>
@@ -86,6 +94,14 @@
           <artifactId>netty-transport-native-epoll</artifactId>
           <version>${project.version}</version>
           <classifier>linux-x86_64</classifier>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-aarch_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -16,7 +16,3 @@ RUN set -x && \
 
 ENV PATH="/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu/bin:${PATH}"
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"
-
-# Get Netty source
-RUN set -x && \
-  git clone https://github.com/netty/netty

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,0 +1,22 @@
+FROM centos:7.6.1810
+
+ARG gcc_version=4.9-2016.02
+ENV GCC_VERSION $gcc_version
+
+# Install requirements
+RUN yum install -y wget tar git make redhat-lsb-core autoconf automake libtool glibc-devel libaio-devel openssl-devel apr-devel lksctp-tools
+
+# Install Java
+RUN yum install -y java-1.8.0-openjdk-devel
+
+# Install aarch64 gcc toolchain
+RUN set -x && \
+  wget https://releases.linaro.org/components/toolchain/binaries/$GCC_VERSION/aarch64-linux-gnu/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz && \
+  tar xvf gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz
+
+ENV PATH="/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu/bin:${PATH}"
+ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"
+
+# Get Netty source
+RUN set -x && \
+  git clone https://github.com/netty/netty

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,4 +16,11 @@ docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-6.1
 docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml run test
 ```
 
+## aarch64 cross compile for transport-native-epoll on X86_64
+
+```
+docker-compose -f docker/docker-compose.yaml run cross-compile-aarch64
+```
+The default version of aarch64 gcc is `4.9-2016.02`. Update the parameter `gcc_version` in `docker-compose.yaml` to use a version you want.
+
 etc, etc

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -58,4 +58,5 @@ services:
       - ..:/code:delegated
       - ~/.m2:/root/.m2:delegated
     # Since we are cross compiling netty-transport-native-epoll as aarch64 which cannot be loaded on x86_64, we add `skipTests` here to skip the test.
-    command: /bin/bash -cl "pushd netty/transport-native-unix-common && ../mvnw clean install -Plinux-aarch64 && popd && pushd netty/transport-native-epoll && ../mvnw clean install -Plinux-aarch64 -DskipTests && popd"
+    command: /bin/bash -cl "pushd ./transport-native-unix-common && ../mvnw clean install -Plinux-aarch64 && popd && pushd ./transport-native-epoll && ../mvnw clean install -Plinux-aarch64 -DskipTests && popd"
+    working_dir: /code

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -52,5 +52,10 @@ services:
   cross-compile-aarch64:
     image: netty:cross_compile_aarch64
     depends_on: [cross-compile-aarch64-runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ..:/code:delegated
+      - ~/.m2:/root/.m2:delegated
     # Since we are cross compiling netty-transport-native-epoll as aarch64 which cannot be loaded on x86_64, we add `skipTests` here to skip the test.
     command: /bin/bash -cl "pushd netty/transport-native-unix-common && ../mvnw clean install -Plinux-aarch64 && popd && pushd netty/transport-native-epoll && ../mvnw clean install -Plinux-aarch64 -DskipTests && popd"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -40,3 +40,17 @@ services:
       - ..:/code:delegated
       - ~/.m2:/root/.m2:delegated
     entrypoint: /bin/bash
+
+  cross-compile-aarch64-runtime-setup:
+    image: netty:cross_compile_aarch64
+    build:
+      context: .
+      dockerfile: Dockerfile.cross_compile_aarch64
+      args:
+        gcc_version : "4.9-2016.02"
+
+  cross-compile-aarch64:
+    image: netty:cross_compile_aarch64
+    depends_on: [cross-compile-aarch64-runtime-setup]
+    # Since we are cross compiling netty-transport-native-epoll as aarch64 which cannot be loaded on x86_64, we add `skipTests` here to skip the test.
+    command: /bin/bash -cl "pushd netty/transport-native-unix-common && ../mvnw clean install -Plinux-aarch64 && popd && pushd netty/transport-native-epoll && ../mvnw clean install -Plinux-aarch64 -DskipTests && popd"

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -210,6 +210,154 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>linux-aarch64</id>
+      <properties>
+        <jni.classifier>${os.detected.name}-aarch64</jni.classifier>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
+              <dependencies>
+                <!-- Provides the 'requireFilesContent' enforcer rule. -->
+                <dependency>
+                  <groupId>com.ceilfors.maven.plugin</groupId>
+                  <artifactId>enforcer-rules</artifactId>
+                  <version>1.2.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-release-environment</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireProperty>
+                      <regexMessage>
+                        Cross compile and Release process must be performed on linux-x86_64.
+                      </regexMessage>
+                      <property>os.detected.classifier</property>
+                      <regex>^linux-x86_64.*</regex>
+                    </requireProperty>
+                    <requireFilesContent>
+                      <message>
+                        Cross compile and Release process must be performed on RHEL 7.6 or its derivatives.
+                      </message>
+                      <files>
+                        <file>/etc/redhat-release</file>
+                      </files>
+                      <content>release 7.6</content>
+                    </requireFilesContent>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <!-- unpack the unix-common static library and include files -->
+              <execution>
+                <id>unpack</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeGroupIds>${project.groupId}</includeGroupIds>
+                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <classifier>${jni.classifier}</classifier>
+                  <outputDirectory>${unix.common.lib.dir}</outputDirectory>
+                  <includes>META-INF/native/**</includes>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>true</overWriteSnapshots>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.fusesource.hawtjni</groupId>
+            <artifactId>maven-hawtjni-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build-native-lib</id>
+                <configuration>
+                  <name>netty_transport_native_epoll_aarch_64</name>
+                  <nativeSourceDirectory>${nativeSourceDirectory}</nativeSourceDirectory>
+                  <libDirectory>${project.build.outputDirectory}</libDirectory>
+                  <!-- We use Maven's artifact classifier instead.
+                       This hack will make the hawtjni plugin to put the native library
+                       under 'META-INF/native' rather than 'META-INF/native/${platform}'. -->
+                  <platform>.</platform>
+                  <configureArgs>
+                    <arg>${jni.compiler.args.ldflags}</arg>
+                    <arg>${jni.compiler.args.cflags}</arg>
+                    <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
+                    <configureArg>--host=aarch64-linux-gnu</configureArg>
+                  </configureArgs>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <!-- Generate the JAR that contains the native library in it. -->
+              <execution>
+                <id>native-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <archive>
+                    <manifest>
+                      <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                    </manifest>
+                    <manifestEntries>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_epoll_aarch_64.so; osname=Linux; processor=aarch_64,*</Bundle-NativeCode>
+                      <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                    </manifestEntries>
+                    <index>true</index>
+                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                  </archive>
+                  <classifier>${jni.classifier}</classifier>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-unix-common</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <!--
+            The unix-common with classifier dependency is optional because it is not a runtime dependency, but a build time
+            dependency to get the static library which is built directly into the shared library generated by this project.
+          -->
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <dependencies>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -208,6 +208,71 @@
       </build>
     </profile>
     <profile>
+      <id>linux-aarch64</id>
+      <properties>
+        <jni.classifier>${os.detected.name}-aarch64</jni.classifier>
+        <jni.platform>linux</jni.platform>
+        <exe.compiler>aarch64-linux-gnu-gcc</exe.compiler>
+        <exe.archiver>aarch64-linux-gnu-ar</exe.archiver>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <!-- Build the additional JAR that contains the native library. -->
+              <execution>
+                <id>native-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <copy todir="${nativeJarWorkdir}">
+                      <zipfileset src="${defaultJarFile}" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeLibOnlyDir}" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+)$" to="META-INF/native/lib/\1" />
+                    </copy>
+                    <copy todir="${nativeJarWorkdir}" includeEmptyDirs="false">
+                      <zipfileset dir="${nativeIncludeDir}" />
+                      <regexpmapper handledirsep="yes" from="^(?:[^/]+/)*([^/]+).h$" to="META-INF/native/include/\1.h" />
+                    </copy>
+                    <jar destfile="${nativeJarFile}" manifest="${nativeJarWorkdir}/META-INF/MANIFEST.MF" basedir="${nativeJarWorkdir}" index="true" excludes="META-INF/MANIFEST.MF,META-INF/INDEX.LIST" />
+                    <attachartifact file="${nativeJarFile}" classifier="${jni.classifier}" type="jar" />
+                  </target>
+                </configuration>
+              </execution>
+              <!-- invoke the make file to build a static library -->
+              <execution>
+                <id>build-native-lib</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <exec executable="${exe.make}" failonerror="true" resolveexecutable="true">
+                      <env key="CC" value="${exe.compiler}" />
+                      <env key="AR" value="${exe.archiver}" />
+                      <env key="LIB_DIR" value="${nativeLibOnlyDir}" />
+                      <env key="OBJ_DIR" value="${nativeObjsOnlyDir}" />
+                      <env key="JNI_PLATFORM" value="${jni.platform}" />
+                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden" />
+                      <env key="LDFLAGS" value="-Wl,--no-as-needed -lrt" />
+                      <env key="LIB_NAME" value="${nativeLibName}" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>freebsd</id>
       <activation>
         <os>


### PR DESCRIPTION
Motivation:

`transport-native-epoll` doesn't have ARM release package. 

Modification:

This PR added cross compile profile for epoll. Then we can easily build aarch64 package on X86 machine. 
This PR added a Dockerfile for the quick release as well. It pre-installed aarch64 gcc toolchain already.

Please note that the cross compile depends on:
1. aarch64 gcc 4.9 toolchain: https://releases.linaro.org/components/toolchain/binaries/4.9-2016.02/aarch64-linux-gnu/
2. CentOS >=7.6 (glibc version >=2.14  which aarch64-gcc requires.)

**Note**: when testing this PR locally before merging, don't forget to fetch it in Dockerfile or add the code in the docker volume.
```
# Get Netty source
RUN set -x && \
  git clone https://github.com/netty/netty

RUN set -x && \
  pushd netty && \
  git config --global user.email "you@example.com" && \
  git config --global user.name "Your Name" && \
  git fetch origin refs/pull/9804/head:pr_9804 && \
  git checkout pr_9804 && \
  git rebase 4.1 && \
  popd
```
Result:

Fixes #8279 
