### PR TITLE
Use MacOSDnsServerAddressStreamProvider when on the classpath and we …

### DIFF
--- a/resolver-dns-native-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
+++ b/resolver-dns-native-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
@@ -42,9 +42,6 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
 
-    // Fallback provider
-    private static final DnsServerAddressStreamProvider UNIX_PROVIDER;
-
     private static final Throwable UNAVAILABILITY_CAUSE;
 
     private static final InternalLogger logger =
@@ -61,9 +58,6 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
             cause = error;
         }
         UNAVAILABILITY_CAUSE = cause;
-        // It's important that we load the native lib before we call DnsServerAddressStreamProviders to ensure
-        // the default provider is correctly wired up and has all the needed native libs loaded.
-        UNIX_PROVIDER = DnsServerAddressStreamProviders.unixDefault();
     }
 
     private static void loadNativeLibrary() {
@@ -169,7 +163,7 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
                 if (addresses != null) {
                     return addresses.stream();
                 }
-                return UNIX_PROVIDER.nameServerAddressStream(originalHostname);
+                return DnsServerAddressStreamProviders.unixDefault().nameServerAddressStream(originalHostname);
             }
 
             DnsServerAddresses addresses = resolverMap.get(hostname);

--- a/resolver-dns-native-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
+++ b/resolver-dns-native-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
@@ -43,8 +43,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
 
     // Fallback provider
-    private static final DnsServerAddressStreamProvider DEFAULT_PROVIDER =
-            DnsServerAddressStreamProviders.platformDefault();
+    private static final DnsServerAddressStreamProvider UNIX_PROVIDER;
 
     private static final Throwable UNAVAILABILITY_CAUSE;
 
@@ -62,6 +61,9 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
             cause = error;
         }
         UNAVAILABILITY_CAUSE = cause;
+        // It's important that we load the native lib before we call DnsServerAddressStreamProviders to ensure
+        // the default provider is correctly wired up and has all the needed native libs loaded.
+        UNIX_PROVIDER = DnsServerAddressStreamProviders.unixDefault();
     }
 
     private static void loadNativeLibrary() {
@@ -167,7 +169,7 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
                 if (addresses != null) {
                     return addresses.stream();
                 }
-                return DEFAULT_PROVIDER.nameServerAddressStream(originalHostname);
+                return UNIX_PROVIDER.nameServerAddressStream(originalHostname);
             }
 
             DnsServerAddresses addresses = resolverMap.get(hostname);

--- a/resolver-dns-native-macos/src/test/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns-native-macos/src/test/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProviderTest.java
@@ -17,6 +17,8 @@ package io.netty.resolver.dns.macos;
 
 import io.netty.resolver.dns.DnsServerAddressStream;
 import io.netty.resolver.dns.DnsServerAddressStreamProvider;
+import io.netty.resolver.dns.DnsServerAddressStreamProviders;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -30,7 +32,7 @@ public class MacOSDnsServerAddressStreamProviderTest {
     }
 
     @Test
-    public void test() {
+    public void testStream() {
         DnsServerAddressStreamProvider provider = new MacOSDnsServerAddressStreamProvider();
         DnsServerAddressStream stream = provider.nameServerAddressStream("netty.io");
         Assert.assertNotNull(stream);
@@ -40,4 +42,11 @@ public class MacOSDnsServerAddressStreamProviderTest {
             Assert.assertNotEquals(0, stream.next().getPort());
         }
     }
+
+    @Test
+    public void testDefaultUseCorrectInstance() {
+        Assert.assertThat(DnsServerAddressStreamProviders.platformDefault(),
+                Matchers.instanceOf(MacOSDnsServerAddressStreamProvider.class));
+    }
+
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsServerAddressStreamProvidersTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsServerAddressStreamProvidersTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */package io.netty.resolver.dns;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DnsServerAddressStreamProvidersTest {
+
+    @Test
+    public void testUseCorrectProvider() {
+        Assert.assertSame(DnsServerAddressStreamProviders.unixDefault(),
+                DnsServerAddressStreamProviders.platformDefault());
+    }
+}


### PR DESCRIPTION
…are running on MacOS

Motivation:

939e928312f1099373582f9811817a6226550987 introduced MacOSDnsServerAddressStreamProvider which will ensure the right nameservers are selected when running on MacOS. To ensure this is done automatically on MacOS we should use it by default on these platforms.

Modifications:

Try to use MacOSDnsServerAddressStreamProvider when on MacOS via reflection and fallback if not possible

Result:

Ensure the right nameservers are used on MacOS even when a VPN (for example) is used.