### PR TITLE
Fix a javadoc mistake.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -229,7 +229,7 @@ public final class HttpHeaderValues {
      */
     public static final AsciiString WEBSOCKET = AsciiString.cached("websocket");
     /**
-     * {@code "websocket"}
+     * {@code "XmlHttpRequest"}
      */
     public static final AsciiString XML_HTTP_REQUEST = AsciiString.cached("XmlHttpRequest");
 


### PR DESCRIPTION
Motivation:

There exists a `javadoc` mistake in `HttpHeaderValues.java`.

Modification:

Just correct this `javadoc` mistake...

