### PR TITLE
Remove a unused private method with empty body in HttpConversionUtil.java

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -654,8 +654,5 @@ public final class HttpConversionUtil {
                 output.add(COOKIE, cookies.toString());
             }
         }
-
-        private void translateHeader(Entry<CharSequence, CharSequence> entry) throws Http2Exception {
-        }
     }
 }


### PR DESCRIPTION
Motivation:

After searching the whole netty project, I found that the private method `translateHeader(...)` with empty body is never used actually. So I think it could be safely removed.

Modification:

Just remove this unused method.

Result:

Clean up the code.
