### PR TITLE
Remove some debugging cruft

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
@@ -59,7 +59,6 @@ public class RtspDecoderTest {
                         Unpooled.wrappedBuffer(data2));
 
         HttpObject res1 = ch.readInbound();
-        System.out.println(res1);
         assertNotNull(res1);
         assertTrue(res1 instanceof FullHttpRequest);
         ((FullHttpRequest) res1).release();


### PR DESCRIPTION
Motivation:

RtspDecoderTest did include a println(...) call which was a left over from debugging.

Modifications:

Remove println(...)

Result:

Cleanup