### PR TITLE
Disable Maven build HTTP connection pooling

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -19,15 +19,15 @@ services:
 
   test-leak:
     <<: *common
-    command: /bin/bash -cl "./mvnw -Pleak clean install -Dio.netty.testsuite.badHost=netty.io"
+    command: /bin/bash -cl "./mvnw -Pleak clean install -Dio.netty.testsuite.badHost=netty.io -Dmaven.wagon.http.pool=false"
 
   test:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io"
+    command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io -Dmaven.wagon.http.pool=false"
 
   test-boringssl-static:
     <<: *common
-    command: /bin/bash -cl "./mvnw -P boringssl clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
+    command: /bin/bash -cl "./mvnw -P boringssl clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true -Dmaven.wagon.http.pool=false"
 
   shell:
     <<: *common


### PR DESCRIPTION
Motivation:
 The builds often fail when downloading dependencies.
 This might be caused by the build taking a long time, and cause pooled connections to be closed
 by the remote end, if they are idle for too long.

Modification:
 Disable connection pooling. This should force Maven to reestablish the connection for each download,
 thus reducing the likelihood of the remote end closing connections we wish to use.

Result:
 I'll leave it up the statistis of our CI to confirm, but we should see more stable builds.
