### PR TITLE
ReadOnlyByteBuf writable bytes

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -404,20 +404,23 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract ByteBuf setIndex(int readerIndex, int writerIndex);
 
     /**
-     * Returns the number of readable bytes which is equal to
-     * {@code (this.writerIndex - this.readerIndex)}.
+     * Returns the number of readable bytes which is logically equivalent to
+     * {@code (this.writerIndex - this.readerIndex)}, but maybe overridden to accommodate
+     * specialized behavior (e.g. write only).
      */
     public abstract int readableBytes();
 
     /**
-     * Returns the number of writable bytes which is equal to
-     * {@code (this.capacity - this.writerIndex)}.
+     * Returns the number of writable bytes which is logically equivalent to
+     * {@code (this.capacity - this.writerIndex)}, but maybe overridden to accommodate
+     * specialized behavior (e.g. read only).
      */
     public abstract int writableBytes();
 
     /**
-     * Returns the maximum possible number of writable bytes, which is equal to
-     * {@code (this.maxCapacity - this.writerIndex)}.
+     * Returns the maximum possible number of writable bytes, which is logically equivalent to
+     * {@code (this.maxCapacity - this.writerIndex)}, but maybe overridden to accommodate
+     * specialized behavior (e.g. read only).
      */
     public abstract int maxWritableBytes();
 
@@ -431,9 +434,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     }
 
     /**
-     * Returns {@code true}
-     * if and only if {@code (this.writerIndex - this.readerIndex)} is greater
-     * than {@code 0}.
+     * Returns {@code true} if and only if {@link #readableBytes()} is greater than {@code 0}.
      */
     public abstract boolean isReadable();
 
@@ -443,9 +444,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract boolean isReadable(int size);
 
     /**
-     * Returns {@code true}
-     * if and only if {@code (this.capacity - this.writerIndex)} is greater
-     * than {@code 0}.
+     * Returns {@code true} if and only if {@link #writableBytes()} is greater than {@code 0}.
      */
     public abstract boolean isWritable();
 

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -76,6 +76,16 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public int writableBytes() {
+        return 0;
+    }
+
+    @Override
+    public int maxWritableBytes() {
+        return 0;
+    }
+
+    @Override
     public ByteBuf unwrap() {
         return buffer;
     }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -72,6 +72,16 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public int writableBytes() {
+        return 0;
+    }
+
+    @Override
+    public int maxWritableBytes() {
+        return 0;
+    }
+
+    @Override
     public byte getByte(int index) {
         ensureAccessible();
         return _getByte(index);

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -83,8 +83,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             try {
                 final int required = in.readableBytes();
                 if (required > cumulation.maxWritableBytes() ||
-                        (required > cumulation.maxFastWritableBytes() && cumulation.refCnt() > 1) ||
-                        cumulation.isReadOnly()) {
+                        (required > cumulation.maxFastWritableBytes() && cumulation.refCnt() > 1)) {
                     // Expand cumulation (by replacing it) under the following conditions:
                     // - cumulation cannot be resized to accommodate the additional data
                     // - cumulation can be expanded with a reallocation operation to accommodate but the buffer is


### PR DESCRIPTION
Motivation:
ReadOnlyByteBuf and ReadOnlyByteBuffer are not writable, but their writableBytes
related methods return non-zero values. This is inconsistent with the behavior
of these buffer types.

Modifications:
- ReadOnlyByteBuf and ReadOnlyByteBuffer writableBytes related methods should
  return 0
- remove isReadOnly() check from ByteToMessageDecoder which is now unecessary

Result:
More correct ReadOnlyByteBuf and ReadOnlyByteBuffer behavior with respect to
writability.