### PR TITLE
Decouple rwflags from user data

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -80,16 +80,16 @@ final class IOUringCompletionQueue {
           int fd = (int) (udata >>> 32);
           int opMask = (int) (udata & 0xFFFFFFFFL);
           int op = opMask >>> 16;
-          int mask = opMask & 0xffff;
+          int data = opMask & 0xffff;
 
           i++;
-          callback.handle(fd, res, flags, op, mask);
+          callback.handle(fd, res, flags, op, data);
       }
       return i;
   }
 
   interface IOUringCompletionQueueCallback {
-      void handle(int fd, int res, int flags, int op, int mask);
+      void handle(int fd, int res, int flags, int op, int data);
   }
 
   boolean ioUringWaitCqe() {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -221,7 +221,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
     }
 
     @Override
-    public void handle(int fd, int res, int flags, int op, int pollMask) {
+    public void handle(int fd, int res, int flags, int op, int data) {
         if (op == Native.IORING_OP_READ && eventfd.intValue() == fd) {
             if (res != Native.ERRNO_ECANCELED_NEGATIVE) {
                 pendingWakeup = false;
@@ -242,7 +242,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
             } else if (op == Native.IORING_OP_WRITEV || op == Native.IORING_OP_WRITE) {
                 handleWrite(channel, res);
             } else if (op == Native.IORING_OP_POLL_ADD) {
-                handlePollAdd(channel, res, pollMask);
+                handlePollAdd(channel, res, data);
             } else if (op == Native.IORING_OP_POLL_REMOVE) {
                 if (res == Errors.ERRNO_ENOENT_NEGATIVE) {
                     logger.trace("IORING_POLL_REMOVE not successful");


### PR DESCRIPTION
Motivation:

We always encoded the rwflags into user data which only makes sense for
POLL* atm. We should decouple this and so allow to store other things
into the user data for other ops.

Modifications:

Allow to explicit define what to store into user data and so be more
flexible.

Result:

More flexible usage
