### PR TITLE
Fix ByteBufUtil.getBytes() incorrectly sharing the array in some cases

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -906,11 +906,12 @@ public final class ByteBufUtil {
         }
 
         if (buf.hasArray()) {
-            if (copy || start != 0 || length != capacity) {
-                int baseOffset = buf.arrayOffset() + start;
-                return Arrays.copyOfRange(buf.array(), baseOffset, baseOffset + length);
+            int baseOffset = buf.arrayOffset() + start;
+            byte[] bytes = buf.array();
+            if (copy || baseOffset != 0 || length != bytes.length) {
+                return Arrays.copyOfRange(bytes, baseOffset, baseOffset + length);
             } else {
-                return buf.array();
+                return bytes;
             }
         }
 

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -915,9 +915,9 @@ public final class ByteBufUtil {
             }
         }
 
-        byte[] v = PlatformDependent.allocateUninitializedArray(length);
-        buf.getBytes(start, v);
-        return v;
+        byte[] bytes = PlatformDependent.allocateUninitializedArray(length);
+        buf.getBytes(start, bytes);
+        return bytes;
     }
 
     /**


### PR DESCRIPTION
Motivation:

If ByteBufUtil.getBytes() is called with copy=false, it does not correctly check that the underlying array can be shared in some cases.

In particular:

* It does not check that the arrayOffset() is zero. This causes it to incorrectly return the underlying array if the other conditions are met. The returned array will be longer than requested, with additional unwanted bytes at its start.
* It assumes that the capacity() of the ByteBuf is equal to the backing array length. This is not true for some types of ByteBuf, such as PooledHeapByteBuf. This causes it to incorrectly return the underlying array if the other conditions are met. The returned array will be longer than requested, with additional unwanted bytes at its end.

Modifications:

This commit fixes the two bugs by:

* Checking that the arrayOffset() is zero before returning the underlying array.
* Comparing the requested length to the underlying array's length, rather than the ByteBuf's capacity, before returning the underlying array.

This commit also adds a series of test cases for ByteBufUtil.getBytes().

Result:

ByteBufUtil.getBytes() now correctly checks whether the underlying array can be shared or not.

The test cases will ensure the bug is not reintroduced in the future.