### PR TITLE
optimized code,regex precompile and method marked with @Override

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -123,6 +123,7 @@ public final class PlatformDependent {
     private static final String LINUX_ID_PREFIX = "ID=";
     private static final String LINUX_ID_LIKE_PREFIX = "ID_LIKE=";
     public static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+    private static Pattern bitPattern = Pattern.compile("([1-9][0-9]+)-?bit");
 
     private static final Cleaner NOOP = new Cleaner() {
         @Override
@@ -1276,7 +1277,6 @@ public final class PlatformDependent {
 
         // Last resort: guess from VM name and then fall back to most common 64-bit mode.
         String vm = SystemPropertyUtil.get("java.vm.name", "").toLowerCase(Locale.US);
-        Pattern bitPattern = Pattern.compile("([1-9][0-9]+)-?bit");
         Matcher m = bitPattern.matcher(vm);
         if (m.find()) {
             return Integer.parseInt(m.group(1));

--- a/transport-sctp/src/main/java/com/sun/nio/sctp/AbstractNotificationHandler.java
+++ b/transport-sctp/src/main/java/com/sun/nio/sctp/AbstractNotificationHandler.java
@@ -25,6 +25,7 @@ public class AbstractNotificationHandler<T> implements NotificationHandler<T> {
         return null;
     }
 
+    @Override
     public HandlerResult handleNotification(Notification notification, Object o) {
         return null;
     }


### PR DESCRIPTION
…When using regex, precompile needs to be done in order to increase the matching performance.

Motivation:
io.netty.util.internal.PlatformDependent#bitMode0  When using regex, precompile needs to be done in order to increase the matching performance
com.sun.nio.sctp.AbstractNotificationHandler#handleNotification(com.sun.nio.sctp.Notification, java.lang.Object) be marked with @Override annotation

Modification:

Not

Result:

Not

If there is no issue then describe the changes introduced by this PR.
