### PR TITLE
Remove use of PlatformDependent.throwsException in SingleThreadEventExecutor

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -831,9 +831,9 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
                 STATE_UPDATER.set(this, ST_TERMINATED);
                 terminationFuture.tryFailure(cause);
 
-                if (!(cause instanceof Exception)) {
-                    // Also rethrow as it may be an OOME for example
-                    PlatformDependent.throwException(cause);
+                if (cause instanceof Error) {
+                    // Rethrow errors so they can't be ignored.
+                    throw cause;
                 }
                 return true;
             }


### PR DESCRIPTION
Motivation:
We should avoid lying with throws declarations whenever possible.

Modification:
Changed the code to instead directly throw Error, which seems to have been the intent.
Also, while we're here, convert its associated test to JUnit 5 and clean it up a bit.

Result:
Cleaner code.