### PR TITLE
Update Java versions

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.11.0-6"
+        java_version : "adopt@1.11.0-7"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.13.0-2"
+        java_version : "adopt@1.13.0-3"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-6.114.yaml
+++ b/docker/docker-compose.centos-6.114.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.14.0-0"
+        java_version : "adopt@1.14.0-1"
 
   test:
     image: netty:centos-6-1.14

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.0-242"
+        java_version : "adopt@1.8.0-252"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.openj9111.yaml
+++ b/docker/docker-compose.centos-6.openj9111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt-openj9@1.11.0-6"
+        java_version : "adopt-openj9@1.11.0-7"
 
   test:
     image: netty:centos-6-openj9-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.11.0-6"
+        java_version : "adopt@1.11.0-7"
 
   test:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.13.0-2"
+        java_version : "adopt@1.13.0-3"
 
   test:
     image: netty:centos-7-1.13

--- a/docker/docker-compose.centos-7.114.yaml
+++ b/docker/docker-compose.centos-7.114.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "@1.14.0-0"
+        java_version : "@1.14.0-1"
 
   test:
     image: netty:centos-7-1.14

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.8.0-242"
+        java_version : "adopt@1.8.0-252"
 
   test:
     image: netty:centos-7-1.8


### PR DESCRIPTION
Motivation:

We should use the latest patch release of each java version

Modifications:

Update versions

Result:

Use latest versions on CI
