### PR TITLE
Enable IOSQE_ASYNC depending on how many fds are handled

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -103,8 +103,9 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
         logger.trace("Add Channel: {} ", ch.socket.intValue());
         int fd = ch.socket.intValue();
 
-        channels.put(fd, ch);
-        ringBuffer.ioUringSubmissionQueue().incrementHandledFds();
+        if (channels.put(fd, ch) == null) {
+            ringBuffer.ioUringSubmissionQueue().incrementHandledFds();
+        }
     }
 
     void remove(AbstractIOUringChannel ch) {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -113,6 +113,8 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
 
         AbstractIOUringChannel old = channels.remove(fd);
         if (old != null) {
+            ringBuffer.ioUringSubmissionQueue().decrementHandledFds();
+
             if (old != ch) {
                 // The Channel mapping was already replaced due FD reuse, put back the stored Channel.
                 channels.put(fd, old);
@@ -120,8 +122,6 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
                 // If we found another Channel in the map that is mapped to the same FD the given Channel MUST be
                 // closed.
                 assert !ch.isOpen();
-            } else {
-                ringBuffer.ioUringSubmissionQueue().decrementHandledFds();
             }
         }
     }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -58,7 +58,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
     private long prevDeadlineNanos = NONE;
     private boolean pendingWakeup;
 
-    IOUringEventLoop(IOUringEventLoopGroup parent, Executor executor, int ringSize, boolean ioseqAsync,
+    IOUringEventLoop(IOUringEventLoopGroup parent, Executor executor, int ringSize, int iosqeAsyncThreshold,
                      RejectedExecutionHandler rejectedExecutionHandler, EventLoopTaskQueueFactory queueFactory) {
         super(parent, executor, false, newTaskQueue(queueFactory), newTaskQueue(queueFactory),
                 rejectedExecutionHandler);
@@ -68,7 +68,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
         // TODO: Let's hard code this to 8 IovArrays to keep the memory overhead kind of small. We may want to consider
         //       allow to change this in the future.
         iovArrays = new IovArrays(8);
-        ringBuffer = Native.createRingBuffer(ringSize, ioseqAsync, new Runnable() {
+        ringBuffer = Native.createRingBuffer(ringSize, iosqeAsyncThreshold, new Runnable() {
             @Override
             public void run() {
                 // Once we submitted its safe to clear the IovArrays and so be able to re-use these.
@@ -104,6 +104,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
         int fd = ch.socket.intValue();
 
         channels.put(fd, ch);
+        ringBuffer.ioUringSubmissionQueue().incrementHandledFds();
     }
 
     void remove(AbstractIOUringChannel ch) {
@@ -111,12 +112,17 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
         int fd = ch.socket.intValue();
 
         AbstractIOUringChannel old = channels.remove(fd);
-        if (old != null && old != ch) {
-            // The Channel mapping was already replaced due FD reuse, put back the stored Channel.
-            channels.put(fd, old);
+        if (old != null) {
+            if (old != ch) {
+                // The Channel mapping was already replaced due FD reuse, put back the stored Channel.
+                channels.put(fd, old);
 
-            // If we found another Channel in the map that is mapped to the same FD the given Channel MUST be closed.
-            assert !ch.isOpen();
+                // If we found another Channel in the map that is mapped to the same FD the given Channel MUST be
+                // closed.
+                assert !ch.isOpen();
+            } else {
+                ringBuffer.ioUringSubmissionQueue().decrementHandledFds();
+            }
         }
     }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoopGroup.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoopGroup.java
@@ -48,53 +48,57 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
      * Create a new instance using the default number of threads and the given {@link ThreadFactory}.
      */
     public IOUringEventLoopGroup(ThreadFactory threadFactory) {
-        this(0, threadFactory, 0, Native.DEFAULT_USE_IOSEQ_ASYNC);
+        this(0, threadFactory, 0, Native.DEFAULT_IOSEQ_ASYNC_THRESHOLD);
     }
 
     /**
      * Create a new instance using the specified number of threads and the given {@link ThreadFactory}.
      */
     public IOUringEventLoopGroup(int nThreads, ThreadFactory threadFactory) {
-        this(nThreads, threadFactory, 0, Native.DEFAULT_USE_IOSEQ_ASYNC);
+        this(nThreads, threadFactory, 0, Native.DEFAULT_IOSEQ_ASYNC_THRESHOLD);
     }
 
     /**
      * Create a new instance using the specified number of threads and the given {@link Executor}.
      */
     public IOUringEventLoopGroup(int nThreads, Executor executor) {
-        this(nThreads, executor, 0, Native.DEFAULT_USE_IOSEQ_ASYNC);
+        this(nThreads, executor, 0, Native.DEFAULT_IOSEQ_ASYNC_THRESHOLD);
     }
 
     /**
      * Create a new instance using the specified number of threads, the given {@link ThreadFactory}, the given
-     * size of the used ringbuffer and
-     * if <a href=https://manpages.debian.org/unstable/liburing-dev/io_uring_enter.2.en.html>IOSEQ_ASYNC</a> should be
+     * size of the used ringbuffer and a threshold of registered FDs after which
+     * <a href=https://manpages.debian.org/unstable/liburing-dev/io_uring_enter.2.en.html>IOSEQ_ASYNC</a> should be
      * used for  IO operations.
      */
-    public IOUringEventLoopGroup(int nThreads, ThreadFactory threadFactory, int ringSize, boolean iosqeAsync) {
-        this(nThreads, threadFactory == null ? null : new ThreadPerTaskExecutor(threadFactory), ringSize, iosqeAsync);
+    public IOUringEventLoopGroup(int nThreads, ThreadFactory threadFactory, int ringSize, int iosqeAsyncThreshold) {
+        this(nThreads, threadFactory == null ? null : new ThreadPerTaskExecutor(threadFactory),
+                ringSize, iosqeAsyncThreshold);
     }
 
     /**
      * Create a new instance using the specified number of threads, the given {@link Executor}, the given
-     * size of the used ringbuffer and
-     * if <a href=https://manpages.debian.org/unstable/liburing-dev/io_uring_enter.2.en.html>IOSEQ_ASYNC</a> should be
+     * size of the used ringbuffer and a threshold of registered FDs after which
+     * <a href=https://manpages.debian.org/unstable/liburing-dev/io_uring_enter.2.en.html>IOSEQ_ASYNC</a> should be
      * used for  IO operations.
      */
-    public IOUringEventLoopGroup(int nThreads, Executor executor, int ringsize, boolean iosqeAsync) {
+    public IOUringEventLoopGroup(int nThreads, Executor executor, int ringsize, int iosqeAsyncThreshold) {
         this(nThreads, executor, DefaultEventExecutorChooserFactory.INSTANCE,
-                ringsize, iosqeAsync, RejectedExecutionHandlers.reject());
+                ringsize, iosqeAsyncThreshold, RejectedExecutionHandlers.reject());
     }
 
     private IOUringEventLoopGroup(int nThreads, Executor executor, EventExecutorChooserFactory chooserFactory,
-                                  int ringSize, boolean iosqeAsync, RejectedExecutionHandler rejectedExecutionHandler) {
-        this(nThreads, executor, chooserFactory, ringSize, iosqeAsync, rejectedExecutionHandler, null);
+                                  int ringSize, int iosqeAsyncThreshold,
+                                  RejectedExecutionHandler rejectedExecutionHandler) {
+        this(nThreads, executor, chooserFactory, ringSize, iosqeAsyncThreshold, rejectedExecutionHandler, null);
     }
 
     private IOUringEventLoopGroup(int nThreads, Executor executor, EventExecutorChooserFactory chooserFactory,
-                                  int ringSize, boolean iosqeAsync, RejectedExecutionHandler rejectedExecutionHandler,
+                                  int ringSize, int iosqeAsyncThreshold,
+                                  RejectedExecutionHandler rejectedExecutionHandler,
                                   EventLoopTaskQueueFactory queueFactory) {
-        super(nThreads, executor, chooserFactory, ringSize, iosqeAsync, rejectedExecutionHandler, queueFactory);
+        super(nThreads, executor, chooserFactory, ringSize, iosqeAsyncThreshold,
+                rejectedExecutionHandler, queueFactory);
     }
 
     @Override
@@ -102,14 +106,15 @@ public final class IOUringEventLoopGroup extends MultithreadEventLoopGroup {
         if (args.length != 4) {
             throw new IllegalArgumentException("Illegal amount of extra arguments");
         }
-        int ringSize = (Integer) args[0];
-        ObjectUtil.checkPositiveOrZero(ringSize, "ringSize");
+        int ringSize = ObjectUtil.checkPositiveOrZero((Integer) args[0], "ringSize");
         if (ringSize == 0) {
             ringSize = Native.DEFAULT_RING_SIZE;
         }
-        boolean iosqeAsync = (Boolean) args[1];
+
+        int iosqeAsyncThreshold =  ObjectUtil.checkPositiveOrZero((Integer) args[1], "iosqeAsyncThreshold");
         RejectedExecutionHandler rejectedExecutionHandler = (RejectedExecutionHandler) args[2];
         EventLoopTaskQueueFactory taskQueueFactory = (EventLoopTaskQueueFactory) args[3];
-        return new IOUringEventLoop(this, executor, ringSize, iosqeAsync, rejectedExecutionHandler, taskQueueFactory);
+        return new IOUringEventLoop(this, executor, ringSize, iosqeAsyncThreshold,
+                rejectedExecutionHandler, taskQueueFactory);
     }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -62,14 +62,15 @@ final class IOUringSubmissionQueue {
     final int ringFd;
     private final Runnable submissionCallback;
     private final long timeoutMemoryAddress;
-
+    private final int iosqeAsyncThreshold;
+    private int numHandledFds;
     private int head;
     private int tail;
 
     IOUringSubmissionQueue(long kHeadAddress, long kTailAddress, long kRingMaskAddress, long kRingEntriesAddress,
                            long kFlagsAddress, long kDroppedAddress, long kArrayAddress,
                            long submissionQueueArrayAddress, int ringSize, long ringAddress, int ringFd,
-                           boolean iosqeAsync, Runnable submissionCallback) {
+                           int iosqeAsyncThreshold, Runnable submissionCallback) {
         this.kHeadAddress = kHeadAddress;
         this.kTailAddress = kTailAddress;
         this.kFlagsAddress = kFlagsAddress;
@@ -86,6 +87,7 @@ final class IOUringSubmissionQueue {
         this.tail = PlatformDependent.getIntVolatile(kTailAddress);
 
         this.timeoutMemoryAddress = PlatformDependent.allocateMemory(KERNEL_TIMESPEC_SIZE);
+        this.iosqeAsyncThreshold = iosqeAsyncThreshold;
 
         // Zero the whole SQE array first
         PlatformDependent.setMemory(submissionQueueArrayAddress, ringEntries * SQE_SIZE, (byte) 0);
@@ -93,14 +95,26 @@ final class IOUringSubmissionQueue {
         // Fill SQ array indices (1-1 with SQE array) and set nonzero constant SQE fields
         long address = kArrayAddress;
         long sqeFlagsAddress = submissionQueueArrayAddress + SQE_FLAGS_FIELD;
-        byte flag = iosqeAsync ? (byte) Native.IOSQE_ASYNC : 0;
         for (int i = 0; i < ringEntries; i++, address += INT_SIZE, sqeFlagsAddress += SQE_SIZE) {
             PlatformDependent.putInt(address, i);
-            PlatformDependent.putByte(sqeFlagsAddress, flag);
         }
     }
 
-    private boolean enqueueSqe(int op, int rwFlags, int fd, long bufferAddress, int length, long offset, short data) {
+    void incrementHandledFds() {
+        numHandledFds++;
+    }
+
+    void decrementHandledFds() {
+        numHandledFds--;
+        assert numHandledFds >= 0;
+    }
+
+    private int flags() {
+        return numHandledFds < iosqeAsyncThreshold ? 0 : Native.IOSQE_ASYNC;
+    }
+
+    private boolean enqueueSqe(int op, int flags, int rwFlags, int fd,
+                               long bufferAddress, int length, long offset, short data) {
         int pending = tail - head;
         boolean submit = pending == ringEntries;
         if (submit) {
@@ -111,17 +125,17 @@ final class IOUringSubmissionQueue {
             }
         }
         long sqe = submissionQueueArrayAddress + (tail++ & ringMask) * SQE_SIZE;
-        setData(sqe, op, rwFlags, fd, bufferAddress, length, offset, data);
+        setData(sqe, op, flags, rwFlags, fd, bufferAddress, length, offset, data);
         return submit;
     }
 
-    private void setData(long sqe, int op, int rwFlags, int fd, long bufferAddress, int length,
+    private void setData(long sqe, int op, int flags, int rwFlags, int fd, long bufferAddress, int length,
                          long offset, short data) {
         //set sqe(submission queue) properties
 
         PlatformDependent.putByte(sqe + SQE_OP_CODE_FIELD, (byte) op);
-        // These two constants are set up-front
-        //PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, (byte) Native.IOSQE_ASYNC);
+        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, (byte) flags);
+        // This constant is set up-front
         //PlatformDependent.putShort(sqe + SQE_IOPRIO_FIELD, (short) 0);
         PlatformDependent.putInt(sqe + SQE_FD_FIELD, fd);
         PlatformDependent.putLong(sqe + SQE_OFFSET_FIELD, offset);
@@ -139,7 +153,7 @@ final class IOUringSubmissionQueue {
 
     boolean addTimeout(long nanoSeconds, short extraData) {
         setTimeout(nanoSeconds);
-        return enqueueSqe(Native.IORING_OP_TIMEOUT, 0, -1, timeoutMemoryAddress, 1, 0, extraData);
+        return enqueueSqe(Native.IORING_OP_TIMEOUT, 0, 0, -1, timeoutMemoryAddress, 1, 0, extraData);
     }
 
     boolean addPollIn(int fd) {
@@ -155,46 +169,46 @@ final class IOUringSubmissionQueue {
     }
 
     private boolean addPoll(int fd, int pollMask) {
-        return enqueueSqe(Native.IORING_OP_POLL_ADD, pollMask, fd, 0, 0, 0, (short) pollMask);
+        return enqueueSqe(Native.IORING_OP_POLL_ADD, 0, pollMask, fd, 0, 0, 0, (short) pollMask);
     }
 
     boolean addRecvmsg(int fd, long msgHdr, short extraData) {
-        return enqueueSqe(Native.IORING_OP_RECVMSG, 0, fd, msgHdr, 1, 0, extraData);
+        return enqueueSqe(Native.IORING_OP_RECVMSG, flags(), 0, fd, msgHdr, 1, 0, extraData);
     }
 
     boolean addSendmsg(int fd, long msgHdr, short extraData) {
-        return enqueueSqe(Native.IORING_OP_SENDMSG, 0, fd, msgHdr, 1, 0, extraData);
+        return enqueueSqe(Native.IORING_OP_SENDMSG, flags(), 0, fd, msgHdr, 1, 0, extraData);
     }
 
     boolean addRead(int fd, long bufferAddress, int pos, int limit, short extraData) {
-        return enqueueSqe(Native.IORING_OP_READ, 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+        return enqueueSqe(Native.IORING_OP_READ, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
     }
 
     boolean addWrite(int fd, long bufferAddress, int pos, int limit, short extraData) {
-        return enqueueSqe(Native.IORING_OP_WRITE, 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
+        return enqueueSqe(Native.IORING_OP_WRITE, flags(), 0, fd, bufferAddress + pos, limit - pos, 0, extraData);
     }
 
     boolean addAccept(int fd, long address, long addressLength, short extraData) {
-        return enqueueSqe(Native.IORING_OP_ACCEPT, Native.SOCK_NONBLOCK | Native.SOCK_CLOEXEC, fd,
+        return enqueueSqe(Native.IORING_OP_ACCEPT, flags(), Native.SOCK_NONBLOCK | Native.SOCK_CLOEXEC, fd,
                 address, 0, addressLength, extraData);
     }
 
     //fill the address which is associated with server poll link user_data
     boolean addPollRemove(int fd, int pollMask, short extraData) {
-        return enqueueSqe(Native.IORING_OP_POLL_REMOVE, 0, fd,
+        return enqueueSqe(Native.IORING_OP_POLL_REMOVE, 0, 0, fd,
                           encode(fd, Native.IORING_OP_POLL_ADD, (short) pollMask), 0, 0, extraData);
     }
 
     boolean addConnect(int fd, long socketAddress, long socketAddressLength, short extraData) {
-        return enqueueSqe(Native.IORING_OP_CONNECT, 0, fd, socketAddress, 0, socketAddressLength, extraData);
+        return enqueueSqe(Native.IORING_OP_CONNECT, flags(), 0, fd, socketAddress, 0, socketAddressLength, extraData);
     }
 
     boolean addWritev(int fd, long iovecArrayAddress, int length, short extraData) {
-        return enqueueSqe(Native.IORING_OP_WRITEV, 0, fd, iovecArrayAddress, length, 0, extraData);
+        return enqueueSqe(Native.IORING_OP_WRITEV, flags(), 0, fd, iovecArrayAddress, length, 0, extraData);
     }
 
     boolean addClose(int fd, short extraData) {
-        return enqueueSqe(Native.IORING_OP_CLOSE, 0, fd, 0, 0, 0, extraData);
+        return enqueueSqe(Native.IORING_OP_CLOSE, flags(), 0, fd, 0, 0, 0, extraData);
     }
 
     int submit() {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -94,8 +94,7 @@ final class IOUringSubmissionQueue {
 
         // Fill SQ array indices (1-1 with SQE array) and set nonzero constant SQE fields
         long address = kArrayAddress;
-        long sqeFlagsAddress = submissionQueueArrayAddress + SQE_FLAGS_FIELD;
-        for (int i = 0; i < ringEntries; i++, address += INT_SIZE, sqeFlagsAddress += SQE_SIZE) {
+        for (int i = 0; i < ringEntries; i++, address += INT_SIZE) {
             PlatformDependent.putInt(address, i);
         }
     }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -32,7 +32,8 @@ import java.util.Locale;
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
     static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096));
-    static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD = 25;
+    static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD =
+            Math.max(0, SystemPropertyUtil.getInt("io.netty.uring.iosqeAsyncThreshold", 25));
 
     static {
         Selector selector = null;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
     static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096));
-    static final boolean DEFAULT_USE_IOSEQ_ASYNC = true;
+    static final int DEFAULT_IOSEQ_ASYNC_THRESHOLD = 25;
 
     static {
         Selector selector = null;
@@ -133,7 +133,7 @@ final class Native {
     };
 
     static RingBuffer createRingBuffer(int ringSize) {
-        return createRingBuffer(ringSize, DEFAULT_USE_IOSEQ_ASYNC, new Runnable() {
+        return createRingBuffer(ringSize, DEFAULT_IOSEQ_ASYNC_THRESHOLD, new Runnable() {
             @Override
             public void run() {
                 // Noop
@@ -141,7 +141,7 @@ final class Native {
         });
     }
 
-    static RingBuffer createRingBuffer(int ringSize, boolean iosqeAsync, Runnable submissionCallback) {
+    static RingBuffer createRingBuffer(int ringSize, int iosqeAsyncThreshold, Runnable submissionCallback) {
         long[][] values = ioUringSetup(ringSize);
         assert values.length == 2;
         long[] submissionQueueArgs = values[0];
@@ -158,7 +158,7 @@ final class Native {
                 (int) submissionQueueArgs[8],
                 submissionQueueArgs[9],
                 (int) submissionQueueArgs[10],
-                iosqeAsync,
+                iosqeAsyncThreshold,
                 submissionCallback);
         long[] completionQueueArgs = values[1];
         assert completionQueueArgs.length == 9;
@@ -176,7 +176,7 @@ final class Native {
     }
 
     static RingBuffer createRingBuffer(Runnable submissionCallback) {
-        return createRingBuffer(DEFAULT_RING_SIZE, DEFAULT_USE_IOSEQ_ASYNC, submissionCallback);
+        return createRingBuffer(DEFAULT_RING_SIZE, DEFAULT_IOSEQ_ASYNC_THRESHOLD, submissionCallback);
     }
 
     static void checkAllIOSupported(int ringFd) {


### PR DESCRIPTION
Motivation:

It has shown in benchmarks that IOSQE_ASYNC can be harmful when there
are not a lot of fds handled at the same time.

Modifications:

- Dont use IOSEQ_ASYNC for IORING_IO_TIMEOUT, IORING_IO_POLLADD,
IORING_IO_POLLREMOVE
- Enable / disable the usage of IOSEQ_ASYNC for others IO ops based on
the number of fds that are handled

Result:

Better performance without the need of the user to tune things