### PR TITLE
Fix typo in Http2HeadersFrame

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersFrame.java
@@ -34,7 +34,7 @@ public interface Http2HeadersFrame extends Http2StreamFrame {
     int padding();
 
     /**
-     * Returns {@code true} if the END_STREAM flag ist set.
+     * Returns {@code true} if the END_STREAM flag is set.
      */
     boolean isEndStream();
 }


### PR DESCRIPTION
Motivation:
`Http2HeadersFrame#isEndStream()` JavaDoc says `Returns {@code true} if the END_STREAM flag ist set.`. The typo is `ist` word. However, it should be `is`.

Modification:
Changed `ist` to `is`.

Result:
Better JavaDoc by fixing the typo.