### PR TITLE
Don't try to remove the task when the underlying executor fails the e…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
@@ -335,13 +335,7 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
             if (state.compareAndSet(NONE, SUBMITTED)) {
                 // Actually it could happen that the runnable was picked up in between but we not care to much and just
                 // execute ourself. At worst this will be a NOOP when run() is called.
-                try {
-                    executor.execute(this);
-                } catch (Throwable e) {
-                    // Not reset the state as some other Runnable may be added to the queue already in the meantime.
-                    tasks.remove(command);
-                    PlatformDependent.throwException(e);
-                }
+                executor.execute(this);
             }
         }
     }


### PR DESCRIPTION
…xecution of self

Motivation:

It makes no sense to remove the task when the underlying executor fails as we may be able to pick it up later. Beside this the used Queue doesnt support remove(...) and so will throw.

Modifications:

Remove the queue.remove(...) call

Result:

Fixes https://github.com/netty/netty/issues/10501.