### PR TITLE
Add validation when constructing Http2FrameLogger

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -43,20 +43,24 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     private final InternalLogLevel level;
 
     public Http2FrameLogger(LogLevel level) {
-        this(level.toInternalLevel(), InternalLoggerFactory.getInstance(Http2FrameLogger.class));
+        this(checkAndConvertLevel(level), InternalLoggerFactory.getInstance(Http2FrameLogger.class));
     }
 
     public Http2FrameLogger(LogLevel level, String name) {
-        this(level.toInternalLevel(), InternalLoggerFactory.getInstance(name));
+        this(checkAndConvertLevel(level), InternalLoggerFactory.getInstance(checkNotNull(name, "name")));
     }
 
     public Http2FrameLogger(LogLevel level, Class<?> clazz) {
-        this(level.toInternalLevel(), InternalLoggerFactory.getInstance(clazz));
+        this(checkAndConvertLevel(level), InternalLoggerFactory.getInstance(checkNotNull(clazz, "clazz")));
     }
 
     private Http2FrameLogger(InternalLogLevel level, InternalLogger logger) {
-        this.level = checkNotNull(level, "level");
-        this.logger = checkNotNull(logger, "logger");
+        this.level = level;
+        this.logger = logger;
+    }
+
+    private static InternalLogLevel checkAndConvertLevel(LogLevel level) {
+        return checkNotNull(level, "level").toInternalLevel();
     }
 
     public boolean isEnabled() {


### PR DESCRIPTION
Motivation:

There should be a validation for the input arguments when constructing Http2FrameLogger

Modification:

Check that the provided arguments are not null

Result:

Proper validation when constructing Http2FrameLogger
