### PR TITLE
Fix JavaDoc of Http2Headers

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -141,22 +141,22 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
     Http2Headers method(CharSequence value);
 
     /**
-     * Sets the {@link PseudoHeaderName#SCHEME} header if there is no such header
+     * Sets the {@link PseudoHeaderName#SCHEME} header
      */
     Http2Headers scheme(CharSequence value);
 
     /**
-     * Sets the {@link PseudoHeaderName#AUTHORITY} header or {@code null} if there is no such header
+     * Sets the {@link PseudoHeaderName#AUTHORITY} header
      */
     Http2Headers authority(CharSequence value);
 
     /**
-     * Sets the {@link PseudoHeaderName#PATH} header or {@code null} if there is no such header
+     * Sets the {@link PseudoHeaderName#PATH} header
      */
     Http2Headers path(CharSequence value);
 
     /**
-     * Sets the {@link PseudoHeaderName#STATUS} header or {@code null} if there is no such header
+     * Sets the {@link PseudoHeaderName#STATUS} header
      */
     Http2Headers status(CharSequence value);
 


### PR DESCRIPTION
Motivation:
Http2Headers has JavaDoc error which says `Sets the {@link PseudoHeaderName#AUTHORITY} header or {@code null} if there is no such header` however it should be ` Sets the {@link PseudoHeaderName#AUTHORITY} header` in `Http2Headers#authority(CharSequence)` methods because it only sets `CharSequence`.

This is true for all setters in `Http2Headers`.

Modification:
Fixed all JavaDoc errors.

Result:
Better JavaDoc.
