### PR TITLE
X509TrustManager with OPENSSL provider is not wrapped with hostname v…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509TrustManagerWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509TrustManagerWrapper.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PrivilegedAction;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -152,8 +153,10 @@ final class OpenSslX509TrustManagerWrapper {
         X509TrustManager wrapIfNeeded(X509TrustManager manager);
     }
 
-    private static SSLContext newSSLContext() throws NoSuchAlgorithmException {
-        return SSLContext.getInstance("TLS");
+    private static SSLContext newSSLContext() throws NoSuchAlgorithmException, NoSuchProviderException {
+        // As this depends on the implementation detail we should explicit select the correct provider.
+        // See https://github.com/netty/netty/issues/10374
+        return SSLContext.getInstance("TLS", "SunJSSE");
     }
 
     private static final class UnsafeTrustManagerWrapper implements TrustManagerWrapper {
@@ -180,11 +183,15 @@ final class OpenSslX509TrustManagerWrapper {
                         }
                     }
                 } catch (NoSuchAlgorithmException e) {
-                    // This should never happen as we did the same in the static
+                    // This should never happen as we did the same in the static block
                     // before.
                     PlatformDependent.throwException(e);
                 } catch (KeyManagementException e) {
-                    // This should never happen as we did the same in the static
+                    // This should never happen as we did the same in the static block
+                    // before.
+                    PlatformDependent.throwException(e);
+                } catch (NoSuchProviderException e) {
+                    // This should never happen as we did the same in the static block
                     // before.
                     PlatformDependent.throwException(e);
                 }


### PR DESCRIPTION
…erification if Conscrypt is inserted in the first place

Motivation:

Modifications:

Directly specify the provider which is used to create the SSLContext

Result:

Fixes https://github.com/netty/netty/issues/10374
