### PR TITLE
Revert "Enable SSL_MODE_ENABLE_FALSE_START if jdkCompatibilityMode is…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -358,8 +358,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 }
 
                 if (!jdkCompatibilityMode) {
-                    SSL.setMode(ssl, SSL.getMode(ssl) | SSL.SSL_MODE_ENABLE_PARTIAL_WRITE
-                            | SSL.SSL_MODE_ENABLE_FALSE_START);
+                    SSL.setMode(ssl, SSL.getMode(ssl) | SSL.SSL_MODE_ENABLE_PARTIAL_WRITE);
                 }
 
                 // setMode may impact the overhead.


### PR DESCRIPTION
… false (#10407)"

Motivation:

TLS_FALSE_START slightly changes the "flow" during handshake which may cause suprises for the end-user. We should better disable it by default again and later add a way to enable it for the user.

Modification:

This reverts commit 514d349e1fa5a057e815a5f3ac6a7e3f3aa19784.

Result:

Restore "old flow" during TLS handshakes.
