### PR TITLE
Don't depend on implementation details of SSLEngine in SniHandlerTest

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -368,10 +368,12 @@ public class SniHandlerTest {
 
             ch.close();
 
-            // When the channel is closed the SslHandler will write an empty buffer to the channel.
-            ByteBuf buf = ch.readOutbound();
-            if (buf != null) {
-                assertFalse(buf.isReadable());
+            // Consume all the outbound data that may be produced by the SSLEngine.
+            for (;;) {
+                ByteBuf buf = ch.readOutbound();
+                if (buf == null) {
+                    break;
+                }
                 buf.release();
             }
 


### PR DESCRIPTION
Motivation:

In SniHandlerTest we depended on implementation details of the SSLEngine. We should better not doing this

Modifications:

Just release all outbound data

Result:

Dont depend on implementation details