### PR TITLE
Ensure Checkstyle suppression for dependency-reduced-pom.xml on Windows

### DIFF
--- a/nohttp-checkstyle-suppressions.xml
+++ b/nohttp-checkstyle-suppressions.xml
@@ -57,6 +57,6 @@
   <suppress message="http://maven.apache.org/POM/4.0.0" checks="NoHttp"/>
 
   <!-- These files are generated during the build and not under git -->
-  <suppress files="testsuite-shading/dependency-reduced-pom.xml" checks="NoHttp"/>
-  <suppress files="common/dependency-reduced-pom.xml" checks="NoHttp"/>
+  <suppress files="testsuite-shading[/\\]dependency-reduced-pom\.xml" checks="NoHttp"/>
+  <suppress files="common[/\\]dependency-reduced-pom\.xml" checks="NoHttp"/>
 </suppressions>


### PR DESCRIPTION
Motivation:

`mvn package` on Windows fails if there are some `dependency-reduced-pom.xml` files generated by the previous build.
`mvn clean package` does not help because it does not remove those files at the clean phase.

Modification:

Use the correct file pattern for the suppression filters.

Result:

Following `mvn package` runs well on Windows.
