### PR TITLE
Fix possible bugs in HTTP/2 Codec

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -147,8 +147,8 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         REQUESTED
     }
 
-    private final AbstractHttp2StreamChannel.Http2StreamChannelConfig config = new Http2StreamChannelConfig(this);
-    private final AbstractHttp2StreamChannel.Http2ChannelUnsafe unsafe = new Http2ChannelUnsafe();
+    private final Http2StreamChannelConfig config = new Http2StreamChannelConfig(this);
+    private final Http2ChannelUnsafe unsafe = new Http2ChannelUnsafe();
     private final ChannelId channelId;
     private final ChannelPipeline pipeline;
     private final DefaultHttp2FrameStream stream;
@@ -258,7 +258,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             final int oldValue = unwritable;
             final int newValue = oldValue | 1;
             if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
-                if (oldValue == 0 && newValue != 0) {
+                if (oldValue == 0) {
                     fireChannelWritabilityChanged(invokeLater);
                 }
                 break;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -507,10 +507,6 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 return;
             }
 
-            if (parentStream == null) {
-                throw connectionError(PROTOCOL_ERROR, "Stream %d does not exist", streamId);
-            }
-
             switch (parentStream.state()) {
               case OPEN:
               case HALF_CLOSED_LOCAL:

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -219,7 +219,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                     ctx.write(frameHeader2, promiseAggregator.newPromise());
 
                     // Write the payload.
-                    if (frameDataBytes != 0) {
+                    if (frameDataBytes != 0 && data != null) { // Make sure Data is not null
                         if (remainingData == 0) {
                             ByteBuf lastFrame = data.readSlice(frameDataBytes);
                             data = null;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -58,14 +58,18 @@ public class DefaultHttp2Headers
                 }
 
                 if (index != -1) {
-                    PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
-                            "invalid header name [%s]", name));
+                    PlatformDependent.throwException(connectionError(PROTOCOL_ERROR, "invalid header name [%s]",
+                            name));
                 }
             } else {
+                if (name == null) {
+                    PlatformDependent.throwException(connectionError(PROTOCOL_ERROR, "Header name is null"));
+                    return;
+                }
                 for (int i = 0; i < name.length(); ++i) {
                     if (isUpperCase(name.charAt(i))) {
-                        PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
-                                "invalid header name [%s]", name));
+                        PlatformDependent.throwException(connectionError(PROTOCOL_ERROR, "invalid header name [%s]",
+                                name));
                     }
                 }
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -43,7 +43,6 @@ public class DefaultHttp2Headers
             if (name == null || name.length() == 0) {
                 PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
                         "empty headers are not allowed [%s]", name));
-                return;
             }
             if (name instanceof AsciiString) {
                 final int index;
@@ -59,8 +58,8 @@ public class DefaultHttp2Headers
                 }
 
                 if (index != -1) {
-                    PlatformDependent.throwException(connectionError(PROTOCOL_ERROR, "invalid header name [%s]",
-                            name));
+                    PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
+                            "invalid header name [%s]", name));
                 }
             } else {
                 for (int i = 0; i < name.length(); ++i) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -43,6 +43,7 @@ public class DefaultHttp2Headers
             if (name == null || name.length() == 0) {
                 PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
                         "empty headers are not allowed [%s]", name));
+                return;
             }
             if (name instanceof AsciiString) {
                 final int index;
@@ -62,10 +63,6 @@ public class DefaultHttp2Headers
                             name));
                 }
             } else {
-                if (name == null) {
-                    PlatformDependent.throwException(connectionError(PROTOCOL_ERROR, "Header name is null"));
-                    return;
-                }
                 for (int i = 0; i < name.length(); ++i) {
                     if (isUpperCase(name.charAt(i))) {
                         PlatformDependent.throwException(connectionError(PROTOCOL_ERROR, "invalid header name [%s]",

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -64,8 +64,8 @@ public class DefaultHttp2Headers
             } else {
                 for (int i = 0; i < name.length(); ++i) {
                     if (isUpperCase(name.charAt(i))) {
-                        PlatformDependent.throwException(connectionError(PROTOCOL_ERROR, "invalid header name [%s]",
-                                name));
+                        PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
+                                "invalid header name [%s]", name));
                     }
                 }
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java
@@ -183,12 +183,14 @@ final class HpackDynamicTable {
 
         // initially length will be 0 so there will be no copy
         int len = length();
-        int cursor = tail;
-        for (int i = 0; i < len; i++) {
-            HpackHeaderField entry = hpackHeaderFields[cursor++];
-            tmp[i] = entry;
-            if (cursor == hpackHeaderFields.length) {
-                cursor = 0;
+        if (hpackHeaderFields != null) {
+            int cursor = tail;
+            for (int i = 0; i < len; i++) {
+                HpackHeaderField entry = hpackHeaderFields[cursor++];
+                tmp[i] = entry;
+                if (cursor == hpackHeaderFields.length) {
+                    cursor = 0;
+                }
             }
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -823,8 +823,10 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
             for (; i < current.length; i += 2) {
                 AsciiString roName = current[i];
                 if (roName.hashCode() == nameHash && roName.contentEqualsIgnoreCase(name)) {
-                    next = current[i + 1];
-                    i += 2;
+                    if (i + 1 < current.length) {
+                        next = current[i + 1];
+                        i += 2;
+                    }
                     return;
                 }
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -828,7 +828,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
                     return;
                 }
             }
-            if (i >= current.length && current == pseudoHeaders) {
+            if (current == pseudoHeaders) {
                 i = 0;
                 current = otherHeaders;
                 calculateNext();


### PR DESCRIPTION
Motivation:
1. `data` can be `null`
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java#L224

2. `i >= current.length` is always `true`
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java#L831

3. `newValue != 0` is always `true`
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java#L261

4. `(parentStream == null)` is already handled by `shouldIgnoreHeadersOrDataFrame(ctx, streamId, parentStream, "PUSH_PROMISE")` because it'll throw an error.
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java#L510
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java#L582

5. `for (int i = 0; i < name.length(); ++i) {` name can be `null` because we don't return in `null` check.
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java#L65
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java#L43

6. `hpackHeaderFields[cursor++];` can be `null` and it'll throw NPE when we try to access it.
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDynamicTable.java#L188

7. `next = current[i + 1];` can lead to Array Index Out of Bound error.
https://github.com/netty/netty/blob/69b44c6d06d4449920b6b8990b0f6e0473f3532b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java#L826

Modification:
Fixed all the above possible bugs.

Result:
Better code