### PR TITLE
Fix AssertionError caused by incorrect for loop

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -181,7 +181,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
     }
 
     private void clearUsedIovArrays() {
-        for (int i = 0; i < iovArrayIdx; i++) {
+        for (int i = 0; i <= iovArrayIdx; i++) {
             iovArrays[i].clear();
         }
         iovArrayIdx = 0;


### PR DESCRIPTION
Motivation:

incorrect for loop we could end up with an AssertionError (this is
sometimes triggered during testsuite run)

Modifications:

Fix for loop that calls IovArray.clear()

Result:

No more AssertionError