### PR TITLE
Binary search based IpSubnetFilter

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -33,7 +33,7 @@ import java.util.List;
  * <p>
  * This class allows one to filter new {@link Channel}s based on the
  * {@link IpSubnetFilter}s passed to its constructor. If no rules are provided, all connections
- * will be accepted.
+ * will be accepted since {@code acceptIfNotFound} is {@code true} by default.
  * </p>
  *
  * <p>
@@ -62,7 +62,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
 
     /**
      * <p> Create new {@link IpSubnetFilter} Instance with specified {@link IpSubnetFilterRule} as array. </p>
-     * <p> {@code acceptIfNotFound} is set to {@code true} </p>
+     * <p> {@code acceptIfNotFound} is set to {@code true}. </p>
      *
      * @param rules {@link IpSubnetFilterRule} as an array
      */
@@ -83,7 +83,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
 
     /**
      * <p> Create new {@link IpSubnetFilter} Instance with specified {@link IpSubnetFilterRule} as {@link List}. </p>
-     * <p> {@code acceptIfNotFound} is set to {@code true} </p>
+     * <p> {@code acceptIfNotFound} is set to {@code true}. </p>
      *
      * @param rules {@link IpSubnetFilterRule} as a {@link List}
      */

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ipfilter;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class allows one to filter new {@link Channel}s based on the
+ * {@link IpSubnetFilter}s passed to its constructor. If no rules are provided, all connections
+ * will be accepted.
+ * <p>
+ * If you would like to explicitly take action on rejected {@link Channel}s, you should override
+ * {@link #channelRejected(ChannelHandlerContext, SocketAddress)}.
+ */
+@Sharable
+public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
+
+    private final List<IpSubnetFilterRule> rules = new ArrayList<IpSubnetFilterRule>();
+
+    public IpSubnetFilter(IpSubnetFilterRule... rules) {
+        ObjectUtil.checkNotNull(rules, "rules");
+
+        // Iterate over rules and check for `null` and add them to List
+        for (IpSubnetFilterRule ipSubnetFilterRule : rules) {
+            ObjectUtil.checkNotNull(ipSubnetFilterRule, "rule");
+            this.rules.add(ipSubnetFilterRule);
+        }
+
+        Collections.sort(this.rules, new IpSubnetFilterRuleComparator());
+    }
+
+    public IpSubnetFilter(List<IpSubnetFilterRule> rules) {
+        ObjectUtil.checkNotNull(rules, "rules");
+
+        // Iterate over rules and check for `null` and add them to List
+        for (IpSubnetFilterRule ipSubnetFilterRule : rules) {
+            ObjectUtil.checkNotNull(ipSubnetFilterRule, "rule");
+            this.rules.add(ipSubnetFilterRule);
+        }
+
+        Collections.sort(this.rules, new IpSubnetFilterRuleComparator());
+    }
+
+    @Override
+    protected boolean accept(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) {
+        int indexOf = Collections.binarySearch(this.rules, remoteAddress, new IpSubnetFilterRuleComparator());
+        if (indexOf >= 0) {
+            return this.rules.get(indexOf).ruleType() == IpFilterRuleType.ACCEPT;
+        }
+        return true;
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -45,13 +45,49 @@ import java.util.NoSuchElementException;
 public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
 
     private final List<IpSubnetFilterRule> rules;
+    private final boolean acceptIfNotFound;
 
+    /**
+     * <p> Create new {@link IpSubnetFilter} Instance with specified {@link IpSubnetFilterRule} as array. </p>
+     * <p> {@code acceptIfNotFound} is set to {@code true} </p>
+     *
+     * @param rules {@link IpSubnetFilterRule} as array
+     */
     public IpSubnetFilter(IpSubnetFilterRule... rules) {
-        this(Arrays.asList(ObjectUtil.checkNotNull(rules, "rules")));
+        this(true, Arrays.asList(ObjectUtil.checkNotNull(rules, "rules")));
     }
 
+    /**
+     * <p> Create new {@link IpSubnetFilter} Instance with specified {@link IpSubnetFilterRule} as array
+     * and specify if we'll accept a connection if we don't find it in the rule(s). </p>
+     *
+     * @param acceptIfNotFound {@code true} if we'll accept connection if not found in rule(s).
+     * @param rules            {@link IpSubnetFilterRule} as array
+     */
+    public IpSubnetFilter(boolean acceptIfNotFound, IpSubnetFilterRule... rules) {
+        this(acceptIfNotFound, Arrays.asList(ObjectUtil.checkNotNull(rules, "rules")));
+    }
+
+    /**
+     * <p> Create new {@link IpSubnetFilter} Instance with specified {@link IpSubnetFilterRule} as {@link List}. </p>
+     * <p> {@code acceptIfNotFound} is set to {@code true} </p>
+     *
+     * @param rules {@link IpSubnetFilterRule} as {@link List}
+     */
     public IpSubnetFilter(List<IpSubnetFilterRule> rules) {
+        this(true, rules);
+    }
+
+    /**
+     * <p> Create new {@link IpSubnetFilter} Instance with specified {@link IpSubnetFilterRule} as {@link List}
+     * and specify if we'll accept a connection if we don't find it in the rule(s). </p>
+     *
+     * @param acceptIfNotFound {@code true} if we'll accept connection if not found in rule(s).
+     * @param rules            {@link IpSubnetFilterRule} as {@link List}
+     */
+    public IpSubnetFilter(boolean acceptIfNotFound, List<IpSubnetFilterRule> rules) {
         this.rules = ObjectUtil.checkNotNull(rules, "rules");
+        this.acceptIfNotFound = acceptIfNotFound;
 
         // Iterate over rules and check for `null` rule.
         for (IpSubnetFilterRule ipSubnetFilterRule : this.rules) {
@@ -67,7 +103,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
         if (indexOf >= 0) {
             return this.rules.get(indexOf).ruleType() == IpFilterRuleType.ACCEPT;
         }
-        return true;
+        return acceptIfNotFound;
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -114,7 +114,6 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
         for (IpSubnetFilterRule ipSubnetFilterRule : rules) {
             ObjectUtil.checkNotNull(ipSubnetFilterRule, "rule");
 
-
             if (ipSubnetFilterRule.getFilterRule() instanceof IpSubnetFilterRule.Ip4SubnetFilterRule) {
                 unsortedIPv4Rules.add(ipSubnetFilterRule);
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -54,9 +54,9 @@ import java.util.List;
 @Sharable
 public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
 
+    private final boolean acceptIfNotFound;
     private final List<IpSubnetFilterRule> ipv4Rules;
     private final List<IpSubnetFilterRule> ipv6Rules;
-    private final boolean acceptIfNotFound;
     private final IpFilterRuleType ipFilterRuleTypeIPv4;
     private final IpFilterRuleType ipFilterRuleTypeIPv6;
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -121,6 +121,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
         }
 
         this.rules = sortAndFilter(rules);
+        rules.clear(); // Free-up old unsorted list
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -30,12 +30,16 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
+ * <p>
  * This class allows one to filter new {@link Channel}s based on the
  * {@link IpSubnetFilter}s passed to its constructor. If no rules are provided, all connections
  * will be accepted.
+ * </p>
  * <p>
  * If you would like to explicitly take action on rejected {@link Channel}s, you should override
- * {@link #channelRejected(ChannelHandlerContext, SocketAddress)}.
+ * {@link #channelRejected(ChannelHandlerContext, SocketAddress)}. </p>
+ * <p> This filter uses Binary Search for faster filtering so it's a good practice to remove
+ * overlapping subnet rules and also entries should be arranged in incremental order.</p>
  */
 @Sharable
 public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
@@ -69,7 +73,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
     /**
      * <ol>
      *     <li> Sort the list </li>
-     *     <li> Remove over-lapping CIDR </li>
+     *     <li> Remove over-lapping subnet </li>
      *     <li> Sort the list again </li>
      * </ol>
      */
@@ -105,6 +109,6 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
 
         rules.removeAll(toRemove);
         toRemove.clear();
-        Collections.sort(rules);
+        Collections.sort(rules); // Re-sort just to be sure
     }
 }

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -22,7 +22,7 @@ import io.netty.util.internal.ObjectUtil;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,35 +37,33 @@ import java.util.List;
 @Sharable
 public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddress> {
 
-    private final List<IpSubnetFilterRule> rules = new ArrayList<IpSubnetFilterRule>();
+    private final List<IpSubnetFilterRule> rules;
 
     public IpSubnetFilter(IpSubnetFilterRule... rules) {
-        ObjectUtil.checkNotNull(rules, "rules");
+        this.rules = Arrays.asList(ObjectUtil.checkNotNull(rules, "rules"));
 
-        // Iterate over rules and check for `null` and add them to List
-        for (IpSubnetFilterRule ipSubnetFilterRule : rules) {
+        // Iterate over rules and check for `null` rule.
+        for (IpSubnetFilterRule ipSubnetFilterRule : this.rules) {
             ObjectUtil.checkNotNull(ipSubnetFilterRule, "rule");
-            this.rules.add(ipSubnetFilterRule);
         }
 
-        Collections.sort(this.rules, new IpSubnetFilterRuleComparator());
+        Collections.sort(this.rules);
     }
 
     public IpSubnetFilter(List<IpSubnetFilterRule> rules) {
-        ObjectUtil.checkNotNull(rules, "rules");
+        this.rules = ObjectUtil.checkNotNull(rules, "rules");
 
-        // Iterate over rules and check for `null` and add them to List
-        for (IpSubnetFilterRule ipSubnetFilterRule : rules) {
+        // Iterate over rules and check for `null` rule.
+        for (IpSubnetFilterRule ipSubnetFilterRule : this.rules) {
             ObjectUtil.checkNotNull(ipSubnetFilterRule, "rule");
-            this.rules.add(ipSubnetFilterRule);
         }
 
-        Collections.sort(this.rules, new IpSubnetFilterRuleComparator());
+        Collections.sort(this.rules);
     }
 
     @Override
     protected boolean accept(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) {
-        int indexOf = Collections.binarySearch(this.rules, remoteAddress, new IpSubnetFilterRuleComparator());
+        int indexOf = Collections.binarySearch(this.rules, remoteAddress, IpSubnetFilterRuleComparator.INSTANCE);
         if (indexOf >= 0) {
             return this.rules.get(indexOf).ruleType() == IpFilterRuleType.ACCEPT;
         }

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -118,7 +118,11 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
         return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 
-    private static final class Ip4SubnetFilterRule implements IpFilterRule {
+    IpFilterRule getFilterRule() {
+        return filterRule;
+    }
+
+    static final class Ip4SubnetFilterRule implements IpFilterRule {
 
         private final int networkAddress;
         private final int subnetMask;
@@ -175,7 +179,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
         }
     }
 
-    private static final class Ip6SubnetFilterRule implements IpFilterRule {
+    static final class Ip6SubnetFilterRule implements IpFilterRule {
 
         private static final BigInteger MINUS_ONE = BigInteger.valueOf(-1);
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -78,6 +78,13 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
         return ipAddress;
     }
 
+    /**
+     * {@link Ip4SubnetFilterRule} or {@link Ip6SubnetFilterRule}
+     */
+    IpFilterRule getFilterRule() {
+        return filterRule;
+    }
+
     @Override
     public int compareTo(IpSubnetFilterRule ipSubnetFilterRule) {
         if (filterRule instanceof Ip4SubnetFilterRule) {
@@ -116,10 +123,6 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
      */
     private static int compareInt(int x, int y) {
         return (x < y) ? -1 : ((x == y) ? 0 : 1);
-    }
-
-    IpFilterRule getFilterRule() {
-        return filterRule;
     }
 
     static final class Ip4SubnetFilterRule implements IpFilterRule {

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -132,8 +132,8 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
 
         private Ip4SubnetFilterRule(Inet4Address ipAddress, int cidrPrefix, IpFilterRuleType ruleType) {
             if (cidrPrefix < 0 || cidrPrefix > 32) {
-                throw new IllegalArgumentException(String.format("IPv4 requires the subnet prefix to be in range of " +
-                        "[0,32]. The prefix was: %d", cidrPrefix));
+                throw new IllegalArgumentException(String.format("IPv4 requires the subnet prefix to be in range of "
+                        + "[0,32]. The prefix was: %d", cidrPrefix));
             }
 
             subnetMask = prefixToSubnetMask(cidrPrefix);
@@ -181,8 +181,8 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
 
         private Ip6SubnetFilterRule(Inet6Address ipAddress, int cidrPrefix, IpFilterRuleType ruleType) {
             if (cidrPrefix < 0 || cidrPrefix > 128) {
-                throw new IllegalArgumentException(String.format("IPv6 requires the subnet prefix to be in range of " +
-                        "[0,128]. The prefix was: %d", cidrPrefix));
+                throw new IllegalArgumentException(String.format("IPv6 requires the subnet prefix to be in range of "
+                        + "[0,128]. The prefix was: %d", cidrPrefix));
             }
 
             subnetMask = prefixToSubnetMask(cidrPrefix);

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -102,8 +102,6 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
      *
      * @param inetSocketAddress {@link InetSocketAddress} to match
      * @return 0 if IP Address match else difference index.
-     * @see Integer#compareTo(Integer)
-     * @see BigInteger#compareTo(BigInteger)
      */
     int compareTo(InetSocketAddress inetSocketAddress) {
         if (filterRule instanceof Ip4SubnetFilterRule) {

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -71,11 +71,18 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
         return filterRule.ruleType();
     }
 
+    /**
+     * Get IP Address of this rule
+     */
+    String getIpAddress() {
+        return ipAddress;
+    }
+
     @Override
     public int compareTo(IpSubnetFilterRule ipSubnetFilterRule) {
         if (filterRule instanceof Ip4SubnetFilterRule) {
-            return Integer.valueOf(((Ip4SubnetFilterRule) filterRule).networkAddress)
-                    .compareTo(((Ip4SubnetFilterRule) ipSubnetFilterRule.filterRule).networkAddress);
+            return compareInt(((Ip4SubnetFilterRule) filterRule).networkAddress,
+                    ((Ip4SubnetFilterRule) ipSubnetFilterRule.filterRule).networkAddress);
         } else {
             return ((Ip6SubnetFilterRule) filterRule).networkAddress
                     .compareTo(((Ip6SubnetFilterRule) ipSubnetFilterRule.filterRule).networkAddress);
@@ -85,6 +92,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
     /**
      * It'll compare IP address with {@link Ip4SubnetFilterRule#networkAddress} or
      * {@link Ip6SubnetFilterRule#networkAddress}.
+     *
      * @param inetSocketAddress {@link InetSocketAddress} to match
      * @return 0 if IP Address match else difference index.
      * @see Integer#compareTo(Integer)
@@ -93,9 +101,8 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
     int compareTo(InetSocketAddress inetSocketAddress) {
         if (filterRule instanceof Ip4SubnetFilterRule) {
             Ip4SubnetFilterRule ip4SubnetFilterRule = (Ip4SubnetFilterRule) filterRule;
-            return Integer.valueOf(ip4SubnetFilterRule.networkAddress)
-                    .compareTo(Ip4SubnetFilterRule.ipToInt(
-                            (Inet4Address) inetSocketAddress.getAddress()) & ip4SubnetFilterRule.subnetMask);
+            return compareInt(ip4SubnetFilterRule.networkAddress, Ip4SubnetFilterRule.ipToInt((Inet4Address)
+                    inetSocketAddress.getAddress()) & ip4SubnetFilterRule.subnetMask);
         } else {
             Ip6SubnetFilterRule ip6SubnetFilterRule = (Ip6SubnetFilterRule) filterRule;
             return ip6SubnetFilterRule.networkAddress
@@ -104,8 +111,11 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
         }
     }
 
-    String getIpAddress() {
-        return ipAddress;
+    /**
+     * Equivalent to {@link Integer#compare(int, int)}
+     */
+    public static int compareInt(int x, int y) {
+        return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 
     private static final class Ip4SubnetFilterRule implements IpFilterRule {
@@ -145,8 +155,8 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
             assert octets.length == 4;
 
             return (octets[0] & 0xff) << 24 |
-                   (octets[1] & 0xff) << 16 |
-                   (octets[2] & 0xff) << 8 |
+                    (octets[1] & 0xff) << 16 |
+                    (octets[2] & 0xff) << 8 |
                     octets[3] & 0xff;
         }
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -171,7 +171,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
              *
              * Also see https://github.com/netty/netty/issues/2767
              */
-            return (int) ((-1L << 32 - cidrPrefix));
+            return (int) ((-1L << 32 - cidrPrefix) & 0xffffffff);
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -69,21 +69,28 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
     }
 
     @Override
-    public int compareTo(IpSubnetFilterRule o) {
-        return getNetworkAddress().compareTo(o.getNetworkAddress());
+    public int compareTo(IpSubnetFilterRule ipSubnetFilterRule) {
+        if (filterRule instanceof Ip4SubnetFilterRule) {
+            return Integer.valueOf(((Ip4SubnetFilterRule) filterRule).networkAddress)
+                    .compareTo(((Ip4SubnetFilterRule) ipSubnetFilterRule.filterRule).networkAddress);
+        } else {
+            return ((Ip6SubnetFilterRule) filterRule).networkAddress
+                    .compareTo(((Ip6SubnetFilterRule) ipSubnetFilterRule.filterRule).networkAddress);
+        }
     }
 
-    private BigInteger getNetworkAddress() {
+    public int compareTo(InetSocketAddress inetSocketAddress) {
         if (filterRule instanceof Ip4SubnetFilterRule) {
-            return ((Ip4SubnetFilterRule) filterRule).networkAddressAsBigInteger;
+            return Integer.valueOf(((Ip4SubnetFilterRule) filterRule).networkAddress)
+                    .compareTo(Ip4SubnetFilterRule.ipToInt((Inet4Address) inetSocketAddress.getAddress()));
         } else {
-            return ((Ip6SubnetFilterRule) filterRule).networkAddress;
+            return ((Ip6SubnetFilterRule) filterRule).networkAddress
+                    .compareTo(Ip6SubnetFilterRule.ipToInt((Inet6Address) inetSocketAddress.getAddress()));
         }
     }
 
     private static final class Ip4SubnetFilterRule implements IpFilterRule {
 
-        private final BigInteger networkAddressAsBigInteger;
         private final int networkAddress;
         private final int subnetMask;
         private final IpFilterRuleType ruleType;
@@ -96,7 +103,6 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
 
             subnetMask = prefixToSubnetMask(cidrPrefix);
             networkAddress = ipToInt(ipAddress) & subnetMask;
-            networkAddressAsBigInteger = BigInteger.valueOf(networkAddress);
             this.ruleType = ruleType;
         }
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -31,7 +31,6 @@ import java.net.UnknownHostException;
  */
 public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubnetFilterRule> {
 
-
     private final IpFilterRule filterRule;
     private final String ipAddress;
 
@@ -83,17 +82,25 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
         }
     }
 
-    public int compareTo(InetSocketAddress inetSocketAddress) {
+    /**
+     * It'll compare IP address with {@link Ip4SubnetFilterRule#networkAddress} or
+     * {@link Ip6SubnetFilterRule#networkAddress}.
+     * @param inetSocketAddress {@link InetSocketAddress} to match
+     * @return 0 if IP Address match else difference index.
+     * @see Integer#compareTo(Integer)
+     * @see BigInteger#compareTo(BigInteger)
+     */
+    int compareTo(InetSocketAddress inetSocketAddress) {
         if (filterRule instanceof Ip4SubnetFilterRule) {
-            Ip4SubnetFilterRule ip4SubnetFilterRule = ((Ip4SubnetFilterRule) filterRule);
+            Ip4SubnetFilterRule ip4SubnetFilterRule = (Ip4SubnetFilterRule) filterRule;
             return Integer.valueOf(ip4SubnetFilterRule.networkAddress)
                     .compareTo(Ip4SubnetFilterRule.ipToInt(
                             (Inet4Address) inetSocketAddress.getAddress()) & ip4SubnetFilterRule.subnetMask);
         } else {
             Ip6SubnetFilterRule ip6SubnetFilterRule = (Ip6SubnetFilterRule) filterRule;
-            return (ip6SubnetFilterRule.networkAddress
+            return ip6SubnetFilterRule.networkAddress
                     .compareTo(Ip6SubnetFilterRule.ipToInt((Inet6Address) inetSocketAddress.getAddress())
-                            .and(ip6SubnetFilterRule.networkAddress)));
+                            .and(ip6SubnetFilterRule.networkAddress));
         }
     }
 
@@ -138,8 +145,8 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
             assert octets.length == 4;
 
             return (octets[0] & 0xff) << 24 |
-                    (octets[1] & 0xff) << 16 |
-                    (octets[2] & 0xff) << 8 |
+                   (octets[1] & 0xff) << 16 |
+                   (octets[2] & 0xff) << 8 |
                     octets[3] & 0xff;
         }
 
@@ -154,7 +161,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
              *
              * Also see https://github.com/netty/netty/issues/2767
              */
-            return (int) ((-1L << 32 - cidrPrefix) & 0xffffffff);
+            return (int) ((-1L << 32 - cidrPrefix));
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.ipfilter;
 
+import io.netty.util.NetUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SocketUtils;
 
@@ -106,7 +107,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
     int compareTo(InetSocketAddress inetSocketAddress) {
         if (filterRule instanceof Ip4SubnetFilterRule) {
             Ip4SubnetFilterRule ip4SubnetFilterRule = (Ip4SubnetFilterRule) filterRule;
-            return compareInt(ip4SubnetFilterRule.networkAddress, Ip4SubnetFilterRule.ipToInt((Inet4Address)
+            return compareInt(ip4SubnetFilterRule.networkAddress, NetUtil.ipv4AddressToInt((Inet4Address)
                     inetSocketAddress.getAddress()) & ip4SubnetFilterRule.subnetMask);
         } else {
             Ip6SubnetFilterRule ip6SubnetFilterRule = (Ip6SubnetFilterRule) filterRule;
@@ -136,7 +137,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
             }
 
             subnetMask = prefixToSubnetMask(cidrPrefix);
-            networkAddress = ipToInt(ipAddress) & subnetMask;
+            networkAddress = NetUtil.ipv4AddressToInt(ipAddress) & subnetMask;
             this.ruleType = ruleType;
         }
 
@@ -144,7 +145,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
         public boolean matches(InetSocketAddress remoteAddress) {
             final InetAddress inetAddress = remoteAddress.getAddress();
             if (inetAddress instanceof Inet4Address) {
-                int ipAddress = ipToInt((Inet4Address) inetAddress);
+                int ipAddress = NetUtil.ipv4AddressToInt((Inet4Address) inetAddress);
                 return (ipAddress & subnetMask) == networkAddress;
             }
             return false;
@@ -153,16 +154,6 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
         @Override
         public IpFilterRuleType ruleType() {
             return ruleType;
-        }
-
-        private static int ipToInt(Inet4Address ipAddress) {
-            byte[] octets = ipAddress.getAddress();
-            assert octets.length == 4;
-
-            return (octets[0] & 0xff) << 24 |
-                    (octets[1] & 0xff) << 16 |
-                    (octets[2] & 0xff) << 8 |
-                    octets[3] & 0xff;
         }
 
         private static int prefixToSubnetMask(int cidrPrefix) {

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -114,7 +114,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
     /**
      * Equivalent to {@link Integer#compare(int, int)}
      */
-    public static int compareInt(int x, int y) {
+    private static int compareInt(int x, int y) {
         return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRuleComparator.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRuleComparator.java
@@ -28,17 +28,6 @@ final class IpSubnetFilterRuleComparator implements Comparator<Object> {
 
     @Override
     public int compare(Object o1, Object o2) {
-        /*
-         * We'll try to use `matches` method, if IP address successfully matches then
-         * return 0 because we found the result.
-         *
-         * If `matches` returns false, we'll compare the IP address (as Integer) with
-         * `networkAddress` to find the difference.
-         */
-        if (((IpSubnetFilterRule) o1).matches((InetSocketAddress) o2)) {
-            return 0;
-        } else {
-            return ((IpSubnetFilterRule) o1).compareTo((InetSocketAddress) o2);
-        }
+        return ((IpSubnetFilterRule) o1).compareTo((InetSocketAddress) o2);
     }
 }

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRuleComparator.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRuleComparator.java
@@ -20,15 +20,25 @@ import java.util.Comparator;
 
 final class IpSubnetFilterRuleComparator implements Comparator<Object> {
 
+    static final IpSubnetFilterRuleComparator INSTANCE = new IpSubnetFilterRuleComparator();
+
+    private IpSubnetFilterRuleComparator() {
+        // Prevent outside initialization
+    }
+
     @Override
     public int compare(Object o1, Object o2) {
-        if (o1 instanceof IpSubnetFilterRule) {
-            if (o2 instanceof IpSubnetFilterRule) {
-                return ((IpSubnetFilterRule) o1).compareTo((IpSubnetFilterRule) o2);
-            } else if (o2 instanceof InetSocketAddress) {
-                return ((IpSubnetFilterRule) o1).matches((InetSocketAddress) o2) ? 0 : -1;
-            }
+        /*
+         * We'll try to use `matches` method, if IP address successfully matches then
+         * return 0 because we found the result.
+         *
+         * If `matches` returns false, we'll compare the IP address (as Integer) with
+         * `networkAddress` to find the difference.
+         */
+        if (((IpSubnetFilterRule) o1).matches((InetSocketAddress) o2)) {
+            return 0;
+        } else {
+            return ((IpSubnetFilterRule) o1).compareTo((InetSocketAddress) o2);
         }
-        return -1;
     }
 }

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRuleComparator.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRuleComparator.java
@@ -18,6 +18,9 @@ package io.netty.handler.ipfilter;
 import java.net.InetSocketAddress;
 import java.util.Comparator;
 
+/**
+ * This comparator is only used for searching.
+ */
 final class IpSubnetFilterRuleComparator implements Comparator<Object> {
 
     static final IpSubnetFilterRuleComparator INSTANCE = new IpSubnetFilterRuleComparator();

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRuleComparator.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRuleComparator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ipfilter;
+
+import java.net.InetSocketAddress;
+import java.util.Comparator;
+
+final class IpSubnetFilterRuleComparator implements Comparator<Object> {
+
+    @Override
+    public int compare(Object o1, Object o2) {
+        if (o1 instanceof IpSubnetFilterRule) {
+            if (o2 instanceof IpSubnetFilterRule) {
+                return ((IpSubnetFilterRule) o1).compareTo((IpSubnetFilterRule) o2);
+            } else if (o2 instanceof InetSocketAddress) {
+                return ((IpSubnetFilterRule) o1).matches((InetSocketAddress) o2) ? 0 : -1;
+            }
+        }
+        return -1;
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -27,6 +27,9 @@ import org.junit.Test;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 public class IpSubnetFilterTest {
 
@@ -139,6 +142,47 @@ public class IpSubnetFilterTest {
 
         EmbeddedChannel ch4 = newEmbeddedInetChannel("91.92.93.1", handler);
         Assert.assertTrue(ch4.isActive());
+    }
+
+    @Test
+    public void testBinarySearch() {
+        List<IpSubnetFilterRule> ipSubnetFilterRuleList = new ArrayList<IpSubnetFilterRule>();
+
+        Random r = new Random();
+
+        for (int i = 0; i < 50000; i++) {
+            ipSubnetFilterRuleList.add(buildRejectIP(r.nextInt(250) + "." + r.nextInt(250) +
+                    "." + r.nextInt(250) + "." + r.nextInt(250)));
+        }
+
+        ipSubnetFilterRuleList.add(buildRejectIP("1.1.1.1"));
+        ipSubnetFilterRuleList.add(buildRejectIP("200.200.200.200"));
+
+        EmbeddedChannel ch1 = newEmbeddedInetChannel("1.1.1.1", new IpSubnetFilter(ipSubnetFilterRuleList));
+        Assert.assertFalse(ch1.isActive());
+        Assert.assertTrue(ch1.close().isSuccess());
+
+        EmbeddedChannel ch2 = newEmbeddedInetChannel("2.2.2.2", new IpSubnetFilter(ipSubnetFilterRuleList));
+        Assert.assertTrue(ch2.isActive());
+        Assert.assertTrue(ch2.close().isSuccess());
+
+        EmbeddedChannel ch3 = newEmbeddedInetChannel("100.100.100.100", new IpSubnetFilter(ipSubnetFilterRuleList));
+        Assert.assertTrue(ch3.isActive());
+        Assert.assertTrue(ch3.close().isSuccess());
+
+        EmbeddedChannel ch4 = newEmbeddedInetChannel("200.200.200.200", new IpSubnetFilter(ipSubnetFilterRuleList));
+        Assert.assertFalse(ch4.isActive());
+        Assert.assertTrue(ch4.close().isSuccess());
+
+        EmbeddedChannel ch5 = newEmbeddedInetChannel("127.0.0.1", new IpSubnetFilter(ipSubnetFilterRuleList));
+        Assert.assertTrue(ch5.isActive());
+        Assert.assertTrue(ch5.close().isSuccess());
+
+        ipSubnetFilterRuleList.clear(); // Because we're done with the list
+    }
+
+    private static IpSubnetFilterRule buildRejectIP(String ipAddress) {
+        return new IpSubnetFilterRule(ipAddress, 32, IpFilterRuleType.REJECT);
     }
 
     private static EmbeddedChannel newEmbeddedInetChannel(final String ipAddress, ChannelHandler... handlers) {

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -152,6 +152,7 @@ public class IpSubnetFilterTest {
         ipSubnetFilterRuleList.add(buildRejectIP("200.200.200.200", 32));
         ipSubnetFilterRuleList.add(buildRejectIP("108.0.0.0", 4));
         ipSubnetFilterRuleList.add(buildRejectIP("10.10.10.10", 8));
+        ipSubnetFilterRuleList.add(buildRejectIP("2001:db8:abcd:0000::", 52));
 
         // 1.0.0.0/8
         EmbeddedChannel ch1 = newEmbeddedInetChannel("1.1.1.1", new IpSubnetFilter(ipSubnetFilterRuleList));
@@ -182,6 +183,12 @@ public class IpSubnetFilterTest {
         EmbeddedChannel ch6 = newEmbeddedInetChannel("10.1.1.2", new IpSubnetFilter(ipSubnetFilterRuleList));
         Assert.assertFalse(ch6.isActive());
         Assert.assertTrue(ch6.close().isSuccess());
+
+        //2001:db8:abcd:0000::/52
+        EmbeddedChannel ch7 = newEmbeddedInetChannel("2001:db8:abcd:1000::",
+                new IpSubnetFilter(ipSubnetFilterRuleList));
+        Assert.assertFalse(ch7.isActive());
+        Assert.assertTrue(ch7.close().isSuccess());
     }
 
     private static IpSubnetFilterRule buildRejectIP(String ipAddress, int mask) {

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -152,7 +152,6 @@ public class IpSubnetFilterTest {
         ipSubnetFilterRuleList.add(buildRejectIP("200.200.200.200", 32));
         ipSubnetFilterRuleList.add(buildRejectIP("108.0.0.0", 4));
         ipSubnetFilterRuleList.add(buildRejectIP("10.10.10.10", 8));
-        ipSubnetFilterRuleList.add(buildRejectIP("2001:db8:abcd:0000::", 52));
 
         // 1.0.0.0/8
         EmbeddedChannel ch1 = newEmbeddedInetChannel("1.1.1.1", new IpSubnetFilter(ipSubnetFilterRuleList));

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -152,6 +152,7 @@ public class IpSubnetFilterTest {
         ipSubnetFilterRuleList.add(buildRejectIP("200.200.200.200", 32));
         ipSubnetFilterRuleList.add(buildRejectIP("108.0.0.0", 4));
         ipSubnetFilterRuleList.add(buildRejectIP("10.10.10.10", 8));
+        ipSubnetFilterRuleList.add(buildRejectIP("2001:db8:abcd:0000::", 52));
 
         // 1.0.0.0/8
         EmbeddedChannel ch1 = newEmbeddedInetChannel("1.1.1.1", new IpSubnetFilter(ipSubnetFilterRuleList));
@@ -182,8 +183,6 @@ public class IpSubnetFilterTest {
         EmbeddedChannel ch6 = newEmbeddedInetChannel("10.1.1.2", new IpSubnetFilter(ipSubnetFilterRuleList));
         Assert.assertFalse(ch6.isActive());
         Assert.assertTrue(ch6.close().isSuccess());
-
-        ipSubnetFilterRuleList.clear(); // Because we're done with the list
     }
 
     private static IpSubnetFilterRule buildRejectIP(String ipAddress, int mask) {


### PR DESCRIPTION
Motivation:

`IpSubnetFilter` uses Binary Search for IP Address search which is fast if we have large set of IP addresses to filter.

Modification:

Added `IpSubnetFilter` which takes `IpSubnetFilterRule` for filtering.

Result:
Faster IP address filter.
