### PR TITLE
Change String comparison to equals() from ==

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
@@ -99,7 +99,7 @@ public class LastInboundHandler extends ChannelDuplexHandler {
 
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
-        if (writabilityStates == "") {
+        if (writabilityStates.equals("")) {
             writabilityStates = String.valueOf(ctx.channel().isWritable());
         } else {
             writabilityStates += "," + ctx.channel().isWritable();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
@@ -99,7 +99,7 @@ public class LastInboundHandler extends ChannelDuplexHandler {
 
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
-        if (writabilityStates.equals("")) {
+        if ("".equals(writabilityStates)) {
             writabilityStates = String.valueOf(ctx.channel().isWritable());
         } else {
             writabilityStates += "," + ctx.channel().isWritable();


### PR DESCRIPTION
Motivation:

Even if it was stored in the string constant pool, I thought it was safe to compare it through the Equals() method.

Modification:

So, I changed "==" comparison to equals() comparison

Result:

It has become safer to compare String values with different references and with the same values.
