### PR TITLE
Remove extra empty line from Http2Frame

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Frame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Frame.java
@@ -25,5 +25,4 @@ public interface Http2Frame {
      * Returns the name of the HTTP/2 frame e.g. DATA, GOAWAY, etc.
      */
     String name();
-
 }


### PR DESCRIPTION
Motivation:
`Http2Frame` has extra empty line after `String name();`. However, it should not be there.

Modification:
Removed extra empty line.

Result:
Empty-line code style now matching with other classes.
