### PR TITLE
Remove System.out.println(...) in test

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
@@ -65,7 +65,6 @@ public class RtspDecoderTest {
         ((FullHttpRequest) res1).release();
 
         HttpObject res2 = ch.readInbound();
-        System.out.println(res2);
         assertNotNull(res2);
         assertTrue(res2 instanceof FullHttpResponse);
         ((FullHttpResponse) res2).release();


### PR DESCRIPTION
Motivation:

We did had some System.out.println(...) call in a test which seems to be some left-over from debugging.

Modifications:

Remove System.out.println(...)

Result:

Code cleanup