### PR TITLE
Make RetainedHandlingPolicy enum public

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscriptionOption.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscriptionOption.java
@@ -20,7 +20,7 @@ package io.netty.handler.codec.mqtt;
  */
 public final class MqttSubscriptionOption {
 
-    enum RetainedHandlingPolicy {
+    public enum RetainedHandlingPolicy {
         SEND_AT_SUBSCRIBE(0),
         SEND_AT_SUBSCRIBE_IF_NOT_YET_EXISTS(1),
         DONT_SEND_AT_SUBSCRIBE(2);


### PR DESCRIPTION
Motivation:

Impossible to specify retained messages handling policy because the corresponding enum
isn't public (https://github.com/netty/netty/issues/10562)

Modification:

Made `RetainedHandlingPolicy` public

Result:

Fixes #10562. 

