### PR TITLE
Add IndexOutOfBoundsException error message

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/CodecOutputList.java
+++ b/codec/src/main/java/io/netty/handler/codec/CodecOutputList.java
@@ -206,7 +206,8 @@ final class CodecOutputList extends AbstractList<Object> implements RandomAccess
 
     private void checkIndex(int index) {
         if (index >= size) {
-            throw new IndexOutOfBoundsException();
+            throw new IndexOutOfBoundsException("expected: index < ("
+                    + size + "),but actual is (" + size + ")");
         }
     }
 

--- a/common/src/main/java/io/netty/util/internal/AppendableCharSequence.java
+++ b/common/src/main/java/io/netty/util/internal/AppendableCharSequence.java
@@ -98,7 +98,8 @@ public final class AppendableCharSequence implements CharSequence, Appendable {
     @Override
     public AppendableCharSequence append(CharSequence csq, int start, int end) {
         if (csq.length() < end) {
-            throw new IndexOutOfBoundsException();
+            throw new IndexOutOfBoundsException("expected: csq.length() >= ("
+                    + end + "),but actual is (" + csq.length() + ")");
         }
         int length = end - start;
         if (length > chars.length - pos) {
@@ -138,7 +139,8 @@ public final class AppendableCharSequence implements CharSequence, Appendable {
     public String substring(int start, int end) {
         int length = end - start;
         if (start > pos || length > pos) {
-            throw new IndexOutOfBoundsException();
+            throw new IndexOutOfBoundsException("expected: start and length <= ("
+                    + pos + ")");
         }
         return new String(chars, start, length);
     }


### PR DESCRIPTION
Motivation:

Add IndexOutOfBoundsException error information in io.netty.util.internal.AppendableCharSequence and io.netty.handler.codec.CodecOutputList class.please review the pr,thk.

Modification:



Result:


If there is no issue then describe the changes introduced by this PR.
