### PR TITLE
fixes #10929

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -524,7 +524,7 @@ public final class MqttMessageBuilders {
 
     public static final class PubAckBuilder {
 
-        private short packetId;
+        private int packetId;
         private byte reasonCode;
         private MqttProperties properties;
 
@@ -536,7 +536,7 @@ public final class MqttMessageBuilders {
             return this;
         }
 
-        public PubAckBuilder packetId(short packetId) {
+        public PubAckBuilder packetId(int packetId) {
             this.packetId = packetId;
             return this;
         }
@@ -546,25 +546,25 @@ public final class MqttMessageBuilders {
             return this;
         }
 
-        public MqttMessage build() {
+        public MqttPubAckMessage build() {
             MqttFixedHeader mqttFixedHeader =
                     new MqttFixedHeader(MqttMessageType.PUBACK, false, MqttQoS.AT_MOST_ONCE, false, 0);
             MqttPubReplyMessageVariableHeader mqttPubAckVariableHeader =
                     new MqttPubReplyMessageVariableHeader(packetId, reasonCode, properties);
-            return new MqttMessage(mqttFixedHeader, mqttPubAckVariableHeader);
+            return new MqttPubAckMessage(mqttFixedHeader, mqttPubAckVariableHeader);
         }
     }
 
     public static final class SubAckBuilder {
 
-        private short packetId;
+        private int packetId;
         private MqttProperties properties;
         private final List<MqttQoS> grantedQoses = new ArrayList<MqttQoS>();
 
         SubAckBuilder() {
         }
 
-        public SubAckBuilder packetId(short packetId) {
+        public SubAckBuilder packetId(int packetId) {
             this.packetId = packetId;
             return this;
         }
@@ -604,14 +604,14 @@ public final class MqttMessageBuilders {
 
     public static final class UnsubAckBuilder {
 
-        private short packetId;
+        private int packetId;
         private MqttProperties properties;
         private final List<Short> reasonCodes = new ArrayList<Short>();
 
         UnsubAckBuilder() {
         }
 
-        public UnsubAckBuilder packetId(short packetId) {
+        public UnsubAckBuilder packetId(int packetId) {
             this.packetId = packetId;
             return this;
         }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -536,8 +536,8 @@ public final class MqttMessageBuilders {
             return this;
         }
 
-        public PubAckBuilder packetId(int packetId) {
-            this.packetId = packetId;
+        public PubAckBuilder packetId(short packetId) {
+            this.packetId = packetId & 0xFFFF;
             return this;
         }
 
@@ -546,12 +546,12 @@ public final class MqttMessageBuilders {
             return this;
         }
 
-        public MqttPubAckMessage build() {
+        public MqttMessage build() {
             MqttFixedHeader mqttFixedHeader =
                     new MqttFixedHeader(MqttMessageType.PUBACK, false, MqttQoS.AT_MOST_ONCE, false, 0);
             MqttPubReplyMessageVariableHeader mqttPubAckVariableHeader =
                     new MqttPubReplyMessageVariableHeader(packetId, reasonCode, properties);
-            return new MqttPubAckMessage(mqttFixedHeader, mqttPubAckVariableHeader);
+            return new MqttMessage(mqttFixedHeader, mqttPubAckVariableHeader);
         }
     }
 
@@ -564,8 +564,8 @@ public final class MqttMessageBuilders {
         SubAckBuilder() {
         }
 
-        public SubAckBuilder packetId(int packetId) {
-            this.packetId = packetId;
+        public SubAckBuilder packetId(short packetId) {
+            this.packetId = packetId & 0xFFFF;
             return this;
         }
 
@@ -611,8 +611,8 @@ public final class MqttMessageBuilders {
         UnsubAckBuilder() {
         }
 
-        public UnsubAckBuilder packetId(int packetId) {
-            this.packetId = packetId;
+        public UnsubAckBuilder packetId(short packetId) {
+            this.packetId = packetId & 0xFFFF;
             return this;
         }
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -536,9 +536,17 @@ public final class MqttMessageBuilders {
             return this;
         }
 
-        public PubAckBuilder packetId(short packetId) {
-            this.packetId = packetId & 0xFFFF;
+        public PubAckBuilder packetId(int packetId) {
+            this.packetId = packetId;
             return this;
+        }
+
+        /**
+         * @deprecated use {@link PubAckBuilder#packetId(int)} instead
+         */
+        @Deprecated
+        public PubAckBuilder packetId(short packetId) {
+            return packetId(packetId & 0xFFFF);
         }
 
         public PubAckBuilder properties(MqttProperties properties) {
@@ -564,9 +572,17 @@ public final class MqttMessageBuilders {
         SubAckBuilder() {
         }
 
-        public SubAckBuilder packetId(short packetId) {
-            this.packetId = packetId & 0xFFFF;
+        public SubAckBuilder packetId(int packetId) {
+            this.packetId = packetId;
             return this;
+        }
+
+        /**
+         * @deprecated use {@link SubAckBuilder#packetId(int)} instead
+         */
+        @Deprecated
+        public SubAckBuilder packetId(short packetId) {
+            return packetId(packetId & 0xFFFF);
         }
 
         public SubAckBuilder properties(MqttProperties properties) {
@@ -611,9 +627,17 @@ public final class MqttMessageBuilders {
         UnsubAckBuilder() {
         }
 
-        public UnsubAckBuilder packetId(short packetId) {
-            this.packetId = packetId & 0xFFFF;
+        public UnsubAckBuilder packetId(int packetId) {
+            this.packetId = packetId;
             return this;
+        }
+
+        /**
+         * @deprecated use {@link UnsubAckBuilder#packetId(int)} instead
+         */
+        @Deprecated
+        public UnsubAckBuilder packetId(short packetId) {
+            return packetId(packetId & 0xFFFF);
         }
 
         public UnsubAckBuilder properties(MqttProperties properties) {

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersPacketIdTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersPacketIdTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+@RunWith(value = Parameterized.class)
+public class MqttMessageBuildersPacketIdTest {
+    @Parameterized.Parameter
+    public Integer id;
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Iterable<Integer> data() {
+        // we take a subset of valid packetIds
+        return Arrays.asList(
+                0x0001,
+                0x000F,
+                0x00FF,
+                0x0FFF,
+                0xFFFF
+        );
+    }
+
+    @Test
+    public void testUnsubAckMessageId() {
+        final MqttUnsubAckMessage msg = MqttMessageBuilders.unsubAck()
+                .packetId(id)
+                .build();
+
+        assertEquals(
+                id.intValue(),
+                msg.variableHeader().messageId()
+        );
+    }
+
+    @Test
+    public void testSubAckMessageId() {
+        final MqttSubAckMessage msg = MqttMessageBuilders.subAck()
+                .packetId(id)
+                .build();
+
+        assertEquals(
+                id.intValue(),
+                msg.variableHeader().messageId()
+        );
+    }
+
+    @Test
+    public void testPubAckMessageId() {
+        final MqttPubAckMessage msg = MqttMessageBuilders.pubAck()
+                .packetId(id)
+                .build();
+
+        assertEquals(
+                id.intValue(),
+                msg.variableHeader().messageId()
+        );
+    }
+}

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersPacketIdTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersPacketIdTest.java
@@ -42,7 +42,7 @@ public class MqttMessageBuildersPacketIdTest {
     }
 
     @Test
-    public void testUnsubAckMessageId() {
+    public void testUnsubAckMessageIdAsShort() {
         final MqttUnsubAckMessage msg = MqttMessageBuilders.unsubAck()
                 .packetId(id.shortValue())
                 .build();
@@ -54,7 +54,7 @@ public class MqttMessageBuildersPacketIdTest {
     }
 
     @Test
-    public void testSubAckMessageId() {
+    public void testSubAckMessageIdAsShort() {
         final MqttSubAckMessage msg = MqttMessageBuilders.subAck()
                 .packetId(id.shortValue())
                 .build();
@@ -66,9 +66,45 @@ public class MqttMessageBuildersPacketIdTest {
     }
 
     @Test
-    public void testPubAckMessageId() {
+    public void testPubAckMessageIdAsShort() {
         final MqttMessage msg = MqttMessageBuilders.pubAck()
                 .packetId(id.shortValue())
+                .build();
+
+        assertEquals(
+                id.intValue(),
+                ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId()
+        );
+    }
+
+    @Test
+    public void testUnsubAckMessageIdAsInt() {
+        final MqttUnsubAckMessage msg = MqttMessageBuilders.unsubAck()
+                .packetId(id)
+                .build();
+
+        assertEquals(
+                id.intValue(),
+                msg.variableHeader().messageId()
+        );
+    }
+
+    @Test
+    public void testSubAckMessageIdAsInt() {
+        final MqttSubAckMessage msg = MqttMessageBuilders.subAck()
+                .packetId(id)
+                .build();
+
+        assertEquals(
+                id.intValue(),
+                msg.variableHeader().messageId()
+        );
+    }
+
+    @Test
+    public void testPubAckMessageIdAsInt() {
+        final MqttMessage msg = MqttMessageBuilders.pubAck()
+                .packetId(id)
                 .build();
 
         assertEquals(

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersPacketIdTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersPacketIdTest.java
@@ -44,7 +44,7 @@ public class MqttMessageBuildersPacketIdTest {
     @Test
     public void testUnsubAckMessageId() {
         final MqttUnsubAckMessage msg = MqttMessageBuilders.unsubAck()
-                .packetId(id)
+                .packetId(id.shortValue())
                 .build();
 
         assertEquals(
@@ -56,7 +56,7 @@ public class MqttMessageBuildersPacketIdTest {
     @Test
     public void testSubAckMessageId() {
         final MqttSubAckMessage msg = MqttMessageBuilders.subAck()
-                .packetId(id)
+                .packetId(id.shortValue())
                 .build();
 
         assertEquals(
@@ -67,13 +67,13 @@ public class MqttMessageBuildersPacketIdTest {
 
     @Test
     public void testPubAckMessageId() {
-        final MqttPubAckMessage msg = MqttMessageBuilders.pubAck()
-                .packetId(id)
+        final MqttMessage msg = MqttMessageBuilders.pubAck()
+                .packetId(id.shortValue())
                 .build();
 
         assertEquals(
                 id.intValue(),
-                msg.variableHeader().messageId()
+                ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId()
         );
     }
 }


### PR DESCRIPTION
Motivation:

Exception occurs in the MQTT message builder class (`io.netty.handler.codec.mqtt.MqttMessageBuilders`) when trying to create a message with packetId > 32767

Modification:

refactor the `short` packetId into `int`
as the underlying `MqttMessageIdVariableHeader` of the message treats it as an `int` anyway.

Result:
see unit-test: `MqttMessageBuildersPacketIdTest`

Fixes #10929 . 
