### PR TITLE
Avoid auto boxing in PoolChunk#removeAvailRun

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -250,13 +250,13 @@ final class PoolChunk<T> implements PoolChunkMetric {
         assert pre == null;
     }
 
-    private void removeAvailRun(long handle) {
+    private void removeAvailRun(Long handle) {
         int pageIdxFloor = arena.pages2pageIdxFloor(runPages(handle));
         PriorityQueue<Long> queue = runsAvail[pageIdxFloor];
         removeAvailRun(queue, handle);
     }
 
-    private void removeAvailRun(PriorityQueue<Long> queue, long handle) {
+    private void removeAvailRun(PriorityQueue<Long> queue, Long handle) {
         queue.remove(handle);
 
         int runOffset = runOffset(handle);
@@ -335,9 +335,9 @@ final class PoolChunk<T> implements PoolChunkMetric {
 
             //get run with min offset in this queue
             PriorityQueue<Long> queue = runsAvail[queueIdx];
-            long handle = queue.poll();
+            Long handle = queue.poll();
 
-            assert !isUsed(handle);
+            assert handle != null && !isUsed(handle);
 
             removeAvailRun(queue, handle);
 


### PR DESCRIPTION
Motivation:
PoolChunk maintains multiple PriorityQueue<Long> collections. The usage
of PoolChunk#removeAvailRun unboxes the Long values to long, and then
this method uses queue.remove(..) which will auto box the value back to
Long. This creates unnecessary allocations via Long.valueOf(long).

Modifications:
- Adjust method signature and usage of PoolChunk#removeAvailRun to avoid
boxing

Result:
Less allocations as a result of PoolChunk#removeAvailRun.