### PR TITLE
Ensure native methods for unix-native-common are only registered once.

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -48,6 +48,7 @@
 #include "netty_unix_limits.h"
 #include "netty_unix_socket.h"
 #include "netty_unix_util.h"
+#include "netty_unix.h"
 
 // Add define if NETTY_BUILD_STATIC is defined so it is picked up in netty_jni_util.c
 #ifdef NETTY_BUILD_STATIC
@@ -106,6 +107,9 @@ static jfieldID packetScopeIdFieldId = NULL;
 static jfieldID packetPortFieldId = NULL;
 static jfieldID packetMemoryAddressFieldId = NULL;
 static jfieldID packetCountFieldId = NULL;
+
+static const char* staticPackagePrefix = NULL;
+static int register_unix_called = 0;
 
 // util methods
 static int getSysctlValue(const char * property, int* returnValue) {
@@ -523,6 +527,12 @@ static jint netty_epoll_native_tcpMd5SigMaxKeyLen(JNIEnv* env, jclass clazz) {
 
     return TCP_MD5SIG_MAXKEYLEN;
 }
+
+static jint netty_epoll_native_registerUnix(JNIEnv* env, jclass clazz) {
+    register_unix_called = 1;
+    return netty_unix_register(env, staticPackagePrefix);
+}
+
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
@@ -556,7 +566,9 @@ static const JNINativeMethod fixed_method_table[] = {
   // "sendmmsg0" has a dynamic signature
   { "sizeofEpollEvent", "()I", (void *) netty_epoll_native_sizeofEpollEvent },
   { "offsetofEpollData", "()I", (void *) netty_epoll_native_offsetofEpollData },
-  { "splice0", "(IJIJJ)I", (void *) netty_epoll_native_splice0 }
+  { "splice0", "(IJIJJ)I", (void *) netty_epoll_native_splice0 },
+  { "registerUnix", "()I", (void *) netty_epoll_native_registerUnix },
+
 };
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
 
@@ -601,11 +613,6 @@ static jint netty_epoll_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix
     int ret = JNI_ERR;
     int staticallyRegistered = 0;
     int nativeRegistered = 0;
-    int limitsOnLoadCalled = 0;
-    int errorsOnLoadCalled = 0;
-    int filedescriptorOnLoadCalled = 0;
-    int socketOnLoadCalled = 0;
-    int bufferOnLoadCalled = 0;
     int linuxsocketOnLoadCalled = 0;
     char* nettyClassName = NULL;
     jclass nativeDatagramPacketCls = NULL;
@@ -636,32 +643,6 @@ static jint netty_epoll_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix
     }
     nativeRegistered = 1;
 
-    // Load all c modules that we depend upon
-    if (netty_unix_limits_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
-        goto done;
-    }
-    limitsOnLoadCalled = 1;
-
-    if (netty_unix_errors_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
-        goto done;
-    }
-    errorsOnLoadCalled = 1;
-
-    if (netty_unix_filedescriptor_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
-        goto done;
-    }
-    filedescriptorOnLoadCalled = 1;
-
-    if (netty_unix_socket_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
-        goto done;
-    }
-    socketOnLoadCalled = 1;
-
-    if (netty_unix_buffer_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
-        goto done;
-    }
-    bufferOnLoadCalled = 1;
-
     if (netty_epoll_linuxsocket_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
         goto done;
     }
@@ -680,6 +661,10 @@ static jint netty_epoll_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix
     NETTY_JNI_UTIL_GET_FIELD(env, nativeDatagramPacketCls, packetCountFieldId, "count", "I", done);
 
     ret = NETTY_JNI_UTIL_JNI_VERSION;
+
+    if (packagePrefix != NULL) {
+        staticPackagePrefix = strdup(packagePrefix);
+    }
 done:
 
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());
@@ -691,21 +676,6 @@ done:
         }
         if (nativeRegistered == 1) {
             netty_jni_util_unregister_natives(env, packagePrefix, NATIVE_CLASSNAME);
-        }
-        if (limitsOnLoadCalled == 1) {
-            netty_unix_limits_JNI_OnUnLoad(env, packagePrefix);
-        }
-        if (errorsOnLoadCalled == 1) {
-            netty_unix_errors_JNI_OnUnLoad(env, packagePrefix);
-        }
-        if (filedescriptorOnLoadCalled == 1) {
-            netty_unix_filedescriptor_JNI_OnUnLoad(env, packagePrefix);
-        }
-        if (socketOnLoadCalled == 1) {
-            netty_unix_socket_JNI_OnUnLoad(env, packagePrefix);
-        }
-        if (bufferOnLoadCalled == 1) {
-            netty_unix_buffer_JNI_OnUnLoad(env, packagePrefix);
         }
         if (linuxsocketOnLoadCalled == 1) {
             netty_epoll_linuxsocket_JNI_OnUnLoad(env, packagePrefix);
@@ -721,12 +691,16 @@ done:
 }
 
 static void netty_epoll_native_JNI_OnUnload(JNIEnv* env, const char* packagePrefix) {
-    netty_unix_limits_JNI_OnUnLoad(env, packagePrefix);
-    netty_unix_errors_JNI_OnUnLoad(env, packagePrefix);
-    netty_unix_filedescriptor_JNI_OnUnLoad(env, packagePrefix);
-    netty_unix_socket_JNI_OnUnLoad(env, packagePrefix);
-    netty_unix_buffer_JNI_OnUnLoad(env, packagePrefix);
     netty_epoll_linuxsocket_JNI_OnUnLoad(env, packagePrefix);
+
+    if (register_unix_called == 1) {
+        register_unix_called = 0;
+        netty_unix_unregister(env, staticPackagePrefix);
+    }
+    if (staticPackagePrefix != NULL) {
+        free((void *) staticPackagePrefix);
+        staticPackagePrefix = NULL;
+    }
 
     packetAddrFieldId = NULL;
     packetAddrLenFieldId = NULL;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -17,6 +17,7 @@ package io.netty.channel.epoll;
 
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.Socket;
+import io.netty.channel.unix.Unix;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -76,8 +77,15 @@ public final class Native {
                 // Just ignore
             }
         }
-        Socket.initialize();
+        Unix.registerInternal(new Runnable() {
+            @Override
+            public void run() {
+                registerUnix();
+            }
+        });
     }
+
+    private static native int registerUnix();
 
     // EventLoop operations and constants
     public static final int EPOLLIN = epollin();

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -16,7 +16,7 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.unix.FileDescriptor;
-import io.netty.channel.unix.Socket;
+import io.netty.channel.unix.Unix;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -59,8 +59,15 @@ final class Native {
             // The library was not previously loaded, load it now.
             loadNativeLibrary();
         }
-        Socket.initialize();
+        Unix.registerInternal(new Runnable() {
+            @Override
+            public void run() {
+                registerUnix();
+            }
+        });
     }
+
+    private static native int registerUnix();
 
     static final short EV_ADD = evAdd();
     static final short EV_ENABLE = evEnable();

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/UnixTestUtils.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/UnixTestUtils.java
@@ -30,7 +30,7 @@ public final class UnixTestUtils {
                 if (!file.delete()) {
                     throw new IOException("failed to delete: " + file);
                 }
-            } while (file.getAbsolutePath().length() > Socket.UDS_SUN_PATH_SIZE);
+            } while (file.getAbsolutePath().length() > 128);
             return new DomainSocketAddress(file);
         } catch (IOException e) {
             throw new IllegalStateException(e);

--- a/transport-native-unix-common/src/main/c/netty_unix.c
+++ b/transport-native-unix-common/src/main/c/netty_unix.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/transport-native-unix-common/src/main/c/netty_unix.c
+++ b/transport-native-unix-common/src/main/c/netty_unix.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include "netty_unix_jni.h"
+#include "netty_unix.h"
+#include "netty_unix_buffer.h"
+#include "netty_unix_errors.h"
+#include "netty_unix_filedescriptor.h"
+#include "netty_unix_limits.h"
+#include "netty_unix_socket.h"
+#include "netty_unix_util.h"
+
+jint netty_unix_register(JNIEnv* env, const char* packagePrefix) {
+    int limitsOnLoadCalled = 0;
+    int errorsOnLoadCalled = 0;
+    int filedescriptorOnLoadCalled = 0;
+    int socketOnLoadCalled = 0;
+    int bufferOnLoadCalled = 0;
+
+    // Load all c modules that we depend upon
+    if (netty_unix_limits_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
+        goto error;
+    }
+    limitsOnLoadCalled = 1;
+
+    if (netty_unix_errors_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
+        goto error;
+    }
+    errorsOnLoadCalled = 1;
+
+    if (netty_unix_filedescriptor_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
+        goto error;
+    }
+    filedescriptorOnLoadCalled = 1;
+
+    if (netty_unix_socket_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
+        goto error;
+    }
+    socketOnLoadCalled = 1;
+
+    if (netty_unix_buffer_JNI_OnLoad(env, packagePrefix) == JNI_ERR) {
+        goto error;
+    }
+    bufferOnLoadCalled = 1;
+
+    return NETTY_JNI_UTIL_JNI_VERSION;
+error:
+   if (limitsOnLoadCalled == 1) {
+       netty_unix_limits_JNI_OnUnLoad(env, packagePrefix);
+   }
+   if (errorsOnLoadCalled == 1) {
+       netty_unix_errors_JNI_OnUnLoad(env, packagePrefix);
+   }
+   if (filedescriptorOnLoadCalled == 1) {
+       netty_unix_filedescriptor_JNI_OnUnLoad(env, packagePrefix);
+   }
+   if (socketOnLoadCalled == 1) {
+       netty_unix_socket_JNI_OnUnLoad(env, packagePrefix);
+   }
+   if (bufferOnLoadCalled == 1) {
+      netty_unix_buffer_JNI_OnUnLoad(env, packagePrefix);
+   }
+   return JNI_ERR;
+}
+
+void netty_unix_unregister(JNIEnv* env, const char* packagePrefix) {
+    netty_unix_limits_JNI_OnUnLoad(env, packagePrefix);
+    netty_unix_errors_JNI_OnUnLoad(env, packagePrefix);
+    netty_unix_filedescriptor_JNI_OnUnLoad(env, packagePrefix);
+    netty_unix_socket_JNI_OnUnLoad(env, packagePrefix);
+    netty_unix_buffer_JNI_OnUnLoad(env, packagePrefix);
+}
+

--- a/transport-native-unix-common/src/main/c/netty_unix.h
+++ b/transport-native-unix-common/src/main/c/netty_unix.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef NETTY_UNIX_H_
+#define NETTY_UNIX_H_
+
+#include <jni.h>
+
+// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+jint netty_unix_register(JNIEnv* env, const char* packagePrefix);
+void netty_unix_unregister(JNIEnv* env, const char* packagePrefix);
+
+#endif /* NETTY_UNIX_SOCKET_H_ */

--- a/transport-native-unix-common/src/main/c/netty_unix.h
+++ b/transport-native-unix-common/src/main/c/netty_unix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,8 +18,8 @@
 
 #include <jni.h>
 
-// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
+// JNI initialization hooks.
 jint netty_unix_register(JNIEnv* env, const char* packagePrefix);
 void netty_unix_unregister(JNIEnv* env, const char* packagePrefix);
 
-#endif /* NETTY_UNIX_SOCKET_H_ */
+#endif /* NETTY_UNIX_H_ */

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -46,7 +46,8 @@ import static io.netty.channel.unix.NativeInetAddress.ipv4MappedIpv6Address;
  */
 public class Socket extends FileDescriptor {
 
-    public static final int UDS_SUN_PATH_SIZE = udsSunPathSize();
+    @Deprecated
+    public static final int UDS_SUN_PATH_SIZE = 100;
 
     protected final boolean ipv6;
 


### PR DESCRIPTION
Motiviation:

We need to ensure we only register the methods for unix-native-common once as otherwise it may have strange side-effects.

Modifications:

- Add extra method that should be called to signal that we need to register the methods. The registration will only happen once.
- Adjust code to make use of it.

Result:

No more problems due incorrect registration of these methods.