### PR TITLE
Workaround possible JDK bug in SSLEngineImpl when using TLSv1.3 that …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1808,7 +1808,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         // ensure we only notify once in this case.
         //
         // This is safe as TLSv1.3 does not support renegotiation and so we should never see two handshake events.
-        if (notified || engineType == SslEngineType.JDK && !SslUtils.PROTOCOL_TLS_V1_3.equals(session.getProtocol())) {
+        if (notified || !SslUtils.PROTOCOL_TLS_V1_3.equals(session.getProtocol())) {
             if (logger.isDebugEnabled()) {
                 logger.debug(
                         "{} HANDSHAKEN: protocol:{} cipher suite:{}",

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1800,17 +1800,24 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * Notify all the handshake futures about the successfully handshake
      */
     private void setHandshakeSuccess() {
-        handshakePromise.trySuccess(ctx.channel());
+        boolean notified = handshakePromise.trySuccess(ctx.channel());
+        SSLSession session = engine.getSession();
 
-        if (logger.isDebugEnabled()) {
-            SSLSession session = engine.getSession();
-            logger.debug(
-              "{} HANDSHAKEN: protocol:{} cipher suite:{}",
-              ctx.channel(),
-              session.getProtocol(),
-              session.getCipherSuite());
+        // There seems to be a bug in the SSLEngineImpl that is part of the OpenJDK that results in returning
+        // HandshakeStatus.FINISHED multiple times which is not expected. This only happens in TLSv1.3 so lets
+        // ensure we only notify once in this case.
+        //
+        // This is safe as TLSv1.3 does not support renegotiation and so we should never see two handshake events.
+        if (notified || engineType == SslEngineType.JDK && !SslUtils.PROTOCOL_TLS_V1_3.equals(session.getProtocol())) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                        "{} HANDSHAKEN: protocol:{} cipher suite:{}",
+                        ctx.channel(),
+                        session.getProtocol(),
+                        session.getCipherSuite());
+            }
+            ctx.fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         }
-        ctx.fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
 
         if (readDuringHandshake && !ctx.channel().config().isAutoRead()) {
             readDuringHandshake = false;

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -46,7 +46,10 @@ public abstract class RenegotiateTest {
         EventLoopGroup group = new LocalEventLoopGroup();
         try {
             final SslContext context = SslContextBuilder.forServer(cert.key(), cert.cert())
-                    .sslProvider(serverSslProvider()).build();
+                    .sslProvider(serverSslProvider())
+                    .protocols(SslUtils.PROTOCOL_TLS_V1_2)
+                    .build();
+
             ServerBootstrap sb = new ServerBootstrap();
             sb.group(group).channel(LocalServerChannel.class)
                     .childHandler(new ChannelInitializer<Channel>() {
@@ -95,7 +98,10 @@ public abstract class RenegotiateTest {
             Channel channel = sb.bind(new LocalAddress("test")).syncUninterruptibly().channel();
 
             final SslContext clientContext = SslContextBuilder.forClient()
-                    .trustManager(InsecureTrustManagerFactory.INSTANCE).sslProvider(SslProvider.JDK).build();
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .sslProvider(SslProvider.JDK)
+                    .protocols(SslUtils.PROTOCOL_TLS_V1_2)
+                    .build();
 
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(group).channel(LocalChannel.class)


### PR DESCRIPTION
…lead to multiple notifications

Motivation:

When using the JDKs SSLEngineImpl with TLSv1.3 it sometimes returns HandshakeResult.FINISHED multiple times. This can lead to have SslHandshakeCompletionEvents to be fired multiple times.

Modifications:

- Keep track of if we notified before and if so not do so again if we use TLSv1.3
- Add unit test

Result:

Consistent usage of events
