### PR TITLE
fix a potential ByteBuf leak in HttpProxyHandler.

### DIFF
--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -100,12 +100,17 @@ public final class HttpProxyHandler extends ProxyHandler {
         this.password = ObjectUtil.checkNotNull(password, "password");
 
         ByteBuf authz = Unpooled.copiedBuffer(username + ':' + password, CharsetUtil.UTF_8);
-        ByteBuf authzBase64 = Base64.encode(authz, false);
-
-        authorization = new AsciiString("Basic " + authzBase64.toString(CharsetUtil.US_ASCII));
-
-        authz.release();
-        authzBase64.release();
+        ByteBuf authzBase64;
+        try {
+            authzBase64 = Base64.encode(authz, false);
+        } finally {
+            authz.release();
+        }
+        try {
+            authorization = new AsciiString("Basic " + authzBase64.toString(CharsetUtil.US_ASCII));
+        } finally {
+            authzBase64.release();
+        }
 
         this.outboundHeaders = headers;
         this.ignoreDefaultPortsInConnectHostHeader = ignoreDefaultPortsInConnectHostHeader;


### PR DESCRIPTION
Motivation:

An exception may occur between ByteBuf's allocation and release. For example:
```java
java.lang.OutOfMemoryError: Java heap space
	at java.lang.String.<init>(String.java:325)
	at io.netty.buffer.ByteBufUtil.decodeString(ByteBufUtil.java:838)
	at io.netty.buffer.AbstractByteBuf.toString(AbstractByteBuf.java:1247)
	at io.netty.buffer.AbstractByteBuf.toString(AbstractByteBuf.java:1242)
	at io.netty.handler.proxy.HttpProxyHandler.<init>(HttpProxyHandler.java:105)
	at io.netty.handler.proxy.HttpProxyHandler.<init>(HttpProxyHandler.java:90)
	at io.netty.handler.proxy.HttpProxyHandler.<init>(HttpProxyHandler.java:85)
```
It may cause the ByteBuf variable authz and authzBase64's leak.

Modification:

Release the ByteBuf in a finally block as soon as possible.

Result:

Fix a potential ByteBuf leak.
