### PR TITLE
Directly write / read sockaddr_in and sockaddr_in6 from direct memory

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -189,7 +189,7 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
             for (ChannelFuture future: futures) {
                 future.sync();
             }
-            if (!latch.await(10, TimeUnit.SECONDS)) {
+            if (!latch.await(100000, TimeUnit.SECONDS)) {
                 Throwable error = errorRef.get();
                 if (error != null) {
                     throw error;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -189,7 +189,7 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
             for (ChannelFuture future: futures) {
                 future.sync();
             }
-            if (!latch.await(100000, TimeUnit.SECONDS)) {
+            if (!latch.await(10, TimeUnit.SECONDS)) {
                 Throwable error = errorRef.get();
                 if (error != null) {
                     throw error;

--- a/transport-native-io_uring/src/main/c/netty_io_uring_linuxsocket.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_linuxsocket.c
@@ -102,19 +102,6 @@ static void netty_io_uring_linuxsocket_setInterface(JNIEnv* env, jclass clazz, j
     }
 }
 
-static jint netty_io_uring_initAddress(JNIEnv* env, jclass clazz, jint fd, jboolean ipv6, jbyteArray address, jint scopeId, jint port, jlong addressMemory) {
-    struct sockaddr_storage addr;
-    socklen_t addrSize;
-    if (netty_unix_socket_initSockaddr(env, ipv6, address, scopeId, port, &addr, &addrSize) == -1) {
-        // A runtime exception was thrown
-        return -1;
-    }
-
-    memcpy((void *) addressMemory, &addr, sizeof(struct sockaddr_storage));
-
-    return addrSize;
-}
-
 static void netty_io_uring_linuxsocket_setTcpCork(JNIEnv* env, jclass clazz, jint fd, jint optval) {
     netty_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_CORK, &optval, sizeof(optval));
 }
@@ -672,13 +659,6 @@ static jlong netty_io_uring_linuxsocket_sendFile(JNIEnv* env, jclass clazz, jint
     return res;
 }
 
-static int netty_io_uring_linuxsocket_initInetSocketAddressArray(JNIEnv* env, jclass clazz, jlong acceptedAddressMemoryAddress, long acceptedAddressLengthMemoryAddress, jbyteArray array) {
-    const struct sockaddr_storage* addr = (const struct sockaddr_storage*) acceptedAddressMemoryAddress;
-    jsize len = netty_unix_socket_addressArrayLength(addr);
-    netty_unix_socket_initInetSocketAddressArray(env, addr, array, 0, len);
-    return len;
-}
-
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
@@ -721,10 +701,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "joinGroup", "(IZ[B[BII)V", (void *) netty_io_uring_linuxsocket_joinGroup },
   { "joinSsmGroup", "(IZ[B[BII[B)V", (void *) netty_io_uring_linuxsocket_joinSsmGroup },
   { "leaveGroup", "(IZ[B[BII)V", (void *) netty_io_uring_linuxsocket_leaveGroup },
-  { "leaveSsmGroup", "(IZ[B[BII[B)V", (void *) netty_io_uring_linuxsocket_leaveSsmGroup },
-  { "initAddress", "(IZ[BIIJ)I", (void *) netty_io_uring_initAddress },
-  { "initInetSocketAddressArray", "(JJ[B)I", netty_io_uring_linuxsocket_initInetSocketAddressArray }
-  // "sendFile" has a dynamic signature
+  { "leaveSsmGroup", "(IZ[B[BII[B)V", (void *) netty_io_uring_linuxsocket_leaveSsmGroup }
 };
 
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -267,6 +267,22 @@ static jint netty_io_uring_sockCloexec(JNIEnv* env, jclass clazz) {
     return SOCK_CLOEXEC;
 }
 
+static jint netty_io_uring_afInet(JNIEnv* env, jclass clazz) {
+    return AF_INET;
+}
+
+static jint netty_io_uring_afInet6(JNIEnv* env, jclass clazz) {
+    return AF_INET6;
+}
+
+static jint netty_io_uring_sizeofSockaddrIn(JNIEnv* env, jclass clazz) {
+    return sizeof(struct sockaddr_in);
+}
+
+static jint netty_io_uring_sizeofSockaddrIn6(JNIEnv* env, jclass clazz) {
+    return sizeof(struct sockaddr_in6);
+}
+
 static jint netty_io_uring_etime(JNIEnv* env, jclass clazz) {
     return ETIME;
 }
@@ -331,10 +347,15 @@ static jint netty_io_uring_iosqeAsync(JNIEnv* env, jclass clazz) {
     return IOSQE_ASYNC;
 }
 
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "sockNonblock", "()I", (void *) netty_io_uring_sockNonblock },
   { "sockCloexec", "()I", (void *) netty_io_uring_sockCloexec },
+  { "afInet", "()I", (void *) netty_io_uring_afInet },
+  { "afInet6", "()I", (void *) netty_io_uring_afInet6 },
+  { "sizeofSockaddrIn", "()I", (void *) netty_io_uring_sizeofSockaddrIn },
+  { "sizeofSockaddrIn6", "()I", (void *) netty_io_uring_sizeofSockaddrIn6 },
   { "etime", "()I", (void *) netty_io_uring_etime },
   { "ecanceled", "()I", (void *) netty_io_uring_ecanceled },
   { "pollin", "()I", (void *) netty_io_uring_pollin },

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -52,6 +52,9 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
     private final FileDescriptor eventfd;
 
     private final IovArrays iovArrays;
+    // The maximum number of bytes for an InetAddress / Inet6Address
+    private final byte[] inet4AddressArray = new byte[4];
+    private final byte[] inet6AddressArray = new byte[16];
 
     private long prevDeadlineNanos = NONE;
     private boolean pendingWakeup;
@@ -318,5 +321,19 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
             assert iovArray != null;
         }
         return iovArray;
+    }
+
+    /**
+     * {@code byte[]} that can be used as temporary storage to encode the ipv4 address
+     */
+    byte[] inet4AddressArray() {
+        return inet4AddressArray;
+    }
+
+    /**
+     * {@code byte[]} that can be used as temporary storage to encode the ipv6 address
+     */
+    byte[] inet6AddressArray() {
+        return inet6AddressArray;
     }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/LinuxSocket.java
@@ -72,10 +72,6 @@ final class LinuxSocket extends Socket {
         setInterface(intValue(), ipv6, nativeAddress.address(), nativeAddress.scopeId(), interfaceIndex(netInterface));
     }
 
-    int initAddress(byte[] address, int scopeId, int port, long addressMemory) {
-        return initAddress(intValue(), ipv6, address, scopeId, port, addressMemory);
-    }
-
     InetAddress getInterface() throws IOException {
         NetworkInterface inf = getNetworkInterface();
         if (inf != null) {
@@ -314,6 +310,10 @@ final class LinuxSocket extends Socket {
         return ipAny;
     }
 
+    boolean isIpv6() {
+        return ipv6;
+    }
+
     public static LinuxSocket newSocketStream(boolean ipv6) {
         return new LinuxSocket(newSocketStream0(ipv6));
     }
@@ -392,8 +392,4 @@ final class LinuxSocket extends Socket {
     private static native int getIpMulticastLoop(int fd, boolean ipv6) throws IOException;
     private static native void setIpMulticastLoop(int fd, boolean ipv6, int enabled) throws IOException;
     private static native void setTimeToLive(int fd, int ttl) throws IOException;
-    private static native int initAddress(
-            int fd, boolean ipv6, byte[] address, int scopeId, int port, long memoryAddress);
-
-    static native int initInetSocketAddressArray(long addr, long addressLen, byte[] array);
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -64,12 +64,15 @@ final class Native {
     }
     static final int SOCK_NONBLOCK = NativeStaticallyReferencedJniMethods.sockNonblock();
     static final int SOCK_CLOEXEC = NativeStaticallyReferencedJniMethods.sockCloexec();
+    static final short AF_INET = (short) NativeStaticallyReferencedJniMethods.afInet();
+    static final short AF_INET6 = (short) NativeStaticallyReferencedJniMethods.afInet6();
+    static final int SIZEOF_SOCKADDR_IN = NativeStaticallyReferencedJniMethods.sizeofSockaddrIn();
+    static final int SIZEOF_SOCKADDR_IN6 = NativeStaticallyReferencedJniMethods.sizeofSockaddrIn6();
     static final int POLLIN = NativeStaticallyReferencedJniMethods.pollin();
     static final int POLLOUT = NativeStaticallyReferencedJniMethods.pollout();
     static final int POLLRDHUP = NativeStaticallyReferencedJniMethods.pollrdhup();
     static final int ERRNO_ECANCELED_NEGATIVE = -NativeStaticallyReferencedJniMethods.ecanceled();
     static final int ERRNO_ETIME_NEGATIVE = -NativeStaticallyReferencedJniMethods.etime();
-
     static final int IORING_OP_POLL_ADD = NativeStaticallyReferencedJniMethods.ioringOpPollAdd();
     static final int IORING_OP_TIMEOUT = NativeStaticallyReferencedJniMethods.ioringOpTimeout();
     static final int IORING_OP_ACCEPT = NativeStaticallyReferencedJniMethods.ioringOpAccept();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -32,6 +32,11 @@ final class NativeStaticallyReferencedJniMethods {
 
     static native int sockNonblock();
     static native int sockCloexec();
+    static native int afInet();
+    static native int afInet6();
+    static native int sizeofSockaddrIn();
+    static native int sizeofSockaddrIn6();
+
     static native int etime();
     static native int ecanceled();
     static native int pollin();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/SockaddrIn.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/SockaddrIn.java
@@ -59,7 +59,9 @@ final class SockaddrIn {
         PlatformDependent.copyMemory(bytes, offset, memory + written, 4);
         written += 4;
 
-        written += writePadding(memory + written, Native.SIZEOF_SOCKADDR_IN - written);
+        int padding = Native.SIZEOF_SOCKADDR_IN - written;
+        PlatformDependent.setMemory(memory + written, padding, (byte) 0);
+        written += padding;
         assert written == Native.SIZEOF_SOCKADDR_IN;
         return written;
     }
@@ -100,7 +102,9 @@ final class SockaddrIn {
             PlatformDependent.putInt(memory + written, ((Inet6Address) address).getScopeId());
             written += 4;
         }
-        written += writePadding(memory + written, Native.SIZEOF_SOCKADDR_IN6 - written);
+        int padding = Native.SIZEOF_SOCKADDR_IN6 - written;
+        PlatformDependent.setMemory(memory + written, padding, (byte) 0);
+        written += padding;
         assert written == Native.SIZEOF_SOCKADDR_IN6;
         return written;
     }
@@ -130,36 +134,5 @@ final class SockaddrIn {
 
     private static short handleNetworkOrder(short v) {
         return BIG_ENDIAN_NATIVE_ORDER ? v : Short.reverseBytes(v);
-    }
-
-    /**
-     * Fill with {@code 0}s if any padding is needed.
-     */
-    private static int writePadding(long memoryAddress, int length) {
-        if (length == 0) {
-            return length;
-        }
-        int nLong = length >>> 3;
-        int nBytes = length & 7;
-        for (int i = nLong; i > 0; i --) {
-            PlatformDependent.putLong(memoryAddress, 0);
-            memoryAddress += 8;
-        }
-        if (nBytes == 4) {
-            PlatformDependent.putInt(memoryAddress, 0);
-        } else if (nBytes < 4) {
-            for (int i = nBytes; i > 0; i --) {
-                PlatformDependent.putByte(memoryAddress, (byte) 0);
-                memoryAddress++;
-            }
-        } else {
-            PlatformDependent.putInt(memoryAddress, 0);
-            memoryAddress += 4;
-            for (int i = nBytes - 4; i > 0; i --) {
-                PlatformDependent.putByte(memoryAddress, (byte) 0);
-                memoryAddress++;
-            }
-        }
-        return length;
     }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/SockaddrIn.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/SockaddrIn.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import static io.netty.util.internal.PlatformDependent.BIG_ENDIAN_NATIVE_ORDER;
+
+final class SockaddrIn {
+    static final byte[] IPV4_MAPPED_IPV6_PREFIX = {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xff, (byte) 0xff };
+    private SockaddrIn() { }
+
+    /**
+     *
+     * struct sockaddr_in {
+     *      sa_family_t    sin_family; // address family: AF_INET
+     *      in_port_t      sin_port;   // port in network byte order
+     *      struct in_addr sin_addr;   // internet address
+     * };
+     *
+     * // Internet address.
+     * struct in_addr {
+     *     uint32_t       s_addr;     // address in network byte order
+     * };
+     *
+     */
+    static int writeIPv4(long memory, InetAddress address, int port) {
+        int written = 0;
+        PlatformDependent.putShort(memory, Native.AF_INET);
+        written += 2;
+        PlatformDependent.putShort(memory + written, handleNetworkOrder((short) port));
+        written += 2;
+        byte[] bytes = address.getAddress();
+        int offset = 0;
+        if (bytes.length == 16) {
+            // IPV6 mapped IPV4 address
+            offset = 12;
+        }
+        assert bytes.length == offset + 4;
+        PlatformDependent.copyMemory(bytes, offset, memory + written, 4);
+        written += 4;
+
+        written += writePadding(memory + written, Native.SIZEOF_SOCKADDR_IN - written);
+        assert written == Native.SIZEOF_SOCKADDR_IN;
+        return written;
+    }
+
+    /**
+     * struct sockaddr_in6 {
+     *     sa_family_t     sin6_family;   // AF_INET6
+     *     in_port_t       sin6_port;     // port number
+     *     uint32_t        sin6_flowinfo; // IPv6 flow information
+     *     struct in6_addr sin6_addr;     // IPv6 address
+     *     uint32_t        sin6_scope_id; /* Scope ID (new in 2.4)
+     * };
+     *
+     * struct in6_addr{
+     *     unsigned char s6_addr[16];   // IPv6 address
+     * };
+     */
+    static int writeIPv6(long memory, InetAddress address, int port) {
+        int written = 0;
+        // AF_INET6
+        PlatformDependent.putShort(memory, Native.AF_INET6);
+        written += 2;
+        PlatformDependent.putShort(memory + written, handleNetworkOrder((short) port));
+        written += 2;
+        PlatformDependent.putInt(memory + written, 0);
+        written += 4;
+        byte[] bytes = address.getAddress();
+        if  (bytes.length == 4) {
+            PlatformDependent.copyMemory(IPV4_MAPPED_IPV6_PREFIX, 0, memory + written, IPV4_MAPPED_IPV6_PREFIX.length);
+            written += IPV4_MAPPED_IPV6_PREFIX.length;
+            PlatformDependent.copyMemory(bytes, 0, memory + written, 4);
+            written += 4;
+            PlatformDependent.putInt(memory + written, 0);
+            written += 4;
+        } else {
+            PlatformDependent.copyMemory(bytes, 0, memory + written, 16);
+            written += 16;
+            PlatformDependent.putInt(memory + written, ((Inet6Address) address).getScopeId());
+            written += 4;
+        }
+        written += writePadding(memory + written, Native.SIZEOF_SOCKADDR_IN6 - written);
+        assert written == Native.SIZEOF_SOCKADDR_IN6;
+        return written;
+    }
+
+    static InetSocketAddress readIPv4(long memory, byte[] tmpArray) {
+        assert tmpArray.length == 4;
+        int port = handleNetworkOrder(PlatformDependent.getShort(memory + 2)) & 0xFFFF;
+        PlatformDependent.copyMemory(memory + 4, tmpArray, 0, 4);
+        try {
+            return new InetSocketAddress(InetAddress.getByAddress(tmpArray), port);
+        } catch (UnknownHostException ignore) {
+            return null;
+        }
+    }
+
+    static InetSocketAddress readIPv6(long memory, byte[] tmpArray) {
+        assert tmpArray.length == 16;
+        int port = handleNetworkOrder(PlatformDependent.getShort(memory + 2)) & 0xFFFF;
+        PlatformDependent.copyMemory(memory + 8, tmpArray, 0, 16);
+        int scopeId = PlatformDependent.getInt(memory + 24);
+        try {
+            return new InetSocketAddress(Inet6Address.getByAddress(null, tmpArray, scopeId), port);
+        } catch (UnknownHostException ignore) {
+            return null;
+        }
+    }
+
+    private static short handleNetworkOrder(short v) {
+        return BIG_ENDIAN_NATIVE_ORDER ? v : Short.reverseBytes(v);
+    }
+
+    /**
+     * Fill with {@code 0}s if any padding is needed.
+     */
+    private static int writePadding(long memoryAddress, int length) {
+        if (length == 0) {
+            return length;
+        }
+        int nLong = length >>> 3;
+        int nBytes = length & 7;
+        for (int i = nLong; i > 0; i --) {
+            PlatformDependent.putLong(memoryAddress, 0);
+            memoryAddress += 8;
+        }
+        if (nBytes == 4) {
+            PlatformDependent.putInt(memoryAddress, 0);
+        } else if (nBytes < 4) {
+            for (int i = nBytes; i > 0; i --) {
+                PlatformDependent.putByte(memoryAddress, (byte) 0);
+                memoryAddress++;
+            }
+        } else {
+            PlatformDependent.putInt(memoryAddress, 0);
+            memoryAddress += 4;
+            for (int i = nBytes - 4; i > 0; i --) {
+                PlatformDependent.putByte(memoryAddress, (byte) 0);
+                memoryAddress++;
+            }
+        }
+        return length;
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SockaddrInTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SockaddrInTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.channel.unix.Buffer;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+public class SockaddrInTest {
+
+    @Test
+    public void testIp4() throws Exception {
+        Assume.assumeTrue(IOUring.isAvailable());
+
+        ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(64);
+        try {
+            long memoryAddress = Buffer.memoryAddress(buffer);
+            InetAddress address = InetAddress.getByAddress(new byte[] { 10, 10, 10, 10 });
+            int port = 45678;
+            Assert.assertEquals(Native.SIZEOF_SOCKADDR_IN, SockaddrIn.writeIPv4(memoryAddress, address, port));
+            byte[] bytes = new byte[4];
+            InetSocketAddress sockAddr = SockaddrIn.readIPv4(memoryAddress, bytes);
+            Assert.assertArrayEquals(address.getAddress(), sockAddr.getAddress().getAddress());
+            Assert.assertEquals(port, sockAddr.getPort());
+        } finally {
+            Buffer.free(buffer);
+        }
+    }
+
+    @Test
+    public void testIp6() throws Exception {
+        Assume.assumeTrue(IOUring.isAvailable());
+
+        ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(64);
+        try {
+            long memoryAddress = Buffer.memoryAddress(buffer);
+            Inet6Address address = Inet6Address.getByAddress(
+                    null, new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }, 12345);
+            int port = 45678;
+            Assert.assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.writeIPv6(memoryAddress, address, port));
+            byte[] bytes = new byte[16];
+            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, bytes);
+            Inet6Address inet6Address = (Inet6Address) sockAddr.getAddress();
+            Assert.assertArrayEquals(address.getAddress(), inet6Address.getAddress());
+            Assert.assertEquals(address.getScopeId(), inet6Address.getScopeId());
+            Assert.assertEquals(port, sockAddr.getPort());
+        } finally {
+            Buffer.free(buffer);
+        }
+    }
+
+    @Test
+    public void testWriteIp4ReadIpv6Mapped() throws Exception {
+        Assume.assumeTrue(IOUring.isAvailable());
+
+        ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(64);
+        try {
+            long memoryAddress = Buffer.memoryAddress(buffer);
+            InetAddress address = InetAddress.getByAddress(new byte[] { 10, 10, 10, 10 });
+            int port = 45678;
+            Assert.assertEquals(Native.SIZEOF_SOCKADDR_IN6, SockaddrIn.writeIPv6(memoryAddress, address, port));
+            byte[] bytes = new byte[16];
+            InetSocketAddress sockAddr = SockaddrIn.readIPv6(memoryAddress, bytes);
+            Inet6Address inet6Address = (Inet6Address) sockAddr.getAddress();
+
+            System.arraycopy(SockaddrIn.IPV4_MAPPED_IPV6_PREFIX, 0, bytes, 0,
+                    SockaddrIn.IPV4_MAPPED_IPV6_PREFIX.length);
+            System.arraycopy(address.getAddress(), 0, bytes, SockaddrIn.IPV4_MAPPED_IPV6_PREFIX.length, 4);
+            Assert.assertArrayEquals(bytes, inet6Address.getAddress());
+            Assert.assertEquals(0, inet6Address.getScopeId());
+            Assert.assertEquals(port, sockAddr.getPort());
+        } finally {
+            Buffer.free(buffer);
+        }
+    }
+}


### PR DESCRIPTION
without JNI

Motivation:

We want to keep the amount of JNI as small as possible to reduce the
performance overhead now that we eliminated the overhead of the need of
it for syscalls.

Modifications:

Write / read sockaddr_in / sockaddr_in6 via PlatformDependent and so
eliminate the need for JNI

Result:

Less JNI and so less overhead for crossing the border.