### PR TITLE
Introduce ByteBuf#capacityAndDiscard(int) method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -144,6 +144,12 @@ final class AdvancedLeakAwareByteBuf extends SimpleLeakAwareByteBuf {
     }
 
     @Override
+    public boolean capacityAndDiscard(int newCapacity) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.capacityAndDiscard(newCapacity);
+    }
+
+    @Override
     public boolean getBoolean(int index) {
         recordLeakNonRefCountingOperation(leak);
         return super.getBoolean(index);

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
@@ -130,6 +130,12 @@ final class AdvancedLeakAwareCompositeByteBuf extends SimpleLeakAwareCompositeBy
     }
 
     @Override
+    public boolean capacityAndDiscard(int newCapacity) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.capacityAndDiscard(newCapacity);
+    }
+
+    @Override
     public boolean getBoolean(int index) {
         recordLeakNonRefCountingOperation(leak);
         return super.getBoolean(index);

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -556,6 +556,27 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract int ensureWritable(int minWritableBytes, boolean force);
 
     /**
+     * Equivalent to calling {@link #discardReadBytes()}.{@link #capacity(int)}, except that:
+     * <ul>
+     * <li>No attempt is made to preserve data outside of the buffer's currently readable range</li>
+     * <li>A single copy operation is performed at most, instead of possibly two separate copies. The
+     * total number of bytes copied will also usually be much smaller (and never larger)</li>
+     * <li>If the buffer does not support this combined operation then {@code false} is returned -
+     * in which case the caller may choose to use the more expensive formulation above, or to copy the
+     * readable range into the beginning of a newly allocated buffer of the desired capacity (the
+     * latter might often be cheaper)</li>
+     * </ul>
+     *
+     * @return {@code true} if successful, {@code false} if this buffer does not implement a combined
+     *     copy-and-discard operation
+     *
+     * @throws IllegalArgumentException if the {@code newCapacity} is greater than {@link #maxCapacity()}
+     */
+    public boolean capacityAndDiscard(int newCapacity) {
+        return false;
+    }
+
+    /**
      * Gets a boolean at the specified absolute (@code index) in this buffer.
      * This method does not modify the {@code readerIndex} or {@code writerIndex}
      * of this buffer.
@@ -575,7 +596,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 1} is greater than {@code this.capacity}
      */
-    public abstract byte  getByte(int index);
+    public abstract byte getByte(int index);
 
     /**
      * Gets an unsigned byte at the specified absolute {@code index} in this

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -89,6 +89,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean capacityAndDiscard(int newCapacity) {
+        return buf.capacityAndDiscard(newCapacity);
+    }
+
+    @Override
     public int maxCapacity() {
         return buf.maxCapacity();
     }

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -74,6 +74,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean capacityAndDiscard(int newCapacity) {
+        return buf.capacityAndDiscard(newCapacity);
+    }
+
+    @Override
     public final int maxCapacity() {
         return buf.maxCapacity();
     }


### PR DESCRIPTION
Motivation

Using a contiguous, growable `ByteBuf` for FIFO-like cumulation is currently not as efficient as it could be due to the semantics of the `capacity(int)` method, which copies the entire buffer regardless of its current readable range. This behaviour is intentional to ensure any slices that might cover other parts of the buffer remain valid, but for some purposes means more bytes are copied than necessary.

Furthermore, in these cases it's beneficial to discard already consumed bytes to make the most room for incoming data, but this requires a separate copy operation. If combined, the capacity and discard
operations only require a single copy of the readable range.

For example, take a buffer with capacity 32 and readable range [16, 24). To grow the buffer and discard the read bytes currently involves copying 32 + 8 = 40 bytes, instead of just 8 in the combined case where the end result is the same (if we are discarding then it's already implied we don't care about the non-readable range).

Modifications

Add new `capacityAndDiscard(int)` method to `ByteBuf` and implement for the contiguous buffers. The method returns false if the operation is not supported, which is more flexible than "silently" defaulting to `discardReadBytes().capacity(int)`.

Result

More efficient cumulation possible