### PR TITLE
Fix typo in Http2DataFrame

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataFrame.java
@@ -43,7 +43,7 @@ public interface Http2DataFrame extends Http2StreamFrame, ByteBufHolder {
     int initialFlowControlledBytes();
 
     /**
-     * Returns {@code true} if the END_STREAM flag ist set.
+     * Returns {@code true} if the END_STREAM flag is set.
      */
     boolean isEndStream();
 


### PR DESCRIPTION
Motivation:
`Http2DataFrame#isEndStream()` JavaDoc says `Returns {@code true} if the END_STREAM flag ist set.`. The typo is `ist` word. However, it should be `is`.

Modification:
Changed `ist` to `is`.

Result:
Better JavaDoc by fixing the typo.