### PR TITLE
ByteToMessageDecoder avoid using discardSomeReadBytes()

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -543,7 +543,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     final void channelReadComplete0(ChannelHandlerContext ctx) {
         // Discard bytes of the cumulation buffer if needed.
-        discardSomeReadBytes();
+        tryDiscardSomeReadBytes(ctx.alloc());
 
         // Ensure we never stale the HTTP/2 Channel. Flow-control is enforced by HTTP/2.
         //

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1284,7 +1284,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     private void channelReadComplete0(ChannelHandlerContext ctx) {
         // Discard bytes of the cumulation buffer if needed.
-        discardSomeReadBytes();
+        tryDiscardSomeReadBytes(ctx.alloc());
 
         flushIfNeeded(ctx);
         readIfNeeded(ctx);


### PR DESCRIPTION
Motivation:
ByteToMessageDecoder maintains a ByteBuf to aggregate data in the event
a full message requires multiple socket read calls (aka the cumulator).
The cumulator buffer may grow over time and so ByteToMessageDecoder
periodically calls discardSomeReadBytes() in an attempt to reclaim
unused space and compact the buffer. Calling discardSomeReadBytes()
will modify the underlying buffer and if the application has any
views into the buffer (e.g. slice().retain()) their view would be
corrupted, and therefore the refCnt() must be 1 in order for
discardSomeReadBytes() to be called on the buffer. However if an
application habitually processes the data on another thread this
strategy may mean that discardSomeReadBytes() cannot be called in a
timely manner due to the reference count not being 1 and the buffer may
grow relatively large.

Modifications:
- Instead of basing the buffer space reclamation on if the buffer is
"shared", base the criteria on how much "wasted" space exists in the
accumulation buffer. The default policy is if the buffer is at least
half "wasted" space based upon its original capacity then reclaim
space.
- Instead of using ByteBuf#discardSomeReadBytes() to reclaim space,
allocate a new buffer and swap the old buffer. This avoids any risk of
existing views on the data being corrupted.
- Trigger points are added (but made private) such that base classes
can maintain indexes on the cumulation data and reset these indexes
when the underlying cumulation buffer changes. This can be useful to
avoid re-parsing data if partial data is parsed before it is all
received. These methods can be made public later if/when they are used.

Result:
ByteToMessageDecoder reclaims cumulation buffer space according to
wasted space instead of if the buffer is shared.