### PR TITLE
Correctly only active not_x86_64 profile when using a non x86_64 plat…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,9 @@
     <profile>
       <id>not_x86_64</id>
       <activation>
-        <property>
-          <name>os.detected.arch</name>
-          <value>!x86_64</value>
-        </property>
+        <os>
+          <arch>!x86_64</arch>
+        </os>
       </activation>
       <properties>
         <!-- Use no classifier as we only support x86_64 atm-->


### PR DESCRIPTION
…form

Motivation:

21720e4a7865b77d252a4263271663d7ed462440 introduced a change which aimed to enable the not_x86_64 profile when building on a x86_64 platform. Unfortunaly it made an assemption which not holds true and so the profile was already enabled. This lead to the situation that native SSL tests were skipped if non boringssl impl was used.

Modifications:

Fix profile activation to work as expected

Result:

Correctly run all native SSL tests