### PR TITLE
Cleanup the IOUringCompletionQueue and add some javadocs

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -17,91 +17,109 @@ package io.netty.channel.uring;
 
 import io.netty.util.internal.PlatformDependent;
 
+/**
+ * Completion queue implementation for io_uring.
+ */
 final class IOUringCompletionQueue {
 
-  //these offsets are used to access specific properties
-  //CQE (https://github.com/axboe/liburing/blob/master/src/include/liburing/io_uring.h#L162)
-  private static final int CQE_USER_DATA_FIELD = 0;
-  private static final int CQE_RES_FIELD = 8;
-  private static final int CQE_FLAGS_FIELD = 12;
+    //these offsets are used to access specific properties
+    //CQE (https://github.com/axboe/liburing/blob/master/src/include/liburing/io_uring.h#L162)
+    private static final int CQE_USER_DATA_FIELD = 0;
+    private static final int CQE_RES_FIELD = 8;
+    private static final int CQE_FLAGS_FIELD = 12;
 
-  private static final int CQE_SIZE = 16;
+    private static final int CQE_SIZE = 16;
 
-  //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
-  private final long kHeadAddress;
-  private final long kTailAddress;
-  private final long kringMaskAddress;
-  private final long kringEntries;
-  private final long kOverflowAddress;
+    //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
+    private final long kHeadAddress;
+    private final long kTailAddress;
+    private final long kringMaskAddress;
+    private final long kringEntries;
+    private final long kOverflowAddress;
 
-  private final long completionQueueArrayAddress;
+    private final long completionQueueArrayAddress;
 
-  final int ringSize;
-  final long ringAddress;
-  final int ringFd;
+    final int ringSize;
+    final long ringAddress;
+    final int ringFd;
 
-  private final int ringMask;
-  private int ringHead;
+    private final int ringMask;
+    private int ringHead;
 
-  IOUringCompletionQueue(long kHeadAddress, long kTailAddress, long kringMaskAddress, long kringEntries,
-      long kOverflowAddress, long completionQueueArrayAddress, int ringSize, long ringAddress, int ringFd) {
-    this.kHeadAddress = kHeadAddress;
-    this.kTailAddress = kTailAddress;
-    this.kringMaskAddress = kringMaskAddress;
-    this.kringEntries = kringEntries;
-    this.kOverflowAddress = kOverflowAddress;
-    this.completionQueueArrayAddress = completionQueueArrayAddress;
-    this.ringSize = ringSize;
-    this.ringAddress = ringAddress;
-    this.ringFd = ringFd;
+    IOUringCompletionQueue(long kHeadAddress, long kTailAddress, long kringMaskAddress, long kringEntries,
+                           long kOverflowAddress, long completionQueueArrayAddress, int ringSize, long ringAddress,
+                           int ringFd) {
+        this.kHeadAddress = kHeadAddress;
+        this.kTailAddress = kTailAddress;
+        this.kringMaskAddress = kringMaskAddress;
+        this.kringEntries = kringEntries;
+        this.kOverflowAddress = kOverflowAddress;
+        this.completionQueueArrayAddress = completionQueueArrayAddress;
+        this.ringSize = ringSize;
+        this.ringAddress = ringAddress;
+        this.ringFd = ringFd;
 
-    this.ringMask = PlatformDependent.getIntVolatile(kringMaskAddress);
-    this.ringHead = PlatformDependent.getIntVolatile(kHeadAddress);
-  }
-
-  public boolean hasCompletions() {
-      return ringHead != PlatformDependent.getIntVolatile(kTailAddress);
-  }
-
-  int process(IOUringCompletionQueueCallback callback) {
-      int tail = PlatformDependent.getIntVolatile(kTailAddress);
-      int i = 0;
-      while (ringHead != tail) {
-          long cqeAddress = completionQueueArrayAddress + (ringHead & ringMask) * CQE_SIZE;
-
-          long udata = PlatformDependent.getLong(cqeAddress + CQE_USER_DATA_FIELD);
-          int res = PlatformDependent.getInt(cqeAddress + CQE_RES_FIELD);
-          int flags = PlatformDependent.getInt(cqeAddress + CQE_FLAGS_FIELD);
-
-          //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
-          ringHead++;
-          PlatformDependent.putIntOrdered(kHeadAddress, ringHead);
-
-          int fd = (int) (udata >>> 32);
-          int opMask = (int) (udata & 0xFFFFFFFFL);
-          int op = opMask >>> 16;
-          int data = opMask & 0xffff;
-
-          i++;
-          callback.handle(fd, res, flags, op, data);
-      }
-      return i;
-  }
-
-  interface IOUringCompletionQueueCallback {
-      void handle(int fd, int res, int flags, int op, int data);
-  }
-
-  boolean ioUringWaitCqe() {
-    //IORING_ENTER_GETEVENTS -> wait until an event is completely processed
-    int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
-    if (ret < 0) {
-        //Todo throw exception!
-        return false;
-    } else if (ret == 0) {
-        return true;
+        this.ringMask = PlatformDependent.getIntVolatile(kringMaskAddress);
+        this.ringHead = PlatformDependent.getIntVolatile(kHeadAddress);
     }
-    //Todo throw Exception!
-    return false;
-  }
+
+    /**
+     * Returns {@code true} if any completion event is ready to be processed by
+     * {@link #process(IOUringCompletionQueueCallback)}, {@code false} otherwise.
+     */
+    boolean hasCompletions() {
+        return ringHead != PlatformDependent.getIntVolatile(kTailAddress);
+    }
+
+    /**
+     * Process the completion events in the {@link IOUringCompletionQueue} and return the number of processed
+     * events.
+     */
+    int process(IOUringCompletionQueueCallback callback) {
+        int tail = PlatformDependent.getIntVolatile(kTailAddress);
+        int i = 0;
+        while (ringHead != tail) {
+            long cqeAddress = completionQueueArrayAddress + (ringHead & ringMask) * CQE_SIZE;
+
+            long udata = PlatformDependent.getLong(cqeAddress + CQE_USER_DATA_FIELD);
+            int res = PlatformDependent.getInt(cqeAddress + CQE_RES_FIELD);
+            int flags = PlatformDependent.getInt(cqeAddress + CQE_FLAGS_FIELD);
+
+            //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
+            ringHead++;
+            PlatformDependent.putIntOrdered(kHeadAddress, ringHead);
+
+            int fd = (int) (udata >>> 32);
+            int opMask = (int) (udata & 0xFFFFFFFFL);
+            int op = opMask >>> 16;
+            int data = opMask & 0xffff;
+
+            i++;
+            callback.handle(fd, res, flags, op, data);
+        }
+        return i;
+    }
+
+    interface IOUringCompletionQueueCallback {
+        /**
+         * Called for a completion event that was put into the {@link IOUringCompletionQueue}.
+         */
+        void handle(int fd, int res, int flags, int op, int data);
+    }
+
+    /**
+     * Block until there is at least one completion ready to be processed.
+     */
+    boolean ioUringWaitCqe() {
+        //IORING_ENTER_GETEVENTS -> wait until an event is completely processed
+        int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
+        if (ret < 0) {
+            //Todo throw exception!
+            return false;
+        } else if (ret == 0) {
+          return true;
+        }
+        //Todo throw Exception!
+        return false;
+    }
 }


### PR DESCRIPTION
Motivation:

IOUringCompletionQueue did use 2 spaces but we use 4 spaces in netty.
Beside this there were not javadocs

Modifications:

- Use 4 spaces
- Add javadocs
- remove public from method signature

Result:

Code cleanup