### PR TITLE
DelimiterBasedFrameDecoder should contain all the capabilities of LineBasedFrameDecoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
@@ -186,7 +186,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
         this.failFast = failFast;
     }
 
-    /** Returns true if the delimiters are "\n" and "\r\n".  */
+    /** Returns true if the delimiters are "\n" or "\r\n".  */
     private static boolean isLineBased(final ByteBuf[] delimiters) {
         if(delimiters.length == 1){
             ByteBuf a = delimiters[0];

--- a/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
@@ -188,18 +188,22 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
 
     /** Returns true if the delimiters are "\n" and "\r\n".  */
     private static boolean isLineBased(final ByteBuf[] delimiters) {
-        if (delimiters.length != 2) {
-            return false;
+        if(delimiters.length == 1){
+            ByteBuf a = delimiters[0];
+            return a.capacity() == 1 && a.getByte(0) == '\n';
+        }else if(delimiters.length == 2){
+            ByteBuf a = delimiters[0];
+            ByteBuf b = delimiters[1];
+            if (a.capacity() < b.capacity()) {
+                a = delimiters[1];
+                b = delimiters[0];
+            }
+            return a.capacity() == 2 && b.capacity() == 1
+                    && a.getByte(0) == '\r' && a.getByte(1) == '\n'
+                    && b.getByte(0) == '\n';
         }
-        ByteBuf a = delimiters[0];
-        ByteBuf b = delimiters[1];
-        if (a.capacity() < b.capacity()) {
-            a = delimiters[1];
-            b = delimiters[0];
-        }
-        return a.capacity() == 2 && b.capacity() == 1
-                && a.getByte(0) == '\r' && a.getByte(1) == '\n'
-                && b.getByte(0) == '\n';
+        return false;
+
     }
 
     /**


### PR DESCRIPTION
Dear teachers, I think that since the DelimiterBasedFrameDecoder contains LineBasedFrameDecoder, the DelimiterBasedFrameDecoder should contain all the capabilities of LineBasedFrameDecoder

So I think "\n" and "\r\n" should both be "true" when the "isLineBased" function determines whether to use "LineBasedFrameDecoder"

So I changed the “isLineBased” method

Changed
``` java
    /** Returns true if the delimiters are "\n" and "\r\n".  */
    private static boolean isLineBased(final ByteBuf[] delimiters) {
        if (delimiters.length != 2) {
            return false;
        }
        ByteBuf a = delimiters[0];
        ByteBuf b = delimiters[1];
        if (a.capacity() < b.capacity()) {
            a = delimiters[1];
            b = delimiters[0];
        }
        return a.capacity() == 2 && b.capacity() == 1
                && a.getByte(0) == '\r' && a.getByte(1) == '\n'
                && b.getByte(0) == '\n';
    }
```
to
``` java
    /** Returns true if the delimiters are "\n" or "\r\n".  */
    private static boolean isLineBased(final ByteBuf[] delimiters) {
        if(delimiters.length == 1){
            ByteBuf a = delimiters[0];
            return a.capacity() == 1 && a.getByte(0) == '\n';
        }else if(delimiters.length == 2){
            ByteBuf a = delimiters[0];
            ByteBuf b = delimiters[1];
            if (a.capacity() < b.capacity()) {
                a = delimiters[1];
                b = delimiters[0];
            }
            return a.capacity() == 2 && b.capacity() == 1
                    && a.getByte(0) == '\r' && a.getByte(1) == '\n'
                    && b.getByte(0) == '\n';
        }
        return false;

    }
```


