### PR TITLE
Correctly set writerIndex when EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE is used in all cases

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -684,9 +684,10 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             if (localAddress == null) {
                 localAddress = localAddress();
             }
+            int received = remoteAddress.receivedAmount();
             allocHandle.lastBytesRead(maxDatagramPacketSize <= 0 ?
-                    remoteAddress.receivedAmount() : writable);
-            byteBuf.writerIndex(byteBuf.writerIndex() + allocHandle.lastBytesRead());
+                    received : writable);
+            byteBuf.writerIndex(writerIndex + received);
             allocHandle.incMessagesRead(1);
 
             pipeline().fireChannelRead(new DatagramPacket(byteBuf, localAddress, remoteAddress));


### PR DESCRIPTION

Motivation:

Due a bug we did not correctly set the writerIndex of the ByteBuf when a
user specified EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE but we ended
up with a non scattering read.

Modifications:

- Set writerIndex to the correct value
- Add unit tests

Result:

Fixes https://github.com/netty/netty/issues/9788