### PR TITLE
CodecOutputList should be recycled in a finally block

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageDecoder.java
@@ -97,11 +97,14 @@ public abstract class MessageToMessageDecoder<I> extends ChannelInboundHandlerAd
         } catch (Exception e) {
             throw new DecoderException(e);
         } finally {
-            int size = out.size();
-            for (int i = 0; i < size; i ++) {
-                ctx.fireChannelRead(out.getUnsafe(i));
+            try {
+                int size = out.size();
+                for (int i = 0; i < size; i++) {
+                    ctx.fireChannelRead(out.getUnsafe(i));
+                }
+            } finally {
+                out.recycle();
             }
-            out.recycle();
         }
     }
 


### PR DESCRIPTION
Motivation:

To ensure we always recycle the CodecOutputList we should better do it in a finally block

Modifications:

Call CodecOutputList.recycle() in finally

Result:

Less chances of non-recycled lists. Related to https://github.com/netty/netty/issues/10183