### PR TITLE
Fix OutOfMemory in HttpPostMultipartRequestDecoder #10973

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
@@ -321,7 +321,9 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
 
             List<HttpData> list = e.getValue();
             for (HttpData data : list) {
-                data.release();
+                if (data.refCnt() > 0) {
+                    data.release();
+                }
             }
 
             i.remove();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
@@ -975,5 +976,99 @@ public class HttpPostRequestDecoderTest {
         } finally {
             assertTrue(req.release());
         }
+    }
+
+    @Test
+    public void testBIgFileUploadDecoder() throws IOException {
+        int nbChunks = 100;
+        int bytesPerChunk = 1000000;
+        int bytesLastChunk = 10000;
+        int fileSize = bytesPerChunk * nbChunks + bytesLastChunk; // set Xmx to a number lower than this and it crashes
+
+        String prefix = "--861fbeab-cd20-470c-9609-d40a0f704466\n" +
+                        "Content-Disposition: form-data; name=\"image\"; filename=\"guangzhou.jpeg\"\n" +
+                        "Content-Type: image/jpeg\n" +
+                        "Content-Length: " + fileSize + "\n" +
+                        "\n";
+
+        String suffix1 = "\n" +
+                        "--861fbeab-";
+        String suffix2 = "cd20-470c-9609-d40a0f704466--\n";
+        String suffix = suffix1 + suffix2;
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+        request.headers().set("content-type", "multipart/form-data; boundary=861fbeab-cd20-470c-9609-d40a0f704466");
+        request.headers().set("content-length", prefix.length() + fileSize + suffix.length());
+
+        // First Test using Disk
+        HttpDataFactory factory = new DefaultHttpDataFactory(true);
+
+        HttpPostMultipartRequestDecoder decoder = new HttpPostMultipartRequestDecoder(factory, request);
+        decoder.offer(new DefaultHttpContent(Unpooled.wrappedBuffer(prefix.getBytes(CharsetUtil.UTF_8))));
+
+        byte[] body = new byte[bytesPerChunk];
+        Arrays.fill(body, (byte) 1);
+        for (int i = 0; i < nbChunks; i++) {
+            ByteBuf content = Unpooled.wrappedBuffer(body, 0, bytesPerChunk);
+            decoder.offer(new DefaultHttpContent(content)); // **OutOfMemory here**
+            content.release();
+        }
+
+        byte[] bsuffix1 = suffix1.getBytes(CharsetUtil.UTF_8);
+        byte[] lastbody = new byte[bytesLastChunk + bsuffix1.length];
+        Arrays.fill(body, (byte) 1);
+        for (int i = 0; i < bsuffix1.length; i++) {
+            lastbody[bytesLastChunk + i] = bsuffix1[i];
+        }
+
+        ByteBuf content2 = Unpooled.wrappedBuffer(lastbody, 0, lastbody.length);
+        decoder.offer(new DefaultHttpContent(content2));
+        content2.release();
+        content2 = Unpooled.wrappedBuffer(suffix2.getBytes(CharsetUtil.UTF_8));
+        decoder.offer(new DefaultHttpContent(content2));
+        content2.release();
+        decoder.offer(new DefaultLastHttpContent());
+        FileUpload data = (FileUpload) decoder.getBodyHttpDatas().get(0);
+        assertEquals(data.length(), fileSize);
+        assertTrue("Capacity should be less than 10M", decoder.getCurrentAllocatedCapacity()
+                                                       < 10 * 1024 * 1024);
+        // To not be done since will load full file on memory: assertEquals(data.get().length, fileSize);
+        // Not mandatory since implicitely called during destroy of decoder
+        for (InterfaceHttpData httpData: decoder.getBodyHttpDatas()) {
+            httpData.release();
+        }
+        factory.cleanAllHttpData();
+        decoder.destroy();
+
+        // Second Test using Memory
+        factory = new DefaultHttpDataFactory(false);
+
+        decoder = new HttpPostMultipartRequestDecoder(factory, request);
+        decoder.offer(new DefaultHttpContent(Unpooled.wrappedBuffer(prefix.getBytes(CharsetUtil.UTF_8))));
+
+        for (int i = 0; i < nbChunks; i++) {
+            ByteBuf content = Unpooled.wrappedBuffer(body, 0, bytesPerChunk);
+            decoder.offer(new DefaultHttpContent(content)); // **OutOfMemory here**
+            content.release();
+        }
+
+        content2 = Unpooled.wrappedBuffer(lastbody);
+        decoder.offer(new DefaultHttpContent(content2));
+        content2.release();
+        content2 = Unpooled.wrappedBuffer(suffix2.getBytes(CharsetUtil.UTF_8));
+        decoder.offer(new DefaultHttpContent(content2));
+        content2.release();
+        decoder.offer(new DefaultLastHttpContent());
+        data = (FileUpload) decoder.getBodyHttpDatas().get(0);
+        assertEquals(data.length(), fileSize);
+        assertFalse("Capacity should be higher than 10M", decoder.getCurrentAllocatedCapacity()
+                                                          < 10 * 1024 * 1024);
+        // To not be done since will load full file on memory: assertEquals(data.get().length, fileSize);
+        // Mandatory with In Memory Factory
+        for (InterfaceHttpData httpData: decoder.getBodyHttpDatas()) {
+            httpData.release();
+        }
+        factory.cleanAllHttpData();
+        decoder.destroy();
     }
 }


### PR DESCRIPTION
Motivation:

While improvements were made on finding delimiters, when HttpDatas do not fit in memory
while using Mixed or Disk mode in HttpDataFactory, the memory was exhausted.

Modifications:

Change the way `loadDataMultipart` tries to add contents. Instead of waiting to found the delimiter,
it will add the current buffer and, if possible, will try to reuse the current allocated buffer.
As the chunk is a retained buffer from the original one, if the `refCnt()` is 1 after the
`addContent`, then it can be "virtually" released (changing reader and writer indexes).

Note: if the HttpDataFactory is in Memory only, this will not prevent OOME since the full
data will be kept in memory.

Result:

Now the memory cunsumption in Mixed mode or Disk mode is restricted to the minimum.

A test is added to check both in Memory and on Disk behaviors.

Fixes #10973  
