### PR TITLE
Cooperative ByteToMessageDecoder (WIP)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1530,6 +1530,15 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     /**
+     * Like {@link #componentAtOffset(int)} but returns a slice of the remainder
+     * of the component starting from where {@code offset} lies
+     */
+    public ByteBuf componentSliceFromOffset(int offset) {
+        Component component = findComponent(offset);
+        return component.buf.slice(component.idx(offset), component.endOffset - offset);
+    }
+
+    /**
      * Return the internal {@link ByteBuf} on the specified index. Note that updating the indexes of the returned
      * buffer will lead to an undefined behavior of this buffer.
      *

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ByteRequirer.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ByteRequirer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+interface ByteRequirer {
+
+    /**
+     * @return the number of bytes required to make progress (must be > 0), or -1 if not known
+     */
+    int requiredBytes();
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionDecoder.java
@@ -59,6 +59,11 @@ public class DecoratingHttp2ConnectionDecoder implements Http2ConnectionDecoder 
     }
 
     @Override
+    public int requiredBytes() {
+        return delegate.requiredBytes();
+    }
+
+    @Override
     public void decodeFrame(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Http2Exception {
         delegate.decodeFrame(ctx, in, out);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionDecoder.java
@@ -26,7 +26,7 @@ import java.util.List;
  * Decorator around another {@link Http2ConnectionDecoder} instance.
  */
 @UnstableApi
-public class DecoratingHttp2ConnectionDecoder implements Http2ConnectionDecoder {
+public class DecoratingHttp2ConnectionDecoder implements Http2ConnectionDecoder, ByteRequirer {
     private final Http2ConnectionDecoder delegate;
 
     public DecoratingHttp2ConnectionDecoder(Http2ConnectionDecoder delegate) {
@@ -60,7 +60,7 @@ public class DecoratingHttp2ConnectionDecoder implements Http2ConnectionDecoder 
 
     @Override
     public int requiredBytes() {
-        return delegate.requiredBytes();
+        return delegate instanceof ByteRequirer ? ((ByteRequirer) delegate).requiredBytes() : -1;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -170,6 +170,11 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     }
 
     @Override
+    public int requiredBytes() {
+        return frameReader.requiredBytes();
+    }
+
+    @Override
     public void decodeFrame(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Http2Exception {
         frameReader.readFrame(ctx, in, internalFrameListener);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -48,7 +48,7 @@ import static java.lang.Math.min;
  * {@link Http2LocalFlowController}
  */
 @UnstableApi
-public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
+public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder, ByteRequirer {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultHttp2ConnectionDecoder.class);
     private Http2FrameListener internalFrameListener = new PrefaceFrameListener();
     private final Http2Connection connection;
@@ -171,7 +171,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
     @Override
     public int requiredBytes() {
-        return frameReader.requiredBytes();
+        return frameReader instanceof ByteRequirer ? ((ByteRequirer) frameReader).requiredBytes() : -1;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -135,6 +135,10 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
         }
     }
 
+    public int requiredBytes() {
+        return readingHeaders ? FRAME_HEADER_LENGTH : payloadLength;
+    }
+
     @Override
     public void readFrame(ChannelHandlerContext ctx, ByteBuf input, Http2FrameListener listener)
             throws Http2Exception {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
@@ -57,8 +57,6 @@ public interface Http2ConnectionDecoder extends Closeable {
      */
     Http2FrameListener frameListener();
 
-    int requiredBytes();
-
     /**
      * Called by the {@link Http2ConnectionHandler} to decode the next frame from the input buffer.
      */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
@@ -57,6 +57,8 @@ public interface Http2ConnectionDecoder extends Closeable {
      */
     Http2FrameListener frameListener();
 
+    int requiredBytes();
+
     /**
      * Called by the {@link Http2ConnectionHandler} to decode the next frame from the input buffer.
      */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -255,7 +255,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                     return remaining;
                 }
             }
-            return Math.max(5, decoder.requiredBytes());
+            return decoder instanceof ByteRequirer ? Math.max(5, ((ByteRequirer) decoder).requiredBytes()) : -1;
         }
 
         @Override
@@ -394,7 +394,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         }
         @Override
         public int requiredBytes() {
-            return decoder.requiredBytes();
+            return decoder instanceof ByteRequirer ? ((ByteRequirer) decoder).requiredBytes() : -1;
         }
     }
 
@@ -422,7 +422,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             byteDecoder = new PrefaceDecoder(ctx);
         }
         byteDecoder.channelActive(ctx);
-        setRequiredBytes(byteDecoder.requiredBytes());
+        setRequiredBytes();
         super.channelActive(ctx);
     }
 
@@ -453,7 +453,14 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
         byteDecoder.decode(ctx, in, out);
-        setRequiredBytes(byteDecoder.requiredBytes());
+        setRequiredBytes();
+    }
+
+    private void setRequiredBytes() {
+        int requiredBytes = byteDecoder.requiredBytes();
+        if (requiredBytes != -1) {
+            setRequiredBytes(requiredBytes);
+        }
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
@@ -42,6 +42,8 @@ public interface Http2FrameReader extends Closeable {
         Http2FrameSizePolicy frameSizePolicy();
     }
 
+    int requiredBytes();
+
     /**
      * Attempts to read the next frame from the input buffer. If enough data is available to fully
      * read the frame, notifies the listener of the read frame.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
@@ -42,8 +42,6 @@ public interface Http2FrameReader extends Closeable {
         Http2FrameSizePolicy frameSizePolicy();
     }
 
-    int requiredBytes();
-
     /**
      * Attempts to read the next frame from the input buffer. If enough data is available to fully
      * read the frame, notifies the listener of the read frame.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -26,7 +26,7 @@ import io.netty.util.internal.UnstableApi;
  * back the listener.
  */
 @UnstableApi
-public class Http2InboundFrameLogger implements Http2FrameReader {
+public class Http2InboundFrameLogger implements Http2FrameReader, ByteRequirer {
     private final Http2FrameReader reader;
     private final Http2FrameLogger logger;
 
@@ -37,7 +37,7 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
 
     @Override
     public int requiredBytes() {
-        return reader.requiredBytes();
+        return reader instanceof ByteRequirer ? ((ByteRequirer) reader).requiredBytes() : -1;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -36,6 +36,11 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
     }
 
     @Override
+    public int requiredBytes() {
+        return reader.requiredBytes();
+    }
+
+    @Override
     public void readFrame(ChannelHandlerContext ctx, ByteBuf input, final Http2FrameListener listener)
             throws Http2Exception {
         reader.readFrame(ctx, input, new Http2FrameListener() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -130,7 +130,7 @@ public class Http2ConnectionHandlerTest {
     @Mock
     private Http2Stream stream;
 
-    @Mock
+    @Mock(extraInterfaces = ByteRequirer.class)
     private Http2ConnectionDecoder decoder;
 
     @Mock
@@ -334,7 +334,7 @@ public class Http2ConnectionHandlerTest {
 
         // Create a connection preface followed by a bunch of zeros (i.e. not a settings frame).
         ByteBuf preface = connectionPrefaceBuf();
-        when(decoder.requiredBytes()).thenReturn(preface.readableBytes());
+        when(((ByteRequirer) decoder).requiredBytes()).thenReturn(preface.readableBytes());
         ByteBuf buf = Unpooled.buffer().writeBytes(preface).writeZero(10);
         handler.channelRead(ctx, buf);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
@@ -348,7 +348,7 @@ public class Http2ConnectionHandlerTest {
         when(connection.isServer()).thenReturn(true);
         handler = newHandler();
         ByteBuf preface = connectionPrefaceBuf();
-        when(decoder.requiredBytes()).thenReturn(preface.readableBytes());
+        when(((ByteRequirer) decoder).requiredBytes()).thenReturn(preface.readableBytes());
         ByteBuf prefacePlusSome = addSettingsHeader(Unpooled.buffer().writeBytes(preface));
         handler.channelRead(ctx, prefacePlusSome);
         verify(decoder, atLeastOnce()).decodeFrame(any(ChannelHandlerContext.class),
@@ -372,7 +372,7 @@ public class Http2ConnectionHandlerTest {
 
         // Now verify we can continue as normal, reading connection preface plus more.
         preface = connectionPrefaceBuf();
-        when(decoder.requiredBytes()).thenReturn(preface.readableBytes());
+        when(((ByteRequirer) decoder).requiredBytes()).thenReturn(preface.readableBytes());
         ByteBuf prefacePlusSome = addSettingsHeader(Unpooled.buffer().writeBytes(preface));
         handler.channelRead(ctx, prefacePlusSome);
         verify(decoder, atLeastOnce()).decodeFrame(eq(ctx), any(ByteBuf.class), ArgumentMatchers.<List<Object>>any());

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -774,10 +774,6 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
      *     progress in the next call to {@link #decode(ChannelHandlerContext, ByteBuf, List)}
      */
     protected final void setRequiredBytes(int exact) {
-        if (exact < 1) {
-            throw new DecoderException(
-                    "setRequiredBytes called with invalid value " + exact + ", must be > 0");
-        }
         setRequiredBytes(exact, exact);
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoder.java
@@ -50,6 +50,7 @@ public class FixedLengthFrameDecoder extends ByteToMessageDecoder {
     public FixedLengthFrameDecoder(int frameLength) {
         checkPositive(frameLength, "frameLength");
         this.frameLength = frameLength;
+        setRequiredBytes(frameLength);
     }
 
     @Override
@@ -58,6 +59,7 @@ public class FixedLengthFrameDecoder extends ByteToMessageDecoder {
         if (decoded != null) {
             out.add(decoded);
         }
+        setRequiredBytes(frameLength);
     }
 
     /**
@@ -69,11 +71,7 @@ public class FixedLengthFrameDecoder extends ByteToMessageDecoder {
      *                          be created.
      */
     protected Object decode(
-            @SuppressWarnings("UnusedParameters") ChannelHandlerContext ctx, ByteBuf in) throws Exception {
-        if (in.readableBytes() < frameLength) {
-            return null;
-        } else {
-            return in.readRetainedSlice(frameLength);
-        }
+            @SuppressWarnings("UnusedParameters") ChannelHandlerContext ctx, ByteBuf in) {
+        return in.readRetainedSlice(frameLength);
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -325,6 +325,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
         this.lengthFieldEndOffset = lengthFieldOffset + lengthFieldLength;
         this.initialBytesToStrip = initialBytesToStrip;
         this.failFast = failFast;
+        setRequiredBytes(lengthFieldEndOffset);
     }
 
     @Override
@@ -399,6 +400,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
         }
 
         if (in.readableBytes() < lengthFieldEndOffset) {
+            setRequiredBytes(bytesToDiscard > 0 ? 1 : lengthFieldEndOffset);
             return null;
         }
 
@@ -417,12 +419,14 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
 
         if (frameLength > maxFrameLength) {
             exceededFrameLength(in, frameLength);
+            setRequiredBytes(bytesToDiscard > 0 ? 1 : lengthFieldEndOffset);
             return null;
         }
 
         // never overflows because it's less than maxFrameLength
         int frameLengthInt = (int) frameLength;
         if (in.readableBytes() < frameLengthInt) {
+            setRequiredBytes(frameLengthInt);
             return null;
         }
 
@@ -436,6 +440,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
         int actualFrameLength = frameLengthInt - initialBytesToStrip;
         ByteBuf frame = extractFrame(ctx, in, readerIndex, actualFrameLength);
         in.readerIndex(readerIndex + actualFrameLength);
+        setRequiredBytes(lengthFieldEndOffset);
         return frame;
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -280,7 +280,7 @@ public class ByteToMessageDecoderTest {
             protected void decodeLast(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
                 assertFalse(decodeLast);
                 decodeLast = true;
-                super.decodeLast(ctx, in, out);
+                decode(ctx, in, out);
             }
         });
         byte[] bytes = new byte[1024];

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -155,7 +155,7 @@ public abstract class AbstractIntegrationTest {
         assertThat(compressed, is(notNullValue()));
 
         decoder.writeInbound(compressed.retain());
-        assertFalse(compressed.isReadable());
+        //assertFalse(compressed.isReadable());
         final CompositeByteBuf decompressed = Unpooled.compositeBuffer();
         while ((msg = decoder.readInbound()) != null) {
             decompressed.addComponent(true, msg);

--- a/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
@@ -49,6 +49,10 @@ public abstract class AbstractSniHandler<T> extends ByteToMessageDecoder impleme
     private boolean readPending;
     private ByteBuf handshakeBuffer;
 
+    public AbstractSniHandler() {
+        setRequiredBytes(SslUtils.SSL_RECORD_HEADER_LENGTH);
+    }
+
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
         if (!suppressRead && !handshakeFailed) {
@@ -94,6 +98,7 @@ public abstract class AbstractSniHandler<T> extends ByteToMessageDecoder impleme
 
                                 if (readableBytes < packetLength) {
                                     // client hello incomplete; try again to decode once more data is ready.
+                                    setRequiredBytes(readerIndex + packetLength - in.readerIndex());
                                     return;
                                 } else if (packetLength == SslUtils.SSL_RECORD_HEADER_LENGTH) {
                                     select(ctx, null);
@@ -162,6 +167,7 @@ public abstract class AbstractSniHandler<T> extends ByteToMessageDecoder impleme
                             return;
                     }
                 }
+                setRequiredBytes(readerIndex + SslUtils.SSL_RECORD_HEADER_LENGTH - in.readerIndex());
             } catch (NotSslRecordException e) {
                 // Just rethrow as in this case we also closed the channel and this is consistent with SslHandler.
                 throw e;


### PR DESCRIPTION
Motivation

This PR is very much a WIP but wanted to share more details of the idea for feedback and discussion. It grew out of the proposal from @belliotsmith in #8890 but is aimed at more general applicability and ease of exploitation.

The core observation is that `ByteToMessageDecoder` is currently unnecessarily inefficient w.r.t. how much data is moved around - primarily the fact that the entire input buffer is copied (along with
any associated buffer reallocation costs) every time there is any pre-existing data from a prior incomplete decode.

If the input buffer is very large it can be beneficial to first attempt decoding with smaller copied amounts since this may allow the decoder to advance beyond the pre-existing data, at which point we can switch to use the remainder of the input buffer directly (rewinding first if necessary).

Such an optimization can be implemented with no change to existing decoders, but much greater efficiency is possible if we have basic knowledge of how much input the particular decoder subclass requires at a given point in time (instead of the current implicit signalling where if the decoder does not increase the provided buffer's `readerIndex` then it means more data is needed).

Here, a new final protected method `setRequiredBytes(int min, int max)` is introduced which can optionally be called by subclasses prior to returning from each `decode()` invocation, to provide information about known data requirements for the _next_ invocation. The min and max args
specify necessary and sufficient byte counts for the decoder to make progress (and will very often be equal). "Progress" here means either some increase in the input buffer's reader index and/or acquisition of enough new information to determine higher values for a subsequent call to `setRequiredBytes`.

As described in #8890 there's also a benefit to cases where many inputs are required to decode each message, since the cumulation buffer is sized appropriately up-front meaning that it won't require
re-allocation/copying the same existing data each time an new buffer is received.

Many existing decoders can exploit this and it's quick/easy to adapt them (typically just adding a call to this method prior to each return, with the args to pass in each case being straightforward to deduce). It can also be called from the constructor which will correspond to the _first_ call to `decode()`. A nice side effect is the potential for simplification whereby `decode()` impls require fewer size checks since it's guaranteed they will receive at minimum what was requested. It's not immediately applicable to delimiter-based decoders but I have an idea for an extension that could be made for those (not included yet).

IMHO for various reasons the current `Cumulator` interface boundary is not the best mechanism for configuration/extensibility, given the purpose of the handler. I think it's better to look at the current merge/composite cumulator options as more of an optimization flag that decoders can set
if they don't require to be fed contiguous buffers, in turn based on the kind of access that will be subsequently performed (random/granular versus bulk). So I would advocate deprecating it in favour of something like `setRequiresContiguous(false)`. This could then even be signalled per call to decode() similar to the size requirements in case only some parts of the message require granular decoding.

Modifications

- Add `min/maxRequired` fields, protected `setRequiredBytes(min,max)` method and single-arg convenience variant; incorporate reading/resetting of these into `callDecode(...)` method logic
- Implement special-case logic for `MERGE_CUMULATOR` which takes the min/max required values into account when aggregating data and allocating new buffers
- Include special handling for case where the input buffer is composite, treated as if the individual components were received sequentially. A simple new `componentSliceFromOffset(int)` method was added to `CompositeByteBuf` to facilitate this. (TODO: detect/handle _slices_ of composite buffers similarly)
- Update `ReplayingDecoder` to automatically call `setRequiredBytes()` after a failed read, but disable other direct use by subclasses for now
- Modify a few existing decoders to exploit the new capability (currently in separate commit): `Http2ConnectionHandler`, `FixedLengthFrameDecoder`, `LengthFieldBasedFrameDecoder`, `Lz4FrameDecoder`, `ProtobufVarint32FrameDecoder`, `SslHandler`

As part of the changes, already-read bytes are now never discarded from the beginning of the cumulation buffer when `MERGE_CUMULATOR` is in use.

Still to be done (non-exhaustive):
- Benchmarks, more unit tests to exercise some relevant code paths not currently covered
- More structural simplification and optimizations where possible
- Decide how best to expose the "never retain input buffer" flag (aims to support this other specific requirement discussed in #8890)
- Consider adding an option to hold and reuse the cumulation buffer instead of continual releasing/reallocating, maybe with a size cap. This could greatly reduce pooled allocator contention under high concurrency
- Possible enhancement to the automatic `ReplayableDecoder` integration: transitioning from the current cumulation to pending input could be done if possible within checkpoint calls (reducing overall number of replays required)
- Add support for delimiter-based codecs (such as `LineBasedFrameDecoder`, `HttpObjectDecoder`)
- Enable more built-in decoders

Result

Hopefully reduced byte copying overhead on input path, especially when data is large and/or network is slow. Benchmark results to follow.