### PR TITLE
Log protocol version during handshake

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1788,7 +1788,12 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         handshakePromise.trySuccess(ctx.channel());
 
         if (logger.isDebugEnabled()) {
-            logger.debug("{} HANDSHAKEN: {}", ctx.channel(), engine.getSession().getCipherSuite());
+            SSLSession session = engine.getSession();
+            logger.debug(
+              "{} HANDSHAKEN: protocol:{} cipher suite:{}",
+              ctx.channel(),
+              session.getProtocol(),
+              session.getCipherSuite());
         }
         ctx.fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
 


### PR DESCRIPTION
Motivation:

Only cipher suite is logged during handshake. Picked protocol is interesting too.

Modification:

Log protocol as well.

Result:

More interesting information when debugging TLS handshakes.