### PR TITLE
Update to netty-tcnative 2.0.28.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
     <!-- keep in sync with PlatformDependent#ALLOWED_LINUX_OS_CLASSIFIERS -->
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.27.Final</tcnative.version>
+    <tcnative.version>2.0.28.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

netty-tcnative 2.0.28.Final was released

Modifications:

Update to latest version

Result:

Use latest version of netty-tcnative