### PR TITLE
PromiseTask.isCancelled performs an unsynchronized read

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/PromiseTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseTask.java
@@ -177,11 +177,6 @@ class PromiseTask<V> extends DefaultPromise<V> implements RunnableFuture<V> {
     }
 
     @Override
-    public final boolean isCancelled() {
-        return task == CANCELLED || super.isCancelled();
-    }
-
-    @Override
     protected StringBuilder toStringBuilder() {
         StringBuilder buf = super.toStringBuilder();
         buf.setCharAt(buf.length() - 1, ',');


### PR DESCRIPTION
Motivation:

PromiseTask.isCancelled performs an unsynchronized read and so may trigger race-detectors. As this was just done for a small optimization which should not really make a lot of difference we should just remove it.

Modifications:

Remove unsynchronized read optimization

Result:

Fixes https://github.com/netty/netty/issues/10026.