### PR TITLE
Add Server Cookie Parser overload for multiple cookies.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
@@ -17,7 +17,10 @@ package io.netty.handler.codec.http.cookie;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -57,18 +60,39 @@ public final class ServerCookieDecoder extends CookieDecoder {
     }
 
     /**
+     * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.  Unlike {@link #decode(String)}, this
+     * includes all cookie values present, even if they have the same name.
+     *
+     * @return the decoded {@link Cookie}
+     */
+    public List<Cookie> decodeAll(String header) {
+        List<Cookie> cookies = new ArrayList<Cookie>();
+        decode(cookies, header);
+        return Collections.unmodifiableList(cookies);
+    }
+
+    /**
      * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.
      *
      * @return the decoded {@link Cookie}
      */
     public Set<Cookie> decode(String header) {
+        Set<Cookie> cookies = new TreeSet<Cookie>();
+        decode(cookies, header);
+        return cookies;
+    }
+
+    /**
+     * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.
+     *
+     * @return the decoded {@link Cookie}
+     */
+    private void decode(Collection<? super Cookie> cookies, String header) {
         final int headerLen = checkNotNull(header, "header").length();
 
         if (headerLen == 0) {
-            return Collections.emptySet();
+            return;
         }
-
-        Set<Cookie> cookies = new TreeSet<Cookie>();
 
         int i = 0;
 
@@ -149,7 +173,5 @@ public final class ServerCookieDecoder extends CookieDecoder {
                 cookies.add(cookie);
             }
         }
-
-        return cookies;
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieDecoderTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http.cookie;
 
+import java.util.List;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -40,6 +41,26 @@ public class ServerCookieDecoderTest {
         String c3 = "myCookie3=myValue3;";
 
         Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode(c1 + c2 + c3);
+        assertEquals(3, cookies.size());
+        Iterator<Cookie> it = cookies.iterator();
+        Cookie cookie = it.next();
+        assertNotNull(cookie);
+        assertEquals("myValue", cookie.value());
+        cookie = it.next();
+        assertNotNull(cookie);
+        assertEquals("myValue2", cookie.value());
+        cookie = it.next();
+        assertNotNull(cookie);
+        assertEquals("myValue3", cookie.value());
+    }
+
+    @Test
+    public void testDecodingAllMultipleCookies() {
+        String c1 = "myCookie=myValue;";
+        String c2 = "myCookie=myValue2;";
+        String c3 = "myCookie=myValue3;";
+
+        List<Cookie> cookies = ServerCookieDecoder.STRICT.decodeAll(c1 + c2 + c3);
         assertEquals(3, cookies.size());
         Iterator<Cookie> it = cookies.iterator();
         Cookie cookie = it.next();


### PR DESCRIPTION
Motivation:

Multiple cookie values can be present in a single header.

Modification:

Add `decodeAll` overload which returns all cookies

Result:

Fixes #7210

Note:

This change is not as perscriptive as the ideas brought up in the linked issue.  Changing the Set implementation or the equals/compareTo definition is likely a breaking change, so they are practical.
