### PR TITLE
Added tests for Transfer-Encoding header with whitespace

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -325,7 +325,30 @@ public class HttpRequestDecoderTest {
     public void testWhitespace() {
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Transfer-Encoding : chunked\r\n" +
-                "Host: netty.io\n\r\n";
+                "Host: netty.io\r\n\r\n";
+        testInvalidHeaders0(requestStr);
+    }
+
+    @Test
+    public void testWhitespaceBeforeTransferEncoding01() {
+        String requestStr = "GET /some/path HTTP/1.1\r\n" +
+                " Transfer-Encoding : chunked\r\n" +
+                "Content-Length: 1\r\n" +
+                "Host: netty.io\r\n\r\n" +
+                "a";
+        testInvalidHeaders0(requestStr);
+    }
+
+    @Test
+    public void testWhitespaceBeforeTransferEncoding02() {
+        String requestStr = "POST / HTTP/1.1" +
+                " Transfer-Encoding : chunked\r\n" +
+                "Host: target.com" +
+                "Content-Length: 65\r\n\r\n" +
+                "0\r\n\r\n" +
+                "GET /maliciousRequest HTTP/1.1\r\n" +
+                "Host: evilServer.com\r\n" +
+                "Foo: x";
         testInvalidHeaders0(requestStr);
     }
 


### PR DESCRIPTION
Motivation:

Need tests to ensure that CVE-2020-7238 is fixed.

Modifications:

Added two test cases into `HttpRequestDecoderTest` which check that
no whitespace is allowed before the Transfer-Encoding header.

The tests are based on jdordonezn/CVE-2020-72381#1 which is mentioned in CVE-2020-7238

I have also updated `testWhitespace()` to use `\r\n\r\n` instead of `\n\r\n`. Please let me know if `\n\r\n` was used intentionally.

Result:

Improved test coverage for #9861 