### PR TITLE
Eliminate a redundant method call in HpackDynamicTable.add(...)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java
@@ -109,7 +109,7 @@ final class HpackDynamicTable {
             remove();
         }
         hpackHeaderFields[head++] = header;
-        size += header.size();
+        size += headerSize;
         if (head == hpackHeaderFields.length) {
             head = 0;
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
@@ -103,4 +103,28 @@ public class HpackDynamicTableTest {
         assertEquals(0, table.length());
         assertEquals(0, table.size());
     }
+
+    @Test
+    public void testAdd() {
+        HpackDynamicTable table = new HpackDynamicTable(100);
+        assertEquals(0, table.size());
+        HpackHeaderField entry1 = new HpackHeaderField("foo", "bar"); //size:3+3+32=38
+        HpackHeaderField entry2 = new HpackHeaderField("hello", "world");
+        table.add(entry1); //success
+        assertEquals(entry1.size(), table.size());
+        table.setCapacity(32); //entry1 is removed from table
+        assertEquals(0, table.size());
+        assertEquals(0, table.length());
+        table.add(entry1); //fail quietly
+        assertEquals(0, table.size());
+        assertEquals(0, table.length());
+        table.setCapacity(64);
+        table.add(entry1); //success
+        assertEquals(entry1.size(), table.size());
+        assertEquals(1, table.length());
+        table.add(entry2); //entry2 is added, but entry1 is removed from table
+        assertEquals(entry2.size(), table.size());
+        assertEquals(1, table.length());
+        assertEquals(entry2, table.getEntry(1));
+    }
 }


### PR DESCRIPTION
Motivation:

The result of `header.size()` is already cached in `headerSize`. There is no need to call it again actually.

Modification:

Replace the second `header.size()` with `headerSize` directly.

Result:

Improve performance slightly.
