### PR TITLE
Update to netty-tcnative 2.0.31.Final and make SslErrorTest more robust

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -54,6 +54,7 @@ import java.security.cert.CertificateRevokedException;
 import java.security.cert.Extension;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -254,28 +255,20 @@ public class SslErrorTest {
                     CertPathValidatorException.Reason reason =
                             ((CertPathValidatorException) exception.getCause()).getReason();
                     if (reason == CertPathValidatorException.BasicReason.EXPIRED) {
-                        verifyException(unwrappedCause, "expired", promise);
+                        verifyException(unwrappedCause, promise, "expired");
                     } else if (reason == CertPathValidatorException.BasicReason.NOT_YET_VALID) {
-                        // BoringSSL uses "expired" in this case while others use "bad"
-                        if (OpenSsl.isBoringSSL()) {
-                            verifyException(unwrappedCause, "expired", promise);
-                        } else {
-                            verifyException(unwrappedCause, "bad", promise);
-                        }
+                        // BoringSSL may use "expired" in this case while others use "bad"
+                        verifyException(unwrappedCause, promise, "expired", "bad");
                     } else if (reason == CertPathValidatorException.BasicReason.REVOKED) {
-                        verifyException(unwrappedCause, "revoked", promise);
+                        verifyException(unwrappedCause, promise, "revoked");
                     }
                 } else if (exception instanceof CertificateExpiredException) {
-                    verifyException(unwrappedCause, "expired", promise);
+                    verifyException(unwrappedCause, promise,  "expired");
                 } else if (exception instanceof CertificateNotYetValidException) {
-                    // BoringSSL uses "expired" in this case while others use "bad"
-                    if (OpenSsl.isBoringSSL()) {
-                        verifyException(unwrappedCause, "expired", promise);
-                    } else {
-                        verifyException(unwrappedCause, "bad", promise);
-                    }
+                    // BoringSSL may use "expired" in this case while others use "bad"
+                    verifyException(unwrappedCause, promise, "expired", "bad");
                 } else if (exception instanceof CertificateRevokedException) {
-                    verifyException(unwrappedCause, "revoked", promise);
+                    verifyException(unwrappedCause, promise, "revoked");
                 }
             }
         }
@@ -283,19 +276,26 @@ public class SslErrorTest {
 
     // Its a bit hacky to verify against the message that is part of the exception but there is no other way
     // at the moment as there are no different exceptions for the different alerts.
-    private void verifyException(Throwable cause, String messagePart, Promise<Void> promise) {
+    private void verifyException(Throwable cause, Promise<Void> promise, String... messageParts) {
         String message = cause.getMessage();
-        if (message.toLowerCase(Locale.UK).contains(messagePart.toLowerCase(Locale.UK)) ||
-                // When the error is produced on the client side and the client side uses JDK as provider it will always
-                // use "certificate unknown".
-                !serverProduceError && clientProvider == SslProvider.JDK &&
-                        message.toLowerCase(Locale.UK).contains("unknown")) {
+        // When the error is produced on the client side and the client side uses JDK as provider it will always
+        // use "certificate unknown".
+        if (!serverProduceError && clientProvider == SslProvider.JDK &&
+                message.toLowerCase(Locale.UK).contains("unknown")) {
             promise.setSuccess(null);
-        } else {
-            Throwable error = new AssertionError("message not contains '" + messagePart + "': " + message);
-            error.initCause(cause);
-            promise.setFailure(error);
+            return;
         }
+
+        for (String m: messageParts) {
+            if (message.toLowerCase(Locale.UK).contains(m.toLowerCase(Locale.UK))) {
+                promise.setSuccess(null);
+                return;
+            }
+        }
+        Throwable error = new AssertionError("message not contains any of '"
+                + Arrays.toString(messageParts) + "': " + message);
+        error.initCause(cause);
+        promise.setFailure(error);
     }
 
     private static final class TestCertificateException extends CertificateException {

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
     <!-- keep in sync with PlatformDependent#ALLOWED_LINUX_OS_CLASSIFIERS -->
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.30.Final</tcnative.version>
+    <tcnative.version>2.0.31.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

There was a new netty-tcnative release which we should use. Beside this the SSLErrorTest was quite fragile and so should be adjusted.

Modifications:

Update netty-tcnative and adjust test

Result:

Use latest netty-tcnative release