### PR TITLE
Only schedule another read if the FD is still open

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -483,8 +483,11 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
         }
 
         protected final void scheduleRead() {
-            ioState |= READ_SCHEDULED;
-            scheduleRead0();
+            // Only schedule another read if the fd is still open.
+            if (fd().isOpen()) {
+                ioState |= READ_SCHEDULED;
+                scheduleRead0();
+            }
         }
 
         protected abstract void scheduleRead0();


### PR DESCRIPTION
Motivation:

We should only keep on reading if the fd is still open, otherwise we
will produce a confusing exception

Modifications:

check if fd is still open before schedule the read.

Result:

Dont produce a confusing excepion when the fd was closed during a read
loop.