### PR TITLE
Fix of undefined behavior of null referencing

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -16,6 +16,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -50,7 +51,7 @@ extern int accept4(int sockFd, struct sockaddr* addr, socklen_t* addrlen, int fl
 
 // macro to calculate the length of a sockaddr_un struct for a given path length.
 // see sys/un.h#SUN_LEN, this is modified to allow nul bytes
-#define _UNIX_ADDR_LENGTH(path_len) (uintptr_t) (((struct sockaddr_un *) 0)->sun_path) + path_len
+#define _UNIX_ADDR_LENGTH(path_len) ((uintptr_t) offsetof(struct sockaddr_un, sun_path) + (uintptr_t) path_len)
 
 static int nettyNonBlockingSocket(int domain, int type, int protocol) {
 #ifdef SOCK_NONBLOCK


### PR DESCRIPTION
Patched code produce the same results without UB https://godbolt.org/z/uHtm_E

Small reproducer:
```
// clang -fsanitize=null test.c && ./a.out

int a(int x) { return (uintptr_t)(((struct sockaddr_un *)0)->sun_path) + x; }

int b(int x) {
  return offsetof(struct sockaddr_un, sun_path) + x;
}

int main() {
  printf("%d\n", b(5));
  printf("%d\n", a(5));
}

```

test.c:11:12: runtime error: member access within null pointer of type 'struct sockaddr_un'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior test.c:11:12 in

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
