### PR TITLE
Mark some methods as protected to make it easier to write own SslCont…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
@@ -286,7 +286,8 @@ public final class JdkSslClientContext extends JdkSslContext {
                 trustManagerFactory = buildTrustManagerFactory(trustCertCollection, trustManagerFactory, keyStore);
             }
             if (keyCertChain != null) {
-                keyManagerFactory = buildKeyManagerFactory(keyCertChain, key, keyPassword, keyManagerFactory, keyStore);
+                keyManagerFactory = buildKeyManagerFactory(keyCertChain, null,
+                        key, keyPassword, keyManagerFactory, keyStore);
             }
             SSLContext ctx = sslContextProvider == null ? SSLContext.getInstance(PROTOCOL)
                 : SSLContext.getInstance(PROTOCOL, sslContextProvider);

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
@@ -263,7 +263,8 @@ public final class JdkSslServerContext extends JdkSslContext {
                 trustManagerFactory = buildTrustManagerFactory(trustCertCollection, trustManagerFactory, keyStore);
             }
             if (key != null) {
-                keyManagerFactory = buildKeyManagerFactory(keyCertChain, key, keyPassword, keyManagerFactory, null);
+                keyManagerFactory = buildKeyManagerFactory(keyCertChain, null,
+                        key, keyPassword, keyManagerFactory, null);
             }
 
             // Initialize the SSLContext to work with our key managers.

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -49,8 +49,7 @@ import javax.security.auth.x500.X500Principal;
  * {@link ReferenceCountedOpenSslEngine} is called which uses this class's JNI resources the JVM may crash.
  */
 public final class ReferenceCountedOpenSslClientContext extends ReferenceCountedOpenSslContext {
-    private static final InternalLogger logger =
-            InternalLoggerFactory.getInstance(ReferenceCountedOpenSslClientContext.class);
+
     private static final Set<String> SUPPORTED_KEY_TYPES = Collections.unmodifiableSet(new LinkedHashSet<String>(
             Arrays.asList(OpenSslKeyMaterialManager.KEY_TYPE_RSA,
                           OpenSslKeyMaterialManager.KEY_TYPE_DH_RSA,

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -16,6 +16,8 @@
 
 package io.netty.handler.ssl;
 
+import io.netty.handler.ssl.util.KeyManagerFactoryWrapper;
+import io.netty.handler.ssl.util.TrustManagerFactoryWrapper;
 import io.netty.util.internal.UnstableApi;
 
 import javax.net.ssl.KeyManager;

--- a/handler/src/main/java/io/netty/handler/ssl/util/KeyManagerFactoryWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/KeyManagerFactoryWrapper.java
@@ -14,19 +14,18 @@
  * under the License.
  */
 
-package io.netty.handler.ssl;
+package io.netty.handler.ssl.util;
 
-import io.netty.handler.ssl.util.SimpleKeyManagerFactory;
 import io.netty.util.internal.ObjectUtil;
 
 import java.security.KeyStore;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.ManagerFactoryParameters;
 
-final class KeyManagerFactoryWrapper extends SimpleKeyManagerFactory {
+public final class KeyManagerFactoryWrapper extends SimpleKeyManagerFactory {
     private final KeyManager km;
 
-    KeyManagerFactoryWrapper(KeyManager km) {
+    public KeyManagerFactoryWrapper(KeyManager km) {
         this.km = ObjectUtil.checkNotNull(km, "km");
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/util/TrustManagerFactoryWrapper.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/TrustManagerFactoryWrapper.java
@@ -14,19 +14,18 @@
  * under the License.
  */
 
-package io.netty.handler.ssl;
+package io.netty.handler.ssl.util;
 
-import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
 import io.netty.util.internal.ObjectUtil;
 
 import java.security.KeyStore;
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.TrustManager;
 
-final class TrustManagerFactoryWrapper extends SimpleTrustManagerFactory {
+public final class TrustManagerFactoryWrapper extends SimpleTrustManagerFactory {
     private final TrustManager tm;
 
-    TrustManagerFactoryWrapper(TrustManager tm) {
+    public TrustManagerFactoryWrapper(TrustManager tm) {
         this.tm = ObjectUtil.checkNotNull(tm, "tm");
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -2947,7 +2947,8 @@ public abstract class SSLEngineTest {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         KeyManagerFactory kmf = useKeyManagerFactory ?
                 SslContext.buildKeyManagerFactory(
-                        new java.security.cert.X509Certificate[] { ssc.cert()}, ssc.key(), null, null, null) : null;
+                        new java.security.cert.X509Certificate[] { ssc.cert()}, null,
+                        ssc.key(), null, null, null) : null;
 
         SslContextBuilder clientContextBuilder = SslContextBuilder.forClient();
         if (mutualAuth) {
@@ -3509,7 +3510,7 @@ public abstract class SSLEngineTest {
             throws UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException,
             CertificateException, IOException {
         return SslContext.buildKeyManagerFactory(
-                new java.security.cert.X509Certificate[] { ssc.cert() }, ssc.key(), null, null, null);
+                new java.security.cert.X509Certificate[] { ssc.cert() }, null, ssc.key(), null, null, null);
     }
 
     private final class TestTrustManagerFactory extends X509ExtendedTrustManager {

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -260,7 +260,7 @@ final class SniClientJava8TestUtil {
                    IOException, CertificateException {
         return new SniX509KeyManagerFactory(
                 new SNIHostName(hostname), SslContext.buildKeyManagerFactory(
-                new X509Certificate[] { cert.cert() }, cert.key(), null, null, null));
+                new X509Certificate[] { cert.cert() }, null,  cert.key(), null, null, null));
     }
 
     private static final class SniX509KeyManagerFactory extends KeyManagerFactory {

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -113,7 +113,8 @@ public class SniClientTest {
                 KeyManagerFactory kmf = PlatformDependent.javaVersion() >= 8 ?
                         SniClientJava8TestUtil.newSniX509KeyManagerFactory(cert, sniHostName) :
                         SslContext.buildKeyManagerFactory(
-                                new X509Certificate[] { cert.cert() }, cert.key(), null, null, null);
+                                new X509Certificate[] { cert.cert() }, null,
+                                cert.key(), null, null, null);
 
                sslServerContext = SslContextBuilder.forServer(kmf)
                                                    .sslProvider(sslServerProvider)


### PR DESCRIPTION
…ext implementations

Motivation:

We should expose some methods as protected to make it easier to write custom SslContext implementations.
This will be reused by the code for https://github.com/netty/netty-incubator-codec-quic/issues/97

Modifications:

- Add protected to some static methods which are useful for sub-classes
- Remove some unused methods
- Move *Wrapper classes to util package and make these public

Result:

Easier to write custom SslContext implementations
