### PR TITLE
DnsNameResolver: dns cache fallback

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -40,6 +40,7 @@ public final class DnsNameResolverBuilder {
     private ChannelFactory<? extends DatagramChannel> channelFactory;
     private ChannelFactory<? extends SocketChannel> socketChannelFactory;
     private DnsCache resolveCache;
+    private DnsCache resolveCacheFallback;
     private DnsCnameCache cnameCache;
     private AuthoritativeDnsServerCache authoritativeDnsServerCache;
     private Integer minTtl;
@@ -152,6 +153,17 @@ public final class DnsNameResolverBuilder {
      */
     public DnsNameResolverBuilder resolveCache(DnsCache resolveCache) {
         this.resolveCache  = resolveCache;
+        return this;
+    }
+
+    /**
+     * Sets the cache fallback for resolution results.
+     *
+     * @param resolveCacheFallback the DNS resolution results cache
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder resolveCacheFallback(DnsCache resolveCacheFallback) {
+        this.resolveCacheFallback = resolveCacheFallback;
         return this;
     }
 
@@ -423,6 +435,10 @@ public final class DnsNameResolverBuilder {
         return new DefaultDnsCache(intValue(minTtl, 0), intValue(maxTtl, Integer.MAX_VALUE), intValue(negativeTtl, 0));
     }
 
+    private DnsCache newCacheFallback() {
+        return null;
+    }
+
     private AuthoritativeDnsServerCache newAuthoritativeDnsServerCache() {
         return new DefaultAuthoritativeDnsServerCache(
                 intValue(minTtl, 0), intValue(maxTtl, Integer.MAX_VALUE),
@@ -467,6 +483,9 @@ public final class DnsNameResolverBuilder {
         }
 
         DnsCache resolveCache = this.resolveCache != null ? this.resolveCache : newCache();
+        DnsCache resolveCacheFallback = this.resolveCacheFallback != null
+                ? this.resolveCacheFallback
+                : newCacheFallback();
         DnsCnameCache cnameCache = this.cnameCache != null ? this.cnameCache : newCnameCache();
         AuthoritativeDnsServerCache authoritativeDnsServerCache = this.authoritativeDnsServerCache != null ?
                 this.authoritativeDnsServerCache : newAuthoritativeDnsServerCache();
@@ -475,6 +494,7 @@ public final class DnsNameResolverBuilder {
                 channelFactory,
                 socketChannelFactory,
                 resolveCache,
+                resolveCacheFallback,
                 cnameCache,
                 authoritativeDnsServerCache,
                 dnsQueryLifecycleObserverFactory,
@@ -515,6 +535,10 @@ public final class DnsNameResolverBuilder {
 
         if (resolveCache != null) {
             copiedBuilder.resolveCache(resolveCache);
+        }
+
+        if (resolveCacheFallback != null) {
+            copiedBuilder.resolveCacheFallback(resolveCacheFallback);
         }
 
         if (cnameCache != null) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/FlatTtlDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/FlatTtlDnsCache.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsRecord;
+import java.net.InetAddress;
+
+/**
+ * A {@link DnsCache} implementation that uses cache TTL instead of DNS record TTL.
+ * If any additional {@link DnsRecord} is used, no caching takes place.
+ */
+public class FlatTtlDnsCache extends DefaultDnsCache {
+
+    private final int ttl;
+
+    /**
+     * Creates a FlatTtlDnsCache with negative caching disabled.
+     * @param ttl TTL in seconds to use for caching all DNS records.
+     */
+    public FlatTtlDnsCache(int ttl) {
+        this(ttl, 0);
+    }
+
+    /**
+     * Creates a FlatTtlDnsCache.
+     * @param ttl TTL in seconds to use for caching all DNS records.
+     * @param negativeTtl TTL in seconds to retain bad DNS answers. 0 to not no cache.
+     */
+    public FlatTtlDnsCache(int ttl, int negativeTtl) {
+        super(ttl, ttl, negativeTtl);
+        this.ttl = ttl;
+    }
+
+    @Override
+    public DnsCacheEntry cache(String hostname, DnsRecord[] additionals, InetAddress address, long originalTtl,
+                               EventLoop loop) {
+        return super.cache(hostname, additionals, address, ttl, loop);
+    }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/FlatTtlDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/FlatTtlDnsCacheTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+public class FlatTtlDnsCacheTest {
+
+    @Test
+    public void testTtlOverride() throws Throwable {
+        final InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
+        final InetAddress addr2 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 });
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final FlatTtlDnsCache cache = new FlatTtlDnsCache(2, 10);
+            cache.cache("netty.io", null, addr1, 1, loop);
+            cache.cache("netty.io", null, addr2, 10000, loop);
+
+            Throwable error = loop.schedule(new Callable<Throwable>() {
+                @Override
+                public Throwable call() {
+                    try {
+                        List<? extends DnsCacheEntry> entries = cache.get("netty.io", null);
+                        assertEquals(2, entries.size());
+                        assertEntry(entries.get(0), addr1);
+                        assertEntry(entries.get(1), addr2);
+                        return null;
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            }, 1, TimeUnit.SECONDS).get();
+            if (error != null) {
+                throw error;
+            }
+
+            error = loop.schedule(new Callable<Throwable>() {
+                @Override
+                public Throwable call() {
+                    try {
+                        assertNull(cache.get("netty.io", null));
+                        return null;
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            }, 1, TimeUnit.SECONDS).get();
+            if (error != null) {
+                throw error;
+            }
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private static void assertEntry(DnsCacheEntry entry, InetAddress address) {
+        assertEquals(address, entry.address());
+        assertNull(entry.cause());
+    }
+
+    @Test
+    public void testCacheFailedNoCaching() throws Exception {
+        InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
+        InetAddress addr2 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 });
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final FlatTtlDnsCache cache = new FlatTtlDnsCache(2, 0);
+            cache.cache("netty.io", null, addr1, 10000, loop);
+            cache.cache("netty.io", null, addr2, 10000, loop);
+
+            List<? extends DnsCacheEntry> entries = cache.get("netty.io", null);
+            assertEquals(2, entries.size());
+            assertEntry(entries.get(0), addr1);
+            assertEntry(entries.get(1), addr2);
+
+            cache.cache("netty.io", null, new Exception(), loop);
+
+            entries = cache.get("netty.io", null);
+            assertEquals(2, entries.size());
+            assertEntry(entries.get(0), addr1);
+            assertEntry(entries.get(1), addr2);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+}


### PR DESCRIPTION
Motivations
-----------
Provide a mechanism to immediately return cached and expired DNS entries
while refreshing them in background to improve resilience in case of DNS
outage for example.

Modifications
-------------
DnsNameResolver can be constructed with an optional fallback DnsCache.
When the hostname cannot be successfully resolved with the primary
DnsCache (resolveCache), the resolver immediately resolves the promise
with the result provided by the fallback cache, if any, and triggers new
DNS queries in background to attempt repopulation the primary cache.

Result
------
Addresses #10203