### PR TITLE
Cleanup: Use compile time constants instead of static field in WebSocketServer…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolConfig.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.ObjectUtil;
 
 import java.net.URI;
 
+import static io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig.DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
@@ -29,9 +30,10 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
  */
 public final class WebSocketClientProtocolConfig {
 
-    static final WebSocketClientProtocolConfig DEFAULT = new WebSocketClientProtocolConfig(
-        URI.create("https://localhost/"), null, WebSocketVersion.V13, false, EmptyHttpHeaders.INSTANCE,
-        65536, true, false, true, WebSocketCloseStatus.NORMAL_CLOSURE, true, 10000L, -1, false);
+    static final boolean DEFAULT_PERFORM_MASKING = true;
+    static final boolean DEFAULT_ALLOW_MASK_MISMATCH = false;
+    static final boolean DEFAULT_HANDLE_CLOSE_FRAMES = true;
+    static final boolean DEFAULT_DROP_PONG_FRAMES = true;
 
     private final URI webSocketUri;
     private final String subprotocol;
@@ -161,7 +163,21 @@ public final class WebSocketClientProtocolConfig {
     }
 
     public static Builder newBuilder() {
-        return new Builder(DEFAULT);
+        return new Builder(
+                URI.create("https://localhost/"),
+                null,
+                WebSocketVersion.V13,
+                false,
+                EmptyHttpHeaders.INSTANCE,
+                65536,
+                DEFAULT_PERFORM_MASKING,
+                DEFAULT_ALLOW_MASK_MISMATCH,
+                DEFAULT_HANDLE_CLOSE_FRAMES,
+                WebSocketCloseStatus.NORMAL_CLOSURE,
+                DEFAULT_DROP_PONG_FRAMES,
+                DEFAULT_HANDSHAKE_TIMEOUT_MILLIS,
+                -1,
+                false);
     }
 
     public static final class Builder {
@@ -181,22 +197,50 @@ public final class WebSocketClientProtocolConfig {
         private boolean absoluteUpgradeUrl;
 
         private Builder(WebSocketClientProtocolConfig clientConfig) {
-            ObjectUtil.checkNotNull(clientConfig, "clientConfig");
+            this(ObjectUtil.checkNotNull(clientConfig, "clientConfig").webSocketUri(),
+                 clientConfig.subprotocol(),
+                 clientConfig.version(),
+                 clientConfig.allowExtensions(),
+                 clientConfig.customHeaders(),
+                 clientConfig.maxFramePayloadLength(),
+                 clientConfig.performMasking(),
+                 clientConfig.allowMaskMismatch(),
+                 clientConfig.handleCloseFrames(),
+                 clientConfig.sendCloseFrame(),
+                 clientConfig.dropPongFrames(),
+                 clientConfig.handshakeTimeoutMillis(),
+                 clientConfig.forceCloseTimeoutMillis(),
+                 clientConfig.absoluteUpgradeUrl());
+        }
 
-            webSocketUri = clientConfig.webSocketUri();
-            subprotocol = clientConfig.subprotocol();
-            version = clientConfig.version();
-            allowExtensions = clientConfig.allowExtensions();
-            customHeaders = clientConfig.customHeaders();
-            maxFramePayloadLength = clientConfig.maxFramePayloadLength();
-            performMasking = clientConfig.performMasking();
-            allowMaskMismatch = clientConfig.allowMaskMismatch();
-            handleCloseFrames = clientConfig.handleCloseFrames();
-            sendCloseFrame = clientConfig.sendCloseFrame();
-            dropPongFrames = clientConfig.dropPongFrames();
-            handshakeTimeoutMillis = clientConfig.handshakeTimeoutMillis();
-            forceCloseTimeoutMillis = clientConfig.forceCloseTimeoutMillis();
-            absoluteUpgradeUrl = clientConfig.absoluteUpgradeUrl();
+        private Builder(URI webSocketUri,
+                        String subprotocol,
+                        WebSocketVersion version,
+                        boolean allowExtensions,
+                        HttpHeaders customHeaders,
+                        int maxFramePayloadLength,
+                        boolean performMasking,
+                        boolean allowMaskMismatch,
+                        boolean handleCloseFrames,
+                        WebSocketCloseStatus sendCloseFrame,
+                        boolean dropPongFrames,
+                        long handshakeTimeoutMillis,
+                        long forceCloseTimeoutMillis,
+                        boolean absoluteUpgradeUrl) {
+            this.webSocketUri = webSocketUri;
+            this.subprotocol = subprotocol;
+            this.version = version;
+            this.allowExtensions = allowExtensions;
+            this.customHeaders = customHeaders;
+            this.maxFramePayloadLength = maxFramePayloadLength;
+            this.performMasking = performMasking;
+            this.allowMaskMismatch = allowMaskMismatch;
+            this.handleCloseFrames = handleCloseFrames;
+            this.sendCloseFrame = sendCloseFrame;
+            this.dropPongFrames = dropPongFrames;
+            this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+            this.forceCloseTimeoutMillis = forceCloseTimeoutMillis;
+            this.absoluteUpgradeUrl = absoluteUpgradeUrl;
         }
 
         /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -23,7 +23,11 @@ import io.netty.handler.codec.http.HttpHeaders;
 import java.net.URI;
 import java.util.List;
 
-import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT;
+import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT_ALLOW_MASK_MISMATCH;
+import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT_DROP_PONG_FRAMES;
+import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT_HANDLE_CLOSE_FRAMES;
+import static io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig.DEFAULT_PERFORM_MASKING;
+import static io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig.DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
 import static io.netty.util.internal.ObjectUtil.*;
 
 /**
@@ -124,7 +128,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
                                           int maxFramePayloadLength, boolean handleCloseFrames,
                                           boolean performMasking, boolean allowMaskMismatch) {
         this(webSocketURL, version, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength,
-            handleCloseFrames, performMasking, allowMaskMismatch, DEFAULT.handshakeTimeoutMillis());
+            handleCloseFrames, performMasking, allowMaskMismatch, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     /**
@@ -185,7 +189,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
                                                    boolean allowExtensions, HttpHeaders customHeaders,
                                                    int maxFramePayloadLength, boolean handleCloseFrames) {
         this(webSocketURL, version, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength,
-             handleCloseFrames, DEFAULT.handshakeTimeoutMillis());
+             handleCloseFrames, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     /**
@@ -212,7 +216,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
                                           boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength,
                                           boolean handleCloseFrames, long handshakeTimeoutMillis) {
         this(webSocketURL, version, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength,
-             handleCloseFrames, DEFAULT.performMasking(), DEFAULT.allowMaskMismatch(), handshakeTimeoutMillis);
+             handleCloseFrames, DEFAULT_PERFORM_MASKING, DEFAULT_ALLOW_MASK_MISMATCH, handshakeTimeoutMillis);
     }
 
     /**
@@ -234,7 +238,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
                                           boolean allowExtensions, HttpHeaders customHeaders,
                                           int maxFramePayloadLength) {
         this(webSocketURL, version, subprotocol, allowExtensions,
-             customHeaders, maxFramePayloadLength, DEFAULT.handshakeTimeoutMillis());
+             customHeaders, maxFramePayloadLength, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     /**
@@ -259,7 +263,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
                                           boolean allowExtensions, HttpHeaders customHeaders,
                                           int maxFramePayloadLength, long handshakeTimeoutMillis) {
         this(webSocketURL, version, subprotocol, allowExtensions, customHeaders,
-             maxFramePayloadLength, DEFAULT.handleCloseFrames(), handshakeTimeoutMillis);
+             maxFramePayloadLength, DEFAULT_HANDLE_CLOSE_FRAMES, handshakeTimeoutMillis);
     }
 
     /**
@@ -272,7 +276,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            {@code true} if close frames should not be forwarded and just close the channel
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames) {
-        this(handshaker, handleCloseFrames, DEFAULT.handshakeTimeoutMillis());
+        this(handshaker, handleCloseFrames, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     /**
@@ -289,7 +293,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           long handshakeTimeoutMillis) {
-        this(handshaker, handleCloseFrames, DEFAULT.dropPongFrames(), handshakeTimeoutMillis);
+        this(handshaker, handleCloseFrames, DEFAULT_DROP_PONG_FRAMES, handshakeTimeoutMillis);
     }
 
     /**
@@ -305,7 +309,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
                                           boolean dropPongFrames) {
-        this(handshaker, handleCloseFrames, dropPongFrames, DEFAULT.handshakeTimeoutMillis());
+        this(handshaker, handleCloseFrames, dropPongFrames, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     /**
@@ -340,7 +344,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            was established to the remote peer.
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker) {
-        this(handshaker, DEFAULT.handshakeTimeoutMillis());
+        this(handshaker, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     /**
@@ -354,7 +358,7 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            event {@link ClientHandshakeStateEvent#HANDSHAKE_TIMEOUT}
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, long handshakeTimeoutMillis) {
-        this(handshaker, DEFAULT.handleCloseFrames(), handshakeTimeoutMillis);
+        this(handshaker, DEFAULT_HANDLE_CLOSE_FRAMES, handshakeTimeoutMillis);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolConfig.java
@@ -25,8 +25,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
  */
 public final class WebSocketServerProtocolConfig {
 
-    static final WebSocketServerProtocolConfig DEFAULT = new WebSocketServerProtocolConfig(
-        "/", null, false, 10000L, 0, true, WebSocketCloseStatus.NORMAL_CLOSURE, true, WebSocketDecoderConfig.DEFAULT);
+    static final long DEFAULT_HANDSHAKE_TIMEOUT_MILLIS = 10000L;
 
     private final String websocketPath;
     private final String subprotocols;
@@ -116,7 +115,8 @@ public final class WebSocketServerProtocolConfig {
     }
 
     public static Builder newBuilder() {
-        return new Builder(DEFAULT);
+        return new Builder("/", null, false, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS, 0L,
+                           true, WebSocketCloseStatus.NORMAL_CLOSURE, true, WebSocketDecoderConfig.DEFAULT);
     }
 
     public static final class Builder {
@@ -132,16 +132,36 @@ public final class WebSocketServerProtocolConfig {
         private WebSocketDecoderConfig.Builder decoderConfigBuilder;
 
         private Builder(WebSocketServerProtocolConfig serverConfig) {
-            ObjectUtil.checkNotNull(serverConfig, "serverConfig");
-            websocketPath = serverConfig.websocketPath();
-            subprotocols = serverConfig.subprotocols();
-            checkStartsWith = serverConfig.checkStartsWith();
-            handshakeTimeoutMillis = serverConfig.handshakeTimeoutMillis();
-            forceCloseTimeoutMillis = serverConfig.forceCloseTimeoutMillis();
-            handleCloseFrames = serverConfig.handleCloseFrames();
-            sendCloseFrame = serverConfig.sendCloseFrame();
-            dropPongFrames = serverConfig.dropPongFrames();
-            decoderConfig = serverConfig.decoderConfig();
+            this(ObjectUtil.checkNotNull(serverConfig, "serverConfig").websocketPath(),
+                 serverConfig.subprotocols(),
+                 serverConfig.checkStartsWith(),
+                 serverConfig.handshakeTimeoutMillis(),
+                 serverConfig.forceCloseTimeoutMillis(),
+                 serverConfig.handleCloseFrames(),
+                 serverConfig.sendCloseFrame(),
+                 serverConfig.dropPongFrames(),
+                 serverConfig.decoderConfig()
+            );
+        }
+
+        private Builder(String websocketPath,
+                        String subprotocols,
+                        boolean checkStartsWith,
+                        long handshakeTimeoutMillis,
+                        long forceCloseTimeoutMillis,
+                        boolean handleCloseFrames,
+                        WebSocketCloseStatus sendCloseFrame,
+                        boolean dropPongFrames,
+                        WebSocketDecoderConfig decoderConfig) {
+            this.websocketPath = websocketPath;
+            this.subprotocols = subprotocols;
+            this.checkStartsWith = checkStartsWith;
+            this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+            this.forceCloseTimeoutMillis = forceCloseTimeoutMillis;
+            this.handleCloseFrames = handleCloseFrames;
+            this.sendCloseFrame = sendCloseFrame;
+            this.dropPongFrames = dropPongFrames;
+            this.decoderConfig = decoderConfig;
         }
 
         /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -29,9 +29,9 @@ import io.netty.util.AttributeKey;
 
 import java.util.List;
 
-import static io.netty.handler.codec.http.HttpVersion.*;
-import static io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig.DEFAULT;
-import static io.netty.util.internal.ObjectUtil.*;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig.DEFAULT_HANDSHAKE_TIMEOUT_MILLIS;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * This handler does all the heavy lifting for you to run a websocket server.
@@ -118,7 +118,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     public WebSocketServerProtocolHandler(String websocketPath) {
-        this(websocketPath, DEFAULT.handshakeTimeoutMillis());
+        this(websocketPath, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, long handshakeTimeoutMillis) {
@@ -126,7 +126,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, boolean checkStartsWith) {
-        this(websocketPath, checkStartsWith, DEFAULT.handshakeTimeoutMillis());
+        this(websocketPath, checkStartsWith, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, boolean checkStartsWith, long handshakeTimeoutMillis) {
@@ -134,7 +134,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols) {
-        this(websocketPath, subprotocols, DEFAULT.handshakeTimeoutMillis());
+        this(websocketPath, subprotocols, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, long handshakeTimeoutMillis) {
@@ -142,7 +142,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions) {
-        this(websocketPath, subprotocols, allowExtensions, DEFAULT.handshakeTimeoutMillis());
+        this(websocketPath, subprotocols, allowExtensions, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,
@@ -152,7 +152,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
                                           boolean allowExtensions, int maxFrameSize) {
-        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, DEFAULT.handshakeTimeoutMillis());
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
@@ -163,7 +163,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch) {
         this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch,
-            DEFAULT.handshakeTimeoutMillis());
+             DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,
@@ -175,7 +175,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
         this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith,
-            DEFAULT.handshakeTimeoutMillis());
+             DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
@@ -189,7 +189,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
                                           boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch,
                                           boolean checkStartsWith, boolean dropPongFrames) {
         this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith,
-             dropPongFrames, DEFAULT.handshakeTimeoutMillis());
+             dropPongFrames, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols, boolean allowExtensions,


### PR DESCRIPTION
Motivation:

Avoid allocation of default static `WebSocketServerProtocolConfig` and `WebSocketClientProtocolConfig` configs. Prefer compile time constants instead.

Modification:

Static field with config object replaced with constructor with default fields.

Result:

No more default config allocation and static field for it. Compile time variables used instead.
