### PR TITLE
Allow blocking calls in UnixResolverDnsServerAddressStreamProvider#parse

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -115,6 +115,10 @@ class Hidden {
                     "sun.security.ssl.SSLEngineImpl",
                     "wrap");
 
+            builder.allowBlockingCallsInside(
+                    "io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider",
+                    "parse");
+
             builder.nonBlockingThreadPredicate(new Function<Predicate<Thread>, Predicate<Thread>>() {
                 @Override
                 public Predicate<Thread> apply(final Predicate<Thread> p) {

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -91,6 +91,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-resolver-dns</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -333,20 +333,24 @@ public class NettyBlockHoundIntegrationTest {
                         }
                     }
                 };
-        CountDownLatch latch = new CountDownLatch(1);
-        List<DnsServerAddressStreamProvider> result = new ArrayList<>();
-        List<Throwable> error = new ArrayList<>();
-        executor.execute(() -> {
-            try {
-                result.add(DnsServerAddressStreamProviders.unixDefault());
-            } catch (Throwable t) {
-                error.add(t);
-            }
-            latch.countDown();
-        });
-        latch.await();
-        assertEquals(0, error.size());
-        assertEquals(1, result.size());
+        try {
+            CountDownLatch latch = new CountDownLatch(1);
+            List<DnsServerAddressStreamProvider> result = new ArrayList<>();
+            List<Throwable> error = new ArrayList<>();
+            executor.execute(() -> {
+                try {
+                    result.add(DnsServerAddressStreamProviders.unixDefault());
+                } catch (Throwable t) {
+                    error.add(t);
+                }
+                latch.countDown();
+            });
+            latch.await();
+            assertEquals(0, error.size());
+            assertEquals(1, result.size());
+        } finally {
+            executor.shutdownGracefully();
+        }
     }
 
     private static void testTrustManagerVerify(String tlsVersion) throws Exception {

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -35,6 +35,8 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.resolver.dns.DnsServerAddressStreamProvider;
+import io.netty.resolver.dns.DnsServerAddressStreamProviders;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -53,6 +55,8 @@ import reactor.blockhound.BlockingOperationError;
 import reactor.blockhound.integration.BlockHoundIntegration;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Queue;
 import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
@@ -69,6 +73,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -312,6 +317,36 @@ public class NettyBlockHoundIntegrationTest {
             group.shutdownGracefully();
             ReferenceCountUtil.release(sslClientCtx);
         }
+    }
+
+    @Test(timeout = 5000L)
+    public void testParseEtcResolverFilesAllowsBlockingCalls() throws InterruptedException {
+        SingleThreadEventExecutor executor =
+                new SingleThreadEventExecutor(null, new DefaultThreadFactory("test"), true) {
+                    @Override
+                    protected void run() {
+                        while (!confirmShutdown()) {
+                            Runnable task = takeTask();
+                            if (task != null) {
+                                task.run();
+                            }
+                        }
+                    }
+                };
+        CountDownLatch latch = new CountDownLatch(1);
+        List<DnsServerAddressStreamProvider> result = new ArrayList<>();
+        List<Throwable> error = new ArrayList<>();
+        executor.execute(() -> {
+            try {
+                result.add(DnsServerAddressStreamProviders.unixDefault());
+            } catch (Throwable t) {
+                error.add(t);
+            }
+            latch.countDown();
+        });
+        latch.await();
+        assertEquals(0, error.size());
+        assertEquals(1, result.size());
     }
 
     private static void testTrustManagerVerify(String tlsVersion) throws Exception {


### PR DESCRIPTION
Motivation:

Internally `UnixResolverDnsServerAddressStreamProvider#parse` calls `FileInputStream.read(...)`
when parsing the `etcResolverFiles`.
This will cause the error below when `BlockHound` is enabled
```
reactor.blockhound.BlockingOperationError: Blocking call! java.io.FileInputStream#readBytes
     	at java.io.FileInputStream.readBytes(FileInputStream.java)
     	at java.io.FileInputStream.read(FileInputStream.java:255)
```

Modifications:

- Add whitelist entry to `BlockHound` configuration
- Add test

Result:

Fixes #10925
