### PR TITLE
Make `DefaultHttp2FrameStream.stream` private

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -675,7 +675,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
     static class DefaultHttp2FrameStream implements Http2FrameStream {
 
         private volatile int id = -1;
-        volatile Http2Stream stream;
+        private volatile Http2Stream stream;
 
         final Http2FrameStreamEvent stateChanged = Http2FrameStreamEvent.stateChanged(this);
         final Http2FrameStreamEvent writabilityChanged = Http2FrameStreamEvent.writabilityChanged(this);


### PR DESCRIPTION
Motivation:

`DefaultHttp2FrameStream.stream` is not used outside of its class and
therefore can be private.

Modifications:

- Make `DefaultHttp2FrameStream.stream` private;

Result:

Correct visibility scoping for `DefaultHttp2FrameStream.stream`.