### PR TITLE
Fix bom aarch64

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -34,6 +34,18 @@
     <skipJapicmp>true</skipJapicmp>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <profiles>
     <!-- If the uber profile is used it will automatically fetch the missing native jar from maven and add it to the all jar as well. -->
     <profile>
@@ -52,7 +64,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
           <classifier>linux-x86_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -60,7 +71,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
           <classifier>linux-aarch64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -68,7 +78,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${project.version}</version>
           <classifier>osx-x86_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -76,7 +85,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <version>${project.version}</version>
           <classifier>osx-x86_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -92,7 +100,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
           <classifier>linux-x86_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -100,7 +107,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
           <classifier>linux-aarch64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -108,7 +114,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${project.version}</version>
           <classifier>osx-x86_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -116,7 +121,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <version>${project.version}</version>
           <classifier>osx-x86_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -148,14 +152,12 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${project.version}</version>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <version>${project.version}</version>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
@@ -184,7 +186,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <version>${project.version}</version>
           <classifier>osx-x86_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
@@ -193,7 +194,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
@@ -221,7 +221,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
@@ -249,7 +248,6 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
@@ -378,161 +376,138 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-dns</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-haproxy</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-http2</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-memcache</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-mqtt</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-redis</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-smtp</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-socks</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-stomp</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-xml</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-handler-proxy</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-resolver</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-resolver-dns</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-rxtx</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-sctp</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-udt</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-example</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -193,6 +193,17 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns-native-macos</artifactId>
+        <version>4.1.51.Final-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns-native-macos</artifactId>
+        <version>4.1.51.Final-SNAPSHOT</version>
+        <classifier>osx-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
         <version>4.1.51.Final-SNAPSHOT</version>
       </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -200,6 +200,12 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
         <version>4.1.51.Final-SNAPSHOT</version>
+        <classifier>linux-aarch64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-unix-common</artifactId>
+        <version>4.1.51.Final-SNAPSHOT</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
@@ -212,6 +218,12 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
         <version>4.1.51.Final-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>4.1.51.Final-SNAPSHOT</version>
+        <classifier>linux-aarch64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
Motivation:

Netty-5.1.50.Final introduced a new artifact (linux-aarch64 version of transport-native-epoll), but that artifact is not part of netty-bom, hence it cannot easily be used. Also there are no safety checks against this sort of an omission.

Modification:

Add the missing declaration to netty-bom as a first step. Refactor netty-all to not use <version>${project.version}</version>, but rather rely on netty-bom to supply the versions needed. This finds another case of missing declaration, netty-resolver-dns-native-macos, which is also fixed.

Result:
All packages that go into netty-all are guaranteed to be declared in netty-bom.

Fixes #10290. 

If there is no issue then describe the changes introduced by this PR.
