### PR TITLE
Improve performance for Unpooled.copiedBuffer

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -794,7 +794,7 @@ public final class ByteBufUtil {
         return reserveAndWriteUtf8Seq(buf, checkCharSequenceBounds(seq, start, end), start, end, reserveBytes);
     }
 
-    private static int reserveAndWriteUtf8Seq(ByteBuf buf, CharSequence seq, int start, int end, int reserveBytes) {
+    static int reserveAndWriteUtf8Seq(ByteBuf buf, CharSequence seq, int start, int end, int reserveBytes) {
         for (;;) {
             if (buf instanceof WrappedCompositeByteBuf) {
                 // WrappedCompositeByteBuf is a sub-class of AbstractByteBuf so it needs special handling.

--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.buffer.CompositeByteBuf.ByteWrapper;
+import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.PlatformDependent;
@@ -647,6 +648,7 @@ public final class Unpooled {
     public static ByteBuf copiedBuffer(
             CharSequence string, int offset, int length, Charset charset) {
         ObjectUtil.checkNotNull(string, "string");
+        checkBounds(offset, length, string.length());
         if (length == 0) {
             return EMPTY_BUFFER;
         }
@@ -702,6 +704,7 @@ public final class Unpooled {
      */
     public static ByteBuf copiedBuffer(char[] array, int offset, int length, Charset charset) {
         ObjectUtil.checkNotNull(array, "array");
+        checkBounds(offset, length, array.length);
         if (length == 0) {
             return EMPTY_BUFFER;
         }
@@ -716,6 +719,13 @@ public final class Unpooled {
 
     private static ByteBuf copiedBuffer(CharBuffer buffer, Charset charset) {
         return ByteBufUtil.encodeString0(ALLOC, true, buffer, charset, 0);
+    }
+
+    private static void checkBounds(int start, int length, int capacity) {
+        if (MathUtil.isOutOfBounds(start, length, capacity)) {
+            throw new IndexOutOfBoundsException("expected: 0 <= start(" + start + ") <= start + length ("
+                                                + (start + length) + ") <= capacity(" + capacity + ')');
+        }
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -660,9 +660,8 @@ public final class Unpooled {
             CharBuffer buf = (CharBuffer) string;
             if (buf.hasArray()) {
                 return copiedBuffer(
-                        buf.array(),
-                        buf.arrayOffset() + buf.position() + offset,
-                        length, charset);
+                        CharBuffer.wrap(buf.array(), buf.arrayOffset() + buf.position() + offset, length),
+                        charset);
             }
 
             buf = buf.slice();

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -302,6 +302,22 @@ public class ByteBufUtilTest {
 
     @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("noUnsafe")
+    public void testWriteUsAsciiOffsetLength(BufferType bufferType) {
+        String usAscii = "NettyRocks";
+        ByteBuf buf = buffer(bufferType, 16);
+        buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII), 5, 4);
+        ByteBuf buf2 = buffer(bufferType, 16);
+        ByteBufUtil.writeAscii(buf2, usAscii, 5, 4);
+
+        assertEquals(buf, buf2);
+        assertEquals("Rock", buf2.toString(CharsetUtil.US_ASCII));
+
+        buf.release();
+        buf2.release();
+    }
+
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
     public void testWriteUsAsciiSwapped(BufferType bufferType) {
         String usAscii = "NettyRocks";
         ByteBuf buf = buffer(bufferType, 16);

--- a/microbench/src/main/java/io/netty/buffer/ByteBufUtilNewVersion.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufUtilNewVersion.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.AsciiString;
+import io.netty.util.CharsetUtil;
+
+public class ByteBufUtilNewVersion {
+    static int reserveAndWriteUtf8Seq(ByteBuf buf, CharSequence seq, int start, int end, int reserveBytes) {
+        for (; ; ) {
+            if (buf instanceof WrappedCompositeByteBuf) {
+                // WrappedCompositeByteBuf is a sub-class of AbstractByteBuf so it needs special handling.
+                buf = buf.unwrap();
+            } else if (buf instanceof AbstractByteBuf) {
+                AbstractByteBuf byteBuf = (AbstractByteBuf) buf;
+                byteBuf.ensureWritable0(reserveBytes);
+                int written = ByteBufUtil.writeUtf8(byteBuf, byteBuf.writerIndex, reserveBytes, seq, start, end);
+                byteBuf.writerIndex += written;
+                return written;
+            } else if (buf instanceof WrappedByteBuf) {
+                // Unwrap as the wrapped buffer may be an AbstractByteBuf and so we can use fast-path.
+                buf = buf.unwrap();
+            } else {
+                byte[] bytes = seq.subSequence(start, end).toString().getBytes(CharsetUtil.UTF_8);
+                buf.writeBytes(bytes);
+                return bytes.length;
+            }
+        }
+    }
+
+
+    /**
+     * Encode a {@link CharSequence} in <a href="http://en.wikipedia.org/wiki/ASCII">ASCII</a> and write it
+     * to a {@link ByteBuf}.
+     * <p>
+     * This method returns the actual number of bytes written.
+     */
+    public static int writeAscii(ByteBuf buf, CharSequence seq, int srcIndex, int len) {
+        // ASCII uses 1 byte per char
+        if (seq instanceof AsciiString) {
+            AsciiString asciiString = (AsciiString) seq;
+            buf.writeBytes(asciiString.array(), srcIndex + asciiString.arrayOffset(), len);
+        } else {
+            for (; ; ) {
+                if (buf instanceof WrappedCompositeByteBuf) {
+                    // WrappedCompositeByteBuf is a sub-class of AbstractByteBuf so it needs special handling.
+                    buf = buf.unwrap();
+                } else if (buf instanceof AbstractByteBuf) {
+                    AbstractByteBuf byteBuf = (AbstractByteBuf) buf;
+                    byteBuf.ensureWritable0(len);
+                    int written = writeAscii(byteBuf, byteBuf.writerIndex, seq, srcIndex, len);
+                    byteBuf.writerIndex += written;
+                    return written;
+                } else if (buf instanceof WrappedByteBuf) {
+                    // Unwrap as the wrapped buffer may be an AbstractByteBuf and so we can use fast-path.
+                    buf = buf.unwrap();
+                } else {
+                    byte[] bytes = seq.subSequence(srcIndex, srcIndex + len).toString().getBytes(CharsetUtil.US_ASCII);
+                    buf.writeBytes(bytes);
+                    return bytes.length;
+                }
+            }
+        }
+        return len;
+    }
+
+    static int writeAscii(AbstractByteBuf buffer, int writerIndex, CharSequence seq, int srcIndex, int len) {
+
+        // We can use the _set methods as these not need to do any index checks and reference checks.
+        // This is possible as we called ensureWritable(...) before.
+        for (int i = srcIndex, end = srcIndex + len; i < end; i++) {
+            buffer._setByte(writerIndex++, AsciiString.c2b(seq.charAt(i)));
+        }
+        return len;
+    }
+
+}

--- a/microbench/src/main/java/io/netty/buffer/UnpooledNewVersion.java
+++ b/microbench/src/main/java/io/netty/buffer/UnpooledNewVersion.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.CharsetUtil;
+import io.netty.util.internal.MathUtil;
+import io.netty.util.internal.ObjectUtil;
+
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+
+public class UnpooledNewVersion {
+    private static final ByteBufAllocator ALLOC = UnpooledByteBufAllocator.DEFAULT;
+
+    /**
+     * A buffer whose capacity is {@code 0}.
+     */
+    public static final ByteBuf EMPTY_BUFFER = ALLOC.buffer(0, 0);
+
+
+    /**
+     * Creates a new big-endian buffer whose content is the specified
+     * {@code string} encoded in the specified {@code charset}.
+     * The new buffer's {@code readerIndex} and {@code writerIndex} are
+     * {@code 0} and the length of the encoded string respectively.
+     */
+    public static ByteBuf copiedBuffer(CharSequence string, Charset charset) {
+        ObjectUtil.checkNotNull(string, "string");
+        if (CharsetUtil.UTF_8.equals(charset)) {
+            return copiedBufferUtf8(string, 0, string.length());
+        }
+        if (CharsetUtil.US_ASCII.equals(charset)) {
+            return copiedBufferAscii(string);
+        }
+        if (string instanceof CharBuffer) {
+            return copiedBuffer((CharBuffer) string, charset);
+        }
+
+        return copiedBuffer(CharBuffer.wrap(string), charset);
+    }
+
+    private static ByteBuf copiedBufferUtf8(CharSequence seq, int start, int length) {
+        int capacity = ByteBufUtil.utf8MaxBytes(length);
+        boolean release = true;
+        // Mimic the same behavior as other copiedBuffer implementations.
+        ByteBuf buffer = ALLOC.heapBuffer(capacity);
+        try {
+            ByteBufUtilNewVersion.reserveAndWriteUtf8Seq(buffer, seq, start, start + length, capacity);
+            release = false;
+            return buffer;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
+    }
+
+    private static ByteBuf copiedBufferAscii(CharSequence string) {
+        boolean release = true;
+        // Mimic the same behavior as other copiedBuffer implementations.
+        ByteBuf buffer = ALLOC.heapBuffer(string.length());
+        try {
+            ByteBufUtil.writeAscii(buffer, string);
+            release = false;
+            return buffer;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
+    }
+
+    private static ByteBuf copiedBufferAscii(CharSequence string, int start, int length) {
+        boolean release = true;
+        // Mimic the same behavior as other copiedBuffer implementations.
+        ByteBuf buffer = ALLOC.heapBuffer(length);
+        try {
+            ByteBufUtilNewVersion.writeAscii(buffer, string, start, length);
+            release = false;
+            return buffer;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
+    }
+
+    /**
+     * Creates a new big-endian buffer whose content is a subregion of
+     * the specified {@code string} encoded in the specified {@code charset}.
+     * The new buffer's {@code readerIndex} and {@code writerIndex} are
+     * {@code 0} and the length of the encoded string respectively.
+     */
+    public static ByteBuf copiedBuffer(
+            CharSequence string, int offset, int length, Charset charset) {
+        ObjectUtil.checkNotNull(string, "string");
+        checkBounds(offset, length, string.length());
+        if (length == 0) {
+            return EMPTY_BUFFER;
+        }
+        if (CharsetUtil.UTF_8.equals(charset)) {
+            return copiedBufferUtf8(string, offset, length);
+        }
+        if (CharsetUtil.US_ASCII.equals(charset)) {
+            return copiedBufferAscii(string, offset, length);
+        }
+        if (string instanceof CharBuffer) {
+            CharBuffer buf = (CharBuffer) string;
+            if (buf.hasArray()) {
+                return copiedBuffer(
+                        CharBuffer.wrap(buf.array(), buf.arrayOffset() + buf.position() + offset, length),
+                        charset);
+            }
+
+            buf = buf.slice();
+            buf.limit(length);
+            buf.position(offset);
+            return copiedBuffer(buf, charset);
+        }
+
+        return copiedBuffer(CharBuffer.wrap(string, offset, offset + length), charset);
+    }
+
+    /**
+     * Creates a new big-endian buffer whose content is the specified
+     * {@code array} encoded in the specified {@code charset}.
+     * The new buffer's {@code readerIndex} and {@code writerIndex} are
+     * {@code 0} and the length of the encoded string respectively.
+     */
+    public static ByteBuf copiedBuffer(char[] array, Charset charset) {
+        ObjectUtil.checkNotNull(array, "array");
+        int length = array.length;
+        if (length == 0) {
+            return EMPTY_BUFFER;
+        }
+        if (CharsetUtil.UTF_8.equals(charset)) {
+            return copiedBufferUtf8(CharBuffer.wrap(array), 0, length);
+        }
+        if (CharsetUtil.US_ASCII.equals(charset)) {
+            return copiedBufferAscii(CharBuffer.wrap(array));
+        }
+        return copiedBuffer(CharBuffer.wrap(array), charset);
+    }
+
+    /**
+     * Creates a new big-endian buffer whose content is a subregion of
+     * the specified {@code array} encoded in the specified {@code charset}.
+     * The new buffer's {@code readerIndex} and {@code writerIndex} are
+     * {@code 0} and the length of the encoded string respectively.
+     */
+    public static ByteBuf copiedBuffer(char[] array, int offset, int length, Charset charset) {
+        ObjectUtil.checkNotNull(array, "array");
+        checkBounds(offset, length, array.length);
+        if (length == 0) {
+            return EMPTY_BUFFER;
+        }
+        if (CharsetUtil.UTF_8.equals(charset)) {
+            return copiedBufferUtf8(CharBuffer.wrap(array), offset, length);
+        }
+        if (CharsetUtil.US_ASCII.equals(charset)) {
+            return copiedBufferAscii(CharBuffer.wrap(array), offset, length);
+        }
+        return copiedBuffer(CharBuffer.wrap(array, offset, length), charset);
+    }
+
+    private static ByteBuf copiedBuffer(CharBuffer buffer, Charset charset) {
+        return ByteBufUtil.encodeString0(ALLOC, true, buffer, charset, 0);
+    }
+
+    private static void checkBounds(int start, int length, int capacity) {
+        if (MathUtil.isOutOfBounds(start, length, capacity)) {
+            throw new IndexOutOfBoundsException("expected: 0 <= start(" + start + ") <= start + length ("
+                    + (start + length) + ") <= capacity(" + capacity + ')');
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/buffer/UnpooledOldVersion.java
+++ b/microbench/src/main/java/io/netty/buffer/UnpooledOldVersion.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
+
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+
+public class UnpooledOldVersion {
+    private static final ByteBufAllocator ALLOC = UnpooledByteBufAllocator.DEFAULT;
+
+    /**
+     * A buffer whose capacity is {@code 0}.
+     */
+    public static final ByteBuf EMPTY_BUFFER = ALLOC.buffer(0, 0);
+
+    /**
+     * Creates a new big-endian buffer whose content is the specified
+     * {@code string} encoded in the specified {@code charset}.
+     * The new buffer's {@code readerIndex} and {@code writerIndex} are
+     * {@code 0} and the length of the encoded string respectively.
+     */
+    public static ByteBuf copiedBuffer(CharSequence string, Charset charset) {
+        ObjectUtil.checkNotNull(string, "string");
+        if (CharsetUtil.UTF_8.equals(charset)) {
+            return copiedBufferUtf8(string);
+        }
+        if (CharsetUtil.US_ASCII.equals(charset)) {
+            return copiedBufferAscii(string);
+        }
+        if (string instanceof CharBuffer) {
+            return copiedBuffer((CharBuffer) string, charset);
+        }
+
+        return copiedBuffer(CharBuffer.wrap(string), charset);
+    }
+
+    private static ByteBuf copiedBufferUtf8(CharSequence string) {
+        boolean release = true;
+        // Mimic the same behavior as other copiedBuffer implementations.
+        ByteBuf buffer = ALLOC.heapBuffer(ByteBufUtil.utf8Bytes(string));
+        try {
+            ByteBufUtil.writeUtf8(buffer, string);
+            release = false;
+            return buffer;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
+    }
+
+    private static ByteBuf copiedBufferAscii(CharSequence string) {
+        boolean release = true;
+        // Mimic the same behavior as other copiedBuffer implementations.
+        ByteBuf buffer = ALLOC.heapBuffer(string.length());
+        try {
+            ByteBufUtil.writeAscii(buffer, string);
+            release = false;
+            return buffer;
+        } finally {
+            if (release) {
+                buffer.release();
+            }
+        }
+    }
+
+    /**
+     * Creates a new big-endian buffer whose content is a subregion of
+     * the specified {@code string} encoded in the specified {@code charset}.
+     * The new buffer's {@code readerIndex} and {@code writerIndex} are
+     * {@code 0} and the length of the encoded string respectively.
+     */
+    public static ByteBuf copiedBuffer(
+            CharSequence string, int offset, int length, Charset charset) {
+        ObjectUtil.checkNotNull(string, "string");
+        if (length == 0) {
+            return EMPTY_BUFFER;
+        }
+
+        if (string instanceof CharBuffer) {
+            CharBuffer buf = (CharBuffer) string;
+            if (buf.hasArray()) {
+                return copiedBuffer(
+                        buf.array(),
+                        buf.arrayOffset() + buf.position() + offset,
+                        length, charset);
+            }
+
+            buf = buf.slice();
+            buf.limit(length);
+            buf.position(offset);
+            return copiedBuffer(buf, charset);
+        }
+
+        return copiedBuffer(CharBuffer.wrap(string, offset, offset + length), charset);
+    }
+
+    /**
+     * Creates a new big-endian buffer whose content is the specified
+     * {@code array} encoded in the specified {@code charset}.
+     * The new buffer's {@code readerIndex} and {@code writerIndex} are
+     * {@code 0} and the length of the encoded string respectively.
+     */
+    public static ByteBuf copiedBuffer(char[] array, Charset charset) {
+        ObjectUtil.checkNotNull(array, "array");
+        return copiedBuffer(array, 0, array.length, charset);
+    }
+
+    /**
+     * Creates a new big-endian buffer whose content is a subregion of
+     * the specified {@code array} encoded in the specified {@code charset}.
+     * The new buffer's {@code readerIndex} and {@code writerIndex} are
+     * {@code 0} and the length of the encoded string respectively.
+     */
+    public static ByteBuf copiedBuffer(char[] array, int offset, int length, Charset charset) {
+        ObjectUtil.checkNotNull(array, "array");
+        if (length == 0) {
+            return EMPTY_BUFFER;
+        }
+        return copiedBuffer(CharBuffer.wrap(array, offset, length), charset);
+    }
+
+    private static ByteBuf copiedBuffer(CharBuffer buffer, Charset charset) {
+        return ByteBufUtil.encodeString0(ALLOC, true, buffer, charset, 0);
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/buffer/UnpooledBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/UnpooledBenchmark.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledNewVersion;
+import io.netty.buffer.UnpooledOldVersion;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.CharsetUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class UnpooledBenchmark extends AbstractMicrobenchmark {
+    @Param({"100", "500", "1000"})
+    private int length;
+
+    private String asciiString;
+    private char[] asciiCharArray;
+
+    private String utf8String;
+    private char[] utf8CharArray;
+
+    @Setup
+    public void setup() {
+        // Use buffer sizes that will also allow to write UTF-8 without grow the buffer
+        StringBuilder asciiSequence = new StringBuilder(length);
+        char[] asciiSeed = "abcdefg".toCharArray();
+        for (int i = 0; i < length; i++) {
+            asciiSequence.append(asciiSeed[i % asciiSeed.length]);
+        }
+        asciiString = asciiSequence.toString();
+        asciiCharArray = asciiString.toCharArray();
+
+        // Generate some mixed UTF-8 String for benchmark
+        StringBuilder utf8Sequence = new StringBuilder(length);
+        char[] utf8Seed = "UTF-8äÄ∏ŒŒ".toCharArray();
+        for (int i = 0; i < length; i++) {
+            utf8Sequence.append(utf8Seed[i % utf8Seed.length]);
+        }
+        utf8String = utf8Sequence.toString();
+        utf8CharArray = utf8String.toCharArray();
+    }
+
+    @Benchmark
+    @Group("ascii_string")
+    public void copiedBufferAscii(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledNewVersion.copiedBuffer(asciiString, CharsetUtil.US_ASCII);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("ascii_string")
+    public void copiedBufferAsciiOldVersion(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledOldVersion.copiedBuffer(asciiString, CharsetUtil.US_ASCII);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("utf8_string")
+    public void copiedBufferUtf8(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledNewVersion.copiedBuffer(utf8String, CharsetUtil.UTF_8);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("utf8_string")
+    public void copiedBufferUtf8OldVersion(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledOldVersion.copiedBuffer(utf8String, CharsetUtil.UTF_8);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("ascii_string_offset")
+    public void copiedBufferAsciiStartLength(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledNewVersion.copiedBuffer(asciiString, length / 3, length / 3, CharsetUtil.US_ASCII);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("ascii_string_offset")
+    public void copiedBufferAsciiStartLengthOldVersion(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledOldVersion.copiedBuffer(asciiString, length / 3, length / 3, CharsetUtil.US_ASCII);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("utf8_string_offset")
+    public void copiedBufferUtf8StartLength(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledNewVersion.copiedBuffer(utf8String, length / 3, length / 3, CharsetUtil.UTF_8);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("utf8_string_offset")
+    public void copiedBufferUtf8StartLengthOldVersion(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledOldVersion.copiedBuffer(utf8String, length / 3, length / 3, CharsetUtil.UTF_8);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("ascii_array")
+    public void copiedBufferAsciiViaArray(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledNewVersion.copiedBuffer(asciiCharArray, CharsetUtil.US_ASCII);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("ascii_array")
+    public void copiedBufferAsciiViaArrayOldVersion(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledOldVersion.copiedBuffer(asciiCharArray, CharsetUtil.US_ASCII);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("utf8_array")
+    public void copiedBufferUtf8ViaArray(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledNewVersion.copiedBuffer(utf8CharArray, CharsetUtil.UTF_8);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("utf8_array")
+    public void copiedBufferUtf8ViaArrayOldVersion(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledOldVersion.copiedBuffer(utf8CharArray, CharsetUtil.UTF_8);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("ascii_array_offset")
+    public void copiedBufferAsciiViaArrayStartLength(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledNewVersion.copiedBuffer(asciiCharArray, length / 3, length / 3, CharsetUtil.US_ASCII);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("ascii_array_offset")
+    public void copiedBufferAsciiViaArrayStartLengthOldVersion(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledOldVersion.copiedBuffer(asciiCharArray, length / 3, length / 3, CharsetUtil.US_ASCII);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("utf8_array_offset")
+    public void copiedBufferUtf8ViaArrayStartLength(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledNewVersion.copiedBuffer(utf8CharArray, length / 3, length / 3, CharsetUtil.UTF_8);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+
+    @Benchmark
+    @Group("utf8_array_offset")
+    public void copiedBufferUtf8ViaArrayStartLengthOldVersion(Blackhole bh) {
+        ByteBuf byteBuf = UnpooledOldVersion.copiedBuffer(utf8CharArray, length / 3, length / 3, CharsetUtil.UTF_8);
+        byteBuf.release();
+        bh.consume(byteBuf);
+    }
+}


### PR DESCRIPTION
Motivation:

Improve performance for these methods
> ByteBuf copiedBuffer(CharSequence string, Charset charset)
> ByteBuf copiedBuffer(CharSequence string, int offset, int length, Charset charset)
> ByteBuf copiedBuffer(char[] array, Charset charset)
> ByteBuf copiedBuffer(char[] array, int offset, int length, Charset charset)

Modification:

- Add an overload method in `ByteBufUtil` to support write ascii string by offset length param.
- Make `ByteBufUtil.reserveAndWriteUtf8Seq` package visible, because `Unpooled` will call this method without check bounds.
- Optimize `Unpooled.copiedBuffer` methods which write CharSequence or char[]
- Optimize call `ByteBuf copiedBuffer(CharBuffer buffer, Charset charset)` directly without check charset twice.
- Rearrange code.
- Add test case.
- Check bounds for index and length of source data.

Result:

Fixes #10205
Reference PR #10206 
