### PR TITLE
Remove extra line from the end of Http2MultiplexHandler

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -362,4 +362,3 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
         }
     }
 }
-


### PR DESCRIPTION
Motivation:
`Http2MultiplexHandler` have to 2 empty lines at the end instead of 1.

Modification:
Removed 1 extra line.

Result:
Little better code style.