### PR TITLE
Fix SimpleChannelPoolTest#testCloseAsync() test flake

### DIFF
--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -334,8 +334,8 @@ public class SimpleChannelPoolTest {
         final SimpleChannelPool pool = new SimpleChannelPool(bootstrap, new CountingChannelPoolHandler());
         Channel ch1 = pool.acquire().syncUninterruptibly().getNow();
         Channel ch2 = pool.acquire().syncUninterruptibly().getNow();
-        pool.release(ch1);
-        pool.release(ch2);
+        pool.release(ch1).get(1, TimeUnit.SECONDS);
+        pool.release(ch2).get(1, TimeUnit.SECONDS);
 
         // Assert that returned channels are open before close
         assertTrue(ch1.isOpen());


### PR DESCRIPTION
Motivation

This test is failing intermittently and upon inspection has a race condition.

Modification

Fix race condition by waiting for async release calls to complete prior to closing the pool.

Result

Hopefully fixed flaky test