### PR TITLE
Add a null check

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -320,7 +320,7 @@ public final class NetUtil {
             BufferedReader br = new BufferedReader(isr);
             try {
                 String line = br.readLine();
-                if (line.startsWith(sysctlKey)) {
+                if (line != null && line.startsWith(sysctlKey)) {
                     for (int i = line.length() - 1; i > sysctlKey.length(); --i) {
                         if (!Character.isDigit(line.charAt(i))) {
                             return Integer.valueOf(line.substring(i + 1));


### PR DESCRIPTION
Motivation:

BufferedReader.readLine() may return null and cause a NPE.

Modification:

Simply add a null check.

Result:

If BufferedReader.readLine() returns null, the sysctlGetInt will just return null rather than cause NPE.
