### PR TITLE
Obtain remoteAddress as part of accept

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_linuxsocket.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_linuxsocket.c
@@ -671,6 +671,14 @@ static jlong netty_io_uring_linuxsocket_sendFile(JNIEnv* env, jclass clazz, jint
 
     return res;
 }
+
+static int netty_io_uring_linuxsocket_initInetSocketAddressArray(JNIEnv* env, jclass clazz, jlong acceptedAddressMemoryAddress, long acceptedAddressLengthMemoryAddress, jbyteArray array) {
+    const struct sockaddr_storage* addr = (const struct sockaddr_storage*) acceptedAddressMemoryAddress;
+    jsize len = netty_unix_socket_addressArrayLength(addr);
+    netty_unix_socket_initInetSocketAddressArray(env, addr, array, 0, len);
+    return len;
+}
+
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
@@ -714,7 +722,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { "joinSsmGroup", "(IZ[B[BII[B)V", (void *) netty_io_uring_linuxsocket_joinSsmGroup },
   { "leaveGroup", "(IZ[B[BII)V", (void *) netty_io_uring_linuxsocket_leaveGroup },
   { "leaveSsmGroup", "(IZ[B[BII[B)V", (void *) netty_io_uring_linuxsocket_leaveSsmGroup },
-  {"initAddress", "(IZ[BIIJ)I", (void *) netty_io_uring_initAddress }
+  { "initAddress", "(IZ[BIIJ)I", (void *) netty_io_uring_initAddress },
+  { "initInetSocketAddressArray", "(JJ[B)I", netty_io_uring_linuxsocket_initInetSocketAddressArray }
   // "sendFile" has a dynamic signature
 };
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -80,7 +80,7 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
 
     private ChannelPromise delayedClose;
     private boolean inputClosedSeenErrorOnRead;
-    private static final int SOCK_ADDR_LEN = 128;
+    static final int SOCK_ADDR_LEN = 128;
 
     /**
      * The future of the current connection attempt.  If not null, subsequent connection attempts will fail.

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
@@ -21,16 +21,38 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.unix.Buffer;
 import io.netty.channel.unix.Errors;
 
 import java.net.SocketAddress;
+import java.nio.ByteBuffer;
 
 import static io.netty.channel.unix.Errors.*;
 
 abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel implements ServerChannel {
+    private final ByteBuffer acceptedAddressMemory;
+    private final ByteBuffer acceptedAddressLengthMemory;
+
+    private final long acceptedAddressMemoryAddress;
+    private final long acceptedAddressLengthMemoryAddress;
 
     protected AbstractIOUringServerChannel(LinuxSocket socket, boolean active) {
         super(null, socket, active);
+
+        acceptedAddressMemory = Buffer.allocateDirectWithNativeOrder(SOCK_ADDR_LEN);
+        acceptedAddressMemoryAddress = Buffer.memoryAddress(acceptedAddressMemory);
+        acceptedAddressLengthMemory = Buffer.allocateDirectWithNativeOrder(Long.BYTES);
+        // Needs to be initialized to the size of acceptedAddressMemory.
+        // See https://man7.org/linux/man-pages/man2/accept.2.html
+        acceptedAddressLengthMemory.putLong(0, SOCK_ADDR_LEN);
+        acceptedAddressLengthMemoryAddress = Buffer.memoryAddress(acceptedAddressLengthMemory);
+    }
+
+    @Override
+    protected void doClose() throws Exception {
+        super.doClose();
+        Buffer.free(acceptedAddressMemory);
+        Buffer.free(acceptedAddressLengthMemory);
     }
 
     @Override
@@ -47,17 +69,21 @@ abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel imple
         return this;
     }
 
-    abstract Channel newChildChannel(int fd) throws Exception;
+    abstract Channel newChildChannel(int fd, byte[] address, int offset, int len) throws Exception;
 
     final class UringServerChannelUnsafe extends AbstractIOUringChannel.AbstractUringUnsafe {
+        // Will hold the remote address after accept4(...) was successful.
+        // We need 24 bytes for the address as maximum
+        private final byte[] acceptedAddress = new byte[24];
+
         @Override
         protected void scheduleRead0() {
             final IOUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             allocHandle.attemptedBytesRead(1);
 
             IOUringSubmissionQueue submissionQueue = submissionQueue();
-            //Todo get network addresses
-            submissionQueue.addAccept(fd().intValue());
+            submissionQueue.addAccept(fd().intValue(),
+                    acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress);
         }
 
         protected void readComplete0(int res) {
@@ -70,7 +96,9 @@ abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel imple
             if (res >= 0) {
                 allocHandle.incMessagesRead(1);
                 try {
-                    Channel channel = newChildChannel(res);
+                    int len = LinuxSocket.initInetSocketAddressArray(
+                            acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress, acceptedAddress);
+                    Channel channel = newChildChannel(res, acceptedAddress, 0, len);
                     pipeline.fireChannelRead(channel);
                     if (allocHandle.continueReading()) {
                         scheduleRead();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
@@ -16,9 +16,7 @@
 package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringServerSocketChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringServerSocketChannel.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.channel.Channel;
 import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.unix.NativeInetAddress;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -35,8 +36,8 @@ public final class IOUringServerSocketChannel extends AbstractIOUringServerChann
     }
 
     @Override
-    Channel newChildChannel(int fd) throws Exception {
-        return new IOUringSocketChannel(this, new LinuxSocket(fd));
+    Channel newChildChannel(int fd, byte[] array, int offset, int len) {
+        return new IOUringSocketChannel(this, new LinuxSocket(fd), NativeInetAddress.address(array, offset, len));
     }
 
     @Override

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannel.java
@@ -30,11 +30,6 @@ public final class IOUringSocketChannel extends AbstractIOUringStreamChannel imp
        this.config = new IOUringSocketChannelConfig(this);
     }
 
-    IOUringSocketChannel(final Channel parent, final LinuxSocket fd) {
-        super(parent, fd);
-        this.config = new IOUringSocketChannelConfig(this);
-    }
-
     IOUringSocketChannel(Channel parent, LinuxSocket fd, SocketAddress remote) {
         super(parent, fd, remote);
         this.config = new IOUringSocketChannelConfig(this);

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSocketChannel.java
@@ -20,6 +20,7 @@ import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 public final class IOUringSocketChannel extends AbstractIOUringStreamChannel implements SocketChannel {
     private final IOUringSocketChannelConfig config;
@@ -31,6 +32,11 @@ public final class IOUringSocketChannel extends AbstractIOUringStreamChannel imp
 
     IOUringSocketChannel(final Channel parent, final LinuxSocket fd) {
         super(parent, fd);
+        this.config = new IOUringSocketChannelConfig(this);
+    }
+
+    IOUringSocketChannel(Channel parent, LinuxSocket fd, SocketAddress remote) {
+        super(parent, fd, remote);
         this.config = new IOUringSocketChannelConfig(this);
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -166,8 +166,9 @@ final class IOUringSubmissionQueue {
         return enqueueSqe(Native.IORING_OP_WRITE, 0, fd, bufferAddress + pos, limit - pos, 0);
     }
 
-    public boolean addAccept(int fd) {
-        return enqueueSqe(Native.IORING_OP_ACCEPT, Native.SOCK_NONBLOCK | Native.SOCK_CLOEXEC, fd, 0, 0, 0);
+    public boolean addAccept(int fd, long address, long addressLength) {
+        return enqueueSqe(Native.IORING_OP_ACCEPT, Native.SOCK_NONBLOCK | Native.SOCK_CLOEXEC, fd,
+                address, 0, addressLength);
     }
 
     //fill the address which is associated with server poll link user_data

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
@@ -393,4 +393,6 @@ final class LinuxSocket extends Socket {
     private static native void setTimeToLive(int fd, int ttl) throws IOException;
     private static native int initAddress(
             int fd, boolean ipv6, byte[] address, int scopeId, int port, long memoryAddress);
+
+    static native int initInetSocketAddressArray(long addr, long addressLen, byte[] array);
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSubmissionQueueTest.java
@@ -15,8 +15,11 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.channel.unix.Buffer;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,6 +35,7 @@ public class IOUringSubmissionQueueTest {
     @Test
     public void sqeFullTest() {
         RingBuffer ringBuffer = Native.createRingBuffer(8);
+        ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(128);
         try {
             IOUringSubmissionQueue submissionQueue = ringBuffer.getIoUringSubmissionQueue();
             final IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
@@ -40,12 +44,14 @@ public class IOUringSubmissionQueueTest {
             assertNotNull(submissionQueue);
             assertNotNull(completionQueue);
 
+            long address = Buffer.memoryAddress(buffer);
             int counter = 0;
-            while (!submissionQueue.addAccept(-1)) {
+            while (!submissionQueue.addAccept(-1, address, 128)) {
                 counter++;
             }
             assertEquals(8, counter);
         } finally {
+            Buffer.free(buffer);
             ringBuffer.close();
         }
     }

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -121,7 +121,7 @@ static jobject createDatagramSocketAddress(JNIEnv* env, const struct sockaddr_st
     return obj;
 }
 
-static jsize addressLength(const struct sockaddr_storage* addr) {
+jsize netty_unix_socket_addressArrayLength(const struct sockaddr_storage* addr) {
     int len = netty_unix_socket_ipAddressLength(addr);
     if (len == 4) {
         // Only encode port into it
@@ -131,7 +131,7 @@ static jsize addressLength(const struct sockaddr_storage* addr) {
     return len + 8;
 }
 
-static void initInetSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr, jbyteArray bArray, int offset, jsize len) {
+void netty_unix_socket_initInetSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr, jbyteArray bArray, int offset, jsize len) {
     int port;
     if (addr->ss_family == AF_INET) {
         struct sockaddr_in* s = (struct sockaddr_in*) addr;
@@ -180,12 +180,12 @@ static void initInetSocketAddressArray(JNIEnv* env, const struct sockaddr_storag
 }
 
 jbyteArray netty_unix_socket_createInetSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr) {
-    jsize len = addressLength(addr);
+    jsize len = netty_unix_socket_addressArrayLength(addr);
     jbyteArray bArray = (*env)->NewByteArray(env, len);
     if (bArray == NULL) {
         return NULL;
     }
-    initInetSocketAddressArray(env, addr, bArray, 0, len);
+    netty_unix_socket_initInetSocketAddressArray(env, addr, bArray, 0, len);
     return bArray;
 }
 
@@ -564,7 +564,6 @@ static jint netty_unix_socket_accept(JNIEnv* env, jclass clazz, jint fd, jbyteAr
 #ifdef SOCK_NONBLOCK
         }
 #endif
-
         if (socketFd != -1) {
             break;
         }
@@ -573,12 +572,12 @@ static jint netty_unix_socket_accept(JNIEnv* env, jclass clazz, jint fd, jbyteAr
         }
     }
 
-    len = addressLength(&addr);
+    len = netty_unix_socket_addressArrayLength(&addr);
     len_b = (jbyte) len;
 
     // Fill in remote address details
     (*env)->SetByteArrayRegion(env, acceptedAddress, 0, 1, (jbyte*) &len_b);
-    initInetSocketAddressArray(env, &addr, acceptedAddress, 1, len);
+    netty_unix_socket_initInetSocketAddressArray(env, &addr, acceptedAddress, 1, len);
 
     if (accept4)  {
         return socketFd;

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.h
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.h
@@ -21,6 +21,9 @@
 
 // External C methods
 int netty_unix_socket_initSockaddr(JNIEnv* env, jboolean ipv6, jbyteArray address, jint scopeId, jint jport, const struct sockaddr_storage* addr, socklen_t* addrSize);
+void netty_unix_socket_initInetSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr, jbyteArray bArray, int offset, jsize len);
+jsize netty_unix_socket_addressArrayLength(const struct sockaddr_storage* addr);
+
 jbyteArray netty_unix_socket_createInetSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr);
 
 int netty_unix_socket_getOption(JNIEnv* env, jint fd, int level, int optname, void* optval, socklen_t optlen);


### PR DESCRIPTION
Motivation:

io_uring supports the same way of obtaining the remoteAddress as
accept4(...) does. We should use it

Modifications:

Obtain the remoteAddress of the accepted socket as part of the accept
operation

Result:

Ensure we always see the correct remoteAddress when accepting sockets