### PR TITLE
Update Bouncycastle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.54</version>
+        <version>1.65</version>
         <scope>compile</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Motivation:

We should update our optional bouncycastle dependency to ensure we use the latest which has all the security fixes

Modifications:

Update bouncycastle version

Result:

Fixes https://github.com/netty/netty/issues/10184
