### PR TITLE
Hack LzfEncoder, let it support directByteBuf for less gc.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/LzfEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzfEncoder.java
@@ -22,16 +22,19 @@ import com.ning.compress.lzf.util.ChunkEncoderFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.handler.codec.compression.lzf.LzfCompressions;
+import io.netty.handler.codec.compression.lzf.VanillaChunkEncoder;
 
-import static com.ning.compress.lzf.LZFChunk.*;
+import static com.ning.compress.lzf.LZFChunk.MAX_CHUNK_LEN;
 
 /**
  * Compresses a {@link ByteBuf} using the LZF format.
- *
+ * <p>
  * See original <a href="http://oldhome.schmorp.de/marc/liblzf.html">LZF package</a>
  * and <a href="https://github.com/ning/compress/wiki/LZFFormat">LZF format</a> for full description.
  */
 public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
+
     /**
      * Minimum block size ready for compression. Blocks with length
      * less than {@link #MIN_BLOCK_TO_COMPRESS} will write as uncompressed.
@@ -44,9 +47,16 @@ public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
     private final ChunkEncoder encoder;
 
     /**
+     * hack lzf's ChunkEncoder.
+     */
+    private final io.netty.handler.codec.compression.lzf.ChunkEncoder nettyEncoder;
+
+    /**
      * Object that handles details of buffer recycling.
      */
     private final BufferRecycler recycler;
+
+    private final boolean safeInstance;
 
     /**
      * Creates a new LZF encoder with the most optimal available methods for underlying data access.
@@ -61,11 +71,10 @@ public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
     /**
      * Creates a new LZF encoder with specified encoding instance.
      *
-     * @param safeInstance
-     *        If {@code true} encoder will use {@link ChunkEncoder} that only uses standard JDK access methods,
-     *        and should work on all Java platforms and JVMs.
-     *        Otherwise encoder will try to use highly optimized {@link ChunkEncoder} implementation that uses
-     *        Sun JDK's {@link sun.misc.Unsafe} class (which may be included by other JDK's as well).
+     * @param safeInstance If {@code true} encoder will use {@link ChunkEncoder} that only uses standard JDK access methods,
+     *                     and should work on all Java platforms and JVMs.
+     *                     Otherwise encoder will try to use highly optimized {@link ChunkEncoder} implementation that uses
+     *                     Sun JDK's {@link sun.misc.Unsafe} class (which may be included by other JDK's as well).
      */
     public LzfEncoder(boolean safeInstance) {
         this(safeInstance, MAX_CHUNK_LEN);
@@ -75,9 +84,8 @@ public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
      * Creates a new LZF encoder with specified total length of encoded chunk. You can configure it to encode
      * your data flow more efficient if you know the average size of messages that you send.
      *
-     * @param totalLength
-     *        Expected total length of content to compress; only matters for outgoing messages that is smaller
-     *        than maximum chunk size (64k), to optimize encoding hash tables.
+     * @param totalLength Expected total length of content to compress; only matters for outgoing messages that is smaller
+     *                    than maximum chunk size (64k), to optimize encoding hash tables.
      */
     public LzfEncoder(int totalLength) {
         this(false, totalLength);
@@ -86,31 +94,67 @@ public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
     /**
      * Creates a new LZF encoder with specified settings.
      *
-     * @param safeInstance
-     *        If {@code true} encoder will use {@link ChunkEncoder} that only uses standard JDK access methods,
-     *        and should work on all Java platforms and JVMs.
-     *        Otherwise encoder will try to use highly optimized {@link ChunkEncoder} implementation that uses
-     *        Sun JDK's {@link sun.misc.Unsafe} class (which may be included by other JDK's as well).
-     * @param totalLength
-     *        Expected total length of content to compress; only matters for outgoing messages that is smaller
-     *        than maximum chunk size (64k), to optimize encoding hash tables.
+     * @param safeInstance If {@code true} encoder will use {@link ChunkEncoder} that only uses standard JDK access methods,
+     *                     and should work on all Java platforms and JVMs.
+     *                     Otherwise encoder will try to use highly optimized {@link ChunkEncoder} implementation that uses
+     *                     Sun JDK's {@link sun.misc.Unsafe} class (which may be included by other JDK's as well).
+     * @param totalLength  Expected total length of content to compress; only matters for outgoing messages that is smaller
+     *                     than maximum chunk size (64k), to optimize encoding hash tables.
      */
     public LzfEncoder(boolean safeInstance, int totalLength) {
-        super(false);
+        // After our hack, we can use `directByteBuf` when safeInstance is true.
+        super(safeInstance);
         if (totalLength < MIN_BLOCK_TO_COMPRESS || totalLength > MAX_CHUNK_LEN) {
             throw new IllegalArgumentException("totalLength: " + totalLength +
                     " (expected: " + MIN_BLOCK_TO_COMPRESS + '-' + MAX_CHUNK_LEN + ')');
         }
 
-        encoder = safeInstance ?
-                ChunkEncoderFactory.safeNonAllocatingInstance(totalLength)
-              : ChunkEncoderFactory.optimalNonAllocatingInstance(totalLength);
+        this.safeInstance = safeInstance;
+        if (safeInstance) {
+            nettyEncoder = new VanillaChunkEncoder(totalLength);
+            encoder = null;
+        } else {
+            encoder = ChunkEncoderFactory.optimalNonAllocatingInstance(totalLength);
+            nettyEncoder = null;
+        }
 
         recycler = BufferRecycler.instance();
     }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) throws Exception {
+        if (safeInstance) {
+            // use netty hack encoder.
+            hackCompress(in, out);
+        } else {
+            // use lzf encoder.
+            lzfCompress(in, out);
+        }
+    }
+
+    private void hackCompress(ByteBuf in, ByteBuf out) {
+        final int length = in.readableBytes();
+        final int idx = in.readerIndex();
+        final byte[] input;
+        final int inputPtr;
+
+        final int maxOutputLength = LZFEncoder.estimateMaxWorkspaceSize(length);
+        out.ensureWritable(maxOutputLength);
+
+        int outputLength;
+        if (in.hasArray()) {
+            input = in.array();
+            inputPtr = in.arrayOffset() + idx;
+            outputLength = LzfCompressions.appendEncoded(nettyEncoder, input, inputPtr, length, out);
+        } else {
+            outputLength = LzfCompressions.appendEncoded(nettyEncoder, in, length, out);
+        }
+
+        out.writerIndex(out.writerIndex() + outputLength);
+        in.skipBytes(length);
+    }
+
+    private void lzfCompress(ByteBuf in, ByteBuf out) {
         final int length = in.readableBytes();
         final int idx = in.readerIndex();
         final byte[] input;
@@ -129,7 +173,7 @@ public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
         final byte[] output = out.array();
         final int outputPtr = out.arrayOffset() + out.writerIndex();
         final int outputLength = LZFEncoder.appendEncoded(encoder,
-                        input, inputPtr, length,  output, outputPtr) - outputPtr;
+                input, inputPtr, length, output, outputPtr) - outputPtr;
         out.writerIndex(out.writerIndex() + outputLength);
         in.skipBytes(length);
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/lzf/ChunkEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/lzf/ChunkEncoder.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2009-2010 Ning, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.compression.lzf;
+
+import com.ning.compress.BufferRecycler;
+import com.ning.compress.lzf.LZFChunk;
+import io.netty.buffer.ByteBuf;
+
+import java.io.Closeable;
+
+/**
+ * Class that handles actual encoding of individual chunks.
+ * Resulting chunks can be compressed or non-compressed; compression
+ * is only used if it actually reduces chunk size (including overhead
+ * of additional header bytes)
+ * <p>
+ * Note that instances <b>are stateful</b> and hence
+ * <b>not thread-safe</b>; one instance is meant to be used
+ * for processing a sequence of chunks where total length
+ * is known.
+ *
+ * @author Tatu Saloranta (tatu.saloranta@iki.fi)
+ */
+public abstract class ChunkEncoder implements Closeable {
+    // // // Constants
+
+    // Beyond certain point we won't be able to compress; let's use 16 bytes as cut-off
+    protected static final int MIN_BLOCK_TO_COMPRESS = 16;
+
+    protected static final int MIN_HASH_SIZE = 256;
+
+    // Not much point in bigger tables, with 8k window
+    protected static final int MAX_HASH_SIZE = 16384;
+
+    protected static final int MAX_OFF = 1 << 13; // 8k
+    protected static final int MAX_REF = (1 << 8) + (1 << 3); // 264
+
+    /**
+     * How many tail bytes are we willing to just copy as is, to simplify
+     * loop end checks? 4 is bare minimum, may be raised to 8?
+     */
+    protected static final int TAIL_LENGTH = 4;
+
+    // // // Encoding tables etc
+
+    protected final BufferRecycler _recycler;
+
+    /**
+     * Hash table contains lookup based on 3-byte sequence; key is hash
+     * of such triplet, value is offset in buffer.
+     */
+    protected int[] _hashTable;
+
+    protected final int _hashModulo;
+
+    /**
+     * Buffer in which encoded content is stored during processing
+     */
+    protected byte[] _encodeBuffer;
+
+    /**
+     * Uses a ThreadLocal soft-referenced BufferRecycler instance.
+     *
+     * @param totalLength Total encoded length; used for calculating size
+     *                    of hash table to use
+     */
+    protected ChunkEncoder(int totalLength) {
+        this(totalLength, BufferRecycler.instance());
+    }
+
+    /**
+     * @param totalLength    Total encoded length; used for calculating size
+     *                       of hash table to use
+     * @param bufferRecycler Buffer recycler instance, for usages where the
+     *                       caller manages the recycler instances
+     */
+    protected ChunkEncoder(int totalLength, BufferRecycler bufferRecycler) {
+        // Need room for at most a single full chunk
+        int largestChunkLen = Math.min(totalLength, LZFChunk.MAX_CHUNK_LEN);
+        int suggestedHashLen = calcHashLen(largestChunkLen);
+        _recycler = bufferRecycler;
+        _hashTable = bufferRecycler.allocEncodingHash(suggestedHashLen);
+        _hashModulo = _hashTable.length - 1;
+        // Ok, then, what's the worst case output buffer length?
+        // length indicator for each 32 literals, so:
+        // 21-Feb-2013, tatu: Plus we want to prepend chunk header in place:
+        int bufferLen = largestChunkLen + ((largestChunkLen + 31) >> 5) + LZFChunk.MAX_HEADER_LEN;
+        _encodeBuffer = bufferRecycler.allocEncodingBuffer(bufferLen);
+    }
+
+    /**
+     * Alternate constructor used when we want to avoid allocation encoding
+     * buffer, in cases where caller wants full control over allocations.
+     */
+    protected ChunkEncoder(int totalLength, boolean bogus) {
+        this(totalLength, BufferRecycler.instance(), bogus);
+    }
+
+    /**
+     * Alternate constructor used when we want to avoid allocation encoding
+     * buffer, in cases where caller wants full control over allocations.
+     */
+    protected ChunkEncoder(int totalLength, BufferRecycler bufferRecycler, boolean bogus) {
+        int largestChunkLen = Math.max(totalLength, LZFChunk.MAX_CHUNK_LEN);
+        int suggestedHashLen = calcHashLen(largestChunkLen);
+        _recycler = bufferRecycler;
+        _hashTable = bufferRecycler.allocEncodingHash(suggestedHashLen);
+        _hashModulo = _hashTable.length - 1;
+        _encodeBuffer = null;
+    }
+
+    private static int calcHashLen(int chunkSize) {
+        // in general try get hash table size of 2x input size
+        chunkSize += chunkSize;
+        // but no larger than max size:
+        if (chunkSize >= MAX_HASH_SIZE) {
+            return MAX_HASH_SIZE;
+        }
+        // otherwise just need to round up to nearest 2x
+        int hashLen = MIN_HASH_SIZE;
+        while (hashLen < chunkSize) {
+            hashLen += hashLen;
+        }
+        return hashLen;
+    }
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // Public API
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    @Override
+    public final void close() {
+        byte[] buf = _encodeBuffer;
+        if (buf != null) {
+            _encodeBuffer = null;
+            _recycler.releaseEncodeBuffer(buf);
+        }
+        int[] ibuf = _hashTable;
+        if (ibuf != null) {
+            _hashTable = null;
+            _recycler.releaseEncodingHash(ibuf);
+        }
+    }
+
+    public int appendEncodedChunk(final ByteBuf input, final int inputPtr, final int inputLen,
+                                  final ByteBuf outputBuffer, final int outputPos) {
+        if (inputLen >= MIN_BLOCK_TO_COMPRESS) {
+            /* If we have non-trivial block, and can compress it by at least
+             * 2 bytes (since header is 2 bytes longer), use as-is
+             */
+            final int compStart = outputPos + LZFChunk.HEADER_LEN_COMPRESSED;
+            final int end = tryCompress(input, inputPtr, inputPtr + inputLen, outputBuffer, compStart);
+            final int uncompEnd = (outputPos + LZFChunk.HEADER_LEN_NOT_COMPRESSED) + inputLen;
+            if (end < uncompEnd) { // yes, compressed by at least one byte
+                final int compLen = end - compStart;
+                appendCompressedHeader(inputLen, compLen, outputBuffer, outputPos);
+                return end;
+            }
+        }
+        // Otherwise append as non-compressed chunk instead (length + 5):
+        return appendNonCompressed(input, inputPtr, inputLen, outputBuffer, outputPos);
+    }
+
+    public int appendEncodedChunk(final byte[] input, final int inputPtr, final int inputLen,
+                                  final ByteBuf outputBuffer, final int outputPos) {
+        if (inputLen >= MIN_BLOCK_TO_COMPRESS) {
+            /* If we have non-trivial block, and can compress it by at least
+             * 2 bytes (since header is 2 bytes longer), use as-is
+             */
+            final int compStart = outputPos + LZFChunk.HEADER_LEN_COMPRESSED;
+            final int end = tryCompress(input, inputPtr, inputPtr + inputLen, outputBuffer, compStart);
+            final int uncompEnd = (outputPos + LZFChunk.HEADER_LEN_NOT_COMPRESSED) + inputLen;
+            if (end < uncompEnd) { // yes, compressed by at least one byte
+                final int compLen = end - compStart;
+                appendCompressedHeader(inputLen, compLen, outputBuffer, outputPos);
+                return end;
+            }
+        }
+        // Otherwise append as non-compressed chunk instead (length + 5):
+        return appendNonCompressed(input, inputPtr, inputLen, outputBuffer, outputPos);
+    }
+
+    public static int appendNonCompressed(byte[] plainData, int ptr, int len,
+                                          ByteBuf outputBuffer, int outputPtr) {
+        outputBuffer.setByte(outputPtr, LZFChunk.BYTE_Z);
+        outputPtr++;
+        outputBuffer.setByte(outputPtr, LZFChunk.BYTE_V);
+        outputPtr++;
+        outputBuffer.setByte(outputPtr, LZFChunk.BLOCK_TYPE_NON_COMPRESSED);
+        outputPtr++;
+        outputBuffer.setByte(outputPtr, (byte) (len >> 8));
+        outputPtr++;
+        outputBuffer.setByte(outputPtr, (byte) len);
+        outputPtr++;
+
+        outputBuffer.markWriterIndex();
+        outputBuffer.writerIndex(outputPtr);
+        outputBuffer.writeBytes(plainData, ptr, len);
+
+        outputBuffer.resetWriterIndex();
+        return outputPtr + len;
+    }
+
+    /**
+     * Method for appending specific content as non-compressed chunk, in
+     * given buffer.
+     */
+    public static int appendNonCompressed(ByteBuf plainData, int ptr, int len,
+                                          ByteBuf outputBuffer, int outputPtr) {
+        outputBuffer.setByte(outputPtr, LZFChunk.BYTE_Z);
+        outputPtr++;
+        outputBuffer.setByte(outputPtr, LZFChunk.BYTE_V);
+        outputPtr++;
+        outputBuffer.setByte(outputPtr, LZFChunk.BLOCK_TYPE_NON_COMPRESSED);
+        outputPtr++;
+        outputBuffer.setByte(outputPtr, (byte) (len >> 8));
+        outputPtr++;
+        outputBuffer.setByte(outputPtr, (byte) len);
+        outputPtr++;
+
+        outputBuffer.markWriterIndex();
+        outputBuffer.writerIndex(outputPtr);
+        outputBuffer.writeBytes(plainData, ptr, len);
+
+        outputBuffer.resetWriterIndex();
+        return outputPtr + len;
+    }
+
+    public static int appendCompressedHeader(int origLen, int encLen, ByteBuf headerBuffer, int offset) {
+        headerBuffer.setByte(offset, LZFChunk.BYTE_Z);
+        offset++;
+        headerBuffer.setByte(offset, LZFChunk.BYTE_V);
+        offset++;
+        headerBuffer.setByte(offset, LZFChunk.BLOCK_TYPE_COMPRESSED);
+        offset++;
+        headerBuffer.setByte(offset, (byte) (encLen >> 8));
+        offset++;
+        headerBuffer.setByte(offset, (byte) encLen);
+        offset++;
+        headerBuffer.setByte(offset, (byte) (origLen >> 8));
+        offset++;
+        headerBuffer.setByte(offset, (byte) origLen);
+        offset++;
+        return offset;
+    }
+
+    public BufferRecycler getBufferRecycler() {
+        return _recycler;
+    }
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // Abstract methods for sub-classes
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    /**
+     * Main workhorse method that will try to compress given chunk, and return
+     * end position (offset to byte after last included byte).
+     * Result will be "raw" encoded contents <b>without</b> chunk header information:
+     * caller is responsible for prepending header, if it chooses to use encoded
+     * data; it may also choose to instead create an uncompressed chunk.
+     *
+     * @return Output pointer after handling content, such that <code>result - originalOutPost</code>
+     * is the actual length of compressed chunk (without header)
+     */
+    protected abstract int tryCompress(ByteBuf in, int inPos, int inEnd, ByteBuf out, int outPos);
+
+    /**
+     * Main workhorse method that will try to compress given chunk, and return
+     * end position (offset to byte after last included byte).
+     * Result will be "raw" encoded contents <b>without</b> chunk header information:
+     * caller is responsible for prepending header, if it chooses to use encoded
+     * data; it may also choose to instead create an uncompressed chunk.
+     *
+     * @return Output pointer after handling content, such that <code>result - originalOutPost</code>
+     * is the actual length of compressed chunk (without header)
+     */
+    protected abstract int tryCompress(byte[] in, int inPos, int inEnd, ByteBuf out, int outPos);
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // Shared helper methods
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    protected final int hash(int h) {
+        // or 184117; but this seems to give better hashing?
+        return ((h * 57321) >> 9) & _hashModulo;
+        // original lzf-c.c used this:
+        //return (((h ^ (h << 5)) >> (24 - HLOG) - h*5) & _hashModulo;
+        // but that didn't seem to provide better matches
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/lzf/LzfCompressions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/lzf/LzfCompressions.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2009-2010 Ning, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.compression.lzf;
+
+import com.ning.compress.lzf.LZFChunk;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * LzfCompressions
+ */
+public final class LzfCompressions {
+
+    /**
+     * input heap byteBuf
+     * output direct byteBuf
+     */
+    public static int appendEncoded(ChunkEncoder enc,
+                                    byte[] input,
+                                    int inputPtr,
+                                    int inputLength,
+                                    ByteBuf outputBuffer) {
+
+        int outputPtr = 0;
+        int left = inputLength;
+        int chunkLen = Math.min(LZFChunk.MAX_CHUNK_LEN, left);
+
+        outputPtr = enc.appendEncodedChunk(input, inputPtr, chunkLen, outputBuffer, outputPtr);
+        left -= chunkLen;
+        // shortcut: if it all fit in, no need to coalesce:
+        if (left < 1) {
+            return outputPtr;
+        }
+        // otherwise need to keep on encoding...
+        inputPtr += chunkLen;
+        do {
+            chunkLen = Math.min(left, LZFChunk.MAX_CHUNK_LEN);
+            outputPtr = enc.appendEncodedChunk(input, inputPtr, chunkLen, outputBuffer, outputPtr);
+            inputPtr += chunkLen;
+            left -= chunkLen;
+        } while (left > 0);
+        return outputPtr;
+    }
+
+    /**
+     * input direct byteBuf
+     * output direct byteBuf
+     */
+    public static int appendEncoded(ChunkEncoder enc,
+                                    ByteBuf input,
+                                    int inputLength,
+                                    ByteBuf outputBuffer) {
+
+        int inputPtr = 0;
+        int outputPtr = 0;
+
+        int left = inputLength;
+        int chunkLen = Math.min(LZFChunk.MAX_CHUNK_LEN, left);
+
+        outputPtr = enc.appendEncodedChunk(input, inputPtr, chunkLen, outputBuffer, outputPtr);
+        left -= chunkLen;
+        // shortcut: if it all fit in, no need to coalesce:
+        if (left < 1) {
+            return outputPtr;
+        }
+        // otherwise need to keep on encoding...
+        inputPtr += chunkLen;
+        do {
+            chunkLen = Math.min(left, LZFChunk.MAX_CHUNK_LEN);
+            outputPtr = enc.appendEncodedChunk(input, inputPtr, chunkLen, outputBuffer, outputPtr);
+            inputPtr += chunkLen;
+            left -= chunkLen;
+        } while (left > 0);
+        return outputPtr;
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/lzf/VanillaChunkEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/lzf/VanillaChunkEncoder.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2009-2010 Ning, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.compression.lzf;
+
+import com.ning.compress.BufferRecycler;
+import com.ning.compress.lzf.LZFChunk;
+import io.netty.buffer.ByteBuf;
+
+public class VanillaChunkEncoder extends ChunkEncoder {
+    /**
+     * @param totalLength Total encoded length; used for calculating size
+     *                    of hash table to use
+     */
+    public VanillaChunkEncoder(int totalLength) {
+        super(totalLength);
+    }
+
+    /**
+     * Alternate constructor used when we want to avoid allocation encoding
+     * buffer, in cases where caller wants full control over allocations.
+     */
+    protected VanillaChunkEncoder(int totalLength, boolean bogus) {
+        super(totalLength, bogus);
+    }
+
+    /**
+     * @param totalLength    Total encoded length; used for calculating size
+     *                       of hash table to use
+     * @param bufferRecycler The BufferRecycler instance
+     */
+    public VanillaChunkEncoder(int totalLength, BufferRecycler bufferRecycler) {
+        super(totalLength, bufferRecycler);
+    }
+
+    /**
+     * Alternate constructor used when we want to avoid allocation encoding
+     * buffer, in cases where caller wants full control over allocations.
+     */
+    protected VanillaChunkEncoder(int totalLength, BufferRecycler bufferRecycler, boolean bogus) {
+        super(totalLength, bufferRecycler, bogus);
+    }
+
+    public static VanillaChunkEncoder nonAllocatingEncoder(int totalLength) {
+        return new VanillaChunkEncoder(totalLength, true);
+    }
+
+    public static VanillaChunkEncoder nonAllocatingEncoder(int totalLength, BufferRecycler bufferRecycler) {
+        return new VanillaChunkEncoder(totalLength, bufferRecycler, true);
+    }
+    
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // Abstract method implementations
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    @Override
+    protected int tryCompress(ByteBuf in, int inPos, int inEnd, ByteBuf out, int outPos) {
+        final int[] hashTable = _hashTable;
+        ++outPos; // To leave one byte for literal-length indicator
+        int seen = first(in, inPos); // past 4 bytes we have seen... (last one is LSB)
+        int literals = 0;
+        inEnd -= TAIL_LENGTH;
+        final int firstPos = inPos; // so that we won't have back references across block boundary
+
+        while (inPos < inEnd) {
+            byte p2 = in.getByte(inPos + 2);
+            // next
+            seen = (seen << 8) + (p2 & 255);
+            int off = hash(seen);
+            int ref = hashTable[off];
+            hashTable[off] = inPos;
+
+            // First expected common case: no back-ref (for whatever reason)
+            if (ref >= inPos // can't refer forward (i.e. leftovers)
+                    || (ref < firstPos) // or to previous block
+                    || (off = inPos - ref) > MAX_OFF
+                    || in.getByte(ref + 2) != p2 // must match hash
+                    || in.getByte(ref + 1) != (byte) (seen >> 8)
+                    || in.getByte(ref) != (byte) (seen >> 16)) {
+                out.setByte(outPos, in.getByte(inPos++));
+                outPos++;
+                literals++;
+                if (literals == LZFChunk.MAX_LITERAL) {
+                    out.setByte(outPos - 33, (byte) 31); // <= out[outPos - literals - 1] = MAX_LITERAL_MINUS_1;
+                    literals = 0;
+                    outPos++; // To leave one byte for literal-length indicator
+                }
+                continue;
+            }
+            // match
+            int maxLen = inEnd - inPos + 2;
+            if (maxLen > MAX_REF) {
+                maxLen = MAX_REF;
+            }
+            if (literals == 0) {
+                outPos--; // We do not need literal length indicator, go back
+            } else {
+                out.setByte(outPos - literals - 1, (byte) (literals - 1));
+                literals = 0;
+            }
+            int len = 3;
+            // find match length
+            while (len < maxLen && in.getByte(ref + len) == in.getByte(inPos + len)) {
+                len++;
+            }
+            len -= 2;
+            --off; // was off by one earlier
+            if (len < 7) {
+                out.setByte(outPos, (byte) ((off >> 8) + (len << 5)));
+                outPos++;
+            } else {
+                out.setByte(outPos, (byte) ((off >> 8) + (7 << 5)));
+                outPos++;
+                out.setByte(outPos, (byte) (len - 7));
+                outPos++;
+            }
+            out.setByte(outPos, (byte) off);
+            outPos += 2;
+            inPos += len;
+            seen = first(in, inPos);
+            seen = (seen << 8) + (in.getByte(inPos + 2) & 255);
+            hashTable[hash(seen)] = inPos;
+            ++inPos;
+            seen = (seen << 8) + (in.getByte(inPos + 2) & 255); // hash = next(hash, in, inPos);
+            hashTable[hash(seen)] = inPos;
+            ++inPos;
+        }
+        // try offlining the tail
+        return _handleTail(in, inPos, inEnd + 4, out, outPos, literals);
+    }
+
+    @Override
+    protected int tryCompress(byte[] in, int inPos, int inEnd, ByteBuf out, int outPos) {
+        final int[] hashTable = _hashTable;
+        ++outPos; // To leave one byte for literal-length indicator
+        int seen = first(in, inPos); // past 4 bytes we have seen... (last one is LSB)
+        int literals = 0;
+        inEnd -= TAIL_LENGTH;
+        final int firstPos = inPos; // so that we won't have back references across block boundary
+
+        while (inPos < inEnd) {
+            byte p2 = in[inPos + 2];
+            // next
+            seen = (seen << 8) + (p2 & 255);
+            int off = hash(seen);
+            int ref = hashTable[off];
+            hashTable[off] = inPos;
+
+            // First expected common case: no back-ref (for whatever reason)
+            if (ref >= inPos // can't refer forward (i.e. leftovers)
+                    || (ref < firstPos) // or to previous block
+                    || (off = inPos - ref) > MAX_OFF
+                    || in[ref + 2] != p2 // must match hash
+                    || in[ref + 1] != (byte) (seen >> 8)
+                    || in[ref] != (byte) (seen >> 16)) {
+
+                out.setByte(outPos, in[inPos++]);
+                outPos++;
+
+                literals++;
+                if (literals == LZFChunk.MAX_LITERAL) {
+
+                    out.setByte(outPos - 33, (byte) 31); // <= out[outPos - literals - 1] = MAX_LITERAL_MINUS_1;
+                    literals = 0;
+                    outPos++; // To leave one byte for literal-length indicator
+                }
+                continue;
+            }
+            // match
+            int maxLen = inEnd - inPos + 2;
+            if (maxLen > MAX_REF) {
+                maxLen = MAX_REF;
+            }
+            if (literals == 0) {
+                outPos--; // We do not need literal length indicator, go back
+            } else {
+                out.setByte(outPos - literals - 1, (byte) (literals - 1));
+                literals = 0;
+            }
+            int len = 3;
+            // find match length
+            while (len < maxLen && in[ref + len] == in[inPos + len]) {
+                len++;
+            }
+            len -= 2;
+            --off; // was off by one earlier
+            if (len < 7) {
+                out.setByte(outPos, (byte) ((off >> 8) + (len << 5)));
+                outPos++;
+            } else {
+                out.setByte(outPos, (byte) ((off >> 8) + (7 << 5)));
+                outPos++;
+                out.setByte(outPos, (byte) (len - 7));
+                outPos++;
+            }
+            out.setByte(outPos, (byte) off);
+            outPos += 2;
+            inPos += len;
+            seen = first(in, inPos);
+            seen = (seen << 8) + (in[inPos + 2] & 255);
+            hashTable[hash(seen)] = inPos;
+            ++inPos;
+            seen = (seen << 8) + (in[inPos + 2] & 255); // hash = next(hash, in, inPos);
+            hashTable[hash(seen)] = inPos;
+            ++inPos;
+        }
+        // try offlining the tail
+        return _handleTail(in, inPos, inEnd + 4, out, outPos, literals);
+    }
+
+    private int _handleTail(byte[] in, int inPos, int inEnd, ByteBuf out, int outPos,
+                            int literals) {
+        while (inPos < inEnd) {
+            out.setByte(outPos, in[inPos++]);
+            outPos++;
+            literals++;
+            if (literals == LZFChunk.MAX_LITERAL) {
+                out.setByte(outPos - literals - 1, (byte) (literals - 1));
+                literals = 0;
+                outPos++;
+            }
+        }
+        out.setByte(outPos - literals - 1, (byte) (literals - 1));
+        if (literals == 0) {
+            outPos--;
+        }
+        return outPos;
+    }
+
+    private int _handleTail(ByteBuf in, int inPos, int inEnd, ByteBuf out, int outPos,
+                            int literals) {
+        while (inPos < inEnd) {
+            out.setByte(outPos, in.getByte(inPos++));
+            outPos++;
+            literals++;
+            if (literals == LZFChunk.MAX_LITERAL) {
+                out.setByte(outPos - literals - 1, (byte) (literals - 1));
+                literals = 0;
+                outPos++;
+            }
+        }
+        out.setByte(outPos - literals - 1, (byte) (literals - 1));
+        if (literals == 0) {
+            outPos--;
+        }
+        return outPos;
+    }
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // Internal methods
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    private final int first(byte[] in, int inPos) {
+        return (in[inPos] << 8) + (in[inPos + 1] & 0xFF);
+    }
+
+    private final int first(ByteBuf in, int inPos) {
+        return (in.getByte(inPos) << 8) + (in.getByte(inPos + 1) & 0xFF);
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfEncoderTest.java
@@ -24,7 +24,7 @@ public class LzfEncoderTest extends AbstractEncoderTest {
 
     @Override
     public void initChannel() {
-        channel = new EmbeddedChannel(new LzfEncoder());
+        channel = new EmbeddedChannel(new LzfEncoder(true));
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfIntegrationTest.java
@@ -21,7 +21,7 @@ public class LzfIntegrationTest extends AbstractIntegrationTest {
 
     @Override
     protected EmbeddedChannel createEncoder() {
-        return new EmbeddedChannel(new LzfEncoder());
+        return new EmbeddedChannel(new LzfEncoder(true));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

In the current lzfEncoder, our `outputBuffer` can only use` heapBuffer`, but for Netty, `heapBuffer` needs to be copied into` directBuffer` to be transmitted. This will undoubtedly increase the pressure on the GC. So we hacked Lzf to enable LzfEncoder to support writing data directly into directBuffer.

Modification:

- hack lzfEncoder, support write to `directByteBuf`
- Don't hack `UnsafeChunkEncoder` because it uses `unsafe` for data reading and writing. This is more complicated for hacking. :(

Result:
less gc pressure.
