### PR TITLE
Revert test debugging flags and update surefire/failsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1321,12 +1321,12 @@
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>2.22.2</version>
         </plugin>
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>2.22.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -298,12 +298,6 @@
       </properties>
     </profile>
     <profile>
-      <id>ijDebug</id>
-      <properties>
-        <argLine.ijDebug>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005</argLine.ijDebug>
-      </properties>
-    </profile>
-    <profile>
       <id>coverage</id>
       <properties>
         <argLine.coverage>${jacoco.argLine}</argLine.coverage>
@@ -368,12 +362,10 @@
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.10</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
-    <argLine.ijDebug /> <!-- Overridden when 'ijDebug' profile is active -->
     <argLine.common>
       -server
       -dsa -da -ea:io.netty...
       -XX:+HeapDumpOnOutOfMemoryError
-      ${argLine.ijDebug}
     </argLine.common>
     <!-- Default to ALPN. See forcenpn profile to force NPN -->
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}=${jetty.alpnAgent.option}</argLine.alpnAgent>


### PR DESCRIPTION
Motivation:

The functionality provided by #11011 already exists natively in the surefire/failsafe plugins by setting the `-Dmaven.surefire.debug` flag.

Modification:

Remove redundant Maven profile.
Also upgrade the surefire/failsafe versions, so they cope better when tests prints to STDOUT.

Result:

Less stuff in our `pom.xml` file, and better console output when our tests are printing stuff.