### PR TITLE
Use ObjectUtil for multiple operations in HTTP/HTTP2 Codec

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Compresses an {@link HttpMessage} and an {@link HttpContent} in {@code gzip} or
@@ -103,27 +104,10 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *        number. {@code 0} will enable compression for all responses.
      */
     public HttpContentCompressor(int compressionLevel, int windowBits, int memLevel, int contentSizeThreshold) {
-        if (compressionLevel < 0 || compressionLevel > 9) {
-            throw new IllegalArgumentException(
-                    "compressionLevel: " + compressionLevel +
-                    " (expected: 0-9)");
-        }
-        if (windowBits < 9 || windowBits > 15) {
-            throw new IllegalArgumentException(
-                    "windowBits: " + windowBits + " (expected: 9-15)");
-        }
-        if (memLevel < 1 || memLevel > 9) {
-            throw new IllegalArgumentException(
-                    "memLevel: " + memLevel + " (expected: 1-9)");
-        }
-        if (contentSizeThreshold < 0) {
-            throw new IllegalArgumentException(
-                    "contentSizeThreshold: " + contentSizeThreshold + " (expected: non negative number)");
-        }
-        this.compressionLevel = compressionLevel;
-        this.windowBits = windowBits;
-        this.memLevel = memLevel;
-        this.contentSizeThreshold = contentSizeThreshold;
+        this.compressionLevel = ObjectUtil.checkInRange(compressionLevel, 0, 9, "compressionLevel");
+        this.windowBits = ObjectUtil.checkInRange(windowBits, 9, 15, "windowBits");
+        this.memLevel = ObjectUtil.checkInRange(memLevel, 1, 9, "memLevel");
+        this.contentSizeThreshold = ObjectUtil.checkPositiveOrZero(contentSizeThreshold, "contentSizeThreshold");
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.util.concurrent.PromiseCombiner;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_ENCODING;
@@ -56,18 +57,9 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
     public CompressorHttp2ConnectionEncoder(Http2ConnectionEncoder delegate, int compressionLevel, int windowBits,
                                             int memLevel) {
         super(delegate);
-        if (compressionLevel < 0 || compressionLevel > 9) {
-            throw new IllegalArgumentException("compressionLevel: " + compressionLevel + " (expected: 0-9)");
-        }
-        if (windowBits < 9 || windowBits > 15) {
-            throw new IllegalArgumentException("windowBits: " + windowBits + " (expected: 9-15)");
-        }
-        if (memLevel < 1 || memLevel > 9) {
-            throw new IllegalArgumentException("memLevel: " + memLevel + " (expected: 1-9)");
-        }
-        this.compressionLevel = compressionLevel;
-        this.windowBits = windowBits;
-        this.memLevel = memLevel;
+        this.compressionLevel = ObjectUtil.checkInRange(compressionLevel, 0, 9, "compressionLevel");
+        this.windowBits = ObjectUtil.checkInRange(windowBits, 9, 15, "windowBits");
+        this.memLevel = ObjectUtil.checkInRange(memLevel, 1, 9, "memLevel");
 
         propertyKey = connection().newKey();
         connection().addListener(new Http2ConnectionAdapter() {


### PR DESCRIPTION
Motivation:
We should use ObjectUtil for checking if Compression parameters are in range. This will reduce LOC and make code more readable.

Modification:
Used ObjectUtil

Result:
More readable code
