### PR TITLE
Fix classifier for aarch64

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -61,7 +61,7 @@
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
           <version>${project.version}</version>
-          <classifier>linux-aarch_64</classifier>
+          <classifier>linux-aarch64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
@@ -101,7 +101,7 @@
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
           <version>${project.version}</version>
-          <classifier>linux-aarch_64</classifier>
+          <classifier>linux-aarch64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Motivation:

The defined classifier for aarch64 was not correct

Modifications:

Fix classifier

Result:

Be able to correctly include the aarch64 native libs