### PR TITLE
Add checkInRange in ObjectUtil

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -84,7 +84,7 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static int checkInRange(int i, int start, int end, String name) {
-        if (i < start || end > i) {
+        if (i < start || i > end) {
             throw new IllegalArgumentException(name + ": " + i + " (expected: " + start + "-" + end + ")");
         }
         return i;
@@ -95,7 +95,7 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static long checkInRange(long l, long start, long end, String name) {
-        if (l < start || end > l) {
+        if (l < start || l > end) {
             throw new IllegalArgumentException(name + ": " + l + " (expected: " + start + "-" + end + ")");
         }
         return l;

--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -80,6 +80,28 @@ public final class ObjectUtil {
     }
 
     /**
+     * Checks that the given argument is in range. If it is not, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static int checkInRange(int i, int start, int end, String name) {
+        if (i < start || end > i) {
+            throw new IllegalArgumentException(name + ": " + i + " (expected: " + start + "-" + end + ")");
+        }
+        return i;
+    }
+
+    /**
+     * Checks that the given argument is in range. If it is not, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static long checkInRange(long l, long start, long end, String name) {
+        if (l < start || end > l) {
+            throw new IllegalArgumentException(name + ": " + l + " (expected: " + start + "-" + end + ")");
+        }
+        return l;
+    }
+
+    /**
      * Checks that the given argument is neither null nor empty.
      * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
      * Otherwise, returns the argument.


### PR DESCRIPTION
Motivation:
We check lots of numbers if it lies in a range. So it's better to add a method in `ObjectUtil` to check if a number lies inside a range.

Modification:
Added Range check method.

Result:
A faster and better way to check if a number lies inside a range.
