### PR TITLE
Update checkstyle to 8.29 and netty-build to 26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
     <netty.dev.tools.directory>${project.build.directory}/dev-tools</netty.dev.tools.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <netty.build.version>25</netty.build.version>
+    <netty.build.version>26</netty.build.version>
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.8</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
@@ -846,7 +846,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>check-style</id>
@@ -871,7 +871,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.18</version>
+            <version>8.29</version>
           </dependency>
           <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Motivation:

A new checkstyle version was released which fixes a security vulnerability.

Modifications:

- Update to latest checkstyle version
- Update netty-build to latest version to be compatible with latest checkstyle version

Result:

No more security vulnerability caused by checkstyle during build