### PR TITLE
Remove incorrect javadocs that were not updated for new versions of n…

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -65,55 +65,19 @@ import java.nio.channels.Channels;
  * <h3>Storing stateful information</h3>
  *
  * {@link #attr(AttributeKey)} allow you to
- * store and access stateful information that is related with a handler and its
- * context.  Please refer to {@link ChannelHandler} to learn various recommended
+ * store and access stateful information that is related with a {@link ChannelHandler} / {@link Channel} and its
+ * context. Please refer to {@link ChannelHandler} to learn various recommended
  * ways to manage stateful information.
  *
- * <h3>A handler can have more than one context</h3>
+ * <h3>A handler can have more than one {@link ChannelHandlerContext}</h3>
  *
  * Please note that a {@link ChannelHandler} instance can be added to more than
  * one {@link ChannelPipeline}.  It means a single {@link ChannelHandler}
  * instance can have more than one {@link ChannelHandlerContext} and therefore
  * the single instance can be invoked with different
- * {@link ChannelHandlerContext}s if it is added to one or more
- * {@link ChannelPipeline}s more than once.
- * <p>
- * For example, the following handler will have as many independent {@link AttributeKey}s
- * as how many times it is added to pipelines, regardless if it is added to the
- * same pipeline multiple times or added to different pipelines multiple times:
- * <pre>
- * public class FactorialHandler extends {@link ChannelInboundHandlerAdapter} {
- *
- *   private final {@link AttributeKey}&lt;{@link Integer}&gt; counter = {@link AttributeKey}.valueOf("counter");
- *
- *   // This handler will receive a sequence of increasing integers starting
- *   // from 1.
- *   {@code @Override}
- *   public void channelRead({@link ChannelHandlerContext} ctx, Object msg) {
- *     Integer a = ctx.attr(counter).get();
- *
- *     if (a == null) {
- *       a = 1;
- *     }
- *
- *     attr.set(a * (Integer) msg);
- *   }
- * }
- *
- * // Different context objects are given to "f1", "f2", "f3", and "f4" even if
- * // they refer to the same handler instance.  Because the FactorialHandler
- * // stores its state in a context object (using an {@link AttributeKey}), the factorial is
- * // calculated correctly 4 times once the two pipelines (p1 and p2) are active.
- * FactorialHandler fh = new FactorialHandler();
- *
- * {@link ChannelPipeline} p1 = {@link Channels}.pipeline();
- * p1.addLast("f1", fh);
- * p1.addLast("f2", fh);
- *
- * {@link ChannelPipeline} p2 = {@link Channels}.pipeline();
- * p2.addLast("f3", fh);
- * p2.addLast("f4", fh);
- * </pre>
+ * {@link ChannelHandlerContext}s if it is added to one or more {@link ChannelPipeline}s more than once.
+ * Also note that a {@link ChannelHandler} that is supposed to be added to multiple {@link ChannelPipeline}s should
+ * be marked as {@link io.netty.channel.ChannelHandler.Sharable}.
  *
  * <h3>Additional resources worth reading</h3>
  * <p>


### PR DESCRIPTION
…etty

Motivation:

At some point a ChannelHandlerContext did have its own AttributeMap which is not true since 4.1.x was released. Unfortunally we missed to update the javadocs and so these don't reflect reality

Modifications:

Update javadocs

Result:

Fixes https://github.com/netty/netty/issues/10477
