### PR TITLE
Cleanup IOUringEventLoopGroup construction and allow to specify the ring

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoopGroup.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoopGroup.java
@@ -15,14 +15,14 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopTaskQueueFactory;
 import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.SelectStrategyFactory;
+import io.netty.util.concurrent.DefaultEventExecutorChooserFactory;
 import io.netty.util.concurrent.EventExecutorChooserFactory;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
+import io.netty.util.concurrent.ThreadPerTaskExecutor;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -46,105 +46,57 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
     /**
      * Create a new instance using the default number of threads and the given {@link ThreadFactory}.
      */
-    @SuppressWarnings("deprecation")
     public IOUringEventLoopGroup(ThreadFactory threadFactory) {
         this(0, threadFactory, 0);
     }
 
     /**
-     * Create a new instance using the specified number of threads and the default {@link ThreadFactory}.
-     */
-    @SuppressWarnings("deprecation")
-    public IOUringEventLoopGroup(int nThreads, SelectStrategyFactory selectStrategyFactory) {
-        this(nThreads, (ThreadFactory) null, selectStrategyFactory);
-    }
-
-    /**
      * Create a new instance using the specified number of threads and the given {@link ThreadFactory}.
      */
-    @SuppressWarnings("deprecation")
     public IOUringEventLoopGroup(int nThreads, ThreadFactory threadFactory) {
         this(nThreads, threadFactory, 0);
     }
 
     public IOUringEventLoopGroup(int nThreads, Executor executor) {
-        this(nThreads, executor, DefaultSelectStrategyFactory.INSTANCE);
-    }
-
-    /**
-     * Create a new instance using the specified number of threads and the given {@link ThreadFactory}.
-     */
-    @SuppressWarnings("deprecation")
-    public IOUringEventLoopGroup(int nThreads, ThreadFactory threadFactory,
-                                 SelectStrategyFactory selectStrategyFactory) {
-        this(nThreads, threadFactory, 0, selectStrategyFactory);
+        this(nThreads, executor, 0);
     }
 
     /**
      * Create a new instance using the specified number of threads, the given {@link ThreadFactory} and the given
-     * maximal amount of epoll events to handle per epollWait(...).
-     *
-     * @deprecated Use {@link #IOUringEventLoopGroup(int)} or {@link #IOUringEventLoopGroup(int, ThreadFactory)}
+     * maximal size of the used ringbuffer.
      */
-    @Deprecated
-    public IOUringEventLoopGroup(int nThreads, ThreadFactory threadFactory, int maxEventsAtOnce) {
-        this(nThreads, threadFactory, maxEventsAtOnce, DefaultSelectStrategyFactory.INSTANCE);
+    public IOUringEventLoopGroup(int nThreads, ThreadFactory threadFactory, int ringSize) {
+        this(nThreads, threadFactory == null ? null : new ThreadPerTaskExecutor(threadFactory), ringSize);
     }
 
-    /**
-     * Create a new instance using the specified number of threads, the given {@link ThreadFactory} and the given
-     * maximal amount of epoll events to handle per epollWait(...).
-     *
-     * @deprecated Use {@link #IOUringEventLoopGroup(int)}, {@link #IOUringEventLoopGroup(int, ThreadFactory)}, or
-     * {@link #IOUringEventLoopGroup(int, SelectStrategyFactory)}
-     */
-    @Deprecated
-    public IOUringEventLoopGroup(int nThreads, ThreadFactory threadFactory, int maxEventsAtOnce,
-                                 SelectStrategyFactory selectStrategyFactory) {
-        super(nThreads, threadFactory, maxEventsAtOnce, selectStrategyFactory, RejectedExecutionHandlers.reject());
+    public IOUringEventLoopGroup(int nThreads, Executor executor, int ringsize) {
+        this(nThreads, executor, DefaultEventExecutorChooserFactory.INSTANCE,
+                ringsize, RejectedExecutionHandlers.reject());
     }
 
-    public IOUringEventLoopGroup(int nThreads, Executor executor, SelectStrategyFactory selectStrategyFactory) {
-        super(nThreads, executor, 0, selectStrategyFactory, RejectedExecutionHandlers.reject());
+    private IOUringEventLoopGroup(int nThreads, Executor executor, EventExecutorChooserFactory chooserFactory,
+                                  int ringSize, RejectedExecutionHandler rejectedExecutionHandler) {
+        this(nThreads, executor, chooserFactory, ringSize, rejectedExecutionHandler, null);
     }
 
-    public IOUringEventLoopGroup(int nThreads, Executor executor, EventExecutorChooserFactory chooserFactory,
-                                 SelectStrategyFactory selectStrategyFactory) {
-        super(nThreads, executor, chooserFactory, 0, selectStrategyFactory, RejectedExecutionHandlers.reject());
-    }
-
-    public IOUringEventLoopGroup(int nThreads, Executor executor, EventExecutorChooserFactory chooserFactory,
-                                 SelectStrategyFactory selectStrategyFactory,
-                                 RejectedExecutionHandler rejectedExecutionHandler) {
-        super(nThreads, executor, chooserFactory, 0, selectStrategyFactory, rejectedExecutionHandler);
-    }
-
-    public IOUringEventLoopGroup(int nThreads, Executor executor, EventExecutorChooserFactory chooserFactory,
-                                 SelectStrategyFactory selectStrategyFactory,
-                                 RejectedExecutionHandler rejectedExecutionHandler,
-                                 EventLoopTaskQueueFactory queueFactory) {
-        super(nThreads, executor, chooserFactory, 0,
-              selectStrategyFactory, rejectedExecutionHandler, queueFactory);
-    }
-
-    /**
-     * @deprecated This method will be removed in future releases, and is not guaranteed to have any impacts.
-     */
-    @Deprecated
-    public void setIoRatio(int ioRatio) {
-        if (ioRatio <= 0 || ioRatio > 100) {
-            throw new IllegalArgumentException("ioRatio: " + ioRatio + " (expected: 0 < ioRatio <= 100)");
-        }
+    private IOUringEventLoopGroup(int nThreads, Executor executor, EventExecutorChooserFactory chooserFactory,
+                                  int ringSize, RejectedExecutionHandler rejectedExecutionHandler,
+                                  EventLoopTaskQueueFactory queueFactory) {
+        super(nThreads, executor, chooserFactory, ringSize, rejectedExecutionHandler, queueFactory);
     }
 
     //Todo
     @Override
-    protected EventLoop newChild(Executor executor, Object... args) throws Exception {
-     //EventLoopTaskQueueFactory queueFactory = args.length == 4? (EventLoopTaskQueueFactory) args[3] : null;
-//        return new IOUringEventLoop(this, executor, (Integer) args[0],
-//                ((SelectStrategyFactory) args[1]).newSelectStrategy(),
-//                (RejectedExecutionHandler) args[2], queueFactory);
-
-        return new IOUringEventLoop(this, executor, false);
+    protected EventLoop newChild(Executor executor, Object... args) {
+        if (args.length != 3) {
+            throw new IllegalArgumentException("Illegal amount of extra arguments");
+        }
+        int ringSize = (Integer) args[0];
+        if (ringSize == 0) {
+            ringSize = Native.DEFAULT_RING_SIZE;
+        }
+        RejectedExecutionHandler rejectedExecutionHandler = (RejectedExecutionHandler) args[1];
+        EventLoopTaskQueueFactory taskQueueFactory = (EventLoopTaskQueueFactory) args[2];
+        return new IOUringEventLoop(this, executor, ringSize, rejectedExecutionHandler, taskQueueFactory);
     }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoopGroup.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoopGroup.java
@@ -23,6 +23,7 @@ import io.netty.util.concurrent.EventExecutorChooserFactory;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -92,6 +93,7 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
             throw new IllegalArgumentException("Illegal amount of extra arguments");
         }
         int ringSize = (Integer) args[0];
+        ObjectUtil.checkPositiveOrZero(ringSize, "ringSize");
         if (ringSize == 0) {
             ringSize = Native.DEFAULT_RING_SIZE;
         }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
-    static final int DEFAULT_RING_SIZE = SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096);
+    static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096));
 
     static {
         Selector selector = null;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -30,10 +30,9 @@ import java.util.Locale;
 
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
-    // Todo expose this via the EventLoopGroup constructor as well.
-    private static final int DEFAULT_RING_SIZE = SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096);
+    static final int DEFAULT_RING_SIZE = SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096);
 
-     static {
+    static {
         Selector selector = null;
         try {
             // We call Selector.open() as this will under the hood cause IOUtil to be loaded.


### PR DESCRIPTION
size.

Motivation:

We should allow to specify the ringsize when constructing the
IOUringEventLoopGroup and also be constistent with the rest of the
EventLoopGroup implementations

Modifications:

- Cleanup constructors
- Make ringSize configurable

Result:

Cleaner code and more flexible in terms of configuration