### PR TITLE
Add some HTTP header constants

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
@@ -161,6 +161,10 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString DATE = AsciiString.cached("date");
     /**
+     * {@code "dnt"}
+     */
+    public static final AsciiString DNT = AsciiString.cached("dnt");
+    /**
      * {@code "etag"}
      */
     public static final AsciiString ETAG = AsciiString.cached("etag");
@@ -319,6 +323,10 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString UPGRADE = AsciiString.cached("upgrade");
     /**
+     * {@code "upgrade-insecure-requests"}
+     */
+    public static final AsciiString UPGRADE_INSECURE_REQUESTS = AsciiString.cached("upgrade-insecure-requests");
+    /**
      * {@code "user-agent"}
      */
     public static final AsciiString USER_AGENT = AsciiString.cached("user-agent");
@@ -354,6 +362,10 @@ public final class HttpHeaderNames {
      * {@code "x-frame-options"}
      */
     public static final AsciiString X_FRAME_OPTIONS = AsciiString.cached("x-frame-options");
+    /**
+     * {@code "x-requested-with"}
+     */
+    public static final AsciiString X_REQUESTED_WITH = AsciiString.cached("x-requested-with");
 
     private HttpHeaderNames() { }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -36,6 +36,14 @@ public final class HttpHeaderValues {
      */
     public static final AsciiString APPLICATION_OCTET_STREAM = AsciiString.cached("application/octet-stream");
     /**
+     * {@code "application/xhtml+xml"}
+     */
+    public static final AsciiString APPLICATION_XHTML = AsciiString.cached("application/xhtml+xml");
+    /**
+     * {@code "application/xml"}
+     */
+    public static final AsciiString APPLICATION_XML = AsciiString.cached("application/xml");
+    /**
      * {@code "attachment"}
      * See {@link HttpHeaderNames#CONTENT_DISPOSITION}
      */
@@ -193,6 +201,18 @@ public final class HttpHeaderValues {
      */
     public static final AsciiString S_MAXAGE = AsciiString.cached("s-maxage");
     /**
+     * {@code "text/css"}
+     */
+    public static final AsciiString TEXT_CSS = AsciiString.cached("text/css");
+    /**
+     * {@code "text/html"}
+     */
+    public static final AsciiString TEXT_HTML = AsciiString.cached("text/html");
+    /**
+     * {@code "text/event-stream"}
+     */
+    public static final AsciiString TEXT_EVENT_STREAM = AsciiString.cached("text/event-stream");
+    /**
      * {@code "text/plain"}
      */
     public static final AsciiString TEXT_PLAIN = AsciiString.cached("text/plain");
@@ -208,6 +228,10 @@ public final class HttpHeaderValues {
      * {@code "websocket"}
      */
     public static final AsciiString WEBSOCKET = AsciiString.cached("websocket");
+    /**
+     * {@code "websocket"}
+     */
+    public static final AsciiString XML_HTTP_REQUEST = AsciiString.cached("XmlHttpRequest");
 
     private HttpHeaderValues() { }
 }


### PR DESCRIPTION
Motivation:

Add some missing HTTP header names and values constants.

Modification:

* names:
  * dnt (Do Not Track)
  * upgrade-insecure-requests
  * x-requested-with
* values:
  * application/xhtml+xml
  * application/xml
  * text/css
  * text/html
  * text/event-stream
  * XmlHttpRequest

Result:

More constants available