### PR TITLE
Add Http2TranslatedHttpContent for correct handling of StreamID

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -51,7 +51,7 @@ public class DefaultHttpHeaders extends HttpHeaders {
             return true;
         }
     };
-    static final NameValidator<CharSequence> HttpNameValidator = new NameValidator<CharSequence>() {
+    public static final NameValidator<CharSequence> HttpNameValidator = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
             if (name == null || name.length() == 0) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedHttpContent.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedHttpContent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.util.internal.StringUtil;
+
+/**
+ * {@link DefaultHttp2TranslatedHttpContent} contains {@link HttpContent} and {@code streamId}
+ * which are translated from {@link Http2DataFrame}
+ */
+public class DefaultHttp2TranslatedHttpContent extends Http2TranslatedHttpContent {
+
+    /**
+     * Creates a new instance with the specified chunk content and StreamId.
+     */
+    public DefaultHttp2TranslatedHttpContent(ByteBuf content, int streamId) {
+        super(content, streamId);
+    }
+
+    @Override
+    public String toString() {
+        return StringUtil.simpleClassName(this) + "(streamId: " + streamId() + ", data: " + content() +
+                ", decoderResult: " + decoderResult() + ')';
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.DefaultHeaders;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.internal.StringUtil;
+
+import java.util.Map;
+
+/**
+ * {@link DefaultHttp2TranslatedHttpContent} contains {@code streamId}
+ * from last (endOfStream) {@link Http2DataFrame}.
+ */
+public class DefaultHttp2TranslatedLastHttpContent extends DefaultHttp2TranslatedHttpContent
+        implements LastHttpContent {
+
+    private final HttpHeaders trailingHeaders;
+    private final boolean validateHeaders;
+
+    /***
+     * Creates a new instance with the specified chunk content.
+     * @param streamId Stream ID of HTTP/2 Data Frame
+     */
+    public DefaultHttp2TranslatedLastHttpContent(ByteBuf content, int streamId, boolean validateHeaders) {
+        super(content, streamId);
+        this.validateHeaders = validateHeaders;
+        trailingHeaders = new TrailingHttpHeaders(validateHeaders);
+    }
+
+    @Override
+    public LastHttpContent copy() {
+        return replace(content().copy());
+    }
+
+    @Override
+    public LastHttpContent duplicate() {
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public LastHttpContent retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public LastHttpContent replace(ByteBuf content) {
+        DefaultHttp2TranslatedLastHttpContent lastHttpContent = new DefaultHttp2TranslatedLastHttpContent(content,
+                streamId(), validateHeaders);
+        lastHttpContent.trailingHeaders().set(trailingHeaders());
+        return lastHttpContent;
+    }
+
+    @Override
+    public LastHttpContent retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public LastHttpContent retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public LastHttpContent touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public LastHttpContent touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders trailingHeaders() {
+        return trailingHeaders;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder(super.toString());
+        buf.append(StringUtil.NEWLINE);
+        appendHeaders(buf);
+
+        // Remove the last newline.
+        buf.setLength(buf.length() - StringUtil.NEWLINE.length());
+        return buf.toString();
+    }
+
+    private void appendHeaders(StringBuilder buf) {
+        for (Map.Entry<String, String> e : trailingHeaders()) {
+            buf.append(e.getKey());
+            buf.append(": ");
+            buf.append(e.getValue());
+            buf.append(StringUtil.NEWLINE);
+        }
+    }
+
+    private static final class TrailingHttpHeaders extends DefaultHttpHeaders {
+        private static final DefaultHeaders.NameValidator<CharSequence> TrailerNameValidator =
+                new DefaultHeaders.NameValidator<CharSequence>() {
+                    @Override
+                    public void validateName(CharSequence name) {
+                        DefaultHttpHeaders.HttpNameValidator.validateName(name);
+                        if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
+                                || HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
+                                || HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name)) {
+                            throw new IllegalArgumentException("prohibited trailing header: " + name);
+                        }
+                    }
+                };
+
+        @SuppressWarnings("unchecked")
+        TrailingHttpHeaders(boolean validate) {
+            super(validate, validate ? TrailerNameValidator : DefaultHeaders.NameValidator.NOT_NULL);
+        }
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2TranslatedLastHttpContent.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.DefaultHeaders;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -35,9 +36,30 @@ public class DefaultHttp2TranslatedLastHttpContent extends DefaultHttp2Translate
     private final HttpHeaders trailingHeaders;
     private final boolean validateHeaders;
 
+    /**
+     * Creates a new instance with the specified chunk content,
+     * {@link Unpooled#EMPTY_BUFFER} and Header validation disabled.
+     *
+     * @param streamId Stream ID of HTTP/2 Data Frame
+     */
+    public DefaultHttp2TranslatedLastHttpContent(int streamId) {
+        this(Unpooled.EMPTY_BUFFER, streamId, true);
+    }
+
+    /**
+     * Creates a new instance with the specified chunk content and Header validation disabled.
+     *
+     * @param content  {@link ByteBuf} Content
+     * @param streamId Stream ID of HTTP/2 Data Frame
+     */
+    public DefaultHttp2TranslatedLastHttpContent(ByteBuf content, int streamId) {
+        this(content, streamId, true);
+    }
+
     /***
      * Creates a new instance with the specified chunk content.
      * @param streamId Stream ID of HTTP/2 Data Frame
+     * @param validateHeaders Set to {@code true} to validate headers else set to {@code false}
      */
     public DefaultHttp2TranslatedLastHttpContent(ByteBuf content, int streamId, boolean validateHeaders) {
         super(content, streamId);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2TranslatedHttpContent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2TranslatedHttpContent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.DefaultHttpContent;
+
+public abstract class Http2TranslatedHttpContent extends DefaultHttpContent {
+
+    private final int streamId;
+
+    /***
+     * Creates a new instance with the specified chunk content.
+     * @param streamId Stream ID of HTTP/2 Data Frame
+     */
+    public Http2TranslatedHttpContent(ByteBuf content, int streamId) {
+        super(content);
+        this.streamId = streamId;
+    }
+
+    public int streamId() {
+        return streamId;
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -122,6 +122,10 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
                     http2Trailers = HttpConversionUtil.toHttp2Headers(trailers, validateHeaders);
                 }
 
+                if (msg instanceof Http2TranslatedHttpContent) {
+                    currentStreamId = ((Http2TranslatedHttpContent) msg).streamId();
+                }
+
                 // Write the data
                 final ByteBuf content = ((HttpContent) msg).content();
                 endStream = isLastContent && trailers.isEmpty();


### PR DESCRIPTION
Motivation:
`HttpToHttp2ConnectionHandler` translates HTTP/1.1 objects to HTTP/2 frames but when multiple HttpContent are sent for multiple streams, `HttpToHttp2ConnectionHandler` apply wrong `currentStreamId` to HTTP/2 stream.

Modification:
I added `Http2TranslatedHttpContent` which holds `ByteBuf` and `StreamID`.

Result:
Fixes #10742