### PR TITLE
HttpPostRequestDecoder: retain instead of copy when first buf is last

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -39,13 +39,11 @@ import java.net.URLEncoder;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
-/** {@link HttpPostRequestDecoder} test case. */
+/**
+ * {@link HttpPostRequestDecoder} test case.
+ */
 public class HttpPostRequestDecoderTest {
 
     @Test
@@ -80,11 +78,11 @@ public class HttpPostRequestDecoderTest {
         for (String data : Arrays.asList("", "\r", "\r\r", "\r\r\r")) {
             final String body =
                     "--" + boundary + "\r\n" +
-                    "Content-Disposition: form-data; name=\"file\"; filename=\"tmp-0.txt\"\r\n" +
-                    "Content-Type: image/gif\r\n" +
-                    "\r\n" +
-                    data + "\r\n" +
-                    "--" + boundary + "--\r\n";
+                            "Content-Disposition: form-data; name=\"file\"; filename=\"tmp-0.txt\"\r\n" +
+                            "Content-Type: image/gif\r\n" +
+                            "\r\n" +
+                            data + "\r\n" +
+                            "--" + boundary + "--\r\n";
 
             // Create decoder instance to test.
             final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
@@ -100,7 +98,7 @@ public class HttpPostRequestDecoderTest {
 
             // Validate data has been parsed correctly as it was passed into request.
             assertEquals("Invalid decoded data [data=" + data.replaceAll("\r", "\\\\r") + ", upload=" + upload + ']',
-                data, upload.getString(CharsetUtil.UTF_8));
+                    data, upload.getString(CharsetUtil.UTF_8));
             upload.release();
             decoder.destroy();
         }
@@ -225,28 +223,28 @@ public class HttpPostRequestDecoderTest {
         final DefaultHttpDataFactory aMemFactory = new DefaultHttpDataFactory(false);
 
         DefaultHttpRequest aRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                                                             HttpMethod.POST,
-                                                             "http://localhost");
+                HttpMethod.POST,
+                "http://localhost");
         aRequest.headers().set(HttpHeaderNames.CONTENT_TYPE,
-                               "multipart/form-data; boundary=" + boundary);
+                "multipart/form-data; boundary=" + boundary);
         aRequest.headers().set(HttpHeaderNames.TRANSFER_ENCODING,
-                               HttpHeaderValues.CHUNKED);
+                HttpHeaderValues.CHUNKED);
 
         HttpPostRequestDecoder aDecoder = new HttpPostRequestDecoder(aMemFactory, aRequest);
 
         final String aData = "some data would be here. the data should be long enough that it " +
-                             "will be longer than the original buffer length of 256 bytes in " +
-                             "the HttpPostRequestDecoder in order to trigger the issue. Some more " +
-                             "data just to be on the safe side.";
+                "will be longer than the original buffer length of 256 bytes in " +
+                "the HttpPostRequestDecoder in order to trigger the issue. Some more " +
+                "data just to be on the safe side.";
 
         final String body =
                 "--" + boundary + "\r\n" +
-                "Content-Disposition: form-data; name=\"root\"\r\n" +
-                "Content-Type: text/plain\r\n" +
-                "\r\n" +
-                aData +
-                "\r\n" +
-                "--" + boundary + "--\r\n";
+                        "Content-Disposition: form-data; name=\"root\"\r\n" +
+                        "Content-Type: text/plain\r\n" +
+                        "\r\n" +
+                        aData +
+                        "\r\n" +
+                        "--" + boundary + "--\r\n";
 
         byte[] aBytes = body.getBytes();
 
@@ -279,7 +277,7 @@ public class HttpPostRequestDecoderTest {
     // See https://github.com/netty/netty/issues/2305
     @Test
     public void testChunkCorrect() throws Exception {
-       String payload = "town=794649819&town=784444184&town=794649672&town=794657800&town=" +
+        String payload = "town=794649819&town=784444184&town=794649672&town=794657800&town=" +
                 "794655734&town=794649377&town=794652136&town=789936338&town=789948986&town=" +
                 "789949643&town=786358677&town=794655880&town=786398977&town=789901165&town=" +
                 "789913325&town=789903418&town=789903579&town=794645251&town=794694126&town=" +
@@ -308,26 +306,45 @@ public class HttpPostRequestDecoderTest {
                 "789958999&town=789961555&town=794694050&town=794650241&town=794656286&town=" +
                 "794692081&town=794660090&town=794665227&town=794665136&town=794669931";
         DefaultHttpRequest defaultHttpRequest =
-                    new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
 
         HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(defaultHttpRequest);
 
         int firstChunk = 10;
         int middleChunk = 1024;
 
-        HttpContent part1 = new DefaultHttpContent(Unpooled.wrappedBuffer(
-                payload.substring(0, firstChunk).getBytes()));
-        HttpContent part2 = new DefaultHttpContent(Unpooled.wrappedBuffer(
-                payload.substring(firstChunk, firstChunk + middleChunk).getBytes()));
-        HttpContent part3 = new DefaultHttpContent(Unpooled.wrappedBuffer(
-                payload.substring(firstChunk + middleChunk, firstChunk + middleChunk * 2).getBytes()));
-        HttpContent part4 = new DefaultHttpContent(Unpooled.wrappedBuffer(
-                payload.substring(firstChunk + middleChunk * 2).getBytes()));
+        byte[] payload1 = payload.substring(0, firstChunk).getBytes();
+        byte[] payload2 = payload.substring(firstChunk, firstChunk + middleChunk).getBytes();
+        byte[] payload3 = payload.substring(firstChunk + middleChunk, firstChunk + middleChunk * 2).getBytes();
+        byte[] payload4 = payload.substring(firstChunk + middleChunk * 2).getBytes();
 
-        decoder.offer(part1);
-        decoder.offer(part2);
-        decoder.offer(part3);
-        decoder.offer(part4);
+        ByteBuf buf1 = ByteBufAllocator.DEFAULT.directBuffer(payload1.length);
+        ByteBuf buf2 = ByteBufAllocator.DEFAULT.directBuffer(payload2.length);
+        ByteBuf buf3 = ByteBufAllocator.DEFAULT.directBuffer(payload3.length);
+        ByteBuf buf4 = ByteBufAllocator.DEFAULT.directBuffer(payload4.length);
+
+        buf1.writeBytes(payload1);
+        buf2.writeBytes(payload2);
+        buf3.writeBytes(payload3);
+        buf4.writeBytes(payload4);
+
+        decoder.offer(new DefaultHttpContent(buf1));
+        decoder.offer(new DefaultHttpContent(buf2));
+        decoder.offer(new DefaultHttpContent(buf3));
+        decoder.offer(new DefaultLastHttpContent(buf4));
+
+        assertFalse(decoder.getBodyHttpDatas().isEmpty());
+        assertEquals(139, decoder.getBodyHttpDatas().size());
+
+        Attribute attr = (Attribute) decoder.getBodyHttpData("town");
+        assertTrue(attr.getByteBuf().hasArray());
+        assertEquals("794649819", attr.getValue());
+
+        decoder.destroy();
+        buf1.release();
+        buf2.release();
+        buf3.release();
+        buf4.release();
     }
 
     // See https://github.com/netty/netty/issues/3326
@@ -360,7 +377,7 @@ public class HttpPostRequestDecoderTest {
     public void testFilenameContainingSemicolon2() throws Exception {
         final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
-                                                                      "http://localhost");
+                "http://localhost");
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         // Force to use memory-based data.
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
@@ -368,11 +385,11 @@ public class HttpPostRequestDecoderTest {
         final String filename = "tmp;0.txt";
         final String body =
                 "--" + boundary + "\r\n" +
-                "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
-                "Content-Type: image/gif\r\n" +
-                "\r\n" +
-                data + "\r\n" +
-                "--" + boundary + "--\r\n";
+                        "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
+                        "Content-Type: image/gif\r\n" +
+                        "\r\n" +
+                        data + "\r\n" +
+                        "--" + boundary + "--\r\n";
 
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
         // Create decoder instance to test.
@@ -421,19 +438,19 @@ public class HttpPostRequestDecoderTest {
         String filecontent = "123456";
 
         final String body = "--" + boundary + "\r\n" +
-                            "Content-Disposition: form-data; name=\"file\"; filename=" + "\"" + "attached.txt" + "\"" +
-                            "\r\n" +
-                            "Content-Type: application/octet-stream" + "\r\n" +
-                            "Content-Encoding: gzip" + "\r\n" +
-                            "\r\n" +
-                            filecontent +
-                            "\r\n" +
-                            "--" + boundary + "--";
+                "Content-Disposition: form-data; name=\"file\"; filename=" + "\"" + "attached.txt" + "\"" +
+                "\r\n" +
+                "Content-Type: application/octet-stream" + "\r\n" +
+                "Content-Encoding: gzip" + "\r\n" +
+                "\r\n" +
+                filecontent +
+                "\r\n" +
+                "--" + boundary + "--";
 
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
-                                                                      HttpMethod.POST,
-                                                                      "http://localhost",
-                                                                      Unpooled.wrappedBuffer(body.getBytes()));
+                HttpMethod.POST,
+                "http://localhost",
+                Unpooled.wrappedBuffer(body.getBytes()));
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
@@ -452,19 +469,19 @@ public class HttpPostRequestDecoderTest {
     public void testMultipartRequestWithFileInvalidCharset() throws Exception {
         final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
-            "http://localhost");
+                "http://localhost");
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         // Force to use memory-based data.
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
         final String data = "asdf";
         final String filename = "tmp;0.txt";
         final String body =
-            "--" + boundary + "\r\n" +
-                "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
-                "Content-Type: image/gif; charset=ABCD\r\n" +
-                "\r\n" +
-                data + "\r\n" +
-                "--" + boundary + "--\r\n";
+                "--" + boundary + "\r\n" +
+                        "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
+                        "Content-Type: image/gif; charset=ABCD\r\n" +
+                        "\r\n" +
+                        data + "\r\n" +
+                        "--" + boundary + "--\r\n";
 
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         // Create decoder instance to test.
@@ -482,22 +499,22 @@ public class HttpPostRequestDecoderTest {
     public void testMultipartRequestWithFieldInvalidCharset() throws Exception {
         final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
-            "http://localhost");
+                "http://localhost");
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         // Force to use memory-based data.
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
         final String aData = "some data would be here. the data should be long enough that it " +
-            "will be longer than the original buffer length of 256 bytes in " +
-            "the HttpPostRequestDecoder in order to trigger the issue. Some more " +
-            "data just to be on the safe side.";
+                "will be longer than the original buffer length of 256 bytes in " +
+                "the HttpPostRequestDecoder in order to trigger the issue. Some more " +
+                "data just to be on the safe side.";
         final String body =
-            "--" + boundary + "\r\n" +
-                "Content-Disposition: form-data; name=\"root\"\r\n" +
-                "Content-Type: text/plain; charset=ABCD\r\n" +
-                "\r\n" +
-                aData +
-                "\r\n" +
-                "--" + boundary + "--\r\n";
+                "--" + boundary + "\r\n" +
+                        "Content-Disposition: form-data; name=\"root\"\r\n" +
+                        "Content-Type: text/plain; charset=ABCD\r\n" +
+                        "\r\n" +
+                        aData +
+                        "\r\n" +
+                        "--" + boundary + "--\r\n";
 
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         // Create decoder instance to test.
@@ -539,16 +556,16 @@ public class HttpPostRequestDecoderTest {
         String filenameEncoded = URLEncoder.encode(filename, encoding);
 
         final String body = "--" + boundary + "\r\n" +
-          "Content-Disposition: form-data; name=\"file\"; filename*=" + encoding + "''" + filenameEncoded + "\r\n" +
-          "\r\n" +
-          "foo\r\n" +
-          "\r\n" +
-          "--" + boundary + "--";
+                "Content-Disposition: form-data; name=\"file\"; filename*=" + encoding + "''" + filenameEncoded +
+                "\r\n\r\n" +
+                "foo\r\n" +
+                "\r\n" +
+                "--" + boundary + "--";
 
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
-                                                                      HttpMethod.POST,
-                                                                      "http://localhost",
-                                                                      Unpooled.wrappedBuffer(body.getBytes()));
+                HttpMethod.POST,
+                "http://localhost",
+                Unpooled.wrappedBuffer(body.getBytes()));
 
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
@@ -574,17 +591,17 @@ public class HttpPostRequestDecoderTest {
         String filenameEncoded = URLEncoder.encode(filename, encoding);
 
         final String body = "--" + boundary + "\r\n" +
-          "Content-Disposition: form-data; name=\"file\"; filename*=" +
-              encoding + "'" + language + "'" + filenameEncoded + "\r\n" +
-          "\r\n" +
-          "foo\r\n" +
-          "\r\n" +
-          "--" + boundary + "--";
+                "Content-Disposition: form-data; name=\"file\"; filename*=" +
+                encoding + "'" + language + "'" + filenameEncoded + "\r\n" +
+                "\r\n" +
+                "foo\r\n" +
+                "\r\n" +
+                "--" + boundary + "--";
 
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
-                                                                      HttpMethod.POST,
-                                                                      "http://localhost",
-                                                                      Unpooled.wrappedBuffer(body.getBytes()));
+                HttpMethod.POST,
+                "http://localhost",
+                Unpooled.wrappedBuffer(body.getBytes()));
 
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
@@ -605,16 +622,16 @@ public class HttpPostRequestDecoderTest {
         final String boundary = "74e78d11b0214bdcbc2f86491eeb4902";
 
         final String body = "--" + boundary + "\r\n" +
-          "Content-Disposition: form-data; name=\"file\"; filename*=not-encoded\r\n" +
-          "\r\n" +
-          "foo\r\n" +
-          "\r\n" +
-          "--" + boundary + "--";
+                "Content-Disposition: form-data; name=\"file\"; filename*=not-encoded\r\n" +
+                "\r\n" +
+                "foo\r\n" +
+                "\r\n" +
+                "--" + boundary + "--";
 
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
-                                                                      HttpMethod.POST,
-                                                                      "http://localhost",
-                                                                      Unpooled.wrappedBuffer(body.getBytes()));
+                HttpMethod.POST,
+                "http://localhost",
+                Unpooled.wrappedBuffer(body.getBytes()));
 
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
 
@@ -637,16 +654,16 @@ public class HttpPostRequestDecoderTest {
         final String boundary = "74e78d11b0214bdcbc2f86491eeb4902";
 
         final String body = "--" + boundary + "\r\n" +
-          "Content-Disposition: form-data; name=\"file\"; filename*=not-a-charset''filename\r\n" +
-          "\r\n" +
-          "foo\r\n" +
-          "\r\n" +
-          "--" + boundary + "--";
+                "Content-Disposition: form-data; name=\"file\"; filename*=not-a-charset''filename\r\n" +
+                "\r\n" +
+                "foo\r\n" +
+                "\r\n" +
+                "--" + boundary + "--";
 
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
-                                                                      HttpMethod.POST,
-                                                                      "http://localhost",
-                                                                      Unpooled.wrappedBuffer(body.getBytes()));
+                HttpMethod.POST,
+                "http://localhost",
+                Unpooled.wrappedBuffer(body.getBytes()));
 
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
 
@@ -667,7 +684,7 @@ public class HttpPostRequestDecoderTest {
     public void testDecodeMalformedEmptyContentTypeFieldParameters() throws Exception {
         final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
         final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
-                                                                      "http://localhost");
+                "http://localhost");
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         // Force to use memory-based data.
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
@@ -675,11 +692,11 @@ public class HttpPostRequestDecoderTest {
         final String filename = "tmp-0.txt";
         final String body =
                 "--" + boundary + "\r\n" +
-                "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
-                "Content-Type: \r\n" +
-                "\r\n" +
-                data + "\r\n" +
-                "--" + boundary + "--\r\n";
+                        "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
+                        "Content-Type: \r\n" +
+                        "\r\n" +
+                        data + "\r\n" +
+                        "--" + boundary + "--\r\n";
 
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
         // Create decoder instance to test.
@@ -697,7 +714,7 @@ public class HttpPostRequestDecoderTest {
     public void testMultipartRequest() throws Exception {
         String BOUNDARY = "01f136d9282f";
 
-        ByteBuf byteBuf = Unpooled.wrappedBuffer(("--" + BOUNDARY + "\n" +
+        byte[] bodyBytes = ("--" + BOUNDARY + "\n" +
                 "Content-Disposition: form-data; name=\"msg_id\"\n" +
                 "\n" +
                 "15200\n" +
@@ -705,7 +722,9 @@ public class HttpPostRequestDecoderTest {
                 "Content-Disposition: form-data; name=\"msg\"\n" +
                 "\n" +
                 "test message\n" +
-                "--" + BOUNDARY + "--").getBytes());
+                "--" + BOUNDARY + "--").getBytes();
+        ByteBuf byteBuf = Unpooled.directBuffer(bodyBytes.length);
+        byteBuf.writeBytes(bodyBytes);
 
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.POST, "/up", byteBuf);
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + BOUNDARY);
@@ -718,11 +737,16 @@ public class HttpPostRequestDecoderTest {
         assertTrue(decoder.isMultipart());
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         assertEquals(2, decoder.getBodyHttpDatas().size());
-        assertEquals("test message", ((Attribute) decoder.getBodyHttpData("msg")).getValue());
-        assertEquals("15200", ((Attribute) decoder.getBodyHttpData("msg_id")).getValue());
+
+        Attribute attrMsg = (Attribute) decoder.getBodyHttpData("msg");
+        assertTrue(attrMsg.getByteBuf().isDirect());
+        assertEquals("test message", attrMsg.getValue());
+        Attribute attrMsgId = (Attribute) decoder.getBodyHttpData("msg_id");
+        assertTrue(attrMsgId.getByteBuf().isDirect());
+        assertEquals("15200", attrMsgId.getValue());
 
         decoder.destroy();
-        assertEquals(1, req.refCnt());
+        assertTrue(req.release());
     }
 
     @Test(expected = HttpPostRequestDecoder.ErrorDataDecoderException.class)
@@ -800,6 +824,36 @@ public class HttpPostRequestDecoderTest {
         assertTrue("the item should be a FileUpload", part1 instanceof FileUpload);
         FileUpload fileUpload = (FileUpload) part1;
         assertEquals("the filename should be decoded", filename, fileUpload.getFilename());
+
+        decoder.destroy();
+        req.release();
+    }
+
+    @Test
+    public void testFullRequestWithDirectByteBuf() throws Exception {
+        byte[] bodyBytes = "foo=bar&a=b&city=%22london%22".getBytes();
+        ByteBuf content = ByteBufAllocator.DEFAULT.directBuffer(bodyBytes.length);
+        content.writeBytes(bodyBytes);
+
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/", content);
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(req);
+        assertFalse(decoder.getBodyHttpDatas().isEmpty());
+
+        assertFalse(decoder.getBodyHttpDatas().isEmpty());
+        assertEquals(3, decoder.getBodyHttpDatas().size());
+
+        Attribute attr = (Attribute) decoder.getBodyHttpData("foo");
+        assertTrue(attr.getByteBuf().hasArray());
+        assertEquals("bar", attr.getValue());
+
+        attr = (Attribute) decoder.getBodyHttpData("a");
+        assertTrue(attr.getByteBuf().hasArray());
+        assertEquals("b", attr.getValue());
+
+        attr = (Attribute) decoder.getBodyHttpData("city");
+        assertTrue(attr.getByteBuf().hasArray());
+        assertEquals("\"london\"", attr.getValue());
+
         decoder.destroy();
         req.release();
     }


### PR DESCRIPTION
Motivations
-----------
There is no need to copy the "offered" ByteBuf in HttpPostRequestDecoder
when the first HttpContent ByteBuf is also the last (LastHttpContent) as
the full content can immediately be decoded. No extra bookeeping needed.

Modifications
-------------
In HttpPost(Standard|Multipart)RequestDecoder:
 - Retain the first ByteBuf when it is both the first HttpContent and last (LastHttpContent)
offered to the decoder.
 - Retain slices of the final buffers values
 - For non-multi-part content, URL decoding of Attributes' content ByteBuf no longer creates
a ByteBuf when there is nothing to decode. When decoding is necessary, a ByteBuf is created
using the allocator of the HttpContent's ByteBuf.

Results
-------
ByteBufs of FullHttpMessage decoded by HttpPostRequestDecoder are no longer
unnecessarily copied. Attributes are extracted as retained slices. When URL decoding
is necessary, the new ByteBuf is created using the allocator of the HttpContent's ByteBuf.

Partially addresses issue #10200
