### PR TITLE
Make native loading logging less confusing

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -96,7 +96,6 @@ public final class NativeLibraryLoader {
                 load(name, loader);
                 return;
             } catch (Throwable t) {
-                logger.debug("Unable to load the library '{}', trying next name...", name);
                 suppressed.add(t);
             }
         }
@@ -138,11 +137,6 @@ public final class NativeLibraryLoader {
             return;
         } catch (Throwable ex) {
             suppressed.add(ex);
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "{} cannot be loaded from java.library.path, "
-                                + "now trying export to -Dio.netty.native.workdir: {}", name, WORKDIR);
-            }
         }
 
         String libname = System.mapLibraryName(name);
@@ -344,10 +338,8 @@ public final class NativeLibraryLoader {
                 return;
             } catch (UnsatisfiedLinkError e) { // Should by pass the UnsatisfiedLinkError here!
                 suppressed = e;
-                logger.debug("Unable to load the library '{}', trying other loading mechanism.", name);
             } catch (Exception e) {
                 suppressed = e;
-                logger.debug("Unable to load the library '{}', trying other loading mechanism.", name);
             }
             NativeLibraryUtil.loadLibrary(name, absolute);  // Fallback to local helper class.
             logger.debug("Successfully loaded the library {}", name);

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -96,10 +96,11 @@ public final class NativeLibraryLoader {
                 load(name, loader);
                 return;
             } catch (Throwable t) {
+                logger.debug("Unable to load the library '{}', trying next name...", name);
                 suppressed.add(t);
-                logger.debug("Unable to load the library '{}', trying next name...", name, t);
             }
         }
+
         IllegalArgumentException iae =
                 new IllegalArgumentException("Failed to load any of the given libraries: " + Arrays.toString(names));
         ThrowableUtil.addSuppressedAndClear(iae, suppressed);
@@ -140,7 +141,7 @@ public final class NativeLibraryLoader {
             if (logger.isDebugEnabled()) {
                 logger.debug(
                         "{} cannot be loaded from java.library.path, "
-                                + "now trying export to -Dio.netty.native.workdir: {}", name, WORKDIR, ex);
+                                + "now trying export to -Dio.netty.native.workdir: {}", name, WORKDIR);
             }
         }
 
@@ -343,10 +344,10 @@ public final class NativeLibraryLoader {
                 return;
             } catch (UnsatisfiedLinkError e) { // Should by pass the UnsatisfiedLinkError here!
                 suppressed = e;
-                logger.debug("Unable to load the library '{}', trying other loading mechanism.", name, e);
+                logger.debug("Unable to load the library '{}', trying other loading mechanism.", name);
             } catch (Exception e) {
                 suppressed = e;
-                logger.debug("Unable to load the library '{}', trying other loading mechanism.", name, e);
+                logger.debug("Unable to load the library '{}', trying other loading mechanism.", name);
             }
             NativeLibraryUtil.loadLibrary(name, absolute);  // Fallback to local helper class.
             logger.debug("Successfully loaded the library {}", name);


### PR DESCRIPTION
Motivation:

We produced a lot of noise during loading native libraries as we always included the stacktrace if we could not load by one mechanism. We should better just not include the stacktrace in the debugging logging if one mechanism fails. We will log all the stacks anyway when all of the mechanisms fail.

Modifications:

Make logging less aggressive

Result:

Less confusing behaviour for the end-user
