### PR TITLE
Further reduce io_uring syscalls

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -163,9 +163,8 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
     @Override
     protected abstract AbstractUringUnsafe newUnsafe();
 
-    @Override
-    public AbstractUringUnsafe unsafe() {
-        return (AbstractUringUnsafe) super.unsafe();
+    AbstractUringUnsafe ioUringUnsafe() {
+        return (AbstractUringUnsafe) unsafe();
     }
 
     @Override
@@ -261,7 +260,7 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
     @Override
     protected void doBeginRead() {
         if ((ioState & POLL_IN_SCHEDULED) == 0) {
-            unsafe().schedulePollIn();
+            ioUringUnsafe().schedulePollIn();
         }
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -164,6 +164,11 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
     protected abstract AbstractUringUnsafe newUnsafe();
 
     @Override
+    public AbstractUringUnsafe unsafe() {
+        return (AbstractUringUnsafe) super.unsafe();
+    }
+
+    @Override
     protected boolean isCompatible(final EventLoop loop) {
         return loop instanceof IOUringEventLoop;
     }
@@ -255,9 +260,8 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
     // Channel/ChannelHandlerContext.read() was called
     @Override
     protected void doBeginRead() {
-        final AbstractUringUnsafe unsafe = (AbstractUringUnsafe) unsafe();
         if ((ioState & POLL_IN_SCHEDULED) == 0) {
-            unsafe.schedulePollIn();
+            unsafe().schedulePollIn();
         }
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -85,10 +85,6 @@ final class IOUringCompletionQueue {
           if (!callback.handle(fd, res, flags, op, mask)) {
               break;
           }
-          if (ringHead == tail) {
-              // Check again with barrier in case tail has moved on
-              tail = PlatformDependent.getIntVolatile(kTailAddress);
-          }
       }
       return i;
   }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -83,15 +83,13 @@ final class IOUringCompletionQueue {
           int mask = opMask & 0xffff;
 
           i++;
-          if (!callback.handle(fd, res, flags, op, mask)) {
-              break;
-          }
+          callback.handle(fd, res, flags, op, mask);
       }
       return i;
   }
 
   interface IOUringCompletionQueueCallback {
-      boolean handle(int fd, int res, long flags, int op, int mask);
+      void handle(int fd, int res, int flags, int op, int mask);
   }
 
   public boolean ioUringWaitCqe() {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -39,6 +39,9 @@ final class IOUringCompletionQueue {
   private final int ringSize;
   private final long ringAddress;
   private final int ringFd;
+  
+  private final int ringMask;
+  private int ringHead;
 
   IOUringCompletionQueue(long kHeadAddress, long kTailAddress, long kringMaskAddress, long kringEntries,
       long kOverflowAddress, long completionQueueArrayAddress, int ringSize, long ringAddress, int ringFd) {
@@ -51,37 +54,44 @@ final class IOUringCompletionQueue {
     this.ringSize = ringSize;
     this.ringAddress = ringAddress;
     this.ringFd = ringFd;
+
+    this.ringMask = PlatformDependent.getInt(kringMaskAddress);
+    this.ringHead = PlatformDependent.getInt(kHeadAddress);
+  }
+
+  public boolean hasCompletions() {
+      return ringHead != PlatformDependent.getIntVolatile(kTailAddress);
   }
 
   public int process(IOUringCompletionQueueCallback callback) {
+      int tail = PlatformDependent.getIntVolatile(kTailAddress);
+      if (ringHead == tail) {
+          return 0;
+      }
       int i = 0;
       for (;;) {
-          long head = toUnsignedLong(PlatformDependent.getIntVolatile(kHeadAddress));
-          if (head != toUnsignedLong(PlatformDependent.getInt(kTailAddress))) {
-              long index = head & toUnsignedLong(PlatformDependent.getInt(kringMaskAddress));
-              long cqe = index * CQE_SIZE + completionQueueArrayAddress;
+          long index = ringHead & ringMask;
+          long cqe = index * CQE_SIZE + completionQueueArrayAddress;
 
-              long udata = PlatformDependent.getLong(cqe + CQE_USER_DATA_FIELD);
-              int res = PlatformDependent.getInt(cqe + CQE_RES_FIELD);
-              long flags = toUnsignedLong(PlatformDependent.getInt(cqe + CQE_FLAGS_FIELD));
+          long udata = PlatformDependent.getLong(cqe + CQE_USER_DATA_FIELD);
+          int res = PlatformDependent.getInt(cqe + CQE_RES_FIELD);
+          int flags = PlatformDependent.getInt(cqe + CQE_FLAGS_FIELD);
 
-              //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
-              PlatformDependent.putIntOrdered(kHeadAddress, (int) (head + 1));
+          //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
+          PlatformDependent.putIntOrdered(kHeadAddress, ++ringHead);
 
-              int fd = (int) (udata >> 32);
-              int opMask = (int) udata;
-              short op = (short) (opMask >> 16);
-              short mask = (short) opMask;
+          int fd = (int) (udata >>> 32);
+          int opMask = (int) (udata & 0xFFFFFFFFL);
+          int op = opMask >>> 16;
+          int mask = opMask & 0xffff;
 
-              i++;
-              if (!callback.handle(fd, res, flags, op, mask)) {
-                  break;
-              }
-          } else {
-              if (i == 0) {
-                  return -1;
-              }
-              return i;
+          i++;
+          if (!callback.handle(fd, res, flags, op, mask)) {
+              break;
+          }
+          // Check again with barrier in case tail has moved on
+          if (ringHead == tail && ringHead == (tail = PlatformDependent.getIntVolatile(kTailAddress))) {
+              break;
           }
       }
       return i;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -143,20 +143,20 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
                 // avoid blocking for as long as possible
                 completionQueue.process(this);
                 boolean ranTasks = runAllTasks();
-                if (!ranTasks) {
-                    break;
-                }
 
                 try {
                     if (isShuttingDown()) {
                         closeAll();
-                        submissionQueue.submit();
                         if (confirmShutdown()) {
-                            break;
+                            return;
                         }
                     }
                 } catch (Throwable t) {
                     logger.info("Exception error: {}", t);
+                }
+
+                if (!ranTasks) {
+                    break;
                 }
             }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -138,56 +138,78 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         addEventFdRead(submissionQueue);
 
         for (;;) {
-            logger.trace("Run IOUringEventLoop {}", this.toString());
-
-            // Prepare to block wait
-            long curDeadlineNanos = nextScheduledTaskDeadlineNanos();
-            if (curDeadlineNanos == -1L) {
-                curDeadlineNanos = NONE; // nothing on the calendar
-            }
-            nextWakeupNanos.set(curDeadlineNanos);
-
-            // Only submit a timeout if there are no tasks to process and do a blocking operation
-            // on the completionQueue.
             try {
-                if (!hasTasks()) {
-                    if (curDeadlineNanos != prevDeadlineNanos) {
-                        prevDeadlineNanos = curDeadlineNanos;
-                        submissionQueue.addTimeout(deadlineToDelayNanos(curDeadlineNanos));
-                    }
+                logger.trace("Run IOUringEventLoop {}", this);
 
-                    // Check there were any completion events to process
-                    if (!completionQueue.hasCompletions()) {
-                        // Block if there is nothing to process after this try again to call process(....)
-                        logger.trace("submitAndWait {}", this);
-                        submissionQueue.submitAndWait();
-                    }
+                // Prepare to block wait
+                long curDeadlineNanos = nextScheduledTaskDeadlineNanos();
+                if (curDeadlineNanos == -1L) {
+                    curDeadlineNanos = NONE; // nothing on the calendar
                 }
-            } catch (Throwable t) {
-                //Todo handle exception
-            } finally {
-                if (nextWakeupNanos.get() == AWAKE || nextWakeupNanos.getAndSet(AWAKE) == AWAKE) {
-                    pendingWakeup = true;
-                }
-            }
+                nextWakeupNanos.set(curDeadlineNanos);
 
-            // avoid blocking for as long as possible - loop until two consecutive "empty" results
-            boolean maybeMoreTasks;
-            boolean maybeMoreIo;
-            do {
-                maybeMoreIo = completionQueue.process(this) != 0;
-                maybeMoreTasks = runAllTasks();
+                // Only submit a timeout if there are no tasks to process and do a blocking operation
+                // on the completionQueue.
                 try {
-                    if (isShuttingDown()) {
-                        closeAll();
-                        if (confirmShutdown()) {
-                            return;
+                    if (!hasTasks()) {
+                        if (curDeadlineNanos != prevDeadlineNanos) {
+                            prevDeadlineNanos = curDeadlineNanos;
+                            submissionQueue.addTimeout(deadlineToDelayNanos(curDeadlineNanos));
+                        }
+
+                        // Check there were any completion events to process
+                        if (!completionQueue.hasCompletions()) {
+                            // Block if there is nothing to process after this try again to call process(....)
+                            logger.trace("submitAndWait {}", this);
+                            submissionQueue.submitAndWait();
                         }
                     }
-                } catch (Throwable t) {
-                    logger.info("Exception error: {}", t);
+                } finally {
+                    if (nextWakeupNanos.get() == AWAKE || nextWakeupNanos.getAndSet(AWAKE) == AWAKE) {
+                        pendingWakeup = true;
+                    }
                 }
-            } while (maybeMoreTasks | maybeMoreIo);
+
+                // avoid blocking for as long as possible - loop until available work exhausted
+                boolean maybeMoreWork = true;
+                do {
+                    try {
+                        maybeMoreWork = completionQueue.process(this) != 0 | runAllTasks();
+                    } finally {
+                        // Always handle shutdown even if the loop processing threw an exception
+                        try {
+                            if (isShuttingDown()) {
+                                closeAll();
+                                if (confirmShutdown()) {
+                                    return;
+                                }
+                                if (!maybeMoreWork) {
+                                    maybeMoreWork = hasTasks() || completionQueue.hasCompletions();
+                                }
+                            }
+                        } catch (Throwable t) {
+                            handleLoopException(t);
+                        }
+                    }
+                } while (maybeMoreWork);
+            } catch (Throwable t) {
+                handleLoopException(t);
+            }
+        }
+    }
+
+    /**
+     * Visible only for testing!
+     */
+    void handleLoopException(Throwable t) {
+        logger.warn("Unexpected exception in the io_uring event loop", t);
+
+        // Prevent possible consecutive immediate failures that lead to
+        // excessive CPU consumption.
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            // Ignore.
         }
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -169,32 +169,36 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
                         pendingWakeup = true;
                     }
                 }
-
-                // avoid blocking for as long as possible - loop until available work exhausted
-                boolean maybeMoreWork = true;
-                do {
-                    try {
-                        maybeMoreWork = completionQueue.process(this) != 0 | runAllTasks();
-                    } finally {
-                        // Always handle shutdown even if the loop processing threw an exception
-                        try {
-                            if (isShuttingDown()) {
-                                closeAll();
-                                if (confirmShutdown()) {
-                                    return;
-                                }
-                                if (!maybeMoreWork) {
-                                    maybeMoreWork = hasTasks() || completionQueue.hasCompletions();
-                                }
-                            }
-                        } catch (Throwable t) {
-                            handleLoopException(t);
-                        }
-                    }
-                } while (maybeMoreWork);
             } catch (Throwable t) {
                 handleLoopException(t);
             }
+
+            // Avoid blocking for as long as possible - loop until available work exhausted
+            boolean maybeMoreWork = true;
+            do {
+                try {
+                    // CQE processing can produce tasks, and new CQEs could arrive while
+                    // processing tasks. So run both on every iteration and break when
+                    // they both report that nothing was done (| means always run both).
+                    maybeMoreWork = completionQueue.process(this) != 0 | runAllTasks();
+                } catch (Throwable t) {
+                    handleLoopException(t);
+                }
+                // Always handle shutdown even if the loop processing threw an exception
+                try {
+                    if (isShuttingDown()) {
+                        closeAll();
+                        if (confirmShutdown()) {
+                            return;
+                        }
+                        if (!maybeMoreWork) {
+                            maybeMoreWork = hasTasks() || completionQueue.hasCompletions();
+                        }
+                    }
+                } catch (Throwable t) {
+                    handleLoopException(t);
+                }
+            } while (maybeMoreWork);
         }
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -140,7 +140,9 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         for (;;) {
             logger.trace("Run IOUringEventLoop {}", this.toString());
             // avoid blocking for as long as possible - loop until two consecutive "empty" results
-            for (boolean maybeMoreIo = true, maybeMoreTasks = true; maybeMoreIo | maybeMoreTasks;) {
+            boolean maybeMoreTasks = true;
+            boolean maybeMoreIo;
+            do {
                 maybeMoreIo = completionQueue.process(this) != 0;
                 if (!maybeMoreIo & !maybeMoreTasks) {
                     break; // no need to check tasks again here
@@ -156,7 +158,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
                 } catch (Throwable t) {
                     logger.info("Exception error: {}", t);
                 }
-            }
+            } while (maybeMoreIo | maybeMoreTasks);
 
             // No more work, prepare to block wait
             long curDeadlineNanos = nextScheduledTaskDeadlineNanos();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -254,27 +254,27 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
             } else if (op == Native.IORING_OP_CONNECT) {
                 handleConnect(channel, res);
             }
-            channel.unsafe().processDelayedClose();
+            channel.ioUringUnsafe().processDelayedClose();
         }
     }
 
     private void handleRead(AbstractIOUringChannel channel, int res) {
-        channel.unsafe().readComplete(res);
+        channel.ioUringUnsafe().readComplete(res);
     }
 
     private void handleWrite(AbstractIOUringChannel channel, int res) {
-        channel.unsafe().writeComplete(res);
+        channel.ioUringUnsafe().writeComplete(res);
     }
 
     private void handlePollAdd(AbstractIOUringChannel channel, int res, int pollMask) {
         if ((pollMask & Native.POLLOUT) != 0) {
-            channel.unsafe().pollOut(res);
+            channel.ioUringUnsafe().pollOut(res);
         }
         if ((pollMask & Native.POLLIN) != 0) {
-            channel.unsafe().pollIn(res);
+            channel.ioUringUnsafe().pollIn(res);
         }
         if ((pollMask & Native.POLLRDHUP) != 0) {
-            channel.unsafe().pollRdHup(res);
+            channel.ioUringUnsafe().pollRdHup(res);
         }
     }
 
@@ -283,7 +283,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
     }
 
     private void handleConnect(AbstractIOUringChannel channel, int res) {
-        channel.unsafe().connectComplete(res);
+        channel.ioUringUnsafe().connectComplete(res);
     }
 
     @Override

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -101,15 +101,18 @@ final class IOUringSubmissionQueue {
     }
 
     private boolean enqueueSqe(int op, int rwFlags, int fd, long bufferAddress, int length, long offset) {
-        boolean submitted = false;
         int pending = tail - head;
-        if (pending == ringEntries) {
-            submit();
-            submitted = true;
+        boolean submit = pending == ringEntries;
+        if (submit) {
+            int submitted = submit();
+            if (submitted == 0) {
+                // We have a problem, could not submit to make more room in the ring
+                throw new RuntimeException("SQ ring full and no submissions accepted");
+            }
         }
         long sqe = submissionQueueArrayAddress + (tail++ & ringMask) * SQE_SIZE;
         setData(sqe, op, rwFlags, fd, bufferAddress, length, offset);
-        return submitted;
+        return submit;
     }
 
     private void setData(long sqe, int op, int rwFlags, int fd, long bufferAddress, int length, long offset) {
@@ -185,36 +188,35 @@ final class IOUringSubmissionQueue {
         return enqueueSqe(Native.IORING_OP_CLOSE, 0, fd, 0, 0, 0);
     }
 
-    public void submit() {
+    public int submit() {
         int submit = tail - head;
-        if (submit > 0) {
-            submit(submit, 0, 0);
-        }
+        return submit > 0 ? submit(submit, 0, 0) : 0;
     }
 
-    public void submitAndWait() {
+    public int submitAndWait() {
         int submit = tail - head;
         if (submit > 0) {
-            submit(submit, 1, Native.IORING_ENTER_GETEVENTS);
-        } else {
-            int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
-            if (ret < 0) {
-                throw new RuntimeException("ioUringEnter syscall");
-            }
+            return submit(submit, 1, Native.IORING_ENTER_GETEVENTS);
         }
+        int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
+        if (ret < 0) {
+            throw new RuntimeException("ioUringEnter syscall returned " + ret);
+        }
+        return ret; // should be 0
     }
 
-    public void submit(int toSubmit, int minComplete, int flags) {
+    private int submit(int toSubmit, int minComplete, int flags) {
         PlatformDependent.putIntOrdered(kTailAddress, tail); // release memory barrier
         int ret = Native.ioUringEnter(ringFd, toSubmit, minComplete, flags);
         head = PlatformDependent.getIntVolatile(kHeadAddress); // acquire memory barrier
         if (ret != toSubmit) {
             if (ret < 0) {
-                throw new RuntimeException("ioUringEnter syscall");
+                throw new RuntimeException("ioUringEnter syscall returned " + ret);
             }
             logger.warn("Not all submissions succeeded");
         }
         submissionCallback.run();
+        return ret;
     }
 
     private void setTimeout(long timeoutNanoSeconds) {
@@ -247,6 +249,8 @@ final class IOUringSubmissionQueue {
         PlatformDependent.freeMemory(timeoutMemoryAddress);
     }
 
+    // The getters below are called from JNI code
+
     public int getRingEntries() {
         return this.ringEntries;
     }
@@ -270,5 +274,4 @@ final class IOUringSubmissionQueue {
     public long getRingAddress() {
         return this.ringAddress;
     }
-
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -198,6 +198,7 @@ final class IOUringSubmissionQueue {
         if (submit > 0) {
             return submit(submit, 1, Native.IORING_ENTER_GETEVENTS);
         }
+        assert submit == 0;
         int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
         if (ret < 0) {
             throw new RuntimeException("ioUringEnter syscall returned " + ret);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -61,10 +61,9 @@ public class NativeTest {
         assertTrue(completionQueue.ioUringWaitCqe());
         assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
             @Override
-            public boolean handle(int fd, int res, long flags, int op, int mask) {
+            public void handle(int fd, int res, int flags, int op, int mask) {
                 assertEquals(inputString.length(), res);
                 writeEventByteBuf.release();
-                return true;
             }
         }));
 
@@ -76,10 +75,9 @@ public class NativeTest {
         assertTrue(completionQueue.ioUringWaitCqe());
         assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
             @Override
-            public boolean handle(int fd, int res, long flags, int op, int mask) {
+            public void handle(int fd, int res, int flags, int op, int mask) {
                 assertEquals(inputString.length(), res);
                 readEventByteBuf.writerIndex(res);
-                return true;
             }
         }));
         byte[] dataRead = new byte[inputString.length()];
@@ -109,9 +107,8 @@ public class NativeTest {
                 try {
                     completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
                         @Override
-                        public boolean handle(int fd, int res, long flags, int op, int mask) {
+                        public void handle(int fd, int res, int flags, int op, int mask) {
                             assertEquals(-62, res);
-                            return true;
                         }
                     });
                 } catch (Exception e) {
@@ -158,9 +155,8 @@ public class NativeTest {
         assertTrue(completionQueue.ioUringWaitCqe());
         assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
             @Override
-            public boolean handle(int fd, int res, long flags, int op, int mask) {
+            public void handle(int fd, int res, int flags, int op, int mask) {
                 assertEquals(1, res);
-                return true;
             }
         }));
         try {
@@ -190,9 +186,8 @@ public class NativeTest {
                 assertTrue(completionQueue.ioUringWaitCqe());
                 assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
                     @Override
-                    public boolean handle(int fd, int res, long flags, int op, int mask) {
+                    public void handle(int fd, int res, int flags, int op, int mask) {
                         assertEquals(1, res);
-                        return true;
                     }
                 }));
             }
@@ -242,7 +237,7 @@ public class NativeTest {
             private final IOUringCompletionQueue.IOUringCompletionQueueCallback verifyCallback =
                     new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
                 @Override
-                public boolean handle(int fd, int res, long flags, int op, int mask) {
+                public void handle(int fd, int res, int flags, int op, int mask) {
                     if (op == Native.IORING_OP_POLL_ADD) {
                         assertEquals(Native.ERRNO_ECANCELED_NEGATIVE, res);
                     } else if (op == Native.IORING_OP_POLL_REMOVE) {
@@ -250,7 +245,6 @@ public class NativeTest {
                     } else {
                         fail("op " + op);
                     }
-                    return false;
                 }
             };
 
@@ -258,9 +252,7 @@ public class NativeTest {
             public void run() {
                 try {
                     assertTrue(completionQueue.ioUringWaitCqe());
-                    assertEquals(1, completionQueue.process(verifyCallback));
-                    assertTrue(completionQueue.ioUringWaitCqe());
-                    assertEquals(1, completionQueue.process(verifyCallback));
+                    assertEquals(2, completionQueue.process(verifyCallback));
                 } catch (AssertionError error) {
                     errorRef.set(error);
                 }


### PR DESCRIPTION
Motivation

IOUringEventLoop can be streamlined to further reduce io_uring_enter calls in some cases

Modification

- Don't prepare to block-wait until all available work is exhausted
- Combine submission with GETEVENTS

Result

Hopefully faster