### PR TITLE
Add GlobalEventExecutor#addTask to BlockHound exceptions

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -80,6 +80,10 @@ class Hidden {
                     "takeTask");
 
             builder.allowBlockingCallsInside(
+                    "io.netty.util.concurrent.GlobalEventExecutor",
+                    "addTask");
+
+            builder.allowBlockingCallsInside(
                     "io.netty.util.concurrent.SingleThreadEventExecutor",
                     "takeTask");
 


### PR DESCRIPTION
Motivation:

`GlobalEventExecutor#addTask` may be called during `SingleThreadEventExecutor` shutdown.
May result in a blocking call, because `GlobalEventExecutor#taskQueue` is a `BlockingQueue`.

Modifications:

Add `allowBlockingCallsInside` configuration for `GlobalEventExecutor#addTask`.

Result:

Fixes #10257.

---
As discussed in [a comment from #10257](https://github.com/netty/netty/issues/10257#issuecomment-625652765), a unit test showing the blocking call is planned in a separate PR.