### PR TITLE
Added a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting a security issue
+
+If you think the bug you found is likely to make Netty-based applications vulnerable to an attack,
+please do not use our public issue tracker
+but report it to [the dedicated private Google Group](https://groups.google.com/d/forum/netty-security).


### PR DESCRIPTION
I'd like to propose adding a security policy to the project that would be integrated with other GitHub features

https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

The policy just contains contend of the "Report bugs & security issues" section in https://netty.io/community.html

Motivation:

The process of reporting security issues should be documented and easy to find.

Modification:

Added a `SECURITY.md` file that describes how to report a security issue.

Result:

It's a bit easier to find the docs that describe how security issues should be reported. Also, when someone creates an issue the repository, they will see a link to the security policy.
