### PR TITLE
Simplify `flushAtEnd` flag computation in `SslHandler#handlerAdded`

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1963,10 +1963,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         boolean fastOpen = Boolean.TRUE.equals(channel.config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT));
         boolean active = channel.isActive();
         if (active || fastOpen) {
-            // Do not flush the handshake when TCP Fast Open is enabled, unless the channel is active.
+            // Explicitly flush the handshake only if the channel is already active.
             // With TCP Fast Open, we write to the outbound buffer before the TCP connect is established.
-            // The buffer will then be flushed as part of estabilishing the connection, saving us a round-trip.
-            startHandshakeProcessing(active || !fastOpen);
+            // The buffer will then be flushed as part of establishing the connection, saving us a round-trip.
+            startHandshakeProcessing(active);
         }
     }
 


### PR DESCRIPTION
Motivation:

The `!fastOpen` part of `active || !fastOpen` is always false.

Modification:

- Remove `!fastOpen` and keep only `active` as a `flushAtEnd` flag for
`startHandshakeProcessing`;
- Update comment;

Result:

Simplified `flushAtEnd` flag computation in `SslHandler#handlerAdded`.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
