### PR TITLE
Make MQTT property value publicly accessible

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
@@ -117,6 +117,14 @@ public final class MqttProperties {
             this.propertyId = propertyId;
             this.value = value;
         }
+
+        public T value() {
+            return value;
+        }
+
+        public int propertyId() {
+            return propertyId;
+        }
     }
 
     public static final class IntegerProperty extends MqttProperty<Integer> {

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
@@ -109,6 +109,11 @@ public final class MqttProperties {
         return properties;
     }
 
+    /**
+     * MQTT property base class
+     *
+     * @param <T> property type
+     */
     public abstract static class MqttProperty<T> {
         final T value;
         final int propertyId;
@@ -118,10 +123,19 @@ public final class MqttProperties {
             this.value = value;
         }
 
+        /**
+         * Get MQTT property value
+         *
+         * @return property value
+         */
         public T value() {
             return value;
         }
 
+        /**
+         * Get MQTT property ID
+         * @return property ID
+         */
         public int propertyId() {
             return propertyId;
         }


### PR DESCRIPTION
Motivation:

There was no way to read MQTT properties outside of `io.netty.handler.codec.mqtt` package

Modification:

Made `MqttProperties.MqttProperty` final fields `value` and `propertyId` public

Result:

It's possible to read MQTT properties now
