### PR TITLE
Never unset EPOLLOUT interest flag

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -289,8 +289,8 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                 writeSpinCount -= doWriteMultiple(in);
             } else if (msgCount == 0) {
                 // Wrote all messages.
-                clearFlag(Native.EPOLLOUT);
-                // Return here so we not set the EPOLLOUT flag.
+                flushPending = false;
+                // Return here so we not set the flushPending flag.
                 return;
             } else {  // msgCount == 1
                 writeSpinCount -= doWriteSingle(in);
@@ -306,14 +306,14 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             // our write quantum. In this case we no longer want to set the EPOLLOUT flag because the socket is still
             // writable (as far as we know). We will find out next time we attempt to write if the socket is writable
             // and set the EPOLLOUT if necessary.
-            clearFlag(Native.EPOLLOUT);
+            flushPending = false;
 
             // We used our writeSpin quantum, and should try to write again later.
             eventLoop().execute(flushTask);
         } else {
             // Underlying descriptor can not accept all data currently, so set the EPOLLOUT flag to be woken up
             // when it can accept more data.
-            setFlag(Native.EPOLLOUT);
+            flushPending = true;
         }
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -290,7 +290,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             Object msg = in.current();
             if (msg == null) {
                 // Wrote all messages.
-                clearFlag(Native.EPOLLOUT);
+                flushPending = false;
                 break;
             }
 
@@ -310,7 +310,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                             int send = socket.sendmmsg(packets, offset, cnt);
                             if (send == 0) {
                                 // Did not write all messages.
-                                setFlag(Native.EPOLLOUT);
+                                flushPending = true;
                                 return;
                             }
                             for (int i = 0; i < send; i++) {
@@ -334,7 +334,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                     in.remove();
                 } else {
                     // Did not write all messages.
-                    setFlag(Native.EPOLLOUT);
+                    flushPending = true;
                     break;
                 }
             } catch (IOException e) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollHandler.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollHandler.java
@@ -452,7 +452,7 @@ public class EpollHandler implements IoHandler {
 
                     // Check if EPOLLRDHUP was set, this will notify us for connection-reset in which case
                     // we may close the channel directly or try to read more data depending on the state of the
-                    // Channel and als depending on the AbstractEpollChannel subtype.
+                    // Channel and also depending on the AbstractEpollChannel subtype.
                     if ((ev & Native.EPOLLRDHUP) != 0) {
                         unsafe.epollRdHupReady();
                     }


### PR DESCRIPTION
Motivation

This is another go at #9347, which makes more sense now that LT is removed.

Modifications

Always set `EPOLLOUT` flag for sockets in the interest list and use a new boolean `flushPending` field in `AbstractEpollChannel` to track whether there is a flush pending.

Result

Fewer `epoll_ctl` syscalls on event loop in case of send backpressure