### PR TITLE
Close IOUringEventLoop wakeup/eventfd close shutdown race

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -33,9 +33,6 @@ final class IOUringCompletionQueue {
     //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
     private final long kHeadAddress;
     private final long kTailAddress;
-    private final long kRingMaskAddress;
-    private final long kRingEntriesAddress;
-    private final long kOverflowAddress;
 
     private final long completionQueueArrayAddress;
 
@@ -51,9 +48,6 @@ final class IOUringCompletionQueue {
                            int ringFd) {
         this.kHeadAddress = kHeadAddress;
         this.kTailAddress = kTailAddress;
-        this.kRingMaskAddress = kRingMaskAddress;
-        this.kRingEntriesAddress = kRingEntriesAddress;
-        this.kOverflowAddress = kOverflowAddress;
         this.completionQueueArrayAddress = completionQueueArrayAddress;
         this.ringSize = ringSize;
         this.ringAddress = ringAddress;
@@ -110,16 +104,10 @@ final class IOUringCompletionQueue {
     /**
      * Block until there is at least one completion ready to be processed.
      */
-    boolean ioUringWaitCqe() {
-        //IORING_ENTER_GETEVENTS -> wait until an event is completely processed
+    void ioUringWaitCqe() {
         int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
         if (ret < 0) {
-            //Todo throw exception!
-            return false;
-        } else if (ret == 0) {
-          return true;
+            throw new RuntimeException("ioUringEnter syscall returned " + ret);
         }
-        //Todo throw Exception!
-        return false;
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -58,7 +58,7 @@ public class NativeTest {
                                             writeEventByteBuf.readerIndex(), writeEventByteBuf.writerIndex()));
         submissionQueue.submit();
 
-        assertTrue(completionQueue.ioUringWaitCqe());
+        completionQueue.ioUringWaitCqe();
         assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
             @Override
             public void handle(int fd, int res, int flags, int op, int mask) {
@@ -72,7 +72,7 @@ public class NativeTest {
                                            readEventByteBuf.writerIndex(), readEventByteBuf.capacity()));
         submissionQueue.submit();
 
-        assertTrue(completionQueue.ioUringWaitCqe());
+        completionQueue.ioUringWaitCqe();
         assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
             @Override
             public void handle(int fd, int res, int flags, int op, int mask) {
@@ -103,7 +103,7 @@ public class NativeTest {
         Thread thread = new Thread() {
             @Override
             public void run() {
-                assertTrue(completionQueue.ioUringWaitCqe());
+                completionQueue.ioUringWaitCqe();
                 try {
                     completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
                         @Override
@@ -152,7 +152,7 @@ public class NativeTest {
             }
         }.start();
 
-        assertTrue(completionQueue.ioUringWaitCqe());
+        completionQueue.ioUringWaitCqe();
         assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
             @Override
             public void handle(int fd, int res, int flags, int op, int mask) {
@@ -183,7 +183,7 @@ public class NativeTest {
         Thread waitingCqe = new Thread() {
             @Override
             public void run() {
-                assertTrue(completionQueue.ioUringWaitCqe());
+                completionQueue.ioUringWaitCqe();
                 assertEquals(1, completionQueue.process(new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
                     @Override
                     public void handle(int fd, int res, int flags, int op, int mask) {
@@ -251,7 +251,7 @@ public class NativeTest {
             @Override
             public void run() {
                 try {
-                    assertTrue(completionQueue.ioUringWaitCqe());
+                    completionQueue.ioUringWaitCqe();
                     assertEquals(2, completionQueue.process(verifyCallback));
                 } catch (AssertionError error) {
                     errorRef.set(error);


### PR DESCRIPTION
Motivation

There is a race condition when shutting down the event loop where the eventFd write performed in the `wakeup()` method may actually hit a different fd if it's closed and reassigned in the meantime.

This was already encountered and addressed in the epoll case.

Modifications

Similar to what's done for epoll, in `IOUringEventLoop`:
- Reinstate`pendingWakeup` flag which tracks when there is a wakeup pending (CAS of `nextWakeupNanos` performed by other thread in the `wakeup()` method)
- Add logic to the `cleanup()` method to wait for corresponding READ CQE before closing the eventFd
- Remove unused fields from `IOUringCompletionQueue` (cleanup)

Result

No event loop shutdown race