### PR TITLE
Use latest checkstyle version for all artifact as well.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -269,20 +269,7 @@
               <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>netty-build</artifactId>
-                <version>19</version>
-                <exclusions>
-                  <!-- Use version 7.3 until a new netty-build release is out -->
-                  <!-- See https://issues.apache.org/jira/browse/JXR-133 -->
-                  <exclusion>
-                    <groupId>com.puppycrawl.tools</groupId>
-                    <artifactId>checkstyle</artifactId>
-                  </exclusion>
-                </exclusions>
-              </dependency>
-              <dependency>
-                <groupId>com.puppycrawl.tools</groupId>
-                <artifactId>checkstyle</artifactId>
-                <version>7.3</version>
+                <version>${netty.build.version}</version>
               </dependency>
             </dependencies>
           </plugin>


### PR DESCRIPTION
Motivation:

42aa7f0c58375c6fcdc9a3ed26b431999c63c6c7 did update the checkstyle version but missed that we declared it explicitly in the all artifact as well.

Modifications:

Remove explicit definition in the all artifact.

Result:

Use latest checkstyle version everywhere.