### PR TITLE
perf: reduce String allocation and use Unsafe to optimize performance

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -246,3 +246,11 @@ This private header is also used by Apple's open source
     * license/LICENSE.dnsinfo.txt (Apache License 2.0)
   * HOMEPAGE:
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+
+This product contains a modified version of 'Utf8', a Java implementation of
+the UTF-8 encode algorithm. It can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE
+  * HOMEPAGE:
+    * https://github.com/protocolbuffers/protobuf

--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
@@ -395,7 +395,7 @@ public class QueryStringDecoder {
         for (int i = firstEscaped; i < toExcluded; i++) {
             char c = s.charAt(i);
             if (c != '%') {
-                charBuf[charBufIdx++] = c != '+' || isPath ? c : SPACE;
+                PlatformDependent.putChar(charBuf, charBufIdx++, c != '+' || isPath ? c : SPACE);
                 continue;
             }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/Utf8Utils.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/Utf8Utils.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.util.internal.PlatformDependent;
+
+import static java.lang.Character.MIN_HIGH_SURROGATE;
+import static java.lang.Character.MIN_LOW_SURROGATE;
+import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
+
+/**
+ * See original <a
+ * href="https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/Utf8.java">
+ * Utf8.java</a>
+ */
+public final class Utf8Utils {
+
+    private Utf8Utils() {
+        //empty
+    }
+
+    public static void decodeUtf8(byte[] srcBytes, int srcIndex, int size, StringBuilder destStrBuf) {
+        // Bitwise OR combines the sign bits so any negative value fails the check.
+        if ((srcIndex | size | srcBytes.length - srcIndex - size) < 0) {
+            throw new ArrayIndexOutOfBoundsException(
+                    String.format("buffer length=%d, index=%d, size=%d", srcBytes.length, srcIndex, size));
+        }
+
+        if (PlatformDependent.hasUnsafe()) {
+            decodeUtf8Unsafe(srcBytes, srcIndex, size, destStrBuf);
+        } else {
+            decodeUtf8Safe(srcBytes, srcIndex, size, destStrBuf);
+        }
+    }
+
+    public static void decodeUtf8Safe(byte[] srcBytes, int srcIndex, int size, StringBuilder outStrBuf) {
+        int offset = srcIndex;
+        final int limit = offset + size;
+
+        // Optimize for 100% ASCII (Hotspot loves small simple top-level loops like this).
+        // This simple loop stops when we encounter a byte >= 0x80 (i.e. non-ASCII).
+        while (offset < limit) {
+            byte b = srcBytes[offset];
+            if (!DecodeUtil.isOneByte(b)) {
+                break;
+            }
+            offset++;
+            DecodeUtil.handleOneByte(b, outStrBuf);
+        }
+
+        while (offset < limit) {
+            byte byte1 = srcBytes[offset++];
+            if (DecodeUtil.isOneByte(byte1)) {
+                DecodeUtil.handleOneByte(byte1, outStrBuf);
+                // It's common for there to be multiple ASCII characters in a run mixed in, so add an
+                // extra optimized loop to take care of these runs.
+                while (offset < limit) {
+                    byte b = srcBytes[offset];
+                    if (!DecodeUtil.isOneByte(b)) {
+                        break;
+                    }
+                    offset++;
+                    DecodeUtil.handleOneByte(b, outStrBuf);
+                }
+            } else if (DecodeUtil.isTwoBytes(byte1)) {
+                if (offset >= limit) {
+                    throw new IllegalArgumentException("invalid UTF-8.");
+                }
+                DecodeUtil.handleTwoBytes(byte1, /* byte2 */ srcBytes[offset++], outStrBuf);
+            } else if (DecodeUtil.isThreeBytes(byte1)) {
+                if (offset >= limit - 1) {
+                    throw new IllegalArgumentException("invalid UTF-8.");
+                }
+                DecodeUtil.handleThreeBytes(
+                        byte1,
+                        /* byte2 */ srcBytes[offset++],
+                        /* byte3 */ srcBytes[offset++],
+                        outStrBuf);
+            } else {
+                if (offset >= limit - 2) {
+                    throw new IllegalArgumentException("invalid UTF-8.");
+                }
+                DecodeUtil.handleFourBytes(
+                        byte1,
+                        /* byte2 */ srcBytes[offset++],
+                        /* byte3 */ srcBytes[offset++],
+                        /* byte4 */ srcBytes[offset++],
+                        outStrBuf);
+            }
+        }
+    }
+
+    public static void decodeUtf8Unsafe(byte[] srcBytes, int srcIndex, int size, StringBuilder outStrBuf) {
+        int offset = srcIndex;
+        final int limit = offset + size;
+
+        // Optimize for 100% ASCII (Hotspot loves small simple top-level loops like this).
+        // This simple loop stops when we encounter a byte >= 0x80 (i.e. non-ASCII).
+        while (offset < limit) {
+            byte b = PlatformDependent.getByte(srcBytes, offset);
+            if (!DecodeUtil.isOneByte(b)) {
+                break;
+            }
+            offset++;
+            DecodeUtil.handleOneByte(b, outStrBuf);
+        }
+
+        while (offset < limit) {
+            byte byte1 = PlatformDependent.getByte(srcBytes, offset++);
+            if (DecodeUtil.isOneByte(byte1)) {
+                DecodeUtil.handleOneByte(byte1, outStrBuf);
+                // It's common for there to be multiple ASCII characters in a run mixed in, so add an
+                // extra optimized loop to take care of these runs.
+                while (offset < limit) {
+                    byte b = PlatformDependent.getByte(srcBytes, offset);
+                    if (!DecodeUtil.isOneByte(b)) {
+                        break;
+                    }
+                    offset++;
+                    DecodeUtil.handleOneByte(b, outStrBuf);
+                }
+            } else if (DecodeUtil.isTwoBytes(byte1)) {
+                if (offset >= limit) {
+                    throw new IllegalArgumentException("invalid UTF-8.");
+                }
+                DecodeUtil.handleTwoBytes(byte1, /* byte2 */ PlatformDependent.getByte(srcBytes, offset++), outStrBuf);
+            } else if (DecodeUtil.isThreeBytes(byte1)) {
+                if (offset >= limit - 1) {
+                    throw new IllegalArgumentException("invalid UTF-8.");
+                }
+                DecodeUtil.handleThreeBytes(
+                        byte1,
+                        /* byte2 */ PlatformDependent.getByte(srcBytes, offset++),
+                        /* byte3 */ PlatformDependent.getByte(srcBytes, offset++),
+                        outStrBuf);
+            } else {
+                if (offset >= limit - 2) {
+                    throw new IllegalArgumentException("invalid UTF-8.");
+                }
+                DecodeUtil.handleFourBytes(
+                        byte1,
+                        /* byte2 */ PlatformDependent.getByte(srcBytes, offset++),
+                        /* byte3 */ PlatformDependent.getByte(srcBytes, offset++),
+                        /* byte4 */ PlatformDependent.getByte(srcBytes, offset++),
+                        outStrBuf);
+            }
+        }
+    }
+
+    private static class DecodeUtil {
+
+        /**
+         * Returns whether this is a single-byte codepoint (i.e., ASCII) with the form '0XXXXXXX'.
+         */
+        private static boolean isOneByte(byte b) {
+            return b >= 0;
+        }
+
+        /**
+         * Returns whether this is a two-byte codepoint with the form '10XXXXXX'.
+         */
+        private static boolean isTwoBytes(byte b) {
+            return b < (byte) 0xE0;
+        }
+
+        /**
+         * Returns whether this is a three-byte codepoint with the form '110XXXXX'.
+         */
+        private static boolean isThreeBytes(byte b) {
+            return b < (byte) 0xF0;
+        }
+
+        private static void handleOneByte(byte byte1, StringBuilder strBuf) {
+            strBuf.append((char) byte1);
+        }
+
+        private static void handleTwoBytes(byte byte1, byte byte2, StringBuilder strBuf) {
+            // Simultaneously checks for illegal trailing-byte in leading position (<= '11000000') and
+            // overlong 2-byte, '11000001'.
+            if (byte1 < (byte) 0xC2 || isNotTrailingByte(byte2)) {
+                throw new IllegalArgumentException("invalid UTF-8.");
+            }
+            strBuf.append((char) (((byte1 & 0x1F) << 6) | trailingByteValue(byte2)));
+        }
+
+        private static void handleThreeBytes(byte byte1, byte byte2, byte byte3, StringBuilder strBuf) {
+            if (isNotTrailingByte(byte2)
+                    // overlong? 5 most significant bits must not all be zero
+                    || (byte1 == (byte) 0xE0 && byte2 < (byte) 0xA0)
+                    // check for illegal surrogate codepoints
+                    || (byte1 == (byte) 0xED && byte2 >= (byte) 0xA0)
+                    || isNotTrailingByte(byte3)) {
+                throw new IllegalArgumentException("invalid UTF-8.");
+            }
+
+            strBuf.append((char) (((byte1 & 0x0F) << 12) | (trailingByteValue(byte2) << 6) | trailingByteValue(byte3)));
+        }
+
+        private static void handleFourBytes(byte byte1, byte byte2, byte byte3, byte byte4, StringBuilder strBuf) {
+            if (isNotTrailingByte(byte2)
+                    // Check that 1 <= plane <= 16.  Tricky optimized form of:
+                    //   valid 4-byte leading byte?
+                    // if (byte1 > (byte) 0xF4 ||
+                    //   overlong? 4 most significant bits must not all be zero
+                    //     byte1 == (byte) 0xF0 && byte2 < (byte) 0x90 ||
+                    //   codepoint larger than the highest code point (U+10FFFF)?
+                    //     byte1 == (byte) 0xF4 && byte2 > (byte) 0x8F)
+                    || (((byte1 << 28) + (byte2 - (byte) 0x90)) >> 30) != 0
+                    || isNotTrailingByte(byte3)
+                    || isNotTrailingByte(byte4)) {
+                throw new IllegalArgumentException("invalid UTF-8.");
+            }
+            int codepoint =
+                    ((byte1 & 0x07) << 18)
+                            | (trailingByteValue(byte2) << 12)
+                            | (trailingByteValue(byte3) << 6)
+                            | trailingByteValue(byte4);
+            strBuf.append(DecodeUtil.highSurrogate(codepoint));
+            strBuf.append(DecodeUtil.lowSurrogate(codepoint));
+        }
+
+        /**
+         * Returns whether the byte is not a valid continuation of the form '10XXXXXX'.
+         */
+        private static boolean isNotTrailingByte(byte b) {
+            return b > (byte) 0xBF;
+        }
+
+        /**
+         * Returns the actual value of the trailing byte (removes the prefix '10') for composition.
+         */
+        private static int trailingByteValue(byte b) {
+            return b & 0x3F;
+        }
+
+        private static char highSurrogate(int codePoint) {
+            return (char)
+                    ((MIN_HIGH_SURROGATE - (MIN_SUPPLEMENTARY_CODE_POINT >>> 10)) + (codePoint >>> 10));
+        }
+
+        private static char lowSurrogate(int codePoint) {
+            return (char) (MIN_LOW_SURROGATE + (codePoint & 0x3ff));
+        }
+    }
+
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/Utf8Utils.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/Utf8Utils.java
@@ -78,7 +78,7 @@ public final class Utf8Utils {
         }
     }
 
-    public static int decodeUtf8Safe(byte[] srcBytes, int srcIndex, int srcSize, char[] destChars, int destIdx) {
+    private static int decodeUtf8Safe(byte[] srcBytes, int srcIndex, int srcSize, char[] destChars, int destIdx) {
         int offset = srcIndex;
         final int limit = offset + srcSize;
         final int destIdx0 = destIdx;
@@ -140,7 +140,7 @@ public final class Utf8Utils {
         return destIdx - destIdx0;
     }
 
-    public static int decodeUtf8Unsafe(byte[] srcBytes, int srcIndex, int srcSize, char[] destChars, int destIdx) {
+    private static int decodeUtf8Unsafe(byte[] srcBytes, int srcIndex, int srcSize, char[] destChars, int destIdx) {
         int offset = srcIndex;
         final int limit = offset + srcSize;
         final int destIdx0 = destIdx;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/Utf8Utils.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/Utf8Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,35 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package io.netty.handler.codec.http;
 
 import io.netty.util.internal.PlatformDependent;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -519,6 +519,10 @@ public final class PlatformDependent {
         return PlatformDependent0.getByte(data, index);
     }
 
+    public static char getChar(char[] data, int index) {
+        return PlatformDependent0.getChar(data, index);
+    }
+
     public static short getShort(byte[] data, int index) {
         return PlatformDependent0.getShort(data, index);
     }
@@ -645,6 +649,10 @@ public final class PlatformDependent {
 
     public static void putByte(byte[] data, int index, byte value) {
         PlatformDependent0.putByte(data, index, value);
+    }
+
+    public static void putChar(char[] data, int index, char value) {
+        PlatformDependent0.putChar(data, index, value);
     }
 
     public static void putShort(byte[] data, int index, short value) {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -39,6 +39,8 @@ final class PlatformDependent0 {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PlatformDependent0.class);
     private static final long ADDRESS_FIELD_OFFSET;
     private static final long BYTE_ARRAY_BASE_OFFSET;
+    private static final long CHAR_ARRAY_BASE_OFFSET;
+    private static final long CHAR_ARRAY_INDEX_SCALE;
     private static final Constructor<?> DIRECT_BUFFER_CONSTRUCTOR;
     private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
     private static final Method ALLOCATE_ARRAY_METHOD;
@@ -208,6 +210,8 @@ final class PlatformDependent0 {
         if (unsafe == null) {
             ADDRESS_FIELD_OFFSET = -1;
             BYTE_ARRAY_BASE_OFFSET = -1;
+            CHAR_ARRAY_BASE_OFFSET = -1;
+            CHAR_ARRAY_INDEX_SCALE = -1;
             UNALIGNED = false;
             DIRECT_BUFFER_CONSTRUCTOR = null;
             ALLOCATE_ARRAY_METHOD = null;
@@ -263,6 +267,8 @@ final class PlatformDependent0 {
             DIRECT_BUFFER_CONSTRUCTOR = directBufferConstructor;
             ADDRESS_FIELD_OFFSET = objectFieldOffset(addressField);
             BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+            CHAR_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(char[].class);
+            CHAR_ARRAY_INDEX_SCALE = UNSAFE.arrayIndexScale(char[].class);
             final boolean unaligned;
             Object maybeUnaligned = AccessController.doPrivileged(new PrivilegedAction<Object>() {
                 @Override
@@ -525,6 +531,10 @@ final class PlatformDependent0 {
         return UNSAFE.getByte(data, BYTE_ARRAY_BASE_OFFSET + index);
     }
 
+    static char getChar(char[] data, int index) {
+        return UNSAFE.getChar(data, CHAR_ARRAY_BASE_OFFSET + (index * CHAR_ARRAY_INDEX_SCALE));
+    }
+
     static short getShort(byte[] data, int index) {
         return UNSAFE.getShort(data, BYTE_ARRAY_BASE_OFFSET + index);
     }
@@ -555,6 +565,10 @@ final class PlatformDependent0 {
 
     static void putByte(byte[] data, int index, byte value) {
         UNSAFE.putByte(data, BYTE_ARRAY_BASE_OFFSET + index, value);
+    }
+
+    static void putChar(char[] data, int index, char value) {
+        UNSAFE.putChar(data, CHAR_ARRAY_BASE_OFFSET + (index * CHAR_ARRAY_INDEX_SCALE), value);
     }
 
     static void putShort(byte[] data, int index, short value) {

--- a/microbench/src/main/java/io/netty/handler/codec/http/QueryStringDecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/QueryStringDecoderBenchmark.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 @Threads(1)
 @Warmup(iterations = 3)
 @Measurement(iterations = 3)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class QueryStringDecoderBenchmark extends AbstractMicrobenchmark {
 
     private static final Charset SHIFT_JIS = Charset.forName("Shift-JIS");
@@ -62,5 +62,18 @@ public class QueryStringDecoderBenchmark extends AbstractMicrobenchmark {
         return new QueryStringDecoder("%82%D9%82%B0=%82%DA%82%AF&%82%CB%82%B1=%82%A2%82%CA",
                                       SHIFT_JIS, false)
                 .parameters();
+    }
+
+    @Benchmark
+    public Map<String, List<String>> longMixedDecoding() {
+        return new QueryStringDecoder("uniqid=D87B332EFD7643D2AWD9A47F494A536AA&" +
+                "curidentity=0&bundle_id=com.anncded&app_id=1004&client_info=%7B%22" +
+                "version%22%3A%2213.3.1%22%2C%22idfa%22%3A%2232CB5C8E-AA53-422A-9F9D-3E2F2DFAE489%22%2C%22" +
+                "longitude%22%3A%22117.441926%22%2C%22start_time%22%3A%221583589271210%22%2C%22latitude%22%3A%" +
+                "2238.969134%22%2C%22os%22%3A%22iOS%22%2C%22bssid%22%3A%2234%3A96%3A72%3A72%3A20%3A9e%22%2C%22" +
+                "did%22%3A%22D2ADTrsIfqMjkjSGThC9QbmTpOumoq11hZScOSvlVjti8Xc3%22%2C%22end_time%22%3A%221583589268703" +
+                "%22%2C%22ssid%22%3A%2234SA%22%2C%22resume_time%22%3A%221583589271210%22%2C%22model%22%3A%22iPhone12" +
+                "%2C2%22%7D&v=8.020&t=BA2ZRQAIxATsFNFE3CTRSOQw8U2IHOQVh&sig=V2.01ccecs84916839c00604eb31bbd73b9e541" +
+                "&req_time=1583589271285", false).parameters();
     }
 }


### PR DESCRIPTION
Motivation:

Reduce memory allocation and optimize performance for `QueryStringDecoder`.

Modification:

* Replace `new String()` with `Utf8Utils.decodeUtf8` when charset is UTF-8.
* Use `Unsafe` to optimize performance.
* Use `char[]` instead of `StringBuilder` to optimize performance

Result:

Before:
```
Benchmark                                         Mode  Cnt  Score   Error   Units
QueryStringDecoderBenchmark.mixedDecoding        thrpt    6  1.380 ± 0.140  ops/us
QueryStringDecoderBenchmark.noDecoding           thrpt    6  6.670 ± 0.236  ops/us
QueryStringDecoderBenchmark.nonStandardDecoding  thrpt    6  1.825 ± 1.031  ops/us
QueryStringDecoderBenchmark.onlyDecoding         thrpt    6  1.549 ± 0.146  ops/us
```

After:
```
Benchmark                                         Mode  Cnt  Score   Error   Units
QueryStringDecoderBenchmark.mixedDecoding        thrpt    6  1.728 ± 0.313  ops/us
QueryStringDecoderBenchmark.noDecoding           thrpt    6  6.567 ± 0.997  ops/us
QueryStringDecoderBenchmark.nonStandardDecoding  thrpt    6  1.892 ± 0.405  ops/us
QueryStringDecoderBenchmark.onlyDecoding         thrpt    6  2.040 ± 0.076  ops/us
```

