### PR TITLE
Update java patch versions

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.11.0-7"
+        java_version : "adopt@1.11.0-8"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.114.yaml
+++ b/docker/docker-compose.centos-6.114.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.14.0-1"
+        java_version : "adopt@1.14.0-2"
 
   test:
     image: netty:centos-6-1.14

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.0-252"
+        java_version : "adopt@1.8.0-265"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.11.0-7"
+        java_version : "adopt@1.11.0-8"
 
   test:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.114.yaml
+++ b/docker/docker-compose.centos-7.114.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "@1.14.0-1"
+        java_version : "adopt@1.14.0-2"
 
   test:
     image: netty:centos-7-1.14

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.8.0-252"
+        java_version : "adopt@1.8.0-265"
 
   test:
     image: netty:centos-7-1.8


### PR DESCRIPTION
Motivation:

We should use the latest patch releases when building via docker

Modifications:

Update all java versions to the latest patch release

Result:

Use latest releases