### PR TITLE
Replace System.getProperty with SystemPropertyUtil for http client and server

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/client/Http2Client.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/Http2Client.java
@@ -41,6 +41,7 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.SystemPropertyUtil;
 
 import java.util.concurrent.TimeUnit;
 
@@ -60,12 +61,12 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
  */
 public final class Http2Client {
 
-    static final boolean SSL = System.getProperty("ssl") != null;
-    static final String HOST = System.getProperty("host", "127.0.0.1");
-    static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8443" : "8080"));
-    static final String URL = System.getProperty("url", "/whatever");
-    static final String URL2 = System.getProperty("url2");
-    static final String URL2DATA = System.getProperty("url2data", "test data!");
+    static final boolean SSL = SystemPropertyUtil.get("ssl") != null;
+    static final String HOST = SystemPropertyUtil.get("host", "127.0.0.1");
+    static final int PORT = Integer.parseInt(SystemPropertyUtil.get("port", SSL? "8443" : "8080"));
+    static final String URL = SystemPropertyUtil.get("url", "/whatever");
+    static final String URL2 = SystemPropertyUtil.get("url2");
+    static final String URL2DATA = SystemPropertyUtil.get("url2data", "test data!");
 
     public static void main(String[] args) throws Exception {
         // Configure SSL.

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/client/Http2FrameClient.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/client/Http2FrameClient.java
@@ -36,6 +36,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.internal.SystemPropertyUtil;
 
 /**
  * An HTTP2 client that allows you to send HTTP2 frames to a server using the newer HTTP2
@@ -47,10 +48,10 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
  */
 public final class Http2FrameClient {
 
-    static final boolean SSL = System.getProperty("ssl") != null;
-    static final String HOST = System.getProperty("host", "127.0.0.1");
-    static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8443" : "8080"));
-    static final String PATH = System.getProperty("path", "/");
+    static final boolean SSL = SystemPropertyUtil.get("ssl") != null;
+    static final String HOST = SystemPropertyUtil.get("host", "127.0.0.1");
+    static final int PORT = Integer.parseInt(SystemPropertyUtil.get("port", SSL? "8443" : "8080"));
+    static final String PATH = SystemPropertyUtil.get("path", "/");
 
     private Http2FrameClient() {
     }

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2Server.java
@@ -36,6 +36,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.internal.SystemPropertyUtil;
 
 /**
  * An HTTP/2 Server that responds to requests with a Hello World. Once started, you can test the
@@ -46,9 +47,9 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
  */
 public final class Http2Server {
 
-    static final boolean SSL = System.getProperty("ssl") != null;
+    static final boolean SSL = SystemPropertyUtil.get("ssl") != null;
 
-    static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8443" : "8080"));
+    static final int PORT = Integer.parseInt(SystemPropertyUtil.get("port", SSL? "8443" : "8080"));
 
     public static void main(String[] args) throws Exception {
         // Configure SSL.

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2Server.java
@@ -36,6 +36,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.internal.SystemPropertyUtil;
 
 /**
  * An HTTP/2 Server that responds to requests with a Hello World. Once started, you can test the
@@ -46,7 +47,7 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
  */
 public final class Http2Server {
 
-    static final boolean SSL = System.getProperty("ssl") != null;
+    static final boolean SSL = SystemPropertyUtil.get("ssl") != null;
 
     static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8443" : "8080"));
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2Server.java
@@ -36,6 +36,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.internal.SystemPropertyUtil;
 
 /**
  * An HTTP/2 Server that responds to requests with a Hello World. Once started, you can test the
@@ -43,9 +44,9 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
  */
 public final class Http2Server {
 
-    static final boolean SSL = System.getProperty("ssl") != null;
+    static final boolean SSL = SystemPropertyUtil.get("ssl") != null;
 
-    static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8443" : "8080"));
+    static final int PORT = Integer.parseInt(SystemPropertyUtil.get("port", SSL? "8443" : "8080"));
 
     public static void main(String[] args) throws Exception {
         // Configure SSL.


### PR DESCRIPTION
Motivation:

Replace System.getProperty with SystemPropertyUtil for http client and server, please review this pr,thk

Modification:

Replace System.getProperty with SystemPropertyUtil for http client and server

Result:


If there is no issue then describe the changes introduced by this PR.
