### PR TITLE
Improve performance of UnpooledHeapByteBuf construction

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -71,14 +71,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
         checkNotNull(alloc, "alloc");
         checkNotNull(initialArray, "initialArray");
-        if (initialArray.length > maxCapacity) {
+        int initialCapacity = initialArray.length;
+        if (initialCapacity > maxCapacity) {
             throw new IllegalArgumentException(String.format(
-                    "initialCapacity(%d) > maxCapacity(%d)", initialArray.length, maxCapacity));
+                    "initialCapacity(%d) > maxCapacity(%d)", initialCapacity, maxCapacity));
         }
 
         this.alloc = alloc;
         setArray(initialArray);
-        setIndex(0, initialArray.length);
+        setIndex(0, initialCapacity);
     }
 
     protected byte[] allocateArray(int initialCapacity) {


### PR DESCRIPTION
Motivation:

Found a possibility to improve UnpooledHeapByteBuf construction and used it.

Modification:

Added a local variable in the UnpooledHeapByteBuf constructor in order to reuse the length of the passed array instead of accessing the array's length field multiple times.

Result:

Improves the permormance of UnpooledHeapByteBuf construction by a bit.
