### PR TITLE
Return singleton from getAll if header doesn't exist.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -155,17 +155,22 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     public List<V> getAll(K name) {
         requireNonNull(name, "name");
 
-        LinkedList<V> values = new LinkedList<>();
-
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
         HeaderEntry<K, V> e = entries[i];
-        while (e != null) {
+
+        if (e == null) {
+            return Collections.emptyList();
+        }
+
+        LinkedList<V> values = new LinkedList<>();
+
+         do {
             if (e.hash == h && hashingStrategy.equals(name, e.key)) {
                 values.addFirst(e.getValue());
             }
             e = e.next;
-        }
+        } while (e != null);
         return values;
     }
 


### PR DESCRIPTION
Motivation:

It is more efficient to avoid allocating objects when we don't need to.

Modification:

Don't allocate a `LinkedList` for returning an empty list of header values when the header doesn't exist at all.

I noticed this optimization while working on similar code in Armeria - https://github.com/line/armeria/pull/2295/files

Unfortunately, while there the returned values are all immutable so there's no API change, here there is a change from returning a mutable to immutable list. This might not be ok.

I figured I'd send this out and if it's not reasonable, no worries in closing :)

/cc @trustin 