### PR TITLE
Ignore SocketShutdownOutputBySelfTest.testWriteAfterShutdownOutputNoW…

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -26,6 +26,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.oio.OioSocketChannel;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.ServerSocket;
@@ -131,6 +132,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         }
     }
 
+    @Ignore
     @Test(timeout = 30000)
     public void testWriteAfterShutdownOutputNoWritabilityChange() throws Throwable {
         run();


### PR DESCRIPTION
…ritabilityChange

Motivation:

The testWriteAfterShutdownOutputNoWritabilityChange() failed a few times on the CI randomly. Let's skip it for now while we investigate and see if there is anything we can do to make the test less flaky on the CI.

Modifications:

Add @Ignore on the testWriteAfterShutdownOutputNoWritabilityChange method

Result:

Less flaky CI
