### PR TITLE
Clarify exception message when ALPN is not supported

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -144,7 +144,8 @@ public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicati
                 return isServer ? JettyAlpnSslEngine.newServerEngine(engine, applicationNegotiator)
                         : JettyAlpnSslEngine.newClientEngine(engine, applicationNegotiator);
             }
-            throw new RuntimeException("Unable to wrap SSLEngine of type " + engine.getClass().getName());
+            throw new UnsupportedOperationException("ALPN not supported. Unable to wrap SSLEngine of type '"
+                    + engine.getClass().getName() + "')");
         }
     }
 


### PR DESCRIPTION
Motivation:

We should provide more informations when ALPN is not supported and a user tries to use it.

Modifications:

- Use UnsupportedOperationException
- Include java version in message

Result:

Easier to debug ALPN problems
