### PR TITLE
Add support for probing and so be able to detect if we can support

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
@@ -39,6 +39,7 @@ public final class IOUring {
                             // Noop
                         }
                     });
+                    Native.checkAllIOSupported(ringBuffer.fd());
                 } catch (Throwable t) {
                     cause = t;
                 } finally {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/RingBuffer.java
@@ -25,6 +25,10 @@ final class RingBuffer {
         this.ioUringCompletionQueue = ioUringCompletionQueue;
     }
 
+    int fd() {
+        return ioUringCompletionQueue.ringFd;
+    }
+
     IOUringSubmissionQueue ioUringSubmissionQueue() {
         return this.ioUringSubmissionQueue;
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringCompositeBufferGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringCompositeBufferGatheringWriteTest.java
@@ -19,10 +19,18 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.CompositeBufferGatheringWriteTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringCompositeBufferGatheringWriteTest extends CompositeBufferGatheringWriteTest  {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramConnectNotExistsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramConnectNotExistsTest.java
@@ -18,10 +18,18 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramConnectNotExistsTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringDatagramConnectNotExistsTest extends DatagramConnectNotExistsTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramMulticastIPv6Test.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramMulticastIPv6Test.java
@@ -18,10 +18,18 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramMulticastIPv6Test;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringDatagramMulticastIPv6Test extends DatagramMulticastIPv6Test {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramMulticastTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramMulticastTest.java
@@ -18,10 +18,19 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramMulticastTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringDatagramMulticastTest extends DatagramMulticastTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.datagram(internetProtocolFamily());

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramUnicastIPv6MappedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramUnicastIPv6MappedTest.java
@@ -18,10 +18,19 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
 import io.netty.testsuite.transport.socket.DatagramUnicastIPv6MappedTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringDatagramUnicastIPv6MappedTest extends DatagramUnicastIPv6MappedTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.datagram(internetProtocolFamily());

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramUnicastIPv6Test.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramUnicastIPv6Test.java
@@ -18,10 +18,19 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramUnicastIPv6Test;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringDatagramUnicastIPv6Test extends DatagramUnicastIPv6Test {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.datagram(internetProtocolFamily());

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramUnicastTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDatagramUnicastTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramUnicastTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringDatagramUnicastTest extends DatagramUnicastTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.datagram(InternetProtocolFamily.IPv4);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDetectPeerCloseWithReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringDetectPeerCloseWithReadTest.java
@@ -19,8 +19,17 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.unix.tests.DetectPeerCloseWithoutReadTest;
+import org.junit.BeforeClass;
+
+import static org.junit.Assume.assumeTrue;
 
 public class IOUringDetectPeerCloseWithReadTest extends DetectPeerCloseWithoutReadTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected EventLoopGroup newGroup() {
         return new IOUringEventLoopGroup(2);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringEventLoopTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringEventLoopTest.java
@@ -20,11 +20,19 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.testsuite.transport.AbstractSingleThreadEventLoopTest;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringEventLoopTest extends AbstractSingleThreadEventLoopTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected EventLoopGroup newEventLoopGroup() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketAutoReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketAutoReadTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketAutoReadTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketAutoReadTest extends SocketAutoReadTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketChannelNotYetConnectedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketChannelNotYetConnectedTest.java
@@ -18,10 +18,19 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketChannelNotYetConnectedTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketChannelNotYetConnectedTest extends SocketChannelNotYetConnectedTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.clientSocket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketCloseForciblyTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketCloseForciblyTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketCloseForciblyTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketCloseForciblyTest extends SocketCloseForciblyTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConditionalWritabilityTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConditionalWritabilityTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketConditionalWritabilityTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketConditionalWritabilityTest extends SocketConditionalWritabilityTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketConnectTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketConnectTest extends SocketConnectTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectionAttemptTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectionAttemptTest.java
@@ -18,10 +18,19 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketConnectionAttemptTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketConnectionAttemptTest extends SocketConnectionAttemptTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.clientSocket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketDataReadInitialStateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketDataReadInitialStateTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketDataReadInitialStateTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketDataReadInitialStateTest extends SocketDataReadInitialStateTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketEchoTest.java
@@ -19,10 +19,18 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation.BootstrapComboFactory;
 import io.netty.testsuite.transport.socket.SocketEchoTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketEchoTest extends SocketEchoTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketExceptionHandlingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketExceptionHandlingTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketExceptionHandlingTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketExceptionHandlingTest extends SocketExceptionHandlingTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketFixedLengthEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketFixedLengthEchoTest.java
@@ -27,6 +27,11 @@ import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketFixedLengthEchoTest extends SocketFixedLengthEchoTest {
 
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketGatheringWriteTest.java
@@ -19,10 +19,18 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketGatheringWriteTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketGatheringWriteTest extends SocketGatheringWriteTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketHalfClosedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketHalfClosedTest.java
@@ -21,12 +21,21 @@ import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketHalfClosedTest extends SocketHalfClosedTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketMultipleConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketMultipleConnectTest.java
@@ -21,11 +21,19 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketMultipleConnectTest;
+import org.junit.BeforeClass;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketMultipleConnectTest extends SocketMultipleConnectTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketObjectEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketObjectEchoTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketObjectEchoTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketObjectEchoTest extends SocketObjectEchoTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketReadPendingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketReadPendingTest.java
@@ -19,10 +19,19 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketReadPendingTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketReadPendingTest extends SocketReadPendingTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketRstTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketRstTest.java
@@ -21,14 +21,22 @@ import io.netty.channel.Channel;
 import io.netty.channel.unix.Errors;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketRstTest;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketRstTest extends SocketRstTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketShutdownOutputByPeerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketShutdownOutputByPeerTest.java
@@ -18,10 +18,19 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketShutdownOutputByPeerTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketShutdownOutputByPeerTest extends SocketShutdownOutputByPeerTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<ServerBootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.serverSocket();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketShutdownOutputBySelfTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketShutdownOutputBySelfTest.java
@@ -18,10 +18,18 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketShutdownOutputBySelfTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketShutdownOutputBySelfTest extends SocketShutdownOutputBySelfTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketSslClientRenegotiateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketSslClientRenegotiateTest.java
@@ -20,13 +20,21 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslClientRenegotiateTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
+
+import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
 
     public IOUringSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
         super(serverCtx, clientCtx, delegate);
+    }
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketSslEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketSslEchoTest.java
@@ -20,8 +20,11 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslEchoTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
+
+import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslEchoTest extends SocketSslEchoTest {
     public IOUringSocketSslEchoTest(
@@ -32,6 +35,11 @@ public class IOUringSocketSslEchoTest extends SocketSslEchoTest {
         super(serverCtx, clientCtx, renegotiation,
                 serverUsesDelegatedTaskExecutor, clientUsesDelegatedTaskExecutor,
                 autoRead, useChunkedWriteHandler, useCompositeByteBuf);
+    }
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketSslGreetingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketSslGreetingTest.java
@@ -20,13 +20,21 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslGreetingTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
+
+import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslGreetingTest  extends SocketSslGreetingTest {
 
     public IOUringSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
         super(serverCtx, clientCtx, delegate);
+    }
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketSslSessionReuseTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketSslSessionReuseTest.java
@@ -20,13 +20,21 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslSessionReuseTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
+
+import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketSslSessionReuseTest extends SocketSslSessionReuseTest {
 
     public IOUringSocketSslSessionReuseTest(SslContext serverCtx, SslContext clientCtx) {
         super(serverCtx, clientCtx);
+    }
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketStartTlsTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketStartTlsTest.java
@@ -20,13 +20,21 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketStartTlsTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
+
+import static org.junit.Assume.assumeTrue;
 
 public class IOUringSocketStartTlsTest extends SocketStartTlsTest {
 
     public IOUringSocketStartTlsTest(SslContext serverCtx, SslContext clientCtx) {
         super(serverCtx, clientCtx);
+    }
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketStringEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketStringEchoTest.java
@@ -19,10 +19,18 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketStringEchoTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringSocketStringEchoTest extends SocketStringEchoTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringWriteBeforeRegisteredTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringWriteBeforeRegisteredTest.java
@@ -18,10 +18,18 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.WriteBeforeRegisteredTest;
+import org.junit.BeforeClass;
 
 import java.util.List;
 
+import static org.junit.Assume.assumeTrue;
+
 public class IOUringWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IovArraysTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IovArraysTest.java
@@ -18,18 +18,24 @@ package io.netty.channel.uring;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.unix.IovArray;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assume.assumeTrue;
 
 public class IovArraysTest {
 
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
+
     @Test
     public void test() {
-        IOUring.ensureAvailability();
         ByteBuf buf = Unpooled.directBuffer(1).writeZero(1);
         IovArrays arrays = new IovArrays(2);
         try {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SockaddrInTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SockaddrInTest.java
@@ -19,6 +19,7 @@ import io.netty.channel.unix.Buffer;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.Inet6Address;
@@ -26,12 +27,17 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
+import static org.junit.Assume.assumeTrue;
+
 public class SockaddrInTest {
+
+    @BeforeClass
+    public static void loadJNI() {
+        assumeTrue(IOUring.isAvailable());
+    }
 
     @Test
     public void testIp4() throws Exception {
-        Assume.assumeTrue(IOUring.isAvailable());
-
         ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(64);
         try {
             long memoryAddress = Buffer.memoryAddress(buffer);
@@ -49,8 +55,6 @@ public class SockaddrInTest {
 
     @Test
     public void testIp6() throws Exception {
-        Assume.assumeTrue(IOUring.isAvailable());
-
         ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(64);
         try {
             long memoryAddress = Buffer.memoryAddress(buffer);
@@ -71,8 +75,6 @@ public class SockaddrInTest {
 
     @Test
     public void testWriteIp4ReadIpv6Mapped() throws Exception {
-        Assume.assumeTrue(IOUring.isAvailable());
-
         ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(64);
         try {
             long memoryAddress = Buffer.memoryAddress(buffer);


### PR DESCRIPTION
io_uring on the running system.

Motivation:

We should make use of the provided support of probing in io_uring. This
can help us to test if we can use the io_uring based transport on the
running system or not. Beside this it also allows us to compile on linux
systems which don't support all of the required io_uring ops.

Modifications:

- Add native call for probing
- make use of probing when trying to init the native library and fail if
probing fails

Result:

Better detection if the system supports all needed io_uring features or
not
