### PR TITLE
Make ReferenceCountedOpenSslContext.setUseTasks public

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -529,8 +529,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         }
     }
 
-    // Exposed for testing only
-    final void setUseTasks(boolean useTasks) {
+    public final void setUseTasks(boolean useTasks) {
         Lock writerLock = ctxLock.writeLock();
         writerLock.lock();
         try {


### PR DESCRIPTION
Motivation:
make the existing setter `ReferenceCountedOpenSslContext.setUseTasks` public

Modification:

Added the `public` qualified and removed the comment "for tests only"

Result:

Fixes #10288  

