### PR TITLE
Upgrade jctools from 3.0.0 to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Motivation:

JCTools 3.1.0 is out and includes several fixes, see https://github.com/JCTools/JCTools/releases/tag/v3.1.0

Modification:

Upgrade jctools-core version in pom.xml

Result:

Netty ships latest version of jctools.