### PR TITLE
Workaround Android bug that cause AbstractDnsRecord to throw when the…

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
@@ -68,10 +69,21 @@ public abstract class AbstractDnsRecord implements DnsRecord {
         // See:
         //   - https://github.com/netty/netty/issues/4937
         //   - https://github.com/netty/netty/issues/4935
-        this.name = appendTrailingDot(IDN.toASCII(checkNotNull(name, "name")));
+        this.name = appendTrailingDot(IDNtoASCII(name));
         this.type = checkNotNull(type, "type");
         this.dnsClass = (short) dnsClass;
         this.timeToLive = timeToLive;
+    }
+
+    private static String IDNtoASCII(String name) {
+        checkNotNull(name, "name");
+        if (PlatformDependent.isAndroid() && DefaultDnsRecordDecoder.ROOT.equals(name)) {
+            // Prior Android 10 there was a bug that did not correctly parse ".".
+            //
+            // See https://github.com/netty/netty/issues/10034
+            return name;
+        }
+        return IDN.toASCII(name);
     }
 
     private static String appendTrailingDot(String name) {


### PR DESCRIPTION
… name is only a ROOT label

Motivation:

Having only the ROOT label (".") as the name is valid, but Android 9 and prior does not correctly handle the case. We should add a workaround for it.

Modifications:

Detect if we are on Android and if so check if the name is the ROOT label and if so just return the name without trying to convert it

Result:

Fixes https://github.com/netty/netty/issues/10034