### PR TITLE
POC: Register io_uring fixed buffers

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -1473,5 +1473,17 @@ public final class ByteBufUtil {
         } while (outLen > 0);
     }
 
+    /**
+     * @return 0 if not applicable or not available
+     */
+    public static long getPooledMemoryAddress(ByteBuf buf) {
+        for (; buf != null; buf = buf.unwrap()) {
+            if (buf instanceof PooledByteBuf) {
+                return ((PooledByteBuf<?>) buf).chunk.memoryAddress;
+            }
+        }
+        return 0L;
+    }
+
     private ByteBufUtil() { }
 }

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -109,6 +109,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
 
     final PoolArena<T> arena;
     final T memory;
+    final long memoryAddress;
     final boolean unpooled;
     final int offset;
     private final byte[] memoryMap;
@@ -145,6 +146,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         unpooled = false;
         this.arena = arena;
         this.memory = memory;
+        this.memoryAddress = arena.memoryAddress(memory);
         this.pageSize = pageSize;
         this.pageShifts = pageShifts;
         this.maxOrder = maxOrder;
@@ -181,6 +183,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         unpooled = true;
         this.arena = arena;
         this.memory = memory;
+        this.memoryAddress = arena.memoryAddress(memory);
         this.offset = offset;
         memoryMap = null;
         depthMap = null;
@@ -507,6 +510,9 @@ final class PoolChunk<T> implements PoolChunkMetric {
     }
 
     void destroy() {
+        if (!unpooled) {
+            arena.poolChunkDeallocated(this);
+        }
         arena.destroyChunk(this);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -16,6 +16,7 @@
 
 package io.netty.buffer;
 
+import io.netty.buffer.PooledByteBufAllocator.AllocationCallback;
 import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
@@ -247,7 +248,16 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
     void destroy(PoolArena<T> arena) {
         PoolChunk<T> chunk = head;
         while (chunk != null) {
-            arena.destroyChunk(chunk);
+            chunk.destroy();
+            chunk = chunk.next;
+        }
+        head = null;
+    }
+
+    void registerAllChunks(PoolArena<T> arena, AllocationCallback callback) {
+        PoolChunk<T> chunk = head;
+        while (chunk != null) {
+            PoolArena.poolChunkAllocated(chunk, callback);
             chunk = chunk.next;
         }
         head = null;

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -196,6 +196,23 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         this(false);
     }
 
+    public interface AllocationCallback {
+        void bufferAllocated(long address, int length);
+        void bufferDeallocated(long address);
+    }
+
+    public void registerAllocationCallback(AllocationCallback callback) {
+        for (PoolArena<ByteBuffer> arena : directArenas) {
+            arena.registerAllocationCallback(callback);
+        }
+    }
+
+    public void unregisterAllocationCallback(AllocationCallback callback) {
+        for (PoolArena<ByteBuffer> arena : directArenas) {
+            arena.unregisterAllocationCallback(callback);
+        }
+    }
+
     @SuppressWarnings("deprecation")
     public PooledByteBufAllocator(boolean preferDirect) {
         this(preferDirect, DEFAULT_NUM_HEAP_ARENA, DEFAULT_NUM_DIRECT_ARENA, DEFAULT_PAGE_SIZE, DEFAULT_MAX_ORDER);

--- a/transport-native-io_uring/src/main/c/syscall.c
+++ b/transport-native-io_uring/src/main/c/syscall.c
@@ -29,7 +29,6 @@ int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
                  _NSIG / 8);
 }
 
-int sys_io_uring_register(int fd, unsigned opcode, const void *arg,
-			    unsigned nr_args) {
-	return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
+int sys_io_uring_register(int fd, unsigned opcode, const void *arg, unsigned nr_args) {
+    return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
 }

--- a/transport-native-io_uring/src/main/c/syscall.h
+++ b/transport-native-io_uring/src/main/c/syscall.h
@@ -24,6 +24,5 @@
 extern int sys_io_uring_setup(unsigned entries, struct io_uring_params *p);
 extern int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
                               unsigned flags, sigset_t *sig);
-extern int sys_io_uring_register(int fd, unsigned int opcode, const void *arg,
-	unsigned int nr_args);
+extern int sys_io_uring_register(int fd, unsigned int opcode, const void *arg, unsigned int nr_args);
 #endif

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
@@ -190,7 +190,7 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
     }
 
     @Override
-    protected void doRegister() throws Exception {
+    protected void doRegister() {
         super.doRegister();
         if (active) {
             // Register for POLLRDHUP if this channel is already considered active.
@@ -219,7 +219,8 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
             readBuffer = byteBuf;
 
             submissionQueue.addRead(socket.intValue(), byteBuf.memoryAddress(),
-                    byteBuf.writerIndex(), byteBuf.capacity());
+                    byteBuf.writerIndex(), byteBuf.capacity(),
+                    ((IOUringEventLoop) eventLoop()).getFixedBufferIndex(byteBuf), false);
         }
 
         @Override

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/FixedBufferTracker.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/FixedBufferTracker.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.EventLoop;
+import io.netty.channel.unix.Buffer;
+import io.netty.channel.unix.Limits;
+import io.netty.util.internal.PlatformDependent;
+
+public class FixedBufferTracker implements PooledByteBufAllocator.AllocationCallback, Closeable {
+
+    private static final int ADDRESS_SIZE = Buffer.addressSize();
+    private static final int IOV_SIZE = 2 * ADDRESS_SIZE;
+    private static final int MIN_ITERATIONS_BETWEEN_UPDATES = 8;
+
+    private final PooledByteBufAllocator alloc;
+    private final EventLoop loop;
+
+    // linear hash probe map of addr to size,index
+    private long[] bufMap;
+    private int count;
+    private boolean dirty;
+
+    public FixedBufferTracker(EventLoop loop, PooledByteBufAllocator alloc) {
+        bufMap = loop != null ? new long[4 * Limits.IOV_MAX] : null; //TODO start smaller and resize
+        this.loop = loop;
+        this.alloc = alloc;
+    }
+
+    public void start() {
+        if (alloc != null) {
+            alloc.registerAllocationCallback(this);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (alloc != null) {
+            alloc.unregisterAllocationCallback(this);
+        }
+    }
+
+    boolean isDirty() {
+        return dirty;
+    }
+
+    int getCount() {
+        return count;
+    }
+
+    ByteBuf getIoVecs() {
+        if (count == 0) {
+            return Unpooled.EMPTY_BUFFER;
+        }
+        ByteBuf buf = alloc.directBuffer(count * IOV_SIZE);
+        long iovAddr = buf.memoryAddress();
+        for (int i = 0, j = 1; i < bufMap.length; i += 2) {
+            long addr = bufMap[i];
+            if (addr != 0L) {
+                long val = bufMap[i + 1];
+                PlatformDependent.putLong(iovAddr, addr);
+                PlatformDependent.putLong(iovAddr + ADDRESS_SIZE, val >>> 32);
+                iovAddr += IOV_SIZE;
+                bufMap[i + 1] = val & (-1L << 32) | j++;
+            }
+        }
+        dirty = false;
+        return buf.setIndex(0, buf.capacity());
+    }
+
+    short getIndex(long addr) {
+        if (addr == 0L) {
+            return -1;
+        }
+        final long[] table = bufMap;
+        for (int len = table.length, i = hash(addr, len);; i = next(i, len)) {
+            long key = table[i];
+            if (key == addr) {
+                return (short) ((table[i + 1] & 0xffff) - 1); // can also be -1
+            }
+            if (key == 0L) {
+                return -1;
+            }
+        }
+    }
+
+    @Override
+    public void bufferAllocated(final long address, final int length) {
+        if (loop.inEventLoop()) {
+            add(address, length);
+        } else {
+            loop.execute(new Runnable() {
+                @Override
+                public void run() {
+                    add(address, length);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void bufferDeallocated(final long address) {
+        if (loop.inEventLoop()) {
+            remove(address);
+        } else {
+            loop.execute(new Runnable() {
+                @Override
+                public void run() {
+                    remove(address);
+                }
+            });
+        }
+    }
+
+    public void add(long addr, int size) {
+        if (size == 0) {
+            return;
+        }
+        final long[] table = bufMap;
+        for (int len = table.length, i = hash(addr, len);; i = next(i, len)) {
+            long key = table[i];
+            if (key == 0L) {
+                set(table, i, addr, ((long) size) << 32);
+                count++;
+                dirty = true;
+                return;
+            }
+            if (key == addr) {
+                table[i + 1] = ((long) size) << 32;
+                dirty = true;
+                return;
+            }
+        }
+    }
+
+    public void remove(long addr) {
+        final long[] table = bufMap;
+        long key;
+        int len = table.length;
+        for (int i = hash(addr, len), d = -1; (key = table[i]) != 0L; i = next(i, len)) {
+            if (d >= 0) {
+                int r = hash(key, len);
+                if ((i >= r || r > d && d > i) && (r > d || d > i)) {
+                    continue;
+                }
+                set(table, d, key, table[i + 1]);
+            } else if (key != addr) {
+                continue;
+            } else {
+                count--;
+                dirty = true;
+            }
+            set(table, i, 0L, 0L);
+            d = i;
+        }
+    }
+
+    private static void set(long[] table, int i, long addr, long val) {
+        table[i] = addr;
+        table[i + 1] = val;
+    }
+
+    private static int next(int i, int len) {
+        return i == len - 2 ? 0 : i + 2;
+    }
+
+    private static int hash(long addr, int len) {
+        //TODO improve hash maybe
+        int h = (int) (addr ^ (addr >>> 32));
+        return ((h << 1) - (h << 8)) & (len - 1);
+    }
+
+    static final FixedBufferTracker NOOP_TRACKER = new FixedBufferTracker(null, null) {
+        @Override
+        short getIndex(long addr) {
+            return -1;
+        }
+        @Override
+        boolean isDirty() {
+            return false;
+        }
+    };
+}

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
@@ -18,7 +18,7 @@ package io.netty.channel.uring;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 
-final class IOUring {
+public final class IOUring {
 
     private static final Throwable UNAVAILABILITY_CAUSE;
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -63,7 +63,7 @@ final class IOUringCompletionQueue {
       return ringHead != PlatformDependent.getIntVolatile(kTailAddress);
   }
 
-  public int process(IOUringCompletionQueueCallback callback) {
+  int process(IOUringCompletionQueueCallback callback) {
       int tail = PlatformDependent.getIntVolatile(kTailAddress);
       int i = 0;
       while (ringHead != tail) {
@@ -92,7 +92,7 @@ final class IOUringCompletionQueue {
       void handle(int fd, int res, int flags, int op, int mask);
   }
 
-  public boolean ioUringWaitCqe() {
+  boolean ioUringWaitCqe() {
     //IORING_ENTER_GETEVENTS -> wait until an event is completely processed
     int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
     if (ret < 0) {
@@ -103,10 +103,5 @@ final class IOUringCompletionQueue {
     }
     //Todo throw Exception!
     return false;
-  }
-
-  //Todo Integer.toUnsignedLong -> maven checkstyle error
-  public static long toUnsignedLong(int x) {
-    return ((long) x) & 0xffffffffL;
   }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -97,14 +97,14 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
                 : PlatformDependent.<Runnable>newMpscQueue(maxPendingTasks);
     }
 
-    public void add(AbstractIOUringChannel ch) {
+    void add(AbstractIOUringChannel ch) {
         logger.trace("Add Channel: {} ", ch.socket.intValue());
         int fd = ch.socket.intValue();
 
         channels.put(fd, ch);
     }
 
-    public void remove(AbstractIOUringChannel ch) {
+    void remove(AbstractIOUringChannel ch) {
         logger.trace("Remove Channel: {}", ch.socket.intValue());
         int fd = ch.socket.intValue();
 
@@ -298,7 +298,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         PlatformDependent.freeMemory(eventfdReadBuf);
     }
 
-    public RingBuffer getRingBuffer() {
+    RingBuffer getRingBuffer() {
         return ringBuffer;
     }
 
@@ -310,7 +310,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         }
     }
 
-    public IovArray iovArray() {
+    IovArray iovArray() {
         IovArray iovArray = iovArrays.next();
         if (iovArray == null) {
             ringBuffer.ioUringSubmissionQueue().submit();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -135,20 +135,20 @@ final class IOUringSubmissionQueue {
         logger.trace("Offset: {}", offset);
     }
 
-    public boolean addTimeout(long nanoSeconds) {
+    boolean addTimeout(long nanoSeconds) {
         setTimeout(nanoSeconds);
         return enqueueSqe(Native.IORING_OP_TIMEOUT, 0, -1, timeoutMemoryAddress, 1, 0);
     }
 
-    public boolean addPollIn(int fd) {
+    boolean addPollIn(int fd) {
         return addPoll(fd, Native.POLLIN);
     }
 
-    public boolean addPollRdHup(int fd) {
+    boolean addPollRdHup(int fd) {
         return addPoll(fd, Native.POLLRDHUP);
     }
 
-    public boolean addPollOut(int fd) {
+    boolean addPollOut(int fd) {
         return addPoll(fd, Native.POLLOUT);
     }
 
@@ -157,43 +157,43 @@ final class IOUringSubmissionQueue {
     }
 
     //return true -> submit() was called
-    public boolean addRead(int fd, long bufferAddress, int pos, int limit) {
+    boolean addRead(int fd, long bufferAddress, int pos, int limit) {
         return enqueueSqe(Native.IORING_OP_READ, 0, fd, bufferAddress + pos, limit - pos, 0);
     }
 
-    public boolean addWrite(int fd, long bufferAddress, int pos, int limit) {
+    boolean addWrite(int fd, long bufferAddress, int pos, int limit) {
         return enqueueSqe(Native.IORING_OP_WRITE, 0, fd, bufferAddress + pos, limit - pos, 0);
     }
 
-    public boolean addAccept(int fd, long address, long addressLength) {
+    boolean addAccept(int fd, long address, long addressLength) {
         return enqueueSqe(Native.IORING_OP_ACCEPT, Native.SOCK_NONBLOCK | Native.SOCK_CLOEXEC, fd,
                 address, 0, addressLength);
     }
 
     //fill the address which is associated with server poll link user_data
-    public boolean addPollRemove(int fd, int pollMask) {
+    boolean addPollRemove(int fd, int pollMask) {
         return enqueueSqe(Native.IORING_OP_POLL_REMOVE, 0, fd,
                 convertToUserData(Native.IORING_OP_POLL_ADD, fd, pollMask), 0, 0);
     }
 
-    public boolean addConnect(int fd, long socketAddress, long socketAddressLength) {
+    boolean addConnect(int fd, long socketAddress, long socketAddressLength) {
         return enqueueSqe(Native.IORING_OP_CONNECT, 0, fd, socketAddress, 0, socketAddressLength);
     }
 
-    public boolean addWritev(int fd, long iovecArrayAddress, int length) {
+    boolean addWritev(int fd, long iovecArrayAddress, int length) {
         return enqueueSqe(Native.IORING_OP_WRITEV, 0, fd, iovecArrayAddress, length, 0);
     }
 
-    public boolean addClose(int fd) {
+    boolean addClose(int fd) {
         return enqueueSqe(Native.IORING_OP_CLOSE, 0, fd, 0, 0, 0);
     }
 
-    public int submit() {
+    int submit() {
         int submit = tail - head;
         return submit > 0 ? submit(submit, 0, 0) : 0;
     }
 
-    public int submitAndWait() {
+    int submitAndWait() {
         int submit = tail - head;
         if (submit > 0) {
             return submit(submit, 1, Native.IORING_ENTER_GETEVENTS);
@@ -223,7 +223,6 @@ final class IOUringSubmissionQueue {
     private void setTimeout(long timeoutNanoSeconds) {
         long seconds, nanoSeconds;
 
-        //Todo
         if (timeoutNanoSeconds == 0) {
             seconds = 0;
             nanoSeconds = 0;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
@@ -49,6 +49,7 @@ final class LinuxSocket extends Socket {
         return ipv6 ? InternetProtocolFamily.IPv6 : InternetProtocolFamily.IPv4;
     }
 
+    @Override
     public boolean markClosed() {
         return super.markClosed();
     }
@@ -71,7 +72,7 @@ final class LinuxSocket extends Socket {
         setInterface(intValue(), ipv6, nativeAddress.address(), nativeAddress.scopeId(), interfaceIndex(netInterface));
     }
 
-    public int initAddress(byte[] address, int scopeId, int port, long addressMemory) {
+    int initAddress(byte[] address, int scopeId, int port, long addressMemory) {
         return initAddress(intValue(), ipv6, address, scopeId, port, addressMemory);
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -149,10 +149,6 @@ final class Native {
     // for testing(it is only temporary)
     public static native int createFile();
 
-    public static Socket newSocketStream() {
-        return Socket.newSocketStream();
-    }
-
     private Native() {
         // utility
     }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -69,9 +69,11 @@ final class Native {
     static final int POLLRDHUP = NativeStaticallyReferencedJniMethods.pollrdhup();
     static final int ERRNO_ECANCELED_NEGATIVE = -NativeStaticallyReferencedJniMethods.ecanceled();
     static final int ERRNO_ETIME_NEGATIVE = -NativeStaticallyReferencedJniMethods.etime();
+    static final int ERRNO_ENXIO_NEGATIVE = -NativeStaticallyReferencedJniMethods.enxio();
 
     static final int IORING_OP_POLL_ADD = NativeStaticallyReferencedJniMethods.ioringOpPollAdd();
     static final int IORING_OP_TIMEOUT = NativeStaticallyReferencedJniMethods.ioringOpTimeout();
+    static final int IORING_OP_TIMEOUT_REMOVE = NativeStaticallyReferencedJniMethods.ioringOpTimeoutRemove();
     static final int IORING_OP_ACCEPT = NativeStaticallyReferencedJniMethods.ioringOpAccept();
     static final int IORING_OP_READ = NativeStaticallyReferencedJniMethods.ioringOpRead();
     static final int IORING_OP_WRITE = NativeStaticallyReferencedJniMethods.ioringOpWrite();
@@ -79,6 +81,13 @@ final class Native {
     static final int IORING_OP_CONNECT = NativeStaticallyReferencedJniMethods.ioringOpConnect();
     static final int IORING_OP_CLOSE = NativeStaticallyReferencedJniMethods.ioringOpClose();
     static final int IORING_OP_WRITEV = NativeStaticallyReferencedJniMethods.ioringOpWritev();
+    static final int IORING_OP_READ_FIXED = NativeStaticallyReferencedJniMethods.ioringOpReadFixed();
+    static final int IORING_OP_WRITE_FIXED = NativeStaticallyReferencedJniMethods.ioringOpWriteFixed();
+    static final int IORING_OP_ASYNC_CANCEL = NativeStaticallyReferencedJniMethods.ioringOpAsyncCancel();
+
+    static final int IORING_REGISTER_BUFFERS = NativeStaticallyReferencedJniMethods.ioringRegisterBuffers();
+    static final int IORING_UNREGISTER_BUFFERS = NativeStaticallyReferencedJniMethods.ioringUnregisterBuffers();
+
     static final int IORING_ENTER_GETEVENTS = NativeStaticallyReferencedJniMethods.ioringEnterGetevents();
     static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();
 
@@ -132,6 +141,8 @@ final class Native {
     private static native long[][] ioUringSetup(int entries);
 
     public static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);
+
+    public static native int ioUringRegister(int ringFd, int opcode, long argsAddress, int count);
 
     public static native void eventFdWrite(int fd, long value);
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -34,6 +34,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int sockCloexec();
     static native int etime();
     static native int ecanceled();
+    static native int enxio();
     static native int pollin();
     static native int pollout();
     static native int pollrdhup();
@@ -42,11 +43,17 @@ final class NativeStaticallyReferencedJniMethods {
     static native int ioringOpPollAdd();
     static native int ioringOpPollRemove();
     static native int ioringOpTimeout();
+    static native int ioringOpTimeoutRemove();
     static native int ioringOpAccept();
     static native int ioringOpRead();
     static native int ioringOpWrite();
     static native int ioringOpConnect();
     static native int ioringOpClose();
+    static native int ioringOpReadFixed();
+    static native int ioringOpWriteFixed();
+    static native int ioringOpAsyncCancel();
+    static native int ioringRegisterBuffers();
+    static native int ioringUnregisterBuffers();
     static native int ioringEnterGetevents();
     static native int iosqeAsync();
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -25,7 +25,7 @@ final class RingBuffer {
         this.ioUringCompletionQueue = ioUringCompletionQueue;
     }
 
-     IOUringSubmissionQueue ioUringSubmissionQueue() {
+    IOUringSubmissionQueue ioUringSubmissionQueue() {
         return this.ioUringSubmissionQueue;
     }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSubmissionQueueTest.java
@@ -46,7 +46,12 @@ public class IOUringSubmissionQueueTest {
 
             long address = Buffer.memoryAddress(buffer);
             int counter = 0;
-            while (!submissionQueue.addAccept(-1, address, 128)) {
+            for (;;) {
+                int count = submissionQueue.pendingCount();
+                submissionQueue.addAccept(-1, address, 128);
+                if (submissionQueue.pendingCount() <= count) {
+                    break;
+                }
                 counter++;
             }
             assertEquals(8, counter);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -54,9 +54,10 @@ public class NativeTest {
         assertNotNull(submissionQueue);
         assertNotNull(completionQueue);
 
-        assertFalse(submissionQueue.addWrite(fd, writeEventByteBuf.memoryAddress(),
-                                            writeEventByteBuf.readerIndex(), writeEventByteBuf.writerIndex()));
-        submissionQueue.submit();
+        submissionQueue.addWrite(fd, writeEventByteBuf.memoryAddress(),
+                                            writeEventByteBuf.readerIndex(), writeEventByteBuf.writerIndex(),
+                                            (short) -1);
+        assertEquals(1, submissionQueue.submit());
 
         assertTrue(completionQueue.ioUringWaitCqe());
         assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
@@ -68,9 +69,10 @@ public class NativeTest {
         }));
 
         final ByteBuf readEventByteBuf = allocator.directBuffer(100);
-        assertFalse(submissionQueue.addRead(fd, readEventByteBuf.memoryAddress(),
-                                           readEventByteBuf.writerIndex(), readEventByteBuf.capacity()));
-        submissionQueue.submit();
+        submissionQueue.addRead(fd, readEventByteBuf.memoryAddress(),
+                                           readEventByteBuf.writerIndex(), readEventByteBuf.capacity(),
+                                           (short) -1, false);
+        assertEquals(1, submissionQueue.submit());
 
         assertTrue(completionQueue.ioUringWaitCqe());
         assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
@@ -142,8 +144,8 @@ public class NativeTest {
         assertNotNull(completionQueue);
 
         final FileDescriptor eventFd = Native.newBlockingEventFd();
-        assertFalse(submissionQueue.addPollIn(eventFd.intValue()));
-        submissionQueue.submit();
+        submissionQueue.addPollIn(eventFd.intValue());
+        assertEquals(1, submissionQueue.submit());
 
         new Thread() {
             @Override
@@ -194,8 +196,8 @@ public class NativeTest {
         };
         waitingCqe.start();
         final FileDescriptor eventFd = Native.newBlockingEventFd();
-        assertFalse(submissionQueue.addPollIn(eventFd.intValue()));
-        submissionQueue.submit();
+        submissionQueue.addPollIn(eventFd.intValue());
+        assertEquals(1, submissionQueue.submit());
 
         new Thread() {
             @Override


### PR DESCRIPTION
Motivation

io_uring allows pre-registration of user IO buffers with the kernel to avoid having to map/unmap on for every read/write

Modifications

Register direct buffers via integration with netty's PooledByteBufAllocator.

This is complicated somewhat by the fact that backing mem allocation happens dynamically and you cannot (re-)register fixed buffers while any ring operations are in flight.

Result

Hopefully performance gain