### PR TITLE
Skip Null Channel

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -391,7 +391,7 @@ public class SimpleChannelPool implements ChannelPool {
         for (;;) {
             Channel channel = pollChannel();
             if (channel == null) {
-                break;
+                continue; // Skip 'null' channel
             }
             // Just ignore any errors that are reported back from close().
             channel.close().awaitUninterruptibly();


### PR DESCRIPTION
Motivation:
We should skip `null` channels instead of breaking the loop on the `null` channel. This can lead to some sort of memory leak. Let's say, we've 5 elements in Poll. [Channel#1, Channel#2, null, Channel#3, Channel#4]. The current implementation will break close operation on the `null` channel and leave `Channel#3` and `Channel#4` open.

Modification:
Changed `break` to `null`.

Result:
Properly close Poll