### PR TITLE
PemReader should close InputStream after reading certificates / priva…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemReader.java
@@ -58,13 +58,7 @@ final class PemReader {
 
     static ByteBuf[] readCertificates(File file) throws CertificateException {
         try {
-            InputStream in = new FileInputStream(file);
-
-            try {
-                return readCertificates(in);
-            } finally {
-                safeClose(in);
-            }
+            return readCertificates(new FileInputStream(file));
         } catch (FileNotFoundException e) {
             throw new CertificateException("could not find certificate file: " + file);
         }
@@ -103,13 +97,7 @@ final class PemReader {
 
     static ByteBuf readPrivateKey(File file) throws KeyException {
         try {
-            InputStream in = new FileInputStream(file);
-
-            try {
-                return readPrivateKey(in);
-            } finally {
-                safeClose(in);
-            }
+            return readPrivateKey(new FileInputStream(file));
         } catch (FileNotFoundException e) {
             throw new KeyException("could not find key file: " + file);
         }
@@ -149,6 +137,7 @@ final class PemReader {
             return out.toString(CharsetUtil.US_ASCII.name());
         } finally {
             safeClose(out);
+            safeClose(in);
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/PemReaderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PemReaderTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PemReaderTest {
+
+    @Test
+    public void testCertificateInputStreamClosed() throws Exception {
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        TestFilterInputStream inputStream = new TestFilterInputStream(new FileInputStream(ssc.certificate()));
+        ByteBuf[] buffers = PemReader.readCertificates(inputStream);
+        assertEquals(1, buffers.length);
+        buffers[0].release();
+        assertTrue(inputStream.isClosed());
+    }
+
+    @Test
+    public void testPrivateKeyInputStreamClosed() throws Exception {
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        TestFilterInputStream inputStream = new TestFilterInputStream(new FileInputStream(ssc.privateKey()));
+        ByteBuf buffer = PemReader.readPrivateKey(inputStream);
+        buffer.release();
+        assertTrue(inputStream.isClosed());
+    }
+
+    private static final class TestFilterInputStream extends FilterInputStream {
+        private boolean closed;
+
+        TestFilterInputStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                closed = true;
+            }
+        }
+
+        boolean isClosed() {
+            return closed;
+        }
+    }
+}


### PR DESCRIPTION
…te key

Motivation:

At the moment we not close the streams once we are done reading which could lead to ta fd leak if the user not explicit close these. We should just close these once we consumed the streams

Modifications:

- Always close the streams
- Add unit tests

Result:

Fixes https://github.com/netty/netty/issues/10974
