### PR TITLE
Add a profile for debugging tests that run from Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,12 @@
       </properties>
     </profile>
     <profile>
+      <id>ijDebug</id>
+      <properties>
+        <argLine.ijDebug>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</argLine.ijDebug>
+      </properties>
+    </profile>
+    <profile>
       <id>coverage</id>
       <properties>
         <argLine.coverage>${jacoco.argLine}</argLine.coverage>
@@ -362,10 +368,12 @@
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.10</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
+    <argLine.ijDebug /> <!-- Overridden when 'ijDebug' profile is active -->
     <argLine.common>
       -server
       -dsa -da -ea:io.netty...
       -XX:+HeapDumpOnOutOfMemoryError
+      ${argLine.ijDebug}
     </argLine.common>
     <!-- Default to ALPN. See forcenpn profile to force NPN -->
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}=${jetty.alpnAgent.option}</argLine.alpnAgent>


### PR DESCRIPTION
Motivation:
In some cases, Intellij struggles to recreate the build and test
environment/configuration that Maven produces, and this can lead to tests
behaving differently when run from Intellij compared to when they run from
Maven.
This in turn can make debugging those tests harder.

Modification:
Add a profile to the Maven build, that will add the necessary command line
arguments for attaching the Intellij debugger to tests that are executed from
Maven.

Result:
It is now possible to debug the tests that Maven is running, from Intellij,
by enabling the -PijDebug Maven profile.
