### PR TITLE
Filter out duplicates before trying to find the alias to use

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
@@ -21,8 +21,10 @@ import javax.net.ssl.X509KeyManager;
 import javax.security.auth.x500.X500Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,8 +70,12 @@ final class OpenSslKeyMaterialManager {
         if (authMethods.length == 0) {
             return;
         }
-        Set<String> aliases = new HashSet<String>(authMethods.length);
-        for (String authMethod : authMethods) {
+        // authMethods may contain duplicates but call chooseServerAlias(...) may be expensive. So let's ensure
+        // we filter out duplicates.
+        Set<String> authMethodsSet = new LinkedHashSet<String>(authMethods.length);
+        Collections.addAll(authMethodsSet, authMethods);
+        Set<String> aliases = new HashSet<String>(authMethodsSet.size());
+        for (String authMethod : authMethodsSet) {
             String type = KEY_TYPES.get(authMethod);
             if (type != null) {
                 String alias = chooseServerAlias(engine, type);


### PR DESCRIPTION
Motivation:

Calling chooseServerAlias(...) may be expensive so we should ensure we not call it multiple times for the same auth methods.

Modifications:

Remove duplicated from authMethods before trying to call chooseServerAlias(...)

Result:

Less performance overhead during key material selection