### PR TITLE
Avoid possible comparison contract violation

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -109,7 +109,7 @@ public final class ClientCookieEncoder extends CookieEncoder {
             }
             // Rely on Java's sort stability to retain creation order in cases where
             // cookies have same path length.
-            return -1;
+            return 0;
         }
     };
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -107,7 +107,7 @@ public final class ClientCookieEncoder extends CookieEncoder {
             if (diff != 0) {
                 return diff;
             }
-            // Rely on Java's sort stability to retain creation order in cases where
+            // Rely on Arrays.sort's stability to retain creation order in cases where
             // cookies have same path length.
             return 0;
         }


### PR DESCRIPTION
The current implementation would violate comparison contract for two cookies C1 and C2 with same path length, since C1 < C2 and C2 < C1. Returning 0 (equality) does not since C1 == C2 and C2 == C1. See #9881

Motivation:

The current implementation causes IllegalArgumetExceptions to be thrown on Java 11.

Modification:

Return equality instead of less than on same path length.

Result:

Fixes #9881. 

