### PR TITLE
Enable TLS1.3 by default of JDK SSLEngine implementation does by default

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -18,6 +18,7 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -106,11 +107,11 @@ public class JdkSslContext extends SslContext {
         List<String> protocols = new ArrayList<String>();
         addIfSupported(
                 supportedProtocolsSet, protocols,
-                // Do not include TLSv1.3 for now by default.
-                SslUtils.PROTOCOL_TLS_V1_2, SslUtils.PROTOCOL_TLS_V1_1, SslUtils.PROTOCOL_TLS_V1);
+                SslUtils.PROTOCOL_TLS_V1_3, SslUtils.PROTOCOL_TLS_V1_2,
+                SslUtils.PROTOCOL_TLS_V1_1, SslUtils.PROTOCOL_TLS_V1);
 
         if (!protocols.isEmpty()) {
-            return protocols.toArray(new String[0]);
+            return protocols.toArray(EmptyArrays.EMPTY_STRINGS);
         }
         return engine.getEnabledProtocols();
     }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -260,9 +260,6 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             int options = SSLContext.getOptions(ctx) |
                           SSL.SSL_OP_NO_SSLv2 |
                           SSL.SSL_OP_NO_SSLv3 |
-                          // Disable TLSv1.3 by default for now. Even if TLSv1.3 is not supported this will
-                          // work fine as in this case SSL_OP_NO_TLSv1_3 will be 0.
-                          SSL.SSL_OP_NO_TLSv1_3 |
 
                           SSL.SSL_OP_CIPHER_SERVER_PREFERENCE |
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
@@ -68,4 +68,20 @@ public enum SslProvider {
                 throw new Error("Unknown SslProvider: " + provider);
         }
     }
+
+    /**
+     * Returns {@code true} if the specified {@link SslProvider} enables
+     * <a href="https://tools.ietf.org/html/rfc8446">TLS 1.3</a> by default, {@code false} otherwise.
+     */
+    static boolean isTlsv13EnabledByDefault(final SslProvider provider) {
+        switch (provider) {
+            case JDK:
+                return SslUtils.isTLSv13EnabledByJDK();
+            case OPENSSL:
+            case OPENSSL_REFCNT:
+                return OpenSsl.isTlsv13Supported();
+            default:
+                throw new Error("Unknown SslProvider: " + provider);
+        }
+    }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -106,10 +106,13 @@ final class SslUtils {
     static final String[] DEFAULT_TLSV13_CIPHER_SUITES;
     static final String[] TLSV13_CIPHER_SUITES = { "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384" };
 
-    private static final boolean TLSV1_3_SUPPORTED;
+    private static final boolean TLSV1_3_JDK_SUPPORTED;
+    private static final boolean TLSV1_3_JDK_DEFAULT_ENABLED;
 
     static {
         boolean tlsv13Supported = false;
+        boolean tlsv13Enabled = false;
+
         Throwable cause = null;
         try {
             SSLContext context = SSLContext.getInstance("TLS");
@@ -117,6 +120,12 @@ final class SslUtils {
             for (String supported: context.getSupportedSSLParameters().getProtocols()) {
                 if (PROTOCOL_TLS_V1_3.equals(supported)) {
                     tlsv13Supported = true;
+                    break;
+                }
+            }
+            for (String enabled: context.getDefaultSSLParameters().getProtocols()) {
+                if (PROTOCOL_TLS_V1_3.equals(enabled)) {
+                    tlsv13Enabled = true;
                     break;
                 }
             }
@@ -128,9 +137,9 @@ final class SslUtils {
         } else {
             logger.debug("Unable to detect if JDK SSLEngine supports TLSv1.3, assuming no", cause);
         }
-        TLSV1_3_SUPPORTED = tlsv13Supported;
-
-        if (TLSV1_3_SUPPORTED) {
+        TLSV1_3_JDK_SUPPORTED = tlsv13Supported;
+        TLSV1_3_JDK_DEFAULT_ENABLED = tlsv13Enabled;
+        if (TLSV1_3_JDK_SUPPORTED) {
             DEFAULT_TLSV13_CIPHER_SUITES = TLSV13_CIPHER_SUITES;
         } else {
             DEFAULT_TLSV13_CIPHER_SUITES = EmptyArrays.EMPTY_STRINGS;
@@ -153,14 +162,21 @@ final class SslUtils {
 
         Collections.addAll(defaultCiphers, DEFAULT_TLSV13_CIPHER_SUITES);
 
-        DEFAULT_CIPHER_SUITES = defaultCiphers.toArray(new String[0]);
+        DEFAULT_CIPHER_SUITES = defaultCiphers.toArray(EmptyArrays.EMPTY_STRINGS);
     }
 
     /**
      * Returns {@code true} if the JDK itself supports TLSv1.3, {@code false} otherwise.
      */
     static boolean isTLSv13SupportedByJDK() {
-        return TLSV1_3_SUPPORTED;
+        return TLSV1_3_JDK_SUPPORTED;
+    }
+
+    /**
+     * Returns {@code true} if the JDK itself supports TLSv1.3 and enabled it by default, {@code false} otherwise.
+     */
+    static boolean isTLSv13EnabledByJDK() {
+        return TLSV1_3_JDK_DEFAULT_ENABLED;
     }
 
     /**


### PR DESCRIPTION
Motiviation:

When TLSv1.3 was introduced almost 2 years ago, it was decided to disable it by default, even when it's supported by the underlying TLS implementation.

TLSv13 is pretty stable now in Java (out of the box in Java 11, OpenJSSE for Java 8, BoringSSL and OpenSSL) and may be enabled by default.

Modifications:

Ensure TLSv13 is enabled by default when the underyling JDK SSLEngine implementation enables it as well

Result:

TLSv1.3 is now enabled by default, so users don't have to explicitly enable it.