### PR TITLE
Verify we can load native modules and add job that verifies on aarch64 as well

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -58,10 +58,11 @@ jobs:
           # a GitHub package registry.
           githubToken: ${{ github.token }}
 
-          # Mount the artifacts directory as /artifacts in the container
+          # Mount the .m2/repository
           dockerRunArgs: |
             --volume "/home/runner/.m2/repository/:/root/.m2/repository"
 
+          # Install dependencies
           install: |
             apt-get update -q -y
             apt-get install -q -y openjdk-11-jdk autoconf automake libtool make tar maven git

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,6 +30,7 @@ jobs:
         run: mvn verify -B --file pom.xml -DskipTests=true
 
   build-pr-aarch64:
+    name: linux-aarch64-verify-native
     # The host should always be Linux
     runs-on: ubuntu-20.04
     needs: verify-pr

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify:
+  verify-pr:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-    # Cache .m2/repository
+      # Cache .m2/repository
       - uses: actions/cache@v2
         env:
           cache-name: verify-cache-m2-repository
@@ -26,9 +26,50 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pr-${{ env.cache-name }}-
             ${{ runner.os }}-pr-
-
       - name: Verify with Maven
         run: mvn verify -B --file pom.xml -DskipTests=true
+
+  build-pr-aarch64:
+    # The host should always be Linux
+    runs-on: ubuntu-20.04
+    needs: verify-pr
+    steps:
+      - uses: actions/checkout@v2
+
+      # Cache .m2/repository
+      - uses: actions/cache@v2
+        env:
+          cache-name: build-pr-aarch64-cache-m2-repository
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-pr-${{ env.cache-name }}-
+            ${{ runner.os }}-pr-
+
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Run commands
+        id: runcmd
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Mount the artifacts directory as /artifacts in the container
+          dockerRunArgs: |
+            --volume "/home/runner/.m2/repository/:/root/.m2/repository"
+
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y openjdk-11-jdk autoconf automake libtool make tar maven git
+
+          # Compile native code and the modules it depend on and run NativeLoadingTest. This is enough to ensure
+          # we can load the native module on aarch64
+          run: |
+            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64 mvn -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false
 
   build-pr:
     runs-on: ubuntu-latest
@@ -49,7 +90,7 @@ jobs:
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-boringssl-static"
 
     name: ${{ matrix.setup }}
-    needs: verify
+    needs: verify-pr
     steps:
       - uses: actions/checkout@v2
 

--- a/pom.xml
+++ b/pom.xml
@@ -442,6 +442,7 @@
     <module>testsuite-http2</module>
     <module>testsuite-osgi</module>
     <module>testsuite-shading</module>
+    <module>testsuite-native</module>
     <module>testsuite-native-image</module>
     <module>testsuite-native-image-client</module>
     <module>testsuite-native-image-client-runtime-init</module>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -120,9 +120,7 @@
         </dependency>
       </dependencies>
     </profile>
-    <!-- The mac, openbsd and freebsd  profile will only include the native jar for epol to the all jar.
-         If you want to also include the native jar for kqueue use -Puber.
-    -->
+
     <profile>
       <id>mac</id>
       <activation>
@@ -145,7 +143,6 @@
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
         </dependency>
-        <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.1.59.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>netty-testsuite-native</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Netty/Testsuite/Native</name>
+
+  <properties>
+    <skipJapicmp>true</skipJapicmp>
+    <skipNativeTestsuite>false</skipNativeTestsuite>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>skipTests</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <skipNativeTestsuite>true</skipNativeTestsuite>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>linux</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <!-- The mac, openbsd and freebsd  profile will only include the native jar for epol to the all jar.
+         If you want to also include the native jar for kqueue use -Puber.
+    -->
+    <profile>
+      <id>mac</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <scope>compile</scope>
+        </dependency>
+        <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>${skipNativeTestsuite}</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/testsuite-native/src/test/java/io/netty/testsuite_native/NativeLoadingTest.java
+++ b/testsuite-native/src/test/java/io/netty/testsuite_native/NativeLoadingTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite_native;
+
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+public class NativeLoadingTest {
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    public void testNativeLoadingKqueue() {
+        KQueue.ensureAvailability();
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC)
+    public void testNativeLoadingDnsServerAddressStreamProvider() {
+        MacOSDnsServerAddressStreamProvider.ensureAvailability();
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    public void testNativeLoadingEpoll() {
+        Epoll.ensureAvailability();
+    }
+}


### PR DESCRIPTION
Motivation:

As shown in the past we need to verify we actually can load the native as otherwise we may introduce regressions.

Modifications:

- Add new maven module which tests loading of native modules
- Add job that will also test loading on aarch64

Result:

Less likely to introduce regressions related to loading native code in the future