### PR TITLE
 Add ipv4AddressToInt(Inet4Address) in NetUtils

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -421,7 +421,6 @@ public final class NetUtil {
      */
     public static int ipv4AddressToInt(Inet4Address ipAddress) {
         byte[] octets = ipAddress.getAddress();
-        assert octets.length == 4;
 
         return  (octets[0] & 0xff) << 24 |
                 (octets[1] & 0xff) << 16 |

--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -417,6 +417,19 @@ public final class NetUtil {
     }
 
     /**
+     * Convert {@link Inet4Address} into {@code int}
+     */
+    public static int ipv4AddressToInt(Inet4Address ipAddress) {
+        byte[] octets = ipAddress.getAddress();
+        assert octets.length == 4;
+
+        return  (octets[0] & 0xff) << 24 |
+                (octets[1] & 0xff) << 16 |
+                (octets[2] & 0xff) << 8 |
+                 octets[3] & 0xff;
+    }
+
+    /**
      * Converts a 32-bit integer into an IPv4 address.
      */
     public static String intToIpAddress(int i) {

--- a/common/src/test/java/io/netty/util/NetUtilTest.java
+++ b/common/src/test/java/io/netty/util/NetUtilTest.java
@@ -18,6 +18,7 @@ package io.netty.util;
 import io.netty.util.internal.StringUtil;
 import org.junit.Test;
 
+import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -722,6 +723,12 @@ public class NetUtilTest {
         for (Entry<String, String> e : validIpV4Hosts.entrySet()) {
             assertEquals(e.getKey(), toAddressString(InetAddress.getByAddress(unhex(e.getValue()))));
         }
+    }
+
+    @Test
+    public void testIPv4ToInt() throws UnknownHostException {
+        assertEquals(2130706433, ipv4AddressToInt((Inet4Address) InetAddress.getByName("127.0.0.1")));
+        assertEquals(-1062731519, ipv4AddressToInt((Inet4Address) InetAddress.getByName("192.168.1.1")));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We're converting `Inet4Address` to `Integer` quite frequently so it's a good idea to keep that code in `NetUtils`.

Modification:

Added ipv4AddressToInt(Inet4Address) in NetUtils

Result:
Easy conversion of  `Inet4Address` to `Integer`.