### PR TITLE
Ignore inline comments when parsing nameservers

### DIFF
--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -542,11 +542,27 @@ public final class StringUtil {
      *
      * @param seq    The string to search.
      * @param offset The offset to start searching at.
-     * @return the index of the first non-white space character or &lt;{@code 0} if none was found.
+     * @return the index of the first non-white space character or &lt;{@code -1} if none was found.
      */
     public static int indexOfNonWhiteSpace(CharSequence seq, int offset) {
         for (; offset < seq.length(); ++offset) {
             if (!Character.isWhitespace(seq.charAt(offset))) {
+                return offset;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Find the index of the first white space character in {@code s} starting at {@code offset}.
+     *
+     * @param seq    The string to search.
+     * @param offset The offset to start searching at.
+     * @return the index of the first white space character or &lt;{@code -1} if none was found.
+     */
+    public static int indexOfWhiteSpace(CharSequence seq, int offset) {
+        for (; offset < seq.length(); ++offset) {
+            if (Character.isWhitespace(seq.charAt(offset))) {
                 return offset;
             }
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 import static io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider.DNS_PORT;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.StringUtil.indexOfNonWhiteSpace;
+import static io.netty.util.internal.StringUtil.indexOfWhiteSpace;
 
 /**
  * Able to parse files such as <a href="https://linux.die.net/man/5/resolver">/etc/resolv.conf</a> and
@@ -178,7 +179,20 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
                                 throw new IllegalArgumentException("error parsing label " + NAMESERVER_ROW_LABEL +
                                         " in file " + etcResolverFile + ". value: " + line);
                             }
-                            String maybeIP = line.substring(i);
+                            String maybeIP;
+                            int x = indexOfWhiteSpace(line, i);
+                            if (x == -1) {
+                                maybeIP = line.substring(i);
+                            } else {
+                                // ignore comments
+                                int idx = indexOfNonWhiteSpace(line, x);
+                                if (idx == -1 || line.charAt(idx) != '#') {
+                                    throw new IllegalArgumentException("error parsing label " + NAMESERVER_ROW_LABEL +
+                                            " in file " + etcResolverFile + ". value: " + line);
+                                }
+                                maybeIP = line.substring(i, x);
+                            }
+
                             // There may be a port appended onto the IP address so we attempt to extract it.
                             if (!NetUtil.isValidIpV4Address(maybeIP) && !NetUtil.isValidIpV6Address(maybeIP)) {
                                 i = maybeIP.lastIndexOf('.');

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
@@ -188,6 +188,17 @@ public class UnixResolverDnsServerAddressStreamProviderTest {
         return f;
     }
 
+    @Test
+    public void ignoreComments() throws Exception {
+        File f = buildFile("domain linecorp.local\n" +
+                "nameserver 127.0.0.2 #somecomment\n");
+        UnixResolverDnsServerAddressStreamProvider p =
+                new UnixResolverDnsServerAddressStreamProvider(f, null);
+
+        DnsServerAddressStream stream = p.nameServerAddressStream("somehost");
+        assertHostNameEquals("127.0.0.2", stream.next());
+    }
+
     private static void assertHostNameEquals(String expectedHostname, InetSocketAddress next) {
         assertEquals("unexpected hostname: " + next, expectedHostname, next.getHostString());
     }


### PR DESCRIPTION
Motivation:

The resolv.conf file may contain inline comments which should be ignored

Modifications:

- Detect if we have a comment after the ipaddress and if so skip it
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/9889