### PR TITLE
Use aarch_64 in a consistent way

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <classifier>linux-aarch64</classifier>
+          <classifier>linux-aarch_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>
@@ -107,7 +107,7 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
-          <classifier>linux-aarch64</classifier>
+          <classifier>linux-aarch_64</classifier>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,7 @@ docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-7.1
 ## aarch64 cross compile for transport-native-epoll on X86_64
 
 ```
-docker-compose -f docker/docker-compose.yaml run cross-compile-aarch64
+docker-compose -f docker/docker-compose.yaml run cross-compile-aarch64-build
 ```
 The default version of aarch64 gcc is `4.9-2016.02`. Update the parameter `gcc_version` in `docker-compose.yaml` to use a version you want.
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -49,7 +49,18 @@ services:
       args:
         gcc_version : "4.9-2016.02"
 
-  cross-compile-aarch64:
+  cross-compile-aarch64-shell:
+    image: netty:cross_compile_aarch64
+    depends_on: [cross-compile-aarch64-runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh:delegated
+      - ~/.gnupg:/root/.gnupg:delegated
+      - ..:/code:delegated
+      - ~/.m2:/root/.m2:delegated
+    entrypoint: /bin/bash
+    working_dir: /code
+
+  cross-compile-aarch64-build:
     image: netty:cross_compile_aarch64
     depends_on: [cross-compile-aarch64-runtime-setup]
     volumes:

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -213,7 +213,8 @@
     <profile>
       <id>linux-aarch64</id>
       <properties>
-        <jni.classifier>${os.detected.name}-aarch64</jni.classifier>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <jni.classifier>${os.detected.name}-aarch_64</jni.classifier>
       </properties>
       <build>
         <pluginManagement>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -244,7 +244,8 @@
     <profile>
       <id>linux-aarch64</id>
       <properties>
-        <jni.classifier>${os.detected.name}-aarch64</jni.classifier>
+        <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
+        <jni.classifier>${os.detected.name}-aarch_64</jni.classifier>
         <jni.platform>linux</jni.platform>
         <exe.compiler>aarch64-linux-gnu-gcc</exe.compiler>
         <exe.archiver>aarch64-linux-gnu-ar</exe.archiver>


### PR DESCRIPTION
Motivation:

We should use aarch_64 in our classifier / jni libname on aarch64 as  os.detected.arch uses the name. Being non consistent (especially across our different projects) already gave us a lot of trouble in the past.
Let's fix this once for all.

Modifications:

Use aarch_64

Result:

More consistent classifier usage on aarch64