### PR TITLE
Fail fast if CoalescingBufferQueue is somehow corrupted

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -140,6 +140,10 @@ public abstract class AbstractCoalescingBufferQueue {
 
         // Use isEmpty rather than readableBytes==0 as we may have a promise associated with an empty buffer.
         if (bufAndListenerPairs.isEmpty()) {
+            if (readableBytes != 0) {
+                // This prevents DefaultHttp2RemoteFlowController.FlowState#writeAllocatedBytes going into endless loop
+                throw new IllegalStateException("CoalescingBufferQueue is corrupted");
+            }
             return removeEmptyValue();
         }
         bytes = Math.min(bytes, readableBytes);


### PR DESCRIPTION
Motivation:

Prevent DefaultHttp2RemoteFlowController.FlowState#writeAllocatedBytes going into endless loop of memory allocation if CoalescingBufferQueue is somehow corrupted.

Modification:

AbstractCoalescingBufferQueue.java - Throw exception and let the stream close instead of crashing the application.

Result:

Fixes #10286
