### PR TITLE
Add a null check to method HttpStaticFileServerHandler.sendListing

### DIFF
--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
@@ -286,21 +286,24 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
             .append("<ul>")
             .append("<li><a href=\"../\">..</a></li>\r\n");
 
-        for (File f: dir.listFiles()) {
-            if (f.isHidden() || !f.canRead()) {
-                continue;
-            }
+        File[] files = dir.listFiles();
+        if (files != null) {
+            for (File f: files) {
+                if (f.isHidden() || !f.canRead()) {
+                    continue;
+                }
 
-            String name = f.getName();
-            if (!ALLOWED_FILE_NAME.matcher(name).matches()) {
-                continue;
-            }
+                String name = f.getName();
+                if (!ALLOWED_FILE_NAME.matcher(name).matches()) {
+                    continue;
+                }
 
-            buf.append("<li><a href=\"")
-               .append(name)
-               .append("\">")
-               .append(name)
-               .append("</a></li>\r\n");
+                buf.append("<li><a href=\"")
+                .append(name)
+                .append("\">")
+                .append(name)
+                .append("</a></li>\r\n");
+            }
         }
 
         buf.append("</ul></body></html>\r\n");


### PR DESCRIPTION
Motivation:

java.io.File.listFiles() may return null and cause a unexpected NPE.

Modification:

Extract a local variable from the return value of File.listFiles() and do a null check.

Result:

Fix the potential NPE.
