### PR TITLE
Cleanup code

### DIFF
--- a/transport-native-io_uring/src/main/c/syscall.c
+++ b/transport-native-io_uring/src/main/c/syscall.c
@@ -29,7 +29,6 @@ int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
                  _NSIG / 8);
 }
 
-int sys_io_uring_register(int fd, unsigned opcode, const void *arg,
-			    unsigned nr_args) {
-	return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
+int sys_io_uring_register(int fd, unsigned opcode, const void *arg, unsigned nr_args) {
+    return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
 }

--- a/transport-native-io_uring/src/main/c/syscall.h
+++ b/transport-native-io_uring/src/main/c/syscall.h
@@ -24,6 +24,5 @@
 extern int sys_io_uring_setup(unsigned entries, struct io_uring_params *p);
 extern int sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
                               unsigned flags, sigset_t *sig);
-extern int sys_io_uring_register(int fd, unsigned int opcode, const void *arg,
-	unsigned int nr_args);
+extern int sys_io_uring_register(int fd, unsigned int opcode, const void *arg, unsigned int nr_args);
 #endif

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
@@ -18,7 +18,7 @@ package io.netty.channel.uring;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 
-final class IOUring {
+public final class IOUring {
 
     private static final Throwable UNAVAILABILITY_CAUSE;
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -63,7 +63,7 @@ final class IOUringCompletionQueue {
       return ringHead != PlatformDependent.getIntVolatile(kTailAddress);
   }
 
-  public int process(IOUringCompletionQueueCallback callback) {
+  int process(IOUringCompletionQueueCallback callback) {
       int tail = PlatformDependent.getIntVolatile(kTailAddress);
       int i = 0;
       while (ringHead != tail) {
@@ -92,7 +92,7 @@ final class IOUringCompletionQueue {
       void handle(int fd, int res, int flags, int op, int mask);
   }
 
-  public boolean ioUringWaitCqe() {
+  boolean ioUringWaitCqe() {
     //IORING_ENTER_GETEVENTS -> wait until an event is completely processed
     int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
     if (ret < 0) {
@@ -103,10 +103,5 @@ final class IOUringCompletionQueue {
     }
     //Todo throw Exception!
     return false;
-  }
-
-  //Todo Integer.toUnsignedLong -> maven checkstyle error
-  public static long toUnsignedLong(int x) {
-    return ((long) x) & 0xffffffffL;
   }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -97,14 +97,14 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
                 : PlatformDependent.<Runnable>newMpscQueue(maxPendingTasks);
     }
 
-    public void add(AbstractIOUringChannel ch) {
+    void add(AbstractIOUringChannel ch) {
         logger.trace("Add Channel: {} ", ch.socket.intValue());
         int fd = ch.socket.intValue();
 
         channels.put(fd, ch);
     }
 
-    public void remove(AbstractIOUringChannel ch) {
+    void remove(AbstractIOUringChannel ch) {
         logger.trace("Remove Channel: {}", ch.socket.intValue());
         int fd = ch.socket.intValue();
 
@@ -298,7 +298,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         PlatformDependent.freeMemory(eventfdReadBuf);
     }
 
-    public RingBuffer getRingBuffer() {
+    RingBuffer getRingBuffer() {
         return ringBuffer;
     }
 
@@ -310,7 +310,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         }
     }
 
-    public IovArray iovArray() {
+    IovArray iovArray() {
         IovArray iovArray = iovArrays.next();
         if (iovArray == null) {
             ringBuffer.ioUringSubmissionQueue().submit();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -135,20 +135,20 @@ final class IOUringSubmissionQueue {
         logger.trace("Offset: {}", offset);
     }
 
-    public boolean addTimeout(long nanoSeconds) {
+    boolean addTimeout(long nanoSeconds) {
         setTimeout(nanoSeconds);
         return enqueueSqe(Native.IORING_OP_TIMEOUT, 0, -1, timeoutMemoryAddress, 1, 0);
     }
 
-    public boolean addPollIn(int fd) {
+    boolean addPollIn(int fd) {
         return addPoll(fd, Native.POLLIN);
     }
 
-    public boolean addPollRdHup(int fd) {
+    boolean addPollRdHup(int fd) {
         return addPoll(fd, Native.POLLRDHUP);
     }
 
-    public boolean addPollOut(int fd) {
+    boolean addPollOut(int fd) {
         return addPoll(fd, Native.POLLOUT);
     }
 
@@ -157,43 +157,43 @@ final class IOUringSubmissionQueue {
     }
 
     //return true -> submit() was called
-    public boolean addRead(int fd, long bufferAddress, int pos, int limit) {
+    boolean addRead(int fd, long bufferAddress, int pos, int limit) {
         return enqueueSqe(Native.IORING_OP_READ, 0, fd, bufferAddress + pos, limit - pos, 0);
     }
 
-    public boolean addWrite(int fd, long bufferAddress, int pos, int limit) {
+    boolean addWrite(int fd, long bufferAddress, int pos, int limit) {
         return enqueueSqe(Native.IORING_OP_WRITE, 0, fd, bufferAddress + pos, limit - pos, 0);
     }
 
-    public boolean addAccept(int fd, long address, long addressLength) {
+    boolean addAccept(int fd, long address, long addressLength) {
         return enqueueSqe(Native.IORING_OP_ACCEPT, Native.SOCK_NONBLOCK | Native.SOCK_CLOEXEC, fd,
                 address, 0, addressLength);
     }
 
     //fill the address which is associated with server poll link user_data
-    public boolean addPollRemove(int fd, int pollMask) {
+    boolean addPollRemove(int fd, int pollMask) {
         return enqueueSqe(Native.IORING_OP_POLL_REMOVE, 0, fd,
                 convertToUserData(Native.IORING_OP_POLL_ADD, fd, pollMask), 0, 0);
     }
 
-    public boolean addConnect(int fd, long socketAddress, long socketAddressLength) {
+    boolean addConnect(int fd, long socketAddress, long socketAddressLength) {
         return enqueueSqe(Native.IORING_OP_CONNECT, 0, fd, socketAddress, 0, socketAddressLength);
     }
 
-    public boolean addWritev(int fd, long iovecArrayAddress, int length) {
+    boolean addWritev(int fd, long iovecArrayAddress, int length) {
         return enqueueSqe(Native.IORING_OP_WRITEV, 0, fd, iovecArrayAddress, length, 0);
     }
 
-    public boolean addClose(int fd) {
+    boolean addClose(int fd) {
         return enqueueSqe(Native.IORING_OP_CLOSE, 0, fd, 0, 0, 0);
     }
 
-    public int submit() {
+    int submit() {
         int submit = tail - head;
         return submit > 0 ? submit(submit, 0, 0) : 0;
     }
 
-    public int submitAndWait() {
+    int submitAndWait() {
         int submit = tail - head;
         if (submit > 0) {
             return submit(submit, 1, Native.IORING_ENTER_GETEVENTS);
@@ -223,7 +223,6 @@ final class IOUringSubmissionQueue {
     private void setTimeout(long timeoutNanoSeconds) {
         long seconds, nanoSeconds;
 
-        //Todo
         if (timeoutNanoSeconds == 0) {
             seconds = 0;
             nanoSeconds = 0;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
@@ -49,6 +49,7 @@ final class LinuxSocket extends Socket {
         return ipv6 ? InternetProtocolFamily.IPv6 : InternetProtocolFamily.IPv4;
     }
 
+    @Override
     public boolean markClosed() {
         return super.markClosed();
     }
@@ -71,7 +72,7 @@ final class LinuxSocket extends Socket {
         setInterface(intValue(), ipv6, nativeAddress.address(), nativeAddress.scopeId(), interfaceIndex(netInterface));
     }
 
-    public int initAddress(byte[] address, int scopeId, int port, long addressMemory) {
+    int initAddress(byte[] address, int scopeId, int port, long addressMemory) {
         return initAddress(intValue(), ipv6, address, scopeId, port, addressMemory);
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -149,10 +149,6 @@ final class Native {
     // for testing(it is only temporary)
     public static native int createFile();
 
-    public static Socket newSocketStream() {
-        return Socket.newSocketStream();
-    }
-
     private Native() {
         // utility
     }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -25,7 +25,7 @@ final class RingBuffer {
         this.ioUringCompletionQueue = ioUringCompletionQueue;
     }
 
-     IOUringSubmissionQueue ioUringSubmissionQueue() {
+    IOUringSubmissionQueue ioUringSubmissionQueue() {
         return this.ioUringSubmissionQueue;
     }
 


### PR DESCRIPTION
Motivation:

Just some cleanup needed in general

Modifications:

- Make methods package-private when the class is package-private
- Use spaces and not tabs everywhere
- Fix eventfd_write usage as the implementation was only needed like
this for EPOLL when used with edge-triggered
- Correctly handle EINTR

Result:

Cleaner code