### PR TITLE
DatagramDnsResponseDecoder should rethrow as CorruptedFrameException

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.dns;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.util.internal.UnstableApi;
 
@@ -55,7 +56,11 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
 
     @Override
     protected void decode(ChannelHandlerContext ctx, DatagramPacket packet, List<Object> out) throws Exception {
-        out.add(decodeResponse(ctx, packet));
+        try {
+            out.add(decodeResponse(ctx, packet));
+        } catch (IndexOutOfBoundsException e) {
+            throw new CorruptedFrameException("Unable to decode response", e);
+        }
     }
 
     protected DnsResponse decodeResponse(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {


### PR DESCRIPTION
    Motivation:

    DatagramDnsResponseDecoder should rethrow as CorruptedFrameException if an IndexOutOfBoundsException happens.

    Modifications:

    - Catch IndexOutOfBoundsException and rethrow as CorruptedFrameException
    - Add a testcase

    Result:

    Less noise in the logs