### PR TITLE
Add detailed error message corresponding to the IndexOutOfBoundsException while calling getEntry(...)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java
@@ -83,7 +83,8 @@ final class HpackDynamicTable {
      */
     public HpackHeaderField getEntry(int index) {
         if (index <= 0 || index > length()) {
-            throw new IndexOutOfBoundsException();
+            throw new IndexOutOfBoundsException("expected: 0 < index(" + index + ") <= length("
+                    + length() + ')');
         }
         int i = head - index;
         if (i < 0) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java
@@ -83,8 +83,7 @@ final class HpackDynamicTable {
      */
     public HpackHeaderField getEntry(int index) {
         if (index <= 0 || index > length()) {
-            throw new IndexOutOfBoundsException("expected: 0 < index(" + index + ") <= length("
-                    + length() + ')');
+            throw new IndexOutOfBoundsException("Index " + index + " out of bounds for length " + length());
         }
         int i = head - index;
         if (i < 0) {


### PR DESCRIPTION
Motivation:
`getEntry(...)` may throw an IndexOutOfBoundsException without any error messages.


Modification:

Add detailed error message corresponding to the IndexOutOfBoundsException while calling `getEntry(...)` in HpackDynamicTable.java.

