### PR TITLE
Fix a potential fd leak in AbstractDiskHttpData.getChunk

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -312,7 +312,9 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                 }
             }
         } finally {
-            fileChannel.close();
+            if (fileChannel != null) {
+                fileChannel.close();
+            }
         }
         if (read == 0) {
             return EMPTY_BUFFER;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -304,17 +304,14 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             while (read < length) {
                 int readnow = fileChannel.read(byteBuffer);
                 if (readnow == -1) {
-                    fileChannel.close();
-                    fileChannel = null;
                     break;
                 } else {
                     read += readnow;
                 }
             }
         } finally {
-            if (fileChannel != null) {
-                fileChannel.close();
-            }
+            fileChannel.close();
+            fileChannel = null;
         }
         if (read == 0) {
             return EMPTY_BUFFER;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -304,14 +304,17 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             while (read < length) {
                 int readnow = fileChannel.read(byteBuffer);
                 if (readnow == -1) {
+                    fileChannel.close();
+                    fileChannel = null;
                     break;
                 } else {
                     read += readnow;
                 }
             }
         } finally {
-            fileChannel.close();
-            fileChannel = null;
+            if (fileChannel != null) {
+                fileChannel.close();
+            }
         }
         if (read == 0) {
             return EMPTY_BUFFER;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -304,17 +304,13 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             while (read < length) {
                 int readnow = fileChannel.read(byteBuffer);
                 if (readnow == -1) {
-                    fileChannel.close();
-                    fileChannel = null;
                     break;
                 } else {
                     read += readnow;
                 }
             }
         } finally {
-            if (fileChannel != null) {
                 fileChannel.close();
-            }
         }
         if (read == 0) {
             return EMPTY_BUFFER;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -300,7 +300,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
         }
         int read = 0;
         ByteBuffer byteBuffer = ByteBuffer.allocate(length);
-        try{
+        try {
             while (read < length) {
                 int readnow = fileChannel.read(byteBuffer);
                 if (readnow == -1) {
@@ -311,7 +311,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                     read += readnow;
                 }
             }
-        }finally {
+        } finally {
             fileChannel.close();
         }
         if (read == 0) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -311,6 +311,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             }
         } finally {
                 fileChannel.close();
+                fileChannel = null;
         }
         if (read == 0) {
             return EMPTY_BUFFER;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -301,7 +301,15 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
         int read = 0;
         ByteBuffer byteBuffer = ByteBuffer.allocate(length);
         while (read < length) {
-            int readnow = fileChannel.read(byteBuffer);
+            int readnow=-1;
+            try {
+                readnow = fileChannel.read(byteBuffer);
+            }catch (IOException e){
+                logger.warn("Failed to read a file.", e);
+            }
+            finally {
+                fileChannel.close();
+            }
             if (readnow == -1) {
                 fileChannel.close();
                 fileChannel = null;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -305,7 +305,7 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             try {
                 readnow = fileChannel.read(byteBuffer);
             }catch (IOException e){
-                logger.warn("Failed to read a file.", e);
+                logger.warn("Failed to read a Buffer.", e);
             }
             finally {
                 fileChannel.close();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -305,9 +305,8 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                 int readnow = fileChannel.read(byteBuffer);
                 if (readnow == -1) {
                     break;
-                } else {
-                    read += readnow;
                 }
+                read += readnow;
             }
         } finally {
             fileChannel.close();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -310,8 +310,8 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                 }
             }
         } finally {
-                fileChannel.close();
-                fileChannel = null;
+            fileChannel.close();
+            fileChannel = null;
         }
         if (read == 0) {
             return EMPTY_BUFFER;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -300,23 +300,19 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
         }
         int read = 0;
         ByteBuffer byteBuffer = ByteBuffer.allocate(length);
-        while (read < length) {
-            int readnow=-1;
-            try {
-                readnow = fileChannel.read(byteBuffer);
-            }catch (IOException e){
-                logger.warn("Failed to read a Buffer.", e);
+        try{
+            while (read < length) {
+                int readnow = fileChannel.read(byteBuffer);
+                if (readnow == -1) {
+                    fileChannel.close();
+                    fileChannel = null;
+                    break;
+                } else {
+                    read += readnow;
+                }
             }
-            finally {
-                fileChannel.close();
-            }
-            if (readnow == -1) {
-                fileChannel.close();
-                fileChannel = null;
-                break;
-            } else {
-                read += readnow;
-            }
+        }finally {
+            fileChannel.close();
         }
         if (read == 0) {
             return EMPTY_BUFFER;


### PR DESCRIPTION
Motivation:

`FileChannel.read()` may throw an IOException. We must deal with this in case of the occurrence of `I/O` error.

Modification:

Place the `FileChannel.read()` method call in the `try-finally` block.

Result:

Advoid fd leak.


