### PR TITLE
Unregister all native methods on unload for kqueue

### DIFF
--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -371,14 +371,17 @@ error:
    return JNI_ERR;
 }
 
-static void netty_kqueue_native_JNI_OnUnLoad(JNIEnv* env, const char* staticPackagePrefix) {
-    netty_unix_limits_JNI_OnUnLoad(env, staticPackagePrefix);
-    netty_unix_errors_JNI_OnUnLoad(env, staticPackagePrefix);
-    netty_unix_filedescriptor_JNI_OnUnLoad(env, staticPackagePrefix);
-    netty_unix_socket_JNI_OnUnLoad(env, staticPackagePrefix);
-    netty_unix_buffer_JNI_OnUnLoad(env, staticPackagePrefix);
-    netty_kqueue_bsdsocket_JNI_OnUnLoad(env, staticPackagePrefix);
-    netty_kqueue_eventarray_JNI_OnUnLoad(env, staticPackagePrefix);
+static void netty_kqueue_native_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
+    netty_unix_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
+    netty_unix_util_unregister_natives(env, packagePrefix, NATIVE_CLASSNAME);
+
+    netty_unix_limits_JNI_OnUnLoad(env, packagePrefix);
+    netty_unix_errors_JNI_OnUnLoad(env, packagePrefix);
+    netty_unix_filedescriptor_JNI_OnUnLoad(env, packagePrefix);
+    netty_unix_socket_JNI_OnUnLoad(env, packagePrefix);
+    netty_unix_buffer_JNI_OnUnLoad(env, packagePrefix);
+    netty_kqueue_bsdsocket_JNI_OnUnLoad(env, packagePrefix);
+    netty_kqueue_eventarray_JNI_OnUnLoad(env, packagePrefix);
 }
 
 static jint JNI_OnLoad_netty_transport_native_kqueue0(JavaVM* vm, void* reserved) {


### PR DESCRIPTION
Motivation:

03aafb9cff352269a7fc73e4cf0c281770676be9 did ensure we unregister all native methods when we unload / or fail during load of the native library. Unfortunally it missed to unregister in one case for kqueue.

Modifications:

Add unregister calls to the unload function

Result:

Correctly unregister in all cases