### PR TITLE
Enable LGTM support

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,13 @@
+extraction:
+  java:
+    prepare:
+      packages:
+      - "autoconf"
+      - "automake"
+      - "libtool"
+      - "make"
+      - "tar"
+      - "libaio-dev"
+      - "libssl-dev"
+      - "libapr1-dev"
+      - "lksctp-tools"


### PR DESCRIPTION
Enables lgtm.com to process this project and create a CodeQL database
https://lgtm.com/projects/g/netty/netty

Motivation:

I'm performing some security research against various Java-based projects as a part of the new [GitHub Security Lab](https://securitylab.github.com/) Bug Bounty program.
Currently, LGTM.com can't create a CodeQL database for this project because of missing dependencies. This fixes the build so it works correctly.

The maintainers may also want to consider enabling the free [LGTM Integration](https://github.com/marketplace/lgtm) once this PR is merged.

Modification:

Adds a `.lgtm.yml` with a tested configuration:
A successful build can be found here:
https://lgtm.com/logs/6695df28f6b2b1d3fd4d03e968b600a3e9c9aecf/lang:java

Result:

LGTM.com will be able to process this repository to create a CodeQL database.