### PR TITLE
zlib: use ByteBuffer inflater/deflater methods when possible

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/ByteBufChecksum.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ByteBufChecksum.java
@@ -34,7 +34,7 @@ import java.util.zip.Checksum;
  */
 abstract class ByteBufChecksum implements Checksum {
     private static final Method ADLER32_UPDATE_METHOD;
-    private static final Method CRC32_UPDATE_METHOD;
+    static final Method CRC32_UPDATE_METHOD;
 
     static {
         // See if we can use fast-path when using ByteBuf that is not heap based as Adler32 and CRC32 added support


### PR DESCRIPTION
Motivations
-----------
Inflater and Deflater support ByteBuffer arguments since Java 11. These
should be used when possible instead of copying ByteBufs to byte arrays.

Modifications
-------------
Use ByteBuffer methods of Inflater and Deflater in JdkZlibDecoder and
JdkZlibEncoder when Java 11 is detected and the ByteBuf is a direct one.
Added decompression tests covering direct ByteBufs.

Results
-------
Addresses issue #8838


Notes:
 * I am not sure how/where `CompositeByteBuf`s are handled. E.g: what if the CompositeByteBuf has 1 or N direct ByteBuf components...?
 * I also can't run these tests from IntelliJ (only from mvn cli) so I am not sure which new/old methods are covered.
    * Some instructions on how to set up the dev env + IntelliJ are very much needed. Jdk 11 is my default JDK. I have never been able to just mvn install skip tests Netty 4.1 nor 5 in full (it always fail somewhere...). I get some notice from IJ when I try running tests from there saying it doesn't recognize `--illegal-access` option from the pom and many more issues... I can work around some of these issues for some projects but not others.