### PR TITLE
Ensure ApplicationProtocolNegotiationHandler does handle handshake fa…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -20,9 +20,12 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.DecoderException;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import javax.net.ssl.SSLException;
 
 /**
  * Configures a {@link ChannelPipeline} depending on the application-level protocol negotiation result of
@@ -78,30 +81,33 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        if (evt instanceof SslHandshakeCompletionEvent) {
-
-            try {
-                SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
-                if (handshakeEvent.isSuccess()) {
-                    SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
-                    if (sslHandler == null) {
-                        throw new IllegalStateException("cannot find an SslHandler in the pipeline (required for "
-                                + "application-level protocol negotiation)");
-                    }
-                    String protocol = sslHandler.applicationProtocol();
-                    configurePipeline(ctx, protocol != null ? protocol : fallbackProtocol);
-                } else {
-                    handshakeFailure(ctx, handshakeEvent.cause());
+        SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
+        try {
+            if (handshakeEvent.isSuccess()) {
+                SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
+                if (sslHandler == null) {
+                    throw new IllegalStateException("cannot find an SslHandler in the pipeline (required for "
+                            + "application-level protocol negotiation)");
                 }
-            } catch (Throwable cause) {
-                exceptionCaught(ctx, cause);
-            } finally {
-                ChannelPipeline pipeline = ctx.pipeline();
-                if (pipeline.context(this) != null) {
-                    pipeline.remove(this);
-                }
+                String protocol = sslHandler.applicationProtocol();
+                configurePipeline(ctx, protocol != null ? protocol : fallbackProtocol);
+            } else {
+                // if the event is not produced because of an successful handshake we will receive the same exception
+                // in exceptionCaught(...) and handle it there. This will allow us more fine-granted control over
+                // which exception we propergate down the ChannelPipeline.
+                //
+                // See https://github.com/netty/netty/issues/10342
+            }
+        } catch (Throwable cause) {
+            exceptionCaught(ctx, cause);
+        } finally {
+            ChannelPipeline pipeline = ctx.pipeline();
+            // Handshake failures are handled in exceptionCaught(...).
+            if (handshakeEvent.isSuccess() && pipeline.context(this) != null) {
+                pipeline.remove(this);
             }
         }
+
         ctx.fireUserEventTriggered(evt);
     }
 
@@ -125,6 +131,18 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        Throwable wrapped;
+        if (cause instanceof DecoderException && ((wrapped = cause.getCause()) instanceof SSLException)) {
+            try {
+                handshakeFailure(ctx, wrapped);
+                return;
+            } finally {
+                ChannelPipeline pipeline = ctx.pipeline();
+                if (pipeline.context(this) != null) {
+                    pipeline.remove(this);
+                }
+            }
+        }
         logger.warn("{} Failed to select the application-level protocol:", ctx.channel(), cause);
         ctx.fireExceptionCaught(cause);
         ctx.close();

--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -87,6 +87,7 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
                 if (handshakeEvent.isSuccess()) {
                     SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
                     if (sslHandler == null) {
+                        System.err.println(ctx.pipeline().toString());
                         throw new IllegalStateException("cannot find an SslHandler in the pipeline (required for "
                                 + "application-level protocol negotiation)");
                     }

--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -87,7 +87,6 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
                 if (handshakeEvent.isSuccess()) {
                     SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
                     if (sslHandler == null) {
-                        System.err.println(ctx.pipeline().toString());
                         throw new IllegalStateException("cannot find an SslHandler in the pipeline (required for "
                                 + "application-level protocol negotiation)");
                     }

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class ApplicationProtocolNegotiationHandlerTest {
+
+    @Test
+    public void testHandshakeFailure() {
+        ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
+            @Override
+            protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
+                fail();
+            }
+        };
+
+        EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
+        SSLHandshakeException exception = new SSLHandshakeException("error");
+        SslHandshakeCompletionEvent completionEvent = new SslHandshakeCompletionEvent(exception);
+        channel.pipeline().fireUserEventTriggered(completionEvent);
+        channel.pipeline().fireExceptionCaught(new DecoderException(exception));
+        assertNull(channel.pipeline().context(alpnHandler));
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testHandshakeSuccess() throws NoSuchAlgorithmException {
+        final AtomicBoolean configureCalled = new AtomicBoolean(false);
+        ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
+            @Override
+            protected void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception {
+                configureCalled.set(true);
+                assertEquals(ApplicationProtocolNames.HTTP_1_1, protocol);
+            }
+        };
+
+        EmbeddedChannel channel = new EmbeddedChannel(new SslHandler(SSLContext.getDefault().createSSLEngine()),
+                alpnHandler);
+
+        channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        assertNull(channel.pipeline().context(alpnHandler));
+        // Should produce the close_notify messages
+        assertTrue(channel.finishAndReleaseAll());
+        assertTrue(configureCalled.get());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testHandshakeSuccessButNoSslHandler() {
+        ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
+            @Override
+            protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
+                fail();
+            }
+        };
+        EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
+        try {
+            channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        } finally {
+            assertNull(channel.pipeline().context(alpnHandler));
+            assertFalse(channel.finishAndReleaseAll());
+        }
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -45,6 +45,8 @@ public class ApplicationProtocolNegotiationHandlerTest {
         };
 
         EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
+        channel.runPendingTasks();
+
         SSLHandshakeException exception = new SSLHandshakeException("error");
         SslHandshakeCompletionEvent completionEvent = new SslHandshakeCompletionEvent(exception);
         channel.pipeline().fireUserEventTriggered(completionEvent);
@@ -64,8 +66,9 @@ public class ApplicationProtocolNegotiationHandlerTest {
             }
         };
 
-        EmbeddedChannel channel = new EmbeddedChannel(new SslHandler(SSLContext.getDefault().createSSLEngine()),
-                alpnHandler);
+        EmbeddedChannel channel = new EmbeddedChannel(new SslHandler(
+                SSLContext.getDefault().createSSLEngine()), alpnHandler);
+        channel.runPendingTasks();
 
         channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
@@ -83,6 +86,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
             }
         };
         EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
+        channel.runPendingTasks();
         try {
             channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         } finally {

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -58,7 +58,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
         final AtomicBoolean configureCalled = new AtomicBoolean(false);
         ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
             @Override
-            protected void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception {
+            protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
                 configureCalled.set(true);
                 assertEquals(ApplicationProtocolNames.HTTP_1_1, protocol);
             }


### PR DESCRIPTION
…ilures completely

Motivation:

When ApplicationProtocolNegotiationHandler is in the pipeline we should expect that its handshakeFailure(...) method will be able to completly handle the handshake error. At the moment this is not the case as it only handled SslHandshakeCompletionEvent but not the exceptionCaught(...) that is also triggered in this case

Modifications:

- Call handshakeFailure(...) in exceptionCaught and so fix double notification.
- Add testcases

Result:

Fixes https://github.com/netty/netty/issues/10342