### PR TITLE
Update GraalVM with JDK 8 and add GraalVM with JDK 11

### DIFF
--- a/docker/docker-compose.centos-6.graalvm111.yaml
+++ b/docker/docker-compose.centos-6.graalvm111.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-1.11
+    build:
+      args:
+        centos_version : "6"
+        java_version : "graalvm-ce-java11@20.1.0"
+
+  test:
+    image: netty:centos-6-1.11
+
+  test-leak:
+    image: netty:centos-6-1.11
+
+  test-boringssl-static:
+    image: netty:centos-6-1.11
+
+  shell:
+    image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.graalvm18.yaml
+++ b/docker/docker-compose.centos-6.graalvm18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "graalvm@19.2.1"
+        java_version : "graalvm-ce-java8@20.1.0"
 
   test:
     image: netty:centos-6-1.8


### PR DESCRIPTION
Motivation:

A new GraalVM with JDK 11 was released and GraalVM adds Java 11 support

Modification:
- Update GraalVM JDK 8 version
- Add GraalVM JDK 11 support

Result:
Build with GraalVM JDK 11 and use latest GraalVM JDK 8 version

