### PR TITLE
Upgrade graalvm version to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <skipJapicmp>false</skipJapicmp>
-    <graalvm.version>19.0.0</graalvm.version>
+    <graalvm.version>20.3.1</graalvm.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:
The current netty's graalvm dependency version is too low, the latest plug-in fixes some local mirroring problems (https://search.maven.org/artifact/org.graalvm.nativeimage/native-image-maven-plugin/20.3.1 /maven-plugin), so you need to upgrade the plugin
Modification:
Upgrade Graalvm version to the latest version, please review this pr, thank you

