### PR TITLE
Avoid casting numbers to narrower types

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -237,7 +237,7 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
             return true;
         }
         int length = byteBuf.readableBytes();
-        int written = 0;
+        long written = 0;
         RandomAccessFile accessFile = new RandomAccessFile(dest, "rw");
         try {
             FileChannel fileChannel = accessFile.getChannel();

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanStageEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanStageEncoder.java
@@ -219,7 +219,7 @@ final class Bzip2HuffmanStageEncoder {
             final int groupEnd = Math.min(groupStart + HUFFMAN_GROUP_RUN_LENGTH, mtfLength) - 1;
 
             // Calculate the cost of this group when encoded by each table
-            short[] cost = new short[totalTables];
+            int[] cost = new int[totalTables];
             for (int i = groupStart; i <= groupEnd; i++) {
                 final int value = mtfBlock[i];
                 for (int j = 0; j < totalTables; j++) {


### PR DESCRIPTION
Motivation:

Avoid implicit conversions to narrower types in `AbstractMemoryHttpData` and `Bzip2HuffmanStageEncoder` classes reported by LGTM.

Modifications:

Updated the classes to avoid implicit casting to narrower types. It doesn't look like that an integer overflow is possible there, therefore no checks for overflows were added.

Result:

No warnings about implicit conversions to narrower types.

Notes:

The issues were originally reported by LGTM:

- [AbstractMemoryHttpData](https://lgtm.com/projects/g/netty/netty/snapshot/090bf3d107cb3099317e1cd9e0d661ac0797c126/files/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java?sort=name&dir=ASC&mode=heatmap#x9953d3ee87f337fe:1)
- [Bzip2HuffmanStageEncoder](https://lgtm.com/projects/g/netty/netty/snapshot/090bf3d107cb3099317e1cd9e0d661ac0797c126/files/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanStageEncoder.java?sort=name&dir=ASC&mode=heatmap#xa14d0c90a2a21bcb:1)

If I understand the code correctly, an overflow can't happen, therefore I didn't add any checks for that. Please let me know if I am missing something and such checks should be added.