### PR TITLE
Channel Pool LocalAddress initialization and cleanup

### DIFF
--- a/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
@@ -31,15 +31,17 @@ import org.junit.Test;
 import java.net.ConnectException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class AbstractChannelPoolMapTest {
-    private static final String LOCAL_ADDR_ID = "test.id";
-
     @Test(expected = ConnectException.class)
     public void testMap() throws Exception {
         EventLoopGroup group = new LocalEventLoopGroup();
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         final Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -70,12 +72,13 @@ public class AbstractChannelPoolMapTest {
         assertEquals(0, poolMap.size());
 
         pool.acquire().syncUninterruptibly();
+        poolMap.close();
     }
 
     @Test
     public void testRemoveClosesChannelPool() {
         EventLoopGroup group = new LocalEventLoopGroup();
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         final Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -97,12 +100,13 @@ public class AbstractChannelPoolMapTest {
         // the pool should be closed eventually after remove
         pool.closeFuture.awaitUninterruptibly(1, TimeUnit.SECONDS);
         assertTrue(pool.closeFuture.isDone());
+        poolMap.close();
     }
 
     @Test
     public void testCloseClosesPoolsImmediately() {
         EventLoopGroup group = new LocalEventLoopGroup();
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         final Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)

--- a/transport/src/test/java/io/netty/channel/pool/ChannelPoolTestUtils.java
+++ b/transport/src/test/java/io/netty/channel/pool/ChannelPoolTestUtils.java
@@ -1,0 +1,14 @@
+package io.netty.channel.pool;
+
+import io.netty.util.internal.ThreadLocalRandom;
+
+final class ChannelPoolTestUtils {
+    private static final String LOCAL_ADDR_ID = "test.id";
+
+    private ChannelPoolTestUtils() {
+    }
+
+    static String getLocalAddrId() {
+        return LOCAL_ADDR_ID + ThreadLocalRandom.current().nextInt();
+    }
+}

--- a/transport/src/test/java/io/netty/channel/pool/ChannelPoolTestUtils.java
+++ b/transport/src/test/java/io/netty/channel/pool/ChannelPoolTestUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.channel.pool;
 
 import io.netty.util.internal.ThreadLocalRandom;

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolMapDeadlockTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolMapDeadlockTest.java
@@ -66,7 +66,7 @@ public class FixedChannelPoolMapDeadlockTest {
         final CyclicBarrier arrivalBarrier = new CyclicBarrier(4);
         final CyclicBarrier releaseBarrier = new CyclicBarrier(3);
 
-        final ChannelPoolMap<String, FixedChannelPool> channelPoolMap =
+        final AbstractChannelPoolMap<String, FixedChannelPool> channelPoolMap =
                 new AbstractChannelPoolMap<String, FixedChannelPool>() {
 
             @Override
@@ -164,6 +164,11 @@ public class FixedChannelPoolMapDeadlockTest {
             // Fail the test on timeout to distinguish from other errors
             throw new AssertionError(e);
         } finally {
+            poolA1.close();
+            poolA2.close();
+            poolB1.close();
+            poolB2.close();
+            channelPoolMap.close();
             shutdown(threadA1, threadA2, threadB1, threadB2);
         }
     }
@@ -229,6 +234,9 @@ public class FixedChannelPoolMapDeadlockTest {
             // Fail the test on timeout to distinguish from other errors
             throw new AssertionError(e);
         } finally {
+            pool1.close();
+            pool2.close();
+            channelPoolMap.close();
             shutdown(thread1, thread2);
         }
     }

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -38,11 +38,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.*;
+import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class FixedChannelPoolTest {
-    private static final String LOCAL_ADDR_ID = "test.id";
-
     private static EventLoopGroup group;
 
     @BeforeClass
@@ -59,7 +63,7 @@ public class FixedChannelPoolTest {
 
     @Test
     public void testAcquire() throws Exception {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -97,6 +101,7 @@ public class FixedChannelPoolTest {
 
         sc.close().syncUninterruptibly();
         channel2.close().syncUninterruptibly();
+        pool.close();
     }
 
     @Test(expected = TimeoutException.class)
@@ -110,7 +115,7 @@ public class FixedChannelPoolTest {
     }
 
     private static void testAcquireTimeout(long timeoutMillis) throws Exception {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -139,12 +144,13 @@ public class FixedChannelPoolTest {
         } finally {
             sc.close().syncUninterruptibly();
             channel.close().syncUninterruptibly();
+            pool.close();
         }
     }
 
     @Test
     public void testAcquireNewConnection() throws Exception {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -172,6 +178,7 @@ public class FixedChannelPoolTest {
         sc.close().syncUninterruptibly();
         channel.close().syncUninterruptibly();
         channel2.close().syncUninterruptibly();
+        pool.close();
     }
 
     /**
@@ -180,7 +187,7 @@ public class FixedChannelPoolTest {
      */
     @Test
     public void testAcquireNewConnectionWhen() throws Exception {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -209,11 +216,12 @@ public class FixedChannelPoolTest {
         assertNotSame(channel1, channel2);
         sc.close().syncUninterruptibly();
         channel2.close().syncUninterruptibly();
+        pool.close();
     }
 
     @Test(expected = IllegalStateException.class)
     public void testAcquireBoundQueue() throws Exception {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -243,12 +251,13 @@ public class FixedChannelPoolTest {
         } finally {
             sc.close().syncUninterruptibly();
             channel.close().syncUninterruptibly();
+            pool.close();
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testReleaseDifferentPool() throws Exception {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -277,12 +286,14 @@ public class FixedChannelPoolTest {
         } finally {
             sc.close().syncUninterruptibly();
             channel.close().syncUninterruptibly();
+            pool.close();
+            pool2.close();
         }
     }
 
     @Test
     public void testReleaseAfterClosePool() throws Exception {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group).channel(LocalChannel.class);
@@ -320,11 +331,12 @@ public class FixedChannelPoolTest {
         channel.closeFuture().syncUninterruptibly();
         assertFalse("Unexpected open channel", channel.isOpen());
         sc.close().syncUninterruptibly();
+        pool.close();
     }
 
     @Test
     public void testReleaseClosed() {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group).channel(LocalChannel.class);
@@ -348,11 +360,12 @@ public class FixedChannelPoolTest {
         pool.release(channel).syncUninterruptibly();
 
         sc.close().syncUninterruptibly();
+        pool.close();
     }
 
     @Test
     public void testCloseAsync() throws ExecutionException, InterruptedException {
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group).channel(LocalChannel.class);

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -33,15 +33,21 @@ import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SimpleChannelPoolTest {
-    private static final String LOCAL_ADDR_ID = "test.id";
-
     @Test
     public void testAcquire() throws Exception {
         EventLoopGroup group = new DefaultEventLoopGroup();
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -86,12 +92,13 @@ public class SimpleChannelPoolTest {
 
         sc.close().sync();
         group.shutdownGracefully();
+        pool.close();
     }
 
     @Test
     public void testBoundedChannelPoolSegment() throws Exception {
         EventLoopGroup group = new DefaultEventLoopGroup();
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -143,6 +150,7 @@ public class SimpleChannelPoolTest {
         sc.close().sync();
         channel.close().sync();
         channel2.close().sync();
+        pool.close();
         group.shutdownGracefully();
     }
 
@@ -154,7 +162,7 @@ public class SimpleChannelPoolTest {
     @Test
     public void testUnhealthyChannelIsNotOffered() throws Exception {
         EventLoopGroup group = new DefaultEventLoopGroup();
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -188,6 +196,7 @@ public class SimpleChannelPoolTest {
         assertNotSame(channel1, channel3);
         sc.close().syncUninterruptibly();
         channel3.close().syncUninterruptibly();
+        pool.close();
         group.shutdownGracefully();
     }
 
@@ -200,7 +209,7 @@ public class SimpleChannelPoolTest {
     @Test
     public void testUnhealthyChannelIsOfferedWhenNoHealthCheckRequested() throws Exception {
         EventLoopGroup group = new DefaultEventLoopGroup();
-        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
         cb.group(group)
@@ -231,6 +240,7 @@ public class SimpleChannelPoolTest {
         assertNotSame(channel1, channel2);
         sc.close().syncUninterruptibly();
         channel2.close().syncUninterruptibly();
+        pool.close();
         group.shutdownGracefully();
     }
 
@@ -303,7 +313,7 @@ public class SimpleChannelPoolTest {
 
     @Test
     public void testCloseAsync() throws Exception {
-        final LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        final LocalAddress addr = new LocalAddress(getLocalAddrId());
         final EventLoopGroup group = new DefaultEventLoopGroup();
 
         // Start server
@@ -339,6 +349,7 @@ public class SimpleChannelPoolTest {
         assertFalse(ch2.isOpen());
 
         sc.close().sync();
+        pool.close();
         group.shutdownGracefully();
     }
 }

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -91,8 +91,8 @@ public class SimpleChannelPoolTest {
         assertEquals(2, handler.releasedCount());
 
         sc.close().sync();
-        group.shutdownGracefully();
         pool.close();
+        group.shutdownGracefully();
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The Channel Pool tests commonly use the same fixed local address String. This
has been observed to result in test failures if a single test fails and cleanup
is not done properly, or if tests are run in parallel. Also each test should
close any channel pool objects or maps to make sure resources are reclaimed.

Modifications:
- Use a random string for the address on each test to reduce the chance of
  collision.
- close all ChannelPool and ChannelPoolMap objects at the end of each test

Result:
Less likely to observe spurious failures due to LocalAddress collisions and more
complete test cleanup.