### PR TITLE
Fix the transport-native-unix-common build on FreeBSD

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -389,6 +389,9 @@ static jobject _recvFrom(JNIEnv* env, jint fd, void* buffer, jint pos, jint limi
     }
 
 #ifdef IP_RECVORIGDSTADDR
+#if !defined(SOL_IP) && defined(IPPROTO_IP)
+#define SOL_IP IPPROTO_IP
+#endif /* !SOL_IP && IPPROTO_IP */
     if (readLocalAddr) {
         for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
             if (cmsg->cmsg_level == SOL_IP && cmsg->cmsg_type == IP_RECVORIGDSTADDR) {


### PR DESCRIPTION
Motivation:

Modern versions of FreeBSD define IP_RECVORIGDSTADDR, but don't define
SOL_IP.  This causes the build to fail.

Modifications:

The equivalent to SOL_IP on FreeBSD is IPPROTO_IP.  Define SOL_IP as that
if SOL_IP is not defined and IPPROTO_IP is.

Result:

This allows a successful build on FreeBSD