### PR TITLE
We should have a special config that allows to configure half closure…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -20,7 +20,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.socket.SocketChannelConfig;
+import io.netty.channel.socket.DuplexChannelConfig;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.util.internal.ObjectUtil;
@@ -34,7 +34,7 @@ import static io.netty.channel.ChannelOption.SO_SNDBUF;
 import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 
 public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
-        implements DomainSocketChannelConfig {
+        implements DomainSocketChannelConfig, DuplexChannelConfig {
     private volatile DomainSocketReadMode mode = DomainSocketReadMode.BYTES;
     private volatile boolean allowHalfClosure;
 
@@ -170,16 +170,12 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         return mode;
     }
 
-    /**
-     * @see SocketChannelConfig#isAllowHalfClosure()
-     */
+    @Override
     public boolean isAllowHalfClosure() {
         return allowHalfClosure;
     }
 
-    /**
-     * @see SocketChannelConfig#setAllowHalfClosure(boolean)
-     */
+    @Override
     public EpollDomainSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
         this.allowHalfClosure = allowHalfClosure;
         return this;

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.socket.DuplexChannelConfig;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
@@ -35,7 +36,8 @@ import static io.netty.channel.ChannelOption.SO_SNDBUF;
 import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 
 @UnstableApi
-public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig implements DomainSocketChannelConfig {
+public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig
+        implements DomainSocketChannelConfig, DuplexChannelConfig {
     private volatile DomainSocketReadMode mode = DomainSocketReadMode.BYTES;
     private volatile boolean allowHalfClosure;
 
@@ -205,16 +207,12 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
     }
 
-    /**
-     * @see SocketChannelConfig#isAllowHalfClosure()
-     */
+    @Override
     public boolean isAllowHalfClosure() {
         return allowHalfClosure;
     }
 
-    /**
-     * @see SocketChannelConfig#setAllowHalfClosure(boolean)
-     */
+    @Override
     public KQueueDomainSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
         this.allowHalfClosure = allowHalfClosure;
         return this;

--- a/transport/src/main/java/io/netty/channel/socket/DuplexChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DuplexChannelConfig.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+
+/**
+ * A {@link ChannelConfig} for a {@link DuplexChannel}.
+ *
+ * <h3>Available options</h3>
+ *
+ * In addition to the options provided by {@link ChannelConfig},
+ * {@link DuplexChannelConfig} allows the following options in the option map:
+ *
+ * <table border="1" cellspacing="0" cellpadding="6">
+ * <tr>
+ * <td>{@link ChannelOption#ALLOW_HALF_CLOSURE}</td><td>{@link #setAllowHalfClosure(boolean)}</td>
+ * </tr>
+ * </table>
+ */
+public interface DuplexChannelConfig extends ChannelConfig {
+
+    /**
+     * Returns {@code true} if and only if the channel should not close itself when its remote
+     * peer shuts down output to make the connection half-closed.  If {@code false}, the connection
+     * is closed automatically when the remote peer shuts down output.
+     */
+    boolean isAllowHalfClosure();
+
+    /**
+     * Sets whether the channel should not close itself when its remote peer shuts down output to
+     * make the connection half-closed.  If {@code true} the connection is not closed when the
+     * remote peer shuts down output. Instead,
+     * {@link ChannelInboundHandler#userEventTriggered(ChannelHandlerContext, Object)}
+     * is invoked with a {@link ChannelInputShutdownEvent} object. If {@code false}, the connection
+     * is closed automatically.
+     */
+    DuplexChannelConfig setAllowHalfClosure(boolean allowHalfClosure);
+
+    @Override
+    @Deprecated
+    DuplexChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead);
+
+    @Override
+    DuplexChannelConfig setWriteSpinCount(int writeSpinCount);
+
+    @Override
+    DuplexChannelConfig setAllocator(ByteBufAllocator allocator);
+
+    @Override
+    DuplexChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+
+    @Override
+    DuplexChannelConfig setAutoRead(boolean autoRead);
+
+    @Override
+    DuplexChannelConfig setAutoClose(boolean autoClose);
+
+    @Override
+    DuplexChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
+
+    @Override
+    DuplexChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
+}

--- a/transport/src/main/java/io/netty/channel/socket/SocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/SocketChannelConfig.java
@@ -17,8 +17,6 @@ package io.netty.channel.socket;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -32,7 +30,7 @@ import java.net.StandardSocketOptions;
  *
  * <h3>Available options</h3>
  *
- * In addition to the options provided by {@link ChannelConfig},
+ * In addition to the options provided by {@link DuplexChannelConfig},
  * {@link SocketChannelConfig} allows the following options in the option map:
  *
  * <table border="1" cellspacing="0" cellpadding="6">
@@ -57,7 +55,7 @@ import java.net.StandardSocketOptions;
  * </tr>
  * </table>
  */
-public interface SocketChannelConfig extends ChannelConfig {
+public interface SocketChannelConfig extends DuplexChannelConfig {
 
     /**
      * Gets the {@link StandardSocketOptions#TCP_NODELAY} option.  Please note that the default value of this option
@@ -141,21 +139,7 @@ public interface SocketChannelConfig extends ChannelConfig {
      */
     SocketChannelConfig setPerformancePreferences(int connectionTime, int latency, int bandwidth);
 
-    /**
-     * Returns {@code true} if and only if the channel should not close itself when its remote
-     * peer shuts down output to make the connection half-closed.  If {@code false}, the connection
-     * is closed automatically when the remote peer shuts down output.
-     */
-    boolean isAllowHalfClosure();
-
-    /**
-     * Sets whether the channel should not close itself when its remote peer shuts down output to
-     * make the connection half-closed.  If {@code true} the connection is not closed when the
-     * remote peer shuts down output. Instead,
-     * {@link ChannelInboundHandler#userEventTriggered(ChannelHandlerContext, Object)}
-     * is invoked with a {@link ChannelInputShutdownEvent} object. If {@code false}, the connection
-     * is closed automatically.
-     */
+    @Override
     SocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure);
 
     @Override
@@ -185,5 +169,4 @@ public interface SocketChannelConfig extends ChannelConfig {
 
     @Override
     SocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
-
 }


### PR DESCRIPTION
… for DuplexChannel

Motivation:

DuplexChannel allow for half-closure, we should have a special config interface for it as well.

Modifications:

Add DuplexChannelConfig which allows to configure half-closure.

Result:

More consistent types