### PR TITLE
Only generate close stack traces when necessary

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -900,7 +900,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             flush0();
         }
 
-        @SuppressWarnings("deprecation")
         protected void flush0() {
             if (inFlush0) {
                 // Avoid re-entrance
@@ -933,7 +932,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 doWrite(outboundBuffer);
             } catch (final Throwable t) {
                 if (t instanceof IOException && config().isAutoClose()) {
-                    /**
+                    /*
                      * Just call {@link #close(ChannelPromise, Throwable, boolean)} here which will take care of
                      * failing all flushed messages and also ensure the actual close of the underlying transport
                      * will happen before the promises are notified.


### PR DESCRIPTION
Motivation:
 In some benchmarks, AbstractChannel.close becomes a hotspot because it always allocates a
 ClosedChannelException, which involves filling out a stack trace for the exception.

Modification:
 The stack trace is only needed if we have an outbound buffer that needs to have its output
 disrupted. I introduce a BufferCloser that delay the creation of the exception until we are
 sure that we need it.

Result:
 This should make closing channels noticeably faster in the common case of an orderly shut down
 or channel close after the last message has been sent. And in the uncommon case, the extra
 BufferCloser allocation should be a pretty small price to pay.
