### PR TITLE
Add reflection config for JMX runtime

### DIFF
--- a/transport/src/main/resources/META-INF/native-image/io.netty/transport/reflection-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/transport/reflection-config.json
@@ -11,5 +11,23 @@
         { "name": "selectedKeys",  "allowUnsafeAccess" : true},
         { "name": "publicSelectedKeys",  "allowUnsafeAccess" : true}
       ]
+    },
+    {
+        "name": "java.lang.management.ManagementFactory",
+        "methods": [
+            {
+                "name": "getRuntimeMXBean",
+                "parameterTypes": []
+            }
+        ]
+    },
+    {
+        "name": "java.lang.management.RuntimeMXBean",
+        "methods": [
+            {
+                "name": "getName",
+                "parameterTypes": []
+            }
+        ]
     }
 ]


### PR DESCRIPTION
`DefaultChannelId` uses reflection to access the JMX runtime. I'm not sure why that is necessary, but assuming it is, this change, makes it work in a GraalVM native image.

See also https://github.com/spring-projects/spring-boot/issues/22313