### PR TITLE
Close encoder when handlerRemoved.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/LzfEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzfEncoder.java
@@ -137,4 +137,10 @@ public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
             recycler.releaseInputBuffer(input);
         }
     }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        encoder.close();
+        super.handlerRemoved(ctx);
+    }
 }


### PR DESCRIPTION
Motivation:

We should close encoder when `LzfEncoder` was removed from pipeline.

Modification:

call `encoder.close` when `handlerRemoved` triggered.

Result:

Close encoder to release internal buffer.