### PR TITLE
Track memory attributes to avoid memory leak

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -280,4 +280,20 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
         }
         return this;
     }
+
+    @Override
+    public boolean release() {
+        if (byteBuf != null) {
+            return super.release();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean release(final int decrement) {
+        if (byteBuf != null) {
+            return super.release(decrement);
+        }
+        return false;
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
@@ -170,6 +170,8 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
         }
         MemoryAttribute attribute = new MemoryAttribute(name);
         attribute.setMaxSize(maxSize);
+        List<HttpData> list = getList(request);
+        list.add(attribute);
         return attribute;
     }
 
@@ -191,6 +193,8 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
         }
         MemoryAttribute attribute = new MemoryAttribute(name, definedSize);
         attribute.setMaxSize(maxSize);
+        List<HttpData> list = getList(request);
+        list.add(attribute);
         return attribute;
     }
 
@@ -234,6 +238,8 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
             MemoryAttribute attribute = new MemoryAttribute(name, value, charset);
             attribute.setMaxSize(maxSize);
             checkHttpDataSize(attribute);
+            List<HttpData> list = getList(request);
+            list.add(attribute);
             return attribute;
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
@@ -266,6 +272,8 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
                 contentTransferEncoding, charset, size);
         fileUpload.setMaxSize(maxSize);
         checkHttpDataSize(fileUpload);
+        List<HttpData> list = getList(request);
+        list.add(fileUpload);
         return fileUpload;
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactoryTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactoryTest.java
@@ -193,7 +193,7 @@ public class DefaultHttpDataFactoryTest {
         cleanRequestHttpDataShouldReleaseAllAttributes(new DefaultHttpDataFactory(false));
     }
 
-    private void cleanAllHttpDataShouldReleaseAllAttributes(final HttpDataFactory factory) throws Exception {
+    private static void cleanAllHttpDataShouldReleaseAllAttributes(final HttpDataFactory factory) throws Exception {
         cleanShouldReleaseAllAttributes(factory, new Runnable() {
             @Override
             public void run() {
@@ -202,7 +202,7 @@ public class DefaultHttpDataFactoryTest {
         });
     }
 
-    private void cleanRequestHttpDataShouldReleaseAllAttributes(final HttpDataFactory factory) throws Exception {
+    private static void cleanRequestHttpDataShouldReleaseAllAttributes(final HttpDataFactory factory) throws Exception {
         cleanShouldReleaseAllAttributes(factory, new Runnable() {
             @Override
             public void run() {
@@ -211,7 +211,7 @@ public class DefaultHttpDataFactoryTest {
         });
     }
 
-    private void cleanShouldReleaseAllAttributes(final HttpDataFactory factory, final Runnable cleanup)
+    private static void cleanShouldReleaseAllAttributes(final HttpDataFactory factory, final Runnable cleanup)
             throws Exception {
         final Attribute attribute1 = factory.createAttribute(req1, "attribute1");
         attribute1.setValue("value1");


### PR DESCRIPTION
Motivation:
In commit c354fa48e10de847cf17c10083a2cbc2c0a63a36 (https://github.com/netty/netty/pull/10209) the way attributes are decoded has changed. In `HttpPostStandardRequestDecoder#decodeAttribute(ByteBuf, Charset)` a buffer is allocated but may not be released while calling `InterfaceHttpPostRequestDecoder#destroy()`.

```
HttpPostRequestDecoder decoder =
    new HttpPostRequestDecoder(new MemoryHttpDataFactory(false), request);
try {
    ...
} finally {
    decoder.destroy();
}
```

`decoder.destroy()` invokes `DefaultHttpDataFactory#cleanRequestHttpData(HttpRequest)`, but as the memory attributes are not tracked, nothing is released.

Workaround:
```
HttpPostRequestDecoder decoder =
    new HttpPostRequestDecoder(new MemoryHttpDataFactory(false), request);
try {
    ...
} finally {
    decoder.getBodyHttpDatas()
        .forEach(ReferenceCounted::release);
    decoder.destroy();
}
```

Modification:
Track memory attributes so that they are released by calling `HttpDataFactory#cleanAllHttpData()` or `HttpDataFactory#cleanRequestHttpData(HttpRequest)`.

Result:
Avoid memory leak