### PR TITLE
Small simplification to WriteTask optimization

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -1109,7 +1109,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
 
         private void decrementPendingOutboundBytes() {
             if (ESTIMATE_TASK_SIZE_ON_SUBMIT) {
-                ctx.pipeline.decrementPendingOutboundBytes(size >= 0 ? size : (size & Integer.MAX_VALUE));
+                ctx.pipeline.decrementPendingOutboundBytes(size & Integer.MAX_VALUE);
             }
         }
 


### PR DESCRIPTION
Motiviation

#9800 was just merged which consolidates the flush/no-flush `WriteTasks` in `AbstractChannelHandlerContext`, but after looking at the changes again I noticed a tiny simplification that would be good to make imo.

Modification

Remove use of conditional operator in `decrementPendingOutboundBytes()`

Result

Simpler code, one less branch on critical path