### PR TITLE
Close SocketChannel upon exceptions to avoid leaking

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -189,7 +189,13 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                                                final SocketAddress localAddress, final ChannelPromise promise) {
         try {
             final EventLoop eventLoop = channel.eventLoop();
-            final AddressResolver<SocketAddress> resolver = this.resolver.getResolver(eventLoop);
+            AddressResolver<SocketAddress> resolver;
+            try {
+                resolver = this.resolver.getResolver(eventLoop);
+            } catch (Throwable e) {
+                channel.close();
+                throw e;
+            }
 
             if (!resolver.isSupported(remoteAddress) || resolver.isResolved(remoteAddress)) {
                 // Resolver has no idea about what to do with the specified remote address or it's resolved already.

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -192,9 +192,9 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
             AddressResolver<SocketAddress> resolver;
             try {
                 resolver = this.resolver.getResolver(eventLoop);
-            } catch (Throwable e) {
+            } catch (Throwable cause) {
                 channel.close();
-                throw e;
+                return promise.setFailure(cause);
             }
 
             if (!resolver.isSupported(remoteAddress) || resolver.isResolved(remoteAddress)) {

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -41,7 +41,6 @@ import io.netty.resolver.AbstractAddressResolver;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.Test;
 
@@ -304,8 +303,8 @@ public class BootstrapTest {
 
         // Should fail with the IllegalStateException.
         assertThat(connectFuture.await(10000), is(true));
-        assertThat(connectFuture.cause(), Matchers.instanceOf(IllegalStateException.class));
-        assertThat(connectFuture.cause().getCause(), Matchers.instanceOf(TestException.class));
+        assertThat(connectFuture.cause(), instanceOf(IllegalStateException.class));
+        assertThat(connectFuture.cause().getCause(), instanceOf(TestException.class));
         assertThat(connectFuture.channel().isOpen(), is(false));
     }
 


### PR DESCRIPTION
This fixes https://github.com/netty/netty/issues/10109
by correctly closing the channel upon exceptions.

Fixes https://github.com/netty/netty/issues/10109
