### PR TITLE
Fix compilation error on JDK 15

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/OpenJdkSelfSignedCertGenerator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/OpenJdkSelfSignedCertGenerator.java
@@ -66,7 +66,8 @@ final class OpenJdkSelfSignedCertGenerator {
         info.set(X509CertInfo.VALIDITY, new CertificateValidity(notBefore, notAfter));
         info.set(X509CertInfo.KEY, new CertificateX509Key(keypair.getPublic()));
         info.set(X509CertInfo.ALGORITHM_ID,
-                new CertificateAlgorithmId(new AlgorithmId(AlgorithmId.sha256WithRSAEncryption_oid)));
+                // sha256WithRSAEncryption
+                new CertificateAlgorithmId(AlgorithmId.get("1.2.840.113549.1.1.11")));
 
         // Sign the cert to identify the algorithm that's used.
         X509CertImpl cert = new X509CertImpl(info);

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <testJvm />
       </properties>
     </profile>
-    <!-- JDK14 -->
+    <!-- JDK15 -->
     <profile>
       <id>java15</id>
       <activation>
@@ -118,6 +118,7 @@
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
     </profile>
+    <!-- JDK14 -->
     <profile>
       <id>java14</id>
       <activation>


### PR DESCRIPTION
Motivation:

AlgorithmId.sha256WithRSAEncryption_oid was removed in JDK15 and later so we should not depend on it as otherwise we will see compilation errors

Modifications:

Replace AlgorithmId.sha256WithRSAEncryption_oid usage with specify the OID directly

Result:

Compiles on JDK15+
