### PR TITLE
fix: AbstractEventExecutor does not currently log the error

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -163,7 +163,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
         try {
             task.run();
         } catch (Throwable t) {
-            logger.warn("A task raised an exception. Task: {}", task, t);
+            logger.warn(String.format("A task raised an exception. Task: {}", task), t);
         }
     }
 


### PR DESCRIPTION
The existing call is to logger.warn(String format, Object... objs), while it wants to call into logger.warn(String msg, Throwable t).

Motivation: AbstractEventExecutor does not currently log the error, as it calls the wrong overload

Modification:

Make it call the correct overload

Result: It calls the correct overload.
