### PR TITLE
Fixing documentation on executor group

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -191,7 +191,7 @@ import java.util.NoSuchElementException;
  * and it could be represented as shown in the following example:
  *
  * <pre>
- * static final {@link EventExecutorGroup} group = new {@link DefaultEventExecutorGroup}(16);
+ * static final {@link EventExecutorGroup} group = new {@link UnorderedThreadPoolEventExecutor}(16);
  * ...
  *
  * {@link ChannelPipeline} pipeline = ch.pipeline();


### PR DESCRIPTION
Motivation:

The provided example in the documentation does not provide the described result. The same question was asked in 2016: https://stackoverflow.com/questions/39908253/netty-4-parallel-processing-after-bytetomessagecodec so it worth to fix.

Modification:

Changed java-doc.

Result:

Fixes #10352  
