### PR TITLE
Fix event loop hang in SniHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
@@ -153,8 +153,9 @@ public abstract class AbstractSniHandler<T> extends ByteToMessageDecoder impleme
                                     select(ctx, extractSniHostname(handshakeBuffer, 0, handshakeLength));
                                     return;
                                 }
+                                break;
                             }
-                            break;
+                            // fall-through
                         default:
                             // not tls, ssl or application data, do not try sni
                             select(ctx, null);

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -320,7 +320,7 @@ public class SniHandlerTest {
                 ch.writeInbound(Unpooled.wrappedBuffer(message));
                 // TODO(scott): This should fail because the engine should reject zero length records during handshake.
                 // See https://github.com/netty/netty/issues/6348.
-                // fail();
+                fail();
             } catch (Exception e) {
                 // expected
             }
@@ -359,6 +359,7 @@ public class SniHandlerTest {
             try {
                 // Push the handshake message.
                 ch.writeInbound(Unpooled.wrappedBuffer(message));
+                fail();
             } catch (Exception e) {
                 // expected
             }


### PR DESCRIPTION
Motivation

A bug was introduced in #9806 which looks likely to be the cause of #9919. `SniHandler` will enter an infinite loop if an SSL record is received with SSL major version byte != 3 (i.e. something other than TLS or SSL3.0)

Modifications

- Follow default path as intended  for `majorVersion != 3` in `AbstractSniHandler#decode(...)`
- Add unit test to reproduce the hang

Result

Fixes #9919