### PR TITLE
Fix typo in `AttributeMap`

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -322,7 +322,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
          * Peeks at that the next frame in the buffer and verifies that it is a non-ack {@code SETTINGS} frame.
          *
          * @param in the inbound buffer.
-         * @return {@code} true if the next frame is a non-ack {@code SETTINGS} frame, {@code false} if more
+         * @return {@code true} if the next frame is a non-ack {@code SETTINGS} frame, {@code false} if more
          * data is required before we can determine the next frame type.
          * @throws Http2Exception thrown if the next frame is NOT a non-ack {@code SETTINGS} frame.
          */

--- a/common/src/main/java/io/netty/util/AttributeMap.java
+++ b/common/src/main/java/io/netty/util/AttributeMap.java
@@ -28,7 +28,7 @@ public interface AttributeMap {
     <T> Attribute<T> attr(AttributeKey<T> key);
 
     /**
-     * Returns {@code} true if and only if the given {@link Attribute} exists in this {@link AttributeMap}.
+     * Returns {@code true} if and only if the given {@link Attribute} exists in this {@link AttributeMap}.
      */
     <T> boolean hasAttr(AttributeKey<T> key);
 }


### PR DESCRIPTION
While reading `AttributeMap`, I found some typos. 😉

