### PR TITLE
Add NetBSD support

### DIFF
--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -239,6 +239,14 @@ static jshort netty_kqueue_native_noteDisconnected(JNIEnv* env, jclass clazz) {
    return NOTE_DISCONNECTED;
 }
 
+static jboolean netty_kqueue_native_isSendFileSupported(JNIEnv* env, jclass clazz) {
+#ifdef __NetBSD__
+   return JNI_FALSE;
+#else
+   return JNI_TRUE;
+#endif
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "evfiltRead", "()S", (void *) netty_kqueue_native_evfiltRead },
@@ -254,7 +262,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "evError", "()S", (void *) netty_kqueue_native_evError },
   { "noteReadClosed", "()S", (void *) netty_kqueue_native_noteReadClosed },
   { "noteConnReset", "()S", (void *) netty_kqueue_native_noteConnReset },
-  { "noteDisconnected", "()S", (void *) netty_kqueue_native_noteDisconnected }
+  { "noteDisconnected", "()S", (void *) netty_kqueue_native_noteDisconnected },
+  { "isSendFileSupported", "()Z", (void *) netty_kqueue_native_isSendFileSupported }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 static const JNINativeMethod fixed_method_table[] = {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -321,7 +321,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
         Object msg = in.current();
         if (msg instanceof ByteBuf) {
             return writeBytes(in, (ByteBuf) msg);
-        } else if (msg instanceof DefaultFileRegion) {
+        } else if (msg instanceof DefaultFileRegion && Native.IS_SENDFILE_SUPPORTED) {
             return writeDefaultFileRegion(in, (DefaultFileRegion) msg);
         } else if (msg instanceof FileRegion) {
             return writeFileRegion(in, (FileRegion) msg);

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueStaticallyReferencedJniMethods.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueStaticallyReferencedJniMethods.java
@@ -46,4 +46,6 @@ final class KQueueStaticallyReferencedJniMethods {
     static native short evfiltWrite();
     static native short evfiltUser();
     static native short evfiltSock();
+
+    static native boolean isSendFileSupported();
 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -38,6 +38,7 @@ import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evfil
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evfiltSock;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evfiltUser;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evfiltWrite;
+import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.isSendFileSupported;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.noteConnReset;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.noteDisconnected;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.noteReadClosed;
@@ -84,6 +85,7 @@ final class Native {
     static final short EVFILT_WRITE = evfiltWrite();
     static final short EVFILT_USER = evfiltUser();
     static final short EVFILT_SOCK = evfiltSock();
+    static final boolean IS_SENDFILE_SUPPORTED = isSendFileSupported();
 
     static FileDescriptor newKQueue() {
         return new FileDescriptor(kqueueCreate());


### PR DESCRIPTION
Motivation:

Add NetBSD support.

Modification:

NetBSD is a BSD target, but with:
 - lack of sendfile()
 - lack of TCP_NOPUSH
 - different semantics of netty_kqueue_bsdsocket_getPeerCredentials

Result:

Fixes #10809
