### PR TITLE
Replace MQTT deprecated API usage

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -323,7 +323,7 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         buf.writeShort(topicNameBytes.length);
         buf.writeBytes(topicNameBytes);
         if (mqttFixedHeader.qosLevel().value() > 0) {
-            buf.writeShort(variableHeader.messageId());
+            buf.writeShort(variableHeader.packetId());
         }
         buf.writeBytes(payload);
 


### PR DESCRIPTION
Motivation:

Mqtt procotol defines packetId instead of messageId, replace deprecated method to match protocol definition

Modification:

Replace messageId() to packetId() in MqttEncoder

Result:

Match mqtt protocol definition and improve readability
