### PR TITLE
Upgrade Slf4j to 1.7.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.21</version>
+        <version>1.7.30</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>


### PR DESCRIPTION
Motivation:
SLF4J 1.7.30 is the latest version in 1.7.x and we should upgrade to it from 1.7.21.

Modification:
Changed 1.7.21 to 1.7.30

Result:
Newer version of SLF4J