### PR TITLE
Introduce `needReport` for `ResourceLeakDetector`.

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -274,8 +274,19 @@ public class ResourceLeakDetector<T> {
         }
     }
 
+    /**
+     * Whether need to report leak.
+     * When the return value is true, {@link #reportTracedLeak} and {@link #reportUntracedLeak}
+     * can work normally, otherwise, they will have no effect.
+     *
+     * @return true for report leak.
+     */
+    protected boolean needReport() {
+        return logger.isErrorEnabled();
+    }
+
     private void reportLeak() {
-        if (!logger.isErrorEnabled()) {
+        if (!needReport()) {
             clearRefQueue();
             return;
         }

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -275,11 +275,10 @@ public class ResourceLeakDetector<T> {
     }
 
     /**
-     * Whether need to report leak.
-     * When the return value is true, {@link #reportTracedLeak} and {@link #reportUntracedLeak}
-     * can work normally, otherwise, they will have no effect.
+     * When the return value is {@code true}, {@link #reportTracedLeak} and {@link #reportUntracedLeak}
+     * will be called once a leak is detected, otherwise not.
      *
-     * @return true for report leak.
+     * @return {@code true} to enable leak reporting.
      */
     protected boolean needReport() {
         return logger.isErrorEnabled();


### PR DESCRIPTION
Motivation:

We can extend `ResourceLeakDetector` through `ResourceLeakDetectorFactory`, and then report the leaked information by covering `reportTracedLeak` and `reportUntracedLeak`. However, the behavior of `reportTracedLeak` and `reportUntracedLeak` is controlled by `logger.isErrorEnabled()`, which is not reasonable. In the case of extending `ResourceLeakDetector`, we sometimes need `needReport` to always return true instead of relying on `logger.isErrorEnabled ()`.

Modification:

introduce `needReport` method and let it be `protected`

Result:

We can control the report leak behavior.
