### PR TITLE
Cleanup Conscrypt initialization

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
@@ -27,49 +27,43 @@ import java.lang.reflect.Method;
 final class Conscrypt {
     // This class exists to avoid loading other conscrypt related classes using features only available in JDK8+,
     // because we need to maintain JDK6+ runtime compatibility.
-    private static final Method IS_CONSCRYPT_SSLENGINE = loadIsConscryptEngine();
-    private static final boolean CAN_INSTANCE_PROVIDER = canInstanceProvider();
+    private static final Method IS_CONSCRYPT_SSLENGINE;
 
-    private static Method loadIsConscryptEngine() {
-        try {
-            Class<?> conscryptClass = Class.forName("org.conscrypt.Conscrypt", true,
-                    ConscryptAlpnSslEngine.class.getClassLoader());
-            return conscryptClass.getMethod("isConscrypt", SSLEngine.class);
-        } catch (Throwable ignore) {
-            // Conscrypt was not loaded.
-            return null;
-        }
-    }
+    static {
+        Method isConscryptSSLEngine = null;
 
-    private static boolean canInstanceProvider() {
-        try {
-            Class<?> providerClass = Class.forName("org.conscrypt.OpenSSLProvider", true,
-                    ConscryptAlpnSslEngine.class.getClassLoader());
-            providerClass.newInstance();
-            return true;
-        } catch (Throwable ignore) {
-            return false;
+        if ((PlatformDependent.javaVersion() >= 8 &&
+                // Only works on Java14 and earlier for now
+                // See https://github.com/google/conscrypt/issues/838
+                PlatformDependent.javaVersion() < 15) || PlatformDependent.isAndroid()) {
+            try {
+                Class<?> providerClass = Class.forName("org.conscrypt.OpenSSLProvider", true,
+                        PlatformDependent.getClassLoader(ConscryptAlpnSslEngine.class));
+                providerClass.newInstance();
+
+                Class<?> conscryptClass = Class.forName("org.conscrypt.Conscrypt", true,
+                        PlatformDependent.getClassLoader(ConscryptAlpnSslEngine.class));
+                isConscryptSSLEngine = conscryptClass.getMethod("isConscrypt", SSLEngine.class);
+            } catch (Throwable ignore) {
+                // ignore
+            }
         }
+        IS_CONSCRYPT_SSLENGINE = isConscryptSSLEngine;
     }
 
     /**
      * Indicates whether or not conscrypt is available on the current system.
      */
     static boolean isAvailable() {
-        return CAN_INSTANCE_PROVIDER && IS_CONSCRYPT_SSLENGINE != null &&
-                ((PlatformDependent.javaVersion() >= 8 &&
-                        // Only works on Java14 and earlier for now
-                        // See https://github.com/google/conscrypt/issues/838
-                        PlatformDependent.javaVersion() < 15) || PlatformDependent.isAndroid());
+        return IS_CONSCRYPT_SSLENGINE != null;
     }
 
+    /**
+     * Returns {@code true} if the passed in {@link SSLEngine} is handled by Conscrypt, {@code false} otherwise.
+     */
     static boolean isEngineSupported(SSLEngine engine) {
-        return isAvailable() && isConscryptEngine(engine);
-    }
-
-    private static boolean isConscryptEngine(SSLEngine engine) {
         try {
-            return (Boolean) IS_CONSCRYPT_SSLENGINE.invoke(null, engine);
+            return IS_CONSCRYPT_SSLENGINE != null && (Boolean) IS_CONSCRYPT_SSLENGINE.invoke(null, engine);
         } catch (IllegalAccessException ignore) {
             return false;
         } catch (InvocationTargetException ex) {


### PR DESCRIPTION
Motivation:

How we init our static fields in Conscrypt was kind of error-prone and may even lead to NPE later on when methods were invoked out of order.

Modifications:

- Move all the init code to a static block
- Remove static field which is not needed anymore

Result:

Cleanup and also fixes https://github.com/netty/netty/issues/10413

