### PR TITLE
Use named exceptions in ChannelPool implementations

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -194,15 +194,7 @@ public class FixedChannelPool extends SimpleChannelPool {
                     @Override
                     public void onTimeout(AcquireTask task) {
                         // Fail the promise as we timed out.
-                        task.promise.setFailure(new TimeoutException(
-                                "Acquire operation took longer then configured maximum time") {
-
-                            // Suppress a warning since the method doesn't need synchronization
-                            @Override
-                            public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
-                                return this;
-                            }
-                        });
+                        task.promise.setFailure(new AcquireTimeoutException());
                     }
                 };
                 break;
@@ -513,5 +505,18 @@ public class FixedChannelPool extends SimpleChannelPool {
         }
 
         return GlobalEventExecutor.INSTANCE.newSucceededFuture(null);
+    }
+
+    private static final class AcquireTimeoutException extends TimeoutException {
+
+        private AcquireTimeoutException() {
+            super("Acquire operation took longer then configured maximum time");
+        }
+
+        // Suppress a warning since the method doesn't need synchronization
+        @Override
+        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
+            return this;
+        }
     }
 }

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -350,12 +350,7 @@ public class SimpleChannelPool implements ChannelPool {
             handler.channelReleased(channel);
             promise.setSuccess(null);
         } else {
-            closeAndFail(channel, new IllegalStateException("ChannelPool full") {
-                @Override
-                public Throwable fillInStackTrace() {
-                    return this;
-                }
-            }, promise);
+            closeAndFail(channel, new ChannelPoolFullException(), promise);
         }
     }
 
@@ -417,5 +412,18 @@ public class SimpleChannelPool implements ChannelPool {
                 return null;
             }
         });
+    }
+
+    private static final class ChannelPoolFullException extends IllegalStateException {
+
+        private ChannelPoolFullException() {
+            super("ChannelPool full");
+        }
+
+        // Suppress a warning since the method doesn't need synchronization
+        @Override
+        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Motivation:

I was collecting stats for failed promises with a FixedChannelPool and I was bucketing by stats using cause.getSimpleName(). After https://github.com/netty/netty/pull/9152 was released, the introduction of the anonymous classes make getSimpleName() return "" causing confusion.

Modification:

Use named classes in the ChannelPool implementations. I made them private, but I can change that if you think otherwise.

Result:

The SimpleChannelPool fails the promises with a ChannelPoolFullException. The FixedChannelPool fails the promises with an AcquireTimeoutException. Also AcquireTimeoutException is more specific than just a plain TimeoutException, which is also useful for troubleshooting. If you want different class names, please advise.