### PR TITLE
Simplify JNI init code

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -195,18 +195,15 @@ static void netty_io_uring_eventFdWrite(JNIEnv* env, jclass clazz, jint fd, jlon
 }
 
 static void netty_io_uring_ring_buffer_exit(JNIEnv *env, jclass clazz,
-        jlong submissionQueueArrayAddress, jint submissionQueueRingEntries, jlong submissionQueueRingAddress, jint submissionQueueRingSize, jint submissionQueueRingFd,
-        jlong completionQueueRingAddress, jint completionQueueRingSize, jint completionQueueRingfd) {
+        jlong submissionQueueArrayAddress, jint submissionQueueRingEntries, jlong submissionQueueRingAddress, jint submissionQueueRingSize,
+        jlong completionQueueRingAddress, jint completionQueueRingSize, jint ringFd) {
     munmap((struct io_uring_sqe*) submissionQueueArrayAddress, submissionQueueRingEntries * sizeof(struct io_uring_sqe));
     munmap((void*) submissionQueueRingAddress, submissionQueueRingSize);
 
     if (((void *) completionQueueRingAddress) && ((void *) completionQueueRingAddress) != ((void *) submissionQueueRingAddress)) {
         munmap((void *)completionQueueRingAddress, completionQueueRingSize);
     }
-    close(submissionQueueRingFd);
-    if (completionQueueRingfd != submissionQueueRingFd) {
-        close(completionQueueRingfd);
-    }
+    close(ringFd);
 }
 
 static jobjectArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries) {
@@ -379,7 +376,7 @@ static const jint statically_referenced_fixed_method_table_size = sizeof(statica
 
 static const JNINativeMethod method_table[] = {
     {"ioUringSetup", "(I)[[J", (void *) netty_io_uring_setup},
-    {"ioUringExit", "(JIJIIJII)V", (void *) netty_io_uring_ring_buffer_exit},
+    {"ioUringExit", "(JIJIJII)V", (void *) netty_io_uring_ring_buffer_exit},
     {"createFile", "()I", (void *) netty_create_file},
     {"ioUringEnter", "(IIII)I", (void *)netty_io_uring_enter},
     {"blockingEventFd", "()I", (void *) netty_epoll_native_blocking_event_fd},

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -59,12 +59,7 @@
 #include <sys/eventfd.h>
 #include <poll.h>
 
-static jmethodID ringBufferMethodId = NULL;
-static jmethodID ioUringSubmissionQueueMethodId = NULL;
-static jmethodID ioUringCommpletionQueueMethodId = NULL;
-static jclass ringBufferClass = NULL;
-static jclass ioUringCompletionQueueClass = NULL;
-static jclass ioUringSubmissionQueueClass = NULL;
+static jclass longArrayClass = NULL;
 
 static void netty_io_uring_native_JNI_OnUnLoad(JNIEnv* env) {
     netty_unix_limits_JNI_OnUnLoad(env);
@@ -73,12 +68,7 @@ static void netty_io_uring_native_JNI_OnUnLoad(JNIEnv* env) {
     netty_unix_socket_JNI_OnUnLoad(env);
     netty_unix_buffer_JNI_OnUnLoad(env);
 
-    ringBufferMethodId = NULL;
-    ioUringSubmissionQueueMethodId = NULL;
-    ioUringCommpletionQueueMethodId = NULL;
-    ringBufferClass = NULL;
-    ioUringCompletionQueueClass = NULL;
-    ioUringSubmissionQueueClass = NULL;
+    longArrayClass = NULL;
 }
 
 void io_uring_unmap_rings(struct io_uring_sq *sq, struct io_uring_cq *cq) {
@@ -204,47 +194,41 @@ static void netty_io_uring_eventFdWrite(JNIEnv* env, jclass clazz, jint fd, jlon
     }
 }
 
-static void netty_io_uring_ring_buffer_exit(JNIEnv *env, jclass class, jobject ringBuffer) {
-     // Find the id of the Java method to be called
-
-    jclass ringBufferClass = (*env)->GetObjectClass(env, ringBuffer);
-    jmethodID submissionQueueMethodId = (*env)->GetMethodID(env, ringBufferClass, "getIoUringSubmissionQueue", "()Lio/netty/channel/uring/IOUringSubmissionQueue;");
-    jmethodID completionQueueMethodId = (*env)->GetMethodID(env, ringBufferClass, "getIoUringCompletionQueue", "()Lio/netty/channel/uring/IOUringCompletionQueue;");
-
-    jobject submissionQueue = (*env)->CallObjectMethod(env, ringBuffer, submissionQueueMethodId);
-    jobject completionQueue = (*env)->CallObjectMethod(env, ringBuffer, completionQueueMethodId);
-    jclass submissionQueueClass = (*env)->GetObjectClass(env, submissionQueue);
-    jclass completionQueueClass = (*env)->GetObjectClass(env, completionQueue);
-
-    jfieldID submissionQueueArrayAddressFieldId = (*env)->GetFieldID(env, submissionQueueClass, "submissionQueueArrayAddress", "J");
-    jfieldID submissionQueueRingEntriesFieldId = (*env)->GetFieldID(env, submissionQueueClass, "ringEntries", "I");
-    jfieldID submissionQueueRingFdFieldId = (*env)->GetFieldID(env, submissionQueueClass, "ringFd", "I");
-    jfieldID submissionQueueRingAddressFieldId = (*env)->GetFieldID(env, submissionQueueClass, "ringAddress", "J");
-    jfieldID submissionQueueRingSizeFieldId = (*env)->GetFieldID(env, submissionQueueClass, "ringSize", "I");
-
-    jfieldID completionQueueRingAddressFieldId = (*env)->GetFieldID(env, completionQueueClass, "ringAddress", "J");
-    jfieldID completionQueueRingSizeFieldId = (*env)->GetFieldID(env, completionQueueClass, "ringSize", "I");
-
-    jlong submissionQueueArrayAddress = (*env)->GetLongField(env, submissionQueue, submissionQueueArrayAddressFieldId);
-    jint submissionQueueKringEntries = (*env)->GetIntField(env, submissionQueue, submissionQueueRingEntriesFieldId);
-    jint submissionQueueRingFd = (*env)->GetIntField(env, submissionQueue, submissionQueueRingFdFieldId);
-    jlong submissionQueueRingAddress = (*env)->GetLongField(env, submissionQueue, submissionQueueRingAddressFieldId);
-    jint submissionQueueRingSize = (*env)->GetIntField(env, submissionQueue, submissionQueueRingSizeFieldId);
-
-    jlong completionQueueRingAddress = (*env)->GetLongField(env, completionQueue, completionQueueRingAddressFieldId);
-    jint completionQueueRingSize = (*env)->GetIntField(env, completionQueue, completionQueueRingSizeFieldId);
-
-    munmap((struct io_uring_sqe*) submissionQueueArrayAddress, submissionQueueKringEntries * sizeof(struct io_uring_sqe));
+static void netty_io_uring_ring_buffer_exit(JNIEnv *env, jclass clazz,
+        jlong submissionQueueArrayAddress, jint submissionQueueRingEntries, jlong submissionQueueRingAddress, jint submissionQueueRingSize, jint submissionQueueRingFd,
+        jlong completionQueueRingAddress, jint completionQueueRingSize, jint completionQueueRingfd) {
+    munmap((struct io_uring_sqe*) submissionQueueArrayAddress, submissionQueueRingEntries * sizeof(struct io_uring_sqe));
     munmap((void*) submissionQueueRingAddress, submissionQueueRingSize);
-	if (((void *) completionQueueRingAddress) && ((void *) completionQueueRingAddress) != ((void *) submissionQueueRingAddress)) {
-		munmap((void *)completionQueueRingAddress, completionQueueRingSize);
-	}
-	close(submissionQueueRingFd);
+
+    if (((void *) completionQueueRingAddress) && ((void *) completionQueueRingAddress) != ((void *) submissionQueueRingAddress)) {
+        munmap((void *)completionQueueRingAddress, completionQueueRingSize);
+    }
+    close(submissionQueueRingFd);
+    if (completionQueueRingfd != submissionQueueRingFd) {
+        close(completionQueueRingfd);
+    }
 }
 
-static jobject netty_io_uring_setup(JNIEnv *env, jclass class1, jint entries, jobject submitCallback) {
+static jobjectArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries) {
     struct io_uring_params p;
     memset(&p, 0, sizeof(p));
+
+    jobjectArray array = (*env)->NewObjectArray(env, 2, longArrayClass, NULL);
+    if (array == NULL) {
+        // This will put an OOME on the stack
+        return NULL;
+    }
+    jlongArray submissionArray = (*env)->NewLongArray(env, 11);
+    if (submissionArray == NULL) {
+        // This will put an OOME on the stack
+        return NULL;
+
+    }
+    jlongArray completionArray = (*env)->NewLongArray(env, 9);
+    if (completionArray == NULL) {
+        // This will put an OOME on the stack
+        return NULL;
+    }
 
     int ring_fd = sys_io_uring_setup((int)entries, &p);
 
@@ -260,29 +244,37 @@ static jobject netty_io_uring_setup(JNIEnv *env, jclass class1, jint entries, jo
         return NULL;
     }
 
-    jobject ioUringSubmissionQueue = (*env)->NewObject(
-        env, ioUringSubmissionQueueClass, ioUringSubmissionQueueMethodId,
-        (jlong)io_uring_ring.sq.khead, (jlong)io_uring_ring.sq.ktail,
+    jlong submissionArrayElements[] = {
+        (jlong)io_uring_ring.sq.khead,
+        (jlong)io_uring_ring.sq.ktail,
         (jlong)io_uring_ring.sq.kring_mask,
-        (jlong)io_uring_ring.sq.kring_entries, (jlong)io_uring_ring.sq.kflags,
-        (jlong)io_uring_ring.sq.kdropped, (jlong)io_uring_ring.sq.array,
-        (jlong)io_uring_ring.sq.sqes, (jlong)io_uring_ring.sq.ring_sz,
-        (jlong)io_uring_ring.cq.ring_ptr, (jint)ring_fd, submitCallback);
+        (jlong)io_uring_ring.sq.kring_entries,
+        (jlong)io_uring_ring.sq.kflags,
+        (jlong)io_uring_ring.sq.kdropped,
+        (jlong)io_uring_ring.sq.array,
+        (jlong)io_uring_ring.sq.sqes,
+        (jlong)io_uring_ring.sq.ring_sz,
+        (jlong)io_uring_ring.cq.ring_ptr,
+        (jlong)ring_fd
+    };
+    (*env)->SetLongArrayRegion(env, submissionArray, 0, 11, submissionArrayElements);
 
-    jobject ioUringCompletionQueue = (*env)->NewObject(
-        env, ioUringCompletionQueueClass, ioUringCommpletionQueueMethodId,
-        (jlong)io_uring_ring.cq.khead, (jlong)io_uring_ring.cq.ktail,
+    jlong completionArrayElements[] = {
+        (jlong)io_uring_ring.cq.khead,
+        (jlong)io_uring_ring.cq.ktail,
         (jlong)io_uring_ring.cq.kring_mask,
         (jlong)io_uring_ring.cq.kring_entries,
-        (jlong)io_uring_ring.cq.koverflow, (jlong)io_uring_ring.cq.cqes,
-        (jlong)io_uring_ring.cq.ring_sz, (jlong)io_uring_ring.cq.ring_ptr,
-        (jint)ring_fd);
+        (jlong)io_uring_ring.cq.koverflow,
+        (jlong)io_uring_ring.cq.cqes,
+        (jlong)io_uring_ring.cq.ring_sz,
+        (jlong)io_uring_ring.cq.ring_ptr,
+        (jlong)ring_fd
+    };
+    (*env)->SetLongArrayRegion(env, completionArray, 0, 9, completionArrayElements);
 
-    jobject ringBuffer =
-        (*env)->NewObject(env, ringBufferClass, ringBufferMethodId,
-                        ioUringSubmissionQueue, ioUringCompletionQueue);
-
-    return ringBuffer;
+    (*env)->SetObjectArrayElement(env, array, 0, submissionArray);
+    (*env)->SetObjectArrayElement(env, array, 1, completionArray);
+    return array;
 }
 
 static jint netty_create_file(JNIEnv *env, jclass class) {
@@ -386,8 +378,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 
 static const JNINativeMethod method_table[] = {
-    {"ioUringSetup", "(ILjava/lang/Runnable;)Lio/netty/channel/uring/RingBuffer;", (void *) netty_io_uring_setup},
-    {"ioUringExit", "(Lio/netty/channel/uring/RingBuffer;)V", (void *) netty_io_uring_ring_buffer_exit},
+    {"ioUringSetup", "(I)[[J", (void *) netty_io_uring_setup},
+    {"ioUringExit", "(JIJIIJII)V", (void *) netty_io_uring_ring_buffer_exit},
     {"createFile", "()I", (void *) netty_create_file},
     {"ioUringEnter", "(IIII)I", (void *)netty_io_uring_enter},
     {"blockingEventFd", "()I", (void *) netty_epoll_native_blocking_event_fd},
@@ -477,27 +469,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     }
     linuxsocketOnLoadCalled = 1;
 
-    NETTY_PREPEND(packagePrefix, "io/netty/channel/uring/RingBuffer",
-                nettyClassName, done);
-    NETTY_LOAD_CLASS(env, ringBufferClass, nettyClassName, done);
-    NETTY_GET_METHOD(env, ringBufferClass, ringBufferMethodId, "<init>",
-                   "(Lio/netty/channel/uring/IOUringSubmissionQueue;Lio/netty/"
-                   "channel/uring/IOUringCompletionQueue;)V",
-                   done);
-
-    NETTY_PREPEND(packagePrefix, "io/netty/channel/uring/IOUringSubmissionQueue",
-                nettyClassName, done);
-    NETTY_LOAD_CLASS(env, ioUringSubmissionQueueClass, nettyClassName, done);
-    NETTY_GET_METHOD(env, ioUringSubmissionQueueClass,
-                   ioUringSubmissionQueueMethodId, "<init>", "(JJJJJJJJIJILjava/lang/Runnable;)V",
-                   done);
-
-    NETTY_PREPEND(packagePrefix, "io/netty/channel/uring/IOUringCompletionQueue",
-                nettyClassName, done);
-    NETTY_LOAD_CLASS(env, ioUringCompletionQueueClass, nettyClassName, done);
-    NETTY_GET_METHOD(env, ioUringCompletionQueueClass,
-                   ioUringCommpletionQueueMethodId, "<init>", "(JJJJJJIJI)V",
-                   done);
+    NETTY_LOAD_CLASS(env, longArrayClass, "[J", done);
     ret = NETTY_JNI_VERSION;
 done:
     //unload
@@ -522,14 +494,6 @@ done:
         if (linuxsocketOnLoadCalled == 1) {
             netty_io_uring_linuxsocket_JNI_OnUnLoad(env);
         }
-
-        ringBufferMethodId = NULL;
-        ioUringSubmissionQueueMethodId = NULL;
-        ioUringCommpletionQueueMethodId = NULL;
-        ringBufferClass = NULL;
-        ioUringCompletionQueueClass = NULL;
-        ioUringSubmissionQueueClass = NULL;
-
     }
     return ret;
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -703,7 +703,7 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
     protected void doRegister() throws Exception {
         IOUringEventLoop eventLoop = (IOUringEventLoop) eventLoop();
         eventLoop.add(this);
-        submissionQueue = eventLoop.getRingBuffer().getIoUringSubmissionQueue();
+        submissionQueue = eventLoop.getRingBuffer().ioUringSubmissionQueue();
     }
 
     @Override

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -36,9 +36,9 @@ final class IOUringCompletionQueue {
 
   private final long completionQueueArrayAddress;
 
-  private final int ringSize;
-  private final long ringAddress;
-  private final int ringFd;
+  final int ringSize;
+  final long ringAddress;
+  final int ringFd;
 
   private final int ringMask;
   private int ringHead;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -131,8 +131,8 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
 
     @Override
     protected void run() {
-        final IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
-        final IOUringSubmissionQueue submissionQueue = ringBuffer.getIoUringSubmissionQueue();
+        final IOUringCompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
+        final IOUringSubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
 
         // Lets add the eventfd related events before starting to do any real work.
         addEventFdRead(submissionQueue);
@@ -222,7 +222,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         if (op == Native.IORING_OP_READ && eventfd.intValue() == fd) {
             if (res != Native.ERRNO_ECANCELED_NEGATIVE) {
                 pendingWakeup = false;
-                addEventFdRead(ringBuffer.getIoUringSubmissionQueue());
+                addEventFdRead(ringBuffer.ioUringSubmissionQueue());
             }
         } else if (op == Native.IORING_OP_TIMEOUT) {
             if (res == Native.ERRNO_ETIME_NEGATIVE) {
@@ -313,7 +313,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
     public IovArray iovArray() {
         IovArray iovArray = iovArrays.next();
         if (iovArray == null) {
-            ringBuffer.getIoUringSubmissionQueue().submit();
+            ringBuffer.ioUringSubmissionQueue().submit();
             iovArray = iovArrays.next();
             assert iovArray != null;
         }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -51,17 +51,15 @@ final class IOUringSubmissionQueue {
     private final long fFlagsAdress;
     private final long kDroppedAddress;
     private final long arrayAddress;
+    final long submissionQueueArrayAddress;
 
-    private final long submissionQueueArrayAddress;
-
-    private final int ringEntries;
+    final int ringEntries;
     private final int ringMask; // = ringEntries - 1
 
-    private final int ringSize;
-    private final long ringAddress;
-    private final int ringFd;
+    final int ringSize;
+    final long ringAddress;
+    final int ringFd;
     private final Runnable submissionCallback;
-
     private final long timeoutMemoryAddress;
 
     private int head;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -131,10 +131,6 @@ final class Native {
 
     public static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);
 
-    public static native int ioUringRegisterEventFd(int ringFd, int eventFd);
-
-    public static native int ioUringUnregisterEventFd(int ringFd);
-
     public static native void eventFdWrite(int fd, long value);
 
     public static FileDescriptor newBlockingEventFd() {
@@ -143,9 +139,8 @@ final class Native {
 
     public static native void ioUringExit(long submissionQueueArrayAddress, int submissionQueueRingEntries,
                                           long submissionQueueRingAddress, int submissionQueueRingSize,
-                                          int submissionQueueRingFd,
                                           long completionQueueRingAddress, int completionQueueRingSize,
-                                          int completionQueueRingfd);
+                                          int ringFd);
 
     private static native int blockingEventFd();
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -82,8 +82,7 @@ final class Native {
     static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();
 
     static RingBuffer createRingBuffer(int ringSize) {
-        //Todo throw Exception if it's null
-        return ioUringSetup(ringSize, new Runnable() {
+        return createRingBuffer(ringSize, new Runnable() {
             @Override
             public void run() {
                 // Noop
@@ -92,15 +91,43 @@ final class Native {
     }
 
     static RingBuffer createRingBuffer(int ringSize, Runnable submissionCallback) {
-        //Todo throw Exception if it's null
-        return ioUringSetup(ringSize, submissionCallback);
+        long[][] values = ioUringSetup(ringSize);
+        assert values.length == 2;
+        long[] submissionQueueArgs = values[0];
+        assert submissionQueueArgs.length == 11;
+        IOUringSubmissionQueue submissionQueue = new IOUringSubmissionQueue(
+                submissionQueueArgs[0],
+                submissionQueueArgs[1],
+                submissionQueueArgs[2],
+                submissionQueueArgs[3],
+                submissionQueueArgs[4],
+                submissionQueueArgs[5],
+                submissionQueueArgs[6],
+                submissionQueueArgs[7],
+                (int) submissionQueueArgs[8],
+                submissionQueueArgs[9],
+                (int) submissionQueueArgs[10],
+                submissionCallback);
+        long[] completionQueueArgs = values[1];
+        assert completionQueueArgs.length == 9;
+        IOUringCompletionQueue completionQueue = new IOUringCompletionQueue(
+                completionQueueArgs[0],
+                completionQueueArgs[1],
+                completionQueueArgs[2],
+                completionQueueArgs[3],
+                completionQueueArgs[4],
+                completionQueueArgs[5],
+                (int) completionQueueArgs[6],
+                completionQueueArgs[7],
+                (int) completionQueueArgs[8]);
+        return new RingBuffer(submissionQueue, completionQueue);
     }
 
     static RingBuffer createRingBuffer(Runnable submissionCallback) {
         return createRingBuffer(DEFAULT_RING_SIZE, submissionCallback);
     }
 
-    private static native RingBuffer ioUringSetup(int entries, Runnable submissionCallback);
+    private static native long[][] ioUringSetup(int entries);
 
     public static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);
 
@@ -114,7 +141,11 @@ final class Native {
         return new FileDescriptor(blockingEventFd());
     }
 
-    public static native void ioUringExit(RingBuffer ringBuffer);
+    public static native void ioUringExit(long submissionQueueArrayAddress, int submissionQueueRingEntries,
+                                          long submissionQueueRingAddress, int submissionQueueRingSize,
+                                          int submissionQueueRingFd,
+                                          long completionQueueRingAddress, int completionQueueRingSize,
+                                          int completionQueueRingfd);
 
     private static native int blockingEventFd();
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -40,8 +40,6 @@ final class RingBuffer {
                 ioUringSubmissionQueue.ringEntries,
                 ioUringSubmissionQueue.ringAddress,
                 ioUringSubmissionQueue.ringSize,
-                ioUringSubmissionQueue.ringFd,
-
                 ioUringCompletionQueue.ringAddress,
                 ioUringCompletionQueue.ringSize,
                 ioUringCompletionQueue.ringFd);

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -17,24 +17,33 @@ package io.netty.channel.uring;
 
 
 final class RingBuffer {
-  private final IOUringSubmissionQueue ioUringSubmissionQueue;
-  private final IOUringCompletionQueue ioUringCompletionQueue;
+    private final IOUringSubmissionQueue ioUringSubmissionQueue;
+    private final IOUringCompletionQueue ioUringCompletionQueue;
 
-  RingBuffer(IOUringSubmissionQueue ioUringSubmissionQueue, IOUringCompletionQueue ioUringCompletionQueue) {
-    this.ioUringSubmissionQueue = ioUringSubmissionQueue;
-    this.ioUringCompletionQueue = ioUringCompletionQueue;
-  }
+    RingBuffer(IOUringSubmissionQueue ioUringSubmissionQueue, IOUringCompletionQueue ioUringCompletionQueue) {
+        this.ioUringSubmissionQueue = ioUringSubmissionQueue;
+        this.ioUringCompletionQueue = ioUringCompletionQueue;
+    }
 
-  public IOUringSubmissionQueue getIoUringSubmissionQueue() {
-    return this.ioUringSubmissionQueue;
-  }
+     IOUringSubmissionQueue ioUringSubmissionQueue() {
+        return this.ioUringSubmissionQueue;
+    }
 
-  public IOUringCompletionQueue getIoUringCompletionQueue() {
-    return this.ioUringCompletionQueue;
-  }
+    IOUringCompletionQueue ioUringCompletionQueue() {
+        return this.ioUringCompletionQueue;
+    }
 
-  public void close() {
-      getIoUringSubmissionQueue().release();
-      Native.ioUringExit(this);
-  }
+    void close() {
+        ioUringSubmissionQueue.release();
+        Native.ioUringExit(
+                ioUringSubmissionQueue.submissionQueueArrayAddress,
+                ioUringSubmissionQueue.ringEntries,
+                ioUringSubmissionQueue.ringAddress,
+                ioUringSubmissionQueue.ringSize,
+                ioUringSubmissionQueue.ringFd,
+
+                ioUringCompletionQueue.ringAddress,
+                ioUringCompletionQueue.ringSize,
+                ioUringCompletionQueue.ringFd);
+    }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSubmissionQueueTest.java
@@ -33,8 +33,8 @@ public class IOUringSubmissionQueueTest {
     public void sqeFullTest() {
         RingBuffer ringBuffer = Native.createRingBuffer(8);
         try {
-            IOUringSubmissionQueue submissionQueue = ringBuffer.getIoUringSubmissionQueue();
-            final IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
+            IOUringSubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+            final IOUringCompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
 
             assertNotNull(ringBuffer);
             assertNotNull(submissionQueue);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -47,8 +47,8 @@ public class NativeTest {
         int fd = Native.createFile();
 
         RingBuffer ringBuffer = Native.createRingBuffer(32);
-        IOUringSubmissionQueue submissionQueue = ringBuffer.getIoUringSubmissionQueue();
-        IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
+        IOUringSubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        IOUringCompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
 
         assertNotNull(ringBuffer);
         assertNotNull(submissionQueue);
@@ -93,8 +93,8 @@ public class NativeTest {
     public void timeoutTest() throws Exception {
 
         RingBuffer ringBuffer = Native.createRingBuffer(32);
-        IOUringSubmissionQueue submissionQueue = ringBuffer.getIoUringSubmissionQueue();
-        final IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
+        IOUringSubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final IOUringCompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
 
         assertNotNull(ringBuffer);
         assertNotNull(submissionQueue);
@@ -134,8 +134,8 @@ public class NativeTest {
     @Test
     public void eventfdTest() throws Exception {
         RingBuffer ringBuffer = Native.createRingBuffer(32);
-        IOUringSubmissionQueue submissionQueue = ringBuffer.getIoUringSubmissionQueue();
-        final IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
+        IOUringSubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final IOUringCompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
 
         assertNotNull(ringBuffer);
         assertNotNull(submissionQueue);
@@ -173,8 +173,8 @@ public class NativeTest {
     public void eventfdNoSignal() throws Exception {
 
         RingBuffer ringBuffer = Native.createRingBuffer(32);
-        IOUringSubmissionQueue submissionQueue = ringBuffer.getIoUringSubmissionQueue();
-        final IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
+        IOUringSubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final IOUringCompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
 
         assertNotNull(ringBuffer);
         assertNotNull(submissionQueue);
@@ -223,8 +223,8 @@ public class NativeTest {
     @Test
     public void ioUringPollRemoveTest() throws Exception {
         RingBuffer ringBuffer = Native.createRingBuffer(32);
-        IOUringSubmissionQueue submissionQueue = ringBuffer.getIoUringSubmissionQueue();
-        final IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
+        IOUringSubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        final IOUringCompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
 
         FileDescriptor eventFd = Native.newBlockingEventFd();
         submissionQueue.addPollIn(eventFd.intValue());


### PR DESCRIPTION
Motivation:

Using classes which are not provided by the JDK itself in JNI is
problematic when shading may be used by customers of the library. Also
it makes the maintainance of the code often more complicated.

Modifications:

- Only use classes which are provided by the JDK in the JNI code
- Cleanup

Result:

Easier to maintain code