### PR TITLE
[Feature] InboundHttp2ToHttpObjectAdapter

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractInboundHttp2ToHttpObjectAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractInboundHttp2ToHttpObjectAdapterBuilder.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * A skeletal builder implementation of {@link InboundHttp2ToHttpObjectAdapter} and its subtypes.
+ */
+@UnstableApi
+public abstract class AbstractInboundHttp2ToHttpObjectAdapterBuilder<
+        T extends InboundHttp2ToHttpObjectAdapter, B extends AbstractInboundHttp2ToHttpObjectAdapterBuilder<T, B>> {
+
+    private final Http2Connection connection;
+    private int maxContentLength;
+    private boolean validateHttpHeaders;
+    private boolean propagateSettings;
+
+    /**
+     * Creates a new {@link InboundHttp2ToHttpObjectAdapter} builder for the specified {@link Http2Connection}.
+     *
+     * @param connection the object which will provide connection notification events
+     *                   for the current connection
+     */
+    protected AbstractInboundHttp2ToHttpObjectAdapterBuilder(Http2Connection connection) {
+        this.connection = checkNotNull(connection, "connection");
+    }
+
+    @SuppressWarnings("unchecked")
+    protected final B self() {
+        return (B) this;
+    }
+
+    /**
+     * Returns the {@link Http2Connection}.
+     */
+    protected Http2Connection connection() {
+        return connection;
+    }
+
+    /**
+     * Returns the maximum length of the message content.
+     */
+    protected int maxContentLength() {
+        return maxContentLength;
+    }
+
+    /**
+     * Specifies the maximum length of the message content.
+     *
+     * @param maxContentLength the maximum length of the message content. If the length of the message content
+     *                         exceeds this value, a {@link TooLongFrameException} will be raised
+     * @return {@link AbstractInboundHttp2ToHttpObjectAdapterBuilder} the builder for the
+     * {@link InboundHttp2ToHttpObjectAdapter}
+     */
+    protected B maxContentLength(int maxContentLength) {
+        this.maxContentLength = maxContentLength;
+        return self();
+    }
+
+    /**
+     * Return {@code true} if HTTP header validation should be performed.
+     */
+    protected boolean isValidateHttpHeaders() {
+        return validateHttpHeaders;
+    }
+
+    /**
+     * Specifies whether validation of HTTP headers should be performed.
+     *
+     * @param validate <ul>
+     *                 <li>{@code true} to validate HTTP headers in the http-codec</li>
+     *                 <li>{@code false} not to validate HTTP headers in the http-codec</li>
+     *                 </ul>
+     * @return {@link AbstractInboundHttp2ToHttpObjectAdapterBuilder} the builder for the
+     * {@link InboundHttp2ToHttpObjectAdapter}
+     */
+    protected B validateHttpHeaders(boolean validate) {
+        validateHttpHeaders = validate;
+        return self();
+    }
+
+    /**
+     * Returns {@code true} if a read settings frame should be propagated along the channel pipeline.
+     */
+    protected boolean isPropagateSettings() {
+        return propagateSettings;
+    }
+
+    /**
+     * Specifies whether a read settings frame should be propagated along the channel pipeline.
+     *
+     * @param propagate if {@code true} read settings will be passed along the pipeline. This can be useful
+     *                  to clients that need hold off sending data until they have received the settings.
+     * @return {@link AbstractInboundHttp2ToHttpObjectAdapterBuilder} the builder for the
+     * {@link InboundHttp2ToHttpObjectAdapter}
+     */
+    protected B propagateSettings(boolean propagate) {
+        propagateSettings = propagate;
+        return self();
+    }
+
+    /**
+     * Builds/creates a new {@link InboundHttp2ToHttpObjectAdapter} instance using this builder's current settings.
+     */
+    protected T build() {
+        final T instance;
+        try {
+            instance = build(connection(), maxContentLength(), isValidateHttpHeaders(), isPropagateSettings());
+        } catch (Throwable t) {
+            throw new IllegalStateException("failed to create a new InboundHttp2ToHttpObjectAdapter", t);
+        }
+        connection.addListener(instance);
+        return instance;
+    }
+
+    /**
+     * Creates a new {@link InboundHttp2ToHttpObjectAdapter} with the specified properties.
+     */
+    protected abstract T build(Http2Connection connection, int maxContentLength, boolean validateHttpHeaders,
+                               boolean propagateSettings) throws Exception;
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractInboundHttp2ToHttpObjectAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractInboundHttp2ToHttpObjectAdapterBuilder.java
@@ -27,7 +27,7 @@ public abstract class AbstractInboundHttp2ToHttpObjectAdapterBuilder<
         T extends InboundHttp2ToHttpObjectAdapter, B extends AbstractInboundHttp2ToHttpObjectAdapterBuilder<T, B>> {
 
     private final Http2Connection connection;
-    private int maxContentLength;
+    private long maxContentLength;
     private boolean validateHttpHeaders;
     private boolean propagateSettings;
 
@@ -56,7 +56,7 @@ public abstract class AbstractInboundHttp2ToHttpObjectAdapterBuilder<
     /**
      * Returns the maximum length of the message content.
      */
-    protected int maxContentLength() {
+    protected long maxContentLength() {
         return maxContentLength;
     }
 
@@ -68,7 +68,7 @@ public abstract class AbstractInboundHttp2ToHttpObjectAdapterBuilder<
      * @return {@link AbstractInboundHttp2ToHttpObjectAdapterBuilder} the builder for the
      * {@link InboundHttp2ToHttpObjectAdapter}
      */
-    protected B maxContentLength(int maxContentLength) {
+    protected B maxContentLength(long maxContentLength) {
         this.maxContentLength = maxContentLength;
         return self();
     }
@@ -132,6 +132,6 @@ public abstract class AbstractInboundHttp2ToHttpObjectAdapterBuilder<
     /**
      * Creates a new {@link InboundHttp2ToHttpObjectAdapter} with the specified properties.
      */
-    protected abstract T build(Http2Connection connection, int maxContentLength, boolean validateHttpHeaders,
+    protected abstract T build(Http2Connection connection, long maxContentLength, boolean validateHttpHeaders,
                                boolean propagateSettings) throws Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedHttpContent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.util.internal.StringUtil;
+
+/**
+ * {@link DefaultHttp2TranslatedHttpContent} contains {@link HttpContent} and {@code streamId}
+ * which are translated from {@link Http2DataFrame}
+ */
+public class DefaultHttp2TranslatedHttpContent extends DefaultHttpContent {
+    private final int streamId;
+
+    /**
+     * Creates a new instance with the specified chunk content.
+     */
+    public DefaultHttp2TranslatedHttpContent(ByteBuf content, int streamId) {
+        super(content);
+        this.streamId = streamId;
+    }
+
+    public int getStreamId() {
+        return streamId;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtil.simpleClassName(this) + "(streamId: " + streamId + ", data: " + content() +
+                ", decoderResult: " + decoderResult() + ')';
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
@@ -91,7 +91,7 @@ public class DefaultHttp2TranslatedLastHttpContent extends DefaultHttp2Translate
 
     @Override
     public String toString() {
-        return StringUtil.simpleClassName(this) + "(streamId: " + super.toString() + ", data: " + content() +
+        return StringUtil.simpleClassName(this) + "(streamId: " + super.getStreamId() + ", data: " + content() +
                 ", decoderResult: " + decoderResult() + ')';
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.internal.StringUtil;
+
+/**
+ * {@link DefaultHttp2TranslatedHttpContent} contains {@code streamId} from last (endOfStream) {@link Http2DataFrame}.
+ */
+public class DefaultHttp2TranslatedLastHttpContent extends DefaultHttp2TranslatedHttpContent
+        implements LastHttpContent {
+
+    public DefaultHttp2TranslatedLastHttpContent(int streamId) {
+        super(Unpooled.buffer(0), streamId);
+    }
+
+    public DefaultHttp2TranslatedLastHttpContent(ByteBuf content, int streamId) {
+        super(content, streamId);
+    }
+
+    public int getStreamId() {
+        return super.getStreamId();
+    }
+
+    @Override
+    public LastHttpContent copy() {
+        return replace(content().copy());
+    }
+
+    @Override
+    public LastHttpContent duplicate() {
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public LastHttpContent retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public LastHttpContent replace(ByteBuf content) {
+        return new DefaultHttp2TranslatedLastHttpContent(content, super.getStreamId());
+    }
+
+    @Override
+    public LastHttpContent retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public LastHttpContent retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public LastHttpContent touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public LastHttpContent touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        return EmptyHttpHeaders.INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtil.simpleClassName(this) + "(streamId: " + super.toString() + ", data: " + content() +
+                ", decoderResult: " + decoderResult() + ')';
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -66,12 +66,13 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
             ctx.write(msg, promise);
             return;
         }
-        boolean endStream = false;
+
         boolean release = true;
         SimpleChannelPromiseAggregator promiseAggregator = new SimpleChannelPromiseAggregator(promise, ctx.channel(),
                 ctx.executor());
         try {
             Http2ConnectionEncoder encoder = encoder();
+            boolean endStream = false;
 
             if (msg instanceof HttpMessage) {
                 final HttpMessage httpMsg = (HttpMessage) msg;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
@@ -20,7 +20,7 @@ import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
 import io.netty.util.internal.UnstableApi;
 
 /**
- * Builder which builds {@link HttpToHttp2ConnectionHandler} objects.
+ * Builder which builds {@link HttpToHttp2ConnectionHandler}
  */
 @UnstableApi
 public final class HttpToHttp2ConnectionHandlerBuilder extends

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapter.java
@@ -18,7 +18,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.EmptyByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -46,7 +45,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * See {@link HttpToHttp2ConnectionHandler} to get translation from HTTP/1.x objects to HTTP/2 frames for writes.
  */
 @UnstableApi
-public class InboundHttp2ToHttpObjectAdapter extends Http2EventAdapter {
+public final class InboundHttp2ToHttpObjectAdapter extends Http2EventAdapter {
 
     private final int maxContentLength;
     private final Http2Connection.PropertyKey messageKey;
@@ -63,15 +62,15 @@ public class InboundHttp2ToHttpObjectAdapter extends Http2EventAdapter {
         messageKey = connection.newKey();
     }
 
-    protected final void firstHeaderReceived(Http2Stream stream) {
+    protected void firstHeaderReceived(Http2Stream stream) {
         stream.setProperty(messageKey, Boolean.TRUE);
     }
 
-    protected final Boolean isFirstHeaderReceived(Http2Stream stream) {
+    protected Boolean isFirstHeaderReceived(Http2Stream stream) {
         return stream.getProperty(messageKey);
     }
 
-    protected final void removeHeaderRecord(Http2Stream stream) {
+    protected void removeHeaderRecord(Http2Stream stream) {
         stream.removeProperty(messageKey);
     }
 
@@ -227,11 +226,11 @@ public class InboundHttp2ToHttpObjectAdapter extends Http2EventAdapter {
 
         if (endOfStream) {
             if (dataReadableBytes != 0) {
-                fireChannelRead(ctx, new DefaultHttpContent(content));
+                fireChannelRead(ctx, new DefaultHttp2TranslatedHttpContent(content, streamId));
             }
-            fireChannelRead(ctx, DefaultLastHttpContent.EMPTY_LAST_CONTENT.retainedDuplicate());
+            fireChannelRead(ctx, new DefaultHttp2TranslatedLastHttpContent(streamId));
         } else {
-            fireChannelRead(ctx, new DefaultHttpContent(content));
+            fireChannelRead(ctx, new DefaultHttp2TranslatedHttpContent(content, streamId));
         }
 
         return dataReadableBytes;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapter.java
@@ -71,6 +71,22 @@ public class InboundHttp2ToHttpObjectAdapter extends Http2EventAdapter {
         return stream.getProperty(messageKey);
     }
 
+    protected final void removeHeaderRecord(Http2Stream stream) {
+        stream.removeProperty(messageKey);
+    }
+
+    @Override
+    public void onStreamRemoved(Http2Stream stream) {
+        removeHeaderRecord(stream);
+    }
+
+    /**
+     * Called if a {@code RST_STREAM} is received but we have some data for that stream.
+     */
+    protected void onRstStreamRead(Http2Stream stream, FullHttpMessage msg) {
+        removeHeaderRecord(stream);
+    }
+
     /**
      * Set final headers and fire a channel read event
      *

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapter.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.EmptyByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
+import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
+import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * This adapter provides just header/data events from the HTTP message flow defined
+ * in <a href="https://tools.ietf.org/html/rfc7540#section-8.1">[RFC 7540], Section 8.1</a>.
+ * <p>
+ * See {@link HttpToHttp2ConnectionHandler} to get translation from HTTP/1.x objects to HTTP/2 frames for writes.
+ */
+@UnstableApi
+public class InboundHttp2ToHttpObjectAdapter extends Http2EventAdapter {
+
+    private final int maxContentLength;
+    private final Http2Connection.PropertyKey messageKey;
+    private final boolean propagateSettings;
+    protected final Http2Connection connection;
+    protected final boolean validateHttpHeaders;
+
+    protected InboundHttp2ToHttpObjectAdapter(Http2Connection connection, int maxContentLength, boolean validateHttpHeaders,
+                                              boolean propagateSettings) {
+        if (maxContentLength <= 0) {
+            throw new IllegalArgumentException("maxContentLength: " + maxContentLength + " (expected: > 0)");
+        }
+        this.connection = checkNotNull(connection, "connection");
+        this.maxContentLength = maxContentLength;
+        this.validateHttpHeaders = validateHttpHeaders;
+        this.propagateSettings = propagateSettings;
+        messageKey = connection.newKey();
+    }
+
+    protected final void firstHeaderReceived(Http2Stream stream) {
+        stream.setProperty(messageKey, Boolean.TRUE);
+    }
+
+    protected final Boolean isFirstHeaderReceived(Http2Stream stream) {
+        return stream.getProperty(messageKey);
+    }
+
+    /**
+     * Set final headers and fire a channel read event
+     *
+     * @param ctx The context to fire the event on
+     * @param msg The message to send
+     */
+    protected void fireChannelRead(ChannelHandlerContext ctx, HttpObject msg) {
+        if (msg instanceof FullHttpMessage) {
+            HttpUtil.setContentLength((FullHttpMessage) msg, ((FullHttpMessage) msg).content().readableBytes());
+        }
+        System.err.println(msg);
+        ctx.fireChannelRead(msg);
+    }
+
+    /**
+     * Create a new {@link HttpMessage} based upon the current connection parameters
+     *
+     * @param stream              The stream to create a message for
+     * @param headers             The headers associated with {@code stream}
+     * @param validateHttpHeaders <ul>
+     *                            <li>{@code true} to validate HTTP headers in the http-codec</li>
+     *                            <li>{@code false} not to validate HTTP headers in the http-codec</li>
+     *                            </ul>
+     * @param alloc               The {@link ByteBufAllocator} to use to generate the content of the message
+     * @param endOfStream         Set to {@code true} if only {@link Http2Headers} are available
+     *                            in this {@link Http2Stream}
+     * @throws Http2Exception If there is an error when creating {@link HttpMessage} from
+     *                        {@link Http2Stream} or {@link Http2Headers}
+     */
+    protected HttpMessage newMessage(Http2Stream stream, Http2Headers headers, boolean validateHttpHeaders,
+                                     ByteBufAllocator alloc, boolean endOfStream) throws Http2Exception {
+        /*
+         * If `endOfStream` is `true` then we only have headers and no data.
+         * So in this case, we'll create `FullHttpMessage`.
+         *
+         * If `endOfStream` is `false` we will be getting data after headers.
+         * So in this case, we'll create `HttpRequest` and set `TRANSFER_ENCODING:CHUNKED`
+         * and write received data in `HttpContent`.
+         */
+        if (endOfStream) {
+            if (connection.isServer()) {
+                return HttpConversionUtil.toFullHttpRequest(stream.id(), headers, alloc, validateHttpHeaders);
+            } else {
+                return HttpConversionUtil.toFullHttpResponse(stream.id(), headers, alloc, validateHttpHeaders);
+            }
+        } else {
+            if (connection.isServer()) {
+                HttpRequest httpRequest = HttpConversionUtil.toHttpRequest(stream.id(), headers, validateHttpHeaders);
+                httpRequest.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+                return httpRequest;
+            } else {
+                HttpResponse httpResponse = HttpConversionUtil.toHttpResponse(stream.id(), headers, validateHttpHeaders);
+                httpResponse.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+                return httpResponse;
+            }
+        }
+    }
+
+    /**
+     * Provides translation between HTTP/2 and HTTP header objects while ensuring the stream
+     * is in a valid state for additional headers.
+     *
+     * @param ctx             The context for which this message has been received.
+     *                        Used to send informational header if detected.
+     * @param stream          The stream the {@code headers} apply to
+     * @param headers         The headers to process
+     * @param endOfStream     Set to {@code true} if only {@link Http2Headers} are available
+     *                        in this {@link Http2Stream}
+     * @param allowAppend     <ul>
+     *                        <li>{@code true} if headers will be appended if the stream already exists.</li>
+     *                        <li>if {@code false} and the stream already exists this method returns {@code null}.</li>
+     *                        </ul>
+     * @param appendToTrailer <ul>
+     *                        <li>{@code true} if a message {@code stream} already exists then the headers
+     *                        should be added to the trailing headers.</li>
+     *                        <li>{@code false} then appends will be done to the initial headers.</li>
+     *                        </ul>
+     * @return The object used to track the stream corresponding to {@code stream}. {@code null} if
+     * {@code allowAppend} is {@code false} and the stream already exists.
+     * @throws Http2Exception If the stream id is not in the correct state to process the headers request
+     */
+    protected HttpMessage processHeadersBegin(ChannelHandlerContext ctx, Http2Stream stream, Http2Headers headers,
+                                              boolean endOfStream, boolean allowAppend, boolean appendToTrailer)
+            throws Http2Exception {
+
+        /*
+         * If First Header is not received for this stream, we'll go ahead and create a new HttpMessage.
+         *
+         * If First Header is received and `allowAppend` is `true` then we've received trailer header.
+         * We'll convert it to `DefaultLastHttpContent`.
+         */
+        if (isFirstHeaderReceived(stream) == null) {
+            return newMessage(stream, headers, validateHttpHeaders, ctx.alloc(), endOfStream);
+        } else if (allowAppend) {
+            DefaultLastHttpContent defaultLastHttpContent = new DefaultLastHttpContent(new EmptyByteBuf(ctx.alloc()),
+                    false);
+            HttpHeaders httpHeaders = defaultLastHttpContent.trailingHeaders();
+            HttpConversionUtil.addHttp2ToHttpHeaders(stream.id(), headers, httpHeaders, HttpVersion.HTTP_1_1,
+                    appendToTrailer, connection.isServer());
+        }
+
+        return null;
+    }
+
+    /**
+     * After HTTP/2 headers have been processed by {@link #processHeadersBegin} this method either
+     * sends the result up the pipeline or retains the message for future processing.
+     *
+     * @param ctx         The context for which this message has been received
+     * @param stream      The stream the {@code objAccumulator} corresponds to
+     * @param msg         The object which represents all headers/data for corresponding to {@code stream}
+     * @param endOfStream {@code true} if this is the last event for the stream
+     */
+    private void processHeadersEnd(ChannelHandlerContext ctx, Http2Stream stream, HttpObject msg,
+                                   boolean endOfStream) {
+        fireChannelRead(ctx, msg);
+        if (!endOfStream) {
+            firstHeaderReceived(stream);
+        }
+    }
+
+    @Override
+    public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream)
+            throws Http2Exception {
+        Http2Stream stream = connection.stream(streamId);
+        if (isFirstHeaderReceived(stream) == null) {
+            throw connectionError(PROTOCOL_ERROR, "Data Frame received for unknown stream id %d", streamId);
+        }
+
+        ByteBuf content = ctx.alloc().buffer();
+
+        int dataReadableBytes = data.readableBytes();
+        if (dataReadableBytes > maxContentLength) {
+            throw connectionError(INTERNAL_ERROR,
+                    "Content length exceeded max of %d for stream id %d", maxContentLength, streamId);
+        }
+
+        content.writeBytes(data);
+
+        if (endOfStream) {
+            if (dataReadableBytes != 0) {
+                fireChannelRead(ctx, new DefaultHttpContent(content));
+            }
+            fireChannelRead(ctx, DefaultLastHttpContent.EMPTY_LAST_CONTENT.retainedDuplicate());
+        } else {
+            fireChannelRead(ctx, new DefaultHttpContent(content));
+        }
+
+        return dataReadableBytes;
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                              boolean endOfStream) throws Http2Exception {
+        Http2Stream stream = connection.stream(streamId);
+        HttpMessage msg = processHeadersBegin(ctx, stream, headers, endOfStream, true, true);
+        if (msg != null) {
+            processHeadersEnd(ctx, stream, msg, endOfStream);
+        }
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
+                              short weight, boolean exclusive, int padding, boolean endOfStream)
+            throws Http2Exception {
+        Http2Stream stream = connection.stream(streamId);
+        HttpMessage msg = processHeadersBegin(ctx, stream, headers, endOfStream, true, true);
+        if (msg != null) {
+            // Add headers for dependency and weight.
+            // See https://github.com/netty/netty/issues/5866
+            if (streamDependency != Http2CodecUtil.CONNECTION_STREAM_ID) {
+                msg.headers().setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_DEPENDENCY_ID.text(),
+                        streamDependency);
+            }
+            msg.headers().setShort(HttpConversionUtil.ExtensionHeaderNames.STREAM_WEIGHT.text(), weight);
+
+            processHeadersEnd(ctx, stream, msg, endOfStream);
+        }
+    }
+
+    @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
+        ctx.fireExceptionCaught(Http2Exception.streamError(streamId, Http2Error.valueOf(errorCode),
+                "HTTP/2 to HTTP layer caught stream reset"));
+    }
+
+    @Override
+    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId, Http2Headers headers,
+                                  int padding) throws Http2Exception {
+        // A push promise should not be allowed to add headers to an existing stream
+        Http2Stream promisedStream = connection.stream(promisedStreamId);
+        if (headers.status() == null) {
+            // A PUSH_PROMISE frame has no Http response status.
+            // https://tools.ietf.org/html/rfc7540#section-8.2.1
+            // Server push is semantically equivalent to a server responding to a
+            // request; however, in this case, that request is also sent by the
+            // server, as a PUSH_PROMISE frame.
+            headers.status(OK.codeAsText());
+        }
+        HttpMessage msg = processHeadersBegin(ctx, promisedStream, headers, false, false, false);
+        if (msg == null) {
+            throw connectionError(PROTOCOL_ERROR, "Push Promise Frame received for pre-existing stream id %d", promisedStreamId);
+        }
+
+        msg.headers().setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_PROMISE_ID.text(), streamId);
+        msg.headers().setShort(HttpConversionUtil.ExtensionHeaderNames.STREAM_WEIGHT.text(), Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT);
+
+        processHeadersEnd(ctx, promisedStream, msg, false);
+    }
+
+    @Override
+    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
+        if (propagateSettings) {
+            // Provide an interface for non-listeners to capture settings
+            ctx.fireChannelRead(settings);
+        }
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapterBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * Builds an {@link InboundHttp2ToHttpObjectAdapterBuilder}.
+ */
+@UnstableApi
+public final class InboundHttp2ToHttpObjectAdapterBuilder extends AbstractInboundHttp2ToHttpObjectAdapterBuilder
+        <InboundHttp2ToHttpObjectAdapter, InboundHttp2ToHttpObjectAdapterBuilder> {
+
+    /**
+     * Creates a new {@link InboundHttp2ToHttpAdapter} builder for the specified {@link Http2Connection}.
+     *
+     * @param connection the object which will provide connection notification events
+     *                   for the current connection
+     */
+    public InboundHttp2ToHttpObjectAdapterBuilder(Http2Connection connection) {
+        super(connection);
+    }
+
+    @Override
+    public InboundHttp2ToHttpObjectAdapterBuilder maxContentLength(int maxContentLength) {
+        return super.maxContentLength(maxContentLength);
+    }
+
+    @Override
+    public InboundHttp2ToHttpObjectAdapterBuilder validateHttpHeaders(boolean validate) {
+        return super.validateHttpHeaders(validate);
+    }
+
+    @Override
+    public InboundHttp2ToHttpObjectAdapterBuilder propagateSettings(boolean propagate) {
+        return super.propagateSettings(propagate);
+    }
+
+    @Override
+    public InboundHttp2ToHttpObjectAdapter build() {
+        return super.build();
+    }
+
+    @Override
+    protected InboundHttp2ToHttpObjectAdapter build(Http2Connection connection,
+                                              int maxContentLength,
+                                              boolean validateHttpHeaders,
+                                              boolean propagateSettings) throws Exception {
+
+        return new InboundHttp2ToHttpObjectAdapter(connection, maxContentLength,
+                                             validateHttpHeaders, propagateSettings);
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapterBuilder.java
@@ -24,7 +24,7 @@ public final class InboundHttp2ToHttpObjectAdapterBuilder extends AbstractInboun
         <InboundHttp2ToHttpObjectAdapter, InboundHttp2ToHttpObjectAdapterBuilder> {
 
     /**
-     * Creates a new {@link InboundHttp2ToHttpAdapter} builder for the specified {@link Http2Connection}.
+     * Creates a new {@link InboundHttp2ToHttpObjectAdapter} builder for the specified {@link Http2Connection}.
      *
      * @param connection the object which will provide connection notification events
      *                   for the current connection

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapterBuilder.java
@@ -17,7 +17,7 @@ package io.netty.handler.codec.http2;
 import io.netty.util.internal.UnstableApi;
 
 /**
- * Builds an {@link InboundHttp2ToHttpObjectAdapterBuilder}.
+ * Builds an {@link InboundHttp2ToHttpObjectAdapter}.
  */
 @UnstableApi
 public final class InboundHttp2ToHttpObjectAdapterBuilder extends AbstractInboundHttp2ToHttpObjectAdapterBuilder

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapterBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpObjectAdapterBuilder.java
@@ -34,7 +34,7 @@ public final class InboundHttp2ToHttpObjectAdapterBuilder extends AbstractInboun
     }
 
     @Override
-    public InboundHttp2ToHttpObjectAdapterBuilder maxContentLength(int maxContentLength) {
+    public InboundHttp2ToHttpObjectAdapterBuilder maxContentLength(long maxContentLength) {
         return super.maxContentLength(maxContentLength);
     }
 
@@ -55,9 +55,9 @@ public final class InboundHttp2ToHttpObjectAdapterBuilder extends AbstractInboun
 
     @Override
     protected InboundHttp2ToHttpObjectAdapter build(Http2Connection connection,
-                                              int maxContentLength,
-                                              boolean validateHttpHeaders,
-                                              boolean propagateSettings) throws Exception {
+                                                    long maxContentLength,
+                                                    boolean validateHttpHeaders,
+                                                    boolean propagateSettings) throws Exception {
 
         return new InboundHttp2ToHttpObjectAdapter(connection, maxContentLength,
                                              validateHttpHeaders, propagateSettings);


### PR DESCRIPTION
Motivation:
We need something which can convert Http2 Frames to Http Object. Right now, we've `InboundHttp2ToHttpAdapter` but it aggregates Http2 Frames and builds one large `FullHttpMessage`. This is fine and works well in most cases but in some cases, we need to deal with individuals objects and process them as soon as possible. Best example: Load Balancers.

Modification:
`InboundHttp2ToHttpObjectAdapter` which converts Http2 Frames to Http Objects like `HttpMessage` and `HttpContent` and pass down to pipeline.

Result:
Fixes #4073 
