### PR TITLE
MQTT codec: foolproof SUBSCRIBE QoS encoding

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -287,18 +287,22 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
             // Payload
             for (MqttTopicSubscription topic : payload.topicSubscriptions()) {
                 writeUnsafeUTF8String(buf, topic.topicName());
-                final MqttSubscriptionOption option = topic.option();
+                if (mqttVersion == MqttVersion.MQTT_3_1_1 || mqttVersion == MqttVersion.MQTT_3_1) {
+                    buf.writeByte(topic.qualityOfService().value());
+                } else {
+                    final MqttSubscriptionOption option = topic.option();
 
-                int optionEncoded = option.retainHandling().value() << 4;
-                if (option.isRetainAsPublished()) {
-                    optionEncoded |= 0x08;
-                }
-                if (option.isNoLocal()) {
-                    optionEncoded |= 0x04;
-                }
-                optionEncoded |= option.qos().value();
+                    int optionEncoded = option.retainHandling().value() << 4;
+                    if (option.isRetainAsPublished()) {
+                        optionEncoded |= 0x08;
+                    }
+                    if (option.isNoLocal()) {
+                        optionEncoded |= 0x04;
+                    }
+                    optionEncoded |= option.qos().value();
 
-                buf.writeByte(optionEncoded);
+                    buf.writeByte(optionEncoded);
+                }
             }
 
             return buf;


### PR DESCRIPTION
Motivation:

If the MQTT client specifies Subscribe Options parameters only available in MQTT v5 and tries to encode the message as MQTT v3 then an invalid QoS value is encoded

Modification:

Check MQTT version when encoding SUBSCRIBE message options, if it's 3.1 or 3.1.1 - only encode QoS, skip other options.

Result:

MqttEncoder produces a valid SUBSCRIBE message even if the client has specified options not available in the current MQTT version.
