### PR TITLE
Allow EventLoops to rethrow ThreadDeath errors

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -390,8 +390,8 @@ class EpollEventLoop extends SingleThreadEventLoop {
                     //increase the size of the array as we needed the whole space for the events
                     events.increase();
                 }
-            } catch (ThreadDeath td) {
-                throw (ThreadDeath) td;
+            } catch (Error e) {
+                throw (Error) e;
             } catch (Throwable t) {
                 handleLoopException(t);
             } finally {
@@ -403,6 +403,8 @@ class EpollEventLoop extends SingleThreadEventLoop {
                             break;
                         }
                     }
+                } catch (Error e) {
+                    throw (Error) e;
                 } catch (Throwable t) {
                     handleLoopException(t);
                 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -396,16 +396,16 @@ class EpollEventLoop extends SingleThreadEventLoop {
                 handleLoopException(t);
             } finally {
                 // Always handle shutdown even if the loop processing threw an exception.
-               try {
-                   if (isShuttingDown()) {
-                       closeAll();
+                try {
+                    if (isShuttingDown()) {
+                        closeAll();
                         if (confirmShutdown()) {
                             break;
                         }
-                   }
-               } catch (Throwable t) {
-                   handleLoopException(t);
-               }
+                    }
+                } catch (Throwable t) {
+                    handleLoopException(t);
+                }
             }
         }
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -391,7 +391,11 @@ class EpollEventLoop extends SingleThreadEventLoop {
                     events.increase();
                 }
             } catch (Throwable t) {
-                handleLoopException(t);
+                if (t instanceof ThreadDeath) {
+                    throw (ThreadDeath)t;
+                } else {
+                    handleLoopException(t);
+                }
             }
             // Always handle shutdown even if the loop processing threw an exception.
             try {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -394,17 +394,18 @@ class EpollEventLoop extends SingleThreadEventLoop {
                 throw (ThreadDeath) td;
             } catch (Throwable t) {
                 handleLoopException(t);
-            }
-            // Always handle shutdown even if the loop processing threw an exception.
-            try {
-                if (isShuttingDown()) {
-                    closeAll();
-                    if (confirmShutdown()) {
-                        break;
-                    }
-                }
-            } catch (Throwable t) {
-                handleLoopException(t);
+            } finally {
+                // Always handle shutdown even if the loop processing threw an exception.
+               try {
+                   if (isShuttingDown()) {
+                       closeAll();
+                        if (confirmShutdown()) {
+                            break;
+                        }
+                   }
+               } catch (Throwable t) {
+                   handleLoopException(t);
+               }
             }
         }
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -390,12 +390,10 @@ class EpollEventLoop extends SingleThreadEventLoop {
                     //increase the size of the array as we needed the whole space for the events
                     events.increase();
                 }
+            } catch (ThreadDeath td) {
+                throw (ThreadDeath) td;
             } catch (Throwable t) {
-                if (t instanceof ThreadDeath) {
-                    throw (ThreadDeath)t;
-                } else {
-                    handleLoopException(t);
-                }
+                handleLoopException(t);
             }
             // Always handle shutdown even if the loop processing threw an exception.
             try {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -301,17 +301,18 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
                 throw (ThreadDeath) td;
             } catch (Throwable t) {
                 handleLoopException(t);
-            }
-            // Always handle shutdown even if the loop processing threw an exception.
-            try {
-                if (isShuttingDown()) {
-                    closeAll();
-                    if (confirmShutdown()) {
-                        break;
+            } finally {
+               // Always handle shutdown even if the loop processing threw an exception.
+               try {
+                    if (isShuttingDown()) {
+                       closeAll();
+                        if (confirmShutdown()) {
+                           break;
+                        }
                     }
+                } catch (Throwable t) {
+                    handleLoopException(t);
                 }
-            } catch (Throwable t) {
-                handleLoopException(t);
             }
         }
     }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -297,12 +297,10 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
                     //increase the size of the array as we needed the whole space for the events
                     eventList.realloc(false);
                 }
+            } catch (ThreadDeath td) {
+                throw (ThreadDeath) td;
             } catch (Throwable t) {
-                if (t instanceof ThreadDeath) {
-                    throw (ThreadDeath)t;
-                } else {
-                    handleLoopException(t);
-                }
+                handleLoopException(t);
             }
             // Always handle shutdown even if the loop processing threw an exception.
             try {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -298,7 +298,11 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
                     eventList.realloc(false);
                 }
             } catch (Throwable t) {
-                handleLoopException(t);
+                if (t instanceof ThreadDeath) {
+                    throw (ThreadDeath)t;
+                } else {
+                    handleLoopException(t);
+                }
             }
             // Always handle shutdown even if the loop processing threw an exception.
             try {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -297,8 +297,8 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
                     //increase the size of the array as we needed the whole space for the events
                     eventList.realloc(false);
                 }
-            } catch (ThreadDeath td) {
-                throw (ThreadDeath) td;
+            } catch (Error e) {
+                throw (Error) e;
             } catch (Throwable t) {
                 handleLoopException(t);
             } finally {
@@ -310,6 +310,8 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
                             break;
                         }
                     }
+                } catch (Error e) {
+                    throw (Error) e;
                 } catch (Throwable t) {
                     handleLoopException(t);
                 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -302,12 +302,12 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
             } catch (Throwable t) {
                 handleLoopException(t);
             } finally {
-               // Always handle shutdown even if the loop processing threw an exception.
-               try {
+                // Always handle shutdown even if the loop processing threw an exception.
+                try {
                     if (isShuttingDown()) {
-                       closeAll();
+                        closeAll();
                         if (confirmShutdown()) {
-                           break;
+                            break;
                         }
                     }
                 } catch (Throwable t) {

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -522,15 +522,15 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             } finally {
                 // Always handle shutdown even if the loop processing threw an exception.
                 try {
-                   if (isShuttingDown()) {
-                       closeAll();
-                       if (confirmShutdown()) {
-                           return;
-                       }
-                   }
-               } catch (Throwable t) {
-                   handleLoopException(t);
-               }
+                    if (isShuttingDown()) {
+                        closeAll();
+                        if (confirmShutdown()) {
+                            return;
+                        }
+                    }
+                } catch (Throwable t) {
+                  handleLoopException(t);
+                }
             }
         }
     }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -515,12 +515,10 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                     logger.debug(CancelledKeyException.class.getSimpleName() + " raised by a Selector {} - JDK bug?",
                             selector, e);
                 }
+            } catch (ThreadDeath td) {
+                throw (ThreadDeath) td;
             } catch (Throwable t) {
-                if (t instanceof ThreadDeath) {
-                    throw (ThreadDeath)t;
-                } else {
-                    handleLoopException(t);
-                }
+                handleLoopException(t);
             }
             // Always handle shutdown even if the loop processing threw an exception.
             try {

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -516,7 +516,11 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                             selector, e);
                 }
             } catch (Throwable t) {
-                handleLoopException(t);
+                if (t instanceof ThreadDeath) {
+                    throw (ThreadDeath)t;
+                } else {
+                    handleLoopException(t);
+                }
             }
             // Always handle shutdown even if the loop processing threw an exception.
             try {

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -519,17 +519,18 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                 throw (ThreadDeath) td;
             } catch (Throwable t) {
                 handleLoopException(t);
-            }
-            // Always handle shutdown even if the loop processing threw an exception.
-            try {
-                if (isShuttingDown()) {
-                    closeAll();
-                    if (confirmShutdown()) {
-                        return;
-                    }
-                }
-            } catch (Throwable t) {
-                handleLoopException(t);
+            } finally {
+                // Always handle shutdown even if the loop processing threw an exception.
+                try {
+                   if (isShuttingDown()) {
+                       closeAll();
+                       if (confirmShutdown()) {
+                           return;
+                       }
+                   }
+               } catch (Throwable t) {
+                   handleLoopException(t);
+               }
             }
         }
     }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -515,8 +515,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                     logger.debug(CancelledKeyException.class.getSimpleName() + " raised by a Selector {} - JDK bug?",
                             selector, e);
                 }
-            } catch (ThreadDeath td) {
-                throw (ThreadDeath) td;
+            } catch (Error e) {
+                throw (Error) e;
             } catch (Throwable t) {
                 handleLoopException(t);
             } finally {
@@ -528,8 +528,10 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                             return;
                         }
                     }
+                } catch (Error e) {
+                    throw (Error) e;
                 } catch (Throwable t) {
-                  handleLoopException(t);
+                    handleLoopException(t);
                 }
             }
         }


### PR DESCRIPTION
Allows EventLoops to rethrow ThreadDeath errors.

Motivation:

Thread.stop() works by producing a ThreadDeath error in the target thread. EventLoops swallow all Throwables, which makes them effectively unkillable. This is effectively a memory leak, for our application.

Modification:

Edit the EventLoops that swallow Throwables to instead rethrow ThreadDeath errors.