### PR TITLE
Add a null check to method TestUtils.compressHeapDumps.

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
+++ b/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
@@ -141,6 +141,10 @@ public final class TestUtils {
                 return name.endsWith(".hprof");
             }
         });
+        if (files == null) {
+            logger.warn("failed to find heap dump due to I/O error!");
+            return;
+        }
 
         final byte[] buf = new byte[65536];
         final LZMA2Options options = new LZMA2Options(LZMA2Options.PRESET_DEFAULT);


### PR DESCRIPTION
Motivation:

java.io.File.listFiles() may return null and cause a unexpected NPE.

Modification:

Add a null check for variable files. And if variable files is null, the compressHeapDumps method will just return after logging a error message.

Result:

Fix the potential NPE.
