### PR TITLE
Add deploy job for cross compiled aarch64

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -46,3 +46,41 @@ jobs:
 
       - name: Deploy snapshots
         run: docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run deploy
+
+  deploy-linux-aarch64:
+    runs-on: ubuntu-latest
+    # We depend on the deploy of linux-x86_64 so we can download the dependencies
+    needs: deploy-linux-x86_64
+    steps:
+      - uses: s4u/maven-settings-action@v2.2.0
+        with:
+          servers: |
+            [{
+                "id": "sonatype-nexus-snapshots",
+                "username": "${{ secrets.SONATYPE_USERNAME }}",
+                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+
+      - uses: actions/checkout@v2
+
+      # Cache .m2/repository
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: deploy-linux-aarch64-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            deploy-linux-aarch64-${{ runner.os }}-maven-
+
+      # Enable caching of Docker layers
+      - uses: satackey/action-docker-layer-caching@v0.0.8
+        continue-on-error: true
+        with:
+          key: deploy-linux-aarch64-docker-cache-{hash}
+          restore-keys: |
+            deploy-linux-aarch64-docker-cache-
+
+      - name: Build docker image
+        run: docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-7.yaml build
+
+      - name: Deploy snapshots
+        run: docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-7.yaml run deploy

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -1,0 +1,35 @@
+version: "3"
+
+services:
+
+
+  cross-compile-aarch64-runtime-setup:
+    image: netty:cross_compile_aarch64
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.cross_compile_aarch64
+      args:
+        gcc_version: "4.9-2016.02"
+        java_version: "adopt@1.8.0-272"
+
+  cross-compile-aarch64-common: &cross-compile-aarch64-common
+    depends_on: [ cross-compile-aarch64-runtime-setup ]
+    image: netty:cross_compile_aarch64
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ..:/code
+    working_dir: /code
+
+  cross-compile-aarch64-deploy:
+    <<: *cross-compile-aarch64-common
+    command: /bin/bash -cl "./mvnw -pl transport-native-unix-common,transport-native-epoll clean deploy -Plinux-aarch64 -DskipTests=true"
+
+  cross-compile-aarch64-shell:
+    <<: *cross-compile-aarch64-common
+    entrypoint: /bin/bash
+
+  cross-compile-aarch64-build:
+    <<: *cross-compile-aarch64-common
+    command: /bin/bash -cl "./mvnw -pl transport-native-unix-common,transport-native-epoll clean package -Plinux-aarch64 -DskipTests=true"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,9 +12,10 @@ services:
     image: netty:default
     depends_on: [runtime-setup]
     volumes:
-      - ~/.ssh:/root/.ssh:delegated
-      - ~/.gnupg:/root/.gnupg:delegated
-      - ..:/code:delegated
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ~/.m2:/root/.m2
+      - ..:/code
     working_dir: /code
 
   build-leak:
@@ -27,11 +28,6 @@ services:
 
   deploy:
     <<: *common
-    volumes:
-      - ~/.ssh:/root/.ssh
-      - ~/.gnupg:/root/.gnupg
-      - ~/.m2/settings.xml:/root/.m2/settings.xml
-      - ..:/code
     command: /bin/bash -cl "./mvnw clean deploy -DskipTests=true"
 
   test-leak:
@@ -48,9 +44,4 @@ services:
 
   shell:
     <<: *common
-    volumes:
-      - ~/.ssh:/root/.ssh:delegated
-      - ~/.gnupg:/root/.gnupg:delegated
-      - ..:/code:delegated
-      - ~/.m2:/root/.m2:delegated
     entrypoint: /bin/bash


### PR DESCRIPTION
Motivation:

We should also deploy snapshots for our cross compiled native jars.

Modifications:

- Add job and docker files for deploying cross compiled native jars
- Ensure we map the maven cache into our docker containers

Result:

Deploy aarch64 jars and re-use cache

