### PR TITLE
Fix #10449, buffer.getBytes(...) not change a file channel position

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -166,14 +166,17 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                 int totalWritten = 0;
                 while (totalWritten < localsize) {
                     long currentPosition = fileChannel.position();
-                    int written = buffer.getBytes(buffer.readerIndex(), fileChannel, currentPosition, localsize);
-                    if (written > 0) {
-                        totalWritten += written;
-                        fileChannel.position(currentPosition + written);
-                        buffer.readerIndex(buffer.readerIndex() + written);
+                    int written = buffer.getBytes(buffer.readerIndex(), fileChannel, currentPosition,
+                                                  localsize - totalWritten);
+                    if (written <= 0) {
+                        break;
                     }
+
+                    totalWritten += written;
+                    fileChannel.position(currentPosition + written);
+                    buffer.readerIndex(buffer.readerIndex() + written);
+                    size += written;
                 }
-                size += localsize;
             } finally {
                 // Release the buffer as it was retained before and we not need a reference to it at all
                 // See https://github.com/netty/netty/issues/1516

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -156,7 +156,6 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                     throw new IOException("Out of size: " + (size + localsize) +
                             " > " + definedSize);
                 }
-                int written = 0;
                 if (file == null) {
                     file = tempFile();
                 }
@@ -164,9 +163,13 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                     RandomAccessFile accessFile = new RandomAccessFile(file, "rw");
                     fileChannel = accessFile.getChannel();
                 }
-                buffer.getBytes(buffer.readerIndex(), fileChannel, fileChannel.position(), localsize);
+                long currentPosition = fileChannel.position();
+                int written = buffer.getBytes(buffer.readerIndex(), fileChannel, currentPosition, localsize);
+                if (written > 0) {
+                    fileChannel.position(currentPosition + written);
+                    buffer.readerIndex(buffer.readerIndex() + written);
+                }
                 size += localsize;
-                buffer.readerIndex(buffer.readerIndex() + written);
             } finally {
                 // Release the buffer as it was retained before and we not need a reference to it at all
                 // See https://github.com/netty/netty/issues/1516

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -164,19 +164,20 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                     fileChannel = accessFile.getChannel();
                 }
                 int totalWritten = 0;
+                long position = fileChannel.position();
+                int index = buffer.readerIndex();
                 while (totalWritten < localsize) {
-                    long currentPosition = fileChannel.position();
-                    int written = buffer.getBytes(buffer.readerIndex(), fileChannel, currentPosition,
-                                                  localsize - totalWritten);
-                    if (written <= 0) {
+                    int written = buffer.getBytes(index, fileChannel, position, localsize - totalWritten);
+                    if (written < 0) {
                         break;
                     }
-
                     totalWritten += written;
-                    fileChannel.position(currentPosition + written);
-                    buffer.readerIndex(buffer.readerIndex() + written);
-                    size += written;
+                    position += written;
+                    index += written;
                 }
+                fileChannel.position(position);
+                buffer.readerIndex(index);
+                size += localsize;
             } finally {
                 // Release the buffer as it was retained before and we not need a reference to it at all
                 // See https://github.com/netty/netty/issues/1516

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -163,11 +163,15 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
                     RandomAccessFile accessFile = new RandomAccessFile(file, "rw");
                     fileChannel = accessFile.getChannel();
                 }
-                long currentPosition = fileChannel.position();
-                int written = buffer.getBytes(buffer.readerIndex(), fileChannel, currentPosition, localsize);
-                if (written > 0) {
-                    fileChannel.position(currentPosition + written);
-                    buffer.readerIndex(buffer.readerIndex() + written);
+                int totalWritten = 0;
+                while (totalWritten < localsize) {
+                    long currentPosition = fileChannel.position();
+                    int written = buffer.getBytes(buffer.readerIndex(), fileChannel, currentPosition, localsize);
+                    if (written > 0) {
+                        totalWritten += written;
+                        fileChannel.position(currentPosition + written);
+                        buffer.readerIndex(buffer.readerIndex() + written);
+                    }
                 }
                 size += localsize;
             } finally {


### PR DESCRIPTION
Motivation:

Regression appeared after making changes in fix #10360 .
The main problem here that `buffer.getBytes(buffer.readerIndex(), fileChannel, fileChannel.position(), localsize)`
doesn't change channel position after writes.

Modification:

Manually set position according to the written bytes.

Result:

Fixes #10449 . 
