### PR TITLE
Initialize some classes at runtime to improve GraalVM support

### DIFF
--- a/common/src/main/resources/META-INF/native-image/io.netty/common/native-image.properties
+++ b/common/src/main/resources/META-INF/native-image/io.netty/common/native-image.properties
@@ -12,4 +12,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-Args = --initialize-at-run-time=io.netty.util.AbstractReferenceCounted
+Args = --initialize-at-run-time=io.netty.util.AbstractReferenceCounted,io.netty.util.concurrent.GlobalEventExecutor,io.netty.util.concurrent.ImmediateEventExecutor,io.netty.util.concurrent.ScheduledFutureTask


### PR DESCRIPTION
Motivation:

Deploying a Micronaut application as GraalVM native image to AWS Lambda with custom runtime fails when using Micronaut Http Client.

This PR initializes at runtime some classes needed to fix the issue. There is more information in our original issue in Micronaut https://github.com/micronaut-projects/micronaut-core/issues/2335#issuecomment-570151944

At this moment I've added those classes into Micronaut (https://github.com/micronaut-projects/micronaut-core/pull/2680/commits/b383d3ab14a8fb9368758f889f361e76994ac963) as a workaround but this should be included in Netty so it's available for everyone.

Modification:

Mark 3 classes to be initialized at runtime for GraalVM.

Result:

Mark 3 classes to be initialized at runtime for GraalVM.
