### PR TITLE
Uniform null pointer check.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -21,6 +21,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -350,9 +351,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         if (endianness == order()) {
             return this;
         }
-        if (endianness == null) {
-            throw new NullPointerException("endianness");
-        }
+        ObjectUtil.checkNotNull(endianness, "endianness");
         return newSwappedByteBuf();
     }
 
@@ -660,9 +659,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int length) {
         checkIndex(index, length);
-        if (src == null) {
-            throw new NullPointerException("src");
-        }
+        ObjectUtil.checkNotNull(src, "src");
         if (checkBounds) {
             checkReadableBounds(src, length);
         }

--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.ReferenceCounted;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.io.DataInput;
@@ -102,9 +103,7 @@ public class ByteBufInputStream extends InputStream implements DataInput {
      *            {@code writerIndex}
      */
     public ByteBufInputStream(ByteBuf buffer, int length, boolean releaseOnClose) {
-        if (buffer == null) {
-            throw new NullPointerException("buffer");
-        }
+        ObjectUtil.checkNotNull(buffer, "buffer");
         if (length < 0) {
             if (releaseOnClose) {
                 buffer.release();

--- a/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.DataOutput;
 import java.io.DataOutputStream;
@@ -45,9 +46,7 @@ public class ByteBufOutputStream extends OutputStream implements DataOutput {
      * Creates a new stream which writes data to the specified {@code buffer}.
      */
     public ByteBufOutputStream(ByteBuf buffer) {
-        if (buffer == null) {
-            throw new NullPointerException("buffer");
-        }
+        ObjectUtil.checkNotNull(buffer, "buffer");
         this.buffer = buffer;
         startIndex = buffer.writerIndex();
     }

--- a/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
@@ -46,8 +46,7 @@ public class ByteBufOutputStream extends OutputStream implements DataOutput {
      * Creates a new stream which writes data to the specified {@code buffer}.
      */
     public ByteBufOutputStream(ByteBuf buffer) {
-        ObjectUtil.checkNotNull(buffer, "buffer");
-        this.buffer = buffer;
+        this.buffer = ObjectUtil.checkNotNull(buffer, "buffer");
         startIndex = buffer.writerIndex();
     }
 

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -62,12 +62,12 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
 
     private CompositeByteBuf(ByteBufAllocator alloc, boolean direct, int maxNumComponents, int initSize) {
         super(AbstractByteBufAllocator.DEFAULT_MAX_CAPACITY);
-        ObjectUtil.checkNotNull(alloc, "alloc");
         if (maxNumComponents < 1) {
             throw new IllegalArgumentException(
                     "maxNumComponents: " + maxNumComponents + " (expected: >= 1)");
         }
-        this.alloc = alloc;
+
+        this.alloc = ObjectUtil.checkNotNull(alloc, "alloc");
         this.direct = direct;
         this.maxNumComponents = maxNumComponents;
         components = newCompArray(initSize, maxNumComponents);

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -62,12 +62,13 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
 
     private CompositeByteBuf(ByteBufAllocator alloc, boolean direct, int maxNumComponents, int initSize) {
         super(AbstractByteBufAllocator.DEFAULT_MAX_CAPACITY);
+
+        this.alloc = ObjectUtil.checkNotNull(alloc, "alloc");
         if (maxNumComponents < 1) {
             throw new IllegalArgumentException(
                     "maxNumComponents: " + maxNumComponents + " (expected: >= 1)");
         }
 
-        this.alloc = ObjectUtil.checkNotNull(alloc, "alloc");
         this.direct = direct;
         this.maxNumComponents = maxNumComponents;
         components = newCompArray(initSize, maxNumComponents);

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -19,6 +19,7 @@ import io.netty.util.ByteProcessor;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.RecyclableArrayList;
 
 import java.io.IOException;
@@ -61,9 +62,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
 
     private CompositeByteBuf(ByteBufAllocator alloc, boolean direct, int maxNumComponents, int initSize) {
         super(AbstractByteBufAllocator.DEFAULT_MAX_CAPACITY);
-        if (alloc == null) {
-            throw new NullPointerException("alloc");
-        }
+        ObjectUtil.checkNotNull(alloc, "alloc");
         if (maxNumComponents < 1) {
             throw new IllegalArgumentException(
                     "maxNumComponents: " + maxNumComponents + " (expected: >= 1)");

--- a/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
@@ -28,8 +28,7 @@ public class DefaultByteBufHolder implements ByteBufHolder {
     private final ByteBuf data;
 
     public DefaultByteBufHolder(ByteBuf data) {
-        ObjectUtil.checkNotNull(data, "data");
-        this.data = data;
+        this.data = ObjectUtil.checkNotNull(data, "data");
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -27,9 +28,7 @@ public class DefaultByteBufHolder implements ByteBufHolder {
     private final ByteBuf data;
 
     public DefaultByteBufHolder(ByteBuf data) {
-        if (data == null) {
-            throw new NullPointerException("data");
-        }
+        ObjectUtil.checkNotNull(data, "data");
         this.data = data;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -20,6 +20,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 import io.netty.util.ByteProcessor;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
@@ -64,9 +65,7 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     private EmptyByteBuf(ByteBufAllocator alloc, ByteOrder order) {
-        if (alloc == null) {
-            throw new NullPointerException("alloc");
-        }
+        ObjectUtil.checkNotNull(alloc, "alloc");
 
         this.alloc = alloc;
         this.order = order;
@@ -120,9 +119,7 @@ public final class EmptyByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
-        if (endianness == null) {
-            throw new NullPointerException("endianness");
-        }
+        ObjectUtil.checkNotNull(endianness, "endianness");
         if (endianness == order()) {
             return this;
         }

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -65,9 +65,7 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     private EmptyByteBuf(ByteBufAllocator alloc, ByteOrder order) {
-        ObjectUtil.checkNotNull(alloc, "alloc");
-
-        this.alloc = alloc;
+        this.alloc = ObjectUtil.checkNotNull(alloc, "alloc");
         this.order = order;
         str = StringUtil.simpleClassName(this) + (order == ByteOrder.BIG_ENDIAN? "BE" : "LE");
     }

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -117,8 +117,7 @@ public final class EmptyByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
-        ObjectUtil.checkNotNull(endianness, "endianness");
-        if (endianness == order()) {
+        if (ObjectUtil.checkNotNull(endianness, "endianness") == order()) {
             return this;
         }
 

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
@@ -62,9 +63,7 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         checkIndex(index, length);
-        if (dst == null) {
-            throw new NullPointerException("dst");
-        }
+        ObjectUtil.checkNotNull(dst, "dst");
         if (dstIndex < 0 || dstIndex > dst.capacity() - length) {
             throw new IndexOutOfBoundsException("dstIndex: " + dstIndex);
         }
@@ -82,9 +81,7 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         checkIndex(index, length);
-        if (dst == null) {
-            throw new NullPointerException("dst");
-        }
+        ObjectUtil.checkNotNull(dst, "dst");
         if (dstIndex < 0 || dstIndex > dst.length - length) {
             throw new IndexOutOfBoundsException(String.format(
                     "dstIndex: %d, length: %d (expected: range(0, %d))", dstIndex, length, dst.length));

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -41,8 +41,7 @@ public class SwappedByteBuf extends ByteBuf {
     private final ByteOrder order;
 
     public SwappedByteBuf(ByteBuf buf) {
-        ObjectUtil.checkNotNull(buf, "buf");
-        this.buf = buf;
+        this.buf = ObjectUtil.checkNotNull(buf, "buf");
         if (buf.order() == ByteOrder.BIG_ENDIAN) {
             order = ByteOrder.LITTLE_ENDIAN;
         } else {
@@ -57,8 +56,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
-        ObjectUtil.checkNotNull(endianness, "endianness");
-        if (endianness == order) {
+        if (ObjectUtil.checkNotNull(endianness, "endianness") == order) {
             return this;
         }
         return buf;

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,9 +41,7 @@ public class SwappedByteBuf extends ByteBuf {
     private final ByteOrder order;
 
     public SwappedByteBuf(ByteBuf buf) {
-        if (buf == null) {
-            throw new NullPointerException("buf");
-        }
+        ObjectUtil.checkNotNull(buf, "buf");
         this.buf = buf;
         if (buf.order() == ByteOrder.BIG_ENDIAN) {
             order = ByteOrder.LITTLE_ENDIAN;
@@ -58,9 +57,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
-        if (endianness == null) {
-            throw new NullPointerException("endianness");
-        }
+        ObjectUtil.checkNotNull(endianness, "endianness");
         if (endianness == order) {
             return this;
         }

--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.buffer.CompositeByteBuf.ByteWrapper;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
@@ -575,9 +576,7 @@ public final class Unpooled {
      * {@code 0} and the length of the encoded string respectively.
      */
     public static ByteBuf copiedBuffer(CharSequence string, Charset charset) {
-        if (string == null) {
-            throw new NullPointerException("string");
-        }
+        ObjectUtil.checkNotNull(string, "string");
 
         if (string instanceof CharBuffer) {
             return copiedBuffer((CharBuffer) string, charset);
@@ -594,9 +593,7 @@ public final class Unpooled {
      */
     public static ByteBuf copiedBuffer(
             CharSequence string, int offset, int length, Charset charset) {
-        if (string == null) {
-            throw new NullPointerException("string");
-        }
+        ObjectUtil.checkNotNull(string, "string");
         if (length == 0) {
             return EMPTY_BUFFER;
         }
@@ -626,9 +623,7 @@ public final class Unpooled {
      * {@code 0} and the length of the encoded string respectively.
      */
     public static ByteBuf copiedBuffer(char[] array, Charset charset) {
-        if (array == null) {
-            throw new NullPointerException("array");
-        }
+        ObjectUtil.checkNotNull(array, "array");
         return copiedBuffer(array, 0, array.length, charset);
     }
 
@@ -639,9 +634,7 @@ public final class Unpooled {
      * {@code 0} and the length of the encoded string respectively.
      */
     public static ByteBuf copiedBuffer(char[] array, int offset, int length, Charset charset) {
-        if (array == null) {
-            throw new NullPointerException("array");
-        }
+        ObjectUtil.checkNotNull(array, "array");
         if (length == 0) {
             return EMPTY_BUFFER;
         }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -15,8 +15,7 @@
  */
 package io.netty.buffer;
 
-import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
-
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
@@ -28,6 +27,8 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
+
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * A NIO {@link ByteBuffer} based buffer. It is recommended to use
@@ -51,9 +52,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
      */
     public UnpooledDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
         super(maxCapacity);
-        if (alloc == null) {
-            throw new NullPointerException("alloc");
-        }
+        ObjectUtil.checkNotNull(alloc, "alloc");
         checkPositiveOrZero(initialCapacity, "initialCapacity");
         checkPositiveOrZero(maxCapacity, "maxCapacity");
         if (initialCapacity > maxCapacity) {
@@ -77,12 +76,8 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     UnpooledDirectByteBuf(ByteBufAllocator alloc, ByteBuffer initialBuffer,
             int maxCapacity, boolean doFree, boolean slice) {
         super(maxCapacity);
-        if (alloc == null) {
-            throw new NullPointerException("alloc");
-        }
-        if (initialBuffer == null) {
-            throw new NullPointerException("initialBuffer");
-        }
+        ObjectUtil.checkNotNull(alloc, "alloc");
+        ObjectUtil.checkNotNull(initialBuffer, "initialBuffer");
         if (!initialBuffer.isDirect()) {
             throw new IllegalArgumentException("initialBuffer is not a direct buffer.");
         }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -50,14 +50,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     public UnpooledHeapByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
         super(maxCapacity);
 
-        checkNotNull(alloc, "alloc");
-
         if (initialCapacity > maxCapacity) {
             throw new IllegalArgumentException(String.format(
                     "initialCapacity(%d) > maxCapacity(%d)", initialCapacity, maxCapacity));
         }
 
-        this.alloc = alloc;
+        this.alloc = checkNotNull(alloc, "alloc");
         setArray(allocateArray(initialCapacity));
         setIndex(0, 0);
     }
@@ -71,15 +69,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     protected UnpooledHeapByteBuf(ByteBufAllocator alloc, byte[] initialArray, int maxCapacity) {
         super(maxCapacity);
 
-        checkNotNull(alloc, "alloc");
         checkNotNull(initialArray, "initialArray");
-
         if (initialArray.length > maxCapacity) {
             throw new IllegalArgumentException(String.format(
                     "initialCapacity(%d) > maxCapacity(%d)", initialArray.length, maxCapacity));
         }
 
-        this.alloc = alloc;
+        this.alloc = checkNotNull(alloc, "alloc");
         setArray(initialArray);
         setIndex(0, initialArray.length);
     }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -69,13 +69,14 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     protected UnpooledHeapByteBuf(ByteBufAllocator alloc, byte[] initialArray, int maxCapacity) {
         super(maxCapacity);
 
+        checkNotNull(alloc, "alloc");
         checkNotNull(initialArray, "initialArray");
         if (initialArray.length > maxCapacity) {
             throw new IllegalArgumentException(String.format(
                     "initialCapacity(%d) > maxCapacity(%d)", initialArray.length, maxCapacity));
         }
 
-        this.alloc = checkNotNull(alloc, "alloc");
+        this.alloc = alloc;
         setArray(initialArray);
         setIndex(0, initialArray.length);
     }

--- a/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
@@ -33,8 +33,7 @@ final class UnreleasableByteBuf extends WrappedByteBuf {
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
-        ObjectUtil.checkNotNull(endianness, "endianness");
-        if (endianness == order()) {
+        if (ObjectUtil.checkNotNull(endianness, "endianness") == order()) {
             return this;
         }
 

--- a/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
@@ -15,6 +15,8 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.nio.ByteOrder;
 
 /**
@@ -31,9 +33,7 @@ final class UnreleasableByteBuf extends WrappedByteBuf {
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
-        if (endianness == null) {
-            throw new NullPointerException("endianness");
-        }
+        ObjectUtil.checkNotNull(endianness, "endianness");
         if (endianness == order()) {
             return this;
         }

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -42,8 +42,7 @@ class WrappedByteBuf extends ByteBuf {
     protected final ByteBuf buf;
 
     protected WrappedByteBuf(ByteBuf buf) {
-        ObjectUtil.checkNotNull(buf, "buf");
-        this.buf = buf;
+        this.buf = ObjectUtil.checkNotNull(buf, "buf");
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -17,6 +17,7 @@
 package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.io.IOException;
@@ -41,9 +42,7 @@ class WrappedByteBuf extends ByteBuf {
     protected final ByteBuf buf;
 
     protected WrappedByteBuf(ByteBuf buf) {
-        if (buf == null) {
-            throw new NullPointerException("buf");
-        }
+        ObjectUtil.checkNotNull(buf, "buf");
         this.buf = buf;
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -58,8 +58,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     private final ByteOrder order;
 
     protected AbstractCompositeByteBufTest(ByteOrder order) {
-        ObjectUtil.checkNotNull(order, "order");
-        this.order = order;
+        this.order = ObjectUtil.checkNotNull(order, "order");
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.Assume;
 import org.junit.Test;
@@ -57,9 +58,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     private final ByteOrder order;
 
     protected AbstractCompositeByteBufTest(ByteOrder order) {
-        if (order == null) {
-            throw new NullPointerException("order");
-        }
+        ObjectUtil.checkNotNull(order, "order");
         this.order = order;
     }
 

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -24,6 +24,7 @@ import io.netty.util.NetUtil;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -76,9 +77,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
             String sourceAddress, String destinationAddress, int sourcePort, int destinationPort,
             List<HAProxyTLV> tlvs) {
 
-        if (proxiedProtocol == null) {
-            throw new NullPointerException("proxiedProtocol");
-        }
+        ObjectUtil.checkNotNull(proxiedProtocol, "proxiedProtocol");
         AddressFamily addrFamily = proxiedProtocol.addressFamily();
 
         checkAddress(sourceAddress, addrFamily);
@@ -106,9 +105,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
      * @throws HAProxyProtocolException  if any portion of the header is invalid
      */
     static HAProxyMessage decodeHeader(ByteBuf header) {
-        if (header == null) {
-            throw new NullPointerException("header");
-        }
+        ObjectUtil.checkNotNull(header, "header");
 
         if (header.readableBytes() < 16) {
             throw new HAProxyProtocolException(
@@ -401,9 +398,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
      * @throws HAProxyProtocolException  if the address is invalid
      */
     private static void checkAddress(String address, AddressFamily addrFamily) {
-        if (addrFamily == null) {
-            throw new NullPointerException("addrFamily");
-        }
+        ObjectUtil.checkNotNull(addrFamily, "addrFamily");
 
         switch (addrFamily) {
             case AF_UNSPEC:
@@ -415,9 +410,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
                 return;
         }
 
-        if (address == null) {
-            throw new NullPointerException("address");
-        }
+        ObjectUtil.checkNotNull(address, "address");
 
         switch (addrFamily) {
             case AF_IPv4:

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
@@ -85,9 +85,7 @@ public class HAProxyTLV extends DefaultByteBufHolder {
      */
     HAProxyTLV(final Type type, final byte typeByteValue, final ByteBuf content) {
         super(content);
-        checkNotNull(type, "type");
-
-        this.type = type;
+        this.type = checkNotNull(type, "type");
         this.typeByteValue = typeByteValue;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultCookie.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
@@ -131,9 +133,7 @@ public class DefaultCookie extends io.netty.handler.codec.http.cookie.DefaultCoo
     @Override
     @Deprecated
     public void setPorts(int... ports) {
-        if (ports == null) {
-            throw new NullPointerException("ports");
-        }
+        ObjectUtil.checkNotNull(ports, "ports");
 
         int[] portsCopy = ports.clone();
         if (portsCopy.length == 0) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpContent.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -29,9 +30,7 @@ public class DefaultHttpContent extends DefaultHttpObject implements HttpContent
      * Creates a new instance with the specified chunk content.
      */
     public DefaultHttpContent(ByteBuf content) {
-        if (content == null) {
-            throw new NullPointerException("content");
-        }
+        ObjectUtil.checkNotNull(content, "content");
         this.content = content;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpContent.java
@@ -30,8 +30,7 @@ public class DefaultHttpContent extends DefaultHttpObject implements HttpContent
      * Creates a new instance with the specified chunk content.
      */
     public DefaultHttpContent(ByteBuf content) {
-        ObjectUtil.checkNotNull(content, "content");
-        this.content = content;
+        this.content = ObjectUtil.checkNotNull(content, "content");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
@@ -91,8 +91,7 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
 
     @Override
     public HttpMessage setProtocolVersion(HttpVersion version) {
-        ObjectUtil.checkNotNull(version, "version");
-        this.version = version;
+        this.version = ObjectUtil.checkNotNull(version, "version");
         return this;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.util.internal.ObjectUtil;
+
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -89,9 +91,7 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
 
     @Override
     public HttpMessage setProtocolVersion(HttpVersion version) {
-        if (version == null) {
-            throw new NullPointerException("version");
-        }
+        ObjectUtil.checkNotNull(version, "version");
         this.version = version;
         return this;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpObject.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpObject.java
@@ -40,8 +40,7 @@ public class DefaultHttpObject implements HttpObject {
 
     @Override
     public void setDecoderResult(DecoderResult decoderResult) {
-        ObjectUtil.checkNotNull(decoderResult, "decoderResult");
-        this.decoderResult = decoderResult;
+        this.decoderResult = ObjectUtil.checkNotNull(decoderResult, "decoderResult");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpObject.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpObject.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.internal.ObjectUtil;
 
 public class DefaultHttpObject implements HttpObject {
 
@@ -39,9 +40,7 @@ public class DefaultHttpObject implements HttpObject {
 
     @Override
     public void setDecoderResult(DecoderResult decoderResult) {
-        if (decoderResult == null) {
-            throw new NullPointerException("decoderResult");
-        }
+        ObjectUtil.checkNotNull(decoderResult, "decoderResult");
         this.decoderResult = decoderResult;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.util.internal.ObjectUtil;
+
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -88,18 +90,14 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
 
     @Override
     public HttpRequest setMethod(HttpMethod method) {
-        if (method == null) {
-            throw new NullPointerException("method");
-        }
+        ObjectUtil.checkNotNull(method, "method");
         this.method = method;
         return this;
     }
 
     @Override
     public HttpRequest setUri(String uri) {
-        if (uri == null) {
-            throw new NullPointerException("uri");
-        }
+        ObjectUtil.checkNotNull(uri, "uri");
         this.uri = uri;
         return this;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -90,15 +90,13 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
 
     @Override
     public HttpRequest setMethod(HttpMethod method) {
-        ObjectUtil.checkNotNull(method, "method");
-        this.method = method;
+        this.method = ObjectUtil.checkNotNull(method, "method");
         return this;
     }
 
     @Override
     public HttpRequest setUri(String uri) {
-        ObjectUtil.checkNotNull(uri, "uri");
-        this.uri = uri;
+        this.uri = ObjectUtil.checkNotNull(uri, "uri");
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.util.internal.ObjectUtil;
+
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -88,9 +90,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
 
     @Override
     public HttpResponse setStatus(HttpResponseStatus status) {
-        if (status == null) {
-            throw new NullPointerException("status");
-        }
+        ObjectUtil.checkNotNull(status, "status");
         this.status = status;
         return this;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -90,8 +90,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
 
     @Override
     public HttpResponse setStatus(HttpResponseStatus status) {
-        ObjectUtil.checkNotNull(status, "status");
-        this.status = status;
+        this.status = ObjectUtil.checkNotNull(status, "status");
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -116,10 +116,8 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
     public HttpClientUpgradeHandler(SourceCodec sourceCodec, UpgradeCodec upgradeCodec,
                                     int maxContentLength) {
         super(maxContentLength);
-        ObjectUtil.checkNotNull(sourceCodec, "sourceCodec");
-        ObjectUtil.checkNotNull(upgradeCodec, "upgradeCodec");
-        this.sourceCodec = sourceCodec;
-        this.upgradeCodec = upgradeCodec;
+        this.sourceCodec = ObjectUtil.checkNotNull(sourceCodec, "sourceCodec");
+        this.upgradeCodec = ObjectUtil.checkNotNull(upgradeCodec, "upgradeCodec");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -18,6 +18,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.AsciiString;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.SocketAddress;
 import java.util.Collection;
@@ -115,12 +116,8 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
     public HttpClientUpgradeHandler(SourceCodec sourceCodec, UpgradeCodec upgradeCodec,
                                     int maxContentLength) {
         super(maxContentLength);
-        if (sourceCodec == null) {
-            throw new NullPointerException("sourceCodec");
-        }
-        if (upgradeCodec == null) {
-            throw new NullPointerException("upgradeCodec");
-        }
+        ObjectUtil.checkNotNull(sourceCodec, "sourceCodec");
+        ObjectUtil.checkNotNull(upgradeCodec, "upgradeCodec");
         this.sourceCodec = sourceCodec;
         this.upgradeCodec = upgradeCodec;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -22,6 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.MessageToMessageCodec;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayDeque;
@@ -362,13 +363,8 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
         private final EmbeddedChannel contentEncoder;
 
         public Result(String targetContentEncoding, EmbeddedChannel contentEncoder) {
-            if (targetContentEncoding == null) {
-                throw new NullPointerException("targetContentEncoding");
-            }
-            if (contentEncoder == null) {
-                throw new NullPointerException("contentEncoder");
-            }
-
+            ObjectUtil.checkNotNull(targetContentEncoding, "targetContentEncoding");
+            ObjectUtil.checkNotNull(contentEncoder, "contentEncoder");
             this.targetContentEncoding = targetContentEncoding;
             this.contentEncoder = contentEncoder;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -363,10 +363,8 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
         private final EmbeddedChannel contentEncoder;
 
         public Result(String targetContentEncoding, EmbeddedChannel contentEncoder) {
-            ObjectUtil.checkNotNull(targetContentEncoding, "targetContentEncoding");
-            ObjectUtil.checkNotNull(contentEncoder, "contentEncoder");
-            this.targetContentEncoding = targetContentEncoding;
-            this.contentEncoder = contentEncoder;
+            this.targetContentEncoding = ObjectUtil.checkNotNull(targetContentEncoding, "targetContentEncoding");
+            this.contentEncoder = ObjectUtil.checkNotNull(contentEncoder, "contentEncoder");
         }
 
         public String targetContentEncoding() {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.Headers;
 import io.netty.handler.codec.HeadersUtils;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.text.ParseException;
 import java.util.Calendar;
@@ -1412,9 +1413,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * @return {@code this}
      */
     public HttpHeaders add(HttpHeaders headers) {
-        if (headers == null) {
-            throw new NullPointerException("headers");
-        }
+        ObjectUtil.checkNotNull(headers, "headers");
         for (Map.Entry<String, String> e: headers) {
             add(e.getKey(), e.getValue());
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import static io.netty.handler.codec.http.HttpConstants.SP;
 import static io.netty.util.ByteProcessor.FIND_ASCII_SPACE;
@@ -540,10 +541,7 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
 
     private HttpResponseStatus(int code, String reasonPhrase, boolean bytes) {
         checkPositiveOrZero(code, "code");
-
-        if (reasonPhrase == null) {
-            throw new NullPointerException("reasonPhrase");
-        }
+        ObjectUtil.checkNotNull(reasonPhrase, "reasonPhrase");
 
         for (int i = 0; i < reasonPhrase.length(); i ++) {
             char c = reasonPhrase.charAt(i);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -27,6 +27,7 @@ import java.util.List;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Utility methods useful in the HTTP context.
@@ -448,9 +449,7 @@ public final class HttpUtil {
      * @throws NullPointerException in case if {@code contentTypeValue == null}
      */
     public static CharSequence getCharsetAsSequence(CharSequence contentTypeValue) {
-        if (contentTypeValue == null) {
-            throw new NullPointerException("contentTypeValue");
-        }
+        ObjectUtil.checkNotNull(contentTypeValue, "contentTypeValue");
 
         int indexOfCharset = AsciiString.indexOfIgnoreCaseAscii(contentTypeValue, CHARSET_EQUALS, 0);
         if (indexOfCharset == AsciiString.INDEX_NOT_FOUND) {
@@ -504,9 +503,7 @@ public final class HttpUtil {
      * @throws NullPointerException in case if {@code contentTypeValue == null}
      */
     public static CharSequence getMimeType(CharSequence contentTypeValue) {
-        if (contentTypeValue == null) {
-            throw new NullPointerException("contentTypeValue");
-        }
+        ObjectUtil.checkNotNull(contentTypeValue, "contentTypeValue");
 
         int indexOfSemicolon = AsciiString.indexOfIgnoreCaseAscii(contentTypeValue, SEMICOLON, 0);
         if (indexOfSemicolon != AsciiString.INDEX_NOT_FOUND) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -19,6 +19,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,9 +56,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
      * returned.
      */
     public static HttpVersion valueOf(String text) {
-        if (text == null) {
-            throw new NullPointerException("text");
-        }
+        ObjectUtil.checkNotNull(text, "text");
 
         text = text.trim();
 
@@ -109,9 +108,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
      *        the {@code "Connection"} header is set to {@code "close"} explicitly.
      */
     public HttpVersion(String text, boolean keepAliveDefault) {
-        if (text == null) {
-            throw new NullPointerException("text");
-        }
+        ObjectUtil.checkNotNull(text, "text");
 
         text = text.trim().toUpperCase();
         if (text.isEmpty()) {
@@ -151,9 +148,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
     private HttpVersion(
             String protocolName, int majorVersion, int minorVersion,
             boolean keepAliveDefault, boolean bytes) {
-        if (protocolName == null) {
-            throw new NullPointerException("protocolName");
-        }
+        ObjectUtil.checkNotNull(protocolName, "protocolName");
 
         protocolName = protocolName.trim().toUpperCase();
         if (protocolName.isEmpty()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http.multipart;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -99,9 +100,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
 
     @Override
     public void setContent(ByteBuf buffer) throws IOException {
-        if (buffer == null) {
-            throw new NullPointerException("buffer");
-        }
+        ObjectUtil.checkNotNull(buffer, "buffer");
         try {
             size = buffer.readableBytes();
             checkSize(size);
@@ -190,9 +189,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             fileChannel = null;
             setCompleted();
         } else {
-            if (buffer == null) {
-                throw new NullPointerException("buffer");
-            }
+            ObjectUtil.checkNotNull(buffer, "buffer");
         }
     }
 
@@ -210,9 +207,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
 
     @Override
     public void setContent(InputStream inputStream) throws IOException {
-        if (inputStream == null) {
-            throw new NullPointerException("inputStream");
-        }
+        ObjectUtil.checkNotNull(inputStream, "inputStream");
         if (file != null) {
             delete();
         }
@@ -341,9 +336,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
 
     @Override
     public boolean renameTo(File dest) throws IOException {
-        if (dest == null) {
-            throw new NullPointerException("dest");
-        }
+        ObjectUtil.checkNotNull(dest, "dest");
         if (file == null) {
             throw new IOException("No file defined so cannot be renamed");
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -40,9 +41,7 @@ public abstract class AbstractHttpData extends AbstractReferenceCounted implemen
     private long maxSize = DefaultHttpDataFactory.MAXSIZE;
 
     protected AbstractHttpData(String name, Charset charset, long size) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
 
         name = REPLACE_PATTERN.matcher(name).replaceAll(" ");
         name = STRIP_PATTERN.matcher(name).replaceAll("");
@@ -96,9 +95,7 @@ public abstract class AbstractHttpData extends AbstractReferenceCounted implemen
 
     @Override
     public void setCharset(Charset charset) {
-        if (charset == null) {
-            throw new NullPointerException("charset");
-        }
+        ObjectUtil.checkNotNull(charset, "charset");
         this.charset = charset;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
@@ -95,8 +95,7 @@ public abstract class AbstractHttpData extends AbstractReferenceCounted implemen
 
     @Override
     public void setCharset(Charset charset) {
-        ObjectUtil.checkNotNull(charset, "charset");
-        this.charset = charset;
+        this.charset = ObjectUtil.checkNotNull(charset, "charset");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http.multipart;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.handler.codec.http.HttpConstants;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,9 +47,7 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
 
     @Override
     public void setContent(ByteBuf buffer) throws IOException {
-        if (buffer == null) {
-            throw new NullPointerException("buffer");
-        }
+        ObjectUtil.checkNotNull(buffer, "buffer");
         long localsize = buffer.readableBytes();
         checkSize(localsize);
         if (definedSize > 0 && definedSize < localsize) {
@@ -65,9 +64,8 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
 
     @Override
     public void setContent(InputStream inputStream) throws IOException {
-        if (inputStream == null) {
-            throw new NullPointerException("inputStream");
-        }
+        ObjectUtil.checkNotNull(inputStream, "inputStream");
+
         ByteBuf buffer = buffer();
         byte[] bytes = new byte[4096 * 4];
         int read = inputStream.read(bytes);
@@ -114,17 +112,14 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
         if (last) {
             setCompleted();
         } else {
-            if (buffer == null) {
-                throw new NullPointerException("buffer");
-            }
+            ObjectUtil.checkNotNull(buffer, "buffer");
         }
     }
 
     @Override
     public void setContent(File file) throws IOException {
-        if (file == null) {
-            throw new NullPointerException("file");
-        }
+        ObjectUtil.checkNotNull(file, "file");
+
         long newsize = file.length();
         if (newsize > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("File too big to be loaded in memory");
@@ -220,9 +215,7 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
 
     @Override
     public boolean renameTo(File dest) throws IOException {
-        if (dest == null) {
-            throw new NullPointerException("dest");
-        }
+        ObjectUtil.checkNotNull(dest, "dest");
         if (byteBuf == null) {
             // empty file
             if (!dest.createNewFile()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskAttribute.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http.multipart;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http.HttpConstants;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -77,9 +78,7 @@ public class DiskAttribute extends AbstractDiskHttpData implements Attribute {
 
     @Override
     public void setValue(String value) throws IOException {
-        if (value == null) {
-            throw new NullPointerException("value");
-        }
+        ObjectUtil.checkNotNull(value, "value");
         byte [] bytes = value.getBytes(getCharset());
         checkSize(bytes.length);
         ByteBuf buffer = wrappedBuffer(bytes);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
@@ -63,8 +63,7 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
 
     @Override
     public void setFilename(String filename) {
-        ObjectUtil.checkNotNull(filename, "filename");
-        this.filename = filename;
+        this.filename = ObjectUtil.checkNotNull(filename, "filename");
     }
 
     @Override
@@ -92,8 +91,7 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
 
     @Override
     public void setContentType(String contentType) {
-        ObjectUtil.checkNotNull(contentType, "contentType");
-        this.contentType = contentType;
+        this.contentType = ObjectUtil.checkNotNull(contentType, "contentType");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,9 +63,7 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
 
     @Override
     public void setFilename(String filename) {
-        if (filename == null) {
-            throw new NullPointerException("filename");
-        }
+        ObjectUtil.checkNotNull(filename, "filename");
         this.filename = filename;
     }
 
@@ -93,9 +92,7 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
 
     @Override
     public void setContentType(String contentType) {
-        if (contentType == null) {
-            throw new NullPointerException("contentType");
-        }
+        ObjectUtil.checkNotNull(contentType, "contentType");
         this.contentType = contentType;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
@@ -21,6 +21,7 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.nio.charset.Charset;
@@ -83,15 +84,10 @@ public class HttpPostRequestDecoder implements InterfaceHttpPostRequestDecoder {
      *             errors
      */
     public HttpPostRequestDecoder(HttpDataFactory factory, HttpRequest request, Charset charset) {
-        if (factory == null) {
-            throw new NullPointerException("factory");
-        }
-        if (request == null) {
-            throw new NullPointerException("request");
-        }
-        if (charset == null) {
-            throw new NullPointerException("charset");
-        }
+        ObjectUtil.checkNotNull(factory, "factory");
+        ObjectUtil.checkNotNull(request, "request");
+        ObjectUtil.checkNotNull(charset, "charset");
+
         // Fill default values
         if (isMultipart(request)) {
             decoder = new HttpPostMultipartRequestDecoder(factory, request, charset);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedInput;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
@@ -310,9 +311,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      *             if the encoding is in error or if the finalize were already done
      */
     public void setBodyHttpDatas(List<InterfaceHttpData> datas) throws ErrorDataEncoderException {
-        if (datas == null) {
-            throw new NullPointerException("datas");
-        }
+        ObjectUtil.checkNotNull(datas, "datas");
         globalBodySize = 0;
         bodyListDatas.clear();
         currentFileUpload = null;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/InternalAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/InternalAttribute.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http.multipart;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.internal.ObjectUtil;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -42,27 +43,21 @@ final class InternalAttribute extends AbstractReferenceCounted implements Interf
     }
 
     public void addValue(String value) {
-        if (value == null) {
-            throw new NullPointerException("value");
-        }
+        ObjectUtil.checkNotNull(value, "value");
         ByteBuf buf = Unpooled.copiedBuffer(value, charset);
         this.value.add(buf);
         size += buf.readableBytes();
     }
 
     public void addValue(String value, int rank) {
-        if (value == null) {
-            throw new NullPointerException("value");
-        }
+        ObjectUtil.checkNotNull(value, "value");
         ByteBuf buf = Unpooled.copiedBuffer(value, charset);
         this.value.add(rank, buf);
         size += buf.readableBytes();
     }
 
     public void setValue(String value, int rank) {
-        if (value == null) {
-            throw new NullPointerException("value");
-        }
+        ObjectUtil.checkNotNull(value, "value");
         ByteBuf buf = Unpooled.copiedBuffer(value, charset);
         ByteBuf old = this.value.set(rank, buf);
         if (old != null) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryAttribute.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http.multipart;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http.HttpConstants;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -66,9 +67,7 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
 
     @Override
     public void setValue(String value) throws IOException {
-        if (value == null) {
-            throw new NullPointerException("value");
-        }
+        ObjectUtil.checkNotNull(value, "value");
         byte [] bytes = value.getBytes(getCharset());
         checkSize(bytes.length);
         ByteBuf buffer = wrappedBuffer(bytes);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
@@ -57,8 +57,7 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
 
     @Override
     public void setFilename(String filename) {
-        ObjectUtil.checkNotNull(filename, "filename");
-        this.filename = filename;
+        this.filename = ObjectUtil.checkNotNull(filename, "filename");
     }
 
     @Override
@@ -86,8 +85,7 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
 
     @Override
     public void setContentType(String contentType) {
-        ObjectUtil.checkNotNull(contentType, "contentType");
-        this.contentType = contentType;
+        this.contentType = ObjectUtil.checkNotNull(contentType, "contentType");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -56,9 +57,7 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
 
     @Override
     public void setFilename(String filename) {
-        if (filename == null) {
-            throw new NullPointerException("filename");
-        }
+        ObjectUtil.checkNotNull(filename, "filename");
         this.filename = filename;
     }
 
@@ -87,9 +86,7 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
 
     @Override
     public void setContentType(String contentType) {
-        if (contentType == null) {
-            throw new NullPointerException("contentType");
-        }
+        ObjectUtil.checkNotNull(contentType, "contentType");
         this.contentType = contentType;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -35,6 +35,7 @@ import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.URI;
 import java.nio.channels.ClosedChannelException;
@@ -231,9 +232,7 @@ public abstract class WebSocketClientHandshaker {
      *            Channel
      */
     public ChannelFuture handshake(Channel channel) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         return handshake(channel, channel.newPromise());
     }
 
@@ -498,9 +497,7 @@ public abstract class WebSocketClientHandshaker {
      *            Closing Frame that was received
      */
     public ChannelFuture close(Channel channel, CloseWebSocketFrame frame) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         return close(channel, frame, channel.newPromise());
     }
 
@@ -515,9 +512,7 @@ public abstract class WebSocketClientHandshaker {
      *            the {@link ChannelPromise} to be notified when the closing handshake is done
      */
     public ChannelFuture close(Channel channel, CloseWebSocketFrame frame, ChannelPromise promise) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         channel.writeAndFlush(frame, promise);
         applyForceCloseTimeout(channel, promise);
         return promise;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -337,9 +337,7 @@ public abstract class WebSocketServerHandshaker {
      *            Closing Frame that was received
      */
     public ChannelFuture close(Channel channel, CloseWebSocketFrame frame) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         return close(channel, frame, channel.newPromise());
     }
 
@@ -354,9 +352,7 @@ public abstract class WebSocketServerHandshaker {
      *            the {@link ChannelPromise} to be notified when the closing handshake is done
      */
     public ChannelFuture close(Channel channel, CloseWebSocketFrame frame, ChannelPromise promise) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         return channel.writeAndFlush(frame, promise).addListener(ChannelFutureListener.CLOSE);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandler.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,9 +51,7 @@ public class WebSocketClientExtensionHandler extends ChannelDuplexHandler {
      *      with fallback configuration.
      */
     public WebSocketClientExtensionHandler(WebSocketClientExtensionHandshaker... extensionHandshakers) {
-        if (extensionHandshakers == null) {
-            throw new NullPointerException("extensionHandshakers");
-        }
+        ObjectUtil.checkNotNull(extensionHandshakers, "extensionHandshakers");
         if (extensionHandshakers.length == 0) {
             throw new IllegalArgumentException("extensionHandshakers must contains at least one handshaker");
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionData.java
@@ -31,10 +31,9 @@ public final class WebSocketExtensionData {
     private final Map<String, String> parameters;
 
     public WebSocketExtensionData(String name, Map<String, String> parameters) {
-        ObjectUtil.checkNotNull(name, "name");
-        ObjectUtil.checkNotNull(parameters, "parameters");
-        this.name = name;
-        this.parameters = Collections.unmodifiableMap(parameters);
+        this.name = ObjectUtil.checkNotNull(name, "name");
+        this.parameters = Collections.unmodifiableMap(
+                ObjectUtil.checkNotNull(parameters, "parameters"));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionData.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http.websocketx.extensions;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.Collections;
 import java.util.Map;
 
@@ -29,12 +31,8 @@ public final class WebSocketExtensionData {
     private final Map<String, String> parameters;
 
     public WebSocketExtensionData(String name, Map<String, String> parameters) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
-        if (parameters == null) {
-            throw new NullPointerException("parameters");
-        }
+        ObjectUtil.checkNotNull(name, "name");
+        ObjectUtil.checkNotNull(parameters, "parameters");
         this.name = name;
         this.parameters = Collections.unmodifiableMap(parameters);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,9 +54,7 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
      *      with fallback configuration.
      */
     public WebSocketServerExtensionHandler(WebSocketServerExtensionHandshaker... extensionHandshakers) {
-        if (extensionHandshakers == null) {
-            throw new NullPointerException("extensionHandshakers");
-        }
+        ObjectUtil.checkNotNull(extensionHandshakers, "extensionHandshakers");
         if (extensionHandshakers.length == 0) {
             throw new IllegalArgumentException("extensionHandshakers must contains at least one handshaker");
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspMethods.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspMethods.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.rtsp;
 
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -117,9 +118,7 @@ public final class RtspMethods {
      * will be returned.  Otherwise, a new instance will be returned.
      */
     public static HttpMethod valueOf(String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
 
         name = name.trim().toUpperCase();
         if (name.isEmpty()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.rtsp;
 
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * The version of RTSP.
@@ -34,9 +35,7 @@ public final class RtspVersions {
      * Otherwise, a new {@link HttpVersion} instance will be returned.
      */
     public static HttpVersion valueOf(String text) {
-        if (text == null) {
-            throw new NullPointerException("text");
-        }
+        ObjectUtil.checkNotNull(text, "text");
 
         text = text.trim().toUpperCase();
         if ("RTSP/1.0".equals(text)) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.spdy;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -44,9 +45,7 @@ public class DefaultSpdyDataFrame extends DefaultSpdyStreamFrame implements Spdy
      */
     public DefaultSpdyDataFrame(int streamId, ByteBuf data) {
         super(streamId);
-        if (data == null) {
-            throw new NullPointerException("data");
-        }
+        ObjectUtil.checkNotNull(data, "data");
         this.data = validate(data);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.java
@@ -45,8 +45,8 @@ public class DefaultSpdyDataFrame extends DefaultSpdyStreamFrame implements Spdy
      */
     public DefaultSpdyDataFrame(int streamId, ByteBuf data) {
         super(streamId);
-        ObjectUtil.checkNotNull(data, "data");
-        this.data = validate(data);
+        this.data = validate(
+                ObjectUtil.checkNotNull(data, "data"));
     }
 
     private static ByteBuf validate(ByteBuf data) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyCodecUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyCodecUtil.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.ObjectUtil;
 
 final class SpdyCodecUtil {
 
@@ -286,9 +287,7 @@ final class SpdyCodecUtil {
      * Validate a SPDY header name.
      */
     static void validateHeaderName(CharSequence name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
         if (name.length() == 0) {
             throw new IllegalArgumentException(
                     "name cannot be length zero");
@@ -319,9 +318,7 @@ final class SpdyCodecUtil {
      * Validate a SPDY header value. Does not validate max length.
      */
     static void validateHeaderValue(CharSequence value) {
-        if (value == null) {
-            throw new NullPointerException("value");
-        }
+        ObjectUtil.checkNotNull(value, "value");
         for (int i = 0; i < value.length(); i ++) {
             char c = value.charAt(i);
             if (c == 0) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -42,6 +42,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Decodes {@link ByteBuf}s into SPDY Frames.
@@ -91,12 +92,8 @@ public class SpdyFrameDecoder {
      * Creates a new instance with the specified parameters.
      */
     public SpdyFrameDecoder(SpdyVersion spdyVersion, SpdyFrameDecoderDelegate delegate, int maxChunkSize) {
-        if (spdyVersion == null) {
-            throw new NullPointerException("spdyVersion");
-        }
-        if (delegate == null) {
-            throw new NullPointerException("delegate");
-        }
+        ObjectUtil.checkNotNull(spdyVersion, "spdyVersion");
+        ObjectUtil.checkNotNull(delegate, "delegate");
         checkPositive(maxChunkSize, "maxChunkSize");
         this.spdyVersion = spdyVersion.getVersion();
         this.delegate = delegate;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -38,7 +38,6 @@ import static io.netty.handler.codec.spdy.SpdyCodecUtil.getSignedInt;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedInt;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedMedium;
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.getUnsignedShort;
-import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -92,12 +91,9 @@ public class SpdyFrameDecoder {
      * Creates a new instance with the specified parameters.
      */
     public SpdyFrameDecoder(SpdyVersion spdyVersion, SpdyFrameDecoderDelegate delegate, int maxChunkSize) {
-        ObjectUtil.checkNotNull(spdyVersion, "spdyVersion");
-        ObjectUtil.checkNotNull(delegate, "delegate");
-        checkPositive(maxChunkSize, "maxChunkSize");
-        this.spdyVersion = spdyVersion.getVersion();
-        this.delegate = delegate;
-        this.maxChunkSize = maxChunkSize;
+        this.spdyVersion = ObjectUtil.checkNotNull(spdyVersion, "spdyVersion").getVersion();
+        this.delegate = ObjectUtil.checkNotNull(delegate, "delegate");
+        this.maxChunkSize = ObjectUtil.checkPositive(maxChunkSize, "maxChunkSize");
         state = State.READ_COMMON_HEADER;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
@@ -35,8 +35,7 @@ public class SpdyFrameEncoder {
      * Creates a new instance with the specified {@code spdyVersion}.
      */
     public SpdyFrameEncoder(SpdyVersion spdyVersion) {
-        ObjectUtil.checkNotNull(spdyVersion, "spdyVersion");
-        version = spdyVersion.getVersion();
+        version = ObjectUtil.checkNotNull(spdyVersion, "spdyVersion").getVersion();
     }
 
     private void writeControlFrameHeader(ByteBuf buffer, int type, byte flags, int length) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameEncoder.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.ObjectUtil;
 
 import java.nio.ByteOrder;
 import java.util.Set;
@@ -34,9 +35,7 @@ public class SpdyFrameEncoder {
      * Creates a new instance with the specified {@code spdyVersion}.
      */
     public SpdyFrameEncoder(SpdyVersion spdyVersion) {
-        if (spdyVersion == null) {
-            throw new NullPointerException("spdyVersion");
-        }
+        ObjectUtil.checkNotNull(spdyVersion, "spdyVersion");
         version = spdyVersion.getVersion();
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoder.java
@@ -17,8 +17,9 @@ package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.ObjectUtil;
 
-import static io.netty.handler.codec.spdy.SpdyCodecUtil.*;
+import static io.netty.handler.codec.spdy.SpdyCodecUtil.getSignedInt;
 
 public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
 
@@ -48,9 +49,7 @@ public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
     }
 
     public SpdyHeaderBlockRawDecoder(SpdyVersion spdyVersion, int maxHeaderSize) {
-        if (spdyVersion == null) {
-            throw new NullPointerException("spdyVersion");
-        }
+        ObjectUtil.checkNotNull(spdyVersion, "spdyVersion");
         this.maxHeaderSize = maxHeaderSize;
         state = State.READ_NUM_HEADERS;
     }
@@ -63,12 +62,8 @@ public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
 
     @Override
     void decode(ByteBufAllocator alloc, ByteBuf headerBlock, SpdyHeadersFrame frame) throws Exception {
-        if (headerBlock == null) {
-            throw new NullPointerException("headerBlock");
-        }
-        if (frame == null) {
-            throw new NullPointerException("frame");
-        }
+        ObjectUtil.checkNotNull(headerBlock, "headerBlock");
+        ObjectUtil.checkNotNull(frame, "frame");
 
         if (cumulation == null) {
             decodeHeaderBlock(headerBlock, frame);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawEncoder.java
@@ -30,8 +30,7 @@ public class SpdyHeaderBlockRawEncoder extends SpdyHeaderBlockEncoder {
     private final int version;
 
     public SpdyHeaderBlockRawEncoder(SpdyVersion version) {
-        ObjectUtil.checkNotNull(version, "version");
-        this.version = version.getVersion();
+        this.version = ObjectUtil.checkNotNull(version, "version").getVersion();
     }
 
     private static void setLengthField(ByteBuf buffer, int writerIndex, int length) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawEncoder.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.Set;
 
@@ -29,9 +30,7 @@ public class SpdyHeaderBlockRawEncoder extends SpdyHeaderBlockEncoder {
     private final int version;
 
     public SpdyHeaderBlockRawEncoder(SpdyVersion version) {
-        if (version == null) {
-            throw new NullPointerException("version");
-        }
+        ObjectUtil.checkNotNull(version, "version");
         this.version = version.getVersion();
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -102,10 +102,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      */
     protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer,
             FullHttpMessage> messageMap, boolean validateHeaders) {
-        ObjectUtil.checkNotNull(version, "version");
-        checkPositive(maxContentLength, "maxContentLength");
-        spdyVersion = version.getVersion();
-        this.maxContentLength = maxContentLength;
+        spdyVersion = ObjectUtil.checkNotNull(version, "version").getVersion();
+        this.maxContentLength = checkPositive(maxContentLength, "maxContentLength");
         this.messageMap = messageMap;
         this.validateHeaders = validateHeaders;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -32,6 +32,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.spdy.SpdyHttpHeaders.Names;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.HashMap;
 import java.util.List;
@@ -101,9 +102,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      */
     protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer,
             FullHttpMessage> messageMap, boolean validateHeaders) {
-        if (version == null) {
-            throw new NullPointerException("version");
-        }
+        ObjectUtil.checkNotNull(version, "version");
         checkPositive(maxContentLength, "maxContentLength");
         spdyVersion = version.getVersion();
         this.maxContentLength = maxContentLength;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpEncoder.java
@@ -28,6 +28,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AsciiString;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.Iterator;
 import java.util.List;
@@ -144,9 +145,7 @@ public class SpdyHttpEncoder extends MessageToMessageEncoder<HttpObject> {
      * @param validateHeaders    validate the header names and values when adding them to the {@link SpdyHeaders}
      */
     public SpdyHttpEncoder(SpdyVersion version, boolean headersToLowerCase, boolean validateHeaders) {
-        if (version == null) {
-            throw new NullPointerException("version");
-        }
+        ObjectUtil.checkNotNull(version, "version");
         this.headersToLowerCase = headersToLowerCase;
         this.validateHeaders = validateHeaders;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.ThrowableUtil;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -70,9 +71,7 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
      *                handle the client endpoint of the connection.
      */
     public SpdySessionHandler(SpdyVersion version, boolean server) {
-        if (version == null) {
-            throw new NullPointerException("version");
-        }
+        ObjectUtil.checkNotNull(version, "version");
         this.server = server;
         minorVersion = version.getMinorVersion();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -71,9 +71,8 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
      *                handle the client endpoint of the connection.
      */
     public SpdySessionHandler(SpdyVersion version, boolean server) {
-        ObjectUtil.checkNotNull(version, "version");
+        this.minorVersion = ObjectUtil.checkNotNull(version, "version").getMinorVersion();
         this.server = server;
-        minorVersion = version.getMinorVersion();
     }
 
     public void setSessionReceiveWindowSize(int sessionReceiveWindowSize) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionStatus.java
@@ -67,10 +67,8 @@ public class SpdySessionStatus implements Comparable<SpdySessionStatus> {
      * {@code statusPhrase}.
      */
     public SpdySessionStatus(int code, String statusPhrase) {
-        ObjectUtil.checkNotNull(statusPhrase, "statusPhrase");
-
+        this.statusPhrase = ObjectUtil.checkNotNull(statusPhrase, "statusPhrase");
         this.code = code;
-        this.statusPhrase = statusPhrase;
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionStatus.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.spdy;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The SPDY session status code and its description.
  */
@@ -65,9 +67,7 @@ public class SpdySessionStatus implements Comparable<SpdySessionStatus> {
      * {@code statusPhrase}.
      */
     public SpdySessionStatus(int code, String statusPhrase) {
-        if (statusPhrase == null) {
-            throw new NullPointerException("statusPhrase");
-        }
+        ObjectUtil.checkNotNull(statusPhrase, "statusPhrase");
 
         this.code = code;
         this.statusPhrase = statusPhrase;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyStreamStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyStreamStatus.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.spdy;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The SPDY stream status code and its description.
  */
@@ -139,9 +141,7 @@ public class SpdyStreamStatus implements Comparable<SpdyStreamStatus> {
                     "0 is not a valid status code for a RST_STREAM");
         }
 
-        if (statusPhrase == null) {
-            throw new NullPointerException("statusPhrase");
-        }
+        ObjectUtil.checkNotNull(statusPhrase, "statusPhrase");
 
         this.code = code;
         this.statusPhrase = statusPhrase;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyStreamStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyStreamStatus.java
@@ -141,10 +141,8 @@ public class SpdyStreamStatus implements Comparable<SpdyStreamStatus> {
                     "0 is not a valid status code for a RST_STREAM");
         }
 
-        ObjectUtil.checkNotNull(statusPhrase, "statusPhrase");
-
+        this.statusPhrase = ObjectUtil.checkNotNull(statusPhrase, "statusPhrase");
         this.code = code;
-        this.statusPhrase = statusPhrase;
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -58,9 +58,7 @@ public final class Http2StreamChannelBootstrap {
      */
     @SuppressWarnings("unchecked")
     public <T> Http2StreamChannelBootstrap option(ChannelOption<T> option, T value) {
-        if (option == null) {
-            throw new NullPointerException("option");
-        }
+        ObjectUtil.checkNotNull(option, "option");
         if (value == null) {
             synchronized (options) {
                 options.remove(option);
@@ -79,9 +77,7 @@ public final class Http2StreamChannelBootstrap {
      */
     @SuppressWarnings("unchecked")
     public <T> Http2StreamChannelBootstrap attr(AttributeKey<T> key, T value) {
-        if (key == null) {
-            throw new NullPointerException("key");
-        }
+        ObjectUtil.checkNotNull(key, "key");
         if (value == null) {
             synchronized (attrs) {
                 attrs.remove(key);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -72,11 +72,10 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
     protected InboundHttp2ToHttpAdapter(Http2Connection connection, int maxContentLength,
                                         boolean validateHttpHeaders, boolean propagateSettings) {
 
-        checkNotNull(connection, "connection");
         if (maxContentLength <= 0) {
             throw new IllegalArgumentException("maxContentLength: " + maxContentLength + " (expected: > 0)");
         }
-        this.connection = connection;
+        this.connection = checkNotNull(connection, "connection");
         this.maxContentLength = maxContentLength;
         this.validateHttpHeaders = validateHttpHeaders;
         this.propagateSettings = propagateSettings;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTest.java
@@ -31,6 +31,7 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.ResourcesUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,9 +58,7 @@ public class HpackTest {
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         File[] files = ResourcesUtil.getFile(HpackTest.class, TEST_DIR).listFiles();
-        if (files == null) {
-            throw new NullPointerException("files");
-        }
+        ObjectUtil.checkNotNull(files, "files");
 
         ArrayList<Object[]> data = new ArrayList<Object[]>();
         for (File file : files) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
@@ -39,7 +39,6 @@ public abstract class AbstractMemcacheObject extends AbstractReferenceCounted im
 
     @Override
     public void setDecoderResult(DecoderResult result) {
-        ObjectUtil.checkNotNull(result, "DecoderResult should not be null.");
-        decoderResult = result;
+        this.decoderResult = ObjectUtil.checkNotNull(result, "DecoderResult should not be null.");
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.memcache;
 
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -38,10 +39,7 @@ public abstract class AbstractMemcacheObject extends AbstractReferenceCounted im
 
     @Override
     public void setDecoderResult(DecoderResult result) {
-        if (result == null) {
-            throw new NullPointerException("DecoderResult should not be null.");
-        }
-
+        ObjectUtil.checkNotNull(result, "DecoderResult should not be null.");
         decoderResult = result;
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.memcache;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
@@ -31,9 +32,7 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
      * Creates a new instance with the specified content.
      */
     public DefaultMemcacheContent(ByteBuf content) {
-        if (content == null) {
-            throw new NullPointerException("Content cannot be null.");
-        }
+        ObjectUtil.checkNotNull(content, "content");
         this.content = content;
     }
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -32,8 +32,7 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
      * Creates a new instance with the specified content.
      */
     public DefaultMemcacheContent(ByteBuf content) {
-        ObjectUtil.checkNotNull(content, "content");
-        this.content = content;
+        this.content = ObjectUtil.checkNotNull(content, "content");
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.memcache.binary;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -48,9 +49,7 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     public DefaultFullBinaryMemcacheRequest(ByteBuf key, ByteBuf extras,
                                             ByteBuf content) {
         super(key, extras);
-        if (content == null) {
-            throw new NullPointerException("Supplied content is null.");
-        }
+        ObjectUtil.checkNotNull(content, "content");
 
         this.content = content;
         setTotalBodyLength(keyLength() + extrasLength() + content.readableBytes());

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -49,9 +49,7 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     public DefaultFullBinaryMemcacheRequest(ByteBuf key, ByteBuf extras,
                                             ByteBuf content) {
         super(key, extras);
-        ObjectUtil.checkNotNull(content, "content");
-
-        this.content = content;
+        this.content = ObjectUtil.checkNotNull(content, "content");
         setTotalBodyLength(keyLength() + extrasLength() + content.readableBytes());
     }
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -49,9 +49,7 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     public DefaultFullBinaryMemcacheResponse(ByteBuf key, ByteBuf extras,
         ByteBuf content) {
         super(key, extras);
-        ObjectUtil.checkNotNull(content, "content");
-
-        this.content = content;
+        this.content = ObjectUtil.checkNotNull(content, "content");
         setTotalBodyLength(keyLength() + extrasLength() + content.readableBytes());
     }
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.memcache.binary;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -48,9 +49,7 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     public DefaultFullBinaryMemcacheResponse(ByteBuf key, ByteBuf extras,
         ByteBuf content) {
         super(key, extras);
-        if (content == null) {
-            throw new NullPointerException("Supplied content is null.");
-        }
+        ObjectUtil.checkNotNull(content, "content");
 
         this.content = content;
         setTotalBodyLength(keyLength() + extrasLength() + content.readableBytes());

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubAckPayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubAckPayload.java
@@ -16,6 +16,7 @@
 
 package io.netty.handler.codec.mqtt;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
@@ -30,9 +31,7 @@ public class MqttSubAckPayload {
     private final List<Integer> grantedQoSLevels;
 
     public MqttSubAckPayload(int... grantedQoSLevels) {
-        if (grantedQoSLevels == null) {
-            throw new NullPointerException("grantedQoSLevels");
-        }
+        ObjectUtil.checkNotNull(grantedQoSLevels, "grantedQoSLevels");
 
         List<Integer> list = new ArrayList<Integer>(grantedQoSLevels.length);
         for (int v: grantedQoSLevels) {
@@ -42,9 +41,7 @@ public class MqttSubAckPayload {
     }
 
     public MqttSubAckPayload(Iterable<Integer> grantedQoSLevels) {
-        if (grantedQoSLevels == null) {
-            throw new NullPointerException("grantedQoSLevels");
-        }
+        ObjectUtil.checkNotNull(grantedQoSLevels, "grantedQoSLevels");
         List<Integer> list = new ArrayList<Integer>();
         for (Integer v: grantedQoSLevels) {
             if (v == null) {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthRequest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.nio.charset.CharsetEncoder;
 
@@ -33,12 +34,8 @@ public final class SocksAuthRequest extends SocksRequest {
 
     public SocksAuthRequest(String username, String password) {
         super(SocksRequestType.AUTH);
-        if (username == null) {
-            throw new NullPointerException("username");
-        }
-        if (password == null) {
-            throw new NullPointerException("username");
-        }
+        ObjectUtil.checkNotNull(username, "username");
+        ObjectUtil.checkNotNull(password, "password");
         final CharsetEncoder asciiEncoder = CharsetUtil.encoder(CharsetUtil.US_ASCII);
         if (!asciiEncoder.canEncode(username) || !asciiEncoder.canEncode(password)) {
             throw new IllegalArgumentException(

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthResponse.java
@@ -30,8 +30,7 @@ public final class SocksAuthResponse extends SocksResponse {
 
     public SocksAuthResponse(SocksAuthStatus authStatus) {
         super(SocksResponseType.AUTH);
-        ObjectUtil.checkNotNull(authStatus, "authStatus");
-        this.authStatus = authStatus;
+        this.authStatus = ObjectUtil.checkNotNull(authStatus, "authStatus");
     }
 
     /**

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthResponse.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * An socks auth response.
@@ -29,9 +30,7 @@ public final class SocksAuthResponse extends SocksResponse {
 
     public SocksAuthResponse(SocksAuthStatus authStatus) {
         super(SocksResponseType.AUTH);
-        if (authStatus == null) {
-            throw new NullPointerException("authStatus");
-        }
+        ObjectUtil.checkNotNull(authStatus, "authStatus");
         this.authStatus = authStatus;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequest.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.socks;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.IDN;
 
@@ -35,15 +36,10 @@ public final class SocksCmdRequest extends SocksRequest {
 
     public SocksCmdRequest(SocksCmdType cmdType, SocksAddressType addressType, String host, int port) {
         super(SocksRequestType.CMD);
-        if (cmdType == null) {
-            throw new NullPointerException("cmdType");
-        }
-        if (addressType == null) {
-            throw new NullPointerException("addressType");
-        }
-        if (host == null) {
-            throw new NullPointerException("host");
-        }
+        ObjectUtil.checkNotNull(cmdType, "cmdType");
+        ObjectUtil.checkNotNull(addressType, "addressType");
+        ObjectUtil.checkNotNull(host, "host");
+
         switch (addressType) {
             case IPv4:
                 if (!NetUtil.isValidIpV4Address(host)) {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponse.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.socks;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.IDN;
 
@@ -61,12 +62,8 @@ public final class SocksCmdResponse extends SocksResponse {
      */
     public SocksCmdResponse(SocksCmdStatus cmdStatus, SocksAddressType addressType, String host, int port) {
         super(SocksResponseType.CMD);
-        if (cmdStatus == null) {
-            throw new NullPointerException("cmdStatus");
-        }
-        if (addressType == null) {
-            throw new NullPointerException("addressType");
-        }
+        ObjectUtil.checkNotNull(cmdStatus, "cmdStatus");
+        ObjectUtil.checkNotNull(addressType, "addressType");
         if (host != null) {
             switch (addressType) {
                 case IPv4:

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitRequest.java
@@ -32,8 +32,7 @@ public final class SocksInitRequest extends SocksRequest {
 
     public SocksInitRequest(List<SocksAuthScheme> authSchemes) {
         super(SocksRequestType.INIT);
-        ObjectUtil.checkNotNull(authSchemes, "authSchemes");
-        this.authSchemes = authSchemes;
+        this.authSchemes = ObjectUtil.checkNotNull(authSchemes, "authSchemes");
     }
 
     /**

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitRequest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -31,9 +32,7 @@ public final class SocksInitRequest extends SocksRequest {
 
     public SocksInitRequest(List<SocksAuthScheme> authSchemes) {
         super(SocksRequestType.INIT);
-        if (authSchemes == null) {
-            throw new NullPointerException("authSchemes");
-        }
+        ObjectUtil.checkNotNull(authSchemes, "authSchemes");
         this.authSchemes = authSchemes;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitResponse.java
@@ -29,8 +29,7 @@ public final class SocksInitResponse extends SocksResponse {
 
     public SocksInitResponse(SocksAuthScheme authScheme) {
         super(SocksResponseType.INIT);
-        ObjectUtil.checkNotNull(authScheme, "authScheme");
-        this.authScheme = authScheme;
+        this.authScheme = ObjectUtil.checkNotNull(authScheme, "authScheme");
     }
 
     /**

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitResponse.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * An socks init response.
@@ -28,9 +29,7 @@ public final class SocksInitResponse extends SocksResponse {
 
     public SocksInitResponse(SocksAuthScheme authScheme) {
         super(SocksResponseType.INIT);
-        if (authScheme == null) {
-            throw new NullPointerException("authScheme");
-        }
+        ObjectUtil.checkNotNull(authScheme, "authScheme");
         this.authScheme = authScheme;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksMessage.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socks;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * An abstract class that defines a SocksMessage, providing common properties for
@@ -30,9 +31,7 @@ public abstract class SocksMessage {
     private final SocksProtocolVersion protocolVersion = SocksProtocolVersion.SOCKS5;
 
     protected SocksMessage(SocksMessageType type) {
-        if (type == null) {
-            throw new NullPointerException("type");
-        }
+        ObjectUtil.checkNotNull(type, "type");
         this.type = type;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksMessage.java
@@ -31,8 +31,7 @@ public abstract class SocksMessage {
     private final SocksProtocolVersion protocolVersion = SocksProtocolVersion.SOCKS5;
 
     protected SocksMessage(SocksMessageType type) {
-        ObjectUtil.checkNotNull(type, "type");
-        this.type = type;
+        this.type = ObjectUtil.checkNotNull(type, "type");
     }
 
     /**

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksRequest.java
@@ -31,8 +31,7 @@ public abstract class SocksRequest extends SocksMessage {
 
     protected SocksRequest(SocksRequestType requestType) {
         super(SocksMessageType.REQUEST);
-        ObjectUtil.checkNotNull(requestType, "requestType");
-        this.requestType = requestType;
+        this.requestType = ObjectUtil.checkNotNull(requestType, "requestType");
     }
 
     /**

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksRequest.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.socks;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * An abstract class that defines a SocksRequest, providing common properties for
  * {@link SocksInitRequest}, {@link SocksAuthRequest}, {@link SocksCmdRequest} and {@link UnknownSocksRequest}.
@@ -29,9 +31,7 @@ public abstract class SocksRequest extends SocksMessage {
 
     protected SocksRequest(SocksRequestType requestType) {
         super(SocksMessageType.REQUEST);
-        if (requestType == null) {
-            throw new NullPointerException("requestType");
-        }
+        ObjectUtil.checkNotNull(requestType, "requestType");
         this.requestType = requestType;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksResponse.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.socks;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * An abstract class that defines a SocksResponse, providing common properties for
  * {@link SocksInitResponse}, {@link SocksAuthResponse}, {@link SocksCmdResponse} and {@link UnknownSocksResponse}.
@@ -29,9 +31,7 @@ public abstract class SocksResponse extends SocksMessage {
 
     protected SocksResponse(SocksResponseType responseType) {
         super(SocksMessageType.RESPONSE);
-        if (responseType == null) {
-            throw new NullPointerException("responseType");
-        }
+        ObjectUtil.checkNotNull(responseType, "responseType");
         this.responseType = responseType;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksResponse.java
@@ -31,8 +31,7 @@ public abstract class SocksResponse extends SocksMessage {
 
     protected SocksResponse(SocksResponseType responseType) {
         super(SocksMessageType.RESPONSE);
-        ObjectUtil.checkNotNull(responseType, "responseType");
-        this.responseType = responseType;
+        this.responseType = ObjectUtil.checkNotNull(responseType, "responseType");
     }
 
     /**

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/AbstractSocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/AbstractSocksMessage.java
@@ -17,6 +17,7 @@
 package io.netty.handler.codec.socksx;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * An abstract {@link SocksMessage}.
@@ -32,9 +33,7 @@ public abstract class AbstractSocksMessage implements SocksMessage {
 
     @Override
     public void setDecoderResult(DecoderResult decoderResult) {
-        if (decoderResult == null) {
-            throw new NullPointerException("decoderResult");
-        }
+        ObjectUtil.checkNotNull(decoderResult, "decoderResult");
         this.decoderResult = decoderResult;
     }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/AbstractSocksMessage.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/AbstractSocksMessage.java
@@ -33,7 +33,6 @@ public abstract class AbstractSocksMessage implements SocksMessage {
 
     @Override
     public void setDecoderResult(DecoderResult decoderResult) {
-        ObjectUtil.checkNotNull(decoderResult, "decoderResult");
-        this.decoderResult = decoderResult;
+        this.decoderResult = ObjectUtil.checkNotNull(decoderResult, "decoderResult");
     }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/SocksPortUnificationServerHandler.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/SocksPortUnificationServerHandler.java
@@ -54,9 +54,7 @@ public class SocksPortUnificationServerHandler extends ByteToMessageDecoder {
      * This constructor is useful when a user wants to use an alternative {@link Socks5AddressEncoder}.
      */
     public SocksPortUnificationServerHandler(Socks5ServerEncoder socks5encoder) {
-        ObjectUtil.checkNotNull(socks5encoder, "socks5encoder");
-
-        this.socks5encoder = socks5encoder;
+        this.socks5encoder = ObjectUtil.checkNotNull(socks5encoder, "socks5encoder");
     }
 
     @Override

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/SocksPortUnificationServerHandler.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/SocksPortUnificationServerHandler.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.socksx.v4.Socks4ServerEncoder;
 import io.netty.handler.codec.socksx.v5.Socks5AddressEncoder;
 import io.netty.handler.codec.socksx.v5.Socks5InitialRequestDecoder;
 import io.netty.handler.codec.socksx.v5.Socks5ServerEncoder;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -53,9 +54,7 @@ public class SocksPortUnificationServerHandler extends ByteToMessageDecoder {
      * This constructor is useful when a user wants to use an alternative {@link Socks5AddressEncoder}.
      */
     public SocksPortUnificationServerHandler(Socks5ServerEncoder socks5encoder) {
-        if (socks5encoder == null) {
-            throw new NullPointerException("socks5encoder");
-        }
+        ObjectUtil.checkNotNull(socks5encoder, "socks5encoder");
 
         this.socks5encoder = socks5encoder;
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandRequest.java
@@ -51,16 +51,13 @@ public class DefaultSocks4CommandRequest extends AbstractSocks4Message implement
      * @param userId the {@code USERID} field of the request
      */
     public DefaultSocks4CommandRequest(Socks4CommandType type, String dstAddr, int dstPort, String userId) {
-        ObjectUtil.checkNotNull(type, "type");
-        ObjectUtil.checkNotNull(dstAddr, "dstAddr");
-        ObjectUtil.checkNotNull(userId, "userId");
         if (dstPort <= 0 || dstPort >= 65536) {
             throw new IllegalArgumentException("dstPort: " + dstPort + " (expected: 1~65535)");
         }
-
-        this.userId = userId;
-        this.type = type;
-        this.dstAddr = IDN.toASCII(dstAddr);
+        this.type = ObjectUtil.checkNotNull(type, "type");
+        this.dstAddr = IDN.toASCII(
+                ObjectUtil.checkNotNull(dstAddr, "dstAddr"));
+        this.userId = ObjectUtil.checkNotNull(userId, "userId");
         this.dstPort = dstPort;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandRequest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socksx.v4;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.net.IDN;
@@ -50,17 +51,11 @@ public class DefaultSocks4CommandRequest extends AbstractSocks4Message implement
      * @param userId the {@code USERID} field of the request
      */
     public DefaultSocks4CommandRequest(Socks4CommandType type, String dstAddr, int dstPort, String userId) {
-        if (type == null) {
-            throw new NullPointerException("type");
-        }
-        if (dstAddr == null) {
-            throw new NullPointerException("dstAddr");
-        }
+        ObjectUtil.checkNotNull(type, "type");
+        ObjectUtil.checkNotNull(dstAddr, "dstAddr");
+        ObjectUtil.checkNotNull(userId, "userId");
         if (dstPort <= 0 || dstPort >= 65536) {
             throw new IllegalArgumentException("dstPort: " + dstPort + " (expected: 1~65535)");
-        }
-        if (userId == null) {
-            throw new NullPointerException("userId");
         }
 
         this.userId = userId;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandResponse.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.socksx.v4;
 
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -45,9 +46,7 @@ public class DefaultSocks4CommandResponse extends AbstractSocks4Message implemen
      * @param dstPort the {@code DSTPORT} field of the response
      */
     public DefaultSocks4CommandResponse(Socks4CommandStatus status, String dstAddr, int dstPort) {
-        if (status == null) {
-            throw new NullPointerException("cmdStatus");
-        }
+        ObjectUtil.checkNotNull(status, "cmdStatus");
         if (dstAddr != null) {
             if (!NetUtil.isValidIpV4Address(dstAddr)) {
                 throw new IllegalArgumentException(

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandResponse.java
@@ -46,7 +46,6 @@ public class DefaultSocks4CommandResponse extends AbstractSocks4Message implemen
      * @param dstPort the {@code DSTPORT} field of the response
      */
     public DefaultSocks4CommandResponse(Socks4CommandStatus status, String dstAddr, int dstPort) {
-        ObjectUtil.checkNotNull(status, "cmdStatus");
         if (dstAddr != null) {
             if (!NetUtil.isValidIpV4Address(dstAddr)) {
                 throw new IllegalArgumentException(
@@ -57,7 +56,7 @@ public class DefaultSocks4CommandResponse extends AbstractSocks4Message implemen
             throw new IllegalArgumentException("dstPort: " + dstPort + " (expected: 0~65535)");
         }
 
-        this.status = status;
+        this.status = ObjectUtil.checkNotNull(status, "cmdStatus");
         this.dstAddr = dstAddr;
         this.dstPort = dstPort;
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4CommandStatus.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4CommandStatus.java
@@ -51,10 +51,8 @@ public class Socks4CommandStatus implements Comparable<Socks4CommandStatus> {
     }
 
     public Socks4CommandStatus(int byteValue, String name) {
-        ObjectUtil.checkNotNull(name, "name");
-
+        this.name = ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
-        this.name = name;
     }
 
     public byte byteValue() {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4CommandStatus.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4CommandStatus.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.socksx.v4;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The status of {@link Socks4CommandResponse}.
  */
@@ -49,9 +51,7 @@ public class Socks4CommandStatus implements Comparable<Socks4CommandStatus> {
     }
 
     public Socks4CommandStatus(int byteValue, String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
 
         this.byteValue = (byte) byteValue;
         this.name = name;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4CommandType.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4CommandType.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.socksx.v4;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The type of {@link Socks4CommandRequest}.
  */
@@ -43,9 +45,7 @@ public class Socks4CommandType implements Comparable<Socks4CommandType> {
     }
 
     public Socks4CommandType(int byteValue, String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
         this.name = name;
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4CommandType.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4CommandType.java
@@ -45,9 +45,8 @@ public class Socks4CommandType implements Comparable<Socks4CommandType> {
     }
 
     public Socks4CommandType(int byteValue, String name) {
-        ObjectUtil.checkNotNull(name, "name");
+        this.name = ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
-        this.name = name;
     }
 
     public byte byteValue() {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.java
@@ -35,7 +35,6 @@ public final class DefaultSocks5CommandRequest extends AbstractSocks5Message imp
     public DefaultSocks5CommandRequest(
             Socks5CommandType type, Socks5AddressType dstAddrType, String dstAddr, int dstPort) {
 
-        ObjectUtil.checkNotNull(type, "type");
         ObjectUtil.checkNotNull(dstAddrType, "dstAddrType");
         ObjectUtil.checkNotNull(dstAddr, "dstAddr");
 
@@ -58,7 +57,7 @@ public final class DefaultSocks5CommandRequest extends AbstractSocks5Message imp
             throw new IllegalArgumentException("dstPort: " + dstPort + " (expected: 0~65535)");
         }
 
-        this.type = type;
+        this.type = ObjectUtil.checkNotNull(type, "type");
         this.dstAddrType = dstAddrType;
         this.dstAddr = dstAddr;
         this.dstPort = dstPort;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.socksx.v5;
 
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.net.IDN;
@@ -34,15 +35,9 @@ public final class DefaultSocks5CommandRequest extends AbstractSocks5Message imp
     public DefaultSocks5CommandRequest(
             Socks5CommandType type, Socks5AddressType dstAddrType, String dstAddr, int dstPort) {
 
-        if (type == null) {
-            throw new NullPointerException("type");
-        }
-        if (dstAddrType == null) {
-            throw new NullPointerException("dstAddrType");
-        }
-        if (dstAddr == null) {
-            throw new NullPointerException("dstAddr");
-        }
+        ObjectUtil.checkNotNull(type, "type");
+        ObjectUtil.checkNotNull(dstAddrType, "dstAddrType");
+        ObjectUtil.checkNotNull(dstAddr, "dstAddr");
 
         if (dstAddrType == Socks5AddressType.IPv4) {
             if (!NetUtil.isValidIpV4Address(dstAddr)) {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.java
@@ -35,6 +35,7 @@ public final class DefaultSocks5CommandRequest extends AbstractSocks5Message imp
     public DefaultSocks5CommandRequest(
             Socks5CommandType type, Socks5AddressType dstAddrType, String dstAddr, int dstPort) {
 
+        this.type = ObjectUtil.checkNotNull(type, "type");
         ObjectUtil.checkNotNull(dstAddrType, "dstAddrType");
         ObjectUtil.checkNotNull(dstAddr, "dstAddr");
 
@@ -57,7 +58,6 @@ public final class DefaultSocks5CommandRequest extends AbstractSocks5Message imp
             throw new IllegalArgumentException("dstPort: " + dstPort + " (expected: 0~65535)");
         }
 
-        this.type = ObjectUtil.checkNotNull(type, "type");
         this.dstAddrType = dstAddrType;
         this.dstAddr = dstAddr;
         this.dstPort = dstPort;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponse.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.socksx.v5;
 
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.net.IDN;
@@ -38,12 +39,9 @@ public final class DefaultSocks5CommandResponse extends AbstractSocks5Message im
     public DefaultSocks5CommandResponse(
             Socks5CommandStatus status, Socks5AddressType bndAddrType, String bndAddr, int bndPort) {
 
-        if (status == null) {
-            throw new NullPointerException("status");
-        }
-        if (bndAddrType == null) {
-            throw new NullPointerException("bndAddrType");
-        }
+        ObjectUtil.checkNotNull(status, "status");
+        ObjectUtil.checkNotNull(bndAddrType, "bndAddrType");
+
         if (bndAddr != null) {
             if (bndAddrType == Socks5AddressType.IPv4) {
                 if (!NetUtil.isValidIpV4Address(bndAddr)) {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialRequest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
@@ -30,9 +31,7 @@ public class DefaultSocks5InitialRequest extends AbstractSocks5Message implement
     private final List<Socks5AuthMethod> authMethods;
 
     public DefaultSocks5InitialRequest(Socks5AuthMethod... authMethods) {
-        if (authMethods == null) {
-            throw new NullPointerException("authMethods");
-        }
+        ObjectUtil.checkNotNull(authMethods, "authMethods");
 
         List<Socks5AuthMethod> list = new ArrayList<Socks5AuthMethod>(authMethods.length);
         for (Socks5AuthMethod m: authMethods) {
@@ -50,9 +49,7 @@ public class DefaultSocks5InitialRequest extends AbstractSocks5Message implement
     }
 
     public DefaultSocks5InitialRequest(Iterable<Socks5AuthMethod> authMethods) {
-        if (authMethods == null) {
-            throw new NullPointerException("authSchemes");
-        }
+        ObjectUtil.checkNotNull(authMethods, "authSchemes");
 
         List<Socks5AuthMethod> list = new ArrayList<Socks5AuthMethod>();
         for (Socks5AuthMethod m: authMethods) {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialResponse.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -26,9 +27,7 @@ public class DefaultSocks5InitialResponse extends AbstractSocks5Message implemen
     private final Socks5AuthMethod authMethod;
 
     public DefaultSocks5InitialResponse(Socks5AuthMethod authMethod) {
-        if (authMethod == null) {
-            throw new NullPointerException("authMethod");
-        }
+        ObjectUtil.checkNotNull(authMethod, "authMethod");
         this.authMethod = authMethod;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialResponse.java
@@ -27,8 +27,7 @@ public class DefaultSocks5InitialResponse extends AbstractSocks5Message implemen
     private final Socks5AuthMethod authMethod;
 
     public DefaultSocks5InitialResponse(Socks5AuthMethod authMethod) {
-        ObjectUtil.checkNotNull(authMethod, "authMethod");
-        this.authMethod = authMethod;
+        this.authMethod = ObjectUtil.checkNotNull(authMethod, "authMethod");
     }
 
     @Override

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthRequest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -27,12 +28,8 @@ public class DefaultSocks5PasswordAuthRequest extends AbstractSocks5Message impl
     private final String password;
 
     public DefaultSocks5PasswordAuthRequest(String username, String password) {
-        if (username == null) {
-            throw new NullPointerException("username");
-        }
-        if (password == null) {
-            throw new NullPointerException("password");
-        }
+        ObjectUtil.checkNotNull(username, "username");
+        ObjectUtil.checkNotNull(password, "password");
 
         if (username.length() > 255) {
             throw new IllegalArgumentException("username: **** (expected: less than 256 chars)");

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponse.java
@@ -27,8 +27,7 @@ public class DefaultSocks5PasswordAuthResponse extends AbstractSocks5Message imp
     private final Socks5PasswordAuthStatus status;
 
     public DefaultSocks5PasswordAuthResponse(Socks5PasswordAuthStatus status) {
-        ObjectUtil.checkNotNull(status, "status");
-        this.status = status;
+        this.status = ObjectUtil.checkNotNull(status, "status");
     }
 
     @Override

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponse.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponse.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -26,10 +27,7 @@ public class DefaultSocks5PasswordAuthResponse extends AbstractSocks5Message imp
     private final Socks5PasswordAuthStatus status;
 
     public DefaultSocks5PasswordAuthResponse(Socks5PasswordAuthStatus status) {
-        if (status == null) {
-            throw new NullPointerException("status");
-        }
-
+        ObjectUtil.checkNotNull(status, "status");
         this.status = status;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressType.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressType.java
@@ -49,9 +49,8 @@ public class Socks5AddressType implements Comparable<Socks5AddressType> {
     }
 
     public Socks5AddressType(int byteValue, String name) {
-        ObjectUtil.checkNotNull(name, "name");
+        this.name = ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
-        this.name = name;
     }
 
     public byte byteValue() {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressType.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AddressType.java
@@ -16,6 +16,8 @@
 
 package io.netty.handler.codec.socksx.v5;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The type of address in {@link Socks5CommandRequest} and {@link Socks5CommandResponse}.
  */
@@ -47,10 +49,7 @@ public class Socks5AddressType implements Comparable<Socks5AddressType> {
     }
 
     public Socks5AddressType(int byteValue, String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
-
+        ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
         this.name = name;
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AuthMethod.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AuthMethod.java
@@ -56,10 +56,8 @@ public class Socks5AuthMethod implements Comparable<Socks5AuthMethod> {
     }
 
     public Socks5AuthMethod(int byteValue, String name) {
-        ObjectUtil.checkNotNull(name, "name");
-
+        this.name = ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
-        this.name = name;
     }
 
     public byte byteValue() {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AuthMethod.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5AuthMethod.java
@@ -16,6 +16,8 @@
 
 package io.netty.handler.codec.socksx.v5;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The authentication method of SOCKS5.
  */
@@ -54,9 +56,7 @@ public class Socks5AuthMethod implements Comparable<Socks5AuthMethod> {
     }
 
     public Socks5AuthMethod(int byteValue, String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
 
         this.byteValue = (byte) byteValue;
         this.name = name;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -49,8 +49,7 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
      * Creates a new instance with the specified {@link Socks5AddressEncoder}.
      */
     public Socks5ClientEncoder(Socks5AddressEncoder addressEncoder) {
-        ObjectUtil.checkNotNull(addressEncoder, "addressEncoder");
-        this.addressEncoder = addressEncoder;
+        this.addressEncoder = ObjectUtil.checkNotNull(addressEncoder, "addressEncoder");
     }
 
     /**

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.util.List;
@@ -48,10 +49,7 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
      * Creates a new instance with the specified {@link Socks5AddressEncoder}.
      */
     public Socks5ClientEncoder(Socks5AddressEncoder addressEncoder) {
-        if (addressEncoder == null) {
-            throw new NullPointerException("addressEncoder");
-        }
-
+        ObjectUtil.checkNotNull(addressEncoder, "addressEncoder");
         this.addressEncoder = addressEncoder;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
@@ -49,8 +49,7 @@ public class Socks5CommandRequestDecoder extends ReplayingDecoder<State> {
 
     public Socks5CommandRequestDecoder(Socks5AddressDecoder addressDecoder) {
         super(State.INIT);
-        ObjectUtil.checkNotNull(addressDecoder, "addressDecoder");
-        this.addressDecoder = addressDecoder;
+        this.addressDecoder = ObjectUtil.checkNotNull(addressDecoder, "addressDecoder");
     }
 
     @Override

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socksx.SocksVersion;
 import io.netty.handler.codec.socksx.v5.Socks5CommandRequestDecoder.State;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -48,10 +49,7 @@ public class Socks5CommandRequestDecoder extends ReplayingDecoder<State> {
 
     public Socks5CommandRequestDecoder(Socks5AddressDecoder addressDecoder) {
         super(State.INIT);
-        if (addressDecoder == null) {
-            throw new NullPointerException("addressDecoder");
-        }
-
+        ObjectUtil.checkNotNull(addressDecoder, "addressDecoder");
         this.addressDecoder = addressDecoder;
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -49,9 +49,7 @@ public class Socks5CommandResponseDecoder extends ReplayingDecoder<State> {
 
     public Socks5CommandResponseDecoder(Socks5AddressDecoder addressDecoder) {
         super(State.INIT);
-        ObjectUtil.checkNotNull(addressDecoder, "addressDecoder");
-
-        this.addressDecoder = addressDecoder;
+        this.addressDecoder = ObjectUtil.checkNotNull(addressDecoder, "addressDecoder");
     }
 
     @Override

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socksx.SocksVersion;
 import io.netty.handler.codec.socksx.v5.Socks5CommandResponseDecoder.State;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -48,9 +49,7 @@ public class Socks5CommandResponseDecoder extends ReplayingDecoder<State> {
 
     public Socks5CommandResponseDecoder(Socks5AddressDecoder addressDecoder) {
         super(State.INIT);
-        if (addressDecoder == null) {
-            throw new NullPointerException("addressDecoder");
-        }
+        ObjectUtil.checkNotNull(addressDecoder, "addressDecoder");
 
         this.addressDecoder = addressDecoder;
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandStatus.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandStatus.java
@@ -16,6 +16,8 @@
 
 package io.netty.handler.codec.socksx.v5;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The status of {@link Socks5CommandResponse}.
  */
@@ -65,9 +67,7 @@ public class Socks5CommandStatus implements Comparable<Socks5CommandStatus> {
     }
 
     public Socks5CommandStatus(int byteValue, String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
 
         this.byteValue = (byte) byteValue;
         this.name = name;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandStatus.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandStatus.java
@@ -67,10 +67,8 @@ public class Socks5CommandStatus implements Comparable<Socks5CommandStatus> {
     }
 
     public Socks5CommandStatus(int byteValue, String name) {
-        ObjectUtil.checkNotNull(name, "name");
-
+        this.name = ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
-        this.name = name;
     }
 
     public byte byteValue() {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandType.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandType.java
@@ -49,9 +49,8 @@ public class Socks5CommandType implements Comparable<Socks5CommandType> {
     }
 
     public Socks5CommandType(int byteValue, String name) {
-        ObjectUtil.checkNotNull(name, "name");
+        this.name = ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
-        this.name = name;
     }
 
     public byte byteValue() {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandType.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandType.java
@@ -16,6 +16,8 @@
 
 package io.netty.handler.codec.socksx.v5;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The type of {@link Socks5CommandRequest}.
  */
@@ -47,10 +49,7 @@ public class Socks5CommandType implements Comparable<Socks5CommandType> {
     }
 
     public Socks5CommandType(int byteValue, String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
-
+        ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
         this.name = name;
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthStatus.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthStatus.java
@@ -16,6 +16,8 @@
 
 package io.netty.handler.codec.socksx.v5;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * The status of {@link Socks5PasswordAuthResponse}.
  */
@@ -44,10 +46,7 @@ public class Socks5PasswordAuthStatus implements Comparable<Socks5PasswordAuthSt
     }
 
     public Socks5PasswordAuthStatus(int byteValue, String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
-
+        ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
         this.name = name;
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthStatus.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthStatus.java
@@ -46,9 +46,8 @@ public class Socks5PasswordAuthStatus implements Comparable<Socks5PasswordAuthSt
     }
 
     public Socks5PasswordAuthStatus(int byteValue, String name) {
-        ObjectUtil.checkNotNull(name, "name");
+        this.name = ObjectUtil.checkNotNull(name, "name");
         this.byteValue = (byte) byteValue;
-        this.name = name;
     }
 
     public byte byteValue() {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -44,9 +45,7 @@ public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
      * Creates a new instance with the specified {@link Socks5AddressEncoder}.
      */
     public Socks5ServerEncoder(Socks5AddressEncoder addressEncoder) {
-        if (addressEncoder == null) {
-            throw new NullPointerException("addressEncoder");
-        }
+        ObjectUtil.checkNotNull(addressEncoder, "addressEncoder");
 
         this.addressEncoder = addressEncoder;
     }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -45,9 +45,7 @@ public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
      * Creates a new instance with the specified {@link Socks5AddressEncoder}.
      */
     public Socks5ServerEncoder(Socks5AddressEncoder addressEncoder) {
-        ObjectUtil.checkNotNull(addressEncoder, "addressEncoder");
-
-        this.addressEncoder = addressEncoder;
+        this.addressEncoder = ObjectUtil.checkNotNull(addressEncoder, "addressEncoder");
     }
 
     /**

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
@@ -37,8 +37,7 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
 
     DefaultStompFrame(StompCommand command, ByteBuf content, DefaultStompHeaders headers) {
         super(command, headers);
-        ObjectUtil.checkNotNull(content, "content");
-        this.content = content;
+        this.content = ObjectUtil.checkNotNull(content, "content");
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.stomp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Default implementation of {@link StompFrame}.
@@ -36,11 +37,7 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
 
     DefaultStompFrame(StompCommand command, ByteBuf content, DefaultStompHeaders headers) {
         super(command, headers);
-
-        if (content == null) {
-            throw new NullPointerException("content");
-        }
-
+        ObjectUtil.checkNotNull(content, "content");
         this.content = content;
     }
 

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.java
@@ -32,8 +32,7 @@ public class DefaultStompHeadersSubframe implements StompHeadersSubframe {
     }
 
     DefaultStompHeadersSubframe(StompCommand command, DefaultStompHeaders headers) {
-        ObjectUtil.checkNotNull(command, "command");
-        this.command = command;
+        this.command = ObjectUtil.checkNotNull(command, "command");
         this.headers = headers == null ? new DefaultStompHeaders() : headers;
     }
 

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.stomp;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Default implementation of {@link StompHeadersSubframe}.
@@ -31,10 +32,7 @@ public class DefaultStompHeadersSubframe implements StompHeadersSubframe {
     }
 
     DefaultStompHeadersSubframe(StompCommand command, DefaultStompHeaders headers) {
-        if (command == null) {
-            throw new NullPointerException("command");
-        }
-
+        ObjectUtil.checkNotNull(command, "command");
         this.command = command;
         this.headers = headers == null ? new DefaultStompHeaders() : headers;
     }

--- a/codec/src/main/java/io/netty/handler/codec/AsciiHeadersEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/AsciiHeadersEncoder.java
@@ -64,13 +64,9 @@ public final class AsciiHeadersEncoder {
     }
 
     public AsciiHeadersEncoder(ByteBuf buf, SeparatorType separatorType, NewlineType newlineType) {
-        ObjectUtil.checkNotNull(buf, "buf");
-        ObjectUtil.checkNotNull(separatorType, "separatorType");
-        ObjectUtil.checkNotNull(newlineType, "newlineType");
-
-        this.buf = buf;
-        this.separatorType = separatorType;
-        this.newlineType = newlineType;
+        this.buf = ObjectUtil.checkNotNull(buf, "buf");
+        this.separatorType = ObjectUtil.checkNotNull(separatorType, "separatorType");
+        this.newlineType = ObjectUtil.checkNotNull(newlineType, "newlineType");
     }
 
     public void encode(Entry<CharSequence, CharSequence> entry) {

--- a/codec/src/main/java/io/netty/handler/codec/AsciiHeadersEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/AsciiHeadersEncoder.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 public final class AsciiHeadersEncoder {
 
@@ -63,15 +64,9 @@ public final class AsciiHeadersEncoder {
     }
 
     public AsciiHeadersEncoder(ByteBuf buf, SeparatorType separatorType, NewlineType newlineType) {
-        if (buf == null) {
-            throw new NullPointerException("buf");
-        }
-        if (separatorType == null) {
-            throw new NullPointerException("separatorType");
-        }
-        if (newlineType == null) {
-            throw new NullPointerException("newlineType");
-        }
+        ObjectUtil.checkNotNull(buf, "buf");
+        ObjectUtil.checkNotNull(separatorType, "separatorType");
+        ObjectUtil.checkNotNull(newlineType, "newlineType");
 
         this.buf = buf;
         this.separatorType = separatorType;

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -198,8 +198,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
      * Set the {@link Cumulator} to use for cumulate the received {@link ByteBuf}s.
      */
     public void setCumulator(Cumulator cumulator) {
-        ObjectUtil.checkNotNull(cumulator, "cumulator");
-        this.cumulator = cumulator;
+        this.cumulator = ObjectUtil.checkNotNull(cumulator, "cumulator");
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.util.List;
@@ -197,9 +198,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
      * Set the {@link Cumulator} to use for cumulate the received {@link ByteBuf}s.
      */
     public void setCumulator(Cumulator cumulator) {
-        if (cumulator == null) {
-            throw new NullPointerException("cumulator");
-        }
+        ObjectUtil.checkNotNull(cumulator, "cumulator");
         this.cumulator = cumulator;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/DecoderResult.java
+++ b/codec/src/main/java/io/netty/handler/codec/DecoderResult.java
@@ -27,8 +27,7 @@ public class DecoderResult {
     public static final DecoderResult SUCCESS = new DecoderResult(SIGNAL_SUCCESS);
 
     public static DecoderResult failure(Throwable cause) {
-        ObjectUtil.checkNotNull(cause, "cause");
-        return new DecoderResult(cause);
+        return new DecoderResult(ObjectUtil.checkNotNull(cause, "cause"));
     }
 
     private final Throwable cause;

--- a/codec/src/main/java/io/netty/handler/codec/DecoderResult.java
+++ b/codec/src/main/java/io/netty/handler/codec/DecoderResult.java
@@ -34,8 +34,7 @@ public class DecoderResult {
     private final Throwable cause;
 
     protected DecoderResult(Throwable cause) {
-        ObjectUtil.checkNotNull(cause, "cause");
-        this.cause = cause;
+        this.cause = ObjectUtil.checkNotNull(cause, "cause");
     }
 
     public boolean isFinished() {

--- a/codec/src/main/java/io/netty/handler/codec/DecoderResult.java
+++ b/codec/src/main/java/io/netty/handler/codec/DecoderResult.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec;
 
 import io.netty.util.Signal;
+import io.netty.util.internal.ObjectUtil;
 
 public class DecoderResult {
 
@@ -26,18 +27,14 @@ public class DecoderResult {
     public static final DecoderResult SUCCESS = new DecoderResult(SIGNAL_SUCCESS);
 
     public static DecoderResult failure(Throwable cause) {
-        if (cause == null) {
-            throw new NullPointerException("cause");
-        }
+        ObjectUtil.checkNotNull(cause, "cause");
         return new DecoderResult(cause);
     }
 
     private final Throwable cause;
 
     protected DecoderResult(Throwable cause) {
-        if (cause == null) {
-            throw new NullPointerException("cause");
-        }
+        ObjectUtil.checkNotNull(cause, "cause");
         this.cause = cause;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
@@ -19,6 +19,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -166,12 +167,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
     public DelimiterBasedFrameDecoder(
             int maxFrameLength, boolean stripDelimiter, boolean failFast, ByteBuf... delimiters) {
         validateMaxFrameLength(maxFrameLength);
-        if (delimiters == null) {
-            throw new NullPointerException("delimiters");
-        }
-        if (delimiters.length == 0) {
-            throw new IllegalArgumentException("empty delimiters");
-        }
+        ObjectUtil.checkNonEmpty(delimiters, "delimiters");
 
         if (isLineBased(delimiters) && !isSubclass()) {
             lineBasedDecoder = new LineBasedFrameDecoder(maxFrameLength, stripDelimiter, failFast);
@@ -339,9 +335,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
     }
 
     private static void validateDelimiter(ByteBuf delimiter) {
-        if (delimiter == null) {
-            throw new NullPointerException("delimiter");
-        }
+        ObjectUtil.checkNotNull(delimiter, "delimiter");
         if (!delimiter.isReadable()) {
             throw new IllegalArgumentException("empty delimiter");
         }

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec;
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
@@ -23,7 +24,6 @@ import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.serialization.ObjectDecoder;
 
 /**
  * A decoder that splits the received {@link ByteBuf}s dynamically by the
@@ -301,9 +301,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
     public LengthFieldBasedFrameDecoder(
             ByteOrder byteOrder, int maxFrameLength, int lengthFieldOffset, int lengthFieldLength,
             int lengthAdjustment, int initialBytesToStrip, boolean failFast) {
-        if (byteOrder == null) {
-            throw new NullPointerException("byteOrder");
-        }
+        checkNotNull(byteOrder, "byteOrder");
 
         checkPositive(maxFrameLength, "maxFrameLength");
 

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -302,6 +302,8 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
             ByteOrder byteOrder, int maxFrameLength, int lengthFieldOffset, int lengthFieldLength,
             int lengthAdjustment, int initialBytesToStrip, boolean failFast) {
 
+        this.byteOrder = checkNotNull(byteOrder, "byteOrder");
+
         checkPositive(maxFrameLength, "maxFrameLength");
 
         checkPositiveOrZero(lengthFieldOffset, "lengthFieldOffset");
@@ -316,12 +318,11 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
                     "lengthFieldLength (" + lengthFieldLength + ").");
         }
 
-        this.byteOrder = checkNotNull(byteOrder, "byteOrder");
         this.maxFrameLength = maxFrameLength;
         this.lengthFieldOffset = lengthFieldOffset;
         this.lengthFieldLength = lengthFieldLength;
         this.lengthAdjustment = lengthAdjustment;
-        lengthFieldEndOffset = lengthFieldOffset + lengthFieldLength;
+        this.lengthFieldEndOffset = lengthFieldOffset + lengthFieldLength;
         this.initialBytesToStrip = initialBytesToStrip;
         this.failFast = failFast;
     }

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -301,7 +301,6 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
     public LengthFieldBasedFrameDecoder(
             ByteOrder byteOrder, int maxFrameLength, int lengthFieldOffset, int lengthFieldLength,
             int lengthAdjustment, int initialBytesToStrip, boolean failFast) {
-        checkNotNull(byteOrder, "byteOrder");
 
         checkPositive(maxFrameLength, "maxFrameLength");
 
@@ -317,7 +316,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
                     "lengthFieldLength (" + lengthFieldLength + ").");
         }
 
-        this.byteOrder = byteOrder;
+        this.byteOrder = checkNotNull(byteOrder, "byteOrder");
         this.maxFrameLength = maxFrameLength;
         this.lengthFieldOffset = lengthFieldOffset;
         this.lengthFieldLength = lengthFieldLength;

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
@@ -150,9 +150,7 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
                     "lengthFieldLength must be either 1, 2, 3, 4, or 8: " +
                     lengthFieldLength);
         }
-        ObjectUtil.checkNotNull(byteOrder, "byteOrder");
-
-        this.byteOrder = byteOrder;
+        this.byteOrder = ObjectUtil.checkNotNull(byteOrder, "byteOrder");
         this.lengthFieldLength = lengthFieldLength;
         this.lengthIncludesLengthFieldLength = lengthIncludesLengthFieldLength;
         this.lengthAdjustment = lengthAdjustment;

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -30,6 +30,7 @@ import io.netty.buffer.SwappedByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ByteProcessor;
 import io.netty.util.Signal;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -472,9 +473,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
-        if (endianness == null) {
-            throw new NullPointerException("endianness");
-        }
+        ObjectUtil.checkNotNull(endianness, "endianness");
         if (endianness == order()) {
             return this;
         }

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -473,8 +473,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
-        ObjectUtil.checkNotNull(endianness, "endianness");
-        if (endianness == order()) {
+        if (ObjectUtil.checkNotNull(endianness, "endianness") == order()) {
             return this;
         }
 

--- a/codec/src/main/java/io/netty/handler/codec/base64/Base64.java
+++ b/codec/src/main/java/io/netty/handler/codec/base64/Base64.java
@@ -51,18 +51,15 @@ public final class Base64 {
     private static final byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
 
     private static byte[] alphabet(Base64Dialect dialect) {
-        ObjectUtil.checkNotNull(dialect, "dialect");
-        return dialect.alphabet;
+        return ObjectUtil.checkNotNull(dialect, "dialect").alphabet;
     }
 
     private static byte[] decodabet(Base64Dialect dialect) {
-        ObjectUtil.checkNotNull(dialect, "dialect");
-        return dialect.decodabet;
+        return ObjectUtil.checkNotNull(dialect, "dialect").decodabet;
     }
 
     private static boolean breakLines(Base64Dialect dialect) {
-        ObjectUtil.checkNotNull(dialect, "dialect");
-        return dialect.breakLinesByDefault;
+        return ObjectUtil.checkNotNull(dialect, "dialect").breakLinesByDefault;
     }
 
     public static ByteBuf encode(ByteBuf src) {

--- a/codec/src/main/java/io/netty/handler/codec/base64/Base64.java
+++ b/codec/src/main/java/io/netty/handler/codec/base64/Base64.java
@@ -22,6 +22,7 @@ package io.netty.handler.codec.base64;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ByteProcessor;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteOrder;
@@ -50,23 +51,17 @@ public final class Base64 {
     private static final byte EQUALS_SIGN_ENC = -1; // Indicates equals sign in encoding
 
     private static byte[] alphabet(Base64Dialect dialect) {
-        if (dialect == null) {
-            throw new NullPointerException("dialect");
-        }
+        ObjectUtil.checkNotNull(dialect, "dialect");
         return dialect.alphabet;
     }
 
     private static byte[] decodabet(Base64Dialect dialect) {
-        if (dialect == null) {
-            throw new NullPointerException("dialect");
-        }
+        ObjectUtil.checkNotNull(dialect, "dialect");
         return dialect.decodabet;
     }
 
     private static boolean breakLines(Base64Dialect dialect) {
-        if (dialect == null) {
-            throw new NullPointerException("dialect");
-        }
+        ObjectUtil.checkNotNull(dialect, "dialect");
         return dialect.breakLinesByDefault;
     }
 
@@ -83,10 +78,7 @@ public final class Base64 {
     }
 
     public static ByteBuf encode(ByteBuf src, boolean breakLines, Base64Dialect dialect) {
-
-        if (src == null) {
-            throw new NullPointerException("src");
-        }
+        ObjectUtil.checkNotNull(src, "src");
 
         ByteBuf dest = encode(src, src.readerIndex(), src.readableBytes(), breakLines, dialect);
         src.readerIndex(src.writerIndex());
@@ -113,12 +105,8 @@ public final class Base64 {
 
     public static ByteBuf encode(
             ByteBuf src, int off, int len, boolean breakLines, Base64Dialect dialect, ByteBufAllocator allocator) {
-        if (src == null) {
-            throw new NullPointerException("src");
-        }
-        if (dialect == null) {
-            throw new NullPointerException("dialect");
-        }
+        ObjectUtil.checkNotNull(src, "src");
+        ObjectUtil.checkNotNull(dialect, "dialect");
 
         ByteBuf dest = allocator.buffer(encodedBufferSize(len, breakLines)).order(src.order());
         byte[] alphabet = alphabet(dialect);
@@ -291,9 +279,7 @@ public final class Base64 {
     }
 
     public static ByteBuf decode(ByteBuf src, Base64Dialect dialect) {
-        if (src == null) {
-            throw new NullPointerException("src");
-        }
+        ObjectUtil.checkNotNull(src, "src");
 
         ByteBuf dest = decode(src, src.readerIndex(), src.readableBytes(), dialect);
         src.readerIndex(src.writerIndex());
@@ -312,12 +298,8 @@ public final class Base64 {
 
     public static ByteBuf decode(
             ByteBuf src, int off, int len, Base64Dialect dialect, ByteBufAllocator allocator) {
-        if (src == null) {
-            throw new NullPointerException("src");
-        }
-        if (dialect == null) {
-            throw new NullPointerException("dialect");
-        }
+        ObjectUtil.checkNotNull(src, "src");
+        ObjectUtil.checkNotNull(dialect, "dialect");
 
         // Using a ByteProcessor to reduce bound and reference count checking.
         return new Decoder().decode(src, off, len, allocator, dialect);

--- a/codec/src/main/java/io/netty/handler/codec/base64/Base64Decoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/base64/Base64Decoder.java
@@ -54,8 +54,7 @@ public class Base64Decoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     public Base64Decoder(Base64Dialect dialect) {
-        ObjectUtil.checkNotNull(dialect, "dialect");
-        this.dialect = dialect;
+        this.dialect = ObjectUtil.checkNotNull(dialect, "dialect");
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/base64/Base64Decoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/base64/Base64Decoder.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.DelimiterBasedFrameDecoder;
 import io.netty.handler.codec.Delimiters;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -53,9 +54,7 @@ public class Base64Decoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     public Base64Decoder(Base64Dialect dialect) {
-        if (dialect == null) {
-            throw new NullPointerException("dialect");
-        }
+        ObjectUtil.checkNotNull(dialect, "dialect");
         this.dialect = dialect;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/base64/Base64Encoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/base64/Base64Encoder.java
@@ -55,9 +55,8 @@ public class Base64Encoder extends MessageToMessageEncoder<ByteBuf> {
     }
 
     public Base64Encoder(boolean breakLines, Base64Dialect dialect) {
-        ObjectUtil.checkNotNull(dialect, "dialect");
+        this.dialect = ObjectUtil.checkNotNull(dialect, "dialect");
         this.breakLines = breakLines;
-        this.dialect = dialect;
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/base64/Base64Encoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/base64/Base64Encoder.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.DelimiterBasedFrameDecoder;
 import io.netty.handler.codec.Delimiters;
 import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -54,10 +55,7 @@ public class Base64Encoder extends MessageToMessageEncoder<ByteBuf> {
     }
 
     public Base64Encoder(boolean breakLines, Base64Dialect dialect) {
-        if (dialect == null) {
-            throw new NullPointerException("dialect");
-        }
-
+        ObjectUtil.checkNotNull(dialect, "dialect");
         this.breakLines = breakLines;
         this.dialect = dialect;
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -19,6 +19,7 @@ import com.jcraft.jzlib.Inflater;
 import com.jcraft.jzlib.JZlib;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -43,9 +44,7 @@ public class JZlibDecoder extends ZlibDecoder {
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(ZlibWrapper wrapper) {
-        if (wrapper == null) {
-            throw new NullPointerException("wrapper");
-        }
+        ObjectUtil.checkNotNull(wrapper, "wrapper");
 
         int resultCode = z.init(ZlibUtil.convertWrapperType(wrapper));
         if (resultCode != JZlib.Z_OK) {
@@ -61,9 +60,7 @@ public class JZlibDecoder extends ZlibDecoder {
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(byte[] dictionary) {
-        if (dictionary == null) {
-            throw new NullPointerException("dictionary");
-        }
+        ObjectUtil.checkNotNull(dictionary, "dictionary");
         this.dictionary = dictionary;
 
         int resultCode;

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -60,9 +60,7 @@ public class JZlibDecoder extends ZlibDecoder {
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(byte[] dictionary) {
-        ObjectUtil.checkNotNull(dictionary, "dictionary");
-        this.dictionary = dictionary;
-
+        this.dictionary = ObjectUtil.checkNotNull(dictionary, "dictionary");
         int resultCode;
         resultCode = z.inflateInit(JZlib.W_ZLIB);
         if (resultCode != JZlib.Z_OK) {

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.concurrent.TimeUnit;
 
@@ -130,9 +131,7 @@ public class JZlibEncoder extends ZlibEncoder {
             throw new IllegalArgumentException(
                     "memLevel: " + memLevel + " (expected: 1-9)");
         }
-        if (wrapper == null) {
-            throw new NullPointerException("wrapper");
-        }
+        ObjectUtil.checkNotNull(wrapper, "wrapper");
         if (wrapper == ZlibWrapper.ZLIB_OR_NONE) {
             throw new IllegalArgumentException(
                     "wrapper '" + ZlibWrapper.ZLIB_OR_NONE + "' is not " +
@@ -220,9 +219,8 @@ public class JZlibEncoder extends ZlibEncoder {
             throw new IllegalArgumentException(
                     "memLevel: " + memLevel + " (expected: 1-9)");
         }
-        if (dictionary == null) {
-            throw new NullPointerException("dictionary");
-        }
+        ObjectUtil.checkNotNull(dictionary, "dictionary");
+
         int resultCode;
         resultCode = z.deflateInit(
                 compressionLevel, windowBits, memLevel,

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 import java.util.zip.CRC32;
@@ -94,9 +95,8 @@ public class JdkZlibDecoder extends ZlibDecoder {
     }
 
     private JdkZlibDecoder(ZlibWrapper wrapper, byte[] dictionary, boolean decompressConcatenated) {
-        if (wrapper == null) {
-            throw new NullPointerException("wrapper");
-        }
+        ObjectUtil.checkNotNull(wrapper, "wrapper");
+
         this.decompressConcatenated = decompressConcatenated;
         switch (wrapper) {
             case GZIP:

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SuppressJava6Requirement;
 
@@ -97,9 +98,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
             throw new IllegalArgumentException(
                     "compressionLevel: " + compressionLevel + " (expected: 0-9)");
         }
-        if (wrapper == null) {
-            throw new NullPointerException("wrapper");
-        }
+        ObjectUtil.checkNotNull(wrapper, "wrapper");
         if (wrapper == ZlibWrapper.ZLIB_OR_NONE) {
             throw new IllegalArgumentException(
                     "wrapper '" + ZlibWrapper.ZLIB_OR_NONE + "' is not " +
@@ -143,9 +142,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
             throw new IllegalArgumentException(
                     "compressionLevel: " + compressionLevel + " (expected: 0-9)");
         }
-        if (dictionary == null) {
-            throw new NullPointerException("dictionary");
-        }
+        ObjectUtil.checkNotNull(dictionary, "dictionary");
 
         wrapper = ZlibWrapper.ZLIB;
         deflater = new Deflater(compressionLevel);

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
@@ -137,8 +137,7 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
      *                  You may set {@code null} if you do not want to validate checksum of each block
      */
     public Lz4FrameDecoder(LZ4Factory factory, Checksum checksum) {
-        ObjectUtil.checkNotNull(factory, "factory");
-        decompressor = factory.fastDecompressor();
+        decompressor = ObjectUtil.checkNotNull(factory, "factory").fastDecompressor();
         this.checksum = checksum == null ? null : ByteBufChecksum.wrapChecksum(checksum);
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.compression;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.util.internal.ObjectUtil;
 import net.jpountz.lz4.LZ4Exception;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
@@ -136,9 +137,7 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
      *                  You may set {@code null} if you do not want to validate checksum of each block
      */
     public Lz4FrameDecoder(LZ4Factory factory, Checksum checksum) {
-        if (factory == null) {
-            throw new NullPointerException("factory");
-        }
+        ObjectUtil.checkNotNull(factory, "factory");
         decompressor = factory.fastDecompressor();
         this.checksum = checksum == null ? null : ByteBufChecksum.wrapChecksum(checksum);
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -158,12 +158,8 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
          */
     public Lz4FrameEncoder(LZ4Factory factory, boolean highCompressor, int blockSize,
                            Checksum checksum, int maxEncodeSize) {
-        if (factory == null) {
-            throw new NullPointerException("factory");
-        }
-        if (checksum == null) {
-            throw new NullPointerException("checksum");
-        }
+        ObjectUtil.checkNotNull(factory, "factory");
+        ObjectUtil.checkNotNull(checksum, "checksum");
 
         compressor = highCompressor ? factory.highCompressor() : factory.fastCompressor();
         this.checksum = ByteBufChecksum.wrapChecksum(checksum);

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
@@ -28,6 +28,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -95,9 +96,7 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     public ProtobufDecoder(MessageLite prototype, ExtensionRegistryLite extensionRegistry) {
-        if (prototype == null) {
-            throw new NullPointerException("prototype");
-        }
+        ObjectUtil.checkNotNull(prototype, "prototype");
         this.prototype = prototype.getDefaultInstanceForType();
         this.extensionRegistry = extensionRegistry;
     }

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
@@ -96,8 +96,7 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     public ProtobufDecoder(MessageLite prototype, ExtensionRegistryLite extensionRegistry) {
-        ObjectUtil.checkNotNull(prototype, "prototype");
-        this.prototype = prototype.getDefaultInstanceForType();
+        this.prototype = ObjectUtil.checkNotNull(prototype, "prototype").getDefaultInstanceForType();
         this.extensionRegistry = extensionRegistry;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoderInputStream.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoderInputStream.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.serialization;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.io.BufferedReader;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -88,12 +90,9 @@ public class ObjectDecoderInputStream extends InputStream implements
      *        a {@link StreamCorruptedException} will be raised.
      */
     public ObjectDecoderInputStream(InputStream in, ClassLoader classLoader, int maxObjectSize) {
-        if (in == null) {
-            throw new NullPointerException("in");
-        }
-        if (maxObjectSize <= 0) {
-            throw new IllegalArgumentException("maxObjectSize: " + maxObjectSize);
-        }
+        ObjectUtil.checkNotNull(in, "in");
+        ObjectUtil.checkPositive(maxObjectSize, "maxObjectSize");
+
         if (in instanceof DataInputStream) {
             this.in = (DataInputStream) in;
         } else {

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.serialization;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -63,12 +64,8 @@ public class ObjectEncoderOutputStream extends OutputStream implements
      *        cost, please specify the properly estimated value.
      */
     public ObjectEncoderOutputStream(OutputStream out, int estimatedLength) {
-        if (out == null) {
-            throw new NullPointerException("out");
-        }
-        if (estimatedLength < 0) {
-            throw new IllegalArgumentException("estimatedLength: " + estimatedLength);
-        }
+        ObjectUtil.checkNotNull(out, "out");
+        ObjectUtil.checkPositiveOrZero(estimatedLength, "estimatedLength");
 
         if (out instanceof DataOutputStream) {
             this.out = (DataOutputStream) out;

--- a/codec/src/main/java/io/netty/handler/codec/string/StringDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/string/StringDecoder.java
@@ -69,8 +69,7 @@ public class StringDecoder extends MessageToMessageDecoder<ByteBuf> {
      * Creates a new instance with the specified character set.
      */
     public StringDecoder(Charset charset) {
-        ObjectUtil.checkNotNull(charset, "charset");
-        this.charset = charset;
+        this.charset = ObjectUtil.checkNotNull(charset, "charset");
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/string/StringDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/string/StringDecoder.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.DelimiterBasedFrameDecoder;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.util.internal.ObjectUtil;
 
 import java.nio.charset.Charset;
 import java.util.List;
@@ -68,9 +69,7 @@ public class StringDecoder extends MessageToMessageDecoder<ByteBuf> {
      * Creates a new instance with the specified character set.
      */
     public StringDecoder(Charset charset) {
-        if (charset == null) {
-            throw new NullPointerException("charset");
-        }
+        ObjectUtil.checkNotNull(charset, "charset");
         this.charset = charset;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/string/StringEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/string/StringEncoder.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.util.internal.ObjectUtil;
 
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -64,9 +65,7 @@ public class StringEncoder extends MessageToMessageEncoder<CharSequence> {
      * Creates a new instance with the specified character set.
      */
     public StringEncoder(Charset charset) {
-        if (charset == null) {
-            throw new NullPointerException("charset");
-        }
+        ObjectUtil.checkNotNull(charset, "charset");
         this.charset = charset;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/string/StringEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/string/StringEncoder.java
@@ -65,8 +65,7 @@ public class StringEncoder extends MessageToMessageEncoder<CharSequence> {
      * Creates a new instance with the specified character set.
      */
     public StringEncoder(Charset charset) {
-        ObjectUtil.checkNotNull(charset, "charset");
-        this.charset = charset;
+        this.charset = ObjectUtil.checkNotNull(charset, "charset");
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -17,6 +17,7 @@ package io.netty.util;
 
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
@@ -589,9 +590,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
      * @param length the number of characters to copy.
      */
     public void copy(int srcIdx, char[] dst, int dstIdx, int length) {
-        if (dst == null) {
-            throw new NullPointerException("dst");
-        }
+        ObjectUtil.checkNotNull(dst, "dst");
 
         if (isOutOfBounds(srcIdx, length, length())) {
             throw new IndexOutOfBoundsException("expected: " + "0 <= srcIdx(" + srcIdx + ") <= srcIdx + length("
@@ -800,9 +799,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
      * @throws NullPointerException if {@code string} is {@code null}.
      */
     public boolean regionMatches(int thisStart, CharSequence string, int start, int length) {
-        if (string == null) {
-            throw new NullPointerException("string");
-        }
+        ObjectUtil.checkNotNull(string, "string");
 
         if (start < 0 || string.length() - start < length) {
             return false;
@@ -843,9 +840,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
             return regionMatches(thisStart, string, start, length);
         }
 
-        if (string == null) {
-            throw new NullPointerException("string");
-        }
+        ObjectUtil.checkNotNull(string, "string");
 
         final int thisLen = length();
         if (thisStart < 0 || length > thisLen - thisStart) {

--- a/common/src/main/java/io/netty/util/ConstantPool.java
+++ b/common/src/main/java/io/netty/util/ConstantPool.java
@@ -37,13 +37,8 @@ public abstract class ConstantPool<T extends Constant<T>> {
      * Shortcut of {@link #valueOf(String) valueOf(firstNameComponent.getName() + "#" + secondNameComponent)}.
      */
     public T valueOf(Class<?> firstNameComponent, String secondNameComponent) {
-        if (firstNameComponent == null) {
-            throw new NullPointerException("firstNameComponent");
-        }
-        if (secondNameComponent == null) {
-            throw new NullPointerException("secondNameComponent");
-        }
-
+        ObjectUtil.checkNotNull(firstNameComponent, "firstNameComponent");
+        ObjectUtil.checkNotNull(secondNameComponent, "secondNameComponent");
         return valueOf(firstNameComponent.getName() + '#' + secondNameComponent);
     }
 

--- a/common/src/main/java/io/netty/util/ConstantPool.java
+++ b/common/src/main/java/io/netty/util/ConstantPool.java
@@ -37,9 +37,10 @@ public abstract class ConstantPool<T extends Constant<T>> {
      * Shortcut of {@link #valueOf(String) valueOf(firstNameComponent.getName() + "#" + secondNameComponent)}.
      */
     public T valueOf(Class<?> firstNameComponent, String secondNameComponent) {
-        ObjectUtil.checkNotNull(firstNameComponent, "firstNameComponent");
-        ObjectUtil.checkNotNull(secondNameComponent, "secondNameComponent");
-        return valueOf(firstNameComponent.getName() + '#' + secondNameComponent);
+        return valueOf(
+                ObjectUtil.checkNotNull(firstNameComponent, "firstNameComponent").getName() +
+                '#' +
+                ObjectUtil.checkNotNull(secondNameComponent, "secondNameComponent"));
     }
 
     /**

--- a/common/src/main/java/io/netty/util/DefaultAttributeMap.java
+++ b/common/src/main/java/io/netty/util/DefaultAttributeMap.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -39,9 +41,7 @@ public class DefaultAttributeMap implements AttributeMap {
     @SuppressWarnings("unchecked")
     @Override
     public <T> Attribute<T> attr(AttributeKey<T> key) {
-        if (key == null) {
-            throw new NullPointerException("key");
-        }
+        ObjectUtil.checkNotNull(key, "key");
         AtomicReferenceArray<DefaultAttribute<?>> attributes = this.attributes;
         if (attributes == null) {
             // Not using ConcurrentHashMap due to high memory consumption.
@@ -90,9 +90,7 @@ public class DefaultAttributeMap implements AttributeMap {
 
     @Override
     public <T> boolean hasAttr(AttributeKey<T> key) {
-        if (key == null) {
-            throw new NullPointerException("key");
-        }
+        ObjectUtil.checkNotNull(key, "key");
         AtomicReferenceArray<DefaultAttribute<?>> attributes = this.attributes;
         if (attributes == null) {
             // no attribute exists

--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -242,18 +243,10 @@ public class HashedWheelTimer implements Timer {
             long tickDuration, TimeUnit unit, int ticksPerWheel, boolean leakDetection,
             long maxPendingTimeouts) {
 
-        if (threadFactory == null) {
-            throw new NullPointerException("threadFactory");
-        }
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
-        if (tickDuration <= 0) {
-            throw new IllegalArgumentException("tickDuration must be greater than 0: " + tickDuration);
-        }
-        if (ticksPerWheel <= 0) {
-            throw new IllegalArgumentException("ticksPerWheel must be greater than 0: " + ticksPerWheel);
-        }
+        ObjectUtil.checkNotNull(threadFactory, "threadFactory");
+        ObjectUtil.checkNotNull(unit, "unit");
+        ObjectUtil.checkPositive(tickDuration, "tickDuration");
+        ObjectUtil.checkPositive(ticksPerWheel, "ticksPerWheel");
 
         // Normalize ticksPerWheel to power of two and initialize the wheel.
         wheel = createWheel(ticksPerWheel);
@@ -408,12 +401,8 @@ public class HashedWheelTimer implements Timer {
 
     @Override
     public Timeout newTimeout(TimerTask task, long delay, TimeUnit unit) {
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
+        ObjectUtil.checkNotNull(task, "task");
+        ObjectUtil.checkNotNull(unit, "unit");
 
         long pendingTimeoutsCount = pendingTimeouts.incrementAndGet();
 

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -17,6 +17,7 @@
 package io.netty.util;
 
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -150,9 +151,7 @@ public class ResourceLeakDetector<T> {
      * Sets the resource leak detection level.
      */
     public static void setLevel(Level level) {
-        if (level == null) {
-            throw new NullPointerException("level");
-        }
+        ObjectUtil.checkNotNull(level, "level");
         ResourceLeakDetector.level = level;
     }
 
@@ -221,9 +220,7 @@ public class ResourceLeakDetector<T> {
      */
     @Deprecated
     public ResourceLeakDetector(String resourceType, int samplingInterval, long maxActive) {
-        if (resourceType == null) {
-            throw new NullPointerException("resourceType");
-        }
+        ObjectUtil.checkNotNull(resourceType, "resourceType");
 
         this.resourceType = resourceType;
         this.samplingInterval = samplingInterval;

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -151,8 +151,7 @@ public class ResourceLeakDetector<T> {
      * Sets the resource leak detection level.
      */
     public static void setLevel(Level level) {
-        ObjectUtil.checkNotNull(level, "level");
-        ResourceLeakDetector.level = level;
+        ResourceLeakDetector.level = ObjectUtil.checkNotNull(level, "level");
     }
 
     /**
@@ -220,9 +219,7 @@ public class ResourceLeakDetector<T> {
      */
     @Deprecated
     public ResourceLeakDetector(String resourceType, int samplingInterval, long maxActive) {
-        ObjectUtil.checkNotNull(resourceType, "resourceType");
-
-        this.resourceType = resourceType;
+        this.resourceType = ObjectUtil.checkNotNull(resourceType, "resourceType");
         this.samplingInterval = samplingInterval;
     }
 

--- a/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
+++ b/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
@@ -79,12 +79,13 @@ public final class ThreadDeathWatcher {
      */
     public static void watch(Thread thread, Runnable task) {
         ObjectUtil.checkNotNull(thread, "thread");
+        ObjectUtil.checkNotNull(task, "task");
 
         if (!thread.isAlive()) {
             throw new IllegalArgumentException("thread must be alive.");
         }
 
-        schedule(thread, ObjectUtil.checkNotNull(task, "task"), true);
+        schedule(thread, task, true);
     }
 
     /**
@@ -129,10 +130,11 @@ public final class ThreadDeathWatcher {
      * @return {@code true} if and only if the watcher thread has been terminated
      */
     public static boolean awaitInactivity(long timeout, TimeUnit unit) throws InterruptedException {
+        ObjectUtil.checkNotNull(unit, "unit");
+
         Thread watcherThread = ThreadDeathWatcher.watcherThread;
         if (watcherThread != null) {
-            watcherThread.join(
-                    ObjectUtil.checkNotNull(unit, "unit").toMillis(timeout));
+            watcherThread.join(unit.toMillis(timeout));
             return !watcherThread.isAlive();
         } else {
             return true;

--- a/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
+++ b/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
@@ -17,6 +17,7 @@
 package io.netty.util;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -77,12 +78,9 @@ public final class ThreadDeathWatcher {
      * @throws IllegalArgumentException if the specified {@code thread} is not alive
      */
     public static void watch(Thread thread, Runnable task) {
-        if (thread == null) {
-            throw new NullPointerException("thread");
-        }
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
+        ObjectUtil.checkNotNull(thread, "thread");
+        ObjectUtil.checkNotNull(task, "task");
+
         if (!thread.isAlive()) {
             throw new IllegalArgumentException("thread must be alive.");
         }
@@ -94,13 +92,8 @@ public final class ThreadDeathWatcher {
      * Cancels the task scheduled via {@link #watch(Thread, Runnable)}.
      */
     public static void unwatch(Thread thread, Runnable task) {
-        if (thread == null) {
-            throw new NullPointerException("thread");
-        }
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
-
+        ObjectUtil.checkNotNull(thread, "thread");
+        ObjectUtil.checkNotNull(task, "task");
         schedule(thread, task, false);
     }
 
@@ -137,9 +130,7 @@ public final class ThreadDeathWatcher {
      * @return {@code true} if and only if the watcher thread has been terminated
      */
     public static boolean awaitInactivity(long timeout, TimeUnit unit) throws InterruptedException {
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
+        ObjectUtil.checkNotNull(unit, "unit");
 
         Thread watcherThread = ThreadDeathWatcher.watcherThread;
         if (watcherThread != null) {

--- a/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
+++ b/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
@@ -79,22 +79,21 @@ public final class ThreadDeathWatcher {
      */
     public static void watch(Thread thread, Runnable task) {
         ObjectUtil.checkNotNull(thread, "thread");
-        ObjectUtil.checkNotNull(task, "task");
 
         if (!thread.isAlive()) {
             throw new IllegalArgumentException("thread must be alive.");
         }
 
-        schedule(thread, task, true);
+        schedule(thread, ObjectUtil.checkNotNull(task, "task"), true);
     }
 
     /**
      * Cancels the task scheduled via {@link #watch(Thread, Runnable)}.
      */
     public static void unwatch(Thread thread, Runnable task) {
-        ObjectUtil.checkNotNull(thread, "thread");
-        ObjectUtil.checkNotNull(task, "task");
-        schedule(thread, task, false);
+        schedule(ObjectUtil.checkNotNull(thread, "thread"),
+                ObjectUtil.checkNotNull(task, "task"),
+                false);
     }
 
     private static void schedule(Thread thread, Runnable task, boolean isWatch) {
@@ -130,11 +129,10 @@ public final class ThreadDeathWatcher {
      * @return {@code true} if and only if the watcher thread has been terminated
      */
     public static boolean awaitInactivity(long timeout, TimeUnit unit) throws InterruptedException {
-        ObjectUtil.checkNotNull(unit, "unit");
-
         Thread watcherThread = ThreadDeathWatcher.watcherThread;
         if (watcherThread != null) {
-            watcherThread.join(unit.toMillis(timeout));
+            watcherThread.join(
+                    ObjectUtil.checkNotNull(unit, "unit").toMillis(timeout));
             return !watcherThread.isAlive();
         } else {
             return true;

--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -167,6 +167,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
 
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        ObjectUtil.checkNotNull(command, "command");
         ObjectUtil.checkNotNull(unit, "unit");
         if (delay < 0) {
             delay = 0;
@@ -175,7 +176,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
 
         return schedule(new ScheduledFutureTask<Void>(
                 this,
-                ObjectUtil.checkNotNull(command, "command"),
+                command,
                 deadlineNanos(unit.toNanos(delay))));
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -167,7 +167,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
 
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        ObjectUtil.checkNotNull(command, "command");
         ObjectUtil.checkNotNull(unit, "unit");
         if (delay < 0) {
             delay = 0;
@@ -175,7 +174,9 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         validateScheduled0(delay, unit);
 
         return schedule(new ScheduledFutureTask<Void>(
-                this, command, deadlineNanos(unit.toNanos(delay))));
+                this,
+                ObjectUtil.checkNotNull(command, "command"),
+                deadlineNanos(unit.toNanos(delay))));
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/CompleteFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/CompleteFuture.java
@@ -45,15 +45,15 @@ public abstract class CompleteFuture<V> extends AbstractFuture<V> {
 
     @Override
     public Future<V> addListener(GenericFutureListener<? extends Future<? super V>> listener) {
-        ObjectUtil.checkNotNull(listener, "listener");
-        DefaultPromise.notifyListener(executor(), this, listener);
+        DefaultPromise.notifyListener(executor(), this, ObjectUtil.checkNotNull(listener, "listener"));
         return this;
     }
 
     @Override
     public Future<V> addListeners(GenericFutureListener<? extends Future<? super V>>... listeners) {
-        ObjectUtil.checkNotNull(listeners, "listeners");
-        for (GenericFutureListener<? extends Future<? super V>> l: listeners) {
+        for (GenericFutureListener<? extends Future<? super V>> l:
+                ObjectUtil.checkNotNull(listeners, "listeners")) {
+
             if (l == null) {
                 break;
             }

--- a/common/src/main/java/io/netty/util/concurrent/CompleteFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/CompleteFuture.java
@@ -16,6 +16,8 @@
 
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -43,18 +45,14 @@ public abstract class CompleteFuture<V> extends AbstractFuture<V> {
 
     @Override
     public Future<V> addListener(GenericFutureListener<? extends Future<? super V>> listener) {
-        if (listener == null) {
-            throw new NullPointerException("listener");
-        }
+        ObjectUtil.checkNotNull(listener, "listener");
         DefaultPromise.notifyListener(executor(), this, listener);
         return this;
     }
 
     @Override
     public Future<V> addListeners(GenericFutureListener<? extends Future<? super V>>... listeners) {
-        if (listeners == null) {
-            throw new NullPointerException("listeners");
-        }
+        ObjectUtil.checkNotNull(listeners, "listeners");
         for (GenericFutureListener<? extends Future<? super V>> l: listeners) {
             if (l == null) {
                 break;

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -473,10 +473,10 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
      */
     protected static void notifyListener(
             EventExecutor eventExecutor, final Future<?> future, final GenericFutureListener<?> listener) {
-        checkNotNull(eventExecutor, "eventExecutor");
-        checkNotNull(future, "future");
-        checkNotNull(listener, "listener");
-        notifyListenerWithStackOverFlowProtection(eventExecutor, future, listener);
+        notifyListenerWithStackOverFlowProtection(
+                checkNotNull(eventExecutor, "eventExecutor"),
+                checkNotNull(future, "future"),
+                checkNotNull(listener, "listener"));
     }
 
     private void notifyListeners() {

--- a/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java
@@ -16,6 +16,7 @@
 
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.util.Locale;
@@ -64,9 +65,7 @@ public class DefaultThreadFactory implements ThreadFactory {
     }
 
     public static String toPoolName(Class<?> poolType) {
-        if (poolType == null) {
-            throw new NullPointerException("poolType");
-        }
+        ObjectUtil.checkNotNull(poolType, "poolType");
 
         String poolName = StringUtil.simpleClassName(poolType);
         switch (poolName.length()) {
@@ -84,9 +83,8 @@ public class DefaultThreadFactory implements ThreadFactory {
     }
 
     public DefaultThreadFactory(String poolName, boolean daemon, int priority, ThreadGroup threadGroup) {
-        if (poolName == null) {
-            throw new NullPointerException("poolName");
-        }
+        ObjectUtil.checkNotNull(poolName, "poolName");
+
         if (priority < Thread.MIN_PRIORITY || priority > Thread.MAX_PRIORITY) {
             throw new IllegalArgumentException(
                     "priority: " + priority + " (expected: Thread.MIN_PRIORITY <= priority <= Thread.MAX_PRIORITY)");

--- a/common/src/main/java/io/netty/util/concurrent/FailedFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/FailedFuture.java
@@ -35,8 +35,7 @@ public final class FailedFuture<V> extends CompleteFuture<V> {
      */
     public FailedFuture(EventExecutor executor, Throwable cause) {
         super(executor);
-        ObjectUtil.checkNotNull(cause, "cause");
-        this.cause = cause;
+        this.cause = ObjectUtil.checkNotNull(cause, "cause");
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/FailedFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/FailedFuture.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 /**
@@ -34,9 +35,7 @@ public final class FailedFuture<V> extends CompleteFuture<V> {
      */
     public FailedFuture(EventExecutor executor, Throwable cause) {
         super(executor);
-        if (cause == null) {
-            throw new NullPointerException("cause");
-        }
+        ObjectUtil.checkNotNull(cause, "cause");
         this.cause = cause;
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -190,11 +190,13 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
      * @return {@code true} if and only if the worker thread has been terminated
      */
     public boolean awaitInactivity(long timeout, TimeUnit unit) throws InterruptedException {
+        ObjectUtil.checkNotNull(unit, "unit");
+
         final Thread thread = this.thread;
         if (thread == null) {
             throw new IllegalStateException("thread was not started");
         }
-        thread.join(ObjectUtil.checkNotNull(unit, "unit").toMillis(timeout));
+        thread.join(unit.toMillis(timeout));
         return !thread.isAlive();
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.ThreadExecutorMap;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -136,9 +137,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
      * before.
      */
     private void addTask(Runnable task) {
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
+        ObjectUtil.checkNotNull(task, "task");
         taskQueue.add(task);
     }
 
@@ -192,9 +191,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
      * @return {@code true} if and only if the worker thread has been terminated
      */
     public boolean awaitInactivity(long timeout, TimeUnit unit) throws InterruptedException {
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
+        ObjectUtil.checkNotNull(unit, "unit");
 
         final Thread thread = this.thread;
         if (thread == null) {
@@ -206,9 +203,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
 
     @Override
     public void execute(Runnable task) {
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
+        ObjectUtil.checkNotNull(task, "task");
 
         addTask(task);
         if (!inEventLoop()) {

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -137,8 +137,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
      * before.
      */
     private void addTask(Runnable task) {
-        ObjectUtil.checkNotNull(task, "task");
-        taskQueue.add(task);
+        taskQueue.add(ObjectUtil.checkNotNull(task, "task"));
     }
 
     @Override
@@ -191,21 +190,17 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
      * @return {@code true} if and only if the worker thread has been terminated
      */
     public boolean awaitInactivity(long timeout, TimeUnit unit) throws InterruptedException {
-        ObjectUtil.checkNotNull(unit, "unit");
-
         final Thread thread = this.thread;
         if (thread == null) {
             throw new IllegalStateException("thread was not started");
         }
-        thread.join(unit.toMillis(timeout));
+        thread.join(ObjectUtil.checkNotNull(unit, "unit").toMillis(timeout));
         return !thread.isAlive();
     }
 
     @Override
     public void execute(Runnable task) {
-        ObjectUtil.checkNotNull(task, "task");
-
-        addTask(task);
+        addTask(ObjectUtil.checkNotNull(task, "task"));
         if (!inEventLoop()) {
             startThread();
         }

--- a/common/src/main/java/io/netty/util/concurrent/ImmediateEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/ImmediateEventExecutor.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -102,9 +103,7 @@ public final class ImmediateEventExecutor extends AbstractEventExecutor {
 
     @Override
     public void execute(Runnable command) {
-        if (command == null) {
-            throw new NullPointerException("command");
-        }
+        ObjectUtil.checkNotNull(command, "command");
         if (!RUNNING.get()) {
             RUNNING.set(true);
             try {

--- a/common/src/main/java/io/netty/util/concurrent/ImmediateExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/ImmediateExecutor.java
@@ -31,7 +31,6 @@ public final class ImmediateExecutor implements Executor {
 
     @Override
     public void execute(Runnable command) {
-        ObjectUtil.checkNotNull(command, "command");
-        command.run();
+        ObjectUtil.checkNotNull(command, "command").run();
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/ImmediateExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/ImmediateExecutor.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.concurrent.Executor;
 
 /**
@@ -23,15 +25,13 @@ import java.util.concurrent.Executor;
 public final class ImmediateExecutor implements Executor {
     public static final ImmediateExecutor INSTANCE = new ImmediateExecutor();
 
-    private  ImmediateExecutor() {
+    private ImmediateExecutor() {
         // use static instance
     }
 
     @Override
     public void execute(Runnable command) {
-        if (command == null) {
-            throw new NullPointerException("command");
-        }
+        ObjectUtil.checkNotNull(command, "command");
         command.run();
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
@@ -45,8 +45,7 @@ public class PromiseAggregator<V, F extends Future<V>> implements GenericFutureL
      * @param failPending  {@code true} to fail pending promises, false to leave them unaffected
      */
     public PromiseAggregator(Promise<Void> aggregatePromise, boolean failPending) {
-        ObjectUtil.checkNotNull(aggregatePromise, "aggregatePromise");
-        this.aggregatePromise = aggregatePromise;
+        this.aggregatePromise = ObjectUtil.checkNotNull(aggregatePromise, "aggregatePromise");
         this.failPending = failPending;
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
@@ -16,6 +16,8 @@
 
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -43,9 +45,7 @@ public class PromiseAggregator<V, F extends Future<V>> implements GenericFutureL
      * @param failPending  {@code true} to fail pending promises, false to leave them unaffected
      */
     public PromiseAggregator(Promise<Void> aggregatePromise, boolean failPending) {
-        if (aggregatePromise == null) {
-            throw new NullPointerException("aggregatePromise");
-        }
+        ObjectUtil.checkNotNull(aggregatePromise, "aggregatePromise");
         this.aggregatePromise = aggregatePromise;
         this.failPending = failPending;
     }
@@ -63,9 +63,7 @@ public class PromiseAggregator<V, F extends Future<V>> implements GenericFutureL
      */
     @SafeVarargs
     public final PromiseAggregator<V, F> add(Promise<V>... promises) {
-        if (promises == null) {
-            throw new NullPointerException("promises");
-        }
+        ObjectUtil.checkNotNull(promises, "promises");
         if (promises.length == 0) {
             return this;
         }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -342,9 +342,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * before.
      */
     protected void addTask(Runnable task) {
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
+        ObjectUtil.checkNotNull(task, "task");
         if (!offerTask(task)) {
             reject(task);
         }
@@ -361,9 +359,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * @see Queue#remove(Object)
      */
     protected boolean removeTask(Runnable task) {
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
+        ObjectUtil.checkNotNull(task, "task");
         return taskQueue.remove(task);
     }
 
@@ -624,16 +620,12 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     @Override
     public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
-        if (quietPeriod < 0) {
-            throw new IllegalArgumentException("quietPeriod: " + quietPeriod + " (expected >= 0)");
-        }
+        ObjectUtil.checkPositiveOrZero(quietPeriod, "quietPeriod");
         if (timeout < quietPeriod) {
             throw new IllegalArgumentException(
                     "timeout: " + timeout + " (expected >= quietPeriod (" + quietPeriod + "))");
         }
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
+        ObjectUtil.checkNotNull(unit, "unit");
 
         if (isShuttingDown()) {
             return terminationFuture();
@@ -811,9 +803,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
+        ObjectUtil.checkNotNull(unit, "unit");
 
         if (inEventLoop()) {
             throw new IllegalStateException("cannot await termination of the current thread");

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -802,11 +802,12 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        ObjectUtil.checkNotNull(unit, "unit");
         if (inEventLoop()) {
             throw new IllegalStateException("cannot await termination of the current thread");
         }
 
-        threadLock.await(timeout, ObjectUtil.checkNotNull(unit, "unit"));
+        threadLock.await(timeout, unit);
 
         return isTerminated();
     }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -169,7 +169,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
         this.maxPendingTasks = DEFAULT_MAX_PENDING_EXECUTOR_TASKS;
         this.executor = ThreadExecutorMap.apply(executor, this);
         this.taskQueue = ObjectUtil.checkNotNull(taskQueue, "taskQueue");
-        rejectedExecutionHandler = ObjectUtil.checkNotNull(rejectedHandler, "rejectedHandler");
+        this.rejectedExecutionHandler = ObjectUtil.checkNotNull(rejectedHandler, "rejectedHandler");
     }
 
     /**
@@ -359,8 +359,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * @see Queue#remove(Object)
      */
     protected boolean removeTask(Runnable task) {
-        ObjectUtil.checkNotNull(task, "task");
-        return taskQueue.remove(task);
+        return taskQueue.remove(ObjectUtil.checkNotNull(task, "task"));
     }
 
     /**
@@ -803,13 +802,11 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        ObjectUtil.checkNotNull(unit, "unit");
-
         if (inEventLoop()) {
             throw new IllegalStateException("cannot await termination of the current thread");
         }
 
-        threadLock.await(timeout, unit);
+        threadLock.await(timeout, ObjectUtil.checkNotNull(unit, "unit"));
 
         return isTerminated();
     }

--- a/common/src/main/java/io/netty/util/concurrent/ThreadPerTaskExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/ThreadPerTaskExecutor.java
@@ -24,8 +24,7 @@ public final class ThreadPerTaskExecutor implements Executor {
     private final ThreadFactory threadFactory;
 
     public ThreadPerTaskExecutor(ThreadFactory threadFactory) {
-        ObjectUtil.checkNotNull(threadFactory, "threadFactory");
-        this.threadFactory = threadFactory;
+        this.threadFactory = ObjectUtil.checkNotNull(threadFactory, "threadFactory");
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/ThreadPerTaskExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/ThreadPerTaskExecutor.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -22,9 +24,7 @@ public final class ThreadPerTaskExecutor implements Executor {
     private final ThreadFactory threadFactory;
 
     public ThreadPerTaskExecutor(ThreadFactory threadFactory) {
-        if (threadFactory == null) {
-            throw new NullPointerException("threadFactory");
-        }
+        ObjectUtil.checkNotNull(threadFactory, "threadFactory");
         this.threadFactory = threadFactory;
     }
 

--- a/common/src/main/java/io/netty/util/internal/ObjectPool.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectPool.java
@@ -64,9 +64,7 @@ public abstract class ObjectPool<T> {
      * that should be pooled.
      */
     public static <T> ObjectPool<T> newPool(final ObjectCreator<T> creator) {
-        ObjectUtil.checkNotNull(creator, "creator");
-
-        return new RecyclerObjectPool<T>(creator);
+        return new RecyclerObjectPool<T>(ObjectUtil.checkNotNull(creator, "creator"));
     }
 
     private static final class RecyclerObjectPool<T> extends ObjectPool<T> {

--- a/common/src/main/java/io/netty/util/internal/ReadOnlyIterator.java
+++ b/common/src/main/java/io/netty/util/internal/ReadOnlyIterator.java
@@ -22,8 +22,7 @@ public final class ReadOnlyIterator<T> implements Iterator<T> {
     private final Iterator<? extends T> iterator;
 
     public ReadOnlyIterator(Iterator<? extends T> iterator) {
-        ObjectUtil.checkNotNull(iterator, "iterator");
-        this.iterator = iterator;
+        this.iterator = ObjectUtil.checkNotNull(iterator, "iterator");
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/ReadOnlyIterator.java
+++ b/common/src/main/java/io/netty/util/internal/ReadOnlyIterator.java
@@ -22,9 +22,7 @@ public final class ReadOnlyIterator<T> implements Iterator<T> {
     private final Iterator<? extends T> iterator;
 
     public ReadOnlyIterator(Iterator<? extends T> iterator) {
-        if (iterator == null) {
-            throw new NullPointerException("iterator");
-        }
+        ObjectUtil.checkNotNull(iterator, "iterator");
         this.iterator = iterator;
     }
 

--- a/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java
+++ b/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java
@@ -111,9 +111,7 @@ public final class RecyclableArrayList extends ArrayList<Object> {
 
     @Override
     public boolean add(Object element) {
-        if (element == null) {
-            throw new NullPointerException("element");
-        }
+        ObjectUtil.checkNotNull(element, "element");
         if (super.add(element)) {
             insertSinceRecycled = true;
             return true;
@@ -123,18 +121,14 @@ public final class RecyclableArrayList extends ArrayList<Object> {
 
     @Override
     public void add(int index, Object element) {
-        if (element == null) {
-            throw new NullPointerException("element");
-        }
+        ObjectUtil.checkNotNull(element, "element");
         super.add(index, element);
         insertSinceRecycled = true;
     }
 
     @Override
     public Object set(int index, Object element) {
-        if (element == null) {
-            throw new NullPointerException("element");
-        }
+        ObjectUtil.checkNotNull(element, "element");
         Object old = super.set(index, element);
         insertSinceRecycled = true;
         return old;

--- a/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java
+++ b/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java
@@ -111,8 +111,7 @@ public final class RecyclableArrayList extends ArrayList<Object> {
 
     @Override
     public boolean add(Object element) {
-        ObjectUtil.checkNotNull(element, "element");
-        if (super.add(element)) {
+        if (super.add(ObjectUtil.checkNotNull(element, "element"))) {
             insertSinceRecycled = true;
             return true;
         }
@@ -121,15 +120,13 @@ public final class RecyclableArrayList extends ArrayList<Object> {
 
     @Override
     public void add(int index, Object element) {
-        ObjectUtil.checkNotNull(element, "element");
-        super.add(index, element);
+        super.add(index, ObjectUtil.checkNotNull(element, "element"));
         insertSinceRecycled = true;
     }
 
     @Override
     public Object set(int index, Object element) {
-        ObjectUtil.checkNotNull(element, "element");
-        Object old = super.set(index, element);
+        Object old = super.set(index, ObjectUtil.checkNotNull(element, "element"));
         insertSinceRecycled = true;
         return old;
     }

--- a/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
+++ b/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
@@ -56,9 +56,7 @@ public final class SystemPropertyUtil {
      *         specified property is not allowed.
      */
     public static String get(final String key, String def) {
-        if (key == null) {
-            throw new NullPointerException("key");
-        }
+        ObjectUtil.checkNotNull(key, "key");
         if (key.isEmpty()) {
             throw new IllegalArgumentException("key must not be empty.");
         }

--- a/common/src/main/java/io/netty/util/internal/logging/AbstractInternalLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/AbstractInternalLogger.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.internal.logging;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.io.ObjectStreamException;
@@ -37,9 +38,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
      * Creates a new instance.
      */
     protected AbstractInternalLogger(String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
         this.name = name;
     }
 

--- a/common/src/main/java/io/netty/util/internal/logging/AbstractInternalLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/AbstractInternalLogger.java
@@ -38,8 +38,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
      * Creates a new instance.
      */
     protected AbstractInternalLogger(String name) {
-        ObjectUtil.checkNotNull(name, "name");
-        this.name = name;
+        this.name = ObjectUtil.checkNotNull(name, "name");
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/logging/CommonsLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/CommonsLogger.java
@@ -58,8 +58,7 @@ class CommonsLogger extends AbstractInternalLogger {
 
     CommonsLogger(Log logger, String name) {
         super(name);
-        ObjectUtil.checkNotNull(logger, "logger");
-        this.logger = logger;
+        this.logger = ObjectUtil.checkNotNull(logger, "logger");
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/logging/CommonsLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/CommonsLogger.java
@@ -39,6 +39,7 @@
  */
 package io.netty.util.internal.logging;
 
+import io.netty.util.internal.ObjectUtil;
 import org.apache.commons.logging.Log;
 
 /**
@@ -57,9 +58,7 @@ class CommonsLogger extends AbstractInternalLogger {
 
     CommonsLogger(Log logger, String name) {
         super(name);
-        if (logger == null) {
-            throw new NullPointerException("logger");
-        }
+        ObjectUtil.checkNotNull(logger, "logger");
         this.logger = logger;
     }
 

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -75,8 +75,7 @@ public abstract class InternalLoggerFactory {
      * Changes the default factory.
      */
     public static void setDefaultFactory(InternalLoggerFactory defaultFactory) {
-        ObjectUtil.checkNotNull(defaultFactory, "defaultFactory");
-        InternalLoggerFactory.defaultFactory = defaultFactory;
+        InternalLoggerFactory.defaultFactory = ObjectUtil.checkNotNull(defaultFactory, "defaultFactory");
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -16,6 +16,8 @@
 
 package io.netty.util.internal.logging;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * Creates an {@link InternalLogger} or changes the default factory
  * implementation.  This factory allows you to choose what logging framework
@@ -73,9 +75,7 @@ public abstract class InternalLoggerFactory {
      * Changes the default factory.
      */
     public static void setDefaultFactory(InternalLoggerFactory defaultFactory) {
-        if (defaultFactory == null) {
-            throw new NullPointerException("defaultFactory");
-        }
+        ObjectUtil.checkNotNull(defaultFactory, "defaultFactory");
         InternalLoggerFactory.defaultFactory = defaultFactory;
     }
 

--- a/example/src/main/java/io/netty/example/spdy/client/SpdyFrameLogger.java
+++ b/example/src/main/java/io/netty/example/spdy/client/SpdyFrameLogger.java
@@ -37,10 +37,8 @@ public class SpdyFrameLogger extends ChannelDuplexHandler {
     private final InternalLogLevel level;
 
     public SpdyFrameLogger(InternalLogLevel level) {
-        ObjectUtil.checkNotNull(level, "level");
-
-        logger = InternalLoggerFactory.getInstance(getClass());
-        this.level = level;
+        this.level = ObjectUtil.checkNotNull(level, "level");
+        this.logger = InternalLoggerFactory.getInstance(getClass());
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/spdy/client/SpdyFrameLogger.java
+++ b/example/src/main/java/io/netty/example/spdy/client/SpdyFrameLogger.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.spdy.SpdyFrame;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -36,9 +37,7 @@ public class SpdyFrameLogger extends ChannelDuplexHandler {
     private final InternalLogLevel level;
 
     public SpdyFrameLogger(InternalLogLevel level) {
-        if (level == null) {
-            throw new NullPointerException("level");
-        }
+        ObjectUtil.checkNotNull(level, "level");
 
         logger = InternalLoggerFactory.getInstance(getClass());
         this.level = level;

--- a/example/src/main/java/io/netty/example/worldclock/WorldClockProtocol.java
+++ b/example/src/main/java/io/netty/example/worldclock/WorldClockProtocol.java
@@ -19,8 +19,6 @@
 
 package io.netty.example.worldclock;
 
-import io.netty.util.internal.ObjectUtil;
-
 @SuppressWarnings("all")
 public final class WorldClockProtocol {
   private WorldClockProtocol() {}
@@ -824,7 +822,9 @@ public final class WorldClockProtocol {
        * <code>required .io.netty.example.worldclock.Continent continent = 1;</code>
        */
       public Builder setContinent(io.netty.example.worldclock.WorldClockProtocol.Continent value) {
-        ObjectUtil.checkNotNull(value, "value");
+        if (value == null) {
+          throw new NullPointerException();
+        }
         bitField0_ |= 0x00000001;
         continent_ = value;
         onChanged();
@@ -886,7 +886,9 @@ public final class WorldClockProtocol {
        */
       public Builder setCity(
           java.lang.String value) {
-        ObjectUtil.checkNotNull(value, "value");
+        if (value == null) {
+    throw new NullPointerException();
+  }
   bitField0_ |= 0x00000002;
         city_ = value;
         onChanged();
@@ -906,7 +908,9 @@ public final class WorldClockProtocol {
        */
       public Builder setCityBytes(
           com.google.protobuf.ByteString value) {
-        ObjectUtil.checkNotNull(value, "value");
+        if (value == null) {
+    throw new NullPointerException();
+  }
   bitField0_ |= 0x00000002;
         city_ = value;
         onChanged();
@@ -1434,7 +1438,9 @@ public final class WorldClockProtocol {
       public Builder setLocation(
           int index, io.netty.example.worldclock.WorldClockProtocol.Location value) {
         if (locationBuilder_ == null) {
-          ObjectUtil.checkNotNull(value, "value");
+          if (value == null) {
+            throw new NullPointerException();
+          }
           ensureLocationIsMutable();
           location_.set(index, value);
           onChanged();
@@ -1462,7 +1468,9 @@ public final class WorldClockProtocol {
        */
       public Builder addLocation(io.netty.example.worldclock.WorldClockProtocol.Location value) {
         if (locationBuilder_ == null) {
-          ObjectUtil.checkNotNull(value, "value");
+          if (value == null) {
+            throw new NullPointerException();
+          }
           ensureLocationIsMutable();
           location_.add(value);
           onChanged();
@@ -1477,7 +1485,9 @@ public final class WorldClockProtocol {
       public Builder addLocation(
           int index, io.netty.example.worldclock.WorldClockProtocol.Location value) {
         if (locationBuilder_ == null) {
-          ObjectUtil.checkNotNull(value, "value");
+          if (value == null) {
+            throw new NullPointerException();
+          }
           ensureLocationIsMutable();
           location_.add(index, value);
           onChanged();
@@ -2491,7 +2501,9 @@ public final class WorldClockProtocol {
        * <code>required .io.netty.example.worldclock.DayOfWeek dayOfWeek = 5;</code>
        */
       public Builder setDayOfWeek(io.netty.example.worldclock.WorldClockProtocol.DayOfWeek value) {
-        ObjectUtil.checkNotNull(value, "value");
+        if (value == null) {
+          throw new NullPointerException();
+        }
         bitField0_ |= 0x00000008;
         dayOfWeek_ = value;
         onChanged();
@@ -3133,7 +3145,9 @@ public final class WorldClockProtocol {
       public Builder setLocalTime(
           int index, io.netty.example.worldclock.WorldClockProtocol.LocalTime value) {
         if (localTimeBuilder_ == null) {
-          ObjectUtil.checkNotNull(value, "value");
+          if (value == null) {
+            throw new NullPointerException();
+          }
           ensureLocalTimeIsMutable();
           localTime_.set(index, value);
           onChanged();
@@ -3161,7 +3175,9 @@ public final class WorldClockProtocol {
        */
       public Builder addLocalTime(io.netty.example.worldclock.WorldClockProtocol.LocalTime value) {
         if (localTimeBuilder_ == null) {
-          ObjectUtil.checkNotNull(value, "value");
+          if (value == null) {
+            throw new NullPointerException();
+          }
           ensureLocalTimeIsMutable();
           localTime_.add(value);
           onChanged();
@@ -3176,7 +3192,9 @@ public final class WorldClockProtocol {
       public Builder addLocalTime(
           int index, io.netty.example.worldclock.WorldClockProtocol.LocalTime value) {
         if (localTimeBuilder_ == null) {
-          ObjectUtil.checkNotNull(value, "value");
+          if (value == null) {
+            throw new NullPointerException();
+          }
           ensureLocalTimeIsMutable();
           localTime_.add(index, value);
           onChanged();

--- a/example/src/main/java/io/netty/example/worldclock/WorldClockProtocol.java
+++ b/example/src/main/java/io/netty/example/worldclock/WorldClockProtocol.java
@@ -19,6 +19,8 @@
 
 package io.netty.example.worldclock;
 
+import io.netty.util.internal.ObjectUtil;
+
 @SuppressWarnings("all")
 public final class WorldClockProtocol {
   private WorldClockProtocol() {}
@@ -822,9 +824,7 @@ public final class WorldClockProtocol {
        * <code>required .io.netty.example.worldclock.Continent continent = 1;</code>
        */
       public Builder setContinent(io.netty.example.worldclock.WorldClockProtocol.Continent value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
+        ObjectUtil.checkNotNull(value, "value");
         bitField0_ |= 0x00000001;
         continent_ = value;
         onChanged();
@@ -886,9 +886,7 @@ public final class WorldClockProtocol {
        */
       public Builder setCity(
           java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
+        ObjectUtil.checkNotNull(value, "value");
   bitField0_ |= 0x00000002;
         city_ = value;
         onChanged();
@@ -908,9 +906,7 @@ public final class WorldClockProtocol {
        */
       public Builder setCityBytes(
           com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
+        ObjectUtil.checkNotNull(value, "value");
   bitField0_ |= 0x00000002;
         city_ = value;
         onChanged();
@@ -1438,9 +1434,7 @@ public final class WorldClockProtocol {
       public Builder setLocation(
           int index, io.netty.example.worldclock.WorldClockProtocol.Location value) {
         if (locationBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
+          ObjectUtil.checkNotNull(value, "value");
           ensureLocationIsMutable();
           location_.set(index, value);
           onChanged();
@@ -1468,9 +1462,7 @@ public final class WorldClockProtocol {
        */
       public Builder addLocation(io.netty.example.worldclock.WorldClockProtocol.Location value) {
         if (locationBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
+          ObjectUtil.checkNotNull(value, "value");
           ensureLocationIsMutable();
           location_.add(value);
           onChanged();
@@ -1485,9 +1477,7 @@ public final class WorldClockProtocol {
       public Builder addLocation(
           int index, io.netty.example.worldclock.WorldClockProtocol.Location value) {
         if (locationBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
+          ObjectUtil.checkNotNull(value, "value");
           ensureLocationIsMutable();
           location_.add(index, value);
           onChanged();
@@ -2501,9 +2491,7 @@ public final class WorldClockProtocol {
        * <code>required .io.netty.example.worldclock.DayOfWeek dayOfWeek = 5;</code>
        */
       public Builder setDayOfWeek(io.netty.example.worldclock.WorldClockProtocol.DayOfWeek value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
+        ObjectUtil.checkNotNull(value, "value");
         bitField0_ |= 0x00000008;
         dayOfWeek_ = value;
         onChanged();
@@ -3145,9 +3133,7 @@ public final class WorldClockProtocol {
       public Builder setLocalTime(
           int index, io.netty.example.worldclock.WorldClockProtocol.LocalTime value) {
         if (localTimeBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
+          ObjectUtil.checkNotNull(value, "value");
           ensureLocalTimeIsMutable();
           localTime_.set(index, value);
           onChanged();
@@ -3175,9 +3161,7 @@ public final class WorldClockProtocol {
        */
       public Builder addLocalTime(io.netty.example.worldclock.WorldClockProtocol.LocalTime value) {
         if (localTimeBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
+          ObjectUtil.checkNotNull(value, "value");
           ensureLocalTimeIsMutable();
           localTime_.add(value);
           onChanged();
@@ -3192,9 +3176,7 @@ public final class WorldClockProtocol {
       public Builder addLocalTime(
           int index, io.netty.example.worldclock.WorldClockProtocol.LocalTime value) {
         if (localTimeBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
+          ObjectUtil.checkNotNull(value, "value");
           ensureLocalTimeIsMutable();
           localTime_.add(index, value);
           onChanged();

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -87,10 +87,8 @@ public final class HttpProxyHandler extends ProxyHandler {
                             HttpHeaders headers,
                             boolean ignoreDefaultPortsInConnectHostHeader) {
         super(proxyAddress);
-        ObjectUtil.checkNotNull(username, "username");
-        ObjectUtil.checkNotNull(password, "password");
-        this.username = username;
-        this.password = password;
+        this.username = ObjectUtil.checkNotNull(username, "username");
+        this.password = ObjectUtil.checkNotNull(password, "password");
 
         ByteBuf authz = Unpooled.copiedBuffer(username + ':' + password, CharsetUtil.UTF_8);
         ByteBuf authzBase64 = Base64.encode(authz, false);

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -86,12 +87,8 @@ public final class HttpProxyHandler extends ProxyHandler {
                             HttpHeaders headers,
                             boolean ignoreDefaultPortsInConnectHostHeader) {
         super(proxyAddress);
-        if (username == null) {
-            throw new NullPointerException("username");
-        }
-        if (password == null) {
-            throw new NullPointerException("password");
-        }
+        ObjectUtil.checkNotNull(username, "username");
+        ObjectUtil.checkNotNull(password, "password");
         this.username = username;
         this.password = password;
 

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyConnectionEvent.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyConnectionEvent.java
@@ -34,15 +34,10 @@ public final class ProxyConnectionEvent {
      */
     public ProxyConnectionEvent(
             String protocol, String authScheme, SocketAddress proxyAddress, SocketAddress destinationAddress) {
-        ObjectUtil.checkNotNull(protocol, "protocol");
-        ObjectUtil.checkNotNull(authScheme, "authScheme");
-        ObjectUtil.checkNotNull(proxyAddress, "proxyAddress");
-        ObjectUtil.checkNotNull(destinationAddress, "destinationAddress");
-
-        this.protocol = protocol;
-        this.authScheme = authScheme;
-        this.proxyAddress = proxyAddress;
-        this.destinationAddress = destinationAddress;
+        this.protocol = ObjectUtil.checkNotNull(protocol, "protocol");
+        this.authScheme = ObjectUtil.checkNotNull(authScheme, "authScheme");
+        this.proxyAddress = ObjectUtil.checkNotNull(proxyAddress, "proxyAddress");
+        this.destinationAddress = ObjectUtil.checkNotNull(destinationAddress, "destinationAddress");
     }
 
     /**

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyConnectionEvent.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyConnectionEvent.java
@@ -16,6 +16,7 @@
 
 package io.netty.handler.proxy;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.net.SocketAddress;
@@ -33,18 +34,10 @@ public final class ProxyConnectionEvent {
      */
     public ProxyConnectionEvent(
             String protocol, String authScheme, SocketAddress proxyAddress, SocketAddress destinationAddress) {
-        if (protocol == null) {
-            throw new NullPointerException("protocol");
-        }
-        if (authScheme == null) {
-            throw new NullPointerException("authScheme");
-        }
-        if (proxyAddress == null) {
-            throw new NullPointerException("proxyAddress");
-        }
-        if (destinationAddress == null) {
-            throw new NullPointerException("destinationAddress");
-        }
+        ObjectUtil.checkNotNull(protocol, "protocol");
+        ObjectUtil.checkNotNull(authScheme, "authScheme");
+        ObjectUtil.checkNotNull(proxyAddress, "proxyAddress");
+        ObjectUtil.checkNotNull(destinationAddress, "destinationAddress");
 
         this.protocol = protocol;
         this.authScheme = authScheme;

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -71,8 +71,7 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
     };
 
     protected ProxyHandler(SocketAddress proxyAddress) {
-        ObjectUtil.checkNotNull(proxyAddress, "proxyAddress");
-        this.proxyAddress = proxyAddress;
+        this.proxyAddress = ObjectUtil.checkNotNull(proxyAddress, "proxyAddress");
     }
 
     /**

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -28,6 +28,7 @@ import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ScheduledFuture;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -70,9 +71,7 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
     };
 
     protected ProxyHandler(SocketAddress proxyAddress) {
-        if (proxyAddress == null) {
-            throw new NullPointerException("proxyAddress");
-        }
+        ObjectUtil.checkNotNull(proxyAddress, "proxyAddress");
         this.proxyAddress = proxyAddress;
     }
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.ipfilter;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SocketUtils;
 
 import java.math.BigInteger;
@@ -45,13 +46,8 @@ public final class IpSubnetFilterRule implements IpFilterRule {
     }
 
     private static IpFilterRule selectFilterRule(InetAddress ipAddress, int cidrPrefix, IpFilterRuleType ruleType) {
-        if (ipAddress == null) {
-            throw new NullPointerException("ipAddress");
-        }
-
-        if (ruleType == null) {
-            throw new NullPointerException("ruleType");
-        }
+        ObjectUtil.checkNotNull(ipAddress, "ipAddress");
+        ObjectUtil.checkNotNull(ruleType, "ruleType");
 
         if (ipAddress instanceof Inet4Address) {
             return new Ip4SubnetFilterRule((Inet4Address) ipAddress, cidrPrefix, ruleType);

--- a/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
@@ -37,8 +37,7 @@ public class RuleBasedIpFilter extends AbstractRemoteAddressFilter<InetSocketAdd
     private final IpFilterRule[] rules;
 
     public RuleBasedIpFilter(IpFilterRule... rules) {
-        ObjectUtil.checkNotNull(rules, "rules");
-        this.rules = rules;
+        this.rules = ObjectUtil.checkNotNull(rules, "rules");
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
@@ -18,6 +18,7 @@ package io.netty.handler.ipfilter;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -36,10 +37,7 @@ public class RuleBasedIpFilter extends AbstractRemoteAddressFilter<InetSocketAdd
     private final IpFilterRule[] rules;
 
     public RuleBasedIpFilter(IpFilterRule... rules) {
-        if (rules == null) {
-            throw new NullPointerException("rules");
-        }
-
+        ObjectUtil.checkNotNull(rules, "rules");
         this.rules = rules;
     }
 

--- a/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -62,9 +63,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
      * @param level the log level
      */
     public LoggingHandler(LogLevel level) {
-        if (level == null) {
-            throw new NullPointerException("level");
-        }
+        ObjectUtil.checkNotNull(level, "level");
 
         logger = InternalLoggerFactory.getInstance(getClass());
         this.level = level;
@@ -88,12 +87,8 @@ public class LoggingHandler extends ChannelDuplexHandler {
      * @param level the log level
      */
     public LoggingHandler(Class<?> clazz, LogLevel level) {
-        if (clazz == null) {
-            throw new NullPointerException("clazz");
-        }
-        if (level == null) {
-            throw new NullPointerException("level");
-        }
+        ObjectUtil.checkNotNull(clazz, "clazz");
+        ObjectUtil.checkNotNull(level, "level");
 
         logger = InternalLoggerFactory.getInstance(clazz);
         this.level = level;
@@ -116,12 +111,8 @@ public class LoggingHandler extends ChannelDuplexHandler {
      * @param level the log level
      */
     public LoggingHandler(String name, LogLevel level) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
-        if (level == null) {
-            throw new NullPointerException("level");
-        }
+        ObjectUtil.checkNotNull(name, "name");
+        ObjectUtil.checkNotNull(level, "level");
 
         logger = InternalLoggerFactory.getInstance(name);
         this.level = level;

--- a/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
@@ -63,10 +63,8 @@ public class LoggingHandler extends ChannelDuplexHandler {
      * @param level the log level
      */
     public LoggingHandler(LogLevel level) {
-        ObjectUtil.checkNotNull(level, "level");
-
+        this.level = ObjectUtil.checkNotNull(level, "level");
         logger = InternalLoggerFactory.getInstance(getClass());
-        this.level = level;
         internalLevel = level.toInternalLevel();
     }
 
@@ -88,10 +86,8 @@ public class LoggingHandler extends ChannelDuplexHandler {
      */
     public LoggingHandler(Class<?> clazz, LogLevel level) {
         ObjectUtil.checkNotNull(clazz, "clazz");
-        ObjectUtil.checkNotNull(level, "level");
-
+        this.level = ObjectUtil.checkNotNull(level, "level");
         logger = InternalLoggerFactory.getInstance(clazz);
-        this.level = level;
         internalLevel = level.toInternalLevel();
     }
 
@@ -112,10 +108,9 @@ public class LoggingHandler extends ChannelDuplexHandler {
      */
     public LoggingHandler(String name, LogLevel level) {
         ObjectUtil.checkNotNull(name, "name");
-        ObjectUtil.checkNotNull(level, "level");
 
+        this.level = ObjectUtil.checkNotNull(level, "level");
         logger = InternalLoggerFactory.getInstance(name);
-        this.level = level;
         internalLevel = level.toInternalLevel();
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -15,10 +15,10 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.ObjectUtil;
 import io.netty.internal.tcnative.SSL;
 import io.netty.internal.tcnative.SSLContext;
 import io.netty.internal.tcnative.SessionTicketKey;
+import io.netty.util.internal.ObjectUtil;
 
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
@@ -54,9 +54,7 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
 
     @Override
     public SSLSession getSession(byte[] bytes) {
-        if (bytes == null) {
-            throw new NullPointerException("bytes");
-        }
+        ObjectUtil.checkNotNull(bytes, "bytes");
         return null;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -26,6 +26,7 @@ import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SuppressJava6Requirement;
@@ -1013,9 +1014,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             final ByteBuffer[] dsts, int dstsOffset, final int dstsLength) throws SSLException {
 
         // Throw required runtime exceptions
-        if (srcs == null) {
-            throw new NullPointerException("srcs");
-        }
+        ObjectUtil.checkNotNull(srcs, "srcs");
         if (srcsOffset >= srcs.length
                 || srcsOffset + srcsLength > srcs.length) {
             throw new IndexOutOfBoundsException(
@@ -2122,12 +2121,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
         @Override
         public void putValue(String name, Object value) {
-            if (name == null) {
-                throw new NullPointerException("name");
-            }
-            if (value == null) {
-                throw new NullPointerException("value");
-            }
+            ObjectUtil.checkNotNull(name, "name");
+            ObjectUtil.checkNotNull(value, "value");
+
             final Object old;
             synchronized (this) {
                 Map<String, Object> values = this.values;
@@ -2147,9 +2143,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
         @Override
         public Object getValue(String name) {
-            if (name == null) {
-                throw new NullPointerException("name");
-            }
+            ObjectUtil.checkNotNull(name, "name");
             synchronized (this) {
                 if (values == null) {
                     return null;
@@ -2160,9 +2154,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
         @Override
         public void removeValue(String name) {
-            if (name == null) {
-                throw new NullPointerException("name");
-            }
+            ObjectUtil.checkNotNull(name, "name");
 
             final Object old;
             synchronized (this) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -483,9 +483,8 @@ public final class SslContextBuilder {
      * cipher suites will be used.
      */
     public SslContextBuilder ciphers(Iterable<String> ciphers, CipherSuiteFilter cipherFilter) {
-        checkNotNull(cipherFilter, "cipherFilter");
+        this.cipherFilter = checkNotNull(cipherFilter, "cipherFilter");
         this.ciphers = ciphers;
-        this.cipherFilter = cipherFilter;
         return this;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -44,6 +44,7 @@ import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
@@ -449,12 +450,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      *                              {@link SSLEngine#getDelegatedTask()}.
      */
     public SslHandler(SSLEngine engine, boolean startTls, Executor delegatedTaskExecutor) {
-        if (engine == null) {
-            throw new NullPointerException("engine");
-        }
-        if (delegatedTaskExecutor == null) {
-            throw new NullPointerException("delegatedTaskExecutor");
-        }
+        ObjectUtil.checkNotNull(engine, "engine");
+        ObjectUtil.checkNotNull(delegatedTaskExecutor, "delegatedTaskExecutor");
         this.engine = engine;
         engineType = SslEngineType.forEngine(engine);
         this.delegatedTaskExecutor = delegatedTaskExecutor;
@@ -468,10 +465,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     public void setHandshakeTimeout(long handshakeTimeout, TimeUnit unit) {
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
-
+        ObjectUtil.checkNotNull(unit, "unit");
         setHandshakeTimeoutMillis(unit.toMillis(handshakeTimeout));
     }
 
@@ -1925,9 +1919,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * Performs TLS renegotiation.
      */
     public Future<Channel> renegotiate(final Promise<Channel> promise) {
-        if (promise == null) {
-            throw new NullPointerException("promise");
-        }
+        ObjectUtil.checkNotNull(promise, "promise");
 
         ChannelHandlerContext ctx = this.ctx;
         if (ctx == null) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -450,11 +450,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      *                              {@link SSLEngine#getDelegatedTask()}.
      */
     public SslHandler(SSLEngine engine, boolean startTls, Executor delegatedTaskExecutor) {
-        ObjectUtil.checkNotNull(engine, "engine");
-        ObjectUtil.checkNotNull(delegatedTaskExecutor, "delegatedTaskExecutor");
-        this.engine = engine;
+        this.engine = ObjectUtil.checkNotNull(engine, "engine");
+        this.delegatedTaskExecutor = ObjectUtil.checkNotNull(delegatedTaskExecutor, "delegatedTaskExecutor");
         engineType = SslEngineType.forEngine(engine);
-        this.delegatedTaskExecutor = delegatedTaskExecutor;
         this.startTls = startTls;
         this.jdkCompatibilityMode = engineType.jdkCompatibilityMode(engine);
         setCumulator(engineType.cumulator);

--- a/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.ObjectUtil;
+
 import javax.net.ssl.SSLEngine;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,12 +33,8 @@ public final class SupportedCipherSuiteFilter implements CipherSuiteFilter {
     @Override
     public String[] filterCipherSuites(Iterable<String> ciphers, List<String> defaultCiphers,
             Set<String> supportedCiphers) {
-        if (defaultCiphers == null) {
-            throw new NullPointerException("defaultCiphers");
-        }
-        if (supportedCiphers == null) {
-            throw new NullPointerException("supportedCiphers");
-        }
+        ObjectUtil.checkNotNull(defaultCiphers, "defaultCiphers");
+        ObjectUtil.checkNotNull(supportedCiphers, "supportedCiphers");
 
         final List<String> newCiphers;
         if (ciphers == null) {

--- a/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactory.java
@@ -18,8 +18,9 @@ package io.netty.handler.ssl.util;
 
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
-import io.netty.util.internal.EmptyArrays;
 import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import javax.net.ssl.ManagerFactoryParameters;
@@ -156,9 +157,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
      * @param fingerprints a list of SHA1 fingerprints
      */
     public FingerprintTrustManagerFactory(byte[]... fingerprints) {
-        if (fingerprints == null) {
-            throw new NullPointerException("fingerprints");
-        }
+        ObjectUtil.checkNotNull(fingerprints, "fingerprints");
 
         List<byte[]> list = new ArrayList<byte[]>(fingerprints.length);
         for (byte[] f: fingerprints) {
@@ -176,9 +175,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
     }
 
     private static byte[][] toFingerprintArray(Iterable<String> fingerprints) {
-        if (fingerprints == null) {
-            throw new NullPointerException("fingerprints");
-        }
+        ObjectUtil.checkNotNull(fingerprints, "fingerprints");
 
         List<byte[]> list = new ArrayList<byte[]>();
         for (String f: fingerprints) {

--- a/handler/src/main/java/io/netty/handler/ssl/util/SimpleTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SimpleTrustManagerFactory.java
@@ -17,6 +17,7 @@
 package io.netty.handler.ssl.util;
 
 import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SuppressJava6Requirement;
 
@@ -73,9 +74,7 @@ public abstract class SimpleTrustManagerFactory extends TrustManagerFactory {
         CURRENT_SPI.get().init(this);
         CURRENT_SPI.remove();
 
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedFile.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedFile.java
@@ -83,15 +83,13 @@ public class ChunkedFile implements ChunkedInput<ByteBuf> {
      *                  {@link #readChunk(ChannelHandlerContext)} call
      */
     public ChunkedFile(RandomAccessFile file, long offset, long length, int chunkSize) throws IOException {
-        ObjectUtil.checkNotNull(file, "file");
         ObjectUtil.checkPositiveOrZero(offset, "offset");
         ObjectUtil.checkPositiveOrZero(length, "length");
-        ObjectUtil.checkPositive(chunkSize, "chunkSize");
 
-        this.file = file;
+        this.file = ObjectUtil.checkNotNull(file, "file");
+        this.chunkSize = ObjectUtil.checkPositive(chunkSize, "chunkSize");
         this.offset = startOffset = offset;
         endOffset = offset + length;
-        this.chunkSize = chunkSize;
 
         file.seek(offset);
     }

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedFile.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedFile.java
@@ -86,7 +86,7 @@ public class ChunkedFile implements ChunkedInput<ByteBuf> {
         ObjectUtil.checkNotNull(file, "file");
         ObjectUtil.checkPositiveOrZero(offset, "offset");
         ObjectUtil.checkPositiveOrZero(length, "length");
-        ObjectUtil.checkPositiveOrZero(chunkSize, "chunkSize");
+        ObjectUtil.checkPositive(chunkSize, "chunkSize");
 
         this.file = file;
         this.offset = startOffset = offset;

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedFile.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedFile.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.FileRegion;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,22 +83,10 @@ public class ChunkedFile implements ChunkedInput<ByteBuf> {
      *                  {@link #readChunk(ChannelHandlerContext)} call
      */
     public ChunkedFile(RandomAccessFile file, long offset, long length, int chunkSize) throws IOException {
-        if (file == null) {
-            throw new NullPointerException("file");
-        }
-        if (offset < 0) {
-            throw new IllegalArgumentException(
-                    "offset: " + offset + " (expected: 0 or greater)");
-        }
-        if (length < 0) {
-            throw new IllegalArgumentException(
-                    "length: " + length + " (expected: 0 or greater)");
-        }
-        if (chunkSize <= 0) {
-            throw new IllegalArgumentException(
-                    "chunkSize: " + chunkSize +
-                    " (expected: a positive integer)");
-        }
+        ObjectUtil.checkNotNull(file, "file");
+        ObjectUtil.checkPositiveOrZero(offset, "offset");
+        ObjectUtil.checkPositiveOrZero(length, "length");
+        ObjectUtil.checkPositiveOrZero(chunkSize, "chunkSize");
 
         this.file = file;
         this.offset = startOffset = offset;

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedFile.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedFile.java
@@ -83,13 +83,15 @@ public class ChunkedFile implements ChunkedInput<ByteBuf> {
      *                  {@link #readChunk(ChannelHandlerContext)} call
      */
     public ChunkedFile(RandomAccessFile file, long offset, long length, int chunkSize) throws IOException {
+        ObjectUtil.checkNotNull(file, "file");
         ObjectUtil.checkPositiveOrZero(offset, "offset");
         ObjectUtil.checkPositiveOrZero(length, "length");
+        ObjectUtil.checkPositive(chunkSize, "chunkSize");
 
-        this.file = ObjectUtil.checkNotNull(file, "file");
-        this.chunkSize = ObjectUtil.checkPositive(chunkSize, "chunkSize");
+        this.file = file;
         this.offset = startOffset = offset;
-        endOffset = offset + length;
+        this.endOffset = offset + length;
+        this.chunkSize = chunkSize;
 
         file.seek(offset);
     }

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedNioFile.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedNioFile.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.FileRegion;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -86,22 +87,10 @@ public class ChunkedNioFile implements ChunkedInput<ByteBuf> {
      */
     public ChunkedNioFile(FileChannel in, long offset, long length, int chunkSize)
             throws IOException {
-        if (in == null) {
-            throw new NullPointerException("in");
-        }
-        if (offset < 0) {
-            throw new IllegalArgumentException(
-                    "offset: " + offset + " (expected: 0 or greater)");
-        }
-        if (length < 0) {
-            throw new IllegalArgumentException(
-                    "length: " + length + " (expected: 0 or greater)");
-        }
-        if (chunkSize <= 0) {
-            throw new IllegalArgumentException(
-                    "chunkSize: " + chunkSize +
-                    " (expected: a positive integer)");
-        }
+        ObjectUtil.checkNotNull(in, "in");
+        ObjectUtil.checkPositiveOrZero(offset, "offset");
+        ObjectUtil.checkPositiveOrZero(length, "length");
+        ObjectUtil.checkPositiveOrZero(chunkSize, "chunkSize");
         if (!in.isOpen()) {
             throw new ClosedChannelException();
         }

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedNioFile.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedNioFile.java
@@ -90,7 +90,7 @@ public class ChunkedNioFile implements ChunkedInput<ByteBuf> {
         ObjectUtil.checkNotNull(in, "in");
         ObjectUtil.checkPositiveOrZero(offset, "offset");
         ObjectUtil.checkPositiveOrZero(length, "length");
-        ObjectUtil.checkPositiveOrZero(chunkSize, "chunkSize");
+        ObjectUtil.checkPositive(chunkSize, "chunkSize");
         if (!in.isOpen()) {
             throw new ClosedChannelException();
         }

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedNioStream.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedNioStream.java
@@ -18,6 +18,7 @@ package io.netty.handler.stream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
 
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
@@ -53,9 +54,7 @@ public class ChunkedNioStream implements ChunkedInput<ByteBuf> {
      *                  {@link #readChunk(ChannelHandlerContext)} call
      */
     public ChunkedNioStream(ReadableByteChannel in, int chunkSize) {
-        if (in == null) {
-            throw new NullPointerException("in");
-        }
+        ObjectUtil.checkNotNull(in, "in");
         if (chunkSize <= 0) {
             throw new IllegalArgumentException("chunkSize: " + chunkSize +
                     " (expected: a positive integer)");

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedStream.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedStream.java
@@ -18,6 +18,7 @@ package io.netty.handler.stream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.InputStream;
 import java.io.PushbackInputStream;
@@ -55,9 +56,7 @@ public class ChunkedStream implements ChunkedInput<ByteBuf> {
      *                  {@link #readChunk(ChannelHandlerContext)} call
      */
     public ChunkedStream(InputStream in, int chunkSize) {
-        if (in == null) {
-            throw new NullPointerException("in");
-        }
+        ObjectUtil.checkNotNull(in, "in");
         if (chunkSize <= 0) {
             throw new IllegalArgumentException(
                     "chunkSize: " + chunkSize +

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedStream.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedStream.java
@@ -57,11 +57,7 @@ public class ChunkedStream implements ChunkedInput<ByteBuf> {
      */
     public ChunkedStream(InputStream in, int chunkSize) {
         ObjectUtil.checkNotNull(in, "in");
-        if (chunkSize <= 0) {
-            throw new IllegalArgumentException(
-                    "chunkSize: " + chunkSize +
-                    " (expected: a positive integer)");
-        }
+        ObjectUtil.checkPositive(chunkSize, "chunkSize");
 
         if (in instanceof PushbackInputStream) {
             this.in = (PushbackInputStream) in;

--- a/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -93,9 +94,7 @@ public class WriteTimeoutHandler extends ChannelOutboundHandlerAdapter {
      *        the {@link TimeUnit} of {@code timeout}
      */
     public WriteTimeoutHandler(long timeout, TimeUnit unit) {
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
+        ObjectUtil.checkNotNull(unit, "unit");
 
         if (timeout <= 0) {
             timeoutNanos = 0;

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.util.ArrayDeque;
@@ -103,9 +104,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
      * Create the global TrafficCounter.
      */
     void createGlobalTrafficCounter(ScheduledExecutorService executor) {
-        if (executor == null) {
-            throw new NullPointerException("executor");
-        }
+        ObjectUtil.checkNotNull(executor, "executor");
         TrafficCounter tc = new TrafficCounter(this, executor, "GlobalTC", checkInterval);
         setTrafficCounter(tc);
         tc.start();

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -104,8 +104,11 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
      * Create the global TrafficCounter.
      */
     void createGlobalTrafficCounter(ScheduledExecutorService executor) {
-        ObjectUtil.checkNotNull(executor, "executor");
-        TrafficCounter tc = new TrafficCounter(this, executor, "GlobalTC", checkInterval);
+        TrafficCounter tc = new TrafficCounter(this,
+                ObjectUtil.checkNotNull(executor, "executor"),
+                "GlobalTC",
+                checkInterval);
+
         setTrafficCounter(tc);
         tc.start();
     }

--- a/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
+++ b/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.traffic;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -250,9 +251,7 @@ public class TrafficCounter {
      *            the checkInterval in millisecond between two computations.
      */
     public TrafficCounter(ScheduledExecutorService executor, String name, long checkInterval) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
 
         trafficShapingHandler = null;
         this.executor = executor;
@@ -282,9 +281,7 @@ public class TrafficCounter {
         if (trafficShapingHandler == null) {
             throw new IllegalArgumentException("trafficShapingHandler");
         }
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
 
         this.trafficShapingHandler = trafficShapingHandler;
         this.executor = executor;

--- a/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
+++ b/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
@@ -251,11 +251,10 @@ public class TrafficCounter {
      *            the checkInterval in millisecond between two computations.
      */
     public TrafficCounter(ScheduledExecutorService executor, String name, long checkInterval) {
-        ObjectUtil.checkNotNull(name, "name");
 
+        this.name = ObjectUtil.checkNotNull(name, "name");
         trafficShapingHandler = null;
         this.executor = executor;
-        this.name = name;
 
         init(checkInterval);
     }
@@ -281,11 +280,10 @@ public class TrafficCounter {
         if (trafficShapingHandler == null) {
             throw new IllegalArgumentException("trafficShapingHandler");
         }
-        ObjectUtil.checkNotNull(name, "name");
 
+        this.name = ObjectUtil.checkNotNull(name, "name");
         this.trafficShapingHandler = trafficShapingHandler;
         this.executor = executor;
-        this.name = name;
 
         init(checkInterval);
     }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -45,7 +45,7 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
         this.alloc = checkNotNull(alloc, "alloc");
         this.channel = checkNotNull(channel, "channel");
         this.handler = checkNotNull(handler, "handler");
-        eventLoop = checkNotNull(channel.eventLoop(), "eventLoop");
+        this.eventLoop = checkNotNull(channel.eventLoop(), "eventLoop");
     }
 
     protected abstract void handleException(Throwable t);

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCache.java
@@ -117,9 +117,7 @@ public class DefaultAuthoritativeDnsServerCache implements AuthoritativeDnsServe
 
     @Override
     public boolean clear(String hostname) {
-        checkNotNull(hostname, "hostname");
-
-        return resolveCache.clear(hostname);
+        return resolveCache.clear(checkNotNull(hostname, "hostname"));
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -115,8 +115,9 @@ public class DefaultDnsCache implements DnsCache {
 
     @Override
     public boolean clear(String hostname) {
-        checkNotNull(hostname, "hostname");
-        return resolveCache.clear(appendDot(hostname));
+        return resolveCache.clear(
+                appendDot(
+                        checkNotNull(hostname, "hostname")));
     }
 
     private static boolean emptyAdditionals(DnsRecord[] additionals) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -115,9 +115,8 @@ public class DefaultDnsCache implements DnsCache {
 
     @Override
     public boolean clear(String hostname) {
-        return resolveCache.clear(
-                appendDot(
-                        checkNotNull(hostname, "hostname")));
+        checkNotNull(hostname, "hostname");
+        return resolveCache.clear(appendDot(hostname));
     }
 
     private static boolean emptyAdditionals(DnsRecord[] additionals) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCnameCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCnameCache.java
@@ -69,8 +69,7 @@ public final class DefaultDnsCnameCache implements DnsCnameCache {
     @SuppressWarnings("unchecked")
     @Override
     public String get(String hostname) {
-        checkNotNull(hostname, "hostname");
-        List<? extends String> cached =  cache.get(hostname);
+        List<? extends String> cached =  cache.get(checkNotNull(hostname, "hostname"));
         if (cached == null || cached.isEmpty()) {
             return null;
         }
@@ -93,7 +92,6 @@ public final class DefaultDnsCnameCache implements DnsCnameCache {
 
     @Override
     public boolean clear(String hostname) {
-        checkNotNull(hostname, "hostname");
-        return cache.clear(hostname);
+        return cache.clear(checkNotNull(hostname, "hostname"));
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
@@ -16,6 +16,7 @@
 
 package io.netty.resolver.dns;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
@@ -149,9 +150,7 @@ public abstract class DnsServerAddresses {
      * Returns the {@link DnsServerAddresses} that yields only a single {@code address}.
      */
     public static DnsServerAddresses singleton(final InetSocketAddress address) {
-        if (address == null) {
-            throw new NullPointerException("address");
-        }
+        ObjectUtil.checkNotNull(address, "address");
         if (address.isUnresolved()) {
             throw new IllegalArgumentException("cannot use an unresolved DNS server address: " + address);
         }
@@ -160,9 +159,7 @@ public abstract class DnsServerAddresses {
     }
 
     private static List<InetSocketAddress> sanitize(Iterable<? extends InetSocketAddress> addresses) {
-        if (addresses == null) {
-            throw new NullPointerException("addresses");
-        }
+        ObjectUtil.checkNotNull(addresses, "addresses");
 
         final List<InetSocketAddress> list;
         if (addresses instanceof Collection) {
@@ -189,9 +186,7 @@ public abstract class DnsServerAddresses {
     }
 
     private static List<InetSocketAddress> sanitize(InetSocketAddress[] addresses) {
-        if (addresses == null) {
-            throw new NullPointerException("addresses");
-        }
+        ObjectUtil.checkNotNull(addresses, "addresses");
 
         List<InetSocketAddress> list = new ArrayList<InetSocketAddress>(addresses.length);
         for (InetSocketAddress a: addresses) {

--- a/resolver/src/main/java/io/netty/resolver/AbstractAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/AbstractAddressResolver.java
@@ -44,7 +44,7 @@ public abstract class AbstractAddressResolver<T extends SocketAddress> implement
      */
     protected AbstractAddressResolver(EventExecutor executor) {
         this.executor = checkNotNull(executor, "executor");
-        matcher = TypeParameterMatcher.find(this, AbstractAddressResolver.class, "T");
+        this.matcher = TypeParameterMatcher.find(this, AbstractAddressResolver.class, "T");
     }
 
     /**
@@ -54,7 +54,7 @@ public abstract class AbstractAddressResolver<T extends SocketAddress> implement
      */
     protected AbstractAddressResolver(EventExecutor executor, Class<? extends T> addressType) {
         this.executor = checkNotNull(executor, "executor");
-        matcher = TypeParameterMatcher.get(addressType);
+        this.matcher = TypeParameterMatcher.get(addressType);
     }
 
     /**

--- a/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
@@ -19,6 +19,7 @@ package io.netty.resolver;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -52,9 +53,7 @@ public abstract class AddressResolverGroup<T extends SocketAddress> implements C
      * {@link #getResolver(EventExecutor)} call with the same {@link EventExecutor}.
      */
     public AddressResolver<T> getResolver(final EventExecutor executor) {
-        if (executor == null) {
-            throw new NullPointerException("executor");
-        }
+        ObjectUtil.checkNotNull(executor, "executor");
 
         if (executor.isShuttingDown()) {
             throw new IllegalStateException("executor not accepting a task");

--- a/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
@@ -19,12 +19,13 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static io.netty.util.internal.ObjectUtil.*;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * A composite {@link SimpleNameResolver} that resolves a host name against a sequence of {@link NameResolver}s.
@@ -45,9 +46,7 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
         super(executor);
         checkNotNull(resolvers, "resolvers");
         for (int i = 0; i < resolvers.length; i++) {
-            if (resolvers[i] == null) {
-                throw new NullPointerException("resolvers[" + i + ']');
-            }
+            ObjectUtil.checkNotNull(resolvers[i], "resolvers[" + i + ']');
         }
         if (resolvers.length < 2) {
             throw new IllegalArgumentException("resolvers: " + Arrays.asList(resolvers) +

--- a/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
+++ b/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
@@ -16,6 +16,7 @@
 package io.netty.testsuite.util;
 
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.rules.TestName;
@@ -112,9 +113,7 @@ public final class TestUtils {
 
     public static void dump(String filenamePrefix) throws IOException {
 
-        if (filenamePrefix == null) {
-            throw new NullPointerException("filenamePrefix");
-        }
+        ObjectUtil.checkNotNull(filenamePrefix, "filenamePrefix");
 
         final String timestamp = timestamp();
         final File heapDumpFile = new File(filenamePrefix + '.' + timestamp + ".hprof");

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -82,24 +82,24 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     AbstractEpollChannel(Channel parent, LinuxSocket fd, boolean active) {
         super(parent);
-        socket = checkNotNull(fd, "fd");
+        this.socket = checkNotNull(fd, "fd");
         this.active = active;
         if (active) {
             // Directly cache the remote and local addresses
             // See https://github.com/netty/netty/issues/2359
-            local = fd.localAddress();
-            remote = fd.remoteAddress();
+            this.local = fd.localAddress();
+            this.remote = fd.remoteAddress();
         }
     }
 
     AbstractEpollChannel(Channel parent, LinuxSocket fd, SocketAddress remote) {
         super(parent);
-        socket = checkNotNull(fd, "fd");
-        active = true;
+        this.socket = checkNotNull(fd, "fd");
+        this.active = true;
         // Directly cache the remote and local addresses
         // See https://github.com/netty/netty/issues/2359
         this.remote = remote;
-        local = fd.localAddress();
+        this.local = fd.localAddress();
     }
 
     static boolean isSoErrorZero(Socket fd) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -22,6 +22,7 @@ import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.util.Map;
@@ -147,9 +148,7 @@ public class EpollChannelConfig extends DefaultChannelConfig {
      * <strong>Be aware this config setting can only be adjusted before the channel was registered.</strong>
      */
     public EpollChannelConfig setEpollMode(EpollMode mode) {
-        if (mode == null) {
-            throw new NullPointerException("mode");
-        }
+        ObjectUtil.checkNotNull(mode, "mode");
         switch (mode) {
             case EDGE_TRIGGERED:
                 checkChannelNotRegistered();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -36,6 +36,7 @@ import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.Socket;
 import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.RecyclableArrayList;
 import io.netty.util.internal.StringUtil;
 
@@ -164,13 +165,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress source, final ChannelPromise promise) {
 
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
         try {
             socket.joinGroup(multicastAddress, networkInterface, source);
@@ -220,12 +216,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     public ChannelFuture leaveGroup(
             final InetAddress multicastAddress, final NetworkInterface networkInterface, final InetAddress source,
             final ChannelPromise promise) {
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
         try {
             socket.leaveGroup(multicastAddress, networkInterface, source);
@@ -247,16 +239,10 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     public ChannelFuture block(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress sourceToBlock, final ChannelPromise promise) {
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-        if (sourceToBlock == null) {
-            throw new NullPointerException("sourceToBlock");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(sourceToBlock, "sourceToBlock");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
         promise.setFailure(new UnsupportedOperationException("Multicast not supported"));
         return promise;
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -23,6 +23,7 @@ import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.util.Map;
@@ -160,9 +161,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
 
     @Override
     public EpollDomainSocketChannelConfig setReadMode(DomainSocketReadMode mode) {
-        if (mode == null) {
-            throw new NullPointerException("mode");
-        }
+        ObjectUtil.checkNotNull(mode, "mode");
         this.mode = mode;
         return this;
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -161,8 +161,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
 
     @Override
     public EpollDomainSocketChannelConfig setReadMode(DomainSocketReadMode mode) {
-        ObjectUtil.checkNotNull(mode, "mode");
-        this.mode = mode;
+        this.mode = ObjectUtil.checkNotNull(mode, "mode");
         return this;
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TcpMd5Util.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TcpMd5Util.java
@@ -39,9 +39,7 @@ final class TcpMd5Util {
             if (e.getKey() == null) {
                 throw new IllegalArgumentException("newKeys contains an entry with null address: " + newKeys);
             }
-            if (key == null) {
-                throw new NullPointerException("newKeys[" + e.getKey() + ']');
-            }
+            ObjectUtil.checkNotNull(key, "newKeys[" + e.getKey() + ']');
             if (key.length == 0) {
                 throw new IllegalArgumentException("newKeys[" + e.getKey() + "] has an empty key.");
             }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -245,7 +245,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
 
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-        for (; ; ) {
+        for (;;) {
             Object msg = in.current();
             if (msg == null) {
                 // Wrote all messages.

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -31,6 +31,7 @@ import io.netty.channel.unix.DatagramSocketAddress;
 import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.UnixChannelUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
@@ -140,13 +141,8 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress source, final ChannelPromise promise) {
 
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
         promise.setFailure(new UnsupportedOperationException("Multicast not supported"));
         return promise;
@@ -191,12 +187,8 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
     public ChannelFuture leaveGroup(
             final InetAddress multicastAddress, final NetworkInterface networkInterface, final InetAddress source,
             final ChannelPromise promise) {
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
         promise.setFailure(new UnsupportedOperationException("Multicast not supported"));
 
@@ -214,16 +206,9 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
     public ChannelFuture block(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress sourceToBlock, final ChannelPromise promise) {
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-        if (sourceToBlock == null) {
-            throw new NullPointerException("sourceToBlock");
-        }
-
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(sourceToBlock, "sourceToBlock");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
         promise.setFailure(new UnsupportedOperationException("Multicast not supported"));
         return promise;
     }
@@ -260,7 +245,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
 
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-        for (;;) {
+        for (; ; ) {
             Object msg = in.current();
             if (msg == null) {
                 // Wrote all messages.
@@ -333,7 +318,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
                 writtenBytes = socket.sendToAddresses(array.memoryAddress(0), cnt,
                         remoteAddress.getAddress(), remoteAddress.getPort());
             }
-        } else  {
+        } else {
             ByteBuffer nioData = data.internalNioBuffer(data.readerIndex(), data.readableBytes());
             if (remoteAddress == null) {
                 writtenBytes = socket.write(nioData, nioData.position(), nioData.limit());
@@ -351,13 +336,13 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
         if (msg instanceof DatagramPacket) {
             DatagramPacket packet = (DatagramPacket) msg;
             ByteBuf content = packet.content();
-            return UnixChannelUtil.isBufferCopyNeededForWrite(content)?
+            return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
                     new DatagramPacket(newDirectBuffer(packet, content), packet.recipient()) : msg;
         }
 
         if (msg instanceof ByteBuf) {
             ByteBuf buf = (ByteBuf) msg;
-            return UnixChannelUtil.isBufferCopyNeededForWrite(buf)? newDirectBuffer(buf) : buf;
+            return UnixChannelUtil.isBufferCopyNeededForWrite(buf) ? newDirectBuffer(buf) : buf;
         }
 
         if (msg instanceof AddressedEnvelope) {
@@ -367,7 +352,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
                     (e.recipient() == null || e.recipient() instanceof InetSocketAddress)) {
 
                 ByteBuf content = (ByteBuf) e.content();
-                return UnixChannelUtil.isBufferCopyNeededForWrite(content)?
+                return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
                         new DefaultAddressedEnvelope<ByteBuf, InetSocketAddress>(
                                 newDirectBuffer(e, content), (InetSocketAddress) e.recipient()) : e;
             }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -162,8 +162,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
 
     @Override
     public KQueueDomainSocketChannelConfig setReadMode(DomainSocketReadMode mode) {
-        ObjectUtil.checkNotNull(mode, "mode");
-        this.mode = mode;
+        this.mode = ObjectUtil.checkNotNull(mode, "mode");
         return this;
     }
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -23,6 +23,7 @@ import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -161,9 +162,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
 
     @Override
     public KQueueDomainSocketChannelConfig setReadMode(DomainSocketReadMode mode) {
-        if (mode == null) {
-            throw new NullPointerException("mode");
-        }
+        ObjectUtil.checkNotNull(mode, "mode");
         this.mode = mode;
         return this;
     }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -76,7 +76,7 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
                     EventLoopTaskQueueFactory queueFactory) {
         super(parent, executor, false, newTaskQueue(queueFactory), newTaskQueue(queueFactory),
                 rejectedExecutionHandler);
-        selectStrategy = ObjectUtil.checkNotNull(strategy, "strategy");
+        this.selectStrategy = ObjectUtil.checkNotNull(strategy, "strategy");
         this.kqueueFd = Native.newKQueue();
         if (maxEvents == 0) {
             allowGrowing = true;
@@ -84,8 +84,8 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
         } else {
             allowGrowing = false;
         }
-        changeList = new KQueueEventArray(maxEvents);
-        eventList = new KQueueEventArray(maxEvents);
+        this.changeList = new KQueueEventArray(maxEvents);
+        this.eventList = new KQueueEventArray(maxEvents);
         int result = Native.keventAddUserEvent(kqueueFd.intValue(), KQUEUE_WAKE_UP_IDENT);
         if (result < 0) {
             cleanup();

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketAddress.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketAddress.java
@@ -29,8 +29,7 @@ public final class DomainSocketAddress extends SocketAddress {
     private final String socketPath;
 
     public DomainSocketAddress(String socketPath) {
-        ObjectUtil.checkNotNull(socketPath, "socketPath");
-        this.socketPath = socketPath;
+        this.socketPath = ObjectUtil.checkNotNull(socketPath, "socketPath");
     }
 
     public DomainSocketAddress(File file) {

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketAddress.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketAddress.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel.unix;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.io.File;
 import java.net.SocketAddress;
 
@@ -27,9 +29,7 @@ public final class DomainSocketAddress extends SocketAddress {
     private final String socketPath;
 
     public DomainSocketAddress(String socketPath) {
-        if (socketPath == null) {
-            throw new NullPointerException("socketPath");
-        }
+        ObjectUtil.checkNotNull(socketPath, "socketPath");
         this.socketPath = socketPath;
     }
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/FileDescriptor.java
@@ -171,8 +171,7 @@ public class FileDescriptor {
      * Open a new {@link FileDescriptor} for the given path.
      */
     public static FileDescriptor from(String path) throws IOException {
-        checkNotNull(path, "path");
-        int res = open(path);
+        int res = open(checkNotNull(path, "path"));
         if (res < 0) {
             throw newIOException("open", res);
         }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpChannelConfig.java
@@ -44,8 +44,7 @@ public class DefaultSctpChannelConfig extends DefaultChannelConfig implements Sc
 
     public DefaultSctpChannelConfig(io.netty.channel.sctp.SctpChannel channel, SctpChannel javaChannel) {
         super(channel);
-        ObjectUtil.checkNotNull(javaChannel, "javaChannel");
-        this.javaChannel = javaChannel;
+        this.javaChannel = ObjectUtil.checkNotNull(javaChannel, "javaChannel");
 
         // Enable TCP_NODELAY by default if possible.
         if (PlatformDependent.canEnableTcpNoDelayByDefault()) {

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpChannelConfig.java
@@ -24,6 +24,7 @@ import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
@@ -43,9 +44,7 @@ public class DefaultSctpChannelConfig extends DefaultChannelConfig implements Sc
 
     public DefaultSctpChannelConfig(io.netty.channel.sctp.SctpChannel channel, SctpChannel javaChannel) {
         super(channel);
-        if (javaChannel == null) {
-            throw new NullPointerException("javaChannel");
-        }
+        ObjectUtil.checkNotNull(javaChannel, "javaChannel");
         this.javaChannel = javaChannel;
 
         // Enable TCP_NODELAY by default if possible.

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
@@ -46,8 +46,7 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
     public DefaultSctpServerChannelConfig(
             io.netty.channel.sctp.SctpServerChannel channel, SctpServerChannel javaChannel) {
         super(channel);
-        ObjectUtil.checkNotNull(javaChannel, "javaChannel");
-        this.javaChannel = javaChannel;
+        this.javaChannel = ObjectUtil.checkNotNull(javaChannel, "javaChannel");
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
@@ -27,6 +27,7 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.util.Map;
@@ -45,9 +46,7 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
     public DefaultSctpServerChannelConfig(
             io.netty.channel.sctp.SctpServerChannel channel, SctpServerChannel javaChannel) {
         super(channel);
-        if (javaChannel == null) {
-            throw new NullPointerException("javaChannel");
-        }
+        ObjectUtil.checkNotNull(javaChannel, "javaChannel");
         this.javaChannel = javaChannel;
     }
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -62,11 +62,10 @@ public final class SctpMessage extends DefaultByteBufHolder {
      */
     public SctpMessage(MessageInfo msgInfo, ByteBuf payloadBuffer) {
         super(payloadBuffer);
-        ObjectUtil.checkNotNull(msgInfo, "msgInfo");
-        this.msgInfo = msgInfo;
-        streamIdentifier = msgInfo.streamNumber();
-        protocolIdentifier = msgInfo.payloadProtocolID();
-        unordered = msgInfo.isUnordered();
+        this.msgInfo = ObjectUtil.checkNotNull(msgInfo, "msgInfo");
+        this.streamIdentifier = msgInfo.streamNumber();
+        this.protocolIdentifier = msgInfo.payloadProtocolID();
+        this.unordered = msgInfo.isUnordered();
     }
 
     /**

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -18,6 +18,7 @@ package io.netty.channel.sctp;
 import com.sun.nio.sctp.MessageInfo;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Representation of SCTP Data Chunk
@@ -61,9 +62,7 @@ public final class SctpMessage extends DefaultByteBufHolder {
      */
     public SctpMessage(MessageInfo msgInfo, ByteBuf payloadBuffer) {
         super(payloadBuffer);
-        if (msgInfo == null) {
-            throw new NullPointerException("msgInfo");
-        }
+        ObjectUtil.checkNotNull(msgInfo, "msgInfo");
         this.msgInfo = msgInfo;
         streamIdentifier = msgInfo.streamNumber();
         protocolIdentifier = msgInfo.payloadProtocolID();

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpNotificationHandler.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpNotificationHandler.java
@@ -35,8 +35,7 @@ public final class SctpNotificationHandler extends AbstractNotificationHandler<O
     private final SctpChannel sctpChannel;
 
     public SctpNotificationHandler(SctpChannel sctpChannel) {
-        ObjectUtil.checkNotNull(sctpChannel, "sctpChannel");
-        this.sctpChannel = sctpChannel;
+        this.sctpChannel = ObjectUtil.checkNotNull(sctpChannel, "sctpChannel");
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpNotificationHandler.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpNotificationHandler.java
@@ -22,8 +22,8 @@ import com.sun.nio.sctp.Notification;
 import com.sun.nio.sctp.PeerAddressChangeNotification;
 import com.sun.nio.sctp.SendFailedNotification;
 import com.sun.nio.sctp.ShutdownNotification;
-
 import io.netty.channel.ChannelPipeline;
+import io.netty.util.internal.ObjectUtil;
 
 
 /**
@@ -35,9 +35,7 @@ public final class SctpNotificationHandler extends AbstractNotificationHandler<O
     private final SctpChannel sctpChannel;
 
     public SctpNotificationHandler(SctpChannel sctpChannel) {
-        if (sctpChannel == null) {
-            throw new NullPointerException("sctpChannel");
-        }
+        ObjectUtil.checkNotNull(sctpChannel, "sctpChannel");
         this.sctpChannel = sctpChannel;
     }
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.oio.AbstractOioMessageChannel;
 import io.netty.channel.sctp.DefaultSctpServerChannelConfig;
 import io.netty.channel.sctp.SctpServerChannelConfig;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -84,9 +85,7 @@ public class OioSctpServerChannel extends AbstractOioMessageChannel
      */
     public OioSctpServerChannel(SctpServerChannel sch) {
         super(null);
-        if (sch == null) {
-            throw new NullPointerException("sctp server channel");
-        }
+        ObjectUtil.checkNotNull(sch, "sctp server channel");
 
         this.sch = sch;
         boolean success = false;

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -85,9 +85,7 @@ public class OioSctpServerChannel extends AbstractOioMessageChannel
      */
     public OioSctpServerChannel(SctpServerChannel sch) {
         super(null);
-        ObjectUtil.checkNotNull(sch, "sctp server channel");
-
-        this.sch = sch;
+        this.sch = ObjectUtil.checkNotNull(sch, "sctp server channel");
         boolean success = false;
         try {
             sch.configureBlocking(false);

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -76,11 +76,10 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
      */
     public ServerBootstrap group(EventLoopGroup parentGroup, EventLoopGroup childGroup) {
         super.group(parentGroup);
-        ObjectUtil.checkNotNull(childGroup, "childGroup");
         if (this.childGroup != null) {
             throw new IllegalStateException("childGroup set already");
         }
-        this.childGroup = childGroup;
+        this.childGroup = ObjectUtil.checkNotNull(childGroup, "childGroup");
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -20,6 +20,7 @@ import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.channel.socket.ChannelOutputShutdownException;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
@@ -450,9 +451,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
         @Override
         public final void register(EventLoop eventLoop, final ChannelPromise promise) {
-            if (eventLoop == null) {
-                throw new NullPointerException("eventLoop");
-            }
+            ObjectUtil.checkNotNull(eventLoop, "eventLoop");
             if (isRegistered()) {
                 promise.setFailure(new IllegalStateException("registered to an event loop already"));
                 return;

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -477,9 +477,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
 
     @Override
     public ChannelFuture bind(final SocketAddress localAddress, final ChannelPromise promise) {
-        if (localAddress == null) {
-            throw new NullPointerException("localAddress");
-        }
+        ObjectUtil.checkNotNull(localAddress, "localAddress");
         if (isNotValidPromise(promise, false)) {
             // cancelled
             return promise;
@@ -520,10 +518,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelFuture connect(
             final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
+        ObjectUtil.checkNotNull(remoteAddress, "remoteAddress");
 
-        if (remoteAddress == null) {
-            throw new NullPointerException("remoteAddress");
-        }
         if (isNotValidPromise(promise, false)) {
             // cancelled
             return promise;
@@ -874,9 +870,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     private boolean isNotValidPromise(ChannelPromise promise, boolean allowVoidPromise) {
-        if (promise == null) {
-            throw new NullPointerException("promise");
-        }
+        ObjectUtil.checkNotNull(promise, "promise");
 
         if (promise.isDone()) {
             // Check if the promise was cancelled and if so signal that the processing of the operation

--- a/transport/src/main/java/io/netty/channel/ChannelFlushPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelFlushPromiseNotifier.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel;
 
+import io.netty.util.internal.ObjectUtil;
+
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 import java.util.ArrayDeque;
@@ -63,9 +65,7 @@ public final class ChannelFlushPromiseNotifier {
      * {@code pendingDataSize} was reached.
      */
     public ChannelFlushPromiseNotifier add(ChannelPromise promise, long pendingDataSize) {
-        if (promise == null) {
-            throw new NullPointerException("promise");
-        }
+        ObjectUtil.checkNotNull(promise, "promise");
         checkPositiveOrZero(pendingDataSize, "pendingDataSize");
         long checkpoint = writeCounter + pendingDataSize;
         if (promise instanceof FlushCheckpoint) {

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -18,6 +18,7 @@ package io.netty.channel;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.AbstractConstant;
 import io.netty.util.ConstantPool;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -149,8 +150,6 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
      * may override this for special checks.
      */
     public void validate(T value) {
-        if (value == null) {
-            throw new NullPointerException("value");
-        }
+        ObjectUtil.checkNotNull(value, "value");
     }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -25,6 +25,7 @@ import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectPool.Handle;
 import io.netty.util.internal.ObjectPool.ObjectCreator;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PromiseNotificationUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -767,9 +768,7 @@ public final class ChannelOutboundBuffer {
      * returns {@code false} or there are no more flushed messages to process.
      */
     public void forEachFlushedMessage(MessageProcessor processor) throws Exception {
-        if (processor == null) {
-            throw new NullPointerException("processor");
-        }
+        ObjectUtil.checkNotNull(processor, "processor");
 
         Entry entry = flushedEntry;
         if (entry == null) {

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -78,12 +79,9 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
                             " was constructed with non-default constructor.");
         }
 
-        if (inboundHandler == null) {
-            throw new NullPointerException("inboundHandler");
-        }
-        if (outboundHandler == null) {
-            throw new NullPointerException("outboundHandler");
-        }
+        ObjectUtil.checkNotNull(inboundHandler, "inboundHandler");
+        ObjectUtil.checkNotNull(outboundHandler, "outboundHandler");
+
         if (inboundHandler instanceof ChannelOutboundHandler) {
             throw new IllegalArgumentException(
                     "inboundHandler must not implement " +

--- a/transport/src/main/java/io/netty/channel/CompleteChannelFuture.java
+++ b/transport/src/main/java/io/netty/channel/CompleteChannelFuture.java
@@ -19,6 +19,7 @@ import io.netty.util.concurrent.CompleteFuture;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * A skeletal {@link ChannelFuture} implementation which represents a
@@ -35,9 +36,7 @@ abstract class CompleteChannelFuture extends CompleteFuture<Void> implements Cha
      */
     protected CompleteChannelFuture(Channel channel, EventExecutor executor) {
         super(executor);
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         this.channel = channel;
     }
 

--- a/transport/src/main/java/io/netty/channel/CompleteChannelFuture.java
+++ b/transport/src/main/java/io/netty/channel/CompleteChannelFuture.java
@@ -36,8 +36,7 @@ abstract class CompleteChannelFuture extends CompleteFuture<Void> implements Cha
      */
     protected CompleteChannelFuture(Channel channel, EventExecutor executor) {
         super(executor);
-        ObjectUtil.checkNotNull(channel, "channel");
-        this.channel = channel;
+        this.channel = ObjectUtil.checkNotNull(channel, "channel");
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/DefaultAddressedEnvelope.java
+++ b/transport/src/main/java/io/netty/channel/DefaultAddressedEnvelope.java
@@ -40,13 +40,11 @@ public class DefaultAddressedEnvelope<M, A extends SocketAddress> implements Add
      * {@code sender} address.
      */
     public DefaultAddressedEnvelope(M message, A recipient, A sender) {
-        ObjectUtil.checkNotNull(message, "message");
-
         if (recipient == null && sender == null) {
             throw new NullPointerException("recipient and sender");
         }
 
-        this.message = message;
+        this.message = ObjectUtil.checkNotNull(message, "message");
         this.sender = sender;
         this.recipient = recipient;
     }

--- a/transport/src/main/java/io/netty/channel/DefaultAddressedEnvelope.java
+++ b/transport/src/main/java/io/netty/channel/DefaultAddressedEnvelope.java
@@ -40,11 +40,12 @@ public class DefaultAddressedEnvelope<M, A extends SocketAddress> implements Add
      * {@code sender} address.
      */
     public DefaultAddressedEnvelope(M message, A recipient, A sender) {
+        ObjectUtil.checkNotNull(message, "message");
         if (recipient == null && sender == null) {
             throw new NullPointerException("recipient and sender");
         }
 
-        this.message = ObjectUtil.checkNotNull(message, "message");
+        this.message = message;
         this.sender = sender;
         this.recipient = recipient;
     }

--- a/transport/src/main/java/io/netty/channel/DefaultAddressedEnvelope.java
+++ b/transport/src/main/java/io/netty/channel/DefaultAddressedEnvelope.java
@@ -18,6 +18,7 @@ package io.netty.channel;
 
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.net.SocketAddress;
@@ -39,9 +40,7 @@ public class DefaultAddressedEnvelope<M, A extends SocketAddress> implements Add
      * {@code sender} address.
      */
     public DefaultAddressedEnvelope(M message, A recipient, A sender) {
-        if (message == null) {
-            throw new NullPointerException("message");
-        }
+        ObjectUtil.checkNotNull(message, "message");
 
         if (recipient == null && sender == null) {
             throw new NullPointerException("recipient and sender");

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -16,6 +16,7 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -101,9 +102,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     @SuppressWarnings("unchecked")
     @Override
     public boolean setOptions(Map<ChannelOption<?>, ?> options) {
-        if (options == null) {
-            throw new NullPointerException("options");
-        }
+        ObjectUtil.checkNotNull(options, "options");
 
         boolean setAllOptions = true;
         for (Entry<ChannelOption<?>, ?> e: options.entrySet()) {
@@ -118,9 +117,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     @Override
     @SuppressWarnings({ "unchecked", "deprecation" })
     public <T> T getOption(ChannelOption<T> option) {
-        if (option == null) {
-            throw new NullPointerException("option");
-        }
+        ObjectUtil.checkNotNull(option, "option");
 
         if (option == CONNECT_TIMEOUT_MILLIS) {
             return (T) Integer.valueOf(getConnectTimeoutMillis());
@@ -198,9 +195,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     }
 
     protected <T> void validate(ChannelOption<T> option, T value) {
-        if (option == null) {
-            throw new NullPointerException("option");
-        }
+        ObjectUtil.checkNotNull(option, "option");
         option.validate(value);
     }
 
@@ -279,9 +274,7 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     @Override
     public ChannelConfig setAllocator(ByteBufAllocator allocator) {
-        if (allocator == null) {
-            throw new NullPointerException("allocator");
-        }
+        ObjectUtil.checkNotNull(allocator, "allocator");
         this.allocator = allocator;
         return this;
     }
@@ -410,9 +403,7 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     @Override
     public ChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
-        if (estimator == null) {
-            throw new NullPointerException("estimator");
-        }
+        ObjectUtil.checkNotNull(estimator, "estimator");
         msgSizeEstimator = estimator;
         return this;
     }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -195,8 +195,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     }
 
     protected <T> void validate(ChannelOption<T> option, T value) {
-        ObjectUtil.checkNotNull(option, "option");
-        option.validate(value);
+        ObjectUtil.checkNotNull(option, "option").validate(value);
     }
 
     @Override
@@ -274,8 +273,7 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     @Override
     public ChannelConfig setAllocator(ByteBufAllocator allocator) {
-        ObjectUtil.checkNotNull(allocator, "allocator");
-        this.allocator = allocator;
+        this.allocator = ObjectUtil.checkNotNull(allocator, "allocator");
         return this;
     }
 
@@ -403,8 +401,7 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     @Override
     public ChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
-        ObjectUtil.checkNotNull(estimator, "estimator");
-        msgSizeEstimator = estimator;
+        this.msgSizeEstimator = ObjectUtil.checkNotNull(estimator, "estimator");
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -341,9 +341,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     @Override
     public final ChannelPipeline addFirst(EventExecutorGroup executor, ChannelHandler... handlers) {
-        if (handlers == null) {
-            throw new NullPointerException("handlers");
-        }
+        ObjectUtil.checkNotNull(handlers, "handlers");
         if (handlers.length == 0 || handlers[0] == null) {
             return this;
         }
@@ -374,9 +372,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     @Override
     public final ChannelPipeline addLast(EventExecutorGroup executor, ChannelHandler... handlers) {
-        if (handlers == null) {
-            throw new NullPointerException("handlers");
-        }
+        ObjectUtil.checkNotNull(handlers, "handlers");
 
         for (ChannelHandler h: handlers) {
             if (h == null) {
@@ -714,18 +710,13 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     @Override
     public final ChannelHandlerContext context(String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
-
+        ObjectUtil.checkNotNull(name, "name");
         return context0(name);
     }
 
     @Override
     public final ChannelHandlerContext context(ChannelHandler handler) {
-        if (handler == null) {
-            throw new NullPointerException("handler");
-        }
+        ObjectUtil.checkNotNull(handler, "handler");
 
         AbstractChannelHandlerContext ctx = head.next;
         for (;;) {
@@ -744,9 +735,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     @Override
     public final ChannelHandlerContext context(Class<? extends ChannelHandler> handlerType) {
-        if (handlerType == null) {
-            throw new NullPointerException("handlerType");
-        }
+        ObjectUtil.checkNotNull(handlerType, "handlerType");
 
         AbstractChannelHandlerContext ctx = head.next;
         for (;;) {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -710,8 +710,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     @Override
     public final ChannelHandlerContext context(String name) {
-        ObjectUtil.checkNotNull(name, "name");
-        return context0(name);
+        return context0(ObjectUtil.checkNotNull(name, "name"));
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
@@ -52,13 +52,10 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
      * @param count     the number of bytes to transfer
      */
     public DefaultFileRegion(FileChannel file, long position, long count) {
-        ObjectUtil.checkNotNull(file, "file");
-        checkPositiveOrZero(position, "position");
-        checkPositiveOrZero(count, "count");
-        this.file = file;
-        this.position = position;
-        this.count = count;
-        f = null;
+        this.file = ObjectUtil.checkNotNull(file, "file");
+        this.position = checkPositiveOrZero(position, "position");
+        this.count = checkPositiveOrZero(count, "count");
+        this.f = null;
     }
 
     /**
@@ -70,12 +67,9 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
      * @param count     the number of bytes to transfer
      */
     public DefaultFileRegion(File f, long position, long count) {
-        ObjectUtil.checkNotNull(f, "file");
-        checkPositiveOrZero(position, "position");
-        checkPositiveOrZero(count, "count");
-        this.position = position;
-        this.count = count;
-        this.f = f;
+        this.f = ObjectUtil.checkNotNull(f, "file");
+        this.position = checkPositiveOrZero(position, "position");
+        this.count = checkPositiveOrZero(count, "count");
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
@@ -67,7 +67,7 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
      * @param count     the number of bytes to transfer
      */
     public DefaultFileRegion(File f, long position, long count) {
-        this.f = ObjectUtil.checkNotNull(f, "file");
+        this.f = ObjectUtil.checkNotNull(f, "f");
         this.position = checkPositiveOrZero(position, "position");
         this.count = checkPositiveOrZero(count, "count");
     }

--- a/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
@@ -15,10 +15,9 @@
  */
 package io.netty.channel;
 
-import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
-
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -27,6 +26,8 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
+
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * Default {@link FileRegion} implementation which transfer data from a {@link FileChannel} or {@link File}.
@@ -51,9 +52,7 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
      * @param count     the number of bytes to transfer
      */
     public DefaultFileRegion(FileChannel file, long position, long count) {
-        if (file == null) {
-            throw new NullPointerException("file");
-        }
+        ObjectUtil.checkNotNull(file, "file");
         checkPositiveOrZero(position, "position");
         checkPositiveOrZero(count, "count");
         this.file = file;
@@ -71,9 +70,7 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
      * @param count     the number of bytes to transfer
      */
     public DefaultFileRegion(File f, long position, long count) {
-        if (f == null) {
-            throw new NullPointerException("f");
-        }
+        ObjectUtil.checkNotNull(f, "file");
         checkPositiveOrZero(position, "position");
         checkPositiveOrZero(count, "count");
         this.position = position;

--- a/transport/src/main/java/io/netty/channel/FailedChannelFuture.java
+++ b/transport/src/main/java/io/netty/channel/FailedChannelFuture.java
@@ -16,6 +16,7 @@
 package io.netty.channel;
 
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 /**
@@ -35,9 +36,7 @@ final class FailedChannelFuture extends CompleteChannelFuture {
      */
     FailedChannelFuture(Channel channel, EventExecutor executor, Throwable cause) {
         super(channel, executor);
-        if (cause == null) {
-            throw new NullPointerException("cause");
-        }
+        ObjectUtil.checkNotNull(cause, "cause");
         this.cause = cause;
     }
 

--- a/transport/src/main/java/io/netty/channel/FailedChannelFuture.java
+++ b/transport/src/main/java/io/netty/channel/FailedChannelFuture.java
@@ -36,8 +36,7 @@ final class FailedChannelFuture extends CompleteChannelFuture {
      */
     FailedChannelFuture(Channel channel, EventExecutor executor, Throwable cause) {
         super(channel, executor);
-        ObjectUtil.checkNotNull(cause, "cause");
-        this.cause = cause;
+        this.cause = ObjectUtil.checkNotNull(cause, "cause");
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -19,6 +19,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectPool.ObjectCreator;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -92,12 +93,8 @@ public final class PendingWriteQueue {
      */
     public void add(Object msg, ChannelPromise promise) {
         assert ctx.executor().inEventLoop();
-        if (msg == null) {
-            throw new NullPointerException("msg");
-        }
-        if (promise == null) {
-            throw new NullPointerException("promise");
-        }
+        ObjectUtil.checkNotNull(msg, "msg");
+        ObjectUtil.checkNotNull(promise, "promise");
         // It is possible for writes to be triggered from removeAndFailAll(). To preserve ordering,
         // we should add them to the queue and let removeAndFailAll() fail them later.
         int messageSize = size(msg);
@@ -165,9 +162,7 @@ public final class PendingWriteQueue {
      */
     public void removeAndFailAll(Throwable cause) {
         assert ctx.executor().inEventLoop();
-        if (cause == null) {
-            throw new NullPointerException("cause");
-        }
+        ObjectUtil.checkNotNull(cause, "cause");
         // It is possible for some of the failed promises to trigger more writes. The new writes
         // will "revive" the queue, so we need to clean them up until the queue is empty.
         for (PendingWrite write = head; write != null; write = head) {
@@ -192,11 +187,9 @@ public final class PendingWriteQueue {
      */
     public void removeAndFail(Throwable cause) {
         assert ctx.executor().inEventLoop();
-        if (cause == null) {
-            throw new NullPointerException("cause");
-        }
-        PendingWrite write = head;
+        ObjectUtil.checkNotNull(cause, "cause");
 
+        PendingWrite write = head;
         if (write == null) {
             return;
         }

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -91,10 +91,10 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     @Deprecated
     @Override
     public ChannelFuture register(final Channel channel, final ChannelPromise promise) {
-        ObjectUtil.checkNotNull(channel, "channel");
         ObjectUtil.checkNotNull(promise, "promise");
-
-        channel.unsafe().register(this, promise);
+        ObjectUtil.checkNotNull(channel, "channel").
+                unsafe().
+                register(this, promise);
         return promise;
     }
 

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -91,12 +91,8 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     @Deprecated
     @Override
     public ChannelFuture register(final Channel channel, final ChannelPromise promise) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
-        if (promise == null) {
-            throw new NullPointerException("promise");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
+        ObjectUtil.checkNotNull(promise, "promise");
 
         channel.unsafe().register(this, promise);
         return promise;

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -92,9 +92,8 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     @Override
     public ChannelFuture register(final Channel channel, final ChannelPromise promise) {
         ObjectUtil.checkNotNull(promise, "promise");
-        ObjectUtil.checkNotNull(channel, "channel").
-                unsafe().
-                register(this, promise);
+        ObjectUtil.checkNotNull(channel, "channel");
+        channel.unsafe().register(this, promise);
         return promise;
     }
 

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
@@ -25,6 +25,7 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReadOnlyIterator;
 import io.netty.util.internal.ThrowableUtil;
@@ -117,13 +118,8 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
      * @param args              arguments which will passed to each {@link #newChild(Object...)} call.
      */
     protected ThreadPerChannelEventLoopGroup(int maxChannels, Executor executor, Object... args) {
-        if (maxChannels < 0) {
-            throw new IllegalArgumentException(String.format(
-                    "maxChannels: %d (expected: >= 0)", maxChannels));
-        }
-        if (executor == null) {
-            throw new NullPointerException("executor");
-        }
+        ObjectUtil.checkPositiveOrZero(maxChannels, "maxChannels");
+        ObjectUtil.checkNotNull(executor, "executor");
 
         if (args == null) {
             childArgs = EmptyArrays.EMPTY_OBJECTS;
@@ -274,9 +270,7 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
 
     @Override
     public ChannelFuture register(Channel channel) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         try {
             EventLoop l = nextChild();
             return l.register(new DefaultChannelPromise(channel, l));
@@ -298,9 +292,7 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
     @Deprecated
     @Override
     public ChannelFuture register(Channel channel, ChannelPromise promise) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         try {
             return nextChild().register(channel, promise);
         } catch (Throwable t) {

--- a/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
+++ b/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
@@ -18,6 +18,7 @@ package io.netty.channel;
 import io.netty.util.concurrent.AbstractFuture;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.util.concurrent.TimeUnit;
@@ -35,9 +36,7 @@ public final class VoidChannelPromise extends AbstractFuture<Void> implements Ch
      * @param channel the {@link Channel} associated with this future
      */
     public VoidChannelPromise(final Channel channel, boolean fireException) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
+        ObjectUtil.checkNotNull(channel, "channel");
         this.channel = channel;
         if (fireException) {
             fireExceptionListener = new ChannelFutureListener() {
@@ -162,6 +161,7 @@ public final class VoidChannelPromise extends AbstractFuture<Void> implements Ch
         fail();
         return this;
     }
+
     @Override
     public VoidChannelPromise setFailure(Throwable cause) {
         fireException0(cause);

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -45,9 +45,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
 
     @Override
     public void execute(Runnable command) {
-        if (command == null) {
-            throw new NullPointerException("command");
-        }
+        ObjectUtil.checkNotNull(command, "command");
         tasks.add(command);
     }
 

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -45,8 +45,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
 
     @Override
     public void execute(Runnable command) {
-        ObjectUtil.checkNotNull(command, "command");
-        tasks.add(command);
+        tasks.add(ObjectUtil.checkNotNull(command, "command"));
     }
 
     void runTasks() {

--- a/transport/src/main/java/io/netty/channel/group/ChannelGroupException.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelGroupException.java
@@ -18,6 +18,7 @@ package io.netty.channel.group;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelFuture;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,12 +33,7 @@ public class ChannelGroupException extends ChannelException implements Iterable<
     private final Collection<Map.Entry<Channel, Throwable>> failed;
 
     public ChannelGroupException(Collection<Map.Entry<Channel, Throwable>> causes) {
-        if (causes == null) {
-            throw new NullPointerException("causes");
-        }
-        if (causes.isEmpty()) {
-            throw new IllegalArgumentException("causes must be non empty");
-        }
+        ObjectUtil.checkNonEmpty(causes, "cause");
         failed = Collections.unmodifiableCollection(causes);
     }
 

--- a/transport/src/main/java/io/netty/channel/group/ChannelGroupException.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelGroupException.java
@@ -34,6 +34,7 @@ public class ChannelGroupException extends ChannelException implements Iterable<
 
     public ChannelGroupException(Collection<Map.Entry<Channel, Throwable>> causes) {
         ObjectUtil.checkNonEmpty(causes, "causes");
+
         failed = Collections.unmodifiableCollection(causes);
     }
 

--- a/transport/src/main/java/io/netty/channel/group/ChannelGroupException.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelGroupException.java
@@ -33,7 +33,7 @@ public class ChannelGroupException extends ChannelException implements Iterable<
     private final Collection<Map.Entry<Channel, Throwable>> failed;
 
     public ChannelGroupException(Collection<Map.Entry<Channel, Throwable>> causes) {
-        ObjectUtil.checkNonEmpty(causes, "cause");
+        ObjectUtil.checkNonEmpty(causes, "causes");
         failed = Collections.unmodifiableCollection(causes);
     }
 

--- a/transport/src/main/java/io/netty/channel/group/CombinedIterator.java
+++ b/transport/src/main/java/io/netty/channel/group/CombinedIterator.java
@@ -29,11 +29,9 @@ final class CombinedIterator<E> implements Iterator<E> {
     private Iterator<E> currentIterator;
 
     CombinedIterator(Iterator<E> i1, Iterator<E> i2) {
-        ObjectUtil.checkNotNull(i1, "i1");
-        ObjectUtil.checkNotNull(i2, "i2");
-        this.i1 = i1;
-        this.i2 = i2;
-        currentIterator = i1;
+        this.i1 = ObjectUtil.checkNotNull(i1, "i1");
+        this.i2 = ObjectUtil.checkNotNull(i2, "i2");
+        this.currentIterator = i1;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/group/CombinedIterator.java
+++ b/transport/src/main/java/io/netty/channel/group/CombinedIterator.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel.group;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -27,12 +29,8 @@ final class CombinedIterator<E> implements Iterator<E> {
     private Iterator<E> currentIterator;
 
     CombinedIterator(Iterator<E> i1, Iterator<E> i2) {
-        if (i1 == null) {
-            throw new NullPointerException("i1");
-        }
-        if (i2 == null) {
-            throw new NullPointerException("i2");
-        }
+        ObjectUtil.checkNotNull(i1, "i1");
+        ObjectUtil.checkNotNull(i2, "i2");
         this.i1 = i1;
         this.i2 = i2;
         currentIterator = i1;

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelId;
 import io.netty.channel.ServerChannel;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
@@ -91,9 +92,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
      * the same name, which means no duplicate check is done against group names.
      */
     public DefaultChannelGroup(String name, EventExecutor executor, boolean stayClosed) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
+        ObjectUtil.checkNotNull(name, "name");
         this.name = name;
         this.executor = executor;
         this.stayClosed = stayClosed;
@@ -256,12 +255,8 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
 
     @Override
     public ChannelGroupFuture write(Object message, ChannelMatcher matcher, boolean voidPromise) {
-        if (message == null) {
-            throw new NullPointerException("message");
-        }
-        if (matcher == null) {
-            throw new NullPointerException("matcher");
-        }
+        ObjectUtil.checkNotNull(message, "message");
+        ObjectUtil.checkNotNull(matcher, "matcher");
 
         final ChannelGroupFuture future;
         if (voidPromise) {
@@ -301,9 +296,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
 
     @Override
     public ChannelGroupFuture disconnect(ChannelMatcher matcher) {
-        if (matcher == null) {
-            throw new NullPointerException("matcher");
-        }
+        ObjectUtil.checkNotNull(matcher, "matcher");
 
         Map<Channel, ChannelFuture> futures =
                 new LinkedHashMap<Channel, ChannelFuture>(size());
@@ -324,9 +317,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
 
     @Override
     public ChannelGroupFuture close(ChannelMatcher matcher) {
-        if (matcher == null) {
-            throw new NullPointerException("matcher");
-        }
+        ObjectUtil.checkNotNull(matcher, "matcher");
 
         Map<Channel, ChannelFuture> futures =
                 new LinkedHashMap<Channel, ChannelFuture>(size());
@@ -357,9 +348,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
 
     @Override
     public ChannelGroupFuture deregister(ChannelMatcher matcher) {
-        if (matcher == null) {
-            throw new NullPointerException("matcher");
-        }
+        ObjectUtil.checkNotNull(matcher, "matcher");
 
         Map<Channel, ChannelFuture> futures =
                 new LinkedHashMap<Channel, ChannelFuture>(size());
@@ -400,9 +389,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
 
     @Override
     public ChannelGroupFuture writeAndFlush(Object message, ChannelMatcher matcher, boolean voidPromise) {
-        if (message == null) {
-            throw new NullPointerException("message");
-        }
+        ObjectUtil.checkNotNull(message, "message");
 
         final ChannelGroupFuture future;
         if (voidPromise) {

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroupFuture.java
@@ -24,6 +24,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -82,12 +83,8 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
      */
     DefaultChannelGroupFuture(ChannelGroup group, Collection<ChannelFuture> futures,  EventExecutor executor) {
         super(executor);
-        if (group == null) {
-            throw new NullPointerException("group");
-        }
-        if (futures == null) {
-            throw new NullPointerException("futures");
-        }
+        ObjectUtil.checkNotNull(group, "group");
+        ObjectUtil.checkNotNull(futures, "futures");
 
         this.group = group;
 

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroupFuture.java
@@ -83,10 +83,8 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
      */
     DefaultChannelGroupFuture(ChannelGroup group, Collection<ChannelFuture> futures,  EventExecutor executor) {
         super(executor);
-        ObjectUtil.checkNotNull(group, "group");
+        this.group = ObjectUtil.checkNotNull(group, "group");
         ObjectUtil.checkNotNull(futures, "futures");
-
-        this.group = group;
 
         Map<Channel, ChannelFuture> futureMap = new LinkedHashMap<Channel, ChannelFuture>();
         for (ChannelFuture f: futures) {

--- a/transport/src/main/java/io/netty/channel/local/LocalAddress.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalAddress.java
@@ -16,6 +16,7 @@
 package io.netty.channel.local;
 
 import io.netty.channel.Channel;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.SocketAddress;
 
@@ -50,9 +51,7 @@ public final class LocalAddress extends SocketAddress implements Comparable<Loca
      * Creates a new instance with the specified ID.
      */
     public LocalAddress(String id) {
-        if (id == null) {
-            throw new NullPointerException("id");
-        }
+        ObjectUtil.checkNotNull(id, "id");
         id = id.trim().toLowerCase();
         if (id.isEmpty()) {
             throw new IllegalArgumentException("empty id");

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -137,13 +137,11 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                  EventLoopTaskQueueFactory queueFactory) {
         super(parent, executor, false, newTaskQueue(queueFactory), newTaskQueue(queueFactory),
                 rejectedExecutionHandler);
-        ObjectUtil.checkNotNull(selectorProvider, "selectorProvider");
-        ObjectUtil.checkNotNull(strategy, "selectStrategy");
-        provider = selectorProvider;
+        this.provider = ObjectUtil.checkNotNull(selectorProvider, "selectorProvider");
+        this.selectStrategy = ObjectUtil.checkNotNull(strategy, "selectStrategy");
         final SelectorTuple selectorTuple = openSelector();
-        selector = selectorTuple.selector;
-        unwrappedSelector = selectorTuple.unwrappedSelector;
-        selectStrategy = strategy;
+        this.selector = selectorTuple.selector;
+        this.unwrappedSelector = selectorTuple.unwrappedSelector;
     }
 
     private static Queue<Runnable> newTaskQueue(

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -24,6 +24,7 @@ import io.netty.channel.SelectStrategy;
 import io.netty.channel.SingleThreadEventLoop;
 import io.netty.util.IntSupplier;
 import io.netty.util.concurrent.RejectedExecutionHandler;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReflectionUtil;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -136,12 +137,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                  EventLoopTaskQueueFactory queueFactory) {
         super(parent, executor, false, newTaskQueue(queueFactory), newTaskQueue(queueFactory),
                 rejectedExecutionHandler);
-        if (selectorProvider == null) {
-            throw new NullPointerException("selectorProvider");
-        }
-        if (strategy == null) {
-            throw new NullPointerException("selectStrategy");
-        }
+        ObjectUtil.checkNotNull(selectorProvider, "selectorProvider");
+        ObjectUtil.checkNotNull(strategy, "selectStrategy");
         provider = selectorProvider;
         final SelectorTuple selectorTuple = openSelector();
         selector = selectorTuple.selector;
@@ -291,9 +288,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
      * be executed by this event loop when the {@link SelectableChannel} is ready.
      */
     public void register(final SelectableChannel ch, final int interestOps, final NioTask<?> task) {
-        if (ch == null) {
-            throw new NullPointerException("ch");
-        }
+        ObjectUtil.checkNotNull(ch, "ch");
         if (interestOps == 0) {
             throw new IllegalArgumentException("interestOps must be non-zero.");
         }
@@ -301,9 +296,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             throw new IllegalArgumentException(
                     "invalid interestOps: " + interestOps + "(validOps: " + ch.validOps() + ')');
         }
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
+        ObjectUtil.checkNotNull(task, "task");
 
         if (isShutdown()) {
             throw new IllegalStateException("event loop shut down");

--- a/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.FileRegion;
 import io.netty.channel.RecvByteBufAllocator;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -75,12 +76,8 @@ public abstract class OioByteStreamChannel extends AbstractOioByteChannel {
         if (this.os != null) {
             throw new IllegalStateException("output was set already");
         }
-        if (is == null) {
-            throw new NullPointerException("is");
-        }
-        if (os == null) {
-            throw new NullPointerException("os");
-        }
+        ObjectUtil.checkNotNull(is, "is");
+        ObjectUtil.checkNotNull(os, "os");
         this.is = is;
         this.os = os;
     }

--- a/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
@@ -76,10 +76,8 @@ public abstract class OioByteStreamChannel extends AbstractOioByteChannel {
         if (this.os != null) {
             throw new IllegalStateException("output was set already");
         }
-        ObjectUtil.checkNotNull(is, "is");
-        ObjectUtil.checkNotNull(os, "os");
-        this.is = is;
-        this.os = os;
+        this.is = ObjectUtil.checkNotNull(is, "is");
+        this.os = ObjectUtil.checkNotNull(os, "os");
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -157,8 +157,7 @@ public class SimpleChannelPool implements ChannelPool {
 
     @Override
     public Future<Channel> acquire(final Promise<Channel> promise) {
-        checkNotNull(promise, "promise");
-        return acquireHealthyFromPoolOrNew(promise);
+        return acquireHealthyFromPoolOrNew(checkNotNull(promise, "promise"));
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/socket/DefaultDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultDatagramChannelConfig.java
@@ -23,6 +23,7 @@ import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -52,9 +53,7 @@ public class DefaultDatagramChannelConfig extends DefaultChannelConfig implement
      */
     public DefaultDatagramChannelConfig(DatagramChannel channel, DatagramSocket javaSocket) {
         super(channel, new FixedRecvByteBufAllocator(2048));
-        if (javaSocket == null) {
-            throw new NullPointerException("javaSocket");
-        }
+        ObjectUtil.checkNotNull(javaSocket, "javaSocket");
         this.javaSocket = javaSocket;
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/DefaultDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultDatagramChannelConfig.java
@@ -53,8 +53,7 @@ public class DefaultDatagramChannelConfig extends DefaultChannelConfig implement
      */
     public DefaultDatagramChannelConfig(DatagramChannel channel, DatagramSocket javaSocket) {
         super(channel, new FixedRecvByteBufAllocator(2048));
-        ObjectUtil.checkNotNull(javaSocket, "javaSocket");
-        this.javaSocket = javaSocket;
+        this.javaSocket = ObjectUtil.checkNotNull(javaSocket, "javaSocket");
     }
 
     protected final DatagramSocket javaSocket() {

--- a/transport/src/main/java/io/netty/channel/socket/DefaultServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultServerSocketChannelConfig.java
@@ -23,6 +23,7 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.NetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.ServerSocket;
 import java.net.SocketException;
@@ -47,9 +48,7 @@ public class DefaultServerSocketChannelConfig extends DefaultChannelConfig
      */
     public DefaultServerSocketChannelConfig(ServerSocketChannel channel, ServerSocket javaSocket) {
         super(channel);
-        if (javaSocket == null) {
-            throw new NullPointerException("javaSocket");
-        }
+        ObjectUtil.checkNotNull(javaSocket, "javaSocket");
         this.javaSocket = javaSocket;
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/DefaultServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultServerSocketChannelConfig.java
@@ -48,8 +48,7 @@ public class DefaultServerSocketChannelConfig extends DefaultChannelConfig
      */
     public DefaultServerSocketChannelConfig(ServerSocketChannel channel, ServerSocket javaSocket) {
         super(channel);
-        ObjectUtil.checkNotNull(javaSocket, "javaSocket");
-        this.javaSocket = javaSocket;
+        this.javaSocket = ObjectUtil.checkNotNull(javaSocket, "javaSocket");
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java
@@ -22,6 +22,7 @@ import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.net.Socket;
@@ -44,9 +45,7 @@ public class DefaultSocketChannelConfig extends DefaultChannelConfig
      */
     public DefaultSocketChannelConfig(SocketChannel channel, Socket javaSocket) {
         super(channel);
-        if (javaSocket == null) {
-            throw new NullPointerException("javaSocket");
-        }
+        ObjectUtil.checkNotNull(javaSocket, "javaSocket");
         this.javaSocket = javaSocket;
 
         // Enable TCP_NODELAY by default if possible.

--- a/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java
@@ -45,8 +45,7 @@ public class DefaultSocketChannelConfig extends DefaultChannelConfig
      */
     public DefaultSocketChannelConfig(SocketChannel channel, Socket javaSocket) {
         super(channel);
-        ObjectUtil.checkNotNull(javaSocket, "javaSocket");
-        this.javaSocket = javaSocket;
+        this.javaSocket = ObjectUtil.checkNotNull(javaSocket, "javaSocket");
 
         // Enable TCP_NODELAY by default if possible.
         if (PlatformDependent.canEnableTcpNoDelayByDefault()) {

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -30,6 +30,7 @@ import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.channel.socket.DatagramChannelConfig;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
@@ -404,13 +405,8 @@ public final class NioDatagramChannel
 
         checkJavaVersion();
 
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
         try {
             MembershipKey key;
@@ -484,12 +480,8 @@ public final class NioDatagramChannel
             ChannelPromise promise) {
         checkJavaVersion();
 
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
         synchronized (this) {
             if (memberships != null) {
@@ -538,16 +530,10 @@ public final class NioDatagramChannel
             InetAddress sourceToBlock, ChannelPromise promise) {
         checkJavaVersion();
 
-        if (multicastAddress == null) {
-            throw new NullPointerException("multicastAddress");
-        }
-        if (sourceToBlock == null) {
-            throw new NullPointerException("sourceToBlock");
-        }
+        ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
+        ObjectUtil.checkNotNull(sourceToBlock, "sourceToBlock");
+        ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
-        if (networkInterface == null) {
-            throw new NullPointerException("networkInterface");
-        }
         synchronized (this) {
             if (memberships != null) {
                 List<MembershipKey> keys = memberships.get(multicastAddress);

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.oio.AbstractOioMessageChannel;
 import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -76,9 +77,7 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
      */
     public OioServerSocketChannel(ServerSocket socket) {
         super(null);
-        if (socket == null) {
-            throw new NullPointerException("socket");
-        }
+        ObjectUtil.checkNotNull(socket, "socket");
 
         boolean success = false;
         try {


### PR DESCRIPTION
Uniform null pointer check.

Modification:
Use `ObjectUtil` uniform null pointer check.

Result:
Less code. 