### PR TITLE
Allow for multiple Content-Length headers behavior to be configurable...

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/AbstractHttpObjectDecoderBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/AbstractHttpObjectDecoderBuilder.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.HttpRequestDecoder.HttpRequestDecoderBuilder;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_CHUNKED_SUPPORTED;
+import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_INITIAL_BUFFER_SIZE;
+import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE;
+import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
+import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
+import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_VALIDATE_HEADERS;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
+/**
+ * Abstract base class for {@link HttpObjectDecoder} builders.
+ *
+ * @param <T> the type of {@link HttpObjectDecoder} that is being built
+ * @param <B> the concrete implementation of this {@link AbstractHttpObjectDecoderBuilder}
+ *
+ * @see HttpRequestDecoderBuilder
+ */
+public abstract class AbstractHttpObjectDecoderBuilder
+        <T extends HttpObjectDecoder, B extends AbstractHttpObjectDecoderBuilder<T, B>> {
+
+    protected int maxInitialLineLength = DEFAULT_MAX_INITIAL_LINE_LENGTH;
+    protected int maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
+    protected boolean chunkedSupported = DEFAULT_CHUNKED_SUPPORTED;
+    protected int maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
+    protected boolean validateHeaders = DEFAULT_VALIDATE_HEADERS;
+    protected int initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE;
+
+    // ReentrantLock used for options to only allocate HashMap when actually in use.
+    protected final Lock optionsLock = new ReentrantLock();
+    protected volatile Map<HttpDecoderOption<?>, Object> options;
+
+    AbstractHttpObjectDecoderBuilder() {
+        // Disallow extending from a different package.
+    }
+
+    @SuppressWarnings("unchecked")
+    protected final B self() {
+        return (B) this;
+    }
+
+    /**
+     * The maximum length of the initial line (e.g. {@code "GET / HTTP/1.0"} or {@code "HTTP/1.0 200 OK"}). If the
+     * length of the initial line exceeds this value, a {@link TooLongFrameException} will be raised.
+     */
+    public B maxInitialLineLength(int maxInitialLineLength) {
+        checkPositive(maxInitialLineLength, "maxInitialLineLength");
+        this.maxInitialLineLength = maxInitialLineLength;
+        return self();
+    }
+
+    /**
+     * The maximum length of all headers. If the sum of the length of each header exceeds this value, a {@link
+     * TooLongFrameException} will be raised.
+     */
+    public B maxHeaderSize(int maxHeaderSize) {
+        checkPositive(maxHeaderSize, "maxHeaderSize");
+        this.maxHeaderSize = maxHeaderSize;
+        return self();
+    }
+
+    public B chunkedSupported(boolean chunkedSupported) {
+        this.chunkedSupported = chunkedSupported;
+        return self();
+    }
+
+    /**
+     * The maximum length of the content or each chunk. If the content length (or the length of each chunk) exceeds this
+     * value, the content or chunk will be split into multiple {@link HttpContent}s whose length is {@code maxChunkSize}
+     * at maximum.
+     */
+    public B maxChunkSize(int maxChunkSize) {
+        checkPositive(maxChunkSize, "maxChunkSize");
+        this.maxChunkSize = maxChunkSize;
+        return self();
+    }
+
+    public B validateHeaders(boolean validateHeaders) {
+        this.validateHeaders = validateHeaders;
+        return self();
+    }
+
+    public B initialBufferSize(int initialBufferSize) {
+        checkPositive(initialBufferSize, "initialBufferSize");
+        this.initialBufferSize = initialBufferSize;
+        return self();
+    }
+
+    /**
+     * Specify a {@link HttpDecoderOption} to configure this {@link HttpObjectDecoder} with special behavior. Use a
+     * value of {@code null} to remove a previously set {@link HttpDecoderOption}.
+     *
+     * @see HttpDecoderOption
+     */
+    public <O> B option(HttpDecoderOption<O> option, O value) {
+        checkNotNull(option, "option");
+        optionsLock.lock();
+        try {
+            if (value == null) {
+                if (options != null) {
+                    options.remove(option);
+                }
+            } else {
+                if (options == null) {
+                    options = new LinkedHashMap<HttpDecoderOption<?>, Object>();
+                }
+                options.put(option, value);
+            }
+        } finally {
+            optionsLock.unlock();
+        }
+        return self();
+    }
+
+    /**
+     * Specify a collection of {@link HttpDecoderOption}s to configure this {@link HttpObjectDecoder} with special
+     * behavior. These options overwrite and append to any existing options, but it will not clear any other unspecified
+     * options.
+     *
+     * @see HttpDecoderOption
+     */
+    public B options(Map<HttpDecoderOption<?>, Object> options) {
+        checkNotNull(options, "options");
+        if (!options.isEmpty()) {
+            optionsLock.lock();
+            try {
+                if (this.options == null) {
+                    this.options = new LinkedHashMap<HttpDecoderOption<?>, Object>(options);
+                } else {
+                    this.options.putAll(options);
+                }
+            } finally {
+                optionsLock.unlock();
+            }
+        }
+        return self();
+    }
+
+    /**
+     * Clear any previously set {@link HttpDecoderOption}s.
+     */
+    public B clearOptions() {
+        optionsLock.lock();
+        try {
+            if (options != null) {
+                options.clear();
+            }
+        } finally {
+            optionsLock.unlock();
+        }
+        return self();
+    }
+
+    public abstract T build();
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderOption.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderOption.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.DecoderResult;
+import io.netty.util.AbstractConstant;
+import io.netty.util.ConstantPool;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * {@link HttpDecoderOption}s may be used when configuring a {@link HttpObjectDecoder}. These options are primarily
+ * intended for when the HTTP RFC offers numerous options or ambiguous interpretations for certain behavior. Where
+ * possible, Netty will offer opinionated defaults for the safest and sanest behavior, but these options may still be
+ * leveraged by users desiring more fine-grained control.
+ * <p>
+ * Some options may only be relevant to specific decoder implementations (e.g., request vs response).
+ *
+ * @param <T> the type of the value which is valid for the {@link HttpDecoderOption}
+ */
+public final class HttpDecoderOption<T> extends AbstractConstant<HttpDecoderOption<T>> {
+
+    private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+
+    private static final ConstantPool<HttpDecoderOption<Object>> pool = new ConstantPool<HttpDecoderOption<Object>>() {
+        @Override
+        protected HttpDecoderOption<Object> newConstant(int id, String name) {
+            return new HttpDecoderOption<Object>(id, name);
+        }
+    };
+
+    // Static methods
+    //---------------------------------------------------------------------------------
+
+    /**
+     * Returns the {@link HttpDecoderOption} of the specified name.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> HttpDecoderOption<T> valueOf(String name) {
+        return (HttpDecoderOption<T>) pool.valueOf(name);
+    }
+
+    /**
+     * Shortcut of {@link #valueOf(String) valueOf(firstNameComponent.getName() + "#" + secondNameComponent)}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> HttpDecoderOption<T> valueOf(Class<?> firstNameComponent, String secondNameComponent) {
+        return (HttpDecoderOption<T>) pool.valueOf(firstNameComponent, secondNameComponent);
+    }
+
+    /**
+     * Returns {@code true} if a {@link HttpDecoderOption} exists for the given {@code name}.
+     */
+    public static boolean exists(String name) {
+        return pool.exists(name);
+    }
+
+    // Available options
+    //---------------------------------------------------------------------------------
+
+    public static final HttpDecoderOption<MultipleContentLengthHeadersBehavior>
+            MULTIPLE_CONTENT_LENGTH_HEADERS_BEHAVIOR = valueOf("MULTIPLE_CONTENT_LENGTH_HEADERS_BEHAVIOR");
+
+    // Option implementations
+    //---------------------------------------------------------------------------------
+
+    /**
+     * {@link MultipleContentLengthHeadersBehavior} allows for different ways to respond to encountering multiple
+     * Content-Length headers as per https://tools.ietf.org/html/rfc7230#section-3.3.2:
+     * <pre>
+     *     If a message is received that has multiple Content-Length header
+     *     fields with field-values consisting of the same decimal value, or a
+     *     single Content-Length header field with a field value containing a
+     *     list of identical decimal values (e.g., "Content-Length: 42, 42"),
+     *     indicating that duplicate Content-Length header fields have been
+     *     generated or combined by an upstream message processor, then the
+     *     recipient MUST either reject the message as invalid or replace the
+     *     duplicated field-values with a single valid Content-Length field
+     *     containing that decimal value prior to determining the message body
+     *     length or forwarding the message.
+     * </pre>
+     * and https://tools.ietf.org/html/rfc7230#section-3.3.3:
+     * <pre>
+     *     If a message is received without Transfer-Encoding and with
+     *     either multiple Content-Length header fields having differing
+     *     field-values or a single Content-Length header field having an
+     *     invalid value, then the message framing is invalid and the
+     *     recipient MUST treat it as an unrecoverable error.
+     * </pre>
+     * You may use one of the pre-defined behaviors in this class or implement your own.
+     */
+    public interface MultipleContentLengthHeadersBehavior {
+
+        /**
+         * Invoked by {@link HttpObjectDecoder} when it encounters an instance of multiple Content-Length headers. Note
+         * that the {@link List} of values represents different header lines and has not been split on commas. A single
+         * line may or may not have multiple, comma-separated values.
+         */
+        long resolveContentLength(HttpHeaders headers, List<String> contentLengthFields);
+
+        /**
+         * {@link #ALWAYS_REJECT} will always throw an {@link IllegalArgumentException} (and thus trigger a failed
+         * {@link DecoderResult}) whenever it encounters multiple Content-Length header values, regardless of them being
+         * the same or not.
+         * <p>
+         * This behavior is consistent with the first option offered in the RFC and has has been the default behavior of
+         * Netty since version 4.1.44.
+         */
+        MultipleContentLengthHeadersBehavior ALWAYS_REJECT =
+                new MultipleContentLengthHeadersBehavior() {
+                    @Override
+                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFields) {
+                        throw new IllegalArgumentException("Multiple Content-Length headers found");
+                    }
+                };
+
+        /**
+         * {@link #IF_DIFFERENT_REJECT_ELSE_DEDUPE} will permit multiple Content-Length header values only if they are
+         * all the same value. When this occurs, the {@link HttpHeaders} are also normalized to only contain the single,
+         * unique value.
+         * <p>
+         * This behavior is consistent with the second option offered in the RFC.
+         */
+        MultipleContentLengthHeadersBehavior IF_DIFFERENT_REJECT_ELSE_DEDUPE =
+                new MultipleContentLengthHeadersBehavior() {
+                    @Override
+                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFields) {
+                        String contentLength = findAndEnforceUniqueContentLength(contentLengthFields);
+                        headers.set(HttpHeaderNames.CONTENT_LENGTH, contentLength);
+                        return Long.parseLong(contentLength);
+                    }
+                };
+
+        /**
+         * {@link #IF_DIFFERENT_REJECT_ELSE_ALLOW} will permit multiple Content-Length header values only if they are
+         * all the same. When this occurs, the original {@link HttpHeaders} (and its multiple values) are left
+         * untouched.
+         * <p>
+         * This behavior is not offered as an explicit option in the RFC but may desired for pass-through behavior.
+         */
+        MultipleContentLengthHeadersBehavior IF_DIFFERENT_REJECT_ELSE_ALLOW =
+                new MultipleContentLengthHeadersBehavior() {
+                    @Override
+                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFields) {
+                        String contentLength = findAndEnforceUniqueContentLength(contentLengthFields);
+                        return Long.parseLong(contentLength);
+                    }
+                };
+
+        MultipleContentLengthHeadersBehavior DEFAULT = ALWAYS_REJECT;
+    }
+
+    private static String findAndEnforceUniqueContentLength(List<String> fields) {
+        String firstValue = null;
+        for (String field : fields) {
+            // limit = -1 so that empty values are not discarded, thereby enforcing stricter formatting
+            String[] tokens = COMMA_PATTERN.split(field, -1);
+            for (String token : tokens) {
+                String trimmed = token.trim();
+                if (firstValue == null) {
+                    firstValue = trimmed;
+                } else if (!trimmed.equals(firstValue)) {
+                    throw new IllegalArgumentException("Multiple different Content-Length headers found");
+                }
+            }
+        }
+        return firstValue;
+    }
+
+    // Instance methods
+    //---------------------------------------------------------------------------------
+
+    /**
+     * Creates a new {@link HttpDecoderOption} with the specified unique {@code name}.
+     */
+    private HttpDecoderOption(int id, String name) {
+        super(id, name);
+    }
+
+    /**
+     * Validate the value which is set for the {@link HttpDecoderOption}. Sub-classes may override this for special
+     * checks.
+     */
+    public void validate(T value) {
+        ObjectUtil.checkNotNull(value, "value");
+    }
+
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderOption.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderOption.java
@@ -111,7 +111,7 @@ public final class HttpDecoderOption<T> extends AbstractConstant<HttpDecoderOpti
          * that the {@link List} of values represents different header lines and has not been split on commas. A single
          * line may or may not have multiple, comma-separated values.
          */
-        long resolveContentLength(HttpHeaders headers, List<String> contentLengthFields);
+        long resolveContentLength(HttpHeaders headers, List<String> contentLengthFieldValues);
 
         /**
          * {@link #ALWAYS_REJECT} will always throw an {@link IllegalArgumentException} (and thus trigger a failed
@@ -124,7 +124,7 @@ public final class HttpDecoderOption<T> extends AbstractConstant<HttpDecoderOpti
         MultipleContentLengthHeadersBehavior ALWAYS_REJECT =
                 new MultipleContentLengthHeadersBehavior() {
                     @Override
-                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFields) {
+                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFieldValues) {
                         throw new IllegalArgumentException("Multiple Content-Length headers found");
                     }
                 };
@@ -139,8 +139,8 @@ public final class HttpDecoderOption<T> extends AbstractConstant<HttpDecoderOpti
         MultipleContentLengthHeadersBehavior IF_DIFFERENT_REJECT_ELSE_DEDUPE =
                 new MultipleContentLengthHeadersBehavior() {
                     @Override
-                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFields) {
-                        String contentLength = findAndEnforceUniqueContentLength(contentLengthFields);
+                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFieldValues) {
+                        String contentLength = findAndEnforceUniqueContentLength(contentLengthFieldValues);
                         headers.set(HttpHeaderNames.CONTENT_LENGTH, contentLength);
                         return Long.parseLong(contentLength);
                     }
@@ -151,13 +151,13 @@ public final class HttpDecoderOption<T> extends AbstractConstant<HttpDecoderOpti
          * all the same. When this occurs, the original {@link HttpHeaders} (and its multiple values) are left
          * untouched.
          * <p>
-         * This behavior is not offered as an explicit option in the RFC but may desired for pass-through behavior.
+         * This behavior is not offered as an explicit option in the RFC but may be desired for pass-through behavior.
          */
         MultipleContentLengthHeadersBehavior IF_DIFFERENT_REJECT_ELSE_ALLOW =
                 new MultipleContentLengthHeadersBehavior() {
                     @Override
-                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFields) {
-                        String contentLength = findAndEnforceUniqueContentLength(contentLengthFields);
+                    public long resolveContentLength(HttpHeaders headers, List<String> contentLengthFieldValues) {
+                        String contentLength = findAndEnforceUniqueContentLength(contentLengthFieldValues);
                         return Long.parseLong(contentLength);
                     }
                 };

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.TooLongFrameException;
 
+import java.util.Map;
 
 /**
  * Decodes {@link ByteBuf}s into {@link HttpRequest}s and {@link HttpContent}s.
@@ -55,30 +56,60 @@ import io.netty.handler.codec.TooLongFrameException;
 public class HttpRequestDecoder extends HttpObjectDecoder {
 
     /**
-     * Creates a new instance with the default
-     * {@code maxInitialLineLength (4096)}, {@code maxHeaderSize (8192)}, and
+     * Create a new builder for building an {@link HttpRequestDecoder}.
+     *
+     * @see HttpRequestDecoderBuilder
+     */
+    public static HttpRequestDecoderBuilder builder() {
+        return new HttpRequestDecoderBuilder();
+    }
+
+    /**
+     * @deprecated Please use {@link #builder()} instead.
+     * <p>
+     * Creates a new instance with the default {@code maxInitialLineLength (4096)}, {@code maxHeaderSize (8192)}, and
      * {@code maxChunkSize (8192)}.
      */
+    @Deprecated
     public HttpRequestDecoder() {
     }
 
     /**
-     * Creates a new instance with the specified parameters.
+     * @deprecated Please use {@link #builder()} instead.
      */
+    @Deprecated
     public HttpRequestDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true);
+        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_CHUNKED_SUPPORTED);
     }
 
+    /**
+     * @deprecated Please use {@link #builder()} instead.
+     */
+    @Deprecated
     public HttpRequestDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true, validateHeaders);
+        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders);
     }
 
+    /**
+     * @deprecated Please use {@link #builder()} instead.
+     */
+    @Deprecated
     public HttpRequestDecoder(
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
             int initialBufferSize) {
-        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, true, validateHeaders, initialBufferSize);
+        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders,
+              initialBufferSize);
+    }
+
+    private HttpRequestDecoder(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
+            boolean chunkedSupported, boolean validateHeaders, int initialBufferSize,
+            Map<HttpDecoderOption<?>, Object> options) {
+        super(maxInitialLineLength, maxHeaderSize, maxChunkSize,
+              chunkedSupported, validateHeaders, initialBufferSize,
+              options);
     }
 
     @Override
@@ -96,5 +127,21 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
     @Override
     protected boolean isDecodingRequest() {
         return true;
+    }
+
+    /**
+     * @see AbstractHttpObjectDecoderBuilder
+     */
+    public static class HttpRequestDecoderBuilder
+            extends AbstractHttpObjectDecoderBuilder<HttpRequestDecoder, HttpRequestDecoderBuilder> {
+
+        HttpRequestDecoderBuilder() {
+        }
+
+        @Override
+        public HttpRequestDecoder build() {
+            return new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, chunkedSupported,
+                                          validateHeaders, initialBufferSize, options);
+        }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspDecoder.java
@@ -72,16 +72,6 @@ public class RtspDecoder extends HttpObjectDecoder {
     private static final Pattern versionPattern = Pattern.compile("RTSP/\\d\\.\\d");
 
     /**
-     * Constant for default max initial line length.
-     */
-    public static final int DEFAULT_MAX_INITIAL_LINE_LENGTH = 4096;
-
-    /**
-     * Constant for default max header size.
-     */
-    public static final int DEFAULT_MAX_HEADER_SIZE = 8192;
-
-    /**
      * Constant for default max content length.
      */
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 8192;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersBehaviorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersBehaviorTest.java
@@ -44,7 +44,6 @@ public class MultipleContentLengthHeadersBehaviorTest {
     private final boolean singleField;
 
     private EmbeddedChannel channel;
-    private HttpRequest request;
 
     @Parameters
     public static Collection<Object[]> parameters() {
@@ -83,7 +82,7 @@ public class MultipleContentLengthHeadersBehaviorTest {
     public void testMultipleContentLengthHeadersBehavior() {
         String requestStr = setupRequestString();
         assertThat(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)), is(true));
-        request = channel.readInbound();
+        HttpRequest request = channel.readInbound();
 
         if (behavior == MultipleContentLengthHeadersBehavior.ALWAYS_REJECT) {
             assertInvalid(request);
@@ -113,7 +112,7 @@ public class MultipleContentLengthHeadersBehaviorTest {
 
     private String setupRequestString() {
         String firstValue = "1";
-        String secondValue = sameValue? firstValue : "2";
+        String secondValue = sameValue ? firstValue : "2";
         String contentLength;
         if (singleField) {
             contentLength = "Content-Length: " + firstValue + ", " + secondValue + "\r\n\r\n";
@@ -133,7 +132,7 @@ public class MultipleContentLengthHeadersBehaviorTest {
                             "Connection: close\n\n" +
                             "b";
         assertThat(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)), is(true));
-        request = channel.readInbound();
+        HttpRequest request = channel.readInbound();
         assertInvalid(request);
         assertThat(channel.finish(), is(false));
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersBehaviorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersBehaviorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpDecoderOption.MultipleContentLengthHeadersBehavior;
+import io.netty.util.CharsetUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static io.netty.handler.codec.http.HttpDecoderOption.MULTIPLE_CONTENT_LENGTH_HEADERS_BEHAVIOR;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+@RunWith(Parameterized.class)
+public class MultipleContentLengthHeadersBehaviorTest {
+
+    private final MultipleContentLengthHeadersBehavior behavior;
+    private final boolean sameValue;
+    private final boolean singleField;
+
+    private EmbeddedChannel channel;
+    private HttpRequest request;
+
+    @Parameters
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+                { MultipleContentLengthHeadersBehavior.ALWAYS_REJECT, false, false },
+                { MultipleContentLengthHeadersBehavior.ALWAYS_REJECT, false, true },
+                { MultipleContentLengthHeadersBehavior.ALWAYS_REJECT, true, false },
+                { MultipleContentLengthHeadersBehavior.ALWAYS_REJECT, true, true },
+                { MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_DEDUPE, false, false },
+                { MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_DEDUPE, false, true },
+                { MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_DEDUPE, true, false },
+                { MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_DEDUPE, true, true },
+                { MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_ALLOW, false, false },
+                { MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_ALLOW, false, true },
+                { MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_ALLOW, true, false },
+                { MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_ALLOW, true, true }
+        });
+    }
+
+    public MultipleContentLengthHeadersBehaviorTest(
+            MultipleContentLengthHeadersBehavior behavior, boolean sameValue, boolean singleField) {
+        this.behavior = behavior;
+        this.sameValue = sameValue;
+        this.singleField = singleField;
+    }
+
+    @Before
+    public void setUp() {
+        HttpRequestDecoder decoder = HttpRequestDecoder.builder()
+                                                       .option(MULTIPLE_CONTENT_LENGTH_HEADERS_BEHAVIOR, behavior)
+                                                       .build();
+        channel = new EmbeddedChannel(decoder);
+    }
+
+    @Test
+    public void testMultipleContentLengthHeadersBehavior() {
+        String requestStr = setupRequestString();
+        assertThat(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)), is(true));
+        request = channel.readInbound();
+
+        if (behavior == MultipleContentLengthHeadersBehavior.ALWAYS_REJECT) {
+            assertInvalid(request);
+        } else if (behavior == MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_DEDUPE) {
+            if (sameValue) {
+                assertValid(request);
+                List<String> contentLengths = request.headers().getAll(HttpHeaderNames.CONTENT_LENGTH);
+                assertThat(contentLengths, contains("1"));
+            } else {
+                assertInvalid(request);
+            }
+        } else if (behavior == MultipleContentLengthHeadersBehavior.IF_DIFFERENT_REJECT_ELSE_ALLOW) {
+            if (sameValue) {
+                assertValid(request);
+                List<String> contentLengths = request.headers().getAll(HttpHeaderNames.CONTENT_LENGTH);
+                if (singleField) {
+                    assertThat(contentLengths, contains("1, 1"));
+                } else {
+                    assertThat(contentLengths, contains("1", "1"));
+                }
+            } else {
+                assertInvalid(request);
+            }
+        }
+        assertThat(channel.finish(), is(false));
+    }
+
+    private String setupRequestString() {
+        String firstValue = "1";
+        String secondValue = sameValue? firstValue : "2";
+        String contentLength;
+        if (singleField) {
+            contentLength = "Content-Length: " + firstValue + ", " + secondValue + "\r\n\r\n";
+        } else {
+            contentLength = "Content-Length: " + firstValue + "\r\n" +
+                            "Content-Length: " + secondValue + "\r\n\r\n";
+        }
+        return "PUT /some/path HTTP/1.1\r\n" +
+               contentLength +
+               "b";
+    }
+
+    @Test
+    public void testDanglingComma() {
+        String requestStr = "GET /some/path HTTP/1.1\r\n" +
+                            "Content-Length: 1,\r\n" +
+                            "Connection: close\n\n" +
+                            "b";
+        assertThat(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)), is(true));
+        request = channel.readInbound();
+        assertInvalid(request);
+        assertThat(channel.finish(), is(false));
+    }
+
+    private void assertValid(HttpRequest request) {
+        assertThat(request.decoderResult().isFailure(), is(false));
+        assertThat(channel.readInbound(), instanceOf(LastHttpContent.class));
+    }
+
+    private static void assertInvalid(HttpRequest request) {
+        assertThat(request.decoderResult().isFailure(), is(true));
+        assertThat(request.decoderResult().cause(), instanceOf(IllegalArgumentException.class));
+        assertThat(request.decoderResult().cause().getMessage(), containsString("Multiple"));
+        assertThat(request.decoderResult().cause().getMessage(), containsString("Content-Length headers found"));
+    }
+}


### PR DESCRIPTION
...and introduce `HttpDecoderOption` & `HttpDecoderBuilder` in doing so.

## Motivation

Since https://github.com/netty/netty/pull/9865 (Netty 4.1.44) the default behavior of the `HttpObjectDecoder` has been to reject any HTTP message that is found to have multiple Content-Length headers when decoding. This behavior is well-justified as per the risks outlined in https://github.com/netty/netty/issues/9861, however, we can see from the cited RFC section that there are multiple possible options offered for responding to this scenario:

> If a message is received that has multiple Content-Length header
> fields with field-values consisting of the same decimal value, or a
> single Content-Length header field with a field value containing a
> list of identical decimal values (e.g., "Content-Length: 42, 42"),
> indicating that duplicate Content-Length header fields have been
> generated or combined by an upstream message processor, then the
> recipient MUST either reject the message as invalid or replace the
> duplicated field-values with a single valid Content-Length field
> containing that decimal value prior to determining the message body
> length or forwarding the message.

https://tools.ietf.org/html/rfc7230#section-3.3.2

Netty opted for the first option (rejecting as invalid), which seems like the safest, but the second option (replacing duplicate values with a single value) is also valid behavior. While it makes sense for Netty to bias towards the safest option, Netty is used as a library for a variety of different use cases, and there is usually no one-size-fits-all for parsing behavior like this...

It seems like the ideal solution would be to default to the safest behavior but to also make these types of decisions configurable. This is further motivated by the fact that the HTTP RFCs are often vague or ambiguous in many areas and we have seen other back-and-forth conversations (e.g., https://github.com/netty/netty/pull/10003/) based on differing interpretations that would probably be most amicably resolved by simply exposing better configuration.

## Modifications

* Deprecate `HttpRequestDecoder`'s telescoping constructors and introduce `AbstractHttpObjectDecoderBuilder` and `HttpRequestDecoderBuilder`. (The current `HttpObjectDecoder` implementations are only minimally configurable, and any further configuration will not scale well with the existing telescoping constructors.)
* Move default decoder values to the `HttpObjectDecoder` class and reference them accordingly.
* Introduce `HttpDecoderOption` class. This option is similar in vein to the `ChannelOption` class, where it is capable of exposing a wide possibility of different configurations.
* Introduce the first decoder option: `MultipleContentLengthHeadersBehavior`. This option sets the precedent of using an interface for its implementation (as opposed to boolean/enum) so that users can easily define their own implementations or even "listen in" on implementations for logging purposes (without having to override).
* Current available options are: `ALWAYS_REJECT`, `IF_DIFFERENT_REJECT_ELSE_DEDUPE`, and `IF_DIFFERENT_REJECT_ELSE_ALLOW` (see Javadoc for more).
* Note that the existing logic would result in `NumberFormatException`s for header values like "Content-Length: 42, 42". The new logic correctly reports these as `IllegalArgumentException`.
* Extend `HttpObjectDecoder` to accept a map of options and use these options to resolve multiple Content-Length scenarios.
* In doing so, also apply this logic to HTTP/1.0 (in addition to 1.1). Even though the cited RFCs were for 1.1, it seems that the risks they are trying to mitigate could still apply to messages in 1.0 that specify a content length.
* Also include HTTP/1.0 in the existing `handleTransferEncodingChunkedWithContentLength` logic for the same reason (this logic could also probably be better served by an `HttpDecoderOption` in the future).
* Include new unit tests to test all of the possible combinations of `MultipleContentLengthHeadersBehavior` and multiple content lengths.

## Result

This is a backwards-compatible change with no functional change to the existing behavior (except for now applying it to HTTP/1.0 as well). Users will now be able to customize the behavior for handling multiple content lengths, and we will be able to more easily add additional options in the future if needed.

To limit the scope of this commit, it does not attempt to introduce the builder or decoder options to the other relevant classes (`HttpResponseDecoder`, `HttpClientCodec`, `HttpServerCodec`), but we may wish to follow-up with those changes.