### PR TITLE
Stop disabling TLSv1.3 by default, close #10439

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -106,8 +106,10 @@ public class JdkSslContext extends SslContext {
         List<String> protocols = new ArrayList<String>();
         addIfSupported(
                 supportedProtocolsSet, protocols,
-                // Do not include TLSv1.3 for now by default.
-                SslUtils.PROTOCOL_TLS_V1_2, SslUtils.PROTOCOL_TLS_V1_1, SslUtils.PROTOCOL_TLS_V1);
+                SslUtils.PROTOCOL_TLS_V1_3,
+                SslUtils.PROTOCOL_TLS_V1_2,
+                SslUtils.PROTOCOL_TLS_V1_1,
+                SslUtils.PROTOCOL_TLS_V1);
 
         if (!protocols.isEmpty()) {
             return protocols.toArray(new String[0]);

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -260,10 +260,6 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             int options = SSLContext.getOptions(ctx) |
                           SSL.SSL_OP_NO_SSLv2 |
                           SSL.SSL_OP_NO_SSLv3 |
-                          // Disable TLSv1.3 by default for now. Even if TLSv1.3 is not supported this will
-                          // work fine as in this case SSL_OP_NO_TLSv1_3 will be 0.
-                          SSL.SSL_OP_NO_TLSv1_3 |
-
                           SSL.SSL_OP_CIPHER_SERVER_PREFERENCE |
 
                           // We do not support compression at the moment so we should explicitly disable it.


### PR DESCRIPTION
Motivation:

When TLSv1.3 was introduced almost 2 years ago, it was decided to disable it by default, even when it's supported by the underlying TLS implementation.

TLSv13 is pretty stable now in Java (out of the box in Java 11, OpenJSSE for Java 8, BoringSSL and OpenSSL).

Modifications:

Remove explicit exclusions from default protocols.

Result:

TLSv1.3 is now enabled by default, so users don't have to explicitly enable it.