### PR TITLE
Remove extra field from ChunkedWriteHandler to make it less error-prone

### DIFF
--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -72,7 +72,6 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
 
     private final Queue<PendingWrite> queue = new ArrayDeque<PendingWrite>();
     private volatile ChannelHandlerContext ctx;
-    private PendingWrite currentWrite;
 
     public ChunkedWriteHandler() {
     }
@@ -150,13 +149,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
 
     private void discard(Throwable cause) {
         for (;;) {
-            PendingWrite currentWrite = this.currentWrite;
-
-            if (this.currentWrite == null) {
-                currentWrite = queue.poll();
-            } else {
-                this.currentWrite = null;
-            }
+            PendingWrite currentWrite = queue.poll();
 
             if (currentWrite == null) {
                 break;
@@ -206,9 +199,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
         boolean requiresFlush = true;
         ByteBufAllocator allocator = ctx.alloc();
         while (channel.isWritable()) {
-            if (currentWrite == null) {
-                currentWrite = queue.poll();
-            }
+            final PendingWrite currentWrite = queue.peek();
 
             if (currentWrite == null) {
                 break;
@@ -224,11 +215,10 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                 // as this had to be done already by someone who resolved the
                 // promise (using ChunkedInput.close method).
                 // See https://github.com/netty/netty/issues/8700.
-                this.currentWrite = null;
+                queue.remove();
                 continue;
             }
 
-            final PendingWrite currentWrite = this.currentWrite;
             final Object pendingMessage = currentWrite.msg;
 
             if (pendingMessage instanceof ChunkedInput) {
@@ -247,7 +237,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                         suspend = false;
                     }
                 } catch (final Throwable t) {
-                    this.currentWrite = null;
+                    queue.remove();
 
                     if (message != null) {
                         ReferenceCountUtil.release(message);
@@ -273,7 +263,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
 
                 ChannelFuture f = ctx.write(message);
                 if (endOfInput) {
-                    this.currentWrite = null;
+                    queue.remove();
 
                     // Register a listener which will close the input once the write is complete.
                     // This is needed because the Chunk may have some resource bound that can not
@@ -328,7 +318,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                 ctx.flush();
                 requiresFlush = false;
             } else {
-                this.currentWrite = null;
+                queue.remove();
                 ctx.write(pendingMessage, currentWrite.promise);
                 requiresFlush = true;
             }


### PR DESCRIPTION
Motivation:

At the moment we use an extra field in ChunedWriteHandler to hold the current write. This is not needed and makes sense even more error-prone. We can just peek in the queue.

Modifications:

Use Queue.peek() to keep track of current write

Result:

Less error-prone code