### PR TITLE
Update testsuite / pom.xml to be able to build with Java15

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
@@ -57,7 +57,9 @@ final class Conscrypt {
      */
     static boolean isAvailable() {
         return CAN_INSTANCE_PROVIDER && IS_CONSCRYPT_SSLENGINE != null &&
-            (PlatformDependent.javaVersion() >= 8 || PlatformDependent.isAndroid());
+                ((PlatformDependent.javaVersion() >= 8 &&
+                        // Only works on Java14 and earlier for now
+                        PlatformDependent.javaVersion() < 15) || PlatformDependent.isAndroid());
     }
 
     static boolean isEngineSupported(SSLEngine engine) {

--- a/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
@@ -59,6 +59,7 @@ final class Conscrypt {
         return CAN_INSTANCE_PROVIDER && IS_CONSCRYPT_SSLENGINE != null &&
                 ((PlatformDependent.javaVersion() >= 8 &&
                         // Only works on Java14 and earlier for now
+                        // See https://github.com/google/conscrypt/issues/838
                         PlatformDependent.javaVersion() < 15) || PlatformDependent.isAndroid());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,26 @@
     </profile>
     <!-- JDK14 -->
     <profile>
+      <id>java15</id>
+      <activation>
+        <jdk>15</jdk>
+      </activation>
+      <properties>
+        <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
+        <argLine.alpnAgent />
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
+        <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
+        <!-- 1.4.x does not work in Java10+ -->
+        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <!-- This is the minimum supported by Java12+ -->
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <!-- pax-exam does not work on latest Java12 EA 22 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+      </properties>
+    </profile>
+    <profile>
       <id>java14</id>
       <activation>
         <jdk>14</jdk>


### PR DESCRIPTION
Motivation:

We need to make some slightly changes to be able to build on Java15 as some previous deprecated methods now throw UnsupportedOperationException

Modifications:

- Add code to handle UnsupportedOperationException
- Revert previous applied workaround for bug that was fixed in Java15
- Add maven profile

Result:

Be able to build with latest Java15 EA release