### PR TITLE
Enable stateless resumption for TLSv1.3 by default when using OpenSSL…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -17,7 +17,6 @@ package io.netty.handler.ssl;
 
 import io.netty.internal.tcnative.CertificateCallback;
 import io.netty.util.internal.SuppressJava6Requirement;
-import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.internal.tcnative.SSL;
 import io.netty.internal.tcnative.SSLContext;
 
@@ -55,8 +54,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                           OpenSslKeyMaterialManager.KEY_TYPE_EC,
                           OpenSslKeyMaterialManager.KEY_TYPE_EC_RSA,
                           OpenSslKeyMaterialManager.KEY_TYPE_EC_EC)));
-    private static final boolean ENABLE_SESSION_TICKET =
-            SystemPropertyUtil.getBoolean("jdk.tls.client.enableSessionTicketExtension", false);
+
     private final OpenSslSessionContext sessionContext;
 
     ReferenceCountedOpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
@@ -166,7 +164,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                 throw new SSLException("unable to setup trustmanager", e);
             }
             OpenSslClientSessionContext context = new OpenSslClientSessionContext(thiz, keyMaterialProvider);
-            if (ENABLE_SESSION_TICKET) {
+            if (CLIENT_ENABLE_SESSION_TICKET) {
                 context.setTicketKeys();
             }
             keyMaterialProvider = null;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -93,6 +93,18 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     // TODO: Maybe make configurable ?
     protected static final int VERIFY_DEPTH = 10;
 
+    static final boolean CLIENT_ENABLE_SESSION_TICKET =
+            SystemPropertyUtil.getBoolean("jdk.tls.client.enableSessionTicketExtension", false);
+
+    static final boolean CLIENT_ENABLE_SESSION_TICKET_TLSV13 =
+            SystemPropertyUtil.getBoolean("jdk.tls.client.enableSessionTicketExtension", true);
+
+    static final boolean SERVER_ENABLE_SESSION_TICKET =
+            SystemPropertyUtil.getBoolean("jdk.tls.server.enableSessionTicketExtension", false);
+
+     static final boolean SERVER_ENABLE_SESSION_TICKET_TLSV13 =
+            SystemPropertyUtil.getBoolean("jdk.tls.server.enableSessionTicketExtension", true);
+
     /**
      * The OpenSSL SSL_CTX object.
      *

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -367,6 +367,17 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 }
                 SSL.setMode(ssl, mode);
 
+                if (isProtocolEnabled(SSL.getOptions(ssl), SSL.SSL_OP_NO_TLSv1_3, PROTOCOL_TLS_V1_3)) {
+                    // We should enable session tickets for stateless resumption when TLSv1.3 is enabled. This
+                    // is also done by OpenJDK and without this session resumption does not work at all with BoringSSL
+                    // when TLSv1.3 is used as BoringSSL only supports stateless resumption with TLSv1.3:
+                    //
+                    // See:
+                    //  - https://bugs.openjdk.java.net/browse/JDK-8223922
+                    //  - https://boringssl.googlesource.com/boringssl/+/refs/heads/master/ssl/tls13_server.cc#104
+                    SSL.clearOptions(ssl, SSL.SSL_OP_NO_TICKET);
+                }
+
                 // setMode may impact the overhead.
                 calculateMaxWrapOverhead();
             } catch (Throwable cause) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -368,14 +368,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 SSL.setMode(ssl, mode);
 
                 if (isProtocolEnabled(SSL.getOptions(ssl), SSL.SSL_OP_NO_TLSv1_3, PROTOCOL_TLS_V1_3)) {
-                    boolean enableTickets = false;
-                    if (clientMode) {
-                        if (ReferenceCountedOpenSslContext.CLIENT_ENABLE_SESSION_TICKET_TLSV13) {
-                            enableTickets = true;
-                        }
-                    } else if (ReferenceCountedOpenSslContext.SERVER_ENABLE_SESSION_TICKET_TLSV13) {
-                        enableTickets = true;
-                    }
+                    final boolean enableTickets = clientMode ?
+                            ReferenceCountedOpenSslContext.CLIENT_ENABLE_SESSION_TICKET_TLSV13 :
+                            ReferenceCountedOpenSslContext.SERVER_ENABLE_SESSION_TICKET_TLSV13;
                     if (enableTickets) {
                         // We should enable session tickets for stateless resumption when TLSv1.3 is enabled. This
                         // is also done by OpenJDK and without this session resumption does not work at all with

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -368,14 +368,24 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 SSL.setMode(ssl, mode);
 
                 if (isProtocolEnabled(SSL.getOptions(ssl), SSL.SSL_OP_NO_TLSv1_3, PROTOCOL_TLS_V1_3)) {
-                    // We should enable session tickets for stateless resumption when TLSv1.3 is enabled. This
-                    // is also done by OpenJDK and without this session resumption does not work at all with BoringSSL
-                    // when TLSv1.3 is used as BoringSSL only supports stateless resumption with TLSv1.3:
-                    //
-                    // See:
-                    //  - https://bugs.openjdk.java.net/browse/JDK-8223922
-                    //  - https://boringssl.googlesource.com/boringssl/+/refs/heads/master/ssl/tls13_server.cc#104
-                    SSL.clearOptions(ssl, SSL.SSL_OP_NO_TICKET);
+                    boolean enableTickets = false;
+                    if (clientMode) {
+                        if (ReferenceCountedOpenSslContext.CLIENT_ENABLE_SESSION_TICKET_TLSV13) {
+                            enableTickets = true;
+                        }
+                    } else if (ReferenceCountedOpenSslContext.SERVER_ENABLE_SESSION_TICKET_TLSV13) {
+                        enableTickets = true;
+                    }
+                    if (enableTickets) {
+                        // We should enable session tickets for stateless resumption when TLSv1.3 is enabled. This
+                        // is also done by OpenJDK and without this session resumption does not work at all with
+                        // BoringSSL when TLSv1.3 is used as BoringSSL only supports stateless resumption with TLSv1.3:
+                        //
+                        // See:
+                        //  - https://bugs.openjdk.java.net/browse/JDK-8223922
+                        //  - https://boringssl.googlesource.com/boringssl/+/refs/heads/master/ssl/tls13_server.cc#104
+                        SSL.clearOptions(ssl, SSL.SSL_OP_NO_TICKET);
+                    }
                 }
 
                 // setMode may impact the overhead.

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -53,9 +53,6 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     private static final byte[] ID = {'n', 'e', 't', 't', 'y'};
     private final OpenSslServerSessionContext sessionContext;
 
-    private static final boolean ENABLE_SESSION_TICKET =
-            SystemPropertyUtil.getBoolean("jdk.tls.server.enableSessionTicketExtension", false);
-
     ReferenceCountedOpenSslServerContext(
             X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
@@ -82,7 +79,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
         try {
             sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
                                                       keyCertChain, key, keyPassword, keyManagerFactory, keyStore);
-            if (ENABLE_SESSION_TICKET) {
+            if (SERVER_ENABLE_SESSION_TICKET) {
                 sessionContext.setTicketKeys();
             }
             success = true;


### PR DESCRIPTION
… / BoringSSL

Motivation:

At the moment we always set SSL_OP_NO_TICKET when building our context. The problem with this is that this also disables resumption for TLSv1.3 in BoringSSL as it only supports stateless resumption for TLSv1.3 which uses tickets.
We should better clear this option when TLSv1.3 is enabled to be able to resume sessions. This is also inline with the OpenJDK which enables this for TLSv1.3 by default as well.

Modifications:

Check for enabled protocols and if TLSv1.3 is set clear SSL_OP_NO_TICKET.

Result:

Be able to resume sessions for TLSv1.3 when using BoringSSL.