### PR TITLE
Select correct nameserver for CNAME

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -986,7 +986,9 @@ abstract class DnsResolveContext<T> {
 
     private DnsServerAddressStream getNameServers(String hostname) {
         DnsServerAddressStream stream = getNameServersFromCache(hostname);
-        return stream == null ? nameServerAddrs.duplicate() : stream;
+        // We need to obtain a new stream from the parent DnsNameResolver as the hostname may not be the same as the
+        // one used for the original query (for example we may follow CNAMEs).
+        return stream == null ? parent.newNameServerAddressStream(hostname) : stream;
     }
 
     private void followCname(DnsQuestion question, String cname, DnsQueryLifecycleObserver queryLifecycleObserver,


### PR DESCRIPTION
Motivation:

The nameserver that should / must be used to resolve a CNAME may be different then the nameserver that was selected for the hostname to resolve. Failing to select the correct nameserver may result in problems during resolution.

Modifications:

Use the correct DnsServerAddressStream for CNAMEs

Result:

Always use the correct DnsServerAddressStream for CNAMEs and so fix resolution failures which could accour when CNAMEs are in the mix that use a different domain then the original hostname that we try to resolve