### PR TITLE
Release the ByteBuf when IOException occurs in AbstractMemoryHttpData.

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
@@ -47,12 +47,15 @@ public class AbstractMemoryHttpDataTest {
         String contentStr = "foo_test";
         ByteBuf buf = Unpooled.wrappedBuffer(contentStr.getBytes(UTF_8));
         buf.markReaderIndex();
-        try (ByteBufInputStream is = new ByteBufInputStream(buf)) {
+        ByteBufInputStream is = new ByteBufInputStream(buf);
+        try {
             test.setContent(is);
             assertFalse(buf.isReadable());
             assertEquals(test.getString(UTF_8), contentStr);
             buf.resetReaderIndex();
             assertTrue(ByteBufUtil.equals(buf, test.getByteBuf()));
+        } finally {
+            is.close();
         }
 
         Random random = new SecureRandom();


### PR DESCRIPTION
Motivation:

An IOException may be thrown from InputStream.read or checkSize method, and cause the ByteBuf  leak.

Modification:

Release the ByteBuf when IOException occurs.

Result:
Avoid ByteBuf leak.

