### PR TITLE
Add a log level check simply before logging.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PromiseNotificationUtil.java
+++ b/common/src/main/java/io/netty/util/internal/PromiseNotificationUtil.java
@@ -66,9 +66,11 @@ public final class PromiseNotificationUtil {
             if (err == null) {
                 logger.warn("Failed to mark a promise as failure because it has succeeded already: {}", p, cause);
             } else {
-                logger.warn(
+                if (logger.isWarnEnabled()) {
+                    logger.warn(
                         "Failed to mark a promise as failure because it has failed already: {}, unnotified cause: {}",
                         p, ThrowableUtil.stackTraceToString(err), cause);
+                }
             }
         }
     }

--- a/common/src/main/java/io/netty/util/internal/PromiseNotificationUtil.java
+++ b/common/src/main/java/io/netty/util/internal/PromiseNotificationUtil.java
@@ -65,12 +65,10 @@ public final class PromiseNotificationUtil {
             Throwable err = p.cause();
             if (err == null) {
                 logger.warn("Failed to mark a promise as failure because it has succeeded already: {}", p, cause);
-            } else {
-                if (logger.isWarnEnabled()) {
-                    logger.warn(
+            } else if (logger.isWarnEnabled()) {
+                logger.warn(
                         "Failed to mark a promise as failure because it has failed already: {}, unnotified cause: {}",
                         p, ThrowableUtil.stackTraceToString(err), cause);
-                }
             }
         }
     }


### PR DESCRIPTION
Motivation:

ThrowableUtil.stackTraceToString is an expensive method call. So I think a log level check before this logging statement is quite needed especially in a environment with the warning log disabled.


Modification:

Add log level check simply before logging.

Result:

Improve performance in a environment with the warning log disabled.
