### PR TITLE
Use allocation free algorithm to detect CNAME cache loops

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -300,7 +300,8 @@ abstract class DnsResolveContext<T> {
     }
 
     private String cnameResolveFromCacheLoop(DnsCnameCache cnameCache, String first, String mapping) {
-        // Detect loops by advance only every other iteration. This is the same concepts as used in guava
+        // Detect loops by advance only every other iteration.
+        // See https://en.wikipedia.org/wiki/Cycle_detection#Floyd's_Tortoise_and_Hare
         String otherMapping = first;
         boolean advance = false;
 
@@ -314,10 +315,8 @@ abstract class DnsResolveContext<T> {
             name = mapping;
             if (advance) {
                 otherMapping = mapping;
-                advance = false;
-            } else {
-                advance = true;
             }
+            advance = !advance;
         }
         return name;
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -303,19 +303,18 @@ abstract class DnsResolveContext<T> {
     static String cnameResolveFromCacheLoop(DnsCnameCache cnameCache, String first, String mapping) {
         // Detect loops by advance only every other iteration.
         // See https://en.wikipedia.org/wiki/Cycle_detection#Floyd's_Tortoise_and_Hare
-        String otherMapping = first;
         boolean advance = false;
 
         String name = mapping;
         // Resolve from cnameCache() until there is no more cname entry cached.
         while ((mapping = cnameCache.get(hostnameWithDot(name))) != null) {
-            if (otherMapping.equals(mapping)) {
+            if (first.equals(mapping)) {
                 // Follow CNAME from cache would loop. Lets break here.
                 break;
             }
             name = mapping;
             if (advance) {
-                otherMapping = cnameCache.get(otherMapping);
+                first = cnameCache.get(first);
             }
             advance = !advance;
         }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsResolveContextTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsResolveContextTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+public class DnsResolveContextTest {
+
+    private static final String HOSTNAME = "netty.io.";
+
+    @Test
+    public void testCnameLoop() {
+        for (int i = 1; i < 128; i++) {
+            DnsResolveContext.cnameResolveFromCache(buildCache(i), HOSTNAME);
+        }
+    }
+
+    private static DnsCnameCache buildCache(int chainLength) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        DnsCnameCache cache = new DefaultDnsCnameCache();
+        if (chainLength == 1) {
+            cache.cache(HOSTNAME, HOSTNAME, Long.MAX_VALUE, channel.eventLoop());
+        } else {
+            String lastName = HOSTNAME;
+            for (int i = 1; i < chainLength; i++) {
+                String nextName = i + "." + lastName;
+                cache.cache(lastName, nextName, Long.MAX_VALUE, channel.eventLoop());
+                lastName = nextName;
+            }
+            cache.cache(lastName, HOSTNAME, Long.MAX_VALUE, channel.eventLoop());
+        }
+        return cache;
+    }
+}


### PR DESCRIPTION
Motivation:

We did use a HashSet to detect CNAME cache loops which needs allocations. We can use an algorithm that doesnt need any allocations

Modifications:

Use algorithm that doesnt need allocations

Result:

Less allocations on the slow path