### PR TITLE
Don't catch Throwable in InternalLoggerFactory

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -68,6 +68,7 @@ public abstract class InternalLoggerFactory {
             return null;
         }
     }
+
     private static InternalLoggerFactory useLog4J2LoggerFactory(String name) {
         try {
             InternalLoggerFactory f = Log4J2LoggerFactory.INSTANCE;

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -65,6 +65,7 @@ public abstract class InternalLoggerFactory {
         } catch (LinkageError ignore) {
             return null;
         } catch (Exception ignore) {
+            // We catch Exception and not ReflectiveOperationException as we still support java 6
             return null;
         }
     }
@@ -77,6 +78,7 @@ public abstract class InternalLoggerFactory {
         } catch (LinkageError ignore) {
             return null;
         } catch (Exception ignore) {
+            // We catch Exception and not ReflectiveOperationException as we still support java 6
             return null;
         }
     }
@@ -89,6 +91,7 @@ public abstract class InternalLoggerFactory {
         } catch (LinkageError ignore) {
             return null;
         } catch (Exception ignore) {
+            // We catch Exception and not ReflectiveOperationException as we still support java 6
             return null;
         }
     }

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -39,24 +39,62 @@ public abstract class InternalLoggerFactory {
 
     @SuppressWarnings("UnusedCatchParameter")
     private static InternalLoggerFactory newDefaultFactory(String name) {
-        InternalLoggerFactory f;
-        try {
-            f = new Slf4JLoggerFactory(true);
-            f.newInstance(name).debug("Using SLF4J as the default logging framework");
-        } catch (Throwable ignore1) {
-            try {
-                f = Log4J2LoggerFactory.INSTANCE;
-                f.newInstance(name).debug("Using Log4J2 as the default logging framework");
-            } catch (Throwable ignore2) {
-                try {
-                    f = Log4JLoggerFactory.INSTANCE;
-                    f.newInstance(name).debug("Using Log4J as the default logging framework");
-                } catch (Throwable ignore3) {
-                    f = JdkLoggerFactory.INSTANCE;
-                    f.newInstance(name).debug("Using java.util.logging as the default logging framework");
-                }
-            }
+        InternalLoggerFactory f = useSlf4JLoggerFactory(name);
+        if (f != null) {
+            return f;
         }
+
+        f = useLog4J2LoggerFactory(name);
+        if (f != null) {
+            return f;
+        }
+
+        f = useLog4JLoggerFactory(name);
+        if (f != null) {
+            return f;
+        }
+
+        return useJdkLoggerFactory(name);
+    }
+
+    private static InternalLoggerFactory useSlf4JLoggerFactory(String name) {
+        try {
+            InternalLoggerFactory f = new Slf4JLoggerFactory(true);
+            f.newInstance(name).debug("Using SLF4J as the default logging framework");
+            return f;
+        } catch (LinkageError ignore) {
+            return null;
+        } catch (Exception ignore) {
+            return null;
+        }
+    }
+    private static InternalLoggerFactory useLog4J2LoggerFactory(String name) {
+        try {
+            InternalLoggerFactory f = Log4J2LoggerFactory.INSTANCE;
+            f.newInstance(name).debug("Using Log4J2 as the default logging framework");
+            return f;
+        } catch (LinkageError ignore) {
+            return null;
+        } catch (Exception ignore) {
+            return null;
+        }
+    }
+
+    private static InternalLoggerFactory useLog4JLoggerFactory(String name) {
+        try {
+            InternalLoggerFactory f = Log4JLoggerFactory.INSTANCE;
+            f.newInstance(name).debug("Using Log4J as the default logging framework");
+            return f;
+        } catch (LinkageError ignore) {
+            return null;
+        } catch (Exception ignore) {
+            return null;
+        }
+    }
+
+    private static InternalLoggerFactory useJdkLoggerFactory(String name) {
+        InternalLoggerFactory f = JdkLoggerFactory.INSTANCE;
+        f.newInstance(name).debug("Using java.util.logging as the default logging framework");
         return f;
     }
 


### PR DESCRIPTION
Motivation:

We shouldnt catch Throwable in InternalLoggerFactory as this may hide OOME etc.

Modifications:

Only catch LinkageError and Exception

Result:

Fixes https://github.com/netty/netty/issues/10857