### PR TITLE
Enable HTTP header validation in HttpServerUpgradeHandler

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
@@ -169,6 +169,7 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
 
     private final SourceCodec sourceCodec;
     private final UpgradeCodecFactory upgradeCodecFactory;
+    private final boolean validateHeaders;
     private boolean handlingUpgrade;
 
     /**
@@ -199,10 +200,25 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
      */
     public HttpServerUpgradeHandler(
             SourceCodec sourceCodec, UpgradeCodecFactory upgradeCodecFactory, int maxContentLength) {
+        this(sourceCodec, upgradeCodecFactory, maxContentLength, true);
+    }
+
+    /**
+     * Constructs the upgrader with the supported codecs.
+     *
+     * @param sourceCodec the codec that is being used initially
+     * @param upgradeCodecFactory the factory that creates a new upgrade codec
+     *                            for one of the requested upgrade protocols
+     * @param maxContentLength the maximum length of the content of an upgrade request
+     * @param validateHeaders validate the header names and values of the upgrade response.
+     */
+    public HttpServerUpgradeHandler(SourceCodec sourceCodec, UpgradeCodecFactory upgradeCodecFactory,
+                                    int maxContentLength, boolean validateHeaders) {
         super(maxContentLength);
 
         this.sourceCodec = checkNotNull(sourceCodec, "sourceCodec");
         this.upgradeCodecFactory = checkNotNull(upgradeCodecFactory, "upgradeCodecFactory");
+        this.validateHeaders = validateHeaders;
     }
 
     @Override
@@ -352,9 +368,9 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
     /**
      * Creates the 101 Switching Protocols response message.
      */
-    private static FullHttpResponse createUpgradeResponse(CharSequence upgradeProtocol) {
-        DefaultFullHttpResponse res = new DefaultFullHttpResponse(HTTP_1_1, SWITCHING_PROTOCOLS,
-                Unpooled.EMPTY_BUFFER, false);
+    private FullHttpResponse createUpgradeResponse(CharSequence upgradeProtocol) {
+        DefaultFullHttpResponse res = new DefaultFullHttpResponse(
+                HTTP_1_1, SWITCHING_PROTOCOLS, Unpooled.EMPTY_BUFFER, validateHeaders);
         res.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE);
         res.headers().add(HttpHeaderNames.UPGRADE, upgradeProtocol);
         return res;


### PR DESCRIPTION
Motivation:

`HttpServerUpgradeHandler` takes a list of protocols from an incoming request and uses them for building a response. Although the class does some validation while parsing the list, it then disables HTTP header validation when it builds a response. The disabled validation may potentially allow HTTP response splitting attacks.

Modifications:

Enabled HTTP header validation in `HttpServerUpgradeHandler` as a defense-in-depth measure to prevent possible HTTP response splitting attacks.

Result:

`HttpServerUpgradeHandler` validates incoming protocols before including them into a response. That should prevent possible HTTP response splitting attacks.

Notes:

The issue was reported by LGTM

https://lgtm.com/projects/g/netty/netty/snapshot/090bf3d107cb3099317e1cd9e0d661ac0797c126/files/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java?sort=name&dir=ASC&mode=heatmap#x3246e2156ce648dd:1

I am not sure how exactly the handler may be used, and therefore I am not sure if and when the attack may be implemented. As I mentioned above, the handler does some checks on the list of protocols. For example, it skips whitespaces. I would consider this update as a defense-in-depth measure rather than a real issue.

The update should not cause problems for applications since a valid `Upgrade` header should not contains any special characters.

If there is a strong reason, which I am not aware of, for not enabling the validation, please let me know. I'll then suppress the warning.
