### PR TITLE
IovArray should support when there is no unsafe present

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollKQueueIovArrayTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollKQueueIovArrayTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.unix.tests.IovArrayTest;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+public class EpollKQueueIovArrayTest extends IovArrayTest {
+
+    @BeforeClass
+    public static void loadNative() {
+        Assume.assumeTrue(Epoll.isAvailable());
+    }
+}

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueIovArrayTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueIovArrayTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.channel.unix.tests.IovArrayTest;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+public class KQueueIovArrayTest extends IovArrayTest {
+
+    @BeforeClass
+    public static void loadNative() {
+        Assume.assumeTrue(KQueue.isAvailable());
+    }
+}

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/IovArrayTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/IovArrayTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 public abstract class IovArrayTest {
 
     @Test
-    public void test() {
+    public void testNotFailsWihtoutMemoryAddress() {
         ByteBuf buffer = new NoMemoryAddressByteBuf(128);
         IovArray array = new IovArray(buffer);
 

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/IovArrayTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/IovArrayTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.unix.tests;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.UnpooledDirectByteBuf;
+import io.netty.channel.unix.IovArray;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public abstract class IovArrayTest {
+
+    @Test
+    public void test() {
+        ByteBuf buffer = new NoMemoryAddressByteBuf(128);
+        IovArray array = new IovArray(buffer);
+
+        ByteBuf buf = Unpooled.directBuffer().writeZero(8);
+        ByteBuf buf2 = new NoMemoryAddressByteBuf(8).writeZero(8);
+        assertTrue(array.add(buf, 0, buf.readableBytes()));
+        assertTrue(array.add(buf, 0, buf2.readableBytes()));
+        assertEquals(2, array.count());
+        assertEquals(16, array.size());
+        assertTrue(buf.release());
+        assertTrue(buf2.release());
+        array.release();
+        assertEquals(0, buffer.refCnt());
+    }
+
+    private static final class NoMemoryAddressByteBuf extends UnpooledDirectByteBuf {
+
+        NoMemoryAddressByteBuf(int capacity) {
+            super(UnpooledByteBufAllocator.DEFAULT, capacity, Integer.MAX_VALUE);
+        }
+
+        @Override
+        public boolean hasMemoryAddress() {
+            return false;
+        }
+
+        @Override
+        public long memoryAddress() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

In some enviroments sun.misc.Unsafe is not present. We should support these as well.

Modifications:

Fallback to JNI if we can't directly access the memoryAddress of the buffer.

Result:

Fixes https://github.com/netty/netty/issues/10813