### PR TITLE
DefaultHttp2FrameStream: make id field package-private

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -674,7 +674,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
     // TODO(buchgr): Merge Http2FrameStream and Http2Stream.
     static class DefaultHttp2FrameStream implements Http2FrameStream {
 
-        private volatile int id = -1;
+        volatile int id = -1;
         volatile Http2Stream stream;
 
         final Http2FrameStreamEvent stateChanged = Http2FrameStreamEvent.stateChanged(this);


### PR DESCRIPTION
Motivation:

- consistency

- DefaultHttp2FrameStream is unusable even inside respective package (outside netty codebase) because its id field is private, and public Http2FrameStream interface is casted to DefaultHttp2FrameStream everywhere inside netty-http2 module. Hence it's hard to make ad-hoc changes/enhancements from within other codebases w/o shading whole netty-http2

Modifications:

- DefaultHttp2FrameStream: change id field visibility from private to package-private

Result:

- DefaultHttp2FrameStream: id field is accessible by same package classes

Relates to #9903 

