### PR TITLE
Add JDK 14 and update JDK 13 for builds

### DIFF
--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.13.0-1"
+        java_version : "adopt@1.13.0-2"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-6.114.yaml
+++ b/docker/docker-compose.centos-6.114.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-1.14
+    build:
+      args:
+        centos_version : "6"
+        java_version : "adopt@1.14.0-0"
+
+  test:
+    image: netty:centos-6-1.14
+
+  test-leak:
+    image: netty:centos-6-1.14
+
+  test-boringssl-static:
+    image: netty:centos-6-1.14
+
+  shell:
+    image: netty:centos-6-1.14

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.13.0-1"
+        java_version : "adopt@1.13.0-2"
 
   test:
     image: netty:centos-7-1.13

--- a/docker/docker-compose.centos-7.114.yaml
+++ b/docker/docker-compose.centos-7.114.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-7-1.14
+    build:
+      args:
+        centos_version : "7"
+        java_version : "@1.14.0-0"
+
+  test:
+    image: netty:centos-7-1.14
+
+  test-leak:
+    image: netty:centos-7-1.14
+
+  test-boringssl-static:
+    image: netty:centos-7-1.14
+
+  shell:
+    image: netty:centos-7-1.14


### PR DESCRIPTION
Motivation:

JDK 14 was released so we should include it in our build matrix. Beside this there was also a JDK 13 update

Modifications:

- Add docker-compose files for JDK 14
- Update JDK 13 version

Result:

Build with JDK 14 as well and use latest JDK 13 release