### PR TITLE
SnappyFrameDecoderTest ByteBuf leak

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -43,7 +43,7 @@ public class SnappyFrameDecoderTest {
             0x03, 0x01, 0x00, 0x00, 0x00
         });
 
-        assertFalse(channel.writeInbound(in));
+        channel.writeInbound(in);
     }
 
     @Test(expected = DecompressionException.class)
@@ -52,7 +52,7 @@ public class SnappyFrameDecoderTest {
             -0x80, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        assertFalse(channel.writeInbound(in));
+        channel.writeInbound(in);
     }
 
     @Test(expected = DecompressionException.class)
@@ -61,7 +61,7 @@ public class SnappyFrameDecoderTest {
             (byte) 0xff, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
         });
 
-        assertFalse(channel.writeInbound(in));
+        channel.writeInbound(in);
     }
 
     @Test(expected = DecompressionException.class)
@@ -70,7 +70,7 @@ public class SnappyFrameDecoderTest {
             -0x7f, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
         });
 
-        assertFalse(channel.writeInbound(in));
+        channel.writeInbound(in);
     }
 
     @Test(expected = DecompressionException.class)
@@ -79,7 +79,7 @@ public class SnappyFrameDecoderTest {
             0x01, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        assertFalse(channel.writeInbound(in));
+        channel.writeInbound(in);
     }
 
     @Test(expected = DecompressionException.class)
@@ -88,7 +88,7 @@ public class SnappyFrameDecoderTest {
             0x00, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        assertFalse(channel.writeInbound(in));
+        channel.writeInbound(in);
     }
 
     @Test
@@ -155,9 +155,9 @@ public class SnappyFrameDecoderTest {
                     0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
             });
 
-            assertFalse(channel.writeInbound(in));
+            channel.writeInbound(in);
         } finally {
-            assertFalse(channel.finishAndReleaseAll());
+            channel.finishAndReleaseAll();
         }
     }
 
@@ -178,9 +178,8 @@ public class SnappyFrameDecoderTest {
 
             expected.release();
             actual.release();
-            assertFalse(channel.finish());
         } finally {
-            assertFalse(channel.finishAndReleaseAll());
+            channel.finishAndReleaseAll();
         }
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.compression;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,6 +32,11 @@ public class SnappyFrameDecoderTest {
         channel = new EmbeddedChannel(new SnappyFrameDecoder());
     }
 
+    @After
+    public void tearDown() {
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
     @Test(expected = DecompressionException.class)
     public void testReservedUnskippableChunkTypeCausesError() throws Exception {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
@@ -38,7 +44,6 @@ public class SnappyFrameDecoderTest {
         });
 
         assertFalse(channel.writeInbound(in));
-        assertFalse(channel.finish());
     }
 
     @Test(expected = DecompressionException.class)
@@ -48,7 +53,6 @@ public class SnappyFrameDecoderTest {
         });
 
         assertFalse(channel.writeInbound(in));
-        assertFalse(channel.finish());
     }
 
     @Test(expected = DecompressionException.class)
@@ -58,7 +62,6 @@ public class SnappyFrameDecoderTest {
         });
 
         assertFalse(channel.writeInbound(in));
-        assertFalse(channel.finish());
     }
 
     @Test(expected = DecompressionException.class)
@@ -67,7 +70,7 @@ public class SnappyFrameDecoderTest {
             -0x7f, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
         });
 
-        channel.writeInbound(in);
+        assertFalse(channel.writeInbound(in));
     }
 
     @Test(expected = DecompressionException.class)
@@ -77,7 +80,6 @@ public class SnappyFrameDecoderTest {
         });
 
         assertFalse(channel.writeInbound(in));
-        assertFalse(channel.finish());
     }
 
     @Test(expected = DecompressionException.class)
@@ -87,7 +89,6 @@ public class SnappyFrameDecoderTest {
         });
 
         assertFalse(channel.writeInbound(in));
-        assertFalse(channel.finish());
     }
 
     @Test
@@ -101,7 +102,6 @@ public class SnappyFrameDecoderTest {
         assertNull(channel.readInbound());
 
         assertFalse(in.isReadable());
-        assertFalse(channel.finish());
     }
 
     @Test
@@ -119,7 +119,6 @@ public class SnappyFrameDecoderTest {
 
         expected.release();
         actual.release();
-        assertFalse(channel.finish());
     }
 
     @Test
@@ -141,7 +140,6 @@ public class SnappyFrameDecoderTest {
 
         expected.release();
         actual.release();
-        assertFalse(channel.finish());
     }
 
     // The following two tests differ in only the checksum provided for the literal
@@ -150,34 +148,39 @@ public class SnappyFrameDecoderTest {
     @Test(expected = DecompressionException.class)
     public void testInvalidChecksumThrowsException() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SnappyFrameDecoder(true));
+        try {
+            // checksum here is presented as 0
+            ByteBuf in = Unpooled.wrappedBuffer(new byte[]{
+                    (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
+                    0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
+            });
 
-        // checksum here is presented as 0
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-           (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
-            0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
-        });
-
-        assertFalse(channel.writeInbound(in));
-        assertFalse(channel.finish());
+            assertFalse(channel.writeInbound(in));
+        } finally {
+            assertFalse(channel.finishAndReleaseAll());
+        }
     }
 
     @Test
     public void testInvalidChecksumDoesNotThrowException() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SnappyFrameDecoder(true));
+        try {
+            // checksum here is presented as a282986f (little endian)
+            ByteBuf in = Unpooled.wrappedBuffer(new byte[]{
+                    (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
+                    0x01, 0x09, 0x00, 0x00, 0x6f, -0x68, -0x7e, -0x5e, 'n', 'e', 't', 't', 'y'
+            });
 
-        // checksum here is presented as a282986f (little endian)
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-           (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
-            0x01, 0x09, 0x00, 0x00, 0x6f, -0x68, -0x7e, -0x5e, 'n', 'e', 't', 't', 'y'
-        });
+            assertTrue(channel.writeInbound(in));
+            ByteBuf expected = Unpooled.wrappedBuffer(new byte[] { 'n', 'e', 't', 't', 'y' });
+            ByteBuf actual = channel.readInbound();
+            assertEquals(expected, actual);
 
-        assertTrue(channel.writeInbound(in));
-        ByteBuf expected = Unpooled.wrappedBuffer(new byte[] { 'n', 'e', 't', 't', 'y' });
-        ByteBuf actual = channel.readInbound();
-        assertEquals(expected, actual);
-
-        expected.release();
-        actual.release();
-        assertFalse(channel.finish());
+            expected.release();
+            actual.release();
+            assertFalse(channel.finish());
+        } finally {
+            assertFalse(channel.finishAndReleaseAll());
+        }
     }
 }


### PR DESCRIPTION
Motivation:
SnappyFrameDecoderTest has a few tests which fail to close the EmbeddedChannel
and therefore may leak ByteBuf objects.

Modifications:
- Make sure EmbeddedChannel#finishAndReleaseAll() is called in all tests

Result:
No more leaks from SnappyFrameDecoderTest.