### PR TITLE
Allow to have the session tickets automatically managed by the native…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -97,7 +97,10 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
     }
 
     /**
-     * Sets the SSL session ticket keys of this context.
+     * Sets the SSL session ticket keys of this context. Depending on the underlying native library you may omit the
+     * argument or pass an empty array and so let the native library handle the key generation and rotating for you.
+     * If this is supported by the underlying native library should be checked in this case. For example
+     * <a href="https://boringssl.googlesource.com/boringssl/">BoringSSL</a> is known to support this.
      */
     public void setTicketKeys(OpenSslSessionTicketKey... keys) {
         ObjectUtil.checkNotNull(keys, "keys");
@@ -109,7 +112,9 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
         writerLock.lock();
         try {
             SSLContext.clearOptions(context.ctx, SSL.SSL_OP_NO_TICKET);
-            SSLContext.setSessionTicketKeys(context.ctx, ticketKeys);
+            if (ticketKeys.length > 0) {
+                SSLContext.setSessionTicketKeys(context.ctx, ticketKeys);
+            }
         } finally {
             writerLock.unlock();
         }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -100,7 +100,8 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
      * Sets the SSL session ticket keys of this context. Depending on the underlying native library you may omit the
      * argument or pass an empty array and so let the native library handle the key generation and rotating for you.
      * If this is supported by the underlying native library should be checked in this case. For example
-     * <a href="https://boringssl.googlesource.com/boringssl/">BoringSSL</a> is known to support this.
+     * <a href="https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#Session-tickets/">
+     *     BoringSSL</a> is known to support this.
      */
     public void setTicketKeys(OpenSslSessionTicketKey... keys) {
         ObjectUtil.checkNotNull(keys, "keys");

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1118,16 +1118,29 @@ public class SslHandlerTest {
 
     @Test(timeout = 5000L)
     public void testSessionTicketsWithTLSv12() throws Throwable {
-        testSessionTickets(SslUtils.PROTOCOL_TLS_V1_2);
+        testSessionTickets(SslUtils.PROTOCOL_TLS_V1_2, true);
     }
 
     @Test(timeout = 5000L)
     public void testSessionTicketsWithTLSv13() throws Throwable {
         assumeTrue(OpenSsl.isTlsv13Supported());
-        testSessionTickets(SslUtils.PROTOCOL_TLS_V1_3);
+        testSessionTickets(SslUtils.PROTOCOL_TLS_V1_3, true);
     }
 
-    private static void testSessionTickets(String protocol) throws Throwable {
+    @Test(timeout = 5000L)
+    public void testSessionTicketsWithTLSv12AndNoKey() throws Throwable {
+        assumeTrue(OpenSsl.isBoringSSL());
+        testSessionTickets(SslUtils.PROTOCOL_TLS_V1_2, false);
+    }
+
+    @Test(timeout = 5000L)
+    public void testSessionTicketsWithTLSv13AndNoKey() throws Throwable {
+        assumeTrue(OpenSsl.isTlsv13Supported());
+        assumeTrue(OpenSsl.isBoringSSL());
+        testSessionTickets(SslUtils.PROTOCOL_TLS_V1_3, false);
+    }
+
+    private static void testSessionTickets(String protocol, boolean withKey) throws Throwable {
         assumeTrue(OpenSsl.isAvailable());
         final SslContext sslClientCtx = SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
@@ -1141,10 +1154,15 @@ public class SslHandlerTest {
                 .protocols(protocol)
                 .build();
 
-        OpenSslSessionTicketKey key = new OpenSslSessionTicketKey(new byte[OpenSslSessionTicketKey.NAME_SIZE],
-                new byte[OpenSslSessionTicketKey.HMAC_KEY_SIZE], new byte[OpenSslSessionTicketKey.AES_KEY_SIZE]);
-        ((OpenSslSessionContext) sslClientCtx.sessionContext()).setTicketKeys(key);
-        ((OpenSslSessionContext) sslServerCtx.sessionContext()).setTicketKeys(key);
+        if (withKey) {
+            OpenSslSessionTicketKey key = new OpenSslSessionTicketKey(new byte[OpenSslSessionTicketKey.NAME_SIZE],
+                    new byte[OpenSslSessionTicketKey.HMAC_KEY_SIZE], new byte[OpenSslSessionTicketKey.AES_KEY_SIZE]);
+            ((OpenSslSessionContext) sslClientCtx.sessionContext()).setTicketKeys(key);
+            ((OpenSslSessionContext) sslServerCtx.sessionContext()).setTicketKeys(key);
+        } else {
+            ((OpenSslSessionContext) sslClientCtx.sessionContext()).setTicketKeys();
+            ((OpenSslSessionContext) sslServerCtx.sessionContext()).setTicketKeys();
+        }
 
         EventLoopGroup group = new NioEventLoopGroup();
         Channel sc = null;

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1136,7 +1136,6 @@ public class SslHandlerTest {
     @Test(timeout = 5000L)
     public void testSessionTicketsWithTLSv13AndNoKey() throws Throwable {
         assumeTrue(OpenSsl.isTlsv13Supported());
-        assumeTrue(OpenSsl.isBoringSSL());
         testSessionTickets(SslUtils.PROTOCOL_TLS_V1_3, false);
     }
 


### PR DESCRIPTION
… library

Motivation:

BoringSSL supports to automatically manage the session tickets to be used and so also rotate them etc. This is often prefered by users as it removed some complexity. We should support to make use of this.

Modifications:

- Allow to have setSessionTickets() called without an argument or an empty array
- Add tests

Result:

Easier usage of session tickets