### PR TITLE
Only create ConnectTimeoutException if really needed

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -674,9 +674,9 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
                     @Override
                     public void run() {
                         ChannelPromise connectPromise = AbstractIOUringChannel.this.connectPromise;
-                        ConnectTimeoutException cause =
-                                new ConnectTimeoutException("connection timed out: " + remoteAddress);
-                        if (connectPromise != null && connectPromise.tryFailure(cause)) {
+                        if (connectPromise != null && !connectPromise.isDone() &&
+                                connectPromise.tryFailure(new ConnectTimeoutException(
+                                        "connection timed out: " + remoteAddress))) {
                             close(voidPromise());
                         }
                     }


### PR DESCRIPTION
Motivation:

Creating exceptions is expensive so we should only do so if really needed. This is basically a port of #10595 for io_uring.

Modifications:

Only create the ConnectTimeoutException if we really need it.

Result:

Less overhead