### PR TITLE
[master] Allow and skip null handlers when adding a vararg list of handlers

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -271,7 +271,7 @@ public interface ChannelPipeline
     ChannelPipeline addAfter(String baseName, String name, ChannelHandler handler);
 
     /**
-     * Inserts {@link ChannelHandler}s at the first position of this pipeline.
+     * Inserts {@link ChannelHandler}s at the first position of this pipeline. {@code null} handlers will be skipped.
      *
      * @param handlers  the handlers to insert first
      *
@@ -279,7 +279,7 @@ public interface ChannelPipeline
     ChannelPipeline addFirst(ChannelHandler... handlers);
 
     /**
-     * Inserts {@link ChannelHandler}s at the last position of this pipeline.
+     * Inserts {@link ChannelHandler}s at the last position of this pipeline. {@code null} handlers will be skipped.
      *
      * @param handlers  the handlers to insert last
      *

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -284,21 +284,11 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     @Override
     public final ChannelPipeline addFirst(ChannelHandler... handlers) {
         requireNonNull(handlers, "handlers");
-        if (handlers.length == 0 || handlers[0] == null) {
-            return this;
-        }
 
-        int size;
-        for (size = 1; size < handlers.length; size ++) {
-            if (handlers[size] == null) {
-                break;
-            }
-        }
-
-        for (int i = size - 1; i >= 0; i--) {
+        for (int i = handlers.length - 1; i >= 0; i--) {
             ChannelHandler h = handlers[i];
             if (h != null) {
-                addFirst(executor, null, h);
+                addFirst(null, h);
             }
         }
 
@@ -315,7 +305,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
         for (ChannelHandler h : handlers) {
             if (h != null) {
-                addLast(executor, null, h);
+                addLast(null, h);
             }
         }
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -295,9 +295,11 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             }
         }
 
-        for (int i = size - 1; i >= 0; i --) {
+        for (int i = size - 1; i >= 0; i--) {
             ChannelHandler h = handlers[i];
-            addFirst(null, h);
+            if (h != null) {
+                addFirst(executor, null, h);
+            }
         }
 
         return this;
@@ -311,11 +313,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     public final ChannelPipeline addLast(ChannelHandler... handlers) {
         requireNonNull(handlers, "handlers");
 
-        for (ChannelHandler h: handlers) {
-            if (h == null) {
-                break;
+        for (ChannelHandler h : handlers) {
+            if (h != null) {
+                addLast(executor, null, h);
             }
-            addLast(null, h);
         }
 
         return this;

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -169,39 +169,37 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testAddLastVarArgsSkipsNull() {
         ChannelPipeline pipeline = newLocalChannel().pipeline();
-        assertEquals(1, pipeline.names().size());
 
         pipeline.addLast(null, newHandler(), null);
-        assertEquals(2, pipeline.names().size());
+        assertEquals(1, pipeline.names().size());
         assertEquals("DefaultChannelPipelineTest$TestHandler#0", pipeline.names().get(0));
 
         pipeline.addLast(newHandler(), null, newHandler());
-        assertEquals(4, pipeline.names().size());
+        assertEquals(3, pipeline.names().size());
         assertEquals("DefaultChannelPipelineTest$TestHandler#0", pipeline.names().get(0));
         assertEquals("DefaultChannelPipelineTest$TestHandler#1", pipeline.names().get(1));
         assertEquals("DefaultChannelPipelineTest$TestHandler#2", pipeline.names().get(2));
 
         pipeline.addLast((ChannelHandler) null);
-        assertEquals(4, pipeline.names().size());
+        assertEquals(3, pipeline.names().size());
     }
 
     @Test
     public void testAddFirstVarArgsSkipsNull() {
         ChannelPipeline pipeline = newLocalChannel().pipeline();
-        assertEquals(1, pipeline.names().size());
 
         pipeline.addFirst(null, newHandler(), null);
-        assertEquals(2, pipeline.names().size());
+        assertEquals(1, pipeline.names().size());
         assertEquals("DefaultChannelPipelineTest$TestHandler#0", pipeline.names().get(0));
 
         pipeline.addFirst(newHandler(), null, newHandler());
-        assertEquals(4, pipeline.names().size());
+        assertEquals(3, pipeline.names().size());
         assertEquals("DefaultChannelPipelineTest$TestHandler#2", pipeline.names().get(0));
         assertEquals("DefaultChannelPipelineTest$TestHandler#1", pipeline.names().get(1));
         assertEquals("DefaultChannelPipelineTest$TestHandler#0", pipeline.names().get(2));
 
         pipeline.addFirst((ChannelHandler) null);
-        assertEquals(4, pipeline.names().size());
+        assertEquals(3, pipeline.names().size());
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -167,6 +167,44 @@ public class DefaultChannelPipelineTest {
     }
 
     @Test
+    public void testAddLastVarArgsSkipsNull() {
+        ChannelPipeline pipeline = newLocalChannel().pipeline();
+        assertEquals(1, pipeline.names().size());
+
+        pipeline.addLast(null, newHandler(), null);
+        assertEquals(2, pipeline.names().size());
+        assertEquals("DefaultChannelPipelineTest$TestHandler#0", pipeline.names().get(0));
+
+        pipeline.addLast(newHandler(), null, newHandler());
+        assertEquals(4, pipeline.names().size());
+        assertEquals("DefaultChannelPipelineTest$TestHandler#0", pipeline.names().get(0));
+        assertEquals("DefaultChannelPipelineTest$TestHandler#1", pipeline.names().get(1));
+        assertEquals("DefaultChannelPipelineTest$TestHandler#2", pipeline.names().get(2));
+
+        pipeline.addLast((ChannelHandler) null);
+        assertEquals(4, pipeline.names().size());
+    }
+
+    @Test
+    public void testAddFirstVarArgsSkipsNull() {
+        ChannelPipeline pipeline = newLocalChannel().pipeline();
+        assertEquals(1, pipeline.names().size());
+
+        pipeline.addFirst(null, newHandler(), null);
+        assertEquals(2, pipeline.names().size());
+        assertEquals("DefaultChannelPipelineTest$TestHandler#0", pipeline.names().get(0));
+
+        pipeline.addFirst(newHandler(), null, newHandler());
+        assertEquals(4, pipeline.names().size());
+        assertEquals("DefaultChannelPipelineTest$TestHandler#2", pipeline.names().get(0));
+        assertEquals("DefaultChannelPipelineTest$TestHandler#1", pipeline.names().get(1));
+        assertEquals("DefaultChannelPipelineTest$TestHandler#0", pipeline.names().get(2));
+
+        pipeline.addFirst((ChannelHandler) null);
+        assertEquals(4, pipeline.names().size());
+    }
+
+    @Test
     public void testRemoveChannelHandler() {
         ChannelPipeline pipeline = newLocalChannel().pipeline();
 


### PR DESCRIPTION
### Motivation

Allowing null handlers allows for more convenient idioms in
conditionally adding handlers, e.g.,

```
ch.pipeline().addLast(
        new FooHandler(),
        condition ? new BarHandler() : null,
        new BazHandler()
);
```

### Modifications

* Change addFirst(..) and addLast(..) to skip null handlers, rather than
break or short-circuit.
* Add new unit tests.

### Result

* Makes addFirst(..) and addLast(..) behavior more consistent
* Resolves https://github.com/netty/netty/issues/10728