### PR TITLE
Initialize ThreadLocalRandom at runtime to improve GraalVM support

### DIFF
--- a/common/src/main/resources/META-INF/native-image/io.netty/common/native-image.properties
+++ b/common/src/main/resources/META-INF/native-image/io.netty/common/native-image.properties
@@ -12,4 +12,4 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-Args = --initialize-at-run-time=io.netty.util.AbstractReferenceCounted,io.netty.util.concurrent.GlobalEventExecutor,io.netty.util.concurrent.ImmediateEventExecutor,io.netty.util.concurrent.ScheduledFutureTask
+Args = --initialize-at-run-time=io.netty.util.AbstractReferenceCounted,io.netty.util.concurrent.GlobalEventExecutor,io.netty.util.concurrent.ImmediateEventExecutor,io.netty.util.concurrent.ScheduledFutureTask,io.netty.util.internal.ThreadLocalRandom


### PR DESCRIPTION
Motivation:

We need to initialize ThreadLocalRandom at runtime as it uses System.nanoTime() in a static block to init the seed.

Modifications:

Add io.netty.util.internal.ThreadLocalRandom to properties file

Result:

Better support for GraalVM