### PR TITLE
Update to latest java 8/11/15 versions

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.11.0-8"
+        java_version : "adopt@1.11.0-9"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.115.yaml
+++ b/docker/docker-compose.centos-6.115.yaml
@@ -9,7 +9,7 @@ services:
         centos_version : "6"
         # use zulu and not adoptjdk for now as adoptjdk15 does not support centos6
         # https://github.com/AdoptOpenJDK/openjdk-build/issues/2097
-        java_version : "zulu@1.15.0-0"
+        java_version : "zulu@1.15.0-1"
 
   test:
     image: netty:centos-6-1.15

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt@1.8.0-265"
+        java_version : "adopt@1.8.0-272"
 
   test:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.openj9111.yaml
+++ b/docker/docker-compose.centos-6.openj9111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "adopt-openj9@1.11.0-7"
+        java_version : "adopt-openj9@1.11.0-9"
 
   test:
     image: netty:centos-6-openj9-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.11.0-8"
+        java_version : "adopt@1.11.0-9"
 
   test:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.115.yaml
+++ b/docker/docker-compose.centos-7.115.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.15.0-0"
+        java_version : "adopt@1.15.0-1"
 
   test:
     image: netty:centos-7-1.15

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "adopt@1.8.0-265"
+        java_version : "adopt@1.8.0-272"
 
   test:
     image: netty:centos-7-1.8


### PR DESCRIPTION
Motivation:

There were new releases of java.

Modifications:

Update java versions so we use the latest on the CI

Result:

Use latest releases