### PR TITLE
Fix causing the connection to hang without flushing data

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -411,7 +411,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
                     final int localWrittenBytes = ch.write(buffer);
                     if (localWrittenBytes <= 0) {
                         incompleteWrite(true);
-                    }else {
+                    } else {
                         adjustMaxBytesPerGatheringWrite(attemptedBytes, localWrittenBytes, maxBytesPerGatheringWrite);
                         in.removeBytes(localWrittenBytes);
                     }
@@ -428,10 +428,9 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
                     //See https://github.com/netty/netty/issues/10353
                     if (localWrittenBytes <= 0) {
                         incompleteWrite(true);
-                    }else {
+                    } else {
                         // Casting to int is safe because we limit the total amount of data in the nioBuffers to int above.
-                        adjustMaxBytesPerGatheringWrite((int) attemptedBytes, (int) localWrittenBytes,
-                                maxBytesPerGatheringWrite);
+                        adjustMaxBytesPerGatheringWrite((int) attemptedBytes, (int) localWrittenBytes,maxBytesPerGatheringWrite);
                         in.removeBytes(localWrittenBytes);
                     }
                     --writeSpinCount;

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -431,7 +431,8 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
                     } else {
                         // Casting to int is safe
                         // because we limit the total amount of data in the nioBuffers to int above.
-                        adjustMaxBytesPerGatheringWrite((int) attemptedBytes, (int) localWrittenBytes, maxBytesPerGatheringWrite);
+                        adjustMaxBytesPerGatheringWrite((int) attemptedBytes, (int) localWrittenBytes,
+                                maxBytesPerGatheringWrite);
                         in.removeBytes(localWrittenBytes);
                     }
                     --writeSpinCount;

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -429,8 +429,9 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
                     if (localWrittenBytes <= 0) {
                         incompleteWrite(true);
                     } else {
-                        // Casting to int is safe because we limit the total amount of data in the nioBuffers to int above.
-                        adjustMaxBytesPerGatheringWrite((int) attemptedBytes, (int) localWrittenBytes,maxBytesPerGatheringWrite);
+                        // Casting to int is safe
+                        // because we limit the total amount of data in the nioBuffers to int above.
+                        adjustMaxBytesPerGatheringWrite((int) attemptedBytes, (int) localWrittenBytes, maxBytesPerGatheringWrite);
                         in.removeBytes(localWrittenBytes);
                     }
                     --writeSpinCount;


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

channel.flush() after a few channel.write() operations may get processed by the pipeline before the writes, causing the connection to hang without flushing data.

Result:

If the write fails, I let it continue to try again.  All the way up to writeSpinCount is zero.

before

`


                    int attemptedBytes = buffer.remaining();
                    final int localWrittenBytes = ch.write(buffer);
                    if (localWrittenBytes <= 0) {
                        incompleteWrite(true);
                        return;
                    }
                    adjustMaxBytesPerGatheringWrite(attemptedBytes, localWrittenBytes, maxBytesPerGatheringWrite);
                    in.removeBytes(localWrittenBytes);
                    --writeSpinCount;
`

after

`
                    

                    int attemptedBytes = buffer.remaining();
                    final int localWrittenBytes = ch.write(buffer);
                    if (localWrittenBytes <= 0) {
                        incompleteWrite(true);
                    }else {
                        adjustMaxBytesPerGatheringWrite(attemptedBytes, localWrittenBytes, maxBytesPerGatheringWrite);
                        in.removeBytes(localWrittenBytes);
                    }
                    --writeSpinCount;

`

Fixes #<10353>. 
fix https://github.com/netty/netty/issues/10353

If there is no issue then describe the changes introduced by this PR.
