### PR TITLE
HttpPostMultipartRequestDecoder regression fix #10281

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -178,11 +178,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         // Fill default values
 
         setMultipart(this.request.headers().get(HttpHeaderNames.CONTENT_TYPE));
-        if (request instanceof HttpContent) {
-            // Offer automatically if the given request is als type of HttpContent
-            // See #1089
-            offer((HttpContent) request);
-        } else {
+        if (!(request instanceof HttpContent)) {
             parseBody();
         }
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -131,6 +131,7 @@ public class HttpPostRequestDecoderTest {
         }
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
     }
@@ -169,6 +170,7 @@ public class HttpPostRequestDecoderTest {
             req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
             // Create decoder instance to test.
             final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+            decoder.offer(req);
             assertFalse(decoder.getBodyHttpDatas().isEmpty());
             // Check correctness: data size
             InterfaceHttpData httpdata = decoder.getBodyHttpData("file" + i);
@@ -210,6 +212,7 @@ public class HttpPostRequestDecoderTest {
         }
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
     }
@@ -367,6 +370,7 @@ public class HttpPostRequestDecoderTest {
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
     }
@@ -392,6 +396,7 @@ public class HttpPostRequestDecoderTest {
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
         assertTrue(part1 instanceof FileUpload);
@@ -426,6 +431,7 @@ public class HttpPostRequestDecoderTest {
         }
         // Create decoder instance to test without any exception.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
     }
@@ -453,6 +459,7 @@ public class HttpPostRequestDecoderTest {
         req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
         assertTrue("the item should be a FileUpload", part1 instanceof FileUpload);
@@ -484,7 +491,7 @@ public class HttpPostRequestDecoderTest {
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         // Create decoder instance to test.
         try {
-            new HttpPostRequestDecoder(inMemoryFactory, req);
+            new HttpPostRequestDecoder(inMemoryFactory, req).offer(req);
             fail("Was expecting an ErrorDataDecoderException");
         } catch (HttpPostRequestDecoder.ErrorDataDecoderException e) {
             assertTrue(e.getCause() instanceof UnsupportedCharsetException);
@@ -517,7 +524,7 @@ public class HttpPostRequestDecoderTest {
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8));
         // Create decoder instance to test.
         try {
-            new HttpPostRequestDecoder(inMemoryFactory, req);
+            new HttpPostRequestDecoder(inMemoryFactory, req).offer(req);
             fail("Was expecting an ErrorDataDecoderException");
         } catch (HttpPostRequestDecoder.ErrorDataDecoderException e) {
             assertTrue(e.getCause() instanceof UnsupportedCharsetException);
@@ -568,6 +575,7 @@ public class HttpPostRequestDecoderTest {
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
         assertTrue("the item should be a FileUpload", part1 instanceof FileUpload);
@@ -604,6 +612,7 @@ public class HttpPostRequestDecoderTest {
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
         assertTrue("the item should be a FileUpload", part1 instanceof FileUpload);
@@ -636,7 +645,7 @@ public class HttpPostRequestDecoderTest {
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
 
         try {
-            new HttpPostRequestDecoder(inMemoryFactory, req);
+            new HttpPostRequestDecoder(inMemoryFactory, req).offer(req);
             fail("Was expecting an ErrorDataDecoderException");
         } catch (HttpPostRequestDecoder.ErrorDataDecoderException e) {
             assertTrue(e.getCause() instanceof ArrayIndexOutOfBoundsException);
@@ -668,7 +677,7 @@ public class HttpPostRequestDecoderTest {
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
 
         try {
-            new HttpPostRequestDecoder(inMemoryFactory, req);
+            new HttpPostRequestDecoder(inMemoryFactory, req).offer(req);
             fail("Was expecting an ErrorDataDecoderException");
         } catch (HttpPostRequestDecoder.ErrorDataDecoderException e) {
             assertTrue(e.getCause() instanceof UnsupportedCharsetException);
@@ -699,6 +708,7 @@ public class HttpPostRequestDecoderTest {
         req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
         // Create decoder instance to test.
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
         assertTrue(part1 instanceof FileUpload);
@@ -731,6 +741,7 @@ public class HttpPostRequestDecoderTest {
                 new HttpPostRequestDecoder(new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE),
                         req,
                         CharsetUtil.UTF_8);
+        decoder.offer(req);
 
         assertTrue(decoder.isMultipart());
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
@@ -817,6 +828,7 @@ public class HttpPostRequestDecoderTest {
         req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
         final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
         final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        decoder.offer(req);
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
         assertTrue("the item should be a FileUpload", part1 instanceof FileUpload);


### PR DESCRIPTION
Motivation:

After upgrade of Netty from 4.1.49 -> 4.1.50 all our tests that have upload functionality are failing now. Look like the issue is due to recent [changes](https://github.com/netty/netty/commit/c354fa48e10de847cf17c10083a2cbc2c0a63a36). The changes doesn't reflect the case when incoming request is `AggregatedFullHttpRequest`. That happens when you have in the pipeline `HttpObjectAggregator`.

You can reproduce the issue with basic upload netty example - `HttpUploadServer` and added `HttpObjectAggregator` to the pipeline.

```
public class HttpUploadServerInitializer extends ChannelInitializer<SocketChannel> {

    private final SslContext sslCtx;

    public HttpUploadServerInitializer(SslContext sslCtx) {
        this.sslCtx = sslCtx;
    }

    @Override
    public void initChannel(SocketChannel ch) {
        ChannelPipeline pipeline = ch.pipeline();

        if (sslCtx != null) {
            pipeline.addLast(sslCtx.newHandler(ch.alloc()));
        }

        pipeline.addLast(new HttpRequestDecoder());
        pipeline.addLast(new HttpResponseEncoder());
        pipeline.addLast(new HttpObjectAggregator(300000));

        // Remove the following line if you don't want automatic content compression.
        pipeline.addLast(new HttpContentCompressor());

        pipeline.addLast(new HttpUploadServerHandler());
    }
}
```

Modification:

Removed `offerChunk` call from the constructor of `HttpPostMultipartRequestDecoder` in case request is `HttpContent` and called explicitly when necessary in the tests. I'm not sure this is exact and correct fix. So please look trough carefully. 

Result:

Fixes https://github.com/netty/netty/issues/10281
