### PR TITLE
Only execute the close once the already added write operations completes

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -389,6 +389,10 @@ static jint netty_io_uring_ioringOpConnect(JNIEnv* env, jclass clazz) {
     return IORING_OP_CONNECT;
 }
 
+static jint netty_io_uring_ioringOpClose(JNIEnv* env, jclass clazz) {
+    return IORING_OP_CLOSE;
+}
+
 static jint netty_io_uring_ioringEnterGetevents(JNIEnv* env, jclass clazz) {
     return IORING_ENTER_GETEVENTS;
 }
@@ -414,6 +418,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "ioringOpRead", "()I", (void *) netty_io_uring_ioringOpRead },
   { "ioringOpWrite", "()I", (void *) netty_io_uring_ioringOpWrite },
   { "ioringOpConnect", "()I", (void *) netty_io_uring_ioringOpConnect },
+  { "ioringOpClose", "()I", (void *) netty_io_uring_ioringOpClose },
   { "ioringEnterGetevents", "()I", (void *) netty_io_uring_ioringEnterGetevents },
   { "iosqeAsync", "()I", (void *) netty_io_uring_iosqeAsync }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
@@ -196,8 +196,7 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
         super.doRegister();
         if (active) {
             // Register for POLLRDHUP if this channel is already considered active.
-            IOUringSubmissionQueue submissionQueue = submissionQueue();
-            submissionQueue.addPollRdHup(fd().intValue());
+            schedulePollRdHup();
         }
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -291,6 +291,22 @@ final class IOUringSubmissionQueue {
         return submitted;
     }
 
+    public boolean addClose(int fd) {
+        long sqe = 0;
+        boolean submitted = false;
+        while (sqe == 0) {
+            sqe = getSqe();
+
+            if (sqe == 0) {
+                submit();
+                submitted = true;
+            }
+        }
+        setData(sqe, (byte) Native.IORING_OP_CLOSE, 0, fd, 0, 0, 0);
+
+        return submitted;
+    }
+
     private int flushSqe() {
         long kTail = toUnsignedLong(PlatformDependent.getInt(kTailAddress));
         long kHead = toUnsignedLong(PlatformDependent.getIntVolatile(kHeadAddress));

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
@@ -49,6 +49,10 @@ final class LinuxSocket extends Socket {
         return ipv6 ? InternetProtocolFamily.IPv6 : InternetProtocolFamily.IPv4;
     }
 
+    public boolean markClosed() {
+        return super.markClosed();
+    }
+
     void setTimeToLive(int ttl) throws IOException {
         setTimeToLive(intValue(), ttl);
     }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -77,6 +77,7 @@ final class Native {
     static final int IORING_OP_WRITE = NativeStaticallyReferencedJniMethods.ioringOpWrite();
     static final int IORING_OP_POLL_REMOVE = NativeStaticallyReferencedJniMethods.ioringOpPollRemove();
     static final int IORING_OP_CONNECT = NativeStaticallyReferencedJniMethods.ioringOpConnect();
+    static final int IORING_OP_CLOSE = NativeStaticallyReferencedJniMethods.ioringOpClose();
     static final int IORING_OP_WRITEV = NativeStaticallyReferencedJniMethods.ioringOpWritev();
     static final int IORING_ENTER_GETEVENTS = NativeStaticallyReferencedJniMethods.ioringEnterGetevents();
     static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -46,6 +46,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int ioringOpRead();
     static native int ioringOpWrite();
     static native int ioringOpConnect();
+    static native int ioringOpClose();
     static native int ioringEnterGetevents();
     static native int iosqeAsync();
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/PollRemoveTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/PollRemoveTest.java
@@ -64,6 +64,9 @@ public class PollRemoveTest {
     @Test
     public void test() throws Exception {
         io_uring_test();
+
+        Thread.sleep(1000);
+
         io_uring_test();
     }
 }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -600,7 +600,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void close(final ChannelPromise promise) {
+        public void close(final ChannelPromise promise) {
             assertEventLoop();
 
             ClosedChannelException closedChannelException = new ClosedChannelException();


### PR DESCRIPTION
@normanmaurer

Motivation:

We need to be careful that we only execute the close(...) once the write
operation completes as otherwise we may close the underlying socket too
fast and also the writes

Modifications:

Keep track of if we need to delay the close or not and if so execute it
once the write completes

Result:

No more test failures