### PR TITLE
Ignore `.shelf/` folder generated by IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.ipr
 *.iws
 .idea/
+.shelf/
 
 # Geany project file
 .geany


### PR DESCRIPTION
Motivation:

IntelliJ IDEA may generate a local folder `.shelf/` for version control.
For more information, see
https://www.jetbrains.com/help/idea/shelving-and-unshelving-changes.html

Modifications:

- Add `.shelf/` folder to the `.gitignore` file;

Result:

IntelliJ IDEA's `.shelf/` folder is ignored by git.