### PR TITLE
Drain all of the input when a POLLRDHUP was received to ensure we not

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -79,10 +79,8 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
     private int ioState;
 
     private ChannelPromise delayedClose;
-
-    boolean inputClosedSeenErrorOnRead;
-
-    static final int SOCK_ADDR_LEN = 128;
+    private boolean inputClosedSeenErrorOnRead;
+    private static final int SOCK_ADDR_LEN = 128;
 
     /**
      * The future of the current connection attempt.  If not null, subsequent connection attempts will fail.
@@ -486,6 +484,10 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
             if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
                 return;
             }
+
+            // Mark that we received a POLLRDHUP and so need to continue reading until all the input ist drained.
+            recvBufAllocHandle().rdHupReceived();
+
             if (isActive()) {
                 if ((ioState & READ_SCHEDULED) == 0) {
                     scheduleFirstRead();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDetectPeerCloseWithReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDetectPeerCloseWithReadTest.java
@@ -19,8 +19,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.unix.tests.DetectPeerCloseWithoutReadTest;
-import org.junit.Ignore;
-import org.junit.Test;
 
 public class IOUringDetectPeerCloseWithReadTest extends DetectPeerCloseWithoutReadTest {
     @Override
@@ -36,19 +34,5 @@ public class IOUringDetectPeerCloseWithReadTest extends DetectPeerCloseWithoutRe
     @Override
     protected Class<? extends Channel> clientChannel() {
         return IOUringSocketChannel.class;
-    }
-
-    @Ignore("FIX ME")
-    @Test
-    @Override
-    public void clientCloseWithoutServerReadIsDetectedNoExtraReadRequested() throws InterruptedException {
-        super.clientCloseWithoutServerReadIsDetectedNoExtraReadRequested();
-    }
-
-    @Ignore("FIX ME")
-    @Test
-    @Override
-    public void serverCloseWithoutClientReadIsDetectedNoExtraReadRequested() throws InterruptedException {
-        super.serverCloseWithoutClientReadIsDetectedNoExtraReadRequested();
     }
 }


### PR DESCRIPTION
see any stales

Motivation:

When a POLLRDHUP was received we need to continue draining the input
until EOF is detected as otherwise we may see stales when the user never
tries to read again.

Modifications:

- Correctly handle reading when POLLRDHUP was seen
- Remove @Ignore from testcases related to POLLRDHUP handling

Result:

Correctly drain input when POLLRDHUP was received in all cases
