### PR TITLE
Allow Conscrypt to be used on Android

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
@@ -56,7 +56,8 @@ final class Conscrypt {
      * Indicates whether or not conscrypt is available on the current system.
      */
     static boolean isAvailable() {
-        return CAN_INSTANCE_PROVIDER && IS_CONSCRYPT_SSLENGINE != null && PlatformDependent.javaVersion() >= 8;
+        return CAN_INSTANCE_PROVIDER && IS_CONSCRYPT_SSLENGINE != null &&
+            (PlatformDependent.javaVersion() >= 8 || PlatformDependent.isAndroid());
     }
 
     static boolean isEngineSupported(SSLEngine engine) {


### PR DESCRIPTION
**Motivation:**

Following up on https://github.com/netty/netty/issues/10181

I was able to successfully setup a Netty server with TLS on Android, using Conscrypt, with the change proposed here. Conscrypt publishes an [Android specific version](https://github.com/google/conscrypt#android). But the current availability check prevents Netty from using it (the call `PlatformDependent.javaVersion()` returns `6` on Android).

**Modification:**

Check whether the java version is above 8, or if it's running on an Android device, to flag Conscrypt as available (besides the remaining checks).

**Result:**

Netty with TLS runs fine on Android 👍
