### PR TITLE
Remove POLLRDHUP flag when handlePollAdd is called

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -742,7 +742,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
 
         if (submissionQueue != null) {
             if ((ioState & (POLL_IN_SCHEDULED | POLL_OUT_SCHEDULED | POLL_RDHUP_SCHEDULED)) == 0) {
-                System.out.println("doDeregister remove Channel");
                 ((IOUringEventLoop) eventLoop()).remove(this);
                 return;
             }
@@ -839,7 +838,5 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
         } else if (pollMask == Native.POLLRDHUP) {
             ioState &= ~POLL_RDHUP_SCHEDULED;
         }
-
-
      }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -244,8 +244,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
             }
 
             cancelConnectTimeoutFuture();
-
-            doDeregister();
         } finally {
             if (submissionQueue != null) {
                 if (socket.markClosed()) {
@@ -493,6 +491,7 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
          * Called once POLLRDHUP event is ready to be processed
          */
         final void pollRdHup(int res) {
+            ioState &= ~POLL_RDHUP_SCHEDULED;
             if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
                 return;
             }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -742,17 +742,18 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
 
         if (submissionQueue != null) {
             if ((ioState & (POLL_IN_SCHEDULED | POLL_OUT_SCHEDULED | POLL_RDHUP_SCHEDULED)) == 0) {
+                System.out.println("doDeregister remove Channel");
                 ((IOUringEventLoop) eventLoop()).remove(this);
                 return;
             }
             if ((ioState & POLL_IN_SCHEDULED) != 0) {
-                submissionQueue.addPollRemove(socket.intValue(), Native.POLLIN, (short) 0);
+                submissionQueue.addPollRemove(socket.intValue(), Native.POLLIN);
             }
             if ((ioState & POLL_OUT_SCHEDULED) != 0) {
-                submissionQueue.addPollRemove(socket.intValue(), Native.POLLOUT, (short) 0);
+                submissionQueue.addPollRemove(socket.intValue(), Native.POLLOUT);
             }
             if ((ioState & POLL_RDHUP_SCHEDULED) != 0) {
-                submissionQueue.addPollRemove(socket.intValue(), Native.POLLRDHUP, (short) 0);
+                submissionQueue.addPollRemove(socket.intValue(), Native.POLLRDHUP);
             }
         }
     }
@@ -829,4 +830,16 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
     private boolean shouldBreakIoUringInReady(ChannelConfig config) {
         return socket.isInputShutdown() && (inputClosedSeenErrorOnRead || !isAllowHalfClosure(config));
     }
+
+    public void clearPollFlag(int pollMask) {
+        if (pollMask == Native.POLLIN) {
+            ioState &= ~POLL_IN_SCHEDULED;
+        } else if (pollMask == Native.POLLOUT) {
+            ioState &= ~POLL_OUT_SCHEDULED;
+        } else if (pollMask == Native.POLLRDHUP) {
+            ioState &= ~POLL_RDHUP_SCHEDULED;
+        }
+
+
+     }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -243,6 +243,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements IOUringCom
                 } else if (res == 0) {
                     logger.trace("IORING_POLL_REMOVE successful");
                 }
+                channel.clearPollFlag(data);
                 if (!channel.ioScheduled()) {
                     // We cancelled the POLL ops which means we are done and should remove the mapping.
                     remove(channel);

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -191,9 +191,9 @@ final class IOUringSubmissionQueue {
     }
 
     //fill the address which is associated with server poll link user_data
-    boolean addPollRemove(int fd, int pollMask, short extraData) {
+    boolean addPollRemove(int fd, int pollMask) {
         return enqueueSqe(Native.IORING_OP_POLL_REMOVE, 0, 0, fd,
-                          encode(fd, Native.IORING_OP_POLL_ADD, (short) pollMask), 0, 0, extraData);
+                          encode(fd, Native.IORING_OP_POLL_ADD, (short) pollMask), 0, 0, (short) pollMask);
     }
 
     boolean addConnect(int fd, long socketAddress, long socketAddressLength, short extraData) {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -192,6 +192,7 @@ final class IOUringSubmissionQueue {
 
     //fill the address which is associated with server poll link user_data
     boolean addPollRemove(int fd, int pollMask) {
+        assert pollMask <= Short.MAX_VALUE && pollMask >= Short.MIN_VALUE;
         return enqueueSqe(Native.IORING_OP_POLL_REMOVE, 0, 0, fd,
                           encode(fd, Native.IORING_OP_POLL_ADD, (short) pollMask), 0, 0, (short) pollMask);
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -224,7 +224,7 @@ public class NativeTest {
         FileDescriptor eventFd = Native.newBlockingEventFd();
         submissionQueue.addPollIn(eventFd.intValue());
         submissionQueue.submit();
-        submissionQueue.addPollRemove(eventFd.intValue(), Native.POLLIN, (short) 0);
+        submissionQueue.addPollRemove(eventFd.intValue(), Native.POLLIN);
         submissionQueue.submit();
 
         final AtomicReference<AssertionError> errorRef = new AtomicReference<AssertionError>();


### PR DESCRIPTION
Motivation:

channel is never removed as POLLRDHUP is not removed

Modifications:

-remove doDeregister as it is already called
-remove POLLRDHUP flag
-clear the poll flags if poll remove is processed 

Result:

channel is removed from channels map