### PR TITLE
FixedCompositeByteBuf.isDirect() may return wrong value when construc…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
@@ -49,7 +49,7 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
             order = ByteOrder.BIG_ENDIAN;
             nioBufferCount = 1;
             capacity = 0;
-            direct = false;
+            direct = Unpooled.EMPTY_BUFFER.isDirect();
         } else {
             ByteBuf b = buffers[0];
             this.buffers = buffers;

--- a/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
@@ -432,10 +432,12 @@ public class FixedCompositeByteBufTest {
     }
 
     @Test
-    public void testHasArrayWhenEmpty() {
+    public void testHasArrayWhenEmptyAndIsDirect() {
         ByteBuf buf = newBuffer(new ByteBuf[0]);
         assertTrue(buf.hasArray());
         assertArrayEquals(EMPTY_BUFFER.array(), buf.array());
+        assertEquals(EMPTY_BUFFER.isDirect(), buf.isDirect());
+        assertEquals(EMPTY_BUFFER.memoryAddress(), buf.memoryAddress());
         buf.release();
     }
 


### PR DESCRIPTION
…ted with empty array

Motivation:

FixedCompositeByteBuf.isDirect() should return the same value as EMPTY_BUFFER.isDirect() when constructed via an empty array

Modifications:

- Return correct value when constructed via empty array.
- Add unit test

Result:

FixedCompositeByteBuf.isDirect() returns correct value