### PR TITLE
Added support for the SameSite attribute in Cookies (#10050)

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/ClientCookieDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/ClientCookieDecoder.java
@@ -16,6 +16,7 @@
 package org.jboss.netty.handler.codec.http.cookie;
 
 import org.jboss.netty.handler.codec.http.HttpHeaderDateFormat;
+import org.jboss.netty.handler.codec.http.cookie.CookieHeaderNames.SameSite;
 
 import java.text.ParsePosition;
 import java.util.Date;
@@ -158,6 +159,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
         private String expires;
         private boolean secure;
         private boolean httpOnly;
+        private SameSite sameSite;
 
         public CookieBuilder(DefaultCookie cookie) {
             this.cookie = cookie;
@@ -183,6 +185,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
             cookie.setMaxAge(mergeMaxAgeAndExpire(maxAge, expires));
             cookie.setSecure(secure);
             cookie.setHttpOnly(httpOnly);
+            cookie.setSameSite(sameSite);
             return cookie;
         }
 
@@ -256,6 +259,8 @@ public final class ClientCookieDecoder extends CookieDecoder {
         private void parse8(String header, int nameStart, String value) {
             if (header.regionMatches(true, nameStart, CookieHeaderNames.HTTPONLY, 0, 8)) {
                 httpOnly = true;
+            } else if (header.regionMatches(true, nameStart, CookieHeaderNames.SAMESITE, 0, 8)) {
+                sameSite = SameSite.of(value);
             }
         }
     }

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/CookieHeaderNames.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/CookieHeaderNames.java
@@ -28,6 +28,35 @@ public final class CookieHeaderNames {
 
     public static final String HTTPONLY = "HTTPOnly";
 
+    public static final String SAMESITE = "SameSite";
+
+    /**
+     * Possible values for the SameSite attribute.
+     * See <a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05">changes to RFC6265bis</a>
+     */
+    public enum SameSite {
+        Lax,
+        Strict,
+        None;
+
+        /**
+         * Return the enum value corresponding to the passed in same-site-flag, using a case insensitive comparison.
+         *
+         * @param name value for the SameSite Attribute
+         * @return enum value for the provided name or null
+         */
+        static SameSite of(String name) {
+            if (name != null) {
+                for (SameSite each : SameSite.class.getEnumConstants()) {
+                    if (each.name().equalsIgnoreCase(name)) {
+                        return each;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+
     private CookieHeaderNames() {
         // Unused.
     }

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -15,6 +15,8 @@
  */
 package org.jboss.netty.handler.codec.http.cookie;
 
+import org.jboss.netty.handler.codec.http.cookie.CookieHeaderNames.SameSite;
+
 /**
  * The default {@link Cookie} implementation.
  */
@@ -28,6 +30,7 @@ public class DefaultCookie implements Cookie {
     private int maxAge = Integer.MIN_VALUE;
     private boolean secure;
     private boolean httpOnly;
+    private SameSite sameSite;
 
     /**
      * Creates a new cookie with the specified name and value.
@@ -129,6 +132,26 @@ public class DefaultCookie implements Cookie {
         this.httpOnly = httpOnly;
     }
 
+    /**
+     * Checks to see if this {@link Cookie} can be sent along cross-site requests.
+     * For more information, please look
+     * <a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05">here</a>
+     * @return <b>same-site-flag</b> value
+     */
+    public SameSite sameSite() {
+        return sameSite;
+    }
+
+    /**
+     * Determines if this this {@link Cookie} can be sent along cross-site requests.
+     * For more information, please look
+     *  <a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05">here</a>
+     * @param sameSite <b>same-site-flag</b> value
+     */
+    public void setSameSite(SameSite sameSite) {
+        this.sameSite = sameSite;
+    }
+
     @Override
     public int hashCode() {
         return name().hashCode();
@@ -228,6 +251,9 @@ public class DefaultCookie implements Cookie {
         }
         if (isHttpOnly()) {
             buf.append(", HTTPOnly");
+        }
+        if (sameSite() != null) {
+            buf.append(", SameSite=").append(sameSite());
         }
         return buf.toString();
     }

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -112,6 +112,12 @@ public final class ServerCookieEncoder extends CookieEncoder {
         if (cookie.isHttpOnly()) {
             add(buf, CookieHeaderNames.HTTPONLY);
         }
+        if (cookie instanceof DefaultCookie) {
+            DefaultCookie c = (DefaultCookie) cookie;
+            if (c.sameSite() != null) {
+                add(buf, CookieHeaderNames.SAMESITE, c.sameSite().name());
+            }
+        }
 
         return stripTrailingSeparator(buf);
     }

--- a/src/test/java/org/jboss/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import org.jboss.netty.handler.codec.http.HttpHeaderDateFormat;
+import org.jboss.netty.handler.codec.http.cookie.CookieHeaderNames.SameSite;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -36,7 +37,7 @@ import java.util.TimeZone;
 public class ClientCookieDecoderTest {
     @Test
     public void testDecodingSingleCookieV0() {
-        String cookieString = "myCookie=myValue;expires=XXX;path=/apathsomewhere;domain=.adomainsomewhere;secure;";
+        String cookieString = "myCookie=myValue;expires=XXX;path=/apathsomewhere;domain=.adomainsomewhere;secure;SameSite=None";
         cookieString = cookieString.replace("XXX", HttpHeaderDateFormat.get()
                 .format(new Date(System.currentTimeMillis() + 50000)));
 
@@ -58,6 +59,8 @@ public class ClientCookieDecoderTest {
 
         assertEquals("/apathsomewhere", cookie.path());
         assertTrue(cookie.isSecure());
+
+        assertEquals(SameSite.None, ((DefaultCookie) cookie).sameSite());
     }
 
     @Test

--- a/src/test/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
@@ -18,6 +18,7 @@ package org.jboss.netty.handler.codec.http.cookie;
 import org.junit.Test;
 
 import org.jboss.netty.handler.codec.http.HttpHeaderDateFormat;
+import org.jboss.netty.handler.codec.http.cookie.CookieHeaderNames.SameSite;
 
 import java.text.ParseException;
 import java.util.Date;
@@ -35,12 +36,13 @@ public class ServerCookieEncoderTest {
         int maxAge = 50;
 
         String result =
-                "myCookie=myValue; Max-Age=50; Expires=(.+?); Path=/apathsomewhere; Domain=.adomainsomewhere; Secure";
-        Cookie cookie = new DefaultCookie("myCookie", "myValue");
+                "myCookie=myValue; Max-Age=50; Expires=(.+?); Path=/apathsomewhere; Domain=.adomainsomewhere; Secure; SameSite=Lax";
+        DefaultCookie cookie = new DefaultCookie("myCookie", "myValue");
         cookie.setDomain(".adomainsomewhere");
         cookie.setMaxAge(maxAge);
         cookie.setPath("/apathsomewhere");
         cookie.setSecure(true);
+        cookie.setSameSite(SameSite.Lax);
 
         String encodedCookie = ServerCookieEncoder.STRICT.encode(cookie);
 


### PR DESCRIPTION
Picked from this pull https://github.com/netty/netty/pull/10050
and this commit https://github.com/netty/netty/commit/e4af5c363152e6589e46eb3e3f7c44e8ebae9b09

Motivation:

Netty currently does not support the SameSite attribute for response cookies (see issue #8161 for discussion).

Modifications:

The attribute has been added to the DefaultCookie class as a quick fix since adding new methods to the Cookie interface would be backwards-incompatible.
ServerCookieEncoder and ClientCookieDecoder have been updated accordingly to process this value. No validation for allowed values (Lax, None, Strict) has been implemented.

Result:

Response cookies with the SameSite attribute set can be read or written by Netty.

Co-authored-by: David Latorre <a-dlatorre@hotels.com>

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
