### PR TITLE
Fix License type of dnsinfo

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -245,4 +245,4 @@ This private header is also used by Apple's open source
  * LICENSE:
     * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
   * HOMEPAGE:
-    * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+    * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -243,6 +243,6 @@ This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
 
  * LICENSE:
-    * license/LICENSE.dnsinfo.txt (Apache License 2.0)
+    * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
   * HOMEPAGE:
     * http://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h


### PR DESCRIPTION
Motivation:
`dnsinfo` uses `Apple Public Source License 2.0` not `Apache License 2.0`.

Modification:
Changed `Apache License 2.0` to `Apple Public Source License 2.0`

Result:
Fixes #10772
