### PR TITLE
Ensure IovArray is usuable without sun.misc.Unsafe

### DIFF
--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/IovArrayTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/IovArrayTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.unix.IovArray;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public abstract class IovArrayTest {
@@ -40,6 +41,7 @@ public abstract class IovArrayTest {
         assertEquals(16, array.size());
         assertTrue(buf.release());
         assertTrue(buf2.release());
+        assertNotEquals(-1, array.memoryAddress(0));
         array.release();
         assertEquals(0, buffer.refCnt());
     }

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
@@ -212,7 +212,7 @@ public final class IovArray implements MessageProcessor {
      * Returns the {@code memoryAddress} for the given {@code offset}.
      */
     public long memoryAddress(int offset) {
-        return memory.memoryAddress() + idx(offset);
+        return memoryAddress + idx(offset);
     }
 
     /**


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/10814 did fix a bug where we did try to call memoryAddress() even tho this is not supported. Unfortunally this fix was only applied for one method and so we missed another method which then could throw an exception when we called memoryAddress()

Modifications:

- Also fix the memoryAddress(offset) method.
- Adjust unit test to also test this.

Result:

Fixes https://github.com/netty/netty/issues/10813 completely.
