### PR TITLE
Use `io.netty.recycler.ratio` directly

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -85,7 +85,7 @@ public abstract class Recycler<T> {
         // By default we allow one push to a Recycler for each 8th try on handles that were never recycled before.
         // This should help to slowly increase the capacity of the recycler while not be too sensitive to allocation
         // bursts.
-        RATIO = safeFindNextPositivePowerOfTwo(SystemPropertyUtil.getInt("io.netty.recycler.ratio", 8));
+        RATIO = max(0, SystemPropertyUtil.getInt("io.netty.recycler.ratio", 8));
 
         if (logger.isDebugEnabled()) {
             if (DEFAULT_MAX_CAPACITY_PER_THREAD == 0) {
@@ -141,7 +141,7 @@ public abstract class Recycler<T> {
 
     protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
                        int ratio, int maxDelayedQueuesPerThread) {
-        interval = safeFindNextPositivePowerOfTwo(ratio);
+        interval = max(0, ratio);
         if (maxCapacityPerThread <= 0) {
             this.maxCapacityPerThread = 0;
             this.maxSharedCapacityFactor = 1;

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -26,8 +26,14 @@ import static org.junit.Assert.*;
 
 public class RecyclerTest {
 
-    private static Recycler<HandledObject> newRecycler(int max) {
-        return new Recycler<HandledObject>(max) {
+    private static Recycler<HandledObject> newRecycler(int maxCapacityPerThread) {
+        return newRecycler(maxCapacityPerThread, 2, 8, 2);
+    }
+
+    private static Recycler<HandledObject> newRecycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
+                                                       int ratio, int maxDelayedQueuesPerThread) {
+        return new Recycler<HandledObject>(maxCapacityPerThread, maxSharedCapacityFactor, ratio,
+                maxDelayedQueuesPerThread) {
             @Override
             protected HandledObject newObject(
                     Recycler.Handle<HandledObject> handle) {
@@ -131,6 +137,19 @@ public class RecyclerTest {
         HandledObject object2 = recycler.get();
         assertNotSame(object, object2);
         object2.recycle();
+    }
+
+    @Test
+    public void testRecycleDisableDrop() {
+        Recycler<HandledObject> recycler = newRecycler(1024, 2, 0, 2);
+        HandledObject object = recycler.get();
+        object.recycle();
+        HandledObject object2 = recycler.get();
+        assertSame(object, object2);
+        object2.recycle();
+        HandledObject object3 = recycler.get();
+        assertSame(object, object3);
+        object3.recycle();
     }
 
     /**


### PR DESCRIPTION
Motivation

1. It's inable to collect all object because RATIO is always >=1 after
`safeFindNextPositivePowerOfTwo`

2. Enable drop object in `WeakOrderQueue`(commit:
71860e5b94dbc665fdb8d279d3780d6fe1c618ea) enlarge the drop ratio. We
can subtly control the overall drop ratio by using `io.netty.recycler.ratio` directly,

Modification

- Remove `safeFindNextPositivePowerOfTwo` before set the ratio

Results

Able to disable drop when recycle object