### PR TITLE
Use custom script to check for build failures

### DIFF
--- a/.github/scripts/check_build_result.sh
+++ b/.github/scripts/check_build_result.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Expected build log as argument"
+    exit 1
+fi
+
+if grep -q 'BUILD FAILURE' $1 ; then
+    echo "Build failure detected, please inspect build log"
+    exit 1
+else
+    echo "Build successful"
+    exit 0
+fi

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,12 +47,10 @@ jobs:
         run: docker-compose ${{ matrix.docker-compose-build }}
 
       - name: Build project without leak detection
-        run: docker-compose ${{ matrix.docker-compose-run }}
+        run: docker-compose ${{ matrix.docker-compose-run }} | tee build.output
 
-      - name: ${{ matrix.setup }} test-report
-        uses: scacap/action-surefire-report@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checking for test failures
+        run: ./.github/scripts/check_build_result.sh build.output
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -121,10 +121,8 @@ jobs:
       - name: Build project with leak detection
         run: docker-compose ${{ matrix.docker-compose-run }} | tee build-leak.output
 
-      - name: ${{ matrix.setup }} test-report
-        uses: scacap/action-surefire-report@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checking for test failures
+        run: ./.github/scripts/check_build_result.sh build-leak.output
 
       - name: Checking for detected leak
         run: ./.github/scripts/check_leak.sh build-leak.output


### PR DESCRIPTION
Motivation:

It turns out we can't use the action to check for build failures as it can't be used when a PR is done from a fork. Let's just use our simple script.

Modifications:

- Replace action with custom script

Result:

Builds for PRs that are done via forks work again.
