### PR TITLE
Fix NullPointerException when receiving server push in Http2MultiplexHandler

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -19,8 +19,13 @@ import io.netty.channel.ChannelHandler;
 public class Http2MultiplexCodecTest extends Http2MultiplexTest<Http2FrameCodec> {
 
     @Override
+    protected boolean isServer() {
+        return true;
+    }
+
+    @Override
     protected Http2FrameCodec newCodec(TestChannelInitializer childChannelInitializer, Http2FrameWriter frameWriter) {
-        return new Http2MultiplexCodecBuilder(true, childChannelInitializer).frameWriter(frameWriter).build();
+        return new Http2MultiplexCodecBuilder(isServer(), childChannelInitializer).frameWriter(frameWriter).build();
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerClientTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -17,13 +17,13 @@ package io.netty.handler.codec.http2;
 import io.netty.channel.ChannelHandler;
 
 /**
- * Unit tests for {@link Http2MultiplexHandler} used for server.
+ * Unit tests for {@link Http2MultiplexHandler} used for client.
  */
-public class Http2MultiplexHandlerTest extends Http2MultiplexTest<Http2FrameCodec> {
+public class Http2MultiplexHandlerClientTest extends Http2MultiplexTest<Http2FrameCodec> {
 
     @Override
     protected boolean isServer() {
-        return true;
+        return false;
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -1244,7 +1244,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         Http2StreamChannel channel = newInboundStream(true, inboundHandler);
         assertTrue(inboundHandler.isChannelActive());
         Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(request, true).stream(channel.stream());
-        assertEquals(headersFrame, inboundHandler.readInbound());
+        assertEqualsAndRelease(headersFrame, inboundHandler.<Http2Frame>readInbound());
 
         //half-closed(local)
         final Http2HeadersFrame outboundHeaders = new DefaultHttp2HeadersFrame(
@@ -1283,7 +1283,10 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             assertFalse(inboundHandler.isChannelActive());
             Http2HeadersFrame pushedHeader = inboundHandler.readInbound();
             assertEquals(pushedHeader.stream().id(), pushedCh.stream().id());
-            assertNotNull(inboundHandler.readInbound());
+            Http2DataFrame data = inboundHandler.readInbound();
+            assertNotNull(data);
+            release(pushedHeader);
+            release(data);
         }
     }
 


### PR DESCRIPTION
 Fix NullPointerException when receiving server push in Http2MultiplexHandler
    
Motivation:
We don't create a child channel for a reserved stream when it receive a header frame, and it can cause NullPointerException in Http2MultiplexHandler.channelRead().
    
Modifications:
Create child channel for reserved stream and add tests for it.
    
Result:
We can received server push.