### PR TITLE
Release message before notify promise

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -991,11 +991,11 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
             return true;
         } catch (Throwable cause) {
             try {
-                promise.setFailure(cause);
-            } finally {
                 if (msg != null) {
                     ReferenceCountUtil.release(msg);
                 }
+            } finally {
+                promise.setFailure(cause);
             }
             return false;
         }


### PR DESCRIPTION
Motivation:

We should preferable always release the message before we notify the promise. Thhis has a few advantages:

 - Release memory as soon as possible
 - Listeners observe the "more correct" reference count

Modifications:

Release message before fail the promises

Result:

Faster releasing of resources. This came up in https://github.com/netty/netty/issues/10723