### PR TITLE
Fix bug in Http2FrameClient

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/client/Http2FrameClient.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/client/Http2FrameClient.java
@@ -103,7 +103,7 @@ public final class Http2FrameClient {
             headers.method("GET");
             headers.path(PATH);
             headers.scheme(SSL? "https" : "http");
-            final Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(headers);
+            final Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(headers, true);
             streamChannel.writeAndFlush(headersFrame);
             System.out.println("Sent HTTP/2 GET request to " + PATH);
 


### PR DESCRIPTION
Motivation:
This request only has headers frame, it should set endOfStream flag, or
it will never get a response.

Modifications:
Set endOfStream=true in header frame.

Result:
Http2FrameClient can get a response now.