### PR TITLE
Fixed typo in LimitingByteInput

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/marshalling/LimitingByteInput.java
+++ b/codec/src/main/java/io/netty/handler/codec/marshalling/LimitingByteInput.java
@@ -96,7 +96,7 @@ class LimitingByteInput implements ByteInput {
     }
 
     /**
-     * Exception that will get thrown if the {@link Object} is to big to unmarshall
+     * Exception that will get thrown if the {@link Object} is too big to unmarshall
      *
      */
     static final class TooBigObjectException extends IOException {


### PR DESCRIPTION
Motivation:

I found a typo in LimitingByteInput.

Modification:

Fixed the typo in LimitingByteInput

Result:

No typo anymore in LimitingByteInput.
