### PR TITLE
Use j.u.Consumer interface instead of bespoke copy

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
@@ -26,6 +26,7 @@ import io.netty.util.internal.PlatformDependent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -41,11 +42,6 @@ public class LastInboundHandler implements ChannelHandler {
     private boolean channelActive;
     private String writabilityStates = "";
 
-    // TODO(scott): use JDK 8's Consumer
-    public interface Consumer<T> {
-        void accept(T obj);
-    }
-
     private static final Consumer<Object> NOOP_CONSUMER = obj -> {
     };
 
@@ -55,7 +51,7 @@ public class LastInboundHandler implements ChannelHandler {
     }
 
     public LastInboundHandler() {
-        this(LastInboundHandler.noopConsumer());
+        this(noopConsumer());
     }
 
     public LastInboundHandler(Consumer<ChannelHandlerContext> channelReadCompleteConsumer) {


### PR DESCRIPTION
Motivation:
 Fix a TODO that was due since the "master" branch is baselined on at least Java 8.

Modification:
 Remove our own copy of the Consumer interface and fix usage sites to use j.u.Consumer.
 Also some cleanup.

Result:
 Cleaner code.
