### PR TITLE
Update WebSocketIndexPageHandler.java

### DIFF
--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketIndexPageHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketIndexPageHandler.java
@@ -56,7 +56,7 @@ public class WebSocketIndexPageHandler extends SimpleChannelInboundHandler<FullH
         }
 
         // Allow only GET methods.
-        if (!GET.equals(req.method())) {
+        if (!GET.toString().equals(req.method().toString())) {
             sendHttpResponse(ctx, req, new DefaultFullHttpResponse(req.protocolVersion(), FORBIDDEN,
                                                                    ctx.alloc().buffer(0)));
             return;


### PR DESCRIPTION
The code  'GET.equals(req.method())'

Motivation:

calls to .equals() where the target and argument are of incompatible types. 

Modification:

GET.toString().equals(req.method().toString()

Result:

Fixes #<GitHub issue number>. 

