### PR TITLE
Add `toString` method in DefaultHttp2WindowUpdateFrame

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
@@ -49,6 +49,6 @@ public class DefaultHttp2WindowUpdateFrame extends AbstractHttp2StreamFrame impl
     @Override
     public String toString() {
         return StringUtil.simpleClassName(this) +
-                "(streamId=" + stream() + ", windowUpdateIncrement=" + windowUpdateIncrement + ')';
+                "(stream=" + stream() + ", windowUpdateIncrement=" + windowUpdateIncrement + ')';
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -43,5 +44,11 @@ public class DefaultHttp2WindowUpdateFrame extends AbstractHttp2StreamFrame impl
     @Override
     public int windowSizeIncrement() {
         return windowUpdateIncrement;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtil.simpleClassName(this) +
+                "(windowUpdateIncrement=" + windowUpdateIncrement + ", streamId=" + stream().id() +')';
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
@@ -49,6 +49,6 @@ public class DefaultHttp2WindowUpdateFrame extends AbstractHttp2StreamFrame impl
     @Override
     public String toString() {
         return StringUtil.simpleClassName(this) +
-                "(windowUpdateIncrement=" + windowUpdateIncrement + ", streamId=" + stream().id() + ')';
+                "(streamId=" + stream() + ", windowUpdateIncrement=" + windowUpdateIncrement + ')';
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2WindowUpdateFrame.java
@@ -49,6 +49,6 @@ public class DefaultHttp2WindowUpdateFrame extends AbstractHttp2StreamFrame impl
     @Override
     public String toString() {
         return StringUtil.simpleClassName(this) +
-                "(windowUpdateIncrement=" + windowUpdateIncrement + ", streamId=" + stream().id() +')';
+                "(windowUpdateIncrement=" + windowUpdateIncrement + ", streamId=" + stream().id() + ')';
     }
 }


### PR DESCRIPTION
Motivation:
We should have the `toString` method in `DefaultHttp2WindowUpdateFrame` because it makes debugging a little easy.

Modification:
Added `toString` method.

Result:
`toString` method to help in debugging.
