### PR TITLE
Do not require BoringSSL for testSessionTicketsWithTLSv12AndNoKey

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1129,7 +1129,6 @@ public class SslHandlerTest {
 
     @Test(timeout = 5000L)
     public void testSessionTicketsWithTLSv12AndNoKey() throws Throwable {
-        assumeTrue(OpenSsl.isBoringSSL());
         testSessionTickets(SslUtils.PROTOCOL_TLS_V1_2, false);
     }
 


### PR DESCRIPTION
Motivation:

`SslHandlerTest.testSessionTicketsWithTLSv12AndNoKey` does not require
BoringSSL and works with OpenSSL as well.

Modifications:

- Remove assume statement that expected BoringSSL;

Result:

The test works for any implementation of `OPENSSL` provider.