### PR TITLE
Fix #10378,ResourceLeakDetectorFactory.newResourceLeakDetector(Class, int) ignores  sampling interval

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
@@ -56,7 +56,7 @@ public abstract class ResourceLeakDetectorFactory {
      * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
      *
      * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
-     * @param <T>      the type of the resource class
+     * @param <T> the type of the resource class
      * @return a new instance of {@link ResourceLeakDetector}
      */
     public final <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource) {
@@ -64,14 +64,15 @@ public abstract class ResourceLeakDetectorFactory {
     }
 
     /**
-     * @param resource         the resource class used to initialize the {@link ResourceLeakDetector}
-     * @param samplingInterval the interval on which sampling takes place
-     * @param maxActive        This is deprecated and will be ignored.
-     * @param <T>              the type of the resource class
-     * @return a new instance of {@link ResourceLeakDetector}
      * @deprecated Use {@link #newResourceLeakDetector(Class, int)} instead.
      * <p>
      * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
+     *
+     * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
+     * @param samplingInterval the interval on which sampling takes place
+     * @param maxActive This is deprecated and will be ignored.
+     * @param <T> the type of the resource class
+     * @return a new instance of {@link ResourceLeakDetector}
      */
     @Deprecated
     public abstract <T> ResourceLeakDetector<T> newResourceLeakDetector(
@@ -80,9 +81,9 @@ public abstract class ResourceLeakDetectorFactory {
     /**
      * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
      *
-     * @param resource         the resource class used to initialize the {@link ResourceLeakDetector}
+     * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
      * @param samplingInterval the interval on which sampling takes place
-     * @param <T>              the type of the resource class
+     * @param <T> the type of the resource class
      * @return a new instance of {@link ResourceLeakDetector}
      */
     @SuppressWarnings("deprecation")
@@ -168,7 +169,7 @@ public abstract class ResourceLeakDetectorFactory {
             }
 
             ResourceLeakDetector<T> resourceLeakDetector = new ResourceLeakDetector<T>(resource, samplingInterval,
-                    maxActive);
+                                                                                       maxActive);
             logger.debug("Loaded default ResourceLeakDetector: {}", resourceLeakDetector);
             return resourceLeakDetector;
         }

--- a/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
@@ -88,6 +88,7 @@ public abstract class ResourceLeakDetectorFactory {
      */
     @SuppressWarnings("deprecation")
     public <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource, int samplingInterval) {
+        ObjectUtil.checkPositive(samplingInterval, "samplingInterval");
         return newResourceLeakDetector(resource, samplingInterval, Long.MAX_VALUE);
     }
 

--- a/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
@@ -88,7 +88,7 @@ public abstract class ResourceLeakDetectorFactory {
      */
     @SuppressWarnings("deprecation")
     public <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource, int samplingInterval) {
-        return newResourceLeakDetector(resource, ResourceLeakDetector.SAMPLING_INTERVAL, Long.MAX_VALUE);
+        return newResourceLeakDetector(resource, samplingInterval, Long.MAX_VALUE);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
@@ -56,7 +56,7 @@ public abstract class ResourceLeakDetectorFactory {
      * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
      *
      * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
-     * @param <T> the type of the resource class
+     * @param <T>      the type of the resource class
      * @return a new instance of {@link ResourceLeakDetector}
      */
     public final <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource) {
@@ -64,15 +64,14 @@ public abstract class ResourceLeakDetectorFactory {
     }
 
     /**
+     * @param resource         the resource class used to initialize the {@link ResourceLeakDetector}
+     * @param samplingInterval the interval on which sampling takes place
+     * @param maxActive        This is deprecated and will be ignored.
+     * @param <T>              the type of the resource class
+     * @return a new instance of {@link ResourceLeakDetector}
      * @deprecated Use {@link #newResourceLeakDetector(Class, int)} instead.
      * <p>
      * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
-     *
-     * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
-     * @param samplingInterval the interval on which sampling takes place
-     * @param maxActive This is deprecated and will be ignored.
-     * @param <T> the type of the resource class
-     * @return a new instance of {@link ResourceLeakDetector}
      */
     @Deprecated
     public abstract <T> ResourceLeakDetector<T> newResourceLeakDetector(
@@ -81,9 +80,9 @@ public abstract class ResourceLeakDetectorFactory {
     /**
      * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
      *
-     * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
+     * @param resource         the resource class used to initialize the {@link ResourceLeakDetector}
      * @param samplingInterval the interval on which sampling takes place
-     * @param <T> the type of the resource class
+     * @param <T>              the type of the resource class
      * @return a new instance of {@link ResourceLeakDetector}
      */
     @SuppressWarnings("deprecation")
@@ -169,7 +168,7 @@ public abstract class ResourceLeakDetectorFactory {
             }
 
             ResourceLeakDetector<T> resourceLeakDetector = new ResourceLeakDetector<T>(resource, samplingInterval,
-                                                                                       maxActive);
+                    maxActive);
             logger.debug("Loaded default ResourceLeakDetector: {}", resourceLeakDetector);
             return resourceLeakDetector;
         }


### PR DESCRIPTION
Motivation:

As described in #10378 this issue, a simple question, please review this pr, thank you

Modification:

ResourceLeakDetectorFactory.newResourceLeakDetector(Class, int) use the second parameter as the sampling interval of the newly created ResourceLeakDetector.

Result:

Fixes #10378

If there is no issue then describe the changes introduced by this PR.
