### PR TITLE
jdk.tls.client.enableSessionTicketExtension must be respected by OPEN…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -73,9 +73,6 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
         try {
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
                                                keyCertChain, key, keyPassword, keyManagerFactory, keyStore);
-            if (ENABLE_SESSION_TICKET) {
-                sessionContext.setTicketKeys();
-            }
             success = true;
         } finally {
             if (!success) {
@@ -170,6 +167,9 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                 throw new SSLException("unable to setup trustmanager", e);
             }
             OpenSslClientSessionContext context = new OpenSslClientSessionContext(thiz, keyMaterialProvider);
+            if (ENABLE_SESSION_TICKET) {
+                context.setTicketKeys();
+            }
             keyMaterialProvider = null;
             return context;
         } finally {


### PR DESCRIPTION
…SSL and OPENSSL_REFCNT SslProviders

Motivation:

jdk.tls.client.enableSessionTicketExtension property must be respect by OPENSSL and OPENSSL_REFCNT SslProvider to ensure a consistent behavior. Due a bug this was not the case and it only worked for OPENSSL_REFCNT but not for OPENSSL.

Modifications:

Move the property check into static method that is used by both

Result:

Correctly respect jdk.tls.client.enableSessionTicketExtension
