### PR TITLE
Add docker-compose files to compile with OpenJDK15

### DIFF
--- a/docker/docker-compose.centos-6.115.yaml
+++ b/docker/docker-compose.centos-6.115.yaml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-6-1.15
+    build:
+      args:
+        centos_version : "6"
+        # use zulu and not adoptjdk for now as adoptjdk15 does not support centos6
+        # https://github.com/AdoptOpenJDK/openjdk-build/issues/2097
+        java_version : "zulu@1.15.0-0"
+
+  test:
+    image: netty:centos-6-1.15
+
+  test-leak:
+    image: netty:centos-6-1.15
+
+  test-boringssl-static:
+    image: netty:centos-6-1.15
+
+  shell:
+    image: netty:centos-6-1.15

--- a/docker/docker-compose.centos-7.115.yaml
+++ b/docker/docker-compose.centos-7.115.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-7-1.15
+    build:
+      args:
+        centos_version : "7"
+        java_version : "adopt@1.15.0-0"
+
+  test:
+    image: netty:centos-7-1.15
+
+  test-leak:
+    image: netty:centos-7-1.15
+
+  test-boringssl-static:
+    image: netty:centos-7-1.15
+
+  shell:
+    image: netty:centos-7-1.15


### PR DESCRIPTION
Motivation:

OpenJDK15 was released, we should compile with it on the CI

Modifications:

Add docker-compose files to be able to compile with OpenJDK15

Result:

Compile with latest major JDK version