### PR TITLE
[DO NOT merge] Try out jemalloc directly.

### DIFF
--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -39,6 +39,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>buffer-jni</artifactId>
+      <version>1</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>

--- a/buffer/src/main/java/io/netty/buffer/JniByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/JniByteBufAllocator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import java.foreign.memory.Pointer;
+import java.nio.ByteBuffer;
+
+public final class JniByteBufAllocator extends UnpooledByteBufAllocator {
+
+    private UnpooledByteBufAllocatorMetric metric = new UnpooledByteBufAllocatorMetric();
+
+    public JniByteBufAllocator(boolean preferDirect) {
+        super(preferDirect);
+    }
+
+    @Override
+    public ByteBufAllocatorMetric metric() {
+        return super.metric();
+    }
+
+    @Override
+    protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+        try (java.foreign.Scope scope = io.netty.buffer.jni.jemalloc_lib.scope().fork()) {
+            metric.directCounter.add(initialCapacity);
+            java.foreign.memory.Pointer<?> ptr =
+                    io.netty.buffer.jni.jemalloc_lib.jni_je_malloc(initialCapacity);
+            return new JniDirectByteBuf(ptr.asDirectByteBuffer(initialCapacity), maxCapacity);
+        }
+    }
+
+    @Override
+    protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+        metric.heapCounter.add(initialCapacity);
+        return super.newHeapBuffer(initialCapacity, maxCapacity);
+    }
+
+    private final class JniDirectByteBuf extends UnpooledDirectByteBuf {
+        JniDirectByteBuf(
+                ByteBuffer initialBuffer, int maxCapacity) {
+            super(JniByteBufAllocator.this, initialBuffer, maxCapacity, /* doFree= */ false, false);
+        }
+
+        @Override
+        protected void freeDirect(ByteBuffer buffer) {
+            Pointer<?> pointer = Pointer.fromByteBuffer(buffer);
+            io.netty.buffer.jni.jemalloc_lib.jni_je_free(pointer);
+        }
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 /**
  * Simplistic {@link ByteBufAllocator} implementation that does not pool anything.
  */
-public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator implements ByteBufAllocatorMetricProvider {
+public class UnpooledByteBufAllocator extends AbstractByteBufAllocator implements ByteBufAllocatorMetricProvider {
 
     private final UnpooledByteBufAllocatorMetric metric = new UnpooledByteBufAllocatorMetric();
     private final boolean disableLeakDetector;
@@ -246,9 +246,9 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         }
     }
 
-    private static final class UnpooledByteBufAllocatorMetric implements ByteBufAllocatorMetric {
-        final LongCounter directCounter = PlatformDependent.newLongCounter();
-        final LongCounter heapCounter = PlatformDependent.newLongCounter();
+    protected static final class UnpooledByteBufAllocatorMetric implements ByteBufAllocatorMetric {
+        protected final LongCounter directCounter = PlatformDependent.newLongCounter();
+        protected final LongCounter heapCounter = PlatformDependent.newLongCounter();
 
         @Override
         public long usedHeapMemory() {

--- a/buffer/src/test/java/io/netty/buffer/UnpooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledByteBufAllocatorTest.java
@@ -15,15 +15,15 @@
  */
 package io.netty.buffer;
 
-public class UnpooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<UnpooledByteBufAllocator> {
+public class UnpooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<JniByteBufAllocator> {
 
     @Override
-    protected UnpooledByteBufAllocator newAllocator(boolean preferDirect) {
-        return new UnpooledByteBufAllocator(preferDirect);
+    protected JniByteBufAllocator newAllocator(boolean preferDirect) {
+        return new JniByteBufAllocator(preferDirect);
     }
 
     @Override
-    protected UnpooledByteBufAllocator newUnpooledAllocator() {
-        return new UnpooledByteBufAllocator(false);
+    protected JniByteBufAllocator newUnpooledAllocator() {
+        return new JniByteBufAllocator(false);
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
@@ -17,6 +17,7 @@ package io.netty.microbench.buffer;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.JniByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.microbench.util.AbstractMicrobenchmark;
@@ -33,7 +34,7 @@ import java.util.Random;
 @State(Scope.Benchmark)
 public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
 
-    private static final ByteBufAllocator unpooledAllocator = new UnpooledByteBufAllocator(true);
+    private static final ByteBufAllocator unpooledAllocator = new JniByteBufAllocator(true);
     private static final ByteBufAllocator pooledAllocator =
             new PooledByteBufAllocator(true, 4, 4, 8192, 11, 0, 0, 0, true, 0); // Disable thread-local cache
 
@@ -50,33 +51,13 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
     public int size;
 
     @Benchmark
-    public void unpooledHeapAllocAndFree() {
-        int idx = rand.nextInt(unpooledHeapBuffers.length);
-        ByteBuf oldBuf = unpooledHeapBuffers[idx];
-        if (oldBuf != null) {
-            oldBuf.release();
-        }
-        unpooledHeapBuffers[idx] = unpooledAllocator.heapBuffer(size);
-    }
-
-    @Benchmark
-    public void unpooledDirectAllocAndFree() {
+    public void npooledDirectAllocAndFree() {
         int idx = rand.nextInt(unpooledDirectBuffers.length);
         ByteBuf oldBuf = unpooledDirectBuffers[idx];
         if (oldBuf != null) {
             oldBuf.release();
         }
         unpooledDirectBuffers[idx] = unpooledAllocator.directBuffer(size);
-    }
-
-    @Benchmark
-    public void pooledHeapAllocAndFree() {
-        int idx = rand.nextInt(pooledHeapBuffers.length);
-        ByteBuf oldBuf = pooledHeapBuffers[idx];
-        if (oldBuf != null) {
-            oldBuf.release();
-        }
-        pooledHeapBuffers[idx] = pooledAllocator.heapBuffer(size);
     }
 
     @Benchmark
@@ -87,25 +68,5 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
             oldBuf.release();
         }
         pooledDirectBuffers[idx] = pooledAllocator.directBuffer(size);
-    }
-
-    @Benchmark
-    public void defaultPooledHeapAllocAndFree() {
-        int idx = rand.nextInt(defaultPooledHeapBuffers.length);
-        ByteBuf oldBuf = defaultPooledHeapBuffers[idx];
-        if (oldBuf != null) {
-            oldBuf.release();
-        }
-        defaultPooledHeapBuffers[idx] = PooledByteBufAllocator.DEFAULT.heapBuffer(size);
-    }
-
-    @Benchmark
-    public void defaultPooledDirectAllocAndFree() {
-        int idx = rand.nextInt(defaultPooledDirectBuffers.length);
-        ByteBuf oldBuf = defaultPooledDirectBuffers[idx];
-        if (oldBuf != null) {
-            oldBuf.release();
-        }
-        defaultPooledDirectBuffers[idx] = PooledByteBufAllocator.DEFAULT.directBuffer(size);
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -33,7 +33,7 @@ import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 @Fork(AbstractMicrobenchmark.DEFAULT_FORKS)
 public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
 
-    protected static final int DEFAULT_FORKS = 2;
+    protected static final int DEFAULT_FORKS = 1;
 
     public static final class HarnessExecutor extends ThreadPoolExecutor {
         private final  InternalLogger logger = InternalLoggerFactory.getInstance(AbstractMicrobenchmark.class);

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.SystemPropertyUtil;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Measurement;
@@ -36,8 +37,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 /**
  * Base class for all JMH benchmarks.
  */
-@Warmup(iterations = AbstractMicrobenchmarkBase.DEFAULT_WARMUP_ITERATIONS)
-@Measurement(iterations = AbstractMicrobenchmarkBase.DEFAULT_MEASURE_ITERATIONS)
+@Warmup(iterations = AbstractMicrobenchmarkBase.DEFAULT_WARMUP_ITERATIONS, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = AbstractMicrobenchmarkBase.DEFAULT_MEASURE_ITERATIONS, time = 1, timeUnit = TimeUnit.SECONDS)
+
 @State(Scope.Thread)
 public abstract class AbstractMicrobenchmarkBase {
     protected static final int DEFAULT_WARMUP_ITERATIONS = 10;

--- a/pom.xml
+++ b/pom.xml
@@ -112,8 +112,8 @@
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
         <!-- This is the minimum supported by Java12+ -->
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -132,8 +132,8 @@
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
         <!-- This is the minimum supported by Java12+ -->
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -153,8 +153,8 @@
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
         <!-- This is the minimum supported by Java12+ -->
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -178,8 +178,8 @@
         <!-- 1.4.x does not work in Java10+ -->
         <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
         <!-- This is the minimum supported by Java12+ -->
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -327,8 +327,8 @@
   </profiles>
 
   <properties>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <netty.dev.tools.directory>${project.build.directory}/dev-tools</netty.dev.tools.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -856,34 +856,6 @@
             <exclude>**/package-info.java</exclude>
           </excludes>
         </configuration>
-      </plugin>
-      <plugin>
-        <!-- ensure that only methods available in java 1.6 can
-             be used even when compiling with java 1.7+ -->
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.16</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
-            <version>1.1</version>
-          </signature>
-          <ignores>
-            <ignore>java.nio.ByteBuffer</ignore>
-          </ignores>
-          <annotations>
-            <annotation>io.netty.util.internal.SuppressJava6Requirement</annotation>
-          </annotations>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
[This is not a serious PR, just a fun experiment I am sharing via the Pull Request system]

I tried out using the Project Panama to link directly to the native malloc/free implementation.  I then implemented a byte buf allocator which calls these functions and wraps the resulting pointers in ByteBuffers.  This can be passed in pretty easily into the existing Unpooled allocator.   The benchmark results don't look great; I haven't dug into the assembly or the perf output, but I have high hopes this could be optimized.   I used jemalloc @  8da0896b7913470250a0220504822028e2aa8f2a, and one of the Panama Preview builds (Build 14-panama+1-15 (2019/8/8)).

Some observations:

* PooledByteBufAllocator is non-final, but UnpooledByteBufAllocator is.  I had to modify the latter to get it working.  I feel these APIs should either both be final, or non-final, but not a diff.

* Pooling I think doesn't make much difference when wrapping the pointers from malloc directly.  Parts of the code seem to care about this distinction (e.g. `isDirectBufferPooled`), but I can't see why.   

* The Foreign Memory scopes, which bound the lifetime of pointers aren't really useful to Netty here.  The memory is going to live for a different time period.  In fact, the ByteBuffer converters in Foreign seem to break the bounding rules.

* Compiling jemalloc was a breeze.  It almost seems to be designed to play well with other allocators.  Compare this to tcmalloc, which is intentionally hostile about use via JNI.

* Working in the constraints of JDK 6/7/8 is going to start making Netty harder to access more advanced Java features.  IntelliJ no long will compile Netty from a clean git repo, complaining about missing JDK classes.  Using try-with complains.   I had to modify a lot of pom to get this working.  

* The Netty Benchmark docs don't show how to run a single benchmark; they only cover the whole suite.  I think running a single benchmark class should be covered in the docs, since Anyone who is benchmarking is likely only interested in a narrow subset.





Compiled jemalloc with the following:

* `./autogen.sh --with-jemalloc-prefix=jni_je_ --disable-initial-exec-tls`
* `make -j8`

This ensures that jemalloc can be loaded as a shared library.   The TLS bit
is to make it work with dlopen.

Next, jextract the interface using jextract:

* `/tmp/jdk-14/bin/jextract -t io.netty.buffer.jni ./include/jemalloc/jemalloc.h -L lib/  -ljemalloc --record-library-path -o mytest.jar`

It will complain about missing libraries, but doesn't seem to indicate which ones.  Oh well.

Install this into the maven local repo:

* `mvn install:install-file -Dfile=mytest.jar -DgroupId=io.netty -DartifactId=buffer-jni -Dversion=1 -Dpackaging=jar`

The changes in this commit should point to it.    To run, the library path and the jdk need to be set to use the Panama JDK.  For the benchmarks this means:

`LD_LIBRARY_PATH=/tmp/jemalloc/lib/ JAVA_HOME=/tmp/jdk-14/ mvn -DskipTests=false test -Dtest=ByteBufAllocatorBenchmark`

Results on my machine is:

```

Benchmark                                            (size)   Mode  Cnt         Score        Error  Units
ByteBufAllocatorBenchmark.npooledDirectAllocAndFree   00000  thrpt   10   1279677.529 ±  16295.712  ops/s
ByteBufAllocatorBenchmark.npooledDirectAllocAndFree   00256  thrpt   10   1228494.551 ±  28719.207  ops/s
ByteBufAllocatorBenchmark.npooledDirectAllocAndFree   01024  thrpt   10   1093685.316 ±  13960.963  ops/s
ByteBufAllocatorBenchmark.npooledDirectAllocAndFree   04096  thrpt   10    771600.730 ±   6824.834  ops/s
ByteBufAllocatorBenchmark.npooledDirectAllocAndFree   16384  thrpt   10    728284.689 ±  19572.337  ops/s
ByteBufAllocatorBenchmark.npooledDirectAllocAndFree   65536  thrpt   10    685682.627 ±  10574.237  ops/s
ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    00000  thrpt   10  11699218.004 ± 162261.422  ops/s
ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    00256  thrpt   10   9897873.583 ± 142163.763  ops/s
ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    01024  thrpt   10   9080045.347 ±  97440.100  ops/s
ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    04096  thrpt   10   8395058.755 ± 104856.751  ops/s
ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    16384  thrpt   10   4219315.933 ±  40225.272  ops/s
ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    65536  thrpt   10   4605456.256 ±  42862.584  ops/s
```
