### PR TITLE
Fix netty_unix_errors.c compilation on MacOS

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -35,7 +35,7 @@ static jmethodID closedChannelExceptionMethodId = NULL;
  Note: `strerrbuf` must be initialized to all zeros prior to calling this function.
  XSI or GNU functions do not have such a requirement, but our wrappers do.
  */
-#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
+#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || __APPLE__) && ! _GNU_SOURCE
     static inline int strerror_r_xsi(int errnum, char *strerrbuf, size_t buflen) {
         return strerror_r(errnum, strerrbuf, buflen);
     }


### PR DESCRIPTION
Motivation:
 The feature test macros did not work as expected on MacOS, so we ended up compiling for the GNU
 variant which resulted in compilation errors.
Modification:
 Add `__APPLE__` as another indicator to use the XSI variant of `strerror_r`.
Result:
 The project now once again compiles on MacOS.