### PR TITLE
Fix allocate additional buffer for encoding stompFrame without readab…

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.stomp;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.util.CharsetUtil;

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.stomp;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.util.CharsetUtil;
@@ -34,9 +35,14 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
         if (msg instanceof StompFrame) {
             StompFrame frame = (StompFrame) msg;
             ByteBuf frameBuf = encodeFrame(frame, ctx);
-            out.add(frameBuf);
-            ByteBuf contentBuf = encodeContent(frame, ctx);
-            out.add(contentBuf);
+            if (frame.content().isReadable()) {
+                out.add(frameBuf);
+                ByteBuf contentBuf = encodeContent(frame, ctx);
+                out.add(contentBuf);
+            } else {
+                frameBuf.writeByte(StompConstants.NUL);
+                out.add(frameBuf);
+            }
         } else if (msg instanceof StompHeadersSubframe) {
             StompHeadersSubframe frame = (StompHeadersSubframe) msg;
             ByteBuf buf = encodeFrame(frame, ctx);

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
@@ -83,4 +83,18 @@ public class StompSubframeEncoderTest {
         assertTrue(fullFrame.release());
     }
 
+    @Test
+    public void testOneBufferForStompFrameWithEmptyContent() {
+        StompFrame connectedFrame = new DefaultStompFrame(StompCommand.CONNECTED);
+        connectedFrame.headers().set(StompHeaders.VERSION, "1.2");
+
+        assertTrue(channel.writeOutbound(connectedFrame));
+
+        ByteBuf stompBuffer = channel.readOutbound();
+
+        assertNotNull(stompBuffer);
+        assertNull(channel.readOutbound());
+        assertEquals("CONNECTED\nversion:1.2\n\n\0", stompBuffer.toString(CharsetUtil.UTF_8));
+        assertTrue(stompBuffer.release());
+    }
 }


### PR DESCRIPTION

Motivation:

Not always STOMP frames contain any payload some times it just headers. So we wan't allocate additional buffer with NULL content for this situation.

Modification:

Modify StompSubframeEncoder to check if content is readable or not. If content is not readable just add NULL byte to encoded header buffer. 
