### PR TITLE
Doc fix at io.netty.util.concurrent.AbstractEventExecutor#lazyExecute

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -171,7 +171,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
      * Like {@link #execute(Runnable)} but does not guarantee the task will be run until either
      * a non-lazy task is executed or the executor is shut down.
      *
-     * This is equivalent to submitting a {@link EventExecutor.LazyRunnable} to
+     * This is equivalent to submitting a {@link AbstractEventExecutor.LazyRunnable} to
      * {@link #execute(Runnable)} but for an arbitrary {@link Runnable}.
      *
      * The default implementation just delegates to {@link #execute(Runnable)}.


### PR DESCRIPTION
LazyRunnable already move to AbstractEventExecutor.

Fixes #11021

