### PR TITLE
Change switch to if in DefaultHttpHeaders

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -489,12 +489,10 @@ public class DefaultHttpHeaders extends HttpHeaders {
                     }
                     break;
                 case 1:
-                    switch (character) {
-                        case '\n':
-                            return 2;
-                        default:
-                            throw new IllegalArgumentException("only '\\n' is allowed after '\\r': " + seq);
+                    if (character == '\n') {
+                        return 2;
                     }
+                    throw new IllegalArgumentException("only '\\n' is allowed after '\\r': " + seq);
                 case 2:
                     switch (character) {
                         case '\t':


### PR DESCRIPTION
Motivation:
`switch` is used when we have a good amount of cases because `switch` is faster than `if-else`. However, we're using only 1 case in `switch` which can affect performance.

Modification:
Changed `switch` to `if`.

Result:
Good code.
