### PR TITLE
Fix the note of allocateNormal

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -152,7 +152,7 @@ final class PoolThreadCache {
     }
 
     /**
-     * Try to allocate a small buffer out of the cache. Returns {@code true} if successful {@code false} otherwise
+     * Try to allocate a normal buffer out of the cache. Returns {@code true} if successful {@code false} otherwise
      */
     boolean allocateNormal(PoolArena<?> area, PooledByteBuf<?> buf, int reqCapacity, int sizeIdx) {
         return allocate(cacheForNormal(area, sizeIdx), buf, reqCapacity);


### PR DESCRIPTION


Motivation:

correct a note of a method in netty/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java

Modification:

origin: Try to allocate a small buffer...
to: Try to allocate a normal buffer...

Result:

