### PR TITLE
Guard against overflow when calling CompositeByteBuf.addComponent(...)

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
@@ -1533,5 +1534,56 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
             assertEquals(0, buffer.refCnt());
         }
         assertTrue(cbuf.release());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testOverflowWhileAddingComponent() {
+        int capacity = 1024 * 1024; // 1MB
+        ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
+        CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
+
+        try {
+            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                ByteBuf duplicate = buffer.duplicate();
+                compositeByteBuf.addComponent(duplicate);
+                duplicate.retain();
+            }
+        } finally {
+            compositeByteBuf.release();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testOverflowWhileAddingComponentsViaVarargs() {
+        int capacity = 1024 * 1024; // 1MB
+        ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
+        CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
+
+        try {
+            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                ByteBuf duplicate = buffer.duplicate();
+                compositeByteBuf.addComponents(duplicate);
+                duplicate.retain();
+            }
+        } finally {
+            compositeByteBuf.release();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testOverflowWhileAddingComponentsViaIterable() {
+        int capacity = 1024 * 1024; // 1MB
+        ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
+        CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
+
+        try {
+            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                ByteBuf duplicate = buffer.duplicate();
+                compositeByteBuf.addComponents(Collections.singletonList(duplicate));
+                duplicate.retain();
+            }
+        } finally {
+            compositeByteBuf.release();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

We need to ensure we not overflow when adding buffers to a CompositeByteBuf

Modifications:

- Correctly validate overflow before adding to the internal storage
- Add testcase

Result:

Fixes https://github.com/netty/netty/issues/10194