### PR TITLE
Avoid name-clash with future java.lang.Record

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -348,9 +348,9 @@ public class ResourceLeakDetector<T> {
             extends WeakReference<Object> implements ResourceLeakTracker<T>, ResourceLeak {
 
         @SuppressWarnings("unchecked") // generics and updaters do not mix.
-        private static final AtomicReferenceFieldUpdater<DefaultResourceLeak<?>, Record> headUpdater =
+        private static final AtomicReferenceFieldUpdater<DefaultResourceLeak<?>, TraceRecord> headUpdater =
                 (AtomicReferenceFieldUpdater)
-                        AtomicReferenceFieldUpdater.newUpdater(DefaultResourceLeak.class, Record.class, "head");
+                        AtomicReferenceFieldUpdater.newUpdater(DefaultResourceLeak.class, TraceRecord.class, "head");
 
         @SuppressWarnings("unchecked") // generics and updaters do not mix.
         private static final AtomicIntegerFieldUpdater<DefaultResourceLeak<?>> droppedRecordsUpdater =
@@ -358,7 +358,7 @@ public class ResourceLeakDetector<T> {
                         AtomicIntegerFieldUpdater.newUpdater(DefaultResourceLeak.class, "droppedRecords");
 
         @SuppressWarnings("unused")
-        private volatile Record head;
+        private volatile TraceRecord head;
         @SuppressWarnings("unused")
         private volatile int droppedRecords;
 
@@ -379,7 +379,7 @@ public class ResourceLeakDetector<T> {
             trackedHash = System.identityHashCode(referent);
             allLeaks.add(this);
             // Create a new Record so we always have the creation stacktrace included.
-            headUpdater.set(this, new Record(Record.BOTTOM));
+            headUpdater.set(this, new TraceRecord(TraceRecord.BOTTOM));
             this.allLeaks = allLeaks;
         }
 
@@ -422,9 +422,9 @@ public class ResourceLeakDetector<T> {
         private void record0(Object hint) {
             // Check TARGET_RECORDS > 0 here to avoid similar check before remove from and add to lastRecords
             if (TARGET_RECORDS > 0) {
-                Record oldHead;
-                Record prevHead;
-                Record newHead;
+                TraceRecord oldHead;
+                TraceRecord prevHead;
+                TraceRecord newHead;
                 boolean dropped;
                 do {
                     if ((prevHead = oldHead = headUpdater.get(this)) == null) {
@@ -440,7 +440,7 @@ public class ResourceLeakDetector<T> {
                     } else {
                         dropped = false;
                     }
-                    newHead = hint != null ? new Record(prevHead, hint) : new Record(prevHead);
+                    newHead = hint != null ? new TraceRecord(prevHead, hint) : new TraceRecord(prevHead);
                 } while (!headUpdater.compareAndSet(this, oldHead, newHead));
                 if (dropped) {
                     droppedRecordsUpdater.incrementAndGet(this);
@@ -509,7 +509,7 @@ public class ResourceLeakDetector<T> {
 
         @Override
         public String toString() {
-            Record oldHead = headUpdater.getAndSet(this, null);
+            TraceRecord oldHead = headUpdater.getAndSet(this, null);
             if (oldHead == null) {
                 // Already closed
                 return EMPTY_STRING;
@@ -525,10 +525,10 @@ public class ResourceLeakDetector<T> {
 
             int i = 1;
             Set<String> seen = new HashSet<String>(present);
-            for (; oldHead != Record.BOTTOM; oldHead = oldHead.next) {
+            for (; oldHead != TraceRecord.BOTTOM; oldHead = oldHead.next) {
                 String s = oldHead.toString();
                 if (seen.add(s)) {
-                    if (oldHead.next == Record.BOTTOM) {
+                    if (oldHead.next == TraceRecord.BOTTOM) {
                         buf.append("Created at:").append(NEWLINE).append(s);
                     } else {
                         buf.append('#').append(i++).append(':').append(NEWLINE).append(s);
@@ -588,30 +588,30 @@ public class ResourceLeakDetector<T> {
         } while (!excludedMethods.compareAndSet(oldMethods, newMethods));
     }
 
-    private static final class Record extends Throwable {
+    private static final class TraceRecord extends Throwable {
         private static final long serialVersionUID = 6065153674892850720L;
 
-        private static final Record BOTTOM = new Record();
+        private static final TraceRecord BOTTOM = new TraceRecord();
 
         private final String hintString;
-        private final Record next;
+        private final TraceRecord next;
         private final int pos;
 
-        Record(Record next, Object hint) {
+        TraceRecord(TraceRecord next, Object hint) {
             // This needs to be generated even if toString() is never called as it may change later on.
             hintString = hint instanceof ResourceLeakHint ? ((ResourceLeakHint) hint).toHintString() : hint.toString();
             this.next = next;
             this.pos = next.pos + 1;
         }
 
-        Record(Record next) {
+        TraceRecord(TraceRecord next) {
            hintString = null;
            this.next = next;
            this.pos = next.pos + 1;
         }
 
         // Used to terminate the stack
-        private Record() {
+        private TraceRecord() {
             hintString = null;
             next = null;
             pos = -1;


### PR DESCRIPTION
Motivation:

 Recent Intellij versions are starting to anticipate future versions of Java that include a `java.lang.Record` class, and the Intellij compiler gets confused by the `Record` class in our `ResorceLeakDetector`.

Modification:

 Rename our `Record` class to `TracerRecord`. This matches what the class is doing, while avoiding any future name clashes.

Result:

 Intellij can now compile the project again, even when configured to use a future (snapshot or early access) version of Java.

This PR is a back port of #10467