### PR TITLE
Use all configured nameservers when using DnsNameResolver in all cases

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -1025,11 +1025,18 @@ abstract class DnsResolveContext<T> {
         }
     }
 
-    private DnsServerAddressStream getNameServers(String hostname) {
-        DnsServerAddressStream stream = getNameServersFromCache(hostname);
-        // We need to obtain a new stream from the parent DnsNameResolver as the hostname may not be the same as the
-        // one used for the original query (for example we may follow CNAMEs).
-        return stream == null ? parent.newNameServerAddressStream(hostname) : stream;
+    private DnsServerAddressStream getNameServers(String name) {
+        DnsServerAddressStream stream = getNameServersFromCache(name);
+        if (stream == null) {
+            // We need to obtain a new stream from the parent DnsNameResolver if the hostname is not the same as
+            // for the original query (for example we may follow CNAMEs). Otherwise let's just duplicate the
+            // original nameservers so we correctly update the internal index
+            if (name.equals(this.hostname)) {
+                return nameServerAddrs.duplicate();
+            }
+            return parent.newNameServerAddressStream(name);
+        }
+        return stream;
     }
 
     private void followCname(DnsQuestion question, String cname, DnsQueryLifecycleObserver queryLifecycleObserver,

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -1031,7 +1031,7 @@ abstract class DnsResolveContext<T> {
             // We need to obtain a new stream from the parent DnsNameResolver if the hostname is not the same as
             // for the original query (for example we may follow CNAMEs). Otherwise let's just duplicate the
             // original nameservers so we correctly update the internal index
-            if (name.equals(this.hostname)) {
+            if (name.equals(hostname)) {
                 return nameServerAddrs.duplicate();
             }
             return parent.newNameServerAddressStream(name);


### PR DESCRIPTION
Motivation:

Due a change introduced in 68105b257d915d8a0cb7b2acd9061661666537b6 we incorrectly skipped the usage of nameservers in some cases.

Modifications:

Only fetch a new stream of nameserver if the hostname not matches the original hostname in the query.

Result:

Use all configured nameservers. Fixes https://github.com/netty/netty/issues/10499