### PR TITLE
Close the file in case of an IOException in AbstractMemoryHttpData.renameTo.

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.nio.charset.Charset;
 import java.security.SecureRandom;
@@ -61,6 +62,32 @@ public class AbstractMemoryHttpDataTest {
             assertArrayEquals(bytes, ByteBufUtil.getBytes(buf));
         } finally {
             //release the ByteBuf
+            test.delete();
+        }
+    }
+
+    @Test
+    public void testRenameTo() throws Exception {
+        TestHttpData test = new TestHttpData("test", UTF_8, 0);
+        try {
+            File tmpFile = File.createTempFile(UUID.randomUUID().toString(), ".tmp");
+            tmpFile.deleteOnExit();
+            byte[] bytes = new byte[4096];
+            PlatformDependent.threadLocalRandom().nextBytes(bytes);
+            ByteBuf content = Unpooled.wrappedBuffer(bytes);
+            test.setContent(content);
+            boolean succ = test.renameTo(tmpFile);
+            assertTrue(succ);
+            FileInputStream fis = new FileInputStream(tmpFile);
+            try {
+                byte[] buf = new byte[4096];
+                fis.read(buf);
+                assertArrayEquals(bytes, buf);
+            } finally {
+                fis.close();
+            }
+        } finally {
+            //release the ByteBuf in AbstractMemoryHttpData
             test.delete();
         }
     }


### PR DESCRIPTION
Motivation:

An `IOException` may be thrown from `FileChannel.write` or `FileChannel.force`, and cause the fd leak.

Modification:

Close the file in a finally block.

Result:

Avoid fd leak.
