### PR TITLE
Add SslHandshakeTimeoutException and use it for handshake timeouts

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -2012,7 +2012,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 if (localHandshakePromise.isDone()) {
                     return;
                 }
-                SSLException exception = new SSLException("handshake timed out");
+                SSLException exception =
+                        new SslHandshakeTimeoutException("handshake timed out after " + handshakeTimeoutMillis + "ms");
                 try {
                     if (localHandshakePromise.tryFailure(exception)) {
                         SslUtils.handleHandshakeFailure(ctx, exception, true);

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandshakeTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandshakeTimeoutException.java
@@ -22,7 +22,7 @@ import javax.net.ssl.SSLHandshakeException;
  */
 public final class SslHandshakeTimeoutException extends SSLHandshakeException {
 
-    public SslHandshakeTimeoutException(String reason) {
+    SslHandshakeTimeoutException(String reason) {
         super(reason);
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandshakeTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandshakeTimeoutException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SSLHandshakeException;
+
+/**
+ * {@link SSLHandshakeException} that is used when a handshake failed due a configured timeout.
+ */
+public final class SslHandshakeTimeoutException extends SSLHandshakeException {
+
+    public SslHandshakeTimeoutException(String reason) {
+        super(reason);
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -191,12 +191,12 @@ public class SslHandlerTest {
         assertFalse(ch.finishAndReleaseAll());
     }
 
-    @Test(expected = SSLException.class, timeout = 3000)
+    @Test(expected = SslHandshakeTimeoutException.class, timeout = 3000)
     public void testClientHandshakeTimeout() throws Exception {
         testHandshakeTimeout(true);
     }
 
-    @Test(expected = SSLException.class, timeout = 3000)
+    @Test(expected = SslHandshakeTimeoutException.class, timeout = 3000)
     public void testServerHandshakeTimeout() throws Exception {
         testHandshakeTimeout(false);
     }


### PR DESCRIPTION
Motivation:

Often it is useful to be able to detect different sorts of SSL errors that cause the handshake to fail. To make this easier we should throw and explicit exception type for handshake timeouts.

Modifications:

- Add SslHandshakeTimeoutException (which extends SSLHandshakeException) and use it for handshake timeouts
- Adjust testcases

Result:

Easier to detect that handshake failed because of a timeout
