### PR TITLE
Use correct JDK 13 version

### DIFF
--- a/docker/docker-compose.centos-6.113.yaml
+++ b/docker/docker-compose.centos-6.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.13.0-3"
+        java_version : "adopt@1.13.0-2"
 
   test:
     image: netty:centos-6-1.13

--- a/docker/docker-compose.centos-7.113.yaml
+++ b/docker/docker-compose.centos-7.113.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.13.0-3"
+        java_version : "adopt@1.13.0-2"
 
   test:
     image: netty:centos-7-1.13


### PR DESCRIPTION
Motivation:

We had a typo in the JDK 13 version to use.

Modifications:

Use the correct version string

Result:

Be able to run CI with JDK13 again