### PR TITLE
Replace usage() with freeBytes() in thresholds within hot paths of PoolChunkList

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -132,7 +132,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     // This may be null if the PoolChunk is unpooled as pooling the ByteBuffer instances does not make any sense here.
     private final Deque<ByteBuffer> cachedNioBuffers;
 
-    private int freeBytes;
+    int freeBytes;
 
     PoolChunkList<T> parent;
     PoolChunk<T> prev;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -89,7 +89,7 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
 
         for (PoolChunk<T> cur = head; cur != null; cur = cur.next) {
             if (cur.allocate(buf, reqCapacity, normCapacity)) {
-                if (cur.freeBytes() <= freeMinThreshold) {
+                if (cur.freeBytes <= freeMinThreshold) {
                     remove(cur);
                     nextList.add(cur);
                 }
@@ -101,7 +101,7 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
 
     boolean free(PoolChunk<T> chunk, long handle, ByteBuffer nioBuffer) {
         chunk.free(handle, nioBuffer);
-        if (chunk.freeBytes() > freeMaxThreshold) {
+        if (chunk.freeBytes > freeMaxThreshold) {
             remove(chunk);
             // Move the PoolChunk down the PoolChunkList linked-list.
             return move0(chunk);
@@ -112,7 +112,7 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
     private boolean move(PoolChunk<T> chunk) {
         assert chunk.usage() < maxUsage;
 
-        if (chunk.freeBytes() > freeMaxThreshold) {
+        if (chunk.freeBytes > freeMaxThreshold) {
             // Move the PoolChunk down the PoolChunkList linked-list.
             return move0(chunk);
         }
@@ -137,7 +137,7 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
     }
 
     void add(PoolChunk<T> chunk) {
-        if (chunk.freeBytes() <= freeMinThreshold) {
+        if (chunk.freeBytes <= freeMinThreshold) {
             nextList.add(chunk);
             return;
         }

--- a/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class SimpleByteBufPooledAllocatorBenchmark extends AbstractMicrobenchmark {
+
+    public SimpleByteBufPooledAllocatorBenchmark() {
+        super(true, false);
+    }
+
+    @Param({"123", "1234", "12345", "123456", "1234567"})
+    public int size;
+
+    @Benchmark
+    public boolean getAndRelease() {
+        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
+        ByteBuf buf = alloc.directBuffer(size);
+        return buf.release();
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
@@ -26,6 +26,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
 
@@ -41,10 +42,16 @@ public class SimpleByteBufPooledAllocatorBenchmark extends AbstractMicrobenchmar
     @Param({"123", "1234", "12345", "123456", "1234567"})
     public int size;
 
+    @Param({"0", "5", "10", "100"})
+    public long tokens;
+
     @Benchmark
     public boolean getAndRelease() {
         ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
         ByteBuf buf = alloc.directBuffer(size);
+        if (tokens > 0) {
+            Blackhole.consumeCPU(tokens);
+        }
         return buf.release();
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/SimpleByteBufPooledAllocatorBenchmark.java
@@ -21,10 +21,12 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -45,10 +47,28 @@ public class SimpleByteBufPooledAllocatorBenchmark extends AbstractMicrobenchmar
     @Param({"0", "5", "10", "100"})
     public long tokens;
 
+    @Param({"false", "true"})
+    public boolean useThreadCache;
+
+    public ByteBufAllocator allocator;
+
+    @Setup(Level.Trial)
+    public void doSetup() {
+        allocator = new PooledByteBufAllocator(
+                PooledByteBufAllocator.defaultPreferDirect(),
+                PooledByteBufAllocator.defaultNumHeapArena(),
+                PooledByteBufAllocator.defaultNumDirectArena(),
+                PooledByteBufAllocator.defaultPageSize(),
+                PooledByteBufAllocator.defaultMaxOrder(),
+                PooledByteBufAllocator.defaultTinyCacheSize(),
+                PooledByteBufAllocator.defaultSmallCacheSize(),
+                PooledByteBufAllocator.defaultNormalCacheSize(),
+                useThreadCache);
+    }
+
     @Benchmark
     public boolean getAndRelease() {
-        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-        ByteBuf buf = alloc.directBuffer(size);
+        ByteBuf buf = allocator.directBuffer(size);
         if (tokens > 0) {
             Blackhole.consumeCPU(tokens);
         }

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -58,9 +58,12 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
     public AbstractMicrobenchmark(boolean disableAssertions, boolean disableHarnessExecutor) {
         final String[] customArgs;
         if (disableHarnessExecutor) {
-            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m"};
+            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m",
+                    "-XX:BiasedLockingStartupDelay=0"};
         } else {
-            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m", "-Djmh.executor=CUSTOM",
+            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m",
+                    "-XX:BiasedLockingStartupDelay=0",
+                    "-Djmh.executor=CUSTOM",
                     "-Djmh.executor.class=io.netty.microbench.util.AbstractMicrobenchmark$HarnessExecutor"};
         }
         String[] jvmArgs = new String[BASE_JVM_ARGS.length + customArgs.length];


### PR DESCRIPTION
Replace usage() with freeBytes() in thresholds within hot paths of PoolChunkList

Motivation:
PoolChunk.usage() method has non-trivial computations. It is used currently in hot path methods invoked when an allocation and de-allocation are happened.
The idea is to replace usage() output comparison against percent thresholds by Chunk.freeBytes plain comparison against absolute thresholds. In such way the majority of computations from the threshold conditions are moved to init logic.

Modifications:
Replace PoolChunk.usage() conditions in PoolChunkList with equivalent conditions for PoolChunk.freeBytes()

Result:
Improve performance of allocation and de-allocation of ByteBuf from normal size caches
