### PR TITLE
Correctly mask values when encoding as user data

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/UserData.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/UserData.java
@@ -21,7 +21,8 @@ final class UserData {
 
     static long encode(int fd, int op, short data) {
         assert op <= Short.MAX_VALUE;
-        return (long) data << 48 | (long) op << 32 | fd;
+        assert op >= Short.MIN_VALUE;
+        return ((long) data << 48) | ((op & 0xFFFFL) << 32) | fd & 0xFFFFFFFFL;
     }
 
     static void decode(int res, int flags, long udata, IOUringCompletionQueueCallback callback) {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/UserDataTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/UserDataTest.java
@@ -23,7 +23,7 @@ public class UserDataTest {
     @Test
     public void testUserData() {
         // Ensure userdata works with negative and positive values
-        for (int fd : new int[] { 0, 1, 10, Short.MAX_VALUE, Integer.MAX_VALUE }) {
+        for (int fd : new int[] { -10, -1, 0, 1, 10, Short.MAX_VALUE, Integer.MAX_VALUE }) {
             for (int op = 0; op < 20; op++) {
                 for (int data = Short.MIN_VALUE; data <= Short.MAX_VALUE; data++) {
                     final int expectedFd = fd;


### PR DESCRIPTION
Motivation:

We did not correctly mask values when encoding as user-data. This could
lead to decoding these incorrectly. This for example happened when fd is
negative (which should never happen in real world tho).

Modifications:

- Correctly mask and bitshit
- Adjust unit test to catch it

Result:

Correctly encode / decode user data