### PR TITLE
Use WebSocketVersion.toAsciiString() as header value when possible

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
@@ -241,7 +241,7 @@ public class WebSocketClientHandshaker07 extends WebSocketClientHandshaker {
             headers.set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, expectedSubprotocol);
         }
 
-        headers.set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "7");
+        headers.set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, version().toAsciiString());
         return request;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
@@ -243,7 +243,7 @@ public class WebSocketClientHandshaker08 extends WebSocketClientHandshaker {
             headers.set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, expectedSubprotocol);
         }
 
-        headers.set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "8");
+        headers.set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, version().toAsciiString());
         return request;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -244,7 +244,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
             headers.set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, expectedSubprotocol);
         }
 
-        headers.set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
+        headers.set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, version().toAsciiString());
         return request;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketVersion.java
@@ -15,6 +15,9 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
+import io.netty.util.AsciiString;
+import io.netty.util.internal.StringUtil;
+
 /**
  * <p>
  * Versions of the web socket specification.
@@ -25,49 +28,50 @@ package io.netty.handler.codec.http.websocketx;
  * </p>
  */
 public enum WebSocketVersion {
-    UNKNOWN,
+    UNKNOWN(AsciiString.cached(StringUtil.EMPTY_STRING)),
 
     /**
      * <a href= "http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-00"
      * >draft-ietf-hybi-thewebsocketprotocol- 00</a>.
      */
-    V00,
+    V00(AsciiString.cached("0")),
 
     /**
      * <a href= "http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-07"
      * >draft-ietf-hybi-thewebsocketprotocol- 07</a>
      */
-    V07,
+    V07(AsciiString.cached("7")),
 
     /**
      * <a href= "http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-10"
      * >draft-ietf-hybi-thewebsocketprotocol- 10</a>
      */
-    V08,
+    V08(AsciiString.cached("8")),
 
     /**
      * <a href="http://tools.ietf.org/html/rfc6455 ">RFC 6455</a>. This was originally <a href=
      * "http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17" >draft-ietf-hybi-thewebsocketprotocol-
      * 17</a>
      */
-    V13;
+    V13(AsciiString.cached("13"));
 
+    private final AsciiString headerValue;
+
+    WebSocketVersion(AsciiString headerValue) {
+        this.headerValue = headerValue;
+    }
     /**
      * @return Value for HTTP Header 'Sec-WebSocket-Version'
      */
     public String toHttpHeaderValue() {
-        if (this == V00) {
-            return "0";
+        return toAsciiString().toString();
+    }
+
+    AsciiString toAsciiString() {
+        if (this == UNKNOWN) {
+            // Let's special case this to preserve behaviour
+            throw new IllegalStateException("Unknown web socket version: " + this);
         }
-        if (this == V07) {
-            return "7";
-        }
-        if (this == V08) {
-            return "8";
-        }
-        if (this == V13) {
-            return "13";
-        }
-        throw new IllegalStateException("Unknown web socket version: " + this);
+        return headerValue;
     }
 }


### PR DESCRIPTION
Motivation:

In our WebSocketClientHandshaker* implementations we "hardcode" the version number to use. This is error-prone, we should better use the WebSocketVersion so we dont need to maintain the value multiple times. Beside this we can also use an AsciiString to improve performance

Modifications:

- Use WebSocketVersion.toAsciiString

Result:

Less stuff to maintain and small performance win