### PR TITLE
Fix Javadoc Typo

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -165,7 +165,7 @@ public final class SslContextBuilder {
     /**
      * Creates a builder for new server-side {@link SslContext} with {@link KeyManager}.
      *
-     * @param KeyManager non-{@code null} KeyManager for server's private key
+     * @param keyManager non-{@code null} KeyManager for server's private key
      */
     public static SslContextBuilder forServer(KeyManager keyManager) {
         return new SslContextBuilder(true).keyManager(keyManager);


### PR DESCRIPTION
Motivation:

Following Javadoc standard

Modification:

Change from `@param KeyManager` to `@param keyManager`

Result:

The `@param` matches the actual parameter variable name
