### PR TITLE
Add ResolveAddressHandler which can be used to resolve addresses on t…

### DIFF
--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -42,6 +42,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-resolver</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/handler/src/main/java/io/netty/handler/address/ResolveAddressHandler.java
+++ b/handler/src/main/java/io/netty/handler/address/ResolveAddressHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.address;
+
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.internal.ObjectUtil;
+
+import java.net.SocketAddress;
+
+/**
+ * {@link ChannelOutboundHandlerAdapter} which will resolve the {@link SocketAddress} that is passed to
+ * {@link #connect(ChannelHandlerContext, SocketAddress, SocketAddress, ChannelPromise)} if it is not already resolved
+ * and the {@link AddressResolver} supports the type of {@link SocketAddress}.
+ */
+@Sharable
+public class ResolveAddressHandler extends ChannelOutboundHandlerAdapter {
+
+    private final AddressResolverGroup<? extends SocketAddress> resolverGroup;
+
+    public ResolveAddressHandler(AddressResolverGroup<? extends SocketAddress> resolverGroup) {
+        this.resolverGroup = ObjectUtil.checkNotNull(resolverGroup, "resolverGroup");
+    }
+
+    @Override
+    public void connect(final ChannelHandlerContext ctx, SocketAddress remoteAddress,
+                        final SocketAddress localAddress, final ChannelPromise promise)  {
+        AddressResolver<? extends SocketAddress> resolver = resolverGroup.getResolver(ctx.executor());
+        if (resolver.isSupported(remoteAddress) && !resolver.isResolved(remoteAddress)) {
+            resolver.resolve(remoteAddress).addListener(new FutureListener<SocketAddress>() {
+                @Override
+                public void operationComplete(Future<SocketAddress> future) {
+                    Throwable cause = future.cause();
+                    if (cause != null) {
+                        promise.setFailure(cause);
+                    } else {
+                        ctx.connect(future.getNow(), localAddress, promise);
+                    }
+                    ctx.pipeline().remove(ResolveAddressHandler.this);
+                }
+            });
+        } else {
+            ctx.connect(remoteAddress, localAddress, promise);
+            ctx.pipeline().remove(this);
+        }
+    }
+}

--- a/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.address;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+import io.netty.resolver.AbstractAddressResolver;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class ResolveAddressHandlerTest {
+
+    private static final LocalAddress UNRESOLVED = new LocalAddress("unresolved-" + UUID.randomUUID().toString());
+    private static final LocalAddress RESOLVED = new LocalAddress("resolved-" + UUID.randomUUID().toString());
+    private static final Exception ERROR = new UnknownHostException();
+
+    private static EventLoopGroup group;
+
+    @BeforeClass
+    public static void createEventLoop() {
+        group = new DefaultEventLoopGroup();
+    }
+
+    @AfterClass
+    public static void destroyEventLoop() {
+        if (group != null) {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testResolveSuccessful() {
+        testResolve(false);
+    }
+
+    @Test
+    public void testResolveFails() {
+        testResolve(true);
+    }
+
+    private static void testResolve(boolean fail) {
+        AddressResolverGroup<SocketAddress> resolverGroup = new TestResolverGroup(fail);
+        Bootstrap cb = new Bootstrap();
+        cb.group(group).channel(LocalChannel.class).handler(new ResolveAddressHandler(resolverGroup));
+
+        ServerBootstrap sb = new ServerBootstrap();
+        sb.group(group)
+                .channel(LocalServerChannel.class)
+                .childHandler(new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelActive(ChannelHandlerContext ctx) {
+                        ctx.close();
+                    }
+                });
+
+        // Start server
+        Channel sc = sb.bind(RESOLVED).syncUninterruptibly().channel();
+        ChannelFuture future = cb.connect(UNRESOLVED).awaitUninterruptibly();
+        try {
+            if (fail) {
+                assertSame(ERROR, future.cause());
+            } else {
+                assertTrue(future.isSuccess());
+            }
+            future.channel().close().syncUninterruptibly();
+        } finally {
+            future.channel().close().syncUninterruptibly();
+            sc.close().syncUninterruptibly();
+            resolverGroup.close();
+        }
+    }
+
+    private static final class TestResolverGroup extends AddressResolverGroup<SocketAddress> {
+        private final boolean fail;
+
+        TestResolverGroup(boolean fail) {
+            this.fail = fail;
+        }
+
+        @Override
+        protected AddressResolver<SocketAddress> newResolver(EventExecutor executor) {
+            return new AbstractAddressResolver<SocketAddress>(executor) {
+                @Override
+                protected boolean doIsResolved(SocketAddress address) {
+                    return address == RESOLVED;
+                }
+
+                @Override
+                protected void doResolve(SocketAddress unresolvedAddress, Promise<SocketAddress> promise) {
+                    assertSame(UNRESOLVED, unresolvedAddress);
+                    if (fail) {
+                        promise.setFailure(ERROR);
+                    } else {
+                        promise.setSuccess(RESOLVED);
+                    }
+                }
+
+                @Override
+                protected void doResolveAll(SocketAddress unresolvedAddress, Promise<List<SocketAddress>> promise) {
+                    fail();
+                }
+            };
+        }
+    };
+}


### PR DESCRIPTION
…he fly

Motivation:

At the moment resolving addresses during connect is done via setting an AddressResolverGroup on the Bootstrap. While this works most of the times as expected sometimes the user want to trigger the connect() from the Channel itself and not via the Bootstrap. For this cases we should provide a ChannelHandler that the user can use that will do the resolution.

Modifications:

Add ResolveAddressHandler and tests

Result:

Be able to resolve addresses without Bootstrap

