### PR TITLE
Remove the synchronized flag of fillInStackTrace method to improve performance while creating exception instance.

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -352,7 +352,7 @@ public class SimpleChannelPool implements ChannelPool {
         } else {
             closeAndFail(channel, new IllegalStateException("ChannelPool full") {
                 @Override
-                public synchronized Throwable fillInStackTrace() {
+                public Throwable fillInStackTrace() {
                     return this;
                 }
             }, promise);


### PR DESCRIPTION
Motivation:

The method body of fillInStackTrace method of IllegalStateException class in SimpleChannelPool.java is so simple (just return this) that there is no need to be marked as synchronized.

Modification:

Remove the synchronized flag of fillInStackTrace method.

Result:

It can improve performance slightly while creating a IllegalStateException instance.
