### PR TITLE
Remove javassist dependency

### DIFF
--- a/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
+++ b/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
@@ -104,15 +104,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Byte code generator - completely optional -->
-      <dependency>
-        <groupId>org.javassist</groupId>
-        <artifactId>javassist</artifactId>
-        <version>3.18.0-GA</version>
-        <scope>compile</scope>
-        <optional>true</optional>
-      </dependency>
-
       <!-- JBoss Marshalling - completely optional -->
       <dependency>
         <groupId>org.jboss.marshalling</groupId>
@@ -218,13 +209,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- Enable Javassist support for all test runs -->
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <!-- Testing frameworks and related dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -142,11 +142,6 @@
       <artifactId>jzlib</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <scope>runtime</scope>
-    </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -427,15 +427,6 @@
         <version>1.2.0</version>
       </dependency>
 
-      <!-- Byte code generator - completely optional -->
-      <dependency>
-        <groupId>org.javassist</groupId>
-        <artifactId>javassist</artifactId>
-        <version>3.20.0-GA</version>
-        <scope>compile</scope>
-        <optional>true</optional>
-      </dependency>
-
       <!-- JBoss Marshalling - completely optional -->
       <dependency>
         <groupId>org.jboss.marshalling</groupId>
@@ -706,13 +697,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- Enable Javassist support for all test runs -->
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <!-- Testing frameworks and related dependencies -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Motivation:
 Avoid keeping unused dependencies around.

Modification:
 Remove all references to javassist dependency, since it does not appear to be used by anything.

Result:
 One less dependency to worry about.
