### PR TITLE
Allow blocking calls when parsing etcResolver/hosts files

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -119,6 +119,18 @@ class Hidden {
                     "io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider",
                     "parse");
 
+            builder.allowBlockingCallsInside(
+                    "io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider",
+                    "parseEtcResolverSearchDomains");
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider",
+                    "parseEtcResolverOptions");
+
+            builder.allowBlockingCallsInside(
+                    "io.netty.resolver.HostsFileParser",
+                    "parse");
+
             builder.nonBlockingThreadPredicate(new Function<Predicate<Thread>, Predicate<Thread>>() {
                 @Override
                 public Predicate<Thread> apply(final Predicate<Thread> p) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
@@ -86,7 +86,7 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
      * the default DNS server to use, and also overrides for individual domains. Also parse list of files of the format
      * <a href="
      * https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man5/resolver.5.html">
-     * /etc/resolver</a> which may contain multiple files to override the name servers used for multimple domains.
+     * /etc/resolver</a> which may contain multiple files to override the name servers used for multiple domains.
      * @param etcResolvConf <a href="https://linux.die.net/man/5/resolver">/etc/resolv.conf</a>.
      * @param etcResolverFiles List of files of the format defined in
      * <a href="
@@ -121,7 +121,7 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
      * the default DNS server to use, and also overrides for individual domains. Also parse a directory of the format
      * <a href="
      * https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man5/resolver.5.html">
-     * /etc/resolver</a> which may contain multiple files to override the name servers used for multimple domains.
+     * /etc/resolver</a> which may contain multiple files to override the name servers used for multiple domains.
      * @param etcResolvConf <a href="https://linux.die.net/man/5/resolver">/etc/resolv.conf</a>.
      * @param etcResolverDir Directory containing files of the format defined in
      * <a href="
@@ -379,7 +379,7 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
                 } else if (line.startsWith(SEARCH_ROW_LABEL)) {
                     int i = indexOfNonWhiteSpace(line, SEARCH_ROW_LABEL.length());
                     if (i >= 0) {
-                        // May contain more then one entry, either seperated by whitespace or tab.
+                        // May contain more then one entry, either separated by whitespace or tab.
                         // See https://linux.die.net/man/5/resolver
                         String[] domains = WHITESPACE_PATTERN.split(line.substring(i));
                         Collections.addAll(searchDomains, domains);


### PR DESCRIPTION
Motivation:

When `etcResolver`/`hosts` files are parsed, `FileInputStream.read(...)` is internally called by

- `UnixResolverDnsServerAddressStreamProvider#parseEtcResolverSearchDomains`
- `UnixResolverDnsServerAddressStreamProvider#parseEtcResolverOptions`
- `HostsFileParser#parse`

This will cause the error below when `BlockHound` is enabled

```
reactor.blockhound.BlockingOperationError: Blocking call! java.io.FileInputStream#readBytes
     	at java.io.FileInputStream.readBytes(FileInputStream.java)
     	at java.io.FileInputStream.read(FileInputStream.java:255)
```

Modifications:

- Add whitelist entries to `BlockHound` configuration
- Fix typos in `UnixResolverDnsServerAddressStreamProvider`
- Add tests

Result:

Fixes #11004
