### PR TITLE
We need to ensure we always drain the error stack when a callback throws

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslErrorStackAssertSSLEngine.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslErrorStackAssertSSLEngine.java
@@ -435,6 +435,7 @@ final class OpenSslErrorStackAssertSSLEngine extends JdkSslEngine implements Ref
     }
 
     private static void assertErrorStackEmpty() {
-        Assert.assertEquals("SSL error stack non-empty", 0, SSL.getLastErrorNumber());
+        long error = SSL.getLastErrorNumber();
+        Assert.assertEquals("SSL error stack non-empty: " + SSL.getErrorString(error), 0, error);
     }
 }


### PR DESCRIPTION
Motivation:

We need to ensure we always drain the error stack when a callback throws as otherwise we may pick up the error on a different SSL instance which uses the same thread.

Modifications:

- Correctly drain the error stack if native method throws
- Add a unit test which failed before the change

Result:

Always drain the error stack