### PR TITLE
Eagerly propagate GOAWAY frames from the Http2FrameCodec

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -483,6 +483,13 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 onHttp2StreamStateChanged(ctx, stream2);
             }
         }
+
+        @Override
+        public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
+            // We want to send the frame more eagerly than through the listener because the
+            // connection is going to be aggressive about closing the individual streams.
+            onHttp2Frame(ctx, new DefaultHttp2GoAwayFrame(lastStreamId, errorCode, debugData).retain());
+        }
     }
 
     @Override
@@ -606,7 +613,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
 
         @Override
         public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData) {
-            onHttp2Frame(ctx, new DefaultHttp2GoAwayFrame(lastStreamId, errorCode, debugData).retain());
+            // We do nothing as this is already handled in the ConnectionListener.
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -360,7 +360,7 @@ public class Http2FrameCodecTest {
                 if (msg instanceof Http2GoAwayFrame) {
                     wasStillOpen.set(frameCodec.connection().stream(4).state() == State.OPEN);
                 }
-                    super.channelRead(ctx, msg);
+                super.channelRead(ctx, msg);
             }
         };
         channel.pipeline().addLast(inboundHandler);


### PR DESCRIPTION
Motivation:

Users of the Http2FrameCodec are notified of inbound GoAwayFrames
after the connection has already closed any ignored streams, potentially
losing the signal that some streams may have been ignored by the peer and
are thus retryable.

Modifications:

The Http2FrameCodec more eagerly sends the Http2GoAwayFrame from the
ConnectionListener which happens before the connection closes ignored
streams.

Result:
Fixes #9986