### PR TITLE
Add silentRelease for silently releasing ReferenceCounted

### DIFF
--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -162,6 +162,22 @@ public final class ReferenceCountUtil {
     }
 
     /**
+     * Try to call {@link ReferenceCounted#release()} and release it completely if the specified
+     * message implements {@link ReferenceCounted}. If the specified message doesn't implement
+     * {@link ReferenceCounted}, this method does nothing.Unlike {@link #release(Object)} this method does
+     * not catches an exception raised by {@link ReferenceCounted#release()}.
+     */
+    public static void silentFullRelease(Object msg) {
+        try {
+            if (msg instanceof ReferenceCounted) {
+                release(msg, ((ReferenceCounted) msg).refCnt());
+            }
+        } catch (Throwable t) {
+            // Swallow the throwable
+        }
+    }
+
+    /**
      * Schedules the specified object to be released when the caller thread terminates. Note that this operation is
      * intended to simplify reference counting of ephemeral objects during unit tests. Do not use it beyond the
      * intended use case.

--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -134,6 +134,36 @@ public final class ReferenceCountUtil {
     }
 
     /**
+     * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
+     * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+     * Unlike {@link #release(Object)} this method does not catches an exception raised by
+     * {@link ReferenceCounted#release()}. It is usually recommended to use {@link #release(Object)} instead,
+     * unless you absolutely need to swallow an exception.
+     */
+    public static void silentRelease(Object msg) {
+        try {
+            release(msg);
+        } catch (Throwable t) {
+            // Swallow the throwable
+        }
+    }
+
+    /**
+     * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
+     * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+     * Unlike {@link #release(Object)} this method does not catches an exception raised by
+     * {@link ReferenceCounted#release()}. It is usually recommended to use {@link #release(Object)} instead,
+     * unless you absolutely need to swallow an exception.
+     */
+    public static void silentRelease(Object msg, int decrement) {
+        try {
+            release(msg, decrement);
+        } catch (Throwable t) {
+            // Swallow the throwable
+        }
+    }
+
+    /**
      * Schedules the specified object to be released when the caller thread terminates. Note that this operation is
      * intended to simplify reference counting of ephemeral objects during unit tests. Do not use it beyond the
      * intended use case.

--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -137,8 +137,7 @@ public final class ReferenceCountUtil {
      * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
      * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
      * Unlike {@link #release(Object)} this method does not catches an exception raised by
-     * {@link ReferenceCounted#release()}. It is usually recommended to use {@link #release(Object)} instead,
-     * unless you absolutely need to swallow an exception.
+     * {@link ReferenceCounted#release()}.
      */
     public static void silentRelease(Object msg) {
         try {
@@ -152,8 +151,7 @@ public final class ReferenceCountUtil {
      * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
      * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
      * Unlike {@link #release(Object)} this method does not catches an exception raised by
-     * {@link ReferenceCounted#release()}. It is usually recommended to use {@link #release(Object)} instead,
-     * unless you absolutely need to swallow an exception.
+     * {@link ReferenceCounted#release()}.
      */
     public static void silentRelease(Object msg, int decrement) {
         try {


### PR DESCRIPTION
Motivation:
We should have a method to release which releases `ReferenceCounted` without throwing any exception. It should simply release the `ReferenceCounted` or catch the exception and suppress it silently. This is useful in some cases.

Modification:
Added `ReferenceCountUtil#silentRelease(Object)` and `ReferenceCountUtil#silentRelease(Object, int)`.

Result:
Silent API for `ReferenceCounted` release.