### PR TITLE
Don't use the cname cache when using DnsRecordResolveContext

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -84,4 +84,10 @@ final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
         // Do not cache.
         // XXX: When we implement cache, we would need to retain the reference count of the result record.
     }
+
+    @Override
+    DnsCnameCache cnameCache() {
+        // We don't use a cache here at all as we also don't cache if we end up using the DnsRecordResolverContext.
+        return NoopDnsCnameCache.INSTANCE;
+    }
 }


### PR DESCRIPTION
Motivation:

When we resolve other records then AAAA / AAAA we will use the resolve(...) overloads that take a DnsQuestion. This will then end up creating a DnsRecordResolveContext, in this case we should not use the CnameCache at all as we also not the result.

Modifications:

Don't cache CNAME and also dont use the cache for CNAME when using DnsRecordResolveContext

Result:

More correct resolving and also not possible to have failures due CNAME still be in the cache while the queried record experied