### PR TITLE
Add Close method for closing OutputStream and PcapWriteHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
@@ -17,8 +17,6 @@ package io.netty.handler.pcap;
 
 import io.netty.buffer.ByteBuf;
 
-import java.util.concurrent.TimeUnit;
-
 final class PcapHeaders {
 
     /**

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -115,7 +115,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
     /**
      * Set to {@code true} if {@link #close()} is called and we should stop writing Pcap.
      */
-    private boolean isClosed = false;
+    private boolean isClosed;
 
     /**
      * Create new {@link PcapWriteHandler} Instance.
@@ -545,8 +545,12 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
      */
     @Override
     public void close() throws IOException {
-        isClosed = true;
-        pCapWriter.close();
-        logger.debug("PcapWriterHandler is Closed");
+        if (isClosed) {
+            logger.debug("PcapWriterHandler is already closed");
+        } else {
+            isClosed = true;
+            pCapWriter.close();
+            logger.debug("PcapWriterHandler is now closed");
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -31,6 +31,7 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Inet4Address;
@@ -61,8 +62,11 @@ import java.net.InetSocketAddress;
  *    </ul>
  * </p>
  */
-public final class PcapWriteHandler extends ChannelDuplexHandler {
+public final class PcapWriteHandler extends ChannelDuplexHandler implements Closeable {
 
+    /**
+     * Logger for logging events
+     */
     private final InternalLogger logger = InternalLoggerFactory.getInstance(PcapWriteHandler.class);
 
     /**
@@ -109,11 +113,17 @@ public final class PcapWriteHandler extends ChannelDuplexHandler {
     private InetSocketAddress dstAddr;
 
     /**
+     * Set to {@code true} if {@link #close()} is called and we should stop writing Pcap.
+     */
+    private boolean isClosed = false;
+
+    /**
      * Create new {@link PcapWriteHandler} Instance.
      * {@code captureZeroByte} is set to {@code false} and
      * {@code writePcapGlobalHeader} is set to {@code true}.
      *
-     * @param outputStream OutputStream where Pcap data will be written
+     * @param outputStream OutputStream where Pcap data will be written. Call {@link #close()} to close this
+     *                     OutputStream.
      * @throws NullPointerException If {@link OutputStream} is {@code null} then we'll throw an
      *                              {@link NullPointerException}
      */
@@ -124,7 +134,8 @@ public final class PcapWriteHandler extends ChannelDuplexHandler {
     /**
      * Create new {@link PcapWriteHandler} Instance
      *
-     * @param outputStream          OutputStream where Pcap data will be written
+     * @param outputStream          OutputStream where Pcap data will be written. Call {@link #close()} to close this
+     *                              OutputStream.
      * @param captureZeroByte       Set to {@code true} to enable capturing packets with empty (0 bytes) payload.
      *                              Otherwise, if set to {@code false}, empty packets will be filtered out.
      * @param writePcapGlobalHeader Set to {@code true} to write Pcap Global Header on initialization.
@@ -214,24 +225,28 @@ public final class PcapWriteHandler extends ChannelDuplexHandler {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (ctx.channel() instanceof SocketChannel) {
-            handleTCP(ctx, msg, false);
-        } else if (ctx.channel() instanceof DatagramChannel) {
-            handleUDP(ctx, msg);
-        } else {
-            logger.debug("Discarding Pcap Write for Unknown Channel Type: {}", ctx.channel());
+        if (!isClosed) {
+            if (ctx.channel() instanceof SocketChannel) {
+                handleTCP(ctx, msg, false);
+            } else if (ctx.channel() instanceof DatagramChannel) {
+                handleUDP(ctx, msg);
+            } else {
+                logger.debug("Discarding Pcap Write for Unknown Channel Type: {}", ctx.channel());
+            }
         }
         super.channelRead(ctx, msg);
     }
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (ctx.channel() instanceof SocketChannel) {
-            handleTCP(ctx, msg, true);
-        } else if (ctx.channel() instanceof DatagramChannel) {
-            handleUDP(ctx, msg);
-        } else {
-            logger.debug("Discarding Pcap Write for Unknown Channel Type: {}", ctx.channel());
+        if (!isClosed) {
+            if (ctx.channel() instanceof SocketChannel) {
+                handleTCP(ctx, msg, true);
+            } else if (ctx.channel() instanceof DatagramChannel) {
+                handleUDP(ctx, msg);
+            } else {
+                logger.debug("Discarding Pcap Write for Unknown Channel Type: {}", ctx.channel());
+            }
         }
         super.write(ctx, msg, promise);
     }
@@ -495,7 +510,7 @@ public final class PcapWriteHandler extends ChannelDuplexHandler {
             logger.debug("Finished Fake TCP FIN+ACK Flow to close connection");
         }
 
-        this.pCapWriter.close();
+        close();
         super.handlerRemoved(ctx);
     }
 
@@ -517,7 +532,21 @@ public final class PcapWriteHandler extends ChannelDuplexHandler {
             logger.debug("Sent Fake TCP RST to close connection");
         }
 
-        this.pCapWriter.close();
+        close();
         ctx.fireExceptionCaught(cause);
+    }
+
+    /**
+     * <p> Close {@code PcapWriter} and {@link OutputStream}. </p>
+     * <p> Note: Calling this method does not close {@link PcapWriteHandler}.
+     * Only Pcap Writes are closed. </p>
+     *
+     * @throws IOException If {@link OutputStream#close()} throws an exception
+     */
+    @Override
+    public void close() throws IOException {
+        isClosed = true;
+        pCapWriter.close();
+        logger.debug("PcapWriterHandler is Closed");
     }
 }

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
@@ -60,10 +60,15 @@ final class PcapWriter implements Closeable {
     void writePacket(ByteBuf packetHeaderBuf, ByteBuf packet) throws IOException {
         long currentTime = System.currentTimeMillis();
 
+        int micro = (int) TimeUnit.MILLISECONDS.toMicros(currentTime) % 1000000;
+        if (micro < 0) {
+            micro = 0;
+        }
+
         PcapHeaders.writePacketHeader(
                 packetHeaderBuf,
                 (int) TimeUnit.MILLISECONDS.toSeconds(currentTime),
-                (int) TimeUnit.MILLISECONDS.toMicros(currentTime) % 1000000,
+                micro,
                 packet.readableBytes(),
                 packet.readableBytes()
         );


### PR DESCRIPTION
Motivation:
We should implement the Closeable method to properly close `OutputStream` and `PcapWriteHandler`. So whenever `handlerRemoved(ChannelHandlerContext)` is called or the user wants to stop the Pcap writes into `OutputStream`, we have a proper method to close it otherwise writing data to close `OutputStream` will result in `IOException`.

Modification:
Implemented `Closeable` in `PcapWriteHandler` which calls `PcapWriter#close` and closes `OutputStream` and stops Pcap writes.

Result:
Better handling of Pcap writes.
