### PR TITLE
Fix or suppress LGTM findings

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -150,8 +150,9 @@ public class ByteBufInputStream extends InputStream implements DataInput {
         return endIndex - buffer.readerIndex();
     }
 
+    // Suppress a warning since the class is not thread-safe
     @Override
-    public void mark(int readlimit) {
+    public void mark(int readlimit) {   // lgtm[java/non-sync-override]
         buffer.markReaderIndex();
     }
 
@@ -181,8 +182,9 @@ public class ByteBufInputStream extends InputStream implements DataInput {
         return len;
     }
 
+    // Suppress a warning since the class is not thread-safe
     @Override
-    public void reset() throws IOException {
+    public void reset() throws IOException {    // lgtm[java/non-sync-override]
         buffer.resetReaderIndex();
     }
 

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -152,7 +152,7 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoder {
             v2MaxHeaderSize = V2_MAX_LENGTH;
         } else {
             int calcMax = maxTlvSize + V2_MIN_LENGTH;
-            if (calcMax > V2_MAX_LENGTH) {
+            if (calcMax > V2_MAX_LENGTH) {  // lgtm[java/constant-comparison]
                 v2MaxHeaderSize = V2_MAX_LENGTH;
             } else {
                 v2MaxHeaderSize = calcMax;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -992,7 +992,8 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         @Override
         public AppendableCharSequence parse(ByteBuf buffer) {
-            reset();
+            // Suppress a warning because HeaderParser.reset() is supposed to be called
+            reset();    // lgtm[java/subtle-inherited-call]
             return super.parse(buffer);
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/ReadOnlyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ReadOnlyHttpHeaders.java
@@ -78,7 +78,8 @@ public final class ReadOnlyHttpHeaders extends HttpHeaders {
         for (int i = 0; i < nameValuePairs.length; i += 2) {
             CharSequence roName = nameValuePairs[i];
             if (AsciiString.hashCode(roName) == nameHash && contentEqualsIgnoreCase(roName, name)) {
-                return nameValuePairs[i + 1];
+                // Suppress a warning out of bounds access since the constructor allows only pairs
+                return nameValuePairs[i + 1]; // lgtm[java/index-out-of-bounds]
             }
         }
         return null;
@@ -136,7 +137,7 @@ public final class ReadOnlyHttpHeaders extends HttpHeaders {
         for (int i = 0; i < nameValuePairs.length; i += 2) {
             CharSequence roName = nameValuePairs[i];
             if (AsciiString.hashCode(roName) == nameHash && contentEqualsIgnoreCase(roName, name)) {
-                values.add(nameValuePairs[i + 1].toString());
+                values.add(nameValuePairs[i + 1].toString()); // lgtm[java/index-out-of-bounds]
             }
         }
         return values;
@@ -150,7 +151,7 @@ public final class ReadOnlyHttpHeaders extends HttpHeaders {
         List<Map.Entry<String, String>> entries = new ArrayList<Map.Entry<String, String>>(size());
         for (int i = 0; i < nameValuePairs.length; i += 2) {
             entries.add(new SimpleImmutableEntry<String, String>(nameValuePairs[i].toString(),
-                    nameValuePairs[i + 1].toString()));
+                    nameValuePairs[i + 1].toString())); // lgtm[java/index-out-of-bounds]
         }
         return entries;
     }
@@ -170,14 +171,14 @@ public final class ReadOnlyHttpHeaders extends HttpHeaders {
         if (ignoreCase) {
             for (int i = 0; i < nameValuePairs.length; i += 2) {
                 if (contentEqualsIgnoreCase(nameValuePairs[i], name) &&
-                        contentEqualsIgnoreCase(nameValuePairs[i + 1], value)) {
+                        contentEqualsIgnoreCase(nameValuePairs[i + 1], value)) { // lgtm[java/index-out-of-bounds]
                     return true;
                 }
             }
         } else {
             for (int i = 0; i < nameValuePairs.length; i += 2) {
                 if (contentEqualsIgnoreCase(nameValuePairs[i], name) &&
-                        contentEquals(nameValuePairs[i + 1], value)) {
+                        contentEquals(nameValuePairs[i + 1], value)) { // lgtm[java/index-out-of-bounds]
                     return true;
                 }
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
@@ -31,14 +31,14 @@ import java.security.NoSuchAlgorithmException;
  */
 final class WebSocketUtil {
 
-    // Suppress a warning about weak hash algorithm since it's defined in draft-ietf-hybi-thewebsocketprotocol-00
-    @SuppressWarnings("lgtm[java/weak-cryptographic-algorithm]")
     private static final FastThreadLocal<MessageDigest> MD5 = new FastThreadLocal<MessageDigest>() {
         @Override
         protected MessageDigest initialValue() throws Exception {
             try {
                 //Try to get a MessageDigest that uses MD5
-                return MessageDigest.getInstance("MD5");
+                //Suppress a warning about weak hash algorithm
+                //since it's defined in draft-ietf-hybi-thewebsocketprotocol-00
+                return MessageDigest.getInstance("MD5"); // lgtm [java/weak-cryptographic-algorithm]
             } catch (NoSuchAlgorithmException e) {
                 //This shouldn't happen! How old is the computer?
                 throw new InternalError("MD5 not supported on this platform - Outdated?");
@@ -46,14 +46,14 @@ final class WebSocketUtil {
         }
     };
 
-    // Suppress a warning about weak hash algorithm since it's defined in draft-ietf-hybi-thewebsocketprotocol-00
-    @SuppressWarnings("lgtm[java/weak-cryptographic-algorithm]")
     private static final FastThreadLocal<MessageDigest> SHA1 = new FastThreadLocal<MessageDigest>() {
         @Override
         protected MessageDigest initialValue() throws Exception {
             try {
                 //Try to get a MessageDigest that uses SHA1
-                return MessageDigest.getInstance("SHA1");
+                //Suppress a warning about weak hash algorithm
+                //since it's defined in draft-ietf-hybi-thewebsocketprotocol-00
+                return MessageDigest.getInstance("SHA1"); // lgtm [java/weak-cryptographic-algorithm]
             } catch (NoSuchAlgorithmException e) {
                 //This shouldn't happen! How old is the computer?
                 throw new InternalError("SHA-1 not supported on this platform - Outdated?");

--- a/codec-http/src/test/java/io/netty/handler/codec/http/ReadOnlyHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/ReadOnlyHttpHeadersTest.java
@@ -119,6 +119,18 @@ public class ReadOnlyHttpHeadersTest {
                 ACCEPT, APPLICATION_JSON, AsciiString.cached(" "));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void emptyHeaderName() {
+        new ReadOnlyHttpHeaders(true,
+                                ACCEPT, APPLICATION_JSON, AsciiString.cached(" "), ZERO);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void headerWithoutValue() {
+        new ReadOnlyHttpHeaders(false,
+                                ACCEPT, APPLICATION_JSON, CONTENT_LENGTH);
+    }
+
     private static void assert3ParisEquals(Iterator<Entry<String, String>> itr) {
         assertTrue(itr.hasNext());
         Entry<String, String> next = itr.next();

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectReturnCode.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectReturnCode.java
@@ -57,7 +57,8 @@ public enum MqttConnectReturnCode {
         VALUES = new MqttConnectReturnCode[160];
         for (MqttConnectReturnCode code : values) {
             final int unsignedByte = code.byteValue & 0xFF;
-            VALUES[unsignedByte] = code;
+            // Suppress a warning about out of bounds access since the enum contains only correct values
+            VALUES[unsignedByte] = code;    // lgtm [java/index-out-of-bounds]
         }
     }
 

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElement.java
@@ -69,7 +69,7 @@ public abstract class XmlElement {
         if (namespace != null ? !namespace.equals(that.namespace) : that.namespace != null) {
             return false;
         }
-        if (namespaces != null ? !namespaces.equals(that.namespaces) : that.namespaces != null) {
+        if (!namespaces.equals(that.namespaces)) {
             return false;
         }
         if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
@@ -84,7 +84,7 @@ public abstract class XmlElement {
         int result = name.hashCode();
         result = 31 * result + (namespace != null ? namespace.hashCode() : 0);
         result = 31 * result + (prefix != null ? prefix.hashCode() : 0);
-        result = 31 * result + (namespaces != null ? namespaces.hashCode() : 0);
+        result = 31 * result + namespaces.hashCode();
         return result;
     }
 

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlElementStart.java
@@ -47,7 +47,7 @@ public class XmlElementStart extends XmlElement {
 
         XmlElementStart that = (XmlElementStart) o;
 
-        if (attributes != null ? !attributes.equals(that.attributes) : that.attributes != null) {
+        if (!attributes.equals(that.attributes)) {
             return false;
         }
 
@@ -57,7 +57,7 @@ public class XmlElementStart extends XmlElement {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
+        result = 31 * result + attributes.hashCode();
         return result;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/DateFormatter.java
+++ b/codec/src/main/java/io/netty/handler/codec/DateFormatter.java
@@ -101,7 +101,7 @@ public final class DateFormatter {
         } else if (length < 0) {
             throw new IllegalArgumentException("Can't have end < start");
         } else if (length > 64) {
-            throw new IllegalArgumentException("Can't parse more than 64 chars," +
+            throw new IllegalArgumentException("Can't parse more than 64 chars, " +
                     "looks like a user error or a malformed header");
         }
         return formatter().parse0(checkNotNull(txt, "txt"), start, end);

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -383,7 +383,9 @@ public class JZlibEncoder extends ZlibEncoder {
             if (resultCode != JZlib.Z_OK && resultCode != JZlib.Z_STREAM_END) {
                 promise.setFailure(ZlibUtil.deflaterException(z, "compression failure", resultCode));
                 return promise;
-            } else if (z.next_out_index != 0) {
+            } else if (z.next_out_index != 0) { // lgtm[java/constant-comparison]
+                // Suppressed a warning above to be on the safe side
+                // even if z.next_out_index seems to be always 0 here
                 footer = Unpooled.wrappedBuffer(out, 0, z.next_out_index);
             } else {
                 footer = Unpooled.EMPTY_BUFFER;

--- a/codec/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
@@ -71,7 +71,9 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
 
     @Override
     protected void encode(ChannelHandlerContext ctx, Serializable msg, ByteBuf out) throws Exception {
-        ObjectOutputStream oos = newObjectOutputStream(new ByteBufOutputStream(out));
+        // Suppress a warning about resource leak since oss is closed below
+        ObjectOutputStream oos = newObjectOutputStream(
+                new ByteBufOutputStream(out));  // lgtm[java/output-resource-leak]
         try {
             if (resetInterval != 0) {
                 // Resetting will prevent OOM on the receiving side.

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoderInputStream.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoderInputStream.java
@@ -126,8 +126,9 @@ public class ObjectDecoderInputStream extends InputStream implements
         in.close();
     }
 
+    // Suppress a warning since the class is not thread-safe
     @Override
-    public void mark(int readlimit) {
+    public void mark(int readlimit) {   // lgtm[java/non-sync-override]
         in.mark(readlimit);
     }
 
@@ -136,8 +137,9 @@ public class ObjectDecoderInputStream extends InputStream implements
         return in.markSupported();
     }
 
+    // Suppress a warning since the class is not thread-safe
     @Override
-    public int read() throws IOException {
+    public int read() throws IOException {  // lgtm[java/non-sync-override]
         return in.read();
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
@@ -79,7 +79,9 @@ public class ObjectEncoderOutputStream extends OutputStream implements
     public void writeObject(Object obj) throws IOException {
         ByteBuf buf = Unpooled.buffer(estimatedLength);
         try {
-            ObjectOutputStream oout = new CompactObjectOutputStream(new ByteBufOutputStream(buf));
+            // Suppress a warning about resource leak since oout is closed below
+            ObjectOutputStream oout = new CompactObjectOutputStream(
+                    new ByteBufOutputStream(buf));  // lgtm[java/output-resource-leak]
             try {
                 oout.writeObject(obj);
                 oout.flush();

--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -439,7 +439,7 @@ public class HashedWheelTimer implements Timer {
         if (logger.isErrorEnabled()) {
             String resourceType = simpleClassName(HashedWheelTimer.class);
             logger.error("You are creating too many " + resourceType + " instances. " +
-                    resourceType + " is a shared resource that must be reused across the JVM," +
+                    resourceType + " is a shared resource that must be reused across the JVM, " +
                     "so that only a few instances are created.");
         }
     }

--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -318,8 +318,9 @@ public final class NetUtil {
     private static Integer sysctlGetInt(String sysctlKey) throws IOException {
         Process process = new ProcessBuilder("sysctl", sysctlKey).start();
         try {
-            InputStream is = process.getInputStream();
-            InputStreamReader isr = new InputStreamReader(is);
+            // Suppress warnings about resource leaks since the buffered reader is closed below
+            InputStream is = process.getInputStream();  // lgtm[java/input-resource-leak
+            InputStreamReader isr = new InputStreamReader(is);  // lgtm[java/input-resource-leak
             BufferedReader br = new BufferedReader(isr);
             try {
                 String line = br.readLine();

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -632,8 +632,10 @@ public class ResourceLeakDetector<T> {
                 // Strip the noisy stack trace elements.
                 String[] exclusions = excludedMethods.get();
                 for (int k = 0; k < exclusions.length; k += 2) {
+                    // Suppress a warning about out of bounds access
+                    // since the length of excludedMethods is always even, see addExclusions()
                     if (exclusions[k].equals(element.getClassName())
-                            && exclusions[k + 1].equals(element.getMethodName())) {
+                            && exclusions[k + 1].equals(element.getMethodName())) { // lgtm[java/index-out-of-bounds]
                         continue out;
                     }
                 }

--- a/common/src/main/java/io/netty/util/Signal.java
+++ b/common/src/main/java/io/netty/util/Signal.java
@@ -64,13 +64,15 @@ public final class Signal extends Error implements Constant<Signal> {
         }
     }
 
+    // Suppress a warning since the method doesn't need synchronization
     @Override
-    public Throwable initCause(Throwable cause) {
+    public Throwable initCause(Throwable cause) {   // lgtm[java/non-sync-override]
         return this;
     }
 
+    // Suppress a warning since the method doesn't need synchronization
     @Override
-    public Throwable fillInStackTrace() {
+    public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
         return this;
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -140,8 +140,9 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     private static final class LeanCancellationException extends CancellationException {
         private static final long serialVersionUID = 2794674970981187807L;
 
+        // Suppress a warning since the method doesn't need synchronization
         @Override
-        public Throwable fillInStackTrace() {
+        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
             setStackTrace(CANCELLATION_STACK);
             return this;
         }

--- a/example/src/main/resources/cors/cors.html
+++ b/example/src/main/resources/cors/cors.html
@@ -30,7 +30,7 @@
                     return document.getElementById('responseText');
                 }
 
-                function appendTextArea(newData) {
+                function appendTextArea(newData) {  // lgtm[js/unused-local-variable]
                     var el = getTextAreaElement();
                     el.value = el.value + '\n' + newData;
                 }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1635,7 +1635,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 if (minProtocolIndex > OPENSSL_OP_NO_PROTOCOL_INDEX_SSLV2) {
                     minProtocolIndex = OPENSSL_OP_NO_PROTOCOL_INDEX_SSLV2;
                 }
-                if (maxProtocolIndex < OPENSSL_OP_NO_PROTOCOL_INDEX_SSLV2) {
+                if (maxProtocolIndex < OPENSSL_OP_NO_PROTOCOL_INDEX_SSLV2) { // lgtm[java/constant-comparison]
                     maxProtocolIndex = OPENSSL_OP_NO_PROTOCOL_INDEX_SSLV2;
                 }
             } else if (p.equals(PROTOCOL_SSL_V3)) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -390,7 +390,7 @@ public final class SslContextBuilder {
     public SslContextBuilder keyManager(PrivateKey key, String keyPassword, X509Certificate... keyCertChain) {
         if (forServer) {
             checkNotNull(keyCertChain, "keyCertChain required for servers");
-            if (keyCertChain.length == 0) {
+            if (keyCertChain.length == 0) { // lgtm[java/dereferenced-value-may-be-null]
                 throw new IllegalArgumentException("keyCertChain must be non-empty");
             }
             checkNotNull(key, "key required for servers");

--- a/handler/src/main/java/io/netty/handler/timeout/TimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/TimeoutException.java
@@ -32,8 +32,9 @@ public class TimeoutException extends ChannelException {
         super(null, null, shared);
     }
 
+    // Suppress a warning since the method doesn't need synchronization
     @Override
-    public Throwable fillInStackTrace() {
+    public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
         return this;
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverException.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverException.java
@@ -66,8 +66,9 @@ public class DnsNameResolverException extends RuntimeException {
         return question;
     }
 
+    // Suppress a warning since the method doesn't need synchronization
     @Override
-    public Throwable fillInStackTrace() {
+    public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
         setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
         return this;
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -259,8 +259,9 @@ abstract class DnsResolveContext<T> {
             initCause(cause.getCause());
         }
 
+        // Suppress a warning since this method doesn't need synchronization
         @Override
-        public Throwable fillInStackTrace() {
+        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
             return this;
         }
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
@@ -99,7 +99,8 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
         final boolean useEtcResolverFiles = etcResolverFiles != null && etcResolverFiles.length != 0;
         domainToNameServerStreamMap = useEtcResolverFiles ? parse(etcResolverFiles) : etcResolvConfMap;
 
-        DnsServerAddresses defaultNameServerAddresses = etcResolvConfMap.get(etcResolvConf.getName());
+        DnsServerAddresses defaultNameServerAddresses
+                = etcResolvConfMap.get(etcResolvConf.getName());  // lgtm[java/dereferenced-value-may-be-null]
         if (defaultNameServerAddresses == null) {
             Collection<DnsServerAddresses> values = etcResolvConfMap.values();
             if (values.isEmpty()) {

--- a/resolver/src/main/java/io/netty/resolver/HostsFileParser.java
+++ b/resolver/src/main/java/io/netty/resolver/HostsFileParser.java
@@ -127,10 +127,15 @@ public final class HostsFileParser {
         checkNotNull(charsets, "charsets");
         if (file.exists() && file.isFile()) {
             for (Charset charset: charsets) {
-                HostsFileEntries entries = parse(new BufferedReader(new InputStreamReader(
-                        new FileInputStream(file), charset)));
-                if (entries != HostsFileEntries.EMPTY) {
-                    return entries;
+                BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(new FileInputStream(file), charset));
+                try {
+                    HostsFileEntries entries = parse(reader);
+                    if (entries != HostsFileEntries.EMPTY) {
+                        return entries;
+                    }
+                } finally {
+                    reader.close();
                 }
             }
         }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventArray.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventArray.java
@@ -109,7 +109,8 @@ final class EpollEventArray {
 
     private int getInt(int index, int offset) {
         if (PlatformDependent.hasUnsafe()) {
-            return PlatformDependent.getInt(memoryAddress + index * EPOLL_EVENT_SIZE + offset);
+            long n = (long) index * (long) EPOLL_EVENT_SIZE;
+            return PlatformDependent.getInt(memoryAddress + n + offset);
         }
         return memory.getInt(index * EPOLL_EVENT_SIZE + offset);
     }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -1173,8 +1173,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             initCause(exception);
         }
 
+        // Suppress a warning since this method doesn't need synchronization
         @Override
-        public Throwable fillInStackTrace() {
+        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
             return this;
         }
     }
@@ -1188,8 +1189,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             initCause(exception);
         }
 
+        // Suppress a warning since this method doesn't need synchronization
         @Override
-        public Throwable fillInStackTrace() {
+        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
             return this;
         }
     }
@@ -1203,8 +1205,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             initCause(exception);
         }
 
+        // Suppress a warning since this method doesn't need synchronization
         @Override
-        public Throwable fillInStackTrace() {
+        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
             return this;
         }
     }

--- a/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
@@ -50,7 +50,8 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
             sizeTable.add(i);
         }
 
-        for (int i = 512; i > 0; i <<= 1) {
+        // Suppress a warning since i becomes negative when an integer overflow happens
+        for (int i = 512; i > 0; i <<= 1) { // lgtm[java/constant-comparison]
             sizeTable.add(i);
         }
 

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -603,7 +603,7 @@ public final class ChannelOutboundBuffer {
             final int oldValue = unwritable;
             final int newValue = oldValue | 1;
             if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
-                if (oldValue == 0 && newValue != 0) {
+                if (oldValue == 0) {
                     fireChannelWritabilityChanged(invokeLater);
                 }
                 break;

--- a/transport/src/main/java/io/netty/channel/ExtendedClosedChannelException.java
+++ b/transport/src/main/java/io/netty/channel/ExtendedClosedChannelException.java
@@ -25,8 +25,9 @@ final class ExtendedClosedChannelException extends ClosedChannelException {
         }
     }
 
+    // Suppress a warning since the method doesn't need synchronization
     @Override
-    public Throwable fillInStackTrace() {
+    public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
         return this;
     }
 }

--- a/transport/src/main/java/io/netty/channel/StacklessClosedChannelException.java
+++ b/transport/src/main/java/io/netty/channel/StacklessClosedChannelException.java
@@ -30,7 +30,8 @@ final class StacklessClosedChannelException extends ClosedChannelException {
 
     @Override
     public Throwable fillInStackTrace() {
-        return this;
+        // Suppress a warning since this method doesn't need synchronization
+        return this; // lgtm [java/non-sync-override]
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/group/VoidChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty/channel/group/VoidChannelGroupFuture.java
@@ -24,7 +24,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
-final class VoidChannelGroupFuture implements ChannelGroupFuture {
+// Suppress a warning about returning the same iterator since it always returns an empty iterator
+final class VoidChannelGroupFuture implements ChannelGroupFuture {  // lgtm[java/iterable-wraps-iterator]
 
     private static final Iterator<ChannelFuture> EMPTY = Collections.<ChannelFuture>emptyList().iterator();
     private final ChannelGroup group;

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -196,8 +196,10 @@ public class FixedChannelPool extends SimpleChannelPool {
                         // Fail the promise as we timed out.
                         task.promise.setFailure(new TimeoutException(
                                 "Acquire operation took longer then configured maximum time") {
+
+                            // Suppress a warning since the method doesn't need synchronization
                             @Override
-                            public Throwable fillInStackTrace() {
+                            public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
                                 return this;
                             }
                         });


### PR DESCRIPTION
Motivation:

LGTM reports multiple issues. They need to be triaged,
and real ones should be fixed.

Modifications:
- Fixed multiple issues reported by LGTM, such as redundant conditions, resource leaks, typos, possible integer overflows.
- Suppressed false-positives.
- Added a few testcases.

Result:

Fixed several possible issues, get rid of false alarms in the LGTM report.

https://lgtm.com/projects/g/netty/netty/?mode=list&tag=

The suppressed warnings don't look like real issues after you have a closed look at the code around. However, they may still be fixed if we don't want to have many suppression comments, of if we'd like to be paranoids. Please let me know.
