### PR TITLE
Implement batching of reading and writing when using datagram with io…

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
@@ -75,26 +75,33 @@ abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel imple
     final class UringServerChannelUnsafe extends AbstractIOUringChannel.AbstractUringUnsafe {
 
         @Override
-        protected void scheduleWriteMultiple(ChannelOutboundBuffer in) {
-            // Do nothing
+        protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
+            throw new UnsupportedOperationException();
         }
 
         @Override
-        protected void scheduleWriteSingle(Object msg) {
-            // Do nothing
+        protected int scheduleWriteSingle(Object msg) {
+            throw new UnsupportedOperationException();
         }
 
         @Override
-        protected void scheduleRead0() {
+        boolean writeComplete0(int res, int data, int outstanding) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected int scheduleRead0() {
             final IOUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             allocHandle.attemptedBytesRead(1);
 
             IOUringSubmissionQueue submissionQueue = submissionQueue();
             submissionQueue.addAccept(fd().intValue(),
                     acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress, (short) 0);
+            return 1;
         }
 
-        protected void readComplete0(int res) {
+        @Override
+        protected void readComplete0(int res, int data, int outstanding) {
             final IOUringRecvByteAllocatorHandle allocHandle =
                     (IOUringRecvByteAllocatorHandle) unsafe()
                             .recvBufAllocHandle();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringChannelOption.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringChannelOption.java
@@ -41,4 +41,6 @@ public class IOUringChannelOption<T> extends UnixChannelOption<T> {
             ChannelOption.valueOf(IOUringChannelOption.class, "TCP_DEFER_ACCEPT");
     public static final ChannelOption<Boolean> TCP_QUICKACK = valueOf(IOUringChannelOption.class, "TCP_QUICKACK");
     public static final ChannelOption<Map<InetAddress, byte[]>> TCP_MD5SIG = valueOf("TCP_MD5SIG");
+
+    public static final ChannelOption<Integer> MAX_DATAGRAM_PAYLOAD_SIZE = valueOf("MAX_DATAGRAM_PAYLOAD_SIZE");
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringDatagramChannelConfig.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringDatagramChannelConfig.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
@@ -24,6 +25,7 @@ import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DatagramChannelConfig;
+import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -33,6 +35,7 @@ import java.util.Map;
 public final class IOUringDatagramChannelConfig extends DefaultChannelConfig implements DatagramChannelConfig {
     private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
     private boolean activeOnOpen;
+    private volatile int maxDatagramSize;
 
     IOUringDatagramChannelConfig(AbstractIOUringChannel channel) {
         super(channel);
@@ -49,7 +52,7 @@ public final class IOUringDatagramChannelConfig extends DefaultChannelConfig imp
                 ChannelOption.IP_MULTICAST_ADDR, ChannelOption.IP_MULTICAST_IF, ChannelOption.IP_MULTICAST_TTL,
                 ChannelOption.IP_TOS, ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION,
                 IOUringChannelOption.SO_REUSEPORT, IOUringChannelOption.IP_FREEBIND,
-                IOUringChannelOption.IP_TRANSPARENT);
+                IOUringChannelOption.IP_TRANSPARENT, IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE);
     }
 
     @SuppressWarnings({ "unchecked", "deprecation" })
@@ -94,6 +97,9 @@ public final class IOUringDatagramChannelConfig extends DefaultChannelConfig imp
         if (option == IOUringChannelOption.IP_FREEBIND) {
             return (T) Boolean.valueOf(isFreeBind());
         }
+        if (option == IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE) {
+            return (T) Integer.valueOf(getMaxDatagramPayloadSize());
+        }
         return super.getOption(option);
     }
 
@@ -128,6 +134,8 @@ public final class IOUringDatagramChannelConfig extends DefaultChannelConfig imp
             setFreeBind((Boolean) value);
         } else if (option == IOUringChannelOption.IP_TRANSPARENT) {
             setIpTransparent((Boolean) value);
+        } else if (option == IOUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE) {
+            setMaxDatagramPayloadSize((Integer) value);
         } else {
             return super.setOption(option, value);
         }
@@ -462,5 +470,26 @@ public final class IOUringDatagramChannelConfig extends DefaultChannelConfig imp
         } catch (IOException e) {
             throw new ChannelException(e);
         }
+    }
+
+    /**
+     * Set the maximum {@link io.netty.channel.socket.DatagramPacket} size. This will be used to determine if
+     * a batch of {@code IORING_IO_RECVMSG} should be used when reading from the underlying socket.
+     * When batched {@code recvmmsg} is used
+     * we may be able to read multiple {@link io.netty.channel.socket.DatagramPacket}s with one syscall and so
+     * greatly improve the performance. This number will be used to slice {@link ByteBuf}s returned by the used
+     * {@link RecvByteBufAllocator}. You can use {@code 0} to disable the usage of batching, any other bigger value
+     * will enable it.
+     */
+    public IOUringDatagramChannelConfig setMaxDatagramPayloadSize(int maxDatagramSize) {
+        this.maxDatagramSize = ObjectUtil.checkPositiveOrZero(maxDatagramSize, "maxDatagramSize");
+        return this;
+    }
+
+    /**
+     * Get the maximum {@link io.netty.channel.socket.DatagramPacket} size.
+     */
+    public int getMaxDatagramPayloadSize() {
+        return maxDatagramSize;
     }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -235,10 +235,10 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
                 return;
             }
             if (op == Native.IORING_OP_READ || op == Native.IORING_OP_ACCEPT || op == Native.IORING_OP_RECVMSG) {
-                handleRead(channel, res);
+                handleRead(channel, res, data);
             } else if (op == Native.IORING_OP_WRITEV ||
                     op == Native.IORING_OP_WRITE || op == Native.IORING_OP_SENDMSG) {
-                handleWrite(channel, res);
+                handleWrite(channel, res, data);
             } else if (op == Native.IORING_OP_POLL_ADD) {
                 handlePollAdd(channel, res, data);
             } else if (op == Native.IORING_OP_POLL_REMOVE) {
@@ -259,12 +259,12 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
         }
     }
 
-    private void handleRead(AbstractIOUringChannel channel, int res) {
-        channel.ioUringUnsafe().readComplete(res);
+    private void handleRead(AbstractIOUringChannel channel, int res, int data) {
+        channel.ioUringUnsafe().readComplete(res, data);
     }
 
-    private void handleWrite(AbstractIOUringChannel channel, int res) {
-        channel.ioUringUnsafe().writeComplete(res);
+    private void handleWrite(AbstractIOUringChannel channel, int res, int data) {
+        channel.ioUringUnsafe().writeComplete(res, data);
     }
 
     private void handlePollAdd(AbstractIOUringChannel channel, int res, int pollMask) {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Iov.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Iov.java
@@ -37,4 +37,20 @@ final class Iov {
             PlatformDependent.putLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN, length);
         }
     }
+
+    static long readBufferAddress(long iovAddress) {
+        if (Native.SIZEOF_SIZE_T == 4) {
+            return PlatformDependent.getInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE);
+        }
+        assert Native.SIZEOF_SIZE_T == 8;
+        return PlatformDependent.getLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_BASE);
+    }
+
+    static int readBufferLength(long iovAddress) {
+        if (Native.SIZEOF_SIZE_T == 4) {
+            return PlatformDependent.getInt(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN);
+        }
+        assert Native.SIZEOF_SIZE_T == 8;
+        return (int) PlatformDependent.getLong(iovAddress + Native.IOVEC_OFFSETOF_IOV_LEN);
+    }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.internal.PlatformDependent;
+
+import java.net.InetSocketAddress;
+
+final class MsgHdrMemory {
+    private final long memory;
+    private final int idx;
+
+    MsgHdrMemory(int idx) {
+        this.idx = idx;
+        int size = Native.SIZEOF_MSGHDR + Native.SIZEOF_SOCKADDR_STORAGE + Native.SIZEOF_IOVEC;
+        memory = PlatformDependent.allocateMemory(size);
+        PlatformDependent.setMemory(memory, size, (byte) 0);
+    }
+
+    void write(LinuxSocket socket, InetSocketAddress address, long bufferAddress , int length) {
+        long sockAddress = memory + Native.SIZEOF_MSGHDR;
+        long iovAddress = sockAddress + Native.SIZEOF_SOCKADDR_STORAGE;
+        int addressLength;
+        if (address == null) {
+            addressLength = socket.isIpv6() ? Native.SIZEOF_SOCKADDR_IN6 : Native.SIZEOF_SOCKADDR_IN;
+            PlatformDependent.setMemory(sockAddress, Native.SIZEOF_SOCKADDR_STORAGE, (byte) 0);
+        } else {
+            addressLength = SockaddrIn.write(socket.isIpv6(), sockAddress, address);
+        }
+        Iov.write(iovAddress, bufferAddress, length);
+        MsgHdr.write(memory, sockAddress, addressLength, iovAddress, 1);
+    }
+
+    DatagramPacket read(IOUringDatagramChannel channel, ByteBuf buffer, int bytesRead) {
+        long sockAddress = memory + Native.SIZEOF_MSGHDR;
+        IOUringEventLoop eventLoop = (IOUringEventLoop) channel.eventLoop();
+        InetSocketAddress sender;
+        if (channel.socket.isIpv6()) {
+            byte[] bytes = eventLoop.inet6AddressArray();
+            sender = SockaddrIn.readIPv6(sockAddress, bytes);
+        } else {
+            byte[] bytes = eventLoop.inet4AddressArray();
+            sender = SockaddrIn.readIPv4(sockAddress, bytes);
+        }
+        long iovAddress = memory + Native.SIZEOF_MSGHDR + Native.SIZEOF_SOCKADDR_STORAGE;
+        long bufferAddress = Iov.readBufferAddress(iovAddress);
+        int bufferLength = Iov.readBufferLength(iovAddress);
+        // reconstruct the reader index based on the memoryAddress of the buffer and the bufferAddress that was used
+        // in the iovec.
+        int readerIndex = (int) (bufferAddress - buffer.memoryAddress());
+
+        ByteBuf slice = buffer.slice(readerIndex, bufferLength)
+                .writerIndex(bytesRead);
+        return new DatagramPacket(slice.retain(), channel.localAddress(), sender);
+    }
+
+    int idx() {
+        return idx;
+    }
+
+    long address() {
+        return memory;
+    }
+
+    void release() {
+        PlatformDependent.freeMemory(memory);
+    }
+}

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+final class MsgHdrMemoryArray {
+    private int idx;
+    private final MsgHdrMemory[] hdrs;
+    private final int capacity;
+
+    MsgHdrMemoryArray(int capacity) {
+        this.capacity = capacity;
+        hdrs = new MsgHdrMemory[capacity];
+        for (int i = 0; i < hdrs.length; i++) {
+            hdrs[i] = new MsgHdrMemory(i);
+        }
+    }
+
+    MsgHdrMemory nextHdr() {
+        if (idx == hdrs.length - 1) {
+            return null;
+        }
+        return hdrs[idx++];
+    }
+
+    MsgHdrMemory hdr(int idx) {
+        return hdrs[idx];
+    }
+
+    void clear() {
+        idx = 0;
+    }
+
+    int length() {
+        return idx;
+    }
+
+    void release() {
+        for (MsgHdrMemory hdr: hdrs) {
+            hdr.release();
+        }
+    }
+
+    int capacity() {
+        return capacity;
+    }
+}

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/SockaddrIn.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/SockaddrIn.java
@@ -29,11 +29,11 @@ final class SockaddrIn {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xff, (byte) 0xff };
     private SockaddrIn() { }
 
-    static void write(boolean ipv6, long memory, InetSocketAddress address) {
+    static int write(boolean ipv6, long memory, InetSocketAddress address) {
         if (ipv6) {
-            SockaddrIn.writeIPv6(memory, address.getAddress(), address.getPort());
+            return SockaddrIn.writeIPv6(memory, address.getAddress(), address.getPort());
         } else {
-            SockaddrIn.writeIPv4(memory, address.getAddress(), address.getPort());
+            return SockaddrIn.writeIPv4(memory, address.getAddress(), address.getPort());
         }
     }
 


### PR DESCRIPTION
…_uring.

Motivation:

io_uring does not support recvmmsg / sendmmsg directly and so we need to
"emulate" it by submitting multiple IORING_IO_RECVMSG /
IORING_IO_SENDMSG calls.

Modifications:

- Allow to issue multiple write / read calls at once no matter what
  concrete AbstractIOUringChannel subclass it is
- Add support for batching recvmsg / sendmsg when using
IOUringDatagramChannel

Result:

Better performance