### PR TITLE
Dns resolver: honor resolv.conf timeout, rotate and attempts options

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.netty.resolver.dns.DnsServerAddressStreamProviders.platformDefault;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.intValue;
 
@@ -46,16 +45,17 @@ public final class DnsNameResolverBuilder {
     private Integer minTtl;
     private Integer maxTtl;
     private Integer negativeTtl;
-    private long queryTimeoutMillis = 5000;
+    private long queryTimeoutMillis = -1;
     private ResolvedAddressTypes resolvedAddressTypes = DnsNameResolver.DEFAULT_RESOLVE_ADDRESS_TYPES;
     private boolean completeOncePreferredResolved;
     private boolean recursionDesired = true;
-    private int maxQueriesPerResolve = 16;
+    private int maxQueriesPerResolve = -1;
     private boolean traceEnabled;
     private int maxPayloadSize = 4096;
     private boolean optResourceEnabled = true;
     private HostsFileEntriesResolver hostsFileEntriesResolver = HostsFileEntriesResolver.DEFAULT;
-    private DnsServerAddressStreamProvider dnsServerAddressStreamProvider = platformDefault();
+    private DnsServerAddressStreamProvider dnsServerAddressStreamProvider =
+            DnsServerAddressStreamProviders.platformDefault();
     private DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory =
             NoopDnsQueryLifecycleObserverFactory.INSTANCE;
     private String[] searchDomains;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverOptions.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverOptions.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+/**
+ * Represents options defined in a file of the format <a href=https://linux.die.net/man/5/resolver>etc/resolv.conf</a>.
+ */
+final class UnixResolverOptions {
+
+    private final int ndots;
+    private final int timeout;
+    private final int attempts;
+
+    UnixResolverOptions(int ndots, int timeout, int attempts) {
+        this.ndots = ndots;
+        this.timeout = timeout;
+        this.attempts = attempts;
+    }
+
+    static UnixResolverOptions.Builder newBuilder() {
+        return new UnixResolverOptions.Builder();
+    }
+
+    /**
+     * The number of dots which must appear in a name before an initial absolute query is made.
+     * The default value is {@code 1}.
+     */
+    int ndots() {
+        return ndots;
+    }
+
+    /**
+     * The timeout of each DNS query performed by this resolver (in seconds).
+     * The default value is {@code 5}.
+     */
+    int timeout() {
+        return timeout;
+    }
+
+    /**
+     * The maximum allowed number of DNS queries to send when resolving a host name.
+     * The default value is {@code 16}.
+     */
+    int attempts() {
+        return attempts;
+    }
+
+    static final class Builder {
+
+        private int ndots = 1;
+        private int timeout = 5;
+        private int attempts = 16;
+
+        private Builder() {
+        }
+
+        void setNdots(int ndots) {
+            this.ndots = ndots;
+        }
+
+        void setTimeout(int timeout) {
+            this.timeout = timeout;
+        }
+
+        void setAttempts(int attempts) {
+            this.attempts = attempts;
+        }
+
+        UnixResolverOptions build() {
+            return new UnixResolverOptions(ndots, timeout, attempts);
+        }
+    }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
@@ -29,8 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider.DEFAULT_NDOTS;
-import static io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider.parseEtcResolverFirstNdots;
+import static io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider.parseEtcResolverOptions;
 import static org.junit.Assert.assertEquals;
 
 public class UnixResolverDnsServerAddressStreamProviderTest {
@@ -48,6 +47,62 @@ public class UnixResolverDnsServerAddressStreamProviderTest {
         DnsServerAddressStream stream = p.nameServerAddressStream("somehost");
         assertHostNameEquals("127.0.0.2", stream.next());
         assertHostNameEquals("127.0.0.3", stream.next());
+    }
+
+    @Test
+    public void nameServerAddressStreamShouldBeRotationalWhenRotationOptionsIsPresent() throws Exception {
+        File f = buildFile("options rotate\n" +
+            "domain linecorp.local\n" +
+            "nameserver 127.0.0.2\n" +
+            "nameserver 127.0.0.3\n" +
+            "nameserver 127.0.0.4\n");
+        UnixResolverDnsServerAddressStreamProvider p =
+            new UnixResolverDnsServerAddressStreamProvider(f, null);
+
+        DnsServerAddressStream stream = p.nameServerAddressStream("");
+        assertHostNameEquals("127.0.0.2", stream.next());
+        assertHostNameEquals("127.0.0.3", stream.next());
+        assertHostNameEquals("127.0.0.4", stream.next());
+
+        stream = p.nameServerAddressStream("");
+        assertHostNameEquals("127.0.0.3", stream.next());
+        assertHostNameEquals("127.0.0.4", stream.next());
+        assertHostNameEquals("127.0.0.2", stream.next());
+
+        stream = p.nameServerAddressStream("");
+        assertHostNameEquals("127.0.0.4", stream.next());
+        assertHostNameEquals("127.0.0.2", stream.next());
+        assertHostNameEquals("127.0.0.3", stream.next());
+
+        stream = p.nameServerAddressStream("");
+        assertHostNameEquals("127.0.0.2", stream.next());
+        assertHostNameEquals("127.0.0.3", stream.next());
+        assertHostNameEquals("127.0.0.4", stream.next());
+    }
+
+    @Test
+    public void nameServerAddressStreamShouldAlwaysStartFromTheTopWhenRotationOptionsIsAbsent() throws Exception {
+        File f = buildFile("domain linecorp.local\n" +
+            "nameserver 127.0.0.2\n" +
+            "nameserver 127.0.0.3\n" +
+            "nameserver 127.0.0.4\n");
+        UnixResolverDnsServerAddressStreamProvider p =
+            new UnixResolverDnsServerAddressStreamProvider(f, null);
+
+        DnsServerAddressStream stream = p.nameServerAddressStream("");
+        assertHostNameEquals("127.0.0.2", stream.next());
+        assertHostNameEquals("127.0.0.3", stream.next());
+        assertHostNameEquals("127.0.0.4", stream.next());
+
+        stream = p.nameServerAddressStream("");
+        assertHostNameEquals("127.0.0.2", stream.next());
+        assertHostNameEquals("127.0.0.3", stream.next());
+        assertHostNameEquals("127.0.0.4", stream.next());
+
+        stream = p.nameServerAddressStream("");
+        assertHostNameEquals("127.0.0.2", stream.next());
+        assertHostNameEquals("127.0.0.3", stream.next());
+        assertHostNameEquals("127.0.0.4", stream.next());
     }
 
     @Test
@@ -83,23 +138,63 @@ public class UnixResolverDnsServerAddressStreamProviderTest {
     }
 
     @Test
-    public void ndotsIsParsedIfPresent() throws IOException {
+    public void ndotsOptionIsParsedIfPresent() throws IOException {
         File f = buildFile("search localdomain\n" +
-                           "nameserver 127.0.0.11\n" +
-                           "options ndots:0\n");
-        assertEquals(0, parseEtcResolverFirstNdots(f));
+            "nameserver 127.0.0.11\n" +
+            "options ndots:0\n");
+        assertEquals(0, parseEtcResolverOptions(f).ndots());
 
         f = buildFile("search localdomain\n" +
-                      "nameserver 127.0.0.11\n" +
-                      "options ndots:123 foo:goo\n");
-        assertEquals(123, parseEtcResolverFirstNdots(f));
+            "nameserver 127.0.0.11\n" +
+            "options ndots:123 foo:goo\n");
+        assertEquals(123, parseEtcResolverOptions(f).ndots());
     }
 
     @Test
-    public void defaultValueReturnedIfNdotsNotPresent() throws IOException {
+    public void defaultValueReturnedIfNdotsOptionsNotPresent() throws IOException {
         File f = buildFile("search localdomain\n" +
-                           "nameserver 127.0.0.11\n");
-        assertEquals(DEFAULT_NDOTS, parseEtcResolverFirstNdots(f));
+            "nameserver 127.0.0.11\n");
+        assertEquals(1, parseEtcResolverOptions(f).ndots());
+    }
+
+    @Test
+    public void timeoutOptionIsParsedIfPresent() throws IOException {
+        File f = buildFile("search localdomain\n" +
+            "nameserver 127.0.0.11\n" +
+            "options timeout:0\n");
+        assertEquals(0, parseEtcResolverOptions(f).timeout());
+
+        f = buildFile("search localdomain\n" +
+            "nameserver 127.0.0.11\n" +
+            "options foo:bar timeout:124\n");
+        assertEquals(124, parseEtcResolverOptions(f).timeout());
+    }
+
+    @Test
+    public void defaultValueReturnedIfTimeoutOptionsIsNotPresent() throws IOException {
+        File f = buildFile("search localdomain\n" +
+            "nameserver 127.0.0.11\n");
+        assertEquals(5, parseEtcResolverOptions(f).timeout());
+    }
+
+    @Test
+    public void attemptsOptionIsParsedIfPresent() throws IOException {
+        File f = buildFile("search localdomain\n" +
+            "nameserver 127.0.0.11\n" +
+            "options attempts:0\n");
+        assertEquals(0, parseEtcResolverOptions(f).attempts());
+
+        f = buildFile("search localdomain\n" +
+            "nameserver 127.0.0.11\n" +
+            "options foo:bar attempts:12\n");
+        assertEquals(12, parseEtcResolverOptions(f).attempts());
+    }
+
+    @Test
+    public void defaultValueReturnedIfAttemptsOptionsIsNotPresent() throws IOException {
+        File f = buildFile("search localdomain\n" +
+            "nameserver 127.0.0.11\n");
+        assertEquals(16, parseEtcResolverOptions(f).attempts());
     }
 
     @Test


### PR DESCRIPTION
Motivations
-----------
DnsNameResolverBuilder and DnsNameResolver do not auto-configure
themselves uing default options define in /etc/resolv.conf.
In particular, rotate, timeout and attempts options are ignored.

Modifications
-------------
 - Modified UnixResolverDnsServerAddressStreamProvider to parse ndots,
attempts and timeout options all at once and use these defaults to
configure DnsNameResolver when values are not provided by the
DnsNameResolverBuilder.
 - When rotate option is specified, the DnsServerAddresses returned by
UnixResolverDnsServerAddressStreamProvider is rotational.
 - Amend resolv.conf options with the RES_OPTIONS environment variable
when present.

Fixes #10202
