### PR TITLE
Publish test results after PR run

### DIFF
--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -1,0 +1,32 @@
+name: PR Reports
+on:
+  workflow_run:
+    workflows: [ "Build PR" ]
+    types:
+      - completed
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - setup: linux-x86_64-java8
+          - setup: linux-x86_64-java11
+          - setup: linux-x86_64-java15
+          - setup: linux-x86_64-java11-boringssl
+    steps:
+      - name: Download Artifacts
+        uses: dawidd6/action-download-artifact@v2.11.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          # File location set in ci-pr.yml and must be coordinated.
+          name: test-results-${{ matrix.setup }}
+      - name: Publish Test Report
+        uses: scacap/action-surefire-report@v1.0.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: '**/target/surefire-reports/TEST-*.xml'
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          check_name: test reports

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -91,7 +91,7 @@ jobs:
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-boringssl-static"
 
-    name: ${{ matrix.setup }}
+    name: ${{ matrix.setup }} build
     needs: verify-pr
     steps:
       - uses: actions/checkout@v2
@@ -126,6 +126,13 @@ jobs:
 
       - name: Checking for detected leak
         run: ./.github/scripts/check_leak.sh build-leak.output
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-${{ matrix.setup }}
+          path: '**/target/surefire-reports/TEST-*.xml'
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}


### PR DESCRIPTION
Motivation:

To make it easier to understand why a build failed let us publish the rest results

Modifications:

Use a new workflow to be able to publish the test reports

Result:

Easier to understand why a PR did fail