### PR TITLE
Remove workaround for previous io_uring bug related to IOSQE_ASYNC and

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -137,10 +137,7 @@ final class IOUringSubmissionQueue {
         }
 
         // TODO: Make it configurable if we should use this flag or not.
-        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD,
-                // Workaround for a kernel bug:
-                // See https://lore.kernel.org/io-uring/6428c1ee0234105d18c5e3e88aa00c57@nickhill.org/T/#t
-                (byte) (op != Native.IORING_OP_WRITEV ? Native.IOSQE_ASYNC : 0));
+        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, (byte) Native.IOSQE_ASYNC);
 
         // pad field array -> all fields should be zero
         long offsetIndex = 0;


### PR DESCRIPTION
IOURING_OP_WRITEV

Motivation:

The bug related to IOSQE_ASYNC and IORING_OP_WRITEV was fixed so no need
to have the workaround

Modifications:

Remove workaround

Result:

Use IOSQE_ASYNC all the time
