### PR TITLE
Add DNS client examples for run-example.sh

### DIFF
--- a/run-example.sh
+++ b/run-example.sh
@@ -42,6 +42,9 @@ EXAMPLE_MAP=(
   'sctpecho-client:io.netty.example.sctp.SctpEchoClient'
   'sctpecho-server:io.netty.example.sctp.SctpEchoServer'
   'localecho:io.netty.example.localecho.LocalEcho'
+  'udp-dns-client:io.netty.example.dns.udp.DnsClient'
+  'tcp-dns-client:io.netty.example.dns.tcp.TcpDnsClient'
+  'dot-dns-client:io.netty.example.dns.dot.DoTClient'
 )
 
 NEEDS_NPN_MAP=(


### PR DESCRIPTION
Motivation:

There exists no DNS client examples in run-example.sh for the moment.

Modification:

Add DNS client examples for run-example.sh.

Result:

Help run the examples.
