### PR TITLE
Use EmbeddedChannel.finishAndReleaseAll() to remove boiler-plate code

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -284,16 +284,7 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
      * @param compressor The compressor for {@code stream}
      */
     void cleanup(Http2Stream stream, EmbeddedChannel compressor) {
-        if (compressor.finish()) {
-            for (;;) {
-                final ByteBuf buf = compressor.readOutbound();
-                if (buf == null) {
-                    break;
-                }
-
-                buf.release();
-            }
-        }
+        compressor.finishAndReleaseAll();
         stream.removeProperty(propertyKey);
     }
 


### PR DESCRIPTION
Motivation:

We can make use of EmbeddedChannel.finishAndReleaseAll() and so remove some code

Modifications:

Use finishAndReleaseAll()

Result:

Less code to maintain