### PR TITLE
Disable caching of CNAMEs to workaround resolving issues

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCnameCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCnameCache.java
@@ -24,7 +24,9 @@ import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * Default implementation of a {@link DnsCnameCache}.
+ * @deprecated will be removed as caching CNAME's during resolution is considered problematic
  */
+@Deprecated
 public final class DefaultDnsCnameCache implements DnsCnameCache {
     private final int minTtl;
     private final int maxTtl;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCnameCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCnameCache.java
@@ -19,7 +19,9 @@ import io.netty.channel.EventLoop;
 
 /**
  * A cache for {@code CNAME}s.
+ * @deprecated will be removed as caching CNAME's during resolution is considered problematic
  */
+@Deprecated
 public interface DnsCnameCache {
 
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -362,6 +362,7 @@ public class DnsNameResolver extends InetNameResolver {
              dnsServerAddressStreamProvider, searchDomains, ndots, decodeIdn, false);
     }
 
+    @SuppressWarnings("deprecation")
     DnsNameResolver(
             EventLoop eventLoop,
             ChannelFactory<? extends DatagramChannel> channelFactory,

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -160,7 +160,9 @@ public final class DnsNameResolverBuilder {
      *
      * @param cnameCache the cache used to cache {@code CNAME} mappings for a domain.
      * @return {@code this}
+     * @deprecated will be removed as caching CNAME's during resolution is considered problematic
      */
+    @Deprecated
     public DnsNameResolverBuilder cnameCache(DnsCnameCache cnameCache) {
         this.cnameCache  = cnameCache;
         return this;
@@ -431,9 +433,9 @@ public final class DnsNameResolverBuilder {
                 new NameServerComparator(DnsNameResolver.preferredAddressType(resolvedAddressTypes).addressType()));
     }
 
+    @SuppressWarnings("deprecation")
     private DnsCnameCache newCnameCache() {
-        return new DefaultDnsCnameCache(
-                intValue(minTtl, 0), intValue(maxTtl, Integer.MAX_VALUE));
+        return NoopDnsCnameCache.INSTANCE;
     }
 
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/NoopDnsCnameCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/NoopDnsCnameCache.java
@@ -17,6 +17,10 @@ package io.netty.resolver.dns;
 
 import io.netty.channel.EventLoop;
 
+/**
+ * @deprecated will be removed as caching CNAME's during resolution is considered problematic
+ */
+@Deprecated
 public final class NoopDnsCnameCache implements DnsCnameCache {
 
     public static final NoopDnsCnameCache INSTANCE = new NoopDnsCnameCache();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2227,6 +2227,16 @@ public class DnsNameResolverTest {
 
     @Test
     public void testCNAMECachedWhenFullChainInResponse() throws IOException {
+        testCNAMECachedWhenFullChainInResponse(null);
+    }
+
+    @Test
+    public void testCNAMECachedWhenFullChainInResponseThrow() throws IOException {
+        expectedException.expect(UnknownHostException.class);
+        testCNAMECachedWhenFullChainInResponse(new DefaultDnsCnameCache());
+    }
+
+    public void testCNAMECachedWhenFullChainInResponse(DnsCnameCache cnameCache) throws IOException {
         final String firstName = "firstname.com";
         final String secondName = "secondname.com";
         final String ipv4Addr = "1.2.3.4";
@@ -2265,6 +2275,9 @@ public class DnsNameResolverTest {
                     .maxQueriesPerResolve(16)
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
             builder.resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED);
+            if (cnameCache != null) {
+                builder.cnameCache(cnameCache);
+            }
             resolver = builder.build();
             InetAddress resolvedAddress = resolver.resolve(firstName).syncUninterruptibly().getNow();
             assertEquals(ipv4Addr, resolvedAddress.getHostAddress());


### PR DESCRIPTION
Motivation:

In netty there is a seperate CNAME cache that is used to cache CNAMEs that are resolved during resolving an A / AAAA record. While this sounded like a great idea when I first implemented this in netty it turned out this is problematic and may produce errors while resolving hostnames later on.
The problem with the CNAME cache is that we may end up with entries in the CNAME cache wile the original cached resolution was already removed from the cache (due TTL). In this case we may find an entry in teh CNAME cache that we will then try to resolve via the specified nameserver. This resolution may fail as the nameserver may not return an entry for the previous cached CNAME. This usually happens when we receive the full "resolution chain" during query for an A / AAAA record.

This problem was introduced by https://github.com/netty/netty/pull/8314

Modifications:

- Use the NoopDnsCnameCache by default
- Deprecate methods that allow to set a custom DnsCnameCache
- Deprecate DnsCnameCache and all the implementations
- Add unit test

Result:

Fixes resolution problem caused by cached cname records