### PR TITLE
Simplify InternalThreadLocalMap

### DIFF
--- a/common/src/main/java/io/netty/util/internal/UnpaddedInternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/UnpaddedInternalThreadLocalMap.java
@@ -13,49 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty.util.internal;
 
-import io.netty.util.concurrent.FastThreadLocal;
-
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CharsetEncoder;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
 /**
- * The internal data structure that stores the thread-local variables for Netty and all {@link FastThreadLocal}s.
- * Note that this class is for internal use only and is subject to change at any time.  Use {@link FastThreadLocal}
- * unless you know what you are doing.
+ * @deprecated This class will be removed in the future.
  */
 class UnpaddedInternalThreadLocalMap {
-
-    static final ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = new ThreadLocal<InternalThreadLocalMap>();
-    static final AtomicInteger nextIndex = new AtomicInteger();
-
-    /** Used by {@link FastThreadLocal} */
-    Object[] indexedVariables;
-
-    // Core thread-locals
-    int futureListenerStackDepth;
-    int localChannelReaderStackDepth;
-    Map<Class<?>, Boolean> handlerSharableCache;
-    IntegerHolder counterHashCode;
-    ThreadLocalRandom random;
-    Map<Class<?>, TypeParameterMatcher> typeParameterMatcherGetCache;
-    Map<Class<?>, Map<String, TypeParameterMatcher>> typeParameterMatcherFindCache;
-
-    // String-related thread-locals
-    StringBuilder stringBuilder;
-    Map<Charset, CharsetEncoder> charsetEncoderCache;
-    Map<Charset, CharsetDecoder> charsetDecoderCache;
-
-    // ArrayList-related thread-locals
-    ArrayList<Object> arrayList;
-
-    UnpaddedInternalThreadLocalMap(Object[] indexedVariables) {
-        this.indexedVariables = indexedVariables;
-    }
+    // We cannot remove this in 4.1 because it could break compatibility.
 }


### PR DESCRIPTION
Motivation:
I did not see any tangible advantage to the padding (in benchmarks).
The only other field that was guarded was a rarely changed object reference to a BitSet.
Without the padding, there is also no longer any use of the inheritance hierarchy.
The padding was also using `long`, which would not necessarily prevent the JVM from fitting the aforementioned object reference in an alignment gap.

Modification:
Move all the fields into the InternalThreadLocalMap and deprecate the stuff we'd like to remove.

Result:
Simpler code.
This resolves the discussion in https://github.com/netty/netty/issues/9284
