### PR TITLE
Optimize stomp encoder

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
@@ -38,9 +38,9 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
             StompFrame frame = (StompFrame) msg;
             ByteBuf frameBuf = encodeFrame(frame, ctx);
             if (frame.content().isReadable()) {
-                out.add(frameBuf);
                 ByteBuf contentBuf = encodeContent(frame, ctx);
-                out.add(contentBuf);
+                ByteBuf buf = Unpooled.wrappedBuffer(frameBuf, contentBuf);
+                out.add(buf);
             } else {
                 frameBuf.writeByte(StompConstants.NUL);
                 out.add(frameBuf);

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
@@ -76,9 +76,8 @@ public class StompSubframeEncoderTest {
 
         channel.writeOutbound(frame);
 
-        ByteBuf headers = channel.readOutbound();
-        ByteBuf content = channel.readOutbound();
-        ByteBuf fullFrame = Unpooled.wrappedBuffer(headers, content);
+        ByteBuf fullFrame = channel.readOutbound();
+        assertNull(channel.readOutbound());
         assertEquals(SEND_FRAME_UTF8, fullFrame.toString(CharsetUtil.UTF_8));
         assertTrue(fullFrame.release());
     }


### PR DESCRIPTION
 
Modification:
- Use unpooled composite contentBuf and NULL to reduce memory alloc and copy.
- In stomp over websocket, Two message object will send two TextWebSocketFrame. To reduce bandwidth usage, we should merge these two messages.

