### PR TITLE
Include TLSv1.3 ciphers as recommented ciphers for HTTP2

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -43,9 +43,9 @@ public final class Http2SecurityUtil {
     public static final List<String> CIPHERS;
 
     /**
-     * <a href="https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility">Mozilla Modern Cipher
-     * Suites</a> minus the following cipher suites that are black listed by the
-     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">HTTP/2 RFC</a>.
+     * <a href="https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29"
+     * >Mozilla Modern Cipher Suites Intermediate compatibility</a> minus the following cipher suites that are black
+     * listed by the <a href="https://tools.ietf.org/html/rfc7540#appendix-A">HTTP/2 RFC</a>.
      */
     private static final List<String> CIPHERS_JAVA_MOZILLA_MODERN_SECURITY = Collections.unmodifiableList(Arrays
             .asList(
@@ -64,7 +64,12 @@ public final class Http2SecurityUtil {
             /* openssl = ECDHE-ECDSA-CHACHA20-POLY1305 */
             "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
             /* openssl = ECDHE-RSA-CHACHA20-POLY1305 */
-            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+
+            /* TLS 1.3 ciphers */
+            "TLS_AES_128_GCM_SHA256",
+            "TLS_AES_256_GCM_SHA384",
+            "TLS_CHACHA20_POLY1305_SHA256"
             ));
 
     static {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SecurityUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SecurityUtilTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+
+public class Http2SecurityUtilTest {
+
+    @Test
+    public void testTLSv13CiphersIncluded() throws SSLException  {
+        Assume.assumeTrue(SslProvider.isTlsv13Supported(SslProvider.JDK));
+        SslContext content = SslContextBuilder.forClient().sslProvider(SslProvider.JDK).protocols("TLSv1.3")
+                .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE).build();
+        SSLEngine engine = content.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        Assert.assertTrue(engine.getEnabledCipherSuites().length > 0);
+    }
+
+    @Test
+    public void testTLSv12CiphersIncluded() throws SSLException  {
+        SslContext content = SslContextBuilder.forClient().sslProvider(SslProvider.JDK).protocols("TLSv1.2")
+                .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE).build();
+        SSLEngine engine = content.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        Assert.assertTrue(engine.getEnabledCipherSuites().length > 0);
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SecurityUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SecurityUtilTest.java
@@ -30,19 +30,20 @@ import javax.net.ssl.SSLException;
 public class Http2SecurityUtilTest {
 
     @Test
-    public void testTLSv13CiphersIncluded() throws SSLException  {
+    public void testTLSv13CiphersIncluded() throws SSLException {
         Assume.assumeTrue(SslProvider.isTlsv13Supported(SslProvider.JDK));
-        SslContext content = SslContextBuilder.forClient().sslProvider(SslProvider.JDK).protocols("TLSv1.3")
-                .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE).build();
-        SSLEngine engine = content.newEngine(UnpooledByteBufAllocator.DEFAULT);
-        Assert.assertTrue(engine.getEnabledCipherSuites().length > 0);
+        testCiphersIncluded("TLSv1.3");
     }
 
     @Test
     public void testTLSv12CiphersIncluded() throws SSLException  {
-        SslContext content = SslContextBuilder.forClient().sslProvider(SslProvider.JDK).protocols("TLSv1.2")
+        testCiphersIncluded("TLSv1.2");
+    }
+
+    private static void testCiphersIncluded(String protocol) throws SSLException  {
+        SslContext context = SslContextBuilder.forClient().sslProvider(SslProvider.JDK).protocols(protocol)
                 .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE).build();
-        SSLEngine engine = content.newEngine(UnpooledByteBufAllocator.DEFAULT);
-        Assert.assertTrue(engine.getEnabledCipherSuites().length > 0);
+        SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        Assert.assertTrue("No " + protocol + " ciphers found", engine.getEnabledCipherSuites().length > 0);
     }
 }


### PR DESCRIPTION
Motivation:

We should include TLSv1.3 ciphers as well as recommented ciphers these days for HTTP/2. That is especially true as Java supports TLSv1.3 these days out of the box

Modifications:

- Add TLSv1.3 ciphers that are recommended by mozilla as was for HTTP/2
- Add unit test

Result:

Include TLSv1.3 ciphers as well

