### PR TITLE
Adjust testsuite to pass on JDK15+

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -33,6 +33,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.Test;
@@ -253,6 +254,12 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
                         fail();
                     } catch (SSLPeerUnverifiedException e) {
                         // expected
+                    } catch (UnsupportedOperationException e) {
+                        // Starting from Java15 this method throws UnsupportedOperationException as it was
+                        // deprecated before and getPeerCertificates() should be used
+                        if (PlatformDependent.javaVersion() < 15) {
+                            throw e;
+                        }
                     }
                     try {
                         session.getPeerPrincipal();


### PR DESCRIPTION
Motivation:

JDK15 is about to be released as GA, we should ensure netty works and builds on it. SSLSession#getPeerCertificateChain() throws UnsupportedOperationException in JDK15 and later as it was deprecated before and people should use SSLSession#getPeerCertificates(). We need to account for that in our tests

Modifications:

- Catch UnsupportedOperationException in our testsuite and ignore it when on JDK15+ while rethrowing it otherwise.

Result:

Testsuite passes on JDK15+