### PR TITLE
Ensure we also build dependent modules for deployments

### DIFF
--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -24,7 +24,7 @@ services:
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean deploy -DskipTests=true"
 
   cross-compile-aarch64-stage-snapshot:
     <<: *cross-compile-aarch64-common
@@ -34,7 +34,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-aarch64-shell:
     <<: *cross-compile-aarch64-common
@@ -42,4 +42,4 @@ services:
 
   cross-compile-aarch64-build:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -pl transport-native-unix-common,transport-native-epoll clean package -Plinux-aarch64 -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -pl transport-native-unix-common,transport-native-epoll -am clean package -Plinux-aarch64 -DskipTests=true"


### PR DESCRIPTION
Motivation:

We need to ensure we also build the modules we depend on as otherwise we may not be able to resolve the dependencies correctly

Modifications:

- Add -am when calling maven

Result:

Deployment works all the time
