### PR TITLE
Use the correct ring_ptr field

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -261,7 +261,7 @@ static jobjectArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries
         (jlong)io_uring_ring.sq.array,
         (jlong)io_uring_ring.sq.sqes,
         (jlong)io_uring_ring.sq.ring_sz,
-        (jlong)io_uring_ring.cq.ring_ptr,
+        (jlong)io_uring_ring.sq.ring_ptr,
         (jlong)ring_fd
     };
     (*env)->SetLongArrayRegion(env, submissionArray, 0, 11, submissionArrayElements);


### PR DESCRIPTION
Motivation:

We had a typo and so used the wrong ring_ptr field when constructing the submission queue

Modifications:

Use correct field

Result:

Fixes https://github.com/netty/netty/issues/10671