### PR TITLE
fix bug: scheduled tasks may not be executed

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -89,7 +89,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
                 return task;
             } else {
                 long delayNanos = scheduledTask.delayNanos();
-                Runnable task;
+                Runnable task = null;
                 if (delayNanos > 0) {
                     try {
                         task = taskQueue.poll(delayNanos, TimeUnit.NANOSECONDS);
@@ -97,11 +97,12 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
                         // Waken up.
                         return null;
                     }
-                } else {
-                    task = taskQueue.poll();
                 }
-
                 if (task == null) {
+                    // We need to fetch the scheduled tasks now as otherwise there may be a chance that
+                    // scheduled tasks are never executed if there is always one task in the taskQueue.
+                    // This is for example true for the read task of OIO Transport
+                    // See https://github.com/netty/netty/issues/1614
                     fetchFromScheduledTaskQueue();
                     task = taskQueue.poll();
                 }

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -20,10 +20,6 @@ import org.junit.Test;
 
 import io.netty.util.concurrent.AbstractEventExecutor.LazyRunnable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -34,8 +30,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class SingleThreadEventExecutorTest {
 
@@ -318,6 +318,101 @@ public class SingleThreadEventExecutorTest {
         assertEquals(attempts.get(), submittedTasks.size() + rejects.get());
         for (Future<?> f : submittedTasks) {
             assertTrue(f.isSuccess());
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void testTakeTask() throws Exception {
+        final SingleThreadEventExecutor executor =
+                new SingleThreadEventExecutor(null, Executors.defaultThreadFactory(), true) {
+            @Override
+            protected void run() {
+                while (!confirmShutdown()) {
+                    Runnable task = takeTask();
+                    if (task != null) {
+                        task.run();
+                    }
+                }
+            }
+        };
+
+        //add task
+        TestRunnable beforeTask = new TestRunnable();
+        executor.execute(beforeTask);
+
+        //add scheduled task
+        TestRunnable scheduledTask = new TestRunnable();
+        ScheduledFuture<?> f = executor.schedule(scheduledTask , 1500, TimeUnit.MILLISECONDS);
+
+        //add task
+        TestRunnable afterTask = new TestRunnable();
+        executor.execute(afterTask);
+
+        f.sync();
+
+        assertThat(beforeTask.ran.get(), is(true));
+        assertThat(scheduledTask.ran.get(), is(true));
+        assertThat(afterTask.ran.get(), is(true));
+    }
+
+    @Test(timeout = 5000)
+    public void testTakeTaskAlwaysHasTask() throws Exception {
+        //for https://github.com/netty/netty/issues/1614
+
+        final SingleThreadEventExecutor executor =
+                new SingleThreadEventExecutor(null, Executors.defaultThreadFactory(), true) {
+            @Override
+            protected void run() {
+                while (!confirmShutdown()) {
+                    Runnable task = takeTask();
+                    if (task != null) {
+                        task.run();
+                    }
+                }
+            }
+        };
+
+        //add scheduled task
+        TestRunnable t = new TestRunnable();
+        ScheduledFuture<?> f = executor.schedule(t, 1500, TimeUnit.MILLISECONDS);
+
+        final Runnable doNothing = new Runnable() {
+            @Override
+            public void run() {
+                //NOOP
+            }
+        };
+        final AtomicBoolean stop = new AtomicBoolean(false);
+
+        //ensure always has at least one task in taskQueue
+        //check if scheduled tasks are triggered
+        try {
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    while (!stop.get()) {
+                        executor.execute(doNothing);
+                    }
+                }
+            }).start();
+
+            f.sync();
+
+            assertThat(t.ran.get(), is(true));
+        } finally {
+            stop.set(true);
+        }
+    }
+
+    private static final class TestRunnable implements Runnable {
+        final AtomicBoolean ran = new AtomicBoolean();
+
+        TestRunnable() {
+        }
+
+        @Override
+        public void run() {
+            ran.set(true);
         }
     }
 }


### PR DESCRIPTION
Motivation:

same problem with #1614
If there was always a task in the taskQueue, scheduled tasks in the
scheduledTaskQueue will never be executed.

Modifications:

fix bug in GlobalEventExecutor#takeTask

Result:

fix bug