### PR TITLE
Ensure we can compile io_uring transport on systems that have linux k…

### DIFF
--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -45,11 +45,15 @@
 
   <profiles>
     <profile>
-      <id>iouring-native</id>
+      <id>linux</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
       <properties>
         <skipTests>false</skipTests>
       </properties>
-
       <build>
         <plugins>
           <plugin>

--- a/transport-native-io_uring/src/main/c/io_uring.h
+++ b/transport-native-io_uring/src/main/c/io_uring.h
@@ -48,7 +48,10 @@ struct io_uring_sqe {
 	};
 	__u32	len;		/* buffer size or number of iovecs */
 	union {
-		__kernel_rwf_t	rw_flags;
+		// IMPORTANT:
+		// We explicit use 'int __bitwise' here and not ' __kernel_rwf_t' as this may not be present in the
+		// kernel headers that are used on the system.
+		int __bitwise	rw_flags;
 		__u32		fsync_flags;
 		__u16		poll_events;	/* compatibility */
 		__u32		poll32_events;	/* word-reversed for BE */

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -201,7 +201,8 @@ static jboolean netty_io_uring_probe(JNIEnv *env, jclass clazz, jint ring_fd, ji
 
     jsize opsLen = (*env)->GetArrayLength(env, ops);
     jint *opsElements = (*env)->GetIntArrayElements(env, ops, 0);
-    for (int i = 0; i < opsLen; i++) {
+    int i;
+    for (i = 0; i < opsLen; i++) {
         int op = opsElements[i];
         if (op > probe->last_op || (probe->ops[op].flags & IO_URING_OP_SUPPORTED) == 0) {
             goto done;

--- a/transport-native-io_uring/src/main/c/syscall.c
+++ b/transport-native-io_uring/src/main/c/syscall.c
@@ -20,6 +20,17 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+// Define syscall numbers if not exists as these are "stable".
+#ifndef __NR_io_uring_setup
+#define __NR_io_uring_setup		425
+#endif
+#ifndef __NR_io_uring_enter
+#define __NR_io_uring_enter		426
+#endif
+#ifndef __NR_io_uring_register
+#define __NR_io_uring_register	427
+#endif
+
 int sys_io_uring_setup(unsigned entries, struct io_uring_params *p) {
     return syscall(__NR_io_uring_setup, entries, p);
 }


### PR DESCRIPTION
…ernel < 5.1

Motivation:

While we need to have a very recent kernel to run the io_uring transport itself we should allow to compile it with earlier versions to help with our build story.

Modifications:

- Ensure we can compile on "older systems"
- Just enable the profile when we build on linux

Result:

Less complicated to build io_uring transport