### PR TITLE
Fix some compilation issues

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -456,7 +456,7 @@ public final class SslContextBuilder {
      */
     public SslContextBuilder keyManager(KeyManager keyManager) {
         if (forServer) {
-            checkNotNull(keyManager, "keyManager required for servers");
+            requireNonNull(keyManager, "keyManager required for servers");
         }
         if (keyManager != null) {
             this.keyManagerFactory = new KeyManagerFactoryWrapper(keyManager);

--- a/handler/src/main/java/io/netty/handler/ssl/util/X509KeyManagerWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/X509KeyManagerWrapper.java
@@ -27,11 +27,11 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
 
-@SuppressJava6Requirement(reason = "Usage guarded by java version check")
 final class X509KeyManagerWrapper extends X509ExtendedKeyManager {
 
     private final X509KeyManager delegate;
 
+    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
     X509KeyManagerWrapper(X509KeyManager delegate) {
         this.delegate = checkNotNull(delegate, "delegate");
     }


### PR DESCRIPTION
@SuppressJava6Requirement can not be applied on class, only method and constructor.
No checkNotNull is available here.

Motivation:

I want to make a improvements for netty but fist need to fix tests and compilation to ensure it works.

Modification:

The PR modifies SSL handler which supposedly not covered by CI.

Result:

Netty builds on my PC.
