### PR TITLE
Respect the Provider when detecting if TLSv1.3 is used by default / s…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
@@ -19,6 +19,8 @@ package io.netty.handler.ssl;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.internal.UnstableApi;
 
+import java.security.Provider;
+
 /**
  * An enumeration of SSL/TLS protocol providers.
  */
@@ -41,6 +43,7 @@ public enum SslProvider {
      * Returns {@code true} if the specified {@link SslProvider} supports
      * <a href="https://tools.ietf.org/html/rfc7301#section-6">TLS ALPN Extension</a>, {@code false} otherwise.
      */
+    @SuppressWarnings("deprecation")
     public static boolean isAlpnSupported(final SslProvider provider) {
         switch (provider) {
             case JDK:
@@ -57,15 +60,23 @@ public enum SslProvider {
      * Returns {@code true} if the specified {@link SslProvider} supports
      * <a href="https://tools.ietf.org/html/rfc8446">TLS 1.3</a>, {@code false} otherwise.
      */
-    public static boolean isTlsv13Supported(final SslProvider provider) {
-        switch (provider) {
+    public static boolean isTlsv13Supported(final SslProvider sslProvider) {
+        return isTlsv13Supported(sslProvider, null);
+    }
+
+    /**
+     * Returns {@code true} if the specified {@link SslProvider} supports
+     * <a href="https://tools.ietf.org/html/rfc8446">TLS 1.3</a>, {@code false} otherwise.
+     */
+    public static boolean isTlsv13Supported(final SslProvider sslProvider, Provider provider) {
+        switch (sslProvider) {
             case JDK:
-                return SslUtils.isTLSv13SupportedByJDK();
+                return SslUtils.isTLSv13SupportedByJDK(provider);
             case OPENSSL:
             case OPENSSL_REFCNT:
                 return OpenSsl.isTlsv13Supported();
             default:
-                throw new Error("Unknown SslProvider: " + provider);
+                throw new Error("Unknown SslProvider: " + sslProvider);
         }
     }
 
@@ -73,15 +84,15 @@ public enum SslProvider {
      * Returns {@code true} if the specified {@link SslProvider} enables
      * <a href="https://tools.ietf.org/html/rfc8446">TLS 1.3</a> by default, {@code false} otherwise.
      */
-    static boolean isTlsv13EnabledByDefault(final SslProvider provider) {
-        switch (provider) {
+    static boolean isTlsv13EnabledByDefault(final SslProvider sslProvider, Provider provider) {
+        switch (sslProvider) {
             case JDK:
-                return SslUtils.isTLSv13EnabledByJDK();
+                return SslUtils.isTLSv13EnabledByJDK(provider);
             case OPENSSL:
             case OPENSSL_REFCNT:
                 return OpenSsl.isTlsv13Supported();
             default:
-                throw new Error("Unknown SslProvider: " + provider);
+                throw new Error("Unknown SslProvider: " + sslProvider);
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -3609,19 +3609,10 @@ public abstract class SSLEngineTest {
             ssc.delete();
         }
 
-        assertEquals(SslProvider.isTlsv13EnabledByDefault(sslClientProvider()),
+        assertEquals(SslProvider.isTlsv13EnabledByDefault(sslClientProvider(), clientSslContextProvider()),
                 arrayContains(clientProtocols, PROTOCOL_TLS_V1_3));
-        assertEquals(SslProvider.isTlsv13EnabledByDefault(sslServerProvider()),
+        assertEquals(SslProvider.isTlsv13EnabledByDefault(sslServerProvider(), serverSslContextProvider()),
                 arrayContains(serverProtocols, PROTOCOL_TLS_V1_3));
-    }
-
-    private static boolean arrayContains(String[] array, String value) {
-        for (String v: array) {
-            if (value.equals(v)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     protected SSLEngine wrapEngine(SSLEngine engine) {


### PR DESCRIPTION
…upported

Motivation:

We need to take the Provider into account as well when trying to detect if TLSv1.3 is used by default / supported

Modifications:

- Change utility method to respect provider as well
- Change testcode

Result:

Less error-prone tests
