### PR TITLE
Cleanup PoolChunk / PoolSubpage and add a few more asserts

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -435,6 +435,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
             }
 
             int runOffset = runOffset(runHandle);
+            assert subpages[runOffset] == null;
             int elemSize = arena.sizeIdx2size(sizeIdx);
 
             PoolSubpage<T> subpage = new PoolSubpage<T>(head, this, pageShifts, runOffset,
@@ -457,7 +458,8 @@ final class PoolChunk<T> implements PoolChunkMetric {
             int sizeIdx = arena.size2SizeIdx(normCapacity);
             PoolSubpage<T> head = arena.findSubpagePoolHead(sizeIdx);
 
-            PoolSubpage<T> subpage = subpages[runOffset(handle)];
+            int sIdx = runOffset(handle);
+            PoolSubpage<T> subpage = subpages[sIdx];
             assert subpage != null && subpage.doNotDestroy;
 
             // Obtain the head of the PoolSubPage pool that is owned by the PoolArena and synchronize on it.
@@ -467,6 +469,9 @@ final class PoolChunk<T> implements PoolChunkMetric {
                     //the subpage is still used, do not free it
                     return;
                 }
+                assert !subpage.doNotDestroy;
+                // Null out slot in the array as it was freed and we should not use it anymore.
+                subpages[sIdx] = null;
             }
         }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -60,10 +60,7 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
         this.runSize = runSize;
         this.elemSize = elemSize;
         bitmap = new long[runSize >>> 6 + LOG2_QUANTUM]; // runSize / 64 / QUANTUM
-        init(head, elemSize);
-    }
 
-    void init(PoolSubpage<T> head, int elemSize) {
         doNotDestroy = true;
         if (elemSize != 0) {
             maxNumElems = numAvail = runSize / elemSize;


### PR DESCRIPTION
Motivation:

As the PooledByteBufAllocator is a critical part of netty we should ensure it works as expected.

Modifications:

- Add a few more asserts to ensure we not see any corrupted state
- Null out slot in the subpage array once the subpage was freed and removed from the pool
- Merge methods into constructor as it was only called from the constructor anyway.

Result:

Code cleanup