### PR TITLE
Rename testmethods to make these more clear

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslClientContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslClientContextTest.java
@@ -22,7 +22,7 @@ import java.io.File;
 
 public class JdkSslClientContextTest extends SslContextTest {
     @Override
-    protected SslContext newServerContext(File crtFile, File keyFile, String pass) throws SSLException {
+    protected SslContext newSslContext(File crtFile, File keyFile, String pass) throws SSLException {
         return new JdkSslClientContext(crtFile, InsecureTrustManagerFactory.INSTANCE, crtFile, keyFile, pass,
                 null, null, IdentityCipherSuiteFilter.INSTANCE, ApplicationProtocolConfig.DISABLED, 0, 0);
     }

--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslServerContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslServerContextTest.java
@@ -21,7 +21,7 @@ import java.io.File;
 public class JdkSslServerContextTest extends SslContextTest {
 
     @Override
-    protected SslContext newServerContext(File crtFile, File keyFile, String pass) throws SSLException {
+    protected SslContext newSslContext(File crtFile, File keyFile, String pass) throws SSLException {
         return new JdkSslServerContext(crtFile, keyFile, pass);
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslClientContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslClientContextTest.java
@@ -31,7 +31,7 @@ public class OpenSslClientContextTest extends SslContextTest  {
     }
 
     @Override
-    protected SslContext newServerContext(File crtFile, File keyFile, String pass) throws SSLException {
+    protected SslContext newSslContext(File crtFile, File keyFile, String pass) throws SSLException {
         return new OpenSslClientContext(crtFile, InsecureTrustManagerFactory.INSTANCE, crtFile, keyFile, pass,
                 null, null, IdentityCipherSuiteFilter.INSTANCE, ApplicationProtocolConfig.DISABLED, 0, 0);
     }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslServerContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslServerContextTest.java
@@ -32,7 +32,7 @@ public class OpenSslServerContextTest extends SslContextTest {
     }
 
     @Override
-    protected SslContext newServerContext(File crtFile, File keyFile, String pass) throws SSLException {
+    protected SslContext newSslContext(File crtFile, File keyFile, String pass) throws SSLException {
         Assume.assumeTrue(OpenSsl.isAvailable());
         return new OpenSslServerContext(crtFile, keyFile, pass);
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextTest.java
@@ -64,35 +64,35 @@ public abstract class SslContextTest {
     }
 
     @Test
-    public void testSslServerWithEncryptedPrivateKey() throws SSLException {
+    public void testSslContextWithEncryptedPrivateKey() throws SSLException {
         File keyFile = ResourcesUtil.getFile(getClass(), "test_encrypted.pem");
         File crtFile = ResourcesUtil.getFile(getClass(), "test.crt");
 
-        newServerContext(crtFile, keyFile, "12345");
+        newSslContext(crtFile, keyFile, "12345");
     }
 
     @Test
-    public void testSslServerWithEncryptedPrivateKey2() throws SSLException {
+    public void testSslContextWithEncryptedPrivateKey2() throws SSLException {
         File keyFile = ResourcesUtil.getFile(getClass(), "test2_encrypted.pem");
         File crtFile = ResourcesUtil.getFile(getClass(), "test2.crt");
 
-        newServerContext(crtFile, keyFile, "12345");
+        newSslContext(crtFile, keyFile, "12345");
     }
 
     @Test
-    public void testSslServerWithUnencryptedPrivateKey() throws SSLException {
+    public void testSslContextWithUnencryptedPrivateKey() throws SSLException {
         File keyFile = ResourcesUtil.getFile(getClass(), "test_unencrypted.pem");
         File crtFile = ResourcesUtil.getFile(getClass(), "test.crt");
 
-        newServerContext(crtFile, keyFile, null);
+        newSslContext(crtFile, keyFile, null);
     }
 
     @Test(expected = SSLException.class)
-    public void testSslServerWithUnencryptedPrivateKeyEmptyPass() throws SSLException {
+    public void testSslContextWithUnencryptedPrivateKeyEmptyPass() throws SSLException {
         File keyFile = ResourcesUtil.getFile(getClass(), "test_unencrypted.pem");
         File crtFile = ResourcesUtil.getFile(getClass(), "test.crt");
 
-        newServerContext(crtFile, keyFile, "");
+        newSslContext(crtFile, keyFile, "");
     }
 
     @Test
@@ -112,14 +112,14 @@ public abstract class SslContextTest {
         File keyFile = ResourcesUtil.getFile(getClass(), "test_unencrypted.pem");
         File crtFile = ResourcesUtil.getFile(getClass(), "test.crt");
 
-        SslContext sslContext = newServerContext(crtFile, keyFile, null);
+        SslContext sslContext = newSslContext(crtFile, keyFile, null);
         assertFalse(sslContext.cipherSuites().contains(unsupportedCipher));
     }
 
     @Test(expected = CertificateException.class)
-    public void test() throws CertificateException {
+    public void testUnsupportedParams() throws CertificateException {
         SslContext.toX509Certificates(new File(getClass().getResource("ec_params_unsupported.pem").getFile()));
     }
 
-    protected abstract SslContext newServerContext(File crtFile, File keyFile, String pass) throws SSLException;
+    protected abstract SslContext newSslContext(File crtFile, File keyFile, String pass) throws SSLException;
 }


### PR DESCRIPTION
Motivation:

The currently used method names don't make a lot of sense.

Modifications:

Rename to cleanup

Result:

Cleanup