### PR TITLE
Replace ObjectUtil.checkNonNull(...) with Objects.requireNonNull(...)

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -27,6 +27,7 @@ import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
@@ -57,10 +58,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     private final ByteOrder order;
 
     protected AbstractCompositeByteBufTest(ByteOrder order) {
-        if (order == null) {
-            throw new NullPointerException("order");
-        }
-        this.order = order;
+        this.order = Objects.requireNonNull(order, "order");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameDecoder.java
@@ -19,9 +19,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.TooLongFrameException;
-import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
+import java.util.Objects;
 
 import static io.netty.buffer.ByteBufUtil.readBytes;
 
@@ -61,7 +61,7 @@ public class WebSocket00FrameDecoder extends ReplayingDecoder<Void> implements W
      *            Frames decoder configuration.
      */
     public WebSocket00FrameDecoder(WebSocketDecoderConfig decoderConfig) {
-        this.maxFrameSize = ObjectUtil.checkNotNull(decoderConfig, "decoderConfig").maxFramePayloadLength();
+        this.maxFrameSize = Objects.requireNonNull(decoderConfig, "decoderConfig").maxFramePayloadLength();
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -59,12 +59,12 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.TooLongFrameException;
-import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Objects;
 
 import static io.netty.buffer.ByteBufUtil.readBytes;
 
@@ -154,7 +154,7 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
      *            Frames decoder configuration.
      */
     public WebSocket08FrameDecoder(WebSocketDecoderConfig decoderConfig) {
-        this.config = ObjectUtil.checkNotNull(decoderConfig, "decoderConfig");
+        this.config = Objects.requireNonNull(decoderConfig, "decoderConfig");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -18,9 +18,9 @@ package io.netty.handler.codec.http.websocketx;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
-import io.netty.util.internal.ObjectUtil;
 
 import java.net.URI;
+import java.util.Objects;
 
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
@@ -181,7 +181,7 @@ public final class WebSocketClientProtocolConfig {
         private boolean absoluteUpgradeUrl;
 
         private Builder(WebSocketClientProtocolConfig clientConfig) {
-            ObjectUtil.checkNotNull(clientConfig, "clientConfig");
+            Objects.requireNonNull(clientConfig, "clientConfig");
 
             webSocketUri = clientConfig.webSocketUri();
             subprotocol = clientConfig.subprotocol();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -22,9 +22,9 @@ import io.netty.handler.codec.http.HttpHeaders;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT;
-import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * This handler does all the heavy lifting for you to run a websocket client.
@@ -78,7 +78,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            Client protocol configuration.
      */
     public WebSocketClientProtocolHandler(WebSocketClientProtocolConfig clientConfig) {
-        super(checkNotNull(clientConfig, "clientConfig").dropPongFrames());
+        super(Objects.requireNonNull(clientConfig, "clientConfig").dropPongFrames());
         this.handshaker = WebSocketClientHandshakerFactory.newHandshaker(
             clientConfig.webSocketUri(),
             clientConfig.version(),

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseFrameHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseFrameHandler.java
@@ -22,9 +22,9 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ScheduledFuture;
-import io.netty.util.internal.ObjectUtil;
 
 import java.nio.channels.ClosedChannelException;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -36,7 +36,7 @@ final class WebSocketCloseFrameHandler extends ChannelOutboundHandlerAdapter {
     private ChannelPromise closeSent;
 
     WebSocketCloseFrameHandler(WebSocketCloseStatus closeStatus, long forceCloseTimeoutMillis) {
-        this.closeStatus = ObjectUtil.checkNotNull(closeStatus, "closeStatus");
+        this.closeStatus = Objects.requireNonNull(closeStatus, "closeStatus");
         this.forceCloseTimeoutMillis = forceCloseTimeoutMillis;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatus.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import java.util.Objects;
 
 /**
  * WebSocket status codes specified in RFC-6455.
@@ -222,7 +222,7 @@ public final class WebSocketCloseStatus implements Comparable<WebSocketCloseStat
                 "WebSocket close status code does NOT comply with RFC-6455: " + statusCode);
         }
         this.statusCode = statusCode;
-        this.reasonText = checkNotNull(reasonText, "reasonText");
+        this.reasonText = Objects.requireNonNull(reasonText, "reasonText");
     }
 
     public int code() {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketDecoderConfig.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.util.internal.ObjectUtil;
+import java.util.Objects;
 
 /**
  * Frames decoder configuration.
@@ -117,7 +117,7 @@ public final class WebSocketDecoderConfig {
         private boolean withUTF8Validator;
 
         private Builder(WebSocketDecoderConfig decoderConfig) {
-            ObjectUtil.checkNotNull(decoderConfig, "decoderConfig");
+            Objects.requireNonNull(decoderConfig, "decoderConfig");
             maxFramePayloadLength = decoderConfig.maxFramePayloadLength();
             expectMaskedFrames = decoderConfig.expectMaskedFrames();
             allowMaskMismatch = decoderConfig.allowMaskMismatch();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -35,13 +35,13 @@ import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -112,7 +112,7 @@ public abstract class WebSocketServerHandshaker {
         } else {
             this.subprotocols = EmptyArrays.EMPTY_STRINGS;
         }
-        this.decoderConfig = ObjectUtil.checkNotNull(decoderConfig, "decoderConfig");
+        this.decoderConfig = Objects.requireNonNull(decoderConfig, "decoderConfig");
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -27,6 +27,8 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.Objects;
+
 /**
  * Auto-detects the version of the Web Socket protocol in use and creates a new proper
  * {@link WebSocketServerHandshaker}.
@@ -117,7 +119,7 @@ public class WebSocketServerHandshakerFactory {
             String webSocketURL, String subprotocols, WebSocketDecoderConfig decoderConfig) {
         this.webSocketURL = webSocketURL;
         this.subprotocols = subprotocols;
-        this.decoderConfig = ObjectUtil.checkNotNull(decoderConfig, "decoderConfig");
+        this.decoderConfig = Objects.requireNonNull(decoderConfig, "decoderConfig");
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
@@ -16,7 +16,8 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
-import io.netty.util.internal.ObjectUtil;
+
+import java.util.Objects;
 
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
@@ -132,7 +133,7 @@ public final class WebSocketServerProtocolConfig {
         private WebSocketDecoderConfig.Builder decoderConfigBuilder;
 
         private Builder(WebSocketServerProtocolConfig serverConfig) {
-            ObjectUtil.checkNotNull(serverConfig, "serverConfig");
+            Objects.requireNonNull(serverConfig, "serverConfig");
             websocketPath = serverConfig.websocketPath();
             subprotocols = serverConfig.subprotocols();
             checkStartsWith = serverConfig.checkStartsWith();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -30,10 +30,10 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.AttributeKey;
 
 import java.util.List;
+import java.util.Objects;
 
 import static io.netty.handler.codec.http.HttpVersion.*;
 import static io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig.DEFAULT;
-import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * This handler does all the heavy lifting for you to run a websocket server.
@@ -112,7 +112,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
      *            Server protocol configuration.
      */
     public WebSocketServerProtocolHandler(WebSocketServerProtocolConfig serverConfig) {
-        super(checkNotNull(serverConfig, "serverConfig").dropPongFrames());
+        super(Objects.requireNonNull(serverConfig, "serverConfig").dropPongFrames());
         this.serverConfig = serverConfig;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -31,13 +31,13 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.handler.codec.http.HttpMethod.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpUtil.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
-import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * Handles the HTTP handshake (the HTTP Upgrade request) for {@link WebSocketServerProtocolHandler}.
@@ -49,7 +49,7 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelInboundHandler {
     private ChannelPromise handshakePromise;
 
     WebSocketServerProtocolHandshakeHandler(WebSocketServerProtocolConfig serverConfig) {
-        this.serverConfig = checkNotNull(serverConfig, "serverConfig");
+        this.serverConfig = Objects.requireNonNull(serverConfig, "serverConfig");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
@@ -31,8 +31,7 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionDecod
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter;
 
 import java.util.List;
-
-import static io.netty.util.internal.ObjectUtil.*;
+import java.util.Objects;
 
 /**
  * Deflate implementation of a payload decompressor for
@@ -61,7 +60,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
      */
     DeflateDecoder(boolean noContext, WebSocketExtensionFilter extensionDecoderFilter) {
         this.noContext = noContext;
-        this.extensionDecoderFilter = checkNotNull(extensionDecoderFilter, "extensionDecoderFilter");
+        this.extensionDecoderFilter = Objects.requireNonNull(extensionDecoderFilter, "extensionDecoderFilter");
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
@@ -30,9 +30,9 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionEncod
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter;
 
 import java.util.List;
+import java.util.Objects;
 
 import static io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateDecoder.*;
-import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * Deflate implementation of a payload compressor for
@@ -59,7 +59,7 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
         this.compressionLevel = compressionLevel;
         this.windowSize = windowSize;
         this.noContext = noContext;
-        this.extensionEncoderFilter = checkNotNull(extensionEncoderFilter, "extensionEncoderFilter");
+        this.extensionEncoderFilter = Objects.requireNonNull(extensionEncoderFilter, "extensionEncoderFilter");
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameClientExtensionHandshaker.java
@@ -23,9 +23,9 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionEncod
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilterProvider;
 
 import java.util.Collections;
+import java.util.Objects;
 
 import static io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameServerExtensionHandshaker.*;
-import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * <a href="https://tools.ietf.org/id/draft-tyoshino-hybi-websocket-perframe-deflate-06.txt">perframe-deflate</a>
@@ -70,7 +70,7 @@ public final class DeflateFrameClientExtensionHandshaker implements WebSocketCli
         }
         this.compressionLevel = compressionLevel;
         this.useWebkitExtensionName = useWebkitExtensionName;
-        this.extensionFilterProvider = checkNotNull(extensionFilterProvider, "extensionFilterProvider");
+        this.extensionFilterProvider = Objects.requireNonNull(extensionFilterProvider, "extensionFilterProvider");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
@@ -23,8 +23,7 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensio
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandshaker;
 
 import java.util.Collections;
-
-import static io.netty.util.internal.ObjectUtil.*;
+import java.util.Objects;
 
 /**
  * <a href="https://tools.ietf.org/id/draft-tyoshino-hybi-websocket-perframe-deflate-06.txt">perframe-deflate</a>
@@ -70,7 +69,7 @@ public final class DeflateFrameServerExtensionHandshaker implements WebSocketSer
                     "compressionLevel: " + compressionLevel + " (expected: 0-9)");
         }
         this.compressionLevel = compressionLevel;
-        this.extensionFilterProvider = checkNotNull(extensionFilterProvider, "extensionFilterProvider");
+        this.extensionFilterProvider = Objects.requireNonNull(extensionFilterProvider, "extensionFilterProvider");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
@@ -26,9 +26,9 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilte
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import static io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker.*;
-import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * <a href="http://tools.ietf.org/html/draft-ietf-hybi-permessage-compression-18">permessage-deflate</a>
@@ -111,7 +111,7 @@ public final class PerMessageDeflateClientExtensionHandshaker implements WebSock
         this.requestedServerWindowSize = requestedServerWindowSize;
         this.allowClientNoContext = allowClientNoContext;
         this.requestedServerNoContext = requestedServerNoContext;
-        this.extensionFilterProvider = checkNotNull(extensionFilterProvider, "extensionFilterProvider");
+        this.extensionFilterProvider = Objects.requireNonNull(extensionFilterProvider, "extensionFilterProvider");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -26,8 +26,7 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensio
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map.Entry;
-
-import static io.netty.util.internal.ObjectUtil.*;
+import java.util.Objects;
 
 /**
  * <a href="http://tools.ietf.org/html/draft-ietf-hybi-permessage-compression-18">permessage-deflate</a>
@@ -118,7 +117,7 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
         this.preferredClientWindowSize = preferredClientWindowSize;
         this.allowServerNoContext = allowServerNoContext;
         this.preferredClientNoContext = preferredClientNoContext;
-        this.extensionFilterProvider = checkNotNull(extensionFilterProvider, "extensionFilterProvider");
+        this.extensionFilterProvider = Objects.requireNonNull(extensionFilterProvider, "extensionFilterProvider");
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -27,10 +27,10 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.ServerChannel;
 import io.netty.handler.codec.http2.Http2FrameCodec.DefaultHttp2FrameStream;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
+import java.util.Objects;
 import java.util.Queue;
 
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
@@ -119,7 +119,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
      *                             upgraded {@link Channel}.
      */
     public Http2MultiplexHandler(ChannelHandler inboundStreamHandler, ChannelHandler upgradeStreamHandler) {
-        this.inboundStreamHandler = ObjectUtil.checkNotNull(inboundStreamHandler, "inboundStreamHandler");
+        this.inboundStreamHandler = Objects.requireNonNull(inboundStreamHandler, "inboundStreamHandler");
         this.upgradeStreamHandler = upgradeStreamHandler;
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTest.java
@@ -41,6 +41,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 
 @RunWith(Parameterized.class)
 public class HpackTest {
@@ -57,9 +58,7 @@ public class HpackTest {
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         File[] files = ResourcesUtil.getFile(HpackTest.class, TEST_DIR).listFiles();
-        if (files == null) {
-            throw new NullPointerException("files");
-        }
+        Objects.requireNonNull(files, "files");
 
         ArrayList<Object[]> data = new ArrayList<>();
         for (File file : files) {

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -25,12 +25,13 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.stomp.StompSubframeDecoder.State;
 import io.netty.util.ByteProcessor;
 import io.netty.util.internal.AppendableCharSequence;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.util.List;
+import java.util.Objects;
 
 import static io.netty.buffer.ByteBufUtil.*;
-import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * Decodes {@link ByteBuf}s into {@link StompHeadersSubframe}s and {@link StompContentSubframe}s.
@@ -85,8 +86,8 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
 
     public StompSubframeDecoder(int maxLineLength, int maxChunkSize, boolean validateHeaders) {
         super(State.SKIP_CONTROL_CHARACTERS);
-        checkPositive(maxLineLength, "maxLineLength");
-        checkPositive(maxChunkSize, "maxChunkSize");
+        ObjectUtil.checkPositive(maxLineLength, "maxLineLength");
+        ObjectUtil.checkPositive(maxChunkSize, "maxChunkSize");
         this.maxChunkSize = maxChunkSize;
         commandParser = new Utf8LineParser(new AppendableCharSequence(16), maxLineLength);
         headerParser = new HeaderParser(new AppendableCharSequence(128), maxLineLength, validateHeaders);
@@ -253,7 +254,7 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
         private boolean nextRead;
 
         Utf8LineParser(AppendableCharSequence charSeq, int maxLineLength) {
-            this.charSeq = checkNotNull(charSeq, "charSeq");
+            this.charSeq = Objects.requireNonNull(charSeq, "charSeq");
             this.maxLineLength = maxLineLength;
         }
 

--- a/common/src/main/java/io/netty/util/internal/ObjectPool.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectPool.java
@@ -17,6 +17,8 @@ package io.netty.util.internal;
 
 import io.netty.util.Recycler;
 
+import java.util.Objects;
+
 /**
  * Light-weight object pool.
  *
@@ -64,9 +66,7 @@ public abstract class ObjectPool<T> {
      * that should be pooled.
      */
     public static <T> ObjectPool<T> newPool(final ObjectCreator<T> creator) {
-        ObjectUtil.checkNotNull(creator, "creator");
-
-        return new RecyclerObjectPool<T>(creator);
+        return new RecyclerObjectPool<T>(Objects.requireNonNull(creator, "creator"));
     }
 
     private static final class RecyclerObjectPool<T> extends ObjectPool<T> {

--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -17,6 +17,7 @@ package io.netty.util.internal;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * A grab-bag of useful utility methods.
@@ -32,10 +33,7 @@ public final class ObjectUtil {
      */
     @Deprecated
     public static <T> T checkNotNull(T arg, String text) {
-        if (arg == null) {
-            throw new NullPointerException(text);
-        }
-        return arg;
+        return Objects.requireNonNull(arg, text);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -607,8 +608,8 @@ public final class StringUtil {
      * @return a char sequence joined by a given separator.
      */
     public static CharSequence join(CharSequence separator, Iterable<? extends CharSequence> elements) {
-        ObjectUtil.checkNotNull(separator, "separator");
-        ObjectUtil.checkNotNull(elements, "elements");
+        Objects.requireNonNull(separator, "separator");
+        Objects.requireNonNull(elements, "elements");
 
         Iterator<? extends CharSequence> iterator = elements.iterator();
         if (!iterator.hasNext()) {

--- a/common/src/main/java/io/netty/util/internal/ThreadExecutorMap.java
+++ b/common/src/main/java/io/netty/util/internal/ThreadExecutorMap.java
@@ -18,6 +18,7 @@ package io.netty.util.internal;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.FastThreadLocal;
 
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -49,8 +50,8 @@ public final class ThreadExecutorMap {
      * when called from within the {@link Runnable} during execution.
      */
     public static Executor apply(final Executor executor, final EventExecutor eventExecutor) {
-        ObjectUtil.checkNotNull(executor, "executor");
-        ObjectUtil.checkNotNull(eventExecutor, "eventExecutor");
+        Objects.requireNonNull(executor, "executor");
+        Objects.requireNonNull(eventExecutor, "eventExecutor");
         return new Executor() {
             @Override
             public void execute(final Runnable command) {
@@ -64,8 +65,8 @@ public final class ThreadExecutorMap {
      * when called from within the {@link Runnable} during execution.
      */
     public static Runnable apply(final Runnable command, final EventExecutor eventExecutor) {
-        ObjectUtil.checkNotNull(command, "command");
-        ObjectUtil.checkNotNull(eventExecutor, "eventExecutor");
+        Objects.requireNonNull(command, "command");
+        Objects.requireNonNull(eventExecutor, "eventExecutor");
         return new Runnable() {
             @Override
             public void run() {
@@ -84,8 +85,8 @@ public final class ThreadExecutorMap {
      * when called from within the {@link Runnable} during execution.
      */
     public static ThreadFactory apply(final ThreadFactory threadFactory, final EventExecutor eventExecutor) {
-        ObjectUtil.checkNotNull(threadFactory, "command");
-        ObjectUtil.checkNotNull(eventExecutor, "eventExecutor");
+        Objects.requireNonNull(threadFactory, "command");
+        Objects.requireNonNull(eventExecutor, "eventExecutor");
         return new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {

--- a/handler/src/main/java/io/netty/handler/ssl/KeyManagerFactoryWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/KeyManagerFactoryWrapper.java
@@ -17,9 +17,9 @@
 package io.netty.handler.ssl;
 
 import io.netty.handler.ssl.util.SimpleKeyManagerFactory;
-import io.netty.util.internal.ObjectUtil;
 
 import java.security.KeyStore;
+import java.util.Objects;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.ManagerFactoryParameters;
 
@@ -27,7 +27,7 @@ final class KeyManagerFactoryWrapper extends SimpleKeyManagerFactory {
     private final KeyManager km;
 
     KeyManagerFactoryWrapper(KeyManager km) {
-        this.km = ObjectUtil.checkNotNull(km, "km");
+        this.km = Objects.requireNonNull(km, "km");
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/TrustManagerFactoryWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/TrustManagerFactoryWrapper.java
@@ -17,9 +17,9 @@
 package io.netty.handler.ssl;
 
 import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
-import io.netty.util.internal.ObjectUtil;
 
 import java.security.KeyStore;
+import java.util.Objects;
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.TrustManager;
 
@@ -27,7 +27,7 @@ final class TrustManagerFactoryWrapper extends SimpleTrustManagerFactory {
     private final TrustManager tm;
 
     TrustManagerFactoryWrapper(TrustManager tm) {
-        this.tm = ObjectUtil.checkNotNull(tm, "tm");
+        this.tm = Objects.requireNonNull(tm, "tm");
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/util/SimpleKeyManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SimpleKeyManagerFactory.java
@@ -17,7 +17,6 @@
 package io.netty.handler.ssl.util;
 
 import io.netty.util.concurrent.FastThreadLocal;
-import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SuppressJava6Requirement;
@@ -25,6 +24,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.Provider;
+import java.util.Objects;
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -70,7 +70,7 @@ public abstract class SimpleKeyManagerFactory extends KeyManagerFactory {
      * @param name the name of this {@link KeyManagerFactory}
      */
     protected SimpleKeyManagerFactory(String name) {
-        super(CURRENT_SPI.get(), PROVIDER, ObjectUtil.checkNotNull(name, "name"));
+        super(CURRENT_SPI.get(), PROVIDER, Objects.requireNonNull(name, "name"));
         CURRENT_SPI.get().init(this);
         CURRENT_SPI.remove();
     }


### PR DESCRIPTION
Motivation:

We should use Objects.requireNonNull(...) as we require java8

Modifications:

Replace ObjectUtil.checkNonNull(...) with Objects.requireNonNull(...)

Result:

Code cleanup