### PR TITLE
Simplify ClearTextHttp2ServerUpgradeHandler internals

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandler.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http.HttpServerCodec;
@@ -39,7 +38,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * prior knowledge or not.
  */
 @UnstableApi
-public final class CleartextHttp2ServerUpgradeHandler extends ChannelHandlerAdapter {
+public final class CleartextHttp2ServerUpgradeHandler extends ByteToMessageDecoder {
     private static final ByteBuf CONNECTION_PREFACE = unreleasableBuffer(connectionPrefaceBuf());
 
     private final HttpServerCodec httpServerCodec;
@@ -64,38 +63,27 @@ public final class CleartextHttp2ServerUpgradeHandler extends ChannelHandlerAdap
     }
 
     @Override
-    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        ctx.pipeline()
-           .addBefore(ctx.name(), null, new PriorKnowledgeHandler())
-           .addBefore(ctx.name(), null, httpServerCodec)
-           .replace(this, null, httpServerUpgradeHandler);
-    }
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        int prefaceLength = CONNECTION_PREFACE.readableBytes();
+        int bytesRead = Math.min(in.readableBytes(), prefaceLength);
+        //
+        // Peek inbound message to determine current connection wants to start HTTP/2
+        // by HTTP upgrade or prior knowledge
+        if (!ByteBufUtil.equals(CONNECTION_PREFACE, CONNECTION_PREFACE.readerIndex(),
+                in, in.readerIndex(), bytesRead)) {
 
-    /**
-     * Peek inbound message to determine current connection wants to start HTTP/2
-     * by HTTP upgrade or prior knowledge
-     */
-    private final class PriorKnowledgeHandler extends ByteToMessageDecoder {
-        @Override
-        protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-            int prefaceLength = CONNECTION_PREFACE.readableBytes();
-            int bytesRead = Math.min(in.readableBytes(), prefaceLength);
+            // no prior knowledge used.
+            ctx.pipeline()
+                    .addAfter(ctx.name(), null, httpServerUpgradeHandler)
+                    .addAfter(ctx.name(), null, httpServerCodec);
 
-            if (!ByteBufUtil.equals(CONNECTION_PREFACE, CONNECTION_PREFACE.readerIndex(),
-                                    in, in.readerIndex(), bytesRead)) {
-                ctx.pipeline().remove(this);
-            } else if (bytesRead == prefaceLength) {
-                // Full h2 preface match, removed source codec, using http2 codec to handle
-                // following network traffic
-                ctx.pipeline()
-                   .remove(httpServerCodec)
-                   .remove(httpServerUpgradeHandler);
-
-                ctx.pipeline().addAfter(ctx.name(), null, http2ServerHandler);
-                ctx.pipeline().remove(this);
-
-                ctx.fireUserEventTriggered(PriorKnowledgeUpgradeEvent.INSTANCE);
-            }
+            ctx.pipeline().remove(this);
+        } else if (bytesRead == prefaceLength) {
+            // Full h2 preface match, removed source codec, using http2 codec to handle
+            // following network traffic
+            ctx.pipeline().addAfter(ctx.name(), null, http2ServerHandler);
+            ctx.fireUserEventTriggered(PriorKnowledgeUpgradeEvent.INSTANCE);
+            ctx.pipeline().remove(this);
         }
     }
 


### PR DESCRIPTION
Motivation:

ClearTextHttp2ServerUpgradeHandler currently adds three handlers to the pipeline and remove itself as soon as it is added to the pipeline. This can be simplified to reduce the pipeline operations and also make the usage pattern a bit less odd.

Modifications:

- Let ClearTextHttp2ServerUpgradeHandler extend ByteToMessageDecoder and directly handle the prior knewledge detection in it.
- Only add the extra handlers once the detection is done and then remove itself from the pipeline

Result:

Cleaner code and less pipeline operations