### PR TITLE
Add missing -XX:+AllowRedefinitionToAddDeleteMethods for blockhound t…

### DIFF
--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -50,6 +50,24 @@
         <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
       </properties>
     </profile>
+    <profile>
+      <id>java15</id>
+      <activation>
+        <jdk>15</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
+    <profile>
+      <id>java16</id>
+      <activation>
+        <jdk>16</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>


### PR DESCRIPTION
…estsuite

Motivation:

We need to also add -XX:+AllowRedefinitionToAddDeleteMethods for JDK15 and 16 as otherwise blockhound will not work

Modifications:

Add profiles for JDK15 and JDK16

Result:

Blockhound tests pass again