### PR TITLE
Let script fail if one command fail

### DIFF
--- a/.github/scripts/check_leak.sh
+++ b/.github/scripts/check_leak.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [ "$#" -ne 1 ]; then
     echo "Expected build log as argument"


### PR DESCRIPTION
Motivation:

We should use `set -e` to ensure we fail the script if one command fails.

Modifications:

Add set -e to script

Result:

Fail fast