### PR TITLE
Fix ByteBuf leaks in HaProxyMessageEncoderTest

### DIFF
--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -254,13 +254,13 @@ public class HaProxyMessageEncoderTest {
         assertEquals(alpnTlv.typeByteValue(), tlv.readByte());
         short bufLength = tlv.readShort();
         assertEquals(helloWorld.array().length, bufLength);
-        assertEquals(helloWorld, tlv.readBytes(bufLength));
+        assertEquals(helloWorld, tlv.readSlice(bufLength));
 
         // authority tlv
         assertEquals(authorityTlv.typeByteValue(), tlv.readByte());
         bufLength = tlv.readShort();
         assertEquals(arbitrary.array().length, bufLength);
-        assertEquals(arbitrary, tlv.readBytes(bufLength));
+        assertEquals(arbitrary, tlv.readSlice(bufLength));
 
         byteBuf.release();
         assertFalse(ch.finish());
@@ -309,13 +309,13 @@ public class HaProxyMessageEncoderTest {
         assertEquals(alpnTlv.typeByteValue(), tlv.readByte());
         bufLength = tlv.readShort();
         assertEquals(helloWorld.array().length, bufLength);
-        assertEquals(helloWorld, tlv.readBytes(bufLength));
+        assertEquals(helloWorld, tlv.readSlice(bufLength));
 
         // authority tlv
         assertEquals(authorityTlv.typeByteValue(), tlv.readByte());
         bufLength = tlv.readShort();
         assertEquals(arbitrary.array().length, bufLength);
-        assertEquals(arbitrary, tlv.readBytes(bufLength));
+        assertEquals(arbitrary, tlv.readSlice(bufLength));
 
         byteBuf.release();
         assertFalse(ch.finish());


### PR DESCRIPTION
Motivation:

We need to ensure we not leak in tests. We did see some leaks reported related to HaProxyMessageEncoderTest on our CI.

Modifications:

- Use readSlice(...) and so not create new ByteBuf instances that need to be released

Result:

No more leaks