### PR TITLE
Use latest java 11 version when building via docker

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.11.0-5"
+        java_version : "adopt@1.11.0-6"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.openj9111.yaml
+++ b/docker/docker-compose.centos-6.openj9111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt-openj9@1.11.0-5"
+        java_version : "adopt-openj9@1.11.0-6"
 
   test:
     image: netty:centos-6-openj9-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.11.0-5"
+        java_version : "adopt@1.11.0-6"
 
   test:
     image: netty:centos-7-1.11


### PR DESCRIPTION
Motivation:

We should update the used java11 version when building via docker to the latest release

Modifications:

Update to 1.11.0-6

Result:

Use latest java11 version