### PR TITLE
method recycle return change to boolean to tell what recycle is ok

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -1506,7 +1506,9 @@ public final class ByteBufUtil {
                 super.deallocate();
             } else {
                 clear();
-                handle.recycle(this);
+                if (!handle.recycle(this)) {
+                    super.deallocate();
+                }
             }
         }
     }
@@ -1535,7 +1537,9 @@ public final class ByteBufUtil {
                 super.deallocate();
             } else {
                 clear();
-                handle.recycle(this);
+                if (!handle.recycle(this)) {
+                    super.deallocate();
+                }
             }
         }
     }

--- a/common/src/main/java/io/netty/util/internal/ObjectPool.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectPool.java
@@ -42,8 +42,10 @@ public abstract class ObjectPool<T> {
     public interface Handle<T> {
         /**
          * Recycle the {@link Object} if possible and so make it ready to be reused.
+         *
+         * @return {@code true} recycle the {@link Object} otherwise drop it.
          */
-        void recycle(T self);
+        boolean recycle(T self);
     }
 
     /**

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -302,6 +302,16 @@ public class RecyclerTest {
                 " internally", array.length - maxCapacity / 2 <= instancesCount.get());
     }
 
+    @Test
+    public void testRecycleOrDrop() {
+        Recycler<HandledObject> recycler = newRecycler(16);
+        HandledObject object1 = recycler.get();
+        HandledObject object2 = recycler.get();
+
+        assertTrue(object1.recycle());
+        assertFalse(object2.recycle());
+    }
+
     static final class HandledObject {
         Recycler.Handle<HandledObject> handle;
 
@@ -309,8 +319,8 @@ public class RecyclerTest {
             this.handle = handle;
         }
 
-        void recycle() {
-            handle.recycle(this);
+        boolean recycle() {
+            return handle.recycle(this);
         }
     }
 }


### PR DESCRIPTION
Motivation:

Recycler can fail when they try to recycle object, and so it is necessary to inform the caller whether the recycle was successful

Modifications:

1. change Recycler#Handle#recycle return boolean
2. change ObjectPool#Handle#recycle return boolean
3. change ByteBufUtil#ThreadLocalUnsafeDirectByteBuf#deallocate deallocate quickly
4. add new unit tests and change recycle method return

Result:
