### PR TITLE
Minor performance improvement in websocket upgrade

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
@@ -37,7 +37,10 @@ public final class WebSocketExtensionUtil {
     private static final Pattern PARAMETER = Pattern.compile("^([^=]+)(=[\\\"]?([^\\\"]+)[\\\"]?)?$");
 
     static boolean isWebsocketUpgrade(HttpHeaders headers) {
-        return headers.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true) &&
+        //this contains check does not allocate an iterator, and most requests are not upgrades
+        //so we do the contains check first before checking for specific values
+        return headers.contains(HttpHeaderNames.UPGRADE) &&
+                headers.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true) &&
                 headers.contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.internal.ObjectUtil;
 
 import java.util.ArrayList;
@@ -104,50 +105,61 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
     @Override
     public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (msg instanceof HttpResponse) {
-            HttpHeaders headers = ((HttpResponse) msg).headers();
-
-            if (WebSocketExtensionUtil.isWebsocketUpgrade(headers)) {
-
-                if (validExtensions != null) {
-                    String headerValue = headers.getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
-
-                    for (WebSocketServerExtension extension : validExtensions) {
-                        WebSocketExtensionData extensionData = extension.newReponseData();
-                        headerValue = WebSocketExtensionUtil.appendExtension(headerValue,
-                                                                             extensionData.name(),
-                                                                             extensionData.parameters());
-                    }
-                    promise.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            if (future.isSuccess()) {
-                                for (WebSocketServerExtension extension : validExtensions) {
-                                    WebSocketExtensionDecoder decoder = extension.newExtensionDecoder();
-                                    WebSocketExtensionEncoder encoder = extension.newExtensionEncoder();
-                                    ctx.pipeline()
-                                       .addAfter(ctx.name(), decoder.getClass().getName(), decoder)
-                                       .addAfter(ctx.name(), encoder.getClass().getName(), encoder);
-                                }
-                            }
-                        }
-                    });
-
-                    if (headerValue != null) {
-                        headers.set(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, headerValue);
-                    }
-                }
-
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (future.isSuccess()) {
-                            ctx.pipeline().remove(WebSocketServerExtensionHandler.this);
-                        }
-                    }
-                });
+            HttpResponse httpResponse = (HttpResponse) msg;
+            //checking the status is faster than looking at headers
+            //so we do this first
+            if (HttpResponseStatus.SWITCHING_PROTOCOLS.equals(httpResponse.status())) {
+                handlePotentialUpgrade(ctx, promise, httpResponse);
             }
         }
 
         super.write(ctx, msg, promise);
+    }
+
+    private void handlePotentialUpgrade(final ChannelHandlerContext ctx,
+                                        ChannelPromise promise, HttpResponse httpResponse) {
+        HttpHeaders headers = httpResponse.headers();
+
+        if (WebSocketExtensionUtil.isWebsocketUpgrade(headers)) {
+
+            if (validExtensions != null) {
+                String headerValue = headers.getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
+
+                for (WebSocketServerExtension extension : validExtensions) {
+                    WebSocketExtensionData extensionData = extension.newReponseData();
+                    headerValue = WebSocketExtensionUtil.appendExtension(headerValue,
+                        extensionData.name(),
+                        extensionData.parameters());
+                }
+                promise.addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) {
+                        if (future.isSuccess()) {
+                            for (WebSocketServerExtension extension : validExtensions) {
+                                WebSocketExtensionDecoder decoder = extension.newExtensionDecoder();
+                                WebSocketExtensionEncoder encoder = extension.newExtensionEncoder();
+                                String name = ctx.name();
+                                ctx.pipeline()
+                                    .addAfter(name, decoder.getClass().getName(), decoder)
+                                    .addAfter(name, encoder.getClass().getName(), encoder);
+                            }
+                        }
+                    }
+                });
+
+                if (headerValue != null) {
+                    headers.set(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, headerValue);
+                }
+            }
+
+            promise.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) {
+                    if (future.isSuccess()) {
+                        ctx.pipeline().remove(WebSocketServerExtensionHandler.this);
+                    }
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Motivation:

I noticed this method taking up ~5% of CPU time in a pipelining based test (similar to techempower plaintext). 

Modification:

I added a check for a 101 response code to check if the response is an upgrade response, as this is faster than reading from a header map. I also moved the actual upgrade code into its own method to increase the chances that the hot path can be inlined.

Result:

I noticed around a 5% speedup in my local testing (this will be nowhere near this big without pipelining, but it still helps).
