### PR TITLE
Errors.throwConnectException(...) should be public

### DIFF
--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
@@ -107,7 +107,7 @@ public final class Errors {
         }
     }
 
-    static void throwConnectException(String method, int err)
+    public static void throwConnectException(String method, int err)
             throws IOException {
         if (err == ERROR_EALREADY_NEGATIVE) {
             throw new ConnectionPendingException();


### PR DESCRIPTION
Motivation:

ddebc1027d7cc09850acdd961417c1d650f43dd5 missed to make Errors.throwConnectException(...) public

Modifications:

Make method public

Result:

Be able to use Errors.throwConnectException(...) from other module
