### PR TITLE
Use maven cachen when running analyze job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,17 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
+    # Cache .m2/repository
+    - uses: actions/cache@v2
+      env:
+        cache-name: verify-cache-m2-repository
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-pr-${{ env.cache-name }}-
+          ${{ runner.os }}-pr-
+
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2


### PR DESCRIPTION
Motivation:

To prevent failures to problems while downloading dependencies we shoud cache these

Modifications:

Add maven cache

Result:

No more failures due problems while downloading dependencies
