### PR TITLE
Fix `isOriginForm` always return `false` in `HttpUtil`

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -44,7 +44,7 @@ public final class HttpUtil {
      * <a href="https://tools.ietf.org/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
      */
     public static boolean isOriginForm(URI uri) {
-        return uri.getScheme() == null && uri.getSchemeSpecificPart() == null &&
+        return uri.getScheme() == null && !"*".equals(uri.getPath()) &&
                uri.getHost() == null && uri.getAuthority() == null;
     }
 
@@ -53,8 +53,7 @@ public final class HttpUtil {
      * <a href="https://tools.ietf.org/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
      */
     public static boolean isAsteriskForm(URI uri) {
-        return "*".equals(uri.getPath()) &&
-                uri.getScheme() == null && uri.getSchemeSpecificPart() == null &&
+        return "*".equals(uri.getPath()) && uri.getScheme() == null &&
                 uri.getHost() == null && uri.getAuthority() == null && uri.getQuery() == null &&
                 uri.getFragment() == null;
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -347,5 +348,29 @@ public class HttpUtilTest {
         http11Message.headers().set(
                 HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE + ", " + HttpHeaderValues.KEEP_ALIVE);
         assertTrue(HttpUtil.isKeepAlive(http11Message));
+    }
+
+    @Test
+    public void testIsOriginFormAndIsAsteriskForm() {
+        // There are four distinct formats for the request-target, depending on both the method
+        // being requested and whether the request is to a proxy..
+        // All examples are from https://tools.ietf.org/html/rfc7230#section-5.3
+
+        URI originFormUri = URI.create("/where?q=now");
+        URI asteriskFormUri = URI.create("*");
+        URI absoluteFormUri = URI.create("http://www.example.org/pub/WWW/TheProject.html");
+        URI authorityFormUri = URI.create("www.example.com:80");
+        URI malformedAsteriskFormUri = URI.create("*?q=now");
+        assertTrue(HttpUtil.isOriginForm(originFormUri));
+        assertFalse(HttpUtil.isOriginForm(asteriskFormUri));
+        assertFalse(HttpUtil.isOriginForm(absoluteFormUri));
+        assertFalse(HttpUtil.isOriginForm(authorityFormUri));
+        assertFalse(HttpUtil.isOriginForm(malformedAsteriskFormUri));
+
+        assertFalse(HttpUtil.isAsteriskForm(originFormUri));
+        assertTrue(HttpUtil.isAsteriskForm(asteriskFormUri));
+        assertFalse(HttpUtil.isAsteriskForm(absoluteFormUri));
+        assertFalse(HttpUtil.isAsteriskForm(authorityFormUri));
+        assertFalse(HttpUtil.isAsteriskForm(malformedAsteriskFormUri));
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -48,6 +48,8 @@ import static io.netty.handler.codec.http.HttpHeaderValues.TRAILERS;
 import static io.netty.handler.codec.http.HttpResponseStatus.parseLine;
 import static io.netty.handler.codec.http.HttpScheme.HTTP;
 import static io.netty.handler.codec.http.HttpScheme.HTTPS;
+import static io.netty.handler.codec.http.HttpUtil.isAsteriskForm;
+import static io.netty.handler.codec.http.HttpUtil.isOriginForm;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.handler.codec.http2.Http2Exception.streamError;
@@ -393,12 +395,10 @@ public final class HttpConversionUtil {
             out.method(request.method().asciiName());
             setHttp2Scheme(inHeaders, requestTargetUri, out);
 
-            // Attempt to take from HOST header before taking from the request-line
-            String host = inHeaders.getAsString(HttpHeaderNames.HOST);
-            if (host != null && !host.isEmpty()) {
-                setHttp2Authority(host, out);
-            } else if (requestTargetUri.getAuthority() != null) {
-                setHttp2Authority(requestTargetUri.getAuthority(), out);
+            if (!isOriginForm(requestTargetUri) && !isAsteriskForm(requestTargetUri)) {
+                // Attempt to take from HOST header before taking from the request-line
+                String host = inHeaders.getAsString(HttpHeaderNames.HOST);
+                setHttp2Authority((host == null || host.isEmpty()) ? requestTargetUri.getAuthority() : host, out);
             }
         } else if (in instanceof HttpResponse) {
             HttpResponse response = (HttpResponse) in;


### PR DESCRIPTION
Motivation:
`isOriginForm` and `isAsteriskForm` in `HttpUtil` always returns `false` because
they check if `uri.getSchemeSpecificPart() == null` which always return not null value

Modifications:
- Fix to return the correct value

Result:
- `isOriginForm` and `isAsteriskFrom` works correctly.
