### PR TITLE
Update ChannelOutboundBuffer.java

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -53,7 +53,7 @@ import static java.lang.Math.min;
 public final class ChannelOutboundBuffer {
     // Assuming a 64-bit JVM:
     //  - 16 bytes object header
-    //  - 8 reference fields
+    //  - 6 reference fields
     //  - 2 long fields
     //  - 2 int fields
     //  - 1 boolean field


### PR DESCRIPTION
Motivation:

fix comment of ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD

Modifications:

6(NOT 8) reference fields is right

Result:
// Assuming a 64-bit JVM:
//  - 16 bytes object header
//  - 6(NOT 8) reference fields
//  - 2 long fields
//  - 2 int fields
//  - 1 boolean field
//  - padding

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
