### PR TITLE
We should have a special config that allows to configure half closure…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -98,6 +98,9 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     }
 
     @Override
+    public abstract EpollDuplexChannelConfig config();
+
+    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDuplexChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDuplexChannelConfig.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.socket.DuplexChannelConfig;
+
+import java.util.Map;
+
+import static io.netty.channel.ChannelOption.*;
+
+public class EpollDuplexChannelConfig extends EpollChannelConfig implements DuplexChannelConfig {
+    private volatile boolean allowHalfClosure;
+
+    EpollDuplexChannelConfig(AbstractEpollChannel channel) {
+        super(channel);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), ALLOW_HALF_CLOSURE);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == ALLOW_HALF_CLOSURE) {
+            return (T) Boolean.valueOf(isAllowHalfClosure());
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+        if (option == ALLOW_HALF_CLOSURE) {
+            setAllowHalfClosure((Boolean) value);
+        } else {
+            return super.setOption(option, value);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isAllowHalfClosure() {
+        return allowHalfClosure;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        this.allowHalfClosure = allowHalfClosure;
+        return this;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
+        super.setConnectTimeoutMillis(connectTimeoutMillis);
+        return this;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public EpollDuplexChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
+        super.setMaxMessagesPerRead(maxMessagesPerRead);
+        return this;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setWriteSpinCount(int writeSpinCount) {
+        super.setWriteSpinCount(writeSpinCount);
+        return this;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setAllocator(ByteBufAllocator allocator) {
+        super.setAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+        super.setRecvByteBufAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setAutoRead(boolean autoRead) {
+        super.setAutoRead(autoRead);
+        return this;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public EpollDuplexChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
+        return this;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public EpollDuplexChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
+        return this;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
+        super.setWriteBufferWaterMark(writeBufferWaterMark);
+        return this;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+        super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+
+    @Override
+    public EpollDuplexChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Map;
 
-import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
 import static io.netty.channel.ChannelOption.IP_TOS;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 import static io.netty.channel.ChannelOption.SO_LINGER;
@@ -37,8 +36,7 @@ import static io.netty.channel.ChannelOption.SO_REUSEADDR;
 import static io.netty.channel.ChannelOption.SO_SNDBUF;
 import static io.netty.channel.ChannelOption.TCP_NODELAY;
 
-public final class EpollSocketChannelConfig extends EpollChannelConfig implements SocketChannelConfig {
-    private volatile boolean allowHalfClosure;
+public final class EpollSocketChannelConfig extends EpollDuplexChannelConfig implements SocketChannelConfig {
 
     /**
      * Creates a new instance.
@@ -57,7 +55,7 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
         return getOptions(
                 super.getOptions(),
                 SO_RCVBUF, SO_SNDBUF, TCP_NODELAY, SO_KEEPALIVE, SO_REUSEADDR, SO_LINGER, IP_TOS,
-                ALLOW_HALF_CLOSURE, EpollChannelOption.TCP_CORK, EpollChannelOption.TCP_NOTSENT_LOWAT,
+                EpollChannelOption.TCP_CORK, EpollChannelOption.TCP_NOTSENT_LOWAT,
                 EpollChannelOption.TCP_KEEPCNT, EpollChannelOption.TCP_KEEPIDLE, EpollChannelOption.TCP_KEEPINTVL,
                 EpollChannelOption.TCP_MD5SIG, EpollChannelOption.TCP_QUICKACK, EpollChannelOption.IP_TRANSPARENT,
                 EpollChannelOption.TCP_FASTOPEN_CONNECT, EpollChannelOption.SO_BUSY_POLL);
@@ -86,9 +84,6 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
         }
         if (option == IP_TOS) {
             return (T) Integer.valueOf(getTrafficClass());
-        }
-        if (option == ALLOW_HALF_CLOSURE) {
-            return (T) Boolean.valueOf(isAllowHalfClosure());
         }
         if (option == EpollChannelOption.TCP_CORK) {
             return (T) Boolean.valueOf(isTcpCork());
@@ -141,8 +136,6 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
             setSoLinger((Integer) value);
         } else if (option == IP_TOS) {
             setTrafficClass((Integer) value);
-        } else if (option == ALLOW_HALF_CLOSURE) {
-            setAllowHalfClosure((Boolean) value);
         } else if (option == EpollChannelOption.TCP_CORK) {
             setTcpCork((Boolean) value);
         } else if (option == EpollChannelOption.TCP_NOTSENT_LOWAT) {
@@ -576,13 +569,8 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
     }
 
     @Override
-    public boolean isAllowHalfClosure() {
-        return allowHalfClosure;
-    }
-
-    @Override
     public EpollSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
-        this.allowHalfClosure = allowHalfClosure;
+        super.setAllowHalfClosure(allowHalfClosure);
         return this;
     }
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -79,6 +79,9 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
     }
 
     @Override
+    public abstract KQueueDuplexChannelConfig config();
+
+    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.util.internal.UnstableApi;
@@ -29,15 +28,14 @@ import java.io.IOException;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
-import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
 import static io.netty.channel.ChannelOption.SO_RCVBUF;
 import static io.netty.channel.ChannelOption.SO_SNDBUF;
 import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
 
 @UnstableApi
-public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig implements DomainSocketChannelConfig {
+public final class KQueueDomainSocketChannelConfig extends KQueueDuplexChannelConfig
+        implements DomainSocketChannelConfig {
     private volatile DomainSocketReadMode mode = DomainSocketReadMode.BYTES;
-    private volatile boolean allowHalfClosure;
 
     KQueueDomainSocketChannelConfig(AbstractKQueueChannel channel) {
         super(channel);
@@ -45,7 +43,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), DOMAIN_SOCKET_READ_MODE, ALLOW_HALF_CLOSURE, SO_SNDBUF, SO_RCVBUF);
+        return getOptions(super.getOptions(), DOMAIN_SOCKET_READ_MODE, SO_SNDBUF, SO_RCVBUF);
     }
 
     @SuppressWarnings("unchecked")
@@ -53,9 +51,6 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
     public <T> T getOption(ChannelOption<T> option) {
         if (option == DOMAIN_SOCKET_READ_MODE) {
             return (T) getReadMode();
-        }
-        if (option == ALLOW_HALF_CLOSURE) {
-            return (T) Boolean.valueOf(isAllowHalfClosure());
         }
         if (option == SO_SNDBUF) {
             return (T) Integer.valueOf(getSendBufferSize());
@@ -72,8 +67,6 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
 
         if (option == DOMAIN_SOCKET_READ_MODE) {
             setReadMode((DomainSocketReadMode) value);
-        } else if (option == ALLOW_HALF_CLOSURE) {
-            setAllowHalfClosure((Boolean) value);
         } else if (option == SO_SNDBUF) {
             setSendBufferSize((Integer) value);
         } else if (option == SO_RCVBUF) {
@@ -210,18 +203,9 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig i
         }
     }
 
-    /**
-     * @see SocketChannelConfig#isAllowHalfClosure()
-     */
-    public boolean isAllowHalfClosure() {
-        return allowHalfClosure;
-    }
-
-    /**
-     * @see SocketChannelConfig#setAllowHalfClosure(boolean)
-     */
+    @Override
     public KQueueDomainSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
-        this.allowHalfClosure = allowHalfClosure;
+        super.setAllowHalfClosure(allowHalfClosure);
         return this;
     }
 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDuplexChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDuplexChannelConfig.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.socket.DuplexChannelConfig;
+
+import java.util.Map;
+
+import static io.netty.channel.ChannelOption.*;
+import static io.netty.channel.unix.UnixChannelOption.DOMAIN_SOCKET_READ_MODE;
+
+public class KQueueDuplexChannelConfig extends KQueueChannelConfig implements DuplexChannelConfig {
+    private volatile boolean allowHalfClosure;
+
+    KQueueDuplexChannelConfig(AbstractKQueueChannel channel) {
+        super(channel);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), DOMAIN_SOCKET_READ_MODE, ALLOW_HALF_CLOSURE, SO_SNDBUF, SO_RCVBUF);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == ALLOW_HALF_CLOSURE) {
+            return (T) Boolean.valueOf(isAllowHalfClosure());
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+        if (option == ALLOW_HALF_CLOSURE) {
+            setAllowHalfClosure((Boolean) value);
+        } else {
+            return super.setOption(option, value);
+        }
+
+        return true;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setRcvAllocTransportProvidesGuess(boolean transportProvidesGuess) {
+        super.setRcvAllocTransportProvidesGuess(transportProvidesGuess);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
+        super.setMaxMessagesPerRead(maxMessagesPerRead);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
+        super.setConnectTimeoutMillis(connectTimeoutMillis);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setWriteSpinCount(int writeSpinCount) {
+        super.setWriteSpinCount(writeSpinCount);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+        super.setRecvByteBufAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setAllocator(ByteBufAllocator allocator) {
+        super.setAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+        super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public KQueueDuplexChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public KQueueDuplexChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
+        super.setWriteBufferWaterMark(writeBufferWaterMark);
+        return this;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setAutoRead(boolean autoRead) {
+        super.setAutoRead(autoRead);
+        return this;
+    }
+
+    @Override
+    public boolean isAllowHalfClosure() {
+        return allowHalfClosure;
+    }
+
+    @Override
+    public KQueueDuplexChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        this.allowHalfClosure = allowHalfClosure;
+        return this;
+    }
+}

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
@@ -28,7 +28,6 @@ import io.netty.util.internal.UnstableApi;
 import java.io.IOException;
 import java.util.Map;
 
-import static io.netty.channel.ChannelOption.ALLOW_HALF_CLOSURE;
 import static io.netty.channel.ChannelOption.IP_TOS;
 import static io.netty.channel.ChannelOption.SO_KEEPALIVE;
 import static io.netty.channel.ChannelOption.SO_LINGER;
@@ -40,8 +39,7 @@ import static io.netty.channel.kqueue.KQueueChannelOption.SO_SNDLOWAT;
 import static io.netty.channel.kqueue.KQueueChannelOption.TCP_NOPUSH;
 
 @UnstableApi
-public final class KQueueSocketChannelConfig extends KQueueChannelConfig implements SocketChannelConfig {
-    private volatile boolean allowHalfClosure;
+public final class KQueueSocketChannelConfig extends KQueueDuplexChannelConfig implements SocketChannelConfig {
 
     KQueueSocketChannelConfig(KQueueSocketChannel channel) {
         super(channel);
@@ -56,7 +54,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
         return getOptions(
                 super.getOptions(),
                 SO_RCVBUF, SO_SNDBUF, TCP_NODELAY, SO_KEEPALIVE, SO_REUSEADDR, SO_LINGER, IP_TOS,
-                ALLOW_HALF_CLOSURE, SO_SNDLOWAT, TCP_NOPUSH);
+                SO_SNDLOWAT, TCP_NOPUSH);
     }
 
     @SuppressWarnings("unchecked")
@@ -82,9 +80,6 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
         }
         if (option == IP_TOS) {
             return (T) Integer.valueOf(getTrafficClass());
-        }
-        if (option == ALLOW_HALF_CLOSURE) {
-            return (T) Boolean.valueOf(isAllowHalfClosure());
         }
         if (option == SO_SNDLOWAT) {
             return (T) Integer.valueOf(getSndLowAt());
@@ -113,8 +108,6 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
             setSoLinger((Integer) value);
         } else if (option == IP_TOS) {
             setTrafficClass((Integer) value);
-        } else if (option == ALLOW_HALF_CLOSURE) {
-            setAllowHalfClosure((Boolean) value);
         } else if (option == SO_SNDLOWAT) {
             setSndLowAt((Integer) value);
         } else if (option == TCP_NOPUSH) {
@@ -293,11 +286,6 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     }
 
     @Override
-    public boolean isAllowHalfClosure() {
-        return allowHalfClosure;
-    }
-
-    @Override
     public KQueueSocketChannelConfig setRcvAllocTransportProvidesGuess(boolean transportProvidesGuess) {
         super.setRcvAllocTransportProvidesGuess(transportProvidesGuess);
         return this;
@@ -311,7 +299,7 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
 
     @Override
     public KQueueSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
-        this.allowHalfClosure = allowHalfClosure;
+        super.setAllowHalfClosure(allowHalfClosure);
         return this;
     }
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.socket.DuplexChannelConfig;
 import io.netty.channel.socket.SocketChannelConfig;
 
 import java.net.StandardSocketOptions;
@@ -27,7 +28,7 @@ import java.net.StandardSocketOptions;
 /**
  * Special {@link ChannelConfig} for {@link DomainSocketChannel}s.
  */
-public interface DomainSocketChannelConfig extends ChannelConfig {
+public interface DomainSocketChannelConfig extends DuplexChannelConfig {
 
     @Override
     @Deprecated

--- a/transport/src/main/java/io/netty/channel/socket/DuplexChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/DuplexChannel.java
@@ -78,4 +78,7 @@ public interface DuplexChannel extends Channel {
      * @return will be completed when both shutdown operations complete.
      */
     ChannelFuture shutdown(ChannelPromise promise);
+
+    @Override
+    DuplexChannelConfig config();
 }

--- a/transport/src/main/java/io/netty/channel/socket/DuplexChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DuplexChannelConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+
+/**
+ * A {@link ChannelConfig} for a {@link DuplexChannel}.
+ *
+ * <h3>Available options</h3>
+ *
+ * In addition to the options provided by {@link ChannelConfig},
+ * {@link DuplexChannelConfig} allows the following options in the option map:
+ *
+ * <table border="1" cellspacing="0" cellpadding="6">
+ * <tr>
+ * <td>{@link ChannelOption#ALLOW_HALF_CLOSURE}</td><td>{@link #setAllowHalfClosure(boolean)}</td>
+ * </tr>
+ * </table>
+ */
+public interface DuplexChannelConfig extends ChannelConfig {
+
+    /**
+     * Returns {@code true} if and only if the channel should not close itself when its remote
+     * peer shuts down output to make the connection half-closed.  If {@code false}, the connection
+     * is closed automatically when the remote peer shuts down output.
+     */
+    boolean isAllowHalfClosure();
+
+    /**
+     * Sets whether the channel should not close itself when its remote peer shuts down output to
+     * make the connection half-closed.  If {@code true} the connection is not closed when the
+     * remote peer shuts down output. Instead,
+     * {@link io.netty.channel.ChannelHandler#userEventTriggered(ChannelHandlerContext, Object)}
+     * is invoked with a {@link ChannelInputShutdownEvent} object. If {@code false}, the connection
+     * is closed automatically.
+     */
+    DuplexChannelConfig setAllowHalfClosure(boolean allowHalfClosure);
+
+    @Override
+    @Deprecated
+    DuplexChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead);
+
+    @Override
+    DuplexChannelConfig setWriteSpinCount(int writeSpinCount);
+
+    @Override
+    DuplexChannelConfig setAllocator(ByteBufAllocator allocator);
+
+    @Override
+    DuplexChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+
+    @Override
+    DuplexChannelConfig setAutoRead(boolean autoRead);
+
+    @Override
+    DuplexChannelConfig setAutoClose(boolean autoClose);
+
+    @Override
+    DuplexChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
+
+    @Override
+    DuplexChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
+}

--- a/transport/src/main/java/io/netty/channel/socket/SocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/SocketChannelConfig.java
@@ -17,8 +17,6 @@ package io.netty.channel.socket;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -32,7 +30,7 @@ import java.net.StandardSocketOptions;
  *
  * <h3>Available options</h3>
  *
- * In addition to the options provided by {@link ChannelConfig},
+ * In addition to the options provided by {@link DuplexChannelConfig},
  * {@link SocketChannelConfig} allows the following options in the option map:
  *
  * <table border="1" cellspacing="0" cellpadding="6">
@@ -57,7 +55,7 @@ import java.net.StandardSocketOptions;
  * </tr>
  * </table>
  */
-public interface SocketChannelConfig extends ChannelConfig {
+public interface SocketChannelConfig extends DuplexChannelConfig {
 
     /**
      * Gets the {@link StandardSocketOptions#TCP_NODELAY} option.  Please note that the default value of this option
@@ -141,21 +139,7 @@ public interface SocketChannelConfig extends ChannelConfig {
      */
     SocketChannelConfig setPerformancePreferences(int connectionTime, int latency, int bandwidth);
 
-    /**
-     * Returns {@code true} if and only if the channel should not close itself when its remote
-     * peer shuts down output to make the connection half-closed.  If {@code false}, the connection
-     * is closed automatically when the remote peer shuts down output.
-     */
-    boolean isAllowHalfClosure();
-
-    /**
-     * Sets whether the channel should not close itself when its remote peer shuts down output to
-     * make the connection half-closed.  If {@code true} the connection is not closed when the
-     * remote peer shuts down output. Instead,
-     * {@link ChannelHandler#userEventTriggered(ChannelHandlerContext, Object)}
-     * is invoked with a {@link ChannelInputShutdownEvent} object. If {@code false}, the connection
-     * is closed automatically.
-     */
+    @Override
     SocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure);
 
     @Override
@@ -185,5 +169,4 @@ public interface SocketChannelConfig extends ChannelConfig {
 
     @Override
     SocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark);
-
 }


### PR DESCRIPTION
… for DuplexChannel (#10701)

Motivation:

DuplexChannel allow for half-closure, we should have a special config interface for it as well.

Modifications:

Add DuplexChannelConfig which allows to configure half-closure.

Result:

More consistent types
