### PR TITLE
Increase initial buffer size in AdaptiveRecvByteBufAllocator

### DIFF
--- a/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
@@ -35,7 +35,8 @@ import static java.lang.Math.min;
 public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllocator {
 
     static final int DEFAULT_MINIMUM = 64;
-    static final int DEFAULT_INITIAL = 1024;
+    // Use an initial value that is bigger than the common MTU of 1500
+    static final int DEFAULT_INITIAL = 2048;
     static final int DEFAULT_MAXIMUM = 65536;
 
     private static final int INDEX_INCREMENT = 4;


### PR DESCRIPTION
Motivation:

We should use an initial buffer size with is >= 1500 (which is a common setting for MTU) to reduce the need for memory copies when a new connection is established. This is especially interesting when SSL / TLS comes into the mix.

This was ported from swiftnio:

https://github.com/apple/swift-nio/pull/1641

Modifications:

Increase the initial size from 1024 to 2048.

Result:

Possible less memory copies on new connections