### PR TITLE
Suppress warnings about weak hash algorithms

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
@@ -31,6 +31,8 @@ import java.security.NoSuchAlgorithmException;
  */
 final class WebSocketUtil {
 
+    // Suppress a warning about weak hash algorithm since it's defined in draft-ietf-hybi-thewebsocketprotocol-00
+    @SuppressWarnings("lgtm[java/weak-cryptographic-algorithm]")
     private static final FastThreadLocal<MessageDigest> MD5 = new FastThreadLocal<MessageDigest>() {
         @Override
         protected MessageDigest initialValue() throws Exception {
@@ -44,6 +46,8 @@ final class WebSocketUtil {
         }
     };
 
+    // Suppress a warning about weak hash algorithm since it's defined in draft-ietf-hybi-thewebsocketprotocol-00
+    @SuppressWarnings("lgtm[java/weak-cryptographic-algorithm]")
     private static final FastThreadLocal<MessageDigest> SHA1 = new FastThreadLocal<MessageDigest>() {
         @Override
         protected MessageDigest initialValue() throws Exception {


### PR DESCRIPTION
Motivation:

LGTM reported that WebSocketUtil uses MD5 and SHA-1 that are considered weak. Although those algorithms are insecure, they are required by draft-ietf-hybi-thewebsocketprotocol-00 specification that is implemented in the corresponding WebSocket handshakers. Once the handshakers are removed, `WebSocketUtil` can be updated to stop using those weak hash functions.

Modifications:

Added `SuppressWarnings` annotations.

Result:

Suppressed warnings.

Notes:

Here are the issues reported by LGTM: [one](https://lgtm.com/projects/g/netty/netty/snapshot/090bf3d107cb3099317e1cd9e0d661ac0797c126/files/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java?sort=name&dir=ASC&mode=heatmap#xfb2d0e0c097d3c56:1), [two](https://lgtm.com/projects/g/netty/netty/snapshot/090bf3d107cb3099317e1cd9e0d661ac0797c126/files/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java?sort=name&dir=ASC&mode=heatmap#xbeb49c7664150c66:1)

I think the best solution would be just removing the calls to MD5 and SHA-1. However, that would break the classes that implement drafts of the WebSocket specification. Please let me know if it's fine to remove them.