### PR TITLE
Fire SniCompletionEvent after onLookupComplete(...) was called

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
@@ -128,8 +128,11 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
 
     @Override
     protected void onLookupComplete(ChannelHandlerContext ctx, Future<T> future) throws Exception {
-        fireSniCompletionEvent(ctx, hostname, future);
-        onLookupComplete(ctx, hostname, future);
+        try {
+            onLookupComplete(ctx, hostname, future);
+        } finally {
+            fireSniCompletionEvent(ctx, hostname, future);
+        }
     }
 
     /**
@@ -148,7 +151,7 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
     protected abstract void onLookupComplete(ChannelHandlerContext ctx,
                                              String hostname, Future<T> future) throws Exception;
 
-    private void fireSniCompletionEvent(ChannelHandlerContext ctx, String hostname, Future<T> future) {
+    private static void fireSniCompletionEvent(ChannelHandlerContext ctx, String hostname, Future<?> future) {
         Throwable cause = future.cause();
         if (cause == null) {
             ctx.fireUserEventTriggered(new SniCompletionEvent(hostname));


### PR DESCRIPTION
Motivation:

Users may want to do special actions when onComplete(...) was called and depend on these once they receive the SniCompletionEvent

Modifications:

Switch order and so call onLookupComplete(...) before we fire the event

Result:

Fixes https://github.com/netty/netty/issues/10655
