### PR TITLE
Remove the synchronized flag of fillInStackTrace method to improve performance while throwing exception.

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -197,7 +197,7 @@ public class FixedChannelPool extends SimpleChannelPool {
                         task.promise.setFailure(new TimeoutException(
                                 "Acquire operation took longer then configured maximum time") {
                             @Override
-                            public synchronized Throwable fillInStackTrace() {
+                            public Throwable fillInStackTrace() {
                                 return this;
                             }
                         });


### PR DESCRIPTION
Motivation:

The method body of fillInStackTrace method of TimeoutException class in FixedChannelPool.java is so simple (just return this) that there is no need to be marked as synchronized.

Modification:

Remove the synchronized flag of fillInStackTrace method.

Result:
It can improve performance slightly while throwing a TimeoutException.

