### PR TITLE
Unify the exception when abstractBootstrap bind.

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -189,9 +189,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
     public ChannelFuture bind() {
         validate();
         SocketAddress localAddress = this.localAddress;
-        if (localAddress == null) {
-            throw new IllegalStateException("localAddress not set");
-        }
+        requireNonNull(localAddress, "localAddress");
         return doBind(localAddress);
     }
 


### PR DESCRIPTION
Nnify the exception when abstractBootstrap bind.

Result:

Fixes #11014 
