### PR TITLE
Solve the echo example code read-write loop problem

### DIFF
--- a/example/src/main/java/io/netty/example/echo/EchoClient.java
+++ b/example/src/main/java/io/netty/example/echo/EchoClient.java
@@ -24,6 +24,8 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -65,7 +67,7 @@ public final class EchoClient {
                      if (sslCtx != null) {
                          p.addLast(sslCtx.newHandler(ch.alloc(), HOST, PORT));
                      }
-                     //p.addLast(new LoggingHandler(LogLevel.INFO));
+                     p.addLast(new LoggingHandler(LogLevel.INFO));
                      p.addLast(new EchoClientHandler());
                  }
              });

--- a/example/src/main/java/io/netty/example/echo/EchoClientHandler.java
+++ b/example/src/main/java/io/netty/example/echo/EchoClientHandler.java
@@ -46,7 +46,7 @@ public class EchoClientHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        System.err.println(msg.toString());
+
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/echo/EchoClientHandler.java
+++ b/example/src/main/java/io/netty/example/echo/EchoClientHandler.java
@@ -46,7 +46,7 @@ public class EchoClientHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        ctx.write(msg);
+        System.err.println(msg.toString());
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/echo/EchoServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoServer.java
@@ -65,7 +65,6 @@ public final class EchoServer {
                      if (sslCtx != null) {
                          p.addLast(sslCtx.newHandler(ch.alloc()));
                      }
-                     //p.addLast(new LoggingHandler(LogLevel.INFO));
                      p.addLast(serverHandler);
                  }
              });


### PR DESCRIPTION
Motivation:

A read/write loop occurred when I ran the echo example code
For the following reasons:
``` java
//EchoClientHandler.java
@Override
public void channelRead(ChannelHandlerContext ctx, Object msg) {
    ctx.write(msg);
}
```
The client writes out the server's return message directly, resulting in a read/write loop


Modification:

The modified:
``` java
//EchoClientHandler.java
@Override
public void channelRead(ChannelHandlerContext ctx, Object msg) {
    System.err.println(msg.toString());
}
```

Result:
Solved the read-write loop problem