### PR TITLE
Fix BufferOverflowException during non-Unsafe PooledDirectByteBuf resize

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -154,6 +154,8 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         ByteBuffer tmpNioBuf = this.tmpNioBuf;
         if (tmpNioBuf == null) {
             this.tmpNioBuf = tmpNioBuf = newInternalNioBuffer(memory);
+        } else {
+            tmpNioBuf.clear();
         }
         return tmpNioBuf;
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -260,7 +260,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         }
 
         index = idx(index);
-        tmpBuf.clear().position(index).limit(index + length);
+        tmpBuf.limit(index + length).position(index);
         tmpBuf.put(src);
         return this;
     }
@@ -274,7 +274,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
             return readBytes;
         }
         ByteBuffer tmpBuf = internalNioBuffer();
-        tmpBuf.clear().position(idx(index));
+        tmpBuf.position(idx(index));
         tmpBuf.put(tmp, 0, readBytes);
         return readBytes;
     }

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -122,5 +122,8 @@ public class PoolArenaTest {
         dst.writeBytes(ByteBuffer.allocate(128));
         // Ensure internal ByteBuffer duplicate limit is properly reset (used in memoryCopy non-Unsafe case)
         dst.chunk.arena.memoryCopy(src.memory, 0, dst, 512);
+
+        src.release();
+        dst.release();
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -111,13 +111,10 @@ public class PoolArenaTest {
         Assert.assertEquals(1, metric.numNormalAllocations());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testDirectArenaMemoryCopy() {
-        PooledByteBuf<ByteBuffer> src =
-                (PooledByteBuf<ByteBuffer>) PooledByteBufAllocator.DEFAULT.directBuffer(512);
-        PooledByteBuf<ByteBuffer> dst =
-                (PooledByteBuf<ByteBuffer>) PooledByteBufAllocator.DEFAULT.directBuffer(512);
+        PooledByteBuf<ByteBuffer> src = unwrapIfNeeded(PooledByteBufAllocator.DEFAULT.directBuffer(512));
+        PooledByteBuf<ByteBuffer> dst = unwrapIfNeeded(PooledByteBufAllocator.DEFAULT.directBuffer(512));
         // This causes the internal reused ByteBuffer duplicate limit to be set to 128
         dst.writeBytes(ByteBuffer.allocate(128));
         // Ensure internal ByteBuffer duplicate limit is properly reset (used in memoryCopy non-Unsafe case)
@@ -125,5 +122,10 @@ public class PoolArenaTest {
 
         src.release();
         dst.release();
+    }
+
+    @SuppressWarnings("unchecked")
+    private PooledByteBuf<ByteBuffer> unwrapIfNeeded(ByteBuf buf) {
+        return (PooledByteBuf<ByteBuffer>) (buf instanceof PooledByteBuf ? buf : buf.unwrap());
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -67,7 +67,7 @@ public class PoolArenaTest {
     }
 
     @Test
-    public final void testAllocationCounter() {
+    public void testAllocationCounter() {
         final PooledByteBufAllocator allocator = new PooledByteBufAllocator(
                 true,   // preferDirect
                 0,      // nHeapArena
@@ -113,7 +113,7 @@ public class PoolArenaTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public final void testDirectArenaMemoryCopy() {
+    public void testDirectArenaMemoryCopy() {
         PooledByteBuf<ByteBuffer> src =
                 (PooledByteBuf<ByteBuffer>) PooledByteBufAllocator.DEFAULT.directBuffer(512);
         PooledByteBuf<ByteBuffer> dst =

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -113,12 +113,16 @@ public class PoolArenaTest {
 
     @Test
     public void testDirectArenaMemoryCopy() {
-        PooledByteBuf<ByteBuffer> src = unwrapIfNeeded(PooledByteBufAllocator.DEFAULT.directBuffer(512));
-        PooledByteBuf<ByteBuffer> dst = unwrapIfNeeded(PooledByteBufAllocator.DEFAULT.directBuffer(512));
+        ByteBuf src = PooledByteBufAllocator.DEFAULT.directBuffer(512);
+        ByteBuf dst = PooledByteBufAllocator.DEFAULT.directBuffer(512);
+
+        PooledByteBuf<ByteBuffer> pooledSrc = unwrapIfNeeded(src);
+        PooledByteBuf<ByteBuffer> pooledDst = unwrapIfNeeded(dst);
+
         // This causes the internal reused ByteBuffer duplicate limit to be set to 128
-        dst.writeBytes(ByteBuffer.allocate(128));
+        pooledDst.writeBytes(ByteBuffer.allocate(128));
         // Ensure internal ByteBuffer duplicate limit is properly reset (used in memoryCopy non-Unsafe case)
-        dst.chunk.arena.memoryCopy(src.memory, 0, dst, 512);
+        pooledDst.chunk.arena.memoryCopy(pooledSrc.memory, 0, pooledDst, 512);
 
         src.release();
         dst.release();


### PR DESCRIPTION
Motivation

Recent optimization #9765 introduced a bug where the native indices of the internal reused duplicate nio buffer are not properly reset prior to using it to copy data during a reallocation operation. This can result in `BufferOverflowException`s thrown during `ByteBuf` capacity changes.

The code path in question applies only to pooled direct buffers when Unsafe is disabled or not available.

Modification

Ensure `ByteBuffer#clear()` is always called on the reused internal nio buffer prior to returning it from `PooledByteBuf#internalNioBuffer()` (protected method); add unit test that exposes the bug.

Result

Fixes #9911