### PR TITLE
Ensure SniCompletionEvent is not lost after onLookupComplete(...)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
@@ -132,7 +132,10 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
         try {
             onLookupComplete(ctx, hostname, future);
         } finally {
-            fireSniCompletionEvent(ctx, hostname, future);
+            fireSniCompletionEvent(
+                    // If this handler was removed as part of onLookupComplete(...) we should fire the
+                    // event from the beginning of the pipeline as otherwise this will fail.
+                    ctx.isRemoved() ? ctx.pipeline().firstContext() : ctx, hostname, future);
         }
     }
 


### PR DESCRIPTION
Motivation:

In the master branch we fail fire* operations on the ChannelHandlerContext once the handler was removed. This is by design as it is "unspecified" what the semantics could be after the handler was removed and may lead to very hard to debug problems. Because of this we need to select the right ChannelHandlerContext for firing the event.

Modifications:

Choose a valid ChannelHandlerContext based on the state of the context of the handler

Result:

No more test failures
