### PR TITLE
Allow a limit to be set on the decompressed buffer size for ZlibDecoders

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -199,6 +199,8 @@ public class JZlibDecoder extends ZlibDecoder {
                 if (decompressed.isReadable()) {
                     out.add(decompressed);
                 } else {
+                    finished = true;
+                    in.skipBytes(in.readableBytes());
                     decompressed.release();
                 }
             }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -199,8 +199,6 @@ public class JZlibDecoder extends ZlibDecoder {
                 if (decompressed.isReadable()) {
                     out.add(decompressed);
                 } else {
-                    finished = true;
-                    in.skipBytes(in.readableBytes());
                     decompressed.release();
                 }
             }
@@ -212,5 +210,10 @@ public class JZlibDecoder extends ZlibDecoder {
             z.next_in = null;
             z.next_out = null;
         }
+    }
+
+    @Override
+    protected void decompressionBufferExhausted(ByteBuf buffer) {
+        finished = true;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.compression;
 import com.jcraft.jzlib.Inflater;
 import com.jcraft.jzlib.JZlib;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.internal.ObjectUtil;
 
@@ -42,6 +43,10 @@ public class JZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB})
      * and specified maximum buffer allocation.
      *
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
+     *
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(int maxAllocation) {
@@ -59,6 +64,10 @@ public class JZlibDecoder extends ZlibDecoder {
 
     /**
      * Creates a new instance with the specified wrapper and maximum buffer allocation.
+     *
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      *
      * @throws DecompressionException if failed to initialize zlib
      */
@@ -88,6 +97,10 @@ public class JZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the specified preset dictionary and maximum buffer allocation.
      * The wrapper is always {@link ZlibWrapper#ZLIB} because it is the only format that
      * supports the preset dictionary.
+     *
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      *
      * @throws DecompressionException if failed to initialize zlib
      */

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -35,7 +35,17 @@ public class JZlibDecoder extends ZlibDecoder {
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder() {
-        this(ZlibWrapper.ZLIB);
+        this(ZlibWrapper.ZLIB, 0);
+    }
+
+    /**
+     * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB})
+     * and specified maximum buffer allocation.
+     *
+     * @throws DecompressionException if failed to initialize zlib
+     */
+    public JZlibDecoder(int maxAllocation) {
+        this(ZlibWrapper.ZLIB, maxAllocation);
     }
 
     /**
@@ -44,6 +54,17 @@ public class JZlibDecoder extends ZlibDecoder {
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(ZlibWrapper wrapper) {
+        this(wrapper, 0);
+    }
+
+    /**
+     * Creates a new instance with the specified wrapper and maximum buffer allocation.
+     *
+     * @throws DecompressionException if failed to initialize zlib
+     */
+    public JZlibDecoder(ZlibWrapper wrapper, int maxAllocation) {
+        super(maxAllocation);
+
         ObjectUtil.checkNotNull(wrapper, "wrapper");
 
         int resultCode = z.init(ZlibUtil.convertWrapperType(wrapper));
@@ -60,6 +81,18 @@ public class JZlibDecoder extends ZlibDecoder {
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(byte[] dictionary) {
+        this(dictionary, 0);
+    }
+
+    /**
+     * Creates a new instance with the specified preset dictionary and maximum buffer allocation.
+     * The wrapper is always {@link ZlibWrapper#ZLIB} because it is the only format that
+     * supports the preset dictionary.
+     *
+     * @throws DecompressionException if failed to initialize zlib
+     */
+    public JZlibDecoder(byte[] dictionary, int maxAllocation) {
+        super(maxAllocation);
         this.dictionary = ObjectUtil.checkNotNull(dictionary, "dictionary");
         int resultCode;
         resultCode = z.inflateInit(JZlib.W_ZLIB);
@@ -105,11 +138,11 @@ public class JZlibDecoder extends ZlibDecoder {
             final int oldNextInIndex = z.next_in_index;
 
             // Configure output.
-            ByteBuf decompressed = ctx.alloc().heapBuffer(inputLength << 1);
+            ByteBuf decompressed = prepareDecompressBuffer(ctx, null, inputLength << 1);
 
             try {
                 loop: for (;;) {
-                    decompressed.ensureWritable(z.avail_in << 1);
+                    decompressed = prepareDecompressBuffer(ctx, decompressed, z.avail_in << 1);
                     z.avail_out = decompressed.writableBytes();
                     z.next_out = decompressed.array();
                     z.next_out_index = decompressed.arrayOffset() + decompressed.writerIndex();

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.internal.ObjectUtil;
 
@@ -71,6 +72,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
     /**
      * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB})
      * and the specified maximum buffer allocation.
+     *
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      */
     public JdkZlibDecoder(int maxAllocation) {
         this(ZlibWrapper.ZLIB, null, false, maxAllocation);
@@ -89,6 +94,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the specified preset dictionary and maximum buffer allocation.
      * The wrapper is always {@link ZlibWrapper#ZLIB} because it is the only format that
      * supports the preset dictionary.
+     *
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      */
     public JdkZlibDecoder(byte[] dictionary, int maxAllocation) {
         this(ZlibWrapper.ZLIB, dictionary, false, maxAllocation);
@@ -107,6 +116,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the specified wrapper and maximum buffer allocation.
      * Be aware that only {@link ZlibWrapper#GZIP}, {@link ZlibWrapper#ZLIB} and {@link ZlibWrapper#NONE} are
      * supported atm.
+     *
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      */
     public JdkZlibDecoder(ZlibWrapper wrapper, int maxAllocation) {
         this(wrapper, null, false, maxAllocation);

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -65,7 +65,15 @@ public class JdkZlibDecoder extends ZlibDecoder {
      * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB}).
      */
     public JdkZlibDecoder() {
-        this(ZlibWrapper.ZLIB, null, false);
+        this(ZlibWrapper.ZLIB, null, false, 0);
+    }
+
+    /**
+     * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB})
+     * and the specified maximum buffer allocation.
+     */
+    public JdkZlibDecoder(int maxAllocation) {
+        this(ZlibWrapper.ZLIB, null, false, maxAllocation);
     }
 
     /**
@@ -74,7 +82,16 @@ public class JdkZlibDecoder extends ZlibDecoder {
      * supports the preset dictionary.
      */
     public JdkZlibDecoder(byte[] dictionary) {
-        this(ZlibWrapper.ZLIB, dictionary, false);
+        this(ZlibWrapper.ZLIB, dictionary, false, 0);
+    }
+
+    /**
+     * Creates a new instance with the specified preset dictionary and maximum buffer allocation.
+     * The wrapper is always {@link ZlibWrapper#ZLIB} because it is the only format that
+     * supports the preset dictionary.
+     */
+    public JdkZlibDecoder(byte[] dictionary, int maxAllocation) {
+        this(ZlibWrapper.ZLIB, dictionary, false, maxAllocation);
     }
 
     /**
@@ -83,18 +100,37 @@ public class JdkZlibDecoder extends ZlibDecoder {
      * supported atm.
      */
     public JdkZlibDecoder(ZlibWrapper wrapper) {
-        this(wrapper, null, false);
+        this(wrapper, null, false, 0);
+    }
+
+    /**
+     * Creates a new instance with the specified wrapper and maximum buffer allocation.
+     * Be aware that only {@link ZlibWrapper#GZIP}, {@link ZlibWrapper#ZLIB} and {@link ZlibWrapper#NONE} are
+     * supported atm.
+     */
+    public JdkZlibDecoder(ZlibWrapper wrapper, int maxAllocation) {
+        this(wrapper, null, false, maxAllocation);
     }
 
     public JdkZlibDecoder(ZlibWrapper wrapper, boolean decompressConcatenated) {
-        this(wrapper, null, decompressConcatenated);
+        this(wrapper, null, decompressConcatenated, 0);
+    }
+
+    public JdkZlibDecoder(ZlibWrapper wrapper, boolean decompressConcatenated, int maxAllocation) {
+        this(wrapper, null, decompressConcatenated, maxAllocation);
     }
 
     public JdkZlibDecoder(boolean decompressConcatenated) {
-        this(ZlibWrapper.GZIP, null, decompressConcatenated);
+        this(ZlibWrapper.GZIP, null, decompressConcatenated, 0);
     }
 
-    private JdkZlibDecoder(ZlibWrapper wrapper, byte[] dictionary, boolean decompressConcatenated) {
+    public JdkZlibDecoder(boolean decompressConcatenated, int maxAllocation) {
+        this(ZlibWrapper.GZIP, null, decompressConcatenated, maxAllocation);
+    }
+
+    private JdkZlibDecoder(ZlibWrapper wrapper, byte[] dictionary, boolean decompressConcatenated, int maxAllocation) {
+        super(maxAllocation);
+
         ObjectUtil.checkNotNull(wrapper, "wrapper");
 
         this.decompressConcatenated = decompressConcatenated;
@@ -177,7 +213,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
             inflater.setInput(array);
         }
 
-        ByteBuf decompressed = ctx.alloc().heapBuffer(inflater.getRemaining() << 1);
+        ByteBuf decompressed = prepareDecompressBuffer(ctx, null, inflater.getRemaining() << 1);
         try {
             boolean readFooter = false;
             while (!inflater.needsInput()) {
@@ -208,7 +244,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
                     }
                     break;
                 } else {
-                    decompressed.ensureWritable(inflater.getRemaining() << 1);
+                    decompressed = prepareDecompressBuffer(ctx, decompressed, inflater.getRemaining() << 1);
                 }
             }
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -282,6 +282,8 @@ public class JdkZlibDecoder extends ZlibDecoder {
             if (decompressed.isReadable()) {
                 out.add(decompressed);
             } else {
+                finished = true;
+                in.skipBytes(in.readableBytes());
                 decompressed.release();
             }
         }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -282,11 +282,14 @@ public class JdkZlibDecoder extends ZlibDecoder {
             if (decompressed.isReadable()) {
                 out.add(decompressed);
             } else {
-                finished = true;
-                in.skipBytes(in.readableBytes());
                 decompressed.release();
             }
         }
+    }
+
+    @Override
+    protected void decompressionBufferExhausted(ByteBuf buffer) {
+        finished = true;
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
@@ -87,7 +87,6 @@ public abstract class ZlibDecoder extends ByteToMessageDecoder {
      * data that was decompressed so far.
      */
     protected void decompressionBufferExhausted(ByteBuf buffer) {
-
     }
 
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
@@ -33,7 +33,7 @@ public abstract class ZlibDecoder extends ByteToMessageDecoder {
     /**
      * Same as {@link #ZlibDecoder(int)} with maxAllocation = 0.
      */
-    public ZlibDecoder() {
+    protected ZlibDecoder() {
         this(0);
     }
 
@@ -43,7 +43,7 @@ public abstract class ZlibDecoder extends ByteToMessageDecoder {
      *          Maximum size of the decompression buffer. Must be &gt;= 0.
      *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      */
-    public ZlibDecoder(int maxAllocation) {
+    protected ZlibDecoder(int maxAllocation) {
         if (maxAllocation < 0) {
             throw new IllegalArgumentException("maxAllocation must be >= 0");
         }
@@ -69,6 +69,9 @@ public abstract class ZlibDecoder extends ByteToMessageDecoder {
             return ctx.alloc().heapBuffer(Math.min(preferredSize, maxAllocation), maxAllocation);
         }
 
+        // this always expands the buffer if possible, even if the expansion is less than preferredSize
+        // we throw the exception only if the buffer could not be expanded at all
+        // this means that one final attempt to deserialize will always be made with the buffer at maxAllocation
         if (buffer.ensureWritable(preferredSize, true) == 1) {
             decompressionBufferExhausted(buffer);
             throw new DecompressionException("Decompression buffer has reached maximum size: " + buffer.maxCapacity());

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
@@ -16,6 +16,8 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
 /**
@@ -24,8 +26,62 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 public abstract class ZlibDecoder extends ByteToMessageDecoder {
 
     /**
+     * Maximum allowed size of the decompression buffer.
+     */
+    protected int maxAllocation;
+
+    /**
+     * Same as {@link #ZlibDecoder(int)} with maxAllocation = 0.
+     */
+    public ZlibDecoder() {
+        this(0);
+    }
+
+    /**
+     * Construct a new ZlibDecoder.
+     * @param maxAllocation
+     *          Maximum size of the decompression buffer. Must be &gt;= 0.
+     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
+     */
+    public ZlibDecoder(int maxAllocation) {
+        if (maxAllocation < 0) {
+            throw new IllegalArgumentException("maxAllocation must be >= 0");
+        }
+        this.maxAllocation = maxAllocation;
+    }
+
+    /**
      * Returns {@code true} if and only if the end of the compressed stream
      * has been reached.
      */
     public abstract boolean isClosed();
+
+    /**
+     * Allocate or expand the decompression buffer, without exceeding the maximum allocation.
+     * Calls {@link #maxAllocationReached(ByteBuf)} if the buffer is full and cannot be expanded further.
+     */
+    protected ByteBuf prepareDecompressBuffer(ChannelHandlerContext ctx, ByteBuf buffer, int preferredSize) {
+        if (buffer == null) {
+            if (maxAllocation == 0) {
+                return ctx.alloc().heapBuffer(preferredSize);
+            } else {
+                return ctx.alloc().heapBuffer(Math.min(preferredSize, maxAllocation), maxAllocation);
+            }
+        }
+
+        if (buffer.ensureWritable(preferredSize, true) == 1) {
+            return maxAllocationReached(buffer);
+        }
+
+        return buffer;
+    }
+
+    /**
+     * Called when the decompression buffer cannot be expanded further.
+     * Default implementation throws an exception, but subclasses can override to change behavior.
+     */
+    protected ByteBuf maxAllocationReached(ByteBuf buffer) {
+        throw new DecompressionException("Decompression buffer has reached maximum size: " + buffer.maxCapacity());
+    }
+
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
@@ -33,7 +33,7 @@ public abstract class ZlibDecoder extends ByteToMessageDecoder {
     /**
      * Same as {@link #ZlibDecoder(int)} with maxAllocation = 0.
      */
-    protected ZlibDecoder() {
+    public ZlibDecoder() {
         this(0);
     }
 
@@ -43,7 +43,7 @@ public abstract class ZlibDecoder extends ByteToMessageDecoder {
      *          Maximum size of the decompression buffer. Must be &gt;= 0.
      *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      */
-    protected ZlibDecoder(int maxAllocation) {
+    public ZlibDecoder(int maxAllocation) {
         if (maxAllocation < 0) {
             throw new IllegalArgumentException("maxAllocation must be >= 0");
         }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
@@ -83,6 +83,8 @@ public abstract class ZlibDecoder extends ByteToMessageDecoder {
      * do something before the {@link DecompressionException} is thrown, such as log the
      * data that was decompressed so far.
      */
-    protected void decompressionBufferExhausted(ByteBuf buffer) {}
+    protected void decompressionBufferExhausted(ByteBuf buffer) {
+
+    }
 
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/JZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JZlibTest.java
@@ -23,7 +23,7 @@ public class JZlibTest extends ZlibTest {
     }
 
     @Override
-    protected ZlibDecoder createDecoder(ZlibWrapper wrapper) {
-        return new JZlibDecoder(wrapper);
+    protected ZlibDecoder createDecoder(ZlibWrapper wrapper, int maxAllocation) {
+        return new JZlibDecoder(wrapper, maxAllocation);
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -38,8 +38,8 @@ public class JdkZlibTest extends ZlibTest {
     }
 
     @Override
-    protected ZlibDecoder createDecoder(ZlibWrapper wrapper) {
-        return new JdkZlibDecoder(wrapper);
+    protected ZlibDecoder createDecoder(ZlibWrapper wrapper, int maxAllocation) {
+        return new JdkZlibDecoder(wrapper, maxAllocation);
     }
 
     @Test(expected = DecompressionException.class)

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest1.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest1.java
@@ -23,7 +23,7 @@ public class ZlibCrossTest1 extends ZlibTest {
     }
 
     @Override
-    protected ZlibDecoder createDecoder(ZlibWrapper wrapper) {
-        return new JZlibDecoder(wrapper);
+    protected ZlibDecoder createDecoder(ZlibWrapper wrapper, int maxAllocation) {
+        return new JZlibDecoder(wrapper, maxAllocation);
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
@@ -25,8 +25,8 @@ public class ZlibCrossTest2 extends ZlibTest {
     }
 
     @Override
-    protected ZlibDecoder createDecoder(ZlibWrapper wrapper) {
-        return new JdkZlibDecoder(wrapper);
+    protected ZlibDecoder createDecoder(ZlibWrapper wrapper, int maxAllocation) {
+        return new JdkZlibDecoder(wrapper, maxAllocation);
     }
 
     @Test(expected = DecompressionException.class)

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -354,7 +354,8 @@ public abstract class ZlibTest {
     @Test
     public void testMaxAllocation() throws Exception {
         int maxAllocation = 1024;
-        EmbeddedChannel chDecoder = new EmbeddedChannel(createDecoder(ZlibWrapper.NONE, maxAllocation));
+        ZlibDecoder decoder = createDecoder(ZlibWrapper.NONE, maxAllocation);
+        EmbeddedChannel chDecoder = new EmbeddedChannel(decoder);
         TestByteBufAllocator alloc = new TestByteBufAllocator(chDecoder.alloc());
         chDecoder.config().setAllocator(alloc);
 
@@ -363,6 +364,8 @@ public abstract class ZlibTest {
             fail("decompressed size > maxAllocation, so should have thrown exception");
         } catch (DecompressionException e) {
             assertEquals(maxAllocation, alloc.getMaxAllocation());
+            assertTrue(decoder.isClosed());
+            assertFalse(chDecoder.finish());
         }
     }
 
@@ -382,7 +385,7 @@ public abstract class ZlibTest {
         return out.toByteArray();
     }
 
-    private static class TestByteBufAllocator extends AbstractByteBufAllocator {
+    private static final class TestByteBufAllocator extends AbstractByteBufAllocator {
         private ByteBufAllocator wrapped;
         private int maxAllocation;
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -386,7 +386,7 @@ public abstract class ZlibTest {
         private ByteBufAllocator wrapped;
         private int maxAllocation;
 
-        public TestByteBufAllocator(ByteBufAllocator wrapped) {
+        TestByteBufAllocator(ByteBufAllocator wrapped) {
             this.wrapped = wrapped;
         }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -354,15 +354,16 @@ public abstract class ZlibTest {
     @Test
     public void testMaxAllocation() throws Exception {
         int maxAllocation = 1024;
-        ZlibDecoder decoder = createDecoder(ZlibWrapper.NONE, maxAllocation);
+        ZlibDecoder decoder = createDecoder(ZlibWrapper.ZLIB, maxAllocation);
         EmbeddedChannel chDecoder = new EmbeddedChannel(decoder);
         TestByteBufAllocator alloc = new TestByteBufAllocator(chDecoder.alloc());
         chDecoder.config().setAllocator(alloc);
 
         try {
-            chDecoder.writeInbound(Unpooled.copiedBuffer(BYTES_LARGE));
+            chDecoder.writeInbound(Unpooled.wrappedBuffer(deflate(BYTES_LARGE)));
             fail("decompressed size > maxAllocation, so should have thrown exception");
         } catch (DecompressionException e) {
+            assertTrue(e.getMessage().startsWith("Decompression buffer has reached maximum size"));
             assertEquals(maxAllocation, alloc.getMaxAllocation());
             assertTrue(decoder.isClosed());
             assertFalse(chDecoder.finish());


### PR DESCRIPTION
Motivation:
It is impossible to know in advance how much memory will be needed to
decompress a stream of bytes that was compressed using the DEFLATE
algorithm. In theory, up to 1032 times the compressed size could be
needed. For untrusted input, an attacker could exploit this to exhaust
the memory pool.

Modifications:
ZlibDecoder and its subclasses now support an optional limit on the size
of the decompressed buffer. By default, if the limit is reached,
decompression stops and a DecompressionException is thrown. Behavior
upon reaching the limit is modifiable by subclasses in case they desire
something else.

Result:
The decompressed buffer can now be limited to a configurable size, thus
mitigating the possibility of memory pool exhaustion.

This fixes #6168 for JZlibDecoder and JdkZlibDecoder.