### PR TITLE
Less noisy logging in `DnsServerAddressStreamProviders`

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -67,11 +67,11 @@ public final class DnsServerAddressStreamProviders {
                     throw (Throwable) maybeProvider;
                 }
             } catch (ClassNotFoundException cause) {
-                LOGGER.warn("Can not find {} in the classpath, fallback to system defaults. {}",
-                        MACOS_PROVIDER_CLASS_NAME, "This may result in incorrect DNS resolutions on MacOS.");
+                LOGGER.warn("Can not find {} in the classpath, fallback to system defaults. This may result in "
+                        + "incorrect DNS resolutions on MacOS.", MACOS_PROVIDER_CLASS_NAME);
             } catch (Throwable cause) {
-                LOGGER.error("Unable to load {}, fallback to system defaults. {}", MACOS_PROVIDER_CLASS_NAME,
-                        "This may result in incorrect DNS resolutions on MacOS.", cause);
+                LOGGER.error("Unable to load {}, fallback to system defaults. This may result in "
+                        + "incorrect DNS resolutions on MacOS.", MACOS_PROVIDER_CLASS_NAME, cause);
                 constructor = null;
             }
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -66,14 +66,12 @@ public final class DnsServerAddressStreamProviders {
                 } else {
                     throw (Throwable) maybeProvider;
                 }
+            } catch (ClassNotFoundException cause) {
+                LOGGER.warn("Can not find {} in the classpath, fallback to system defaults. {}",
+                        MACOS_PROVIDER_CLASS_NAME, "This may result in incorrect DNS resolutions on MacOS.");
             } catch (Throwable cause) {
-                if (cause instanceof ClassNotFoundException) {
-                    LOGGER.warn("Unable to load {}, fallback to system defaults. {}", MACOS_PROVIDER_CLASS_NAME,
-                            "This may result in incorrect DNS resolutions on MacOS.");
-                } else {
-                    LOGGER.error("Unable to load {}, fallback to system defaults. {}", MACOS_PROVIDER_CLASS_NAME,
-                            "This may result in incorrect DNS resolutions on MacOS.", cause);
-                }
+                LOGGER.error("Unable to load {}, fallback to system defaults. {}", MACOS_PROVIDER_CLASS_NAME,
+                        "This may result in incorrect DNS resolutions on MacOS.", cause);
                 constructor = null;
             }
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -67,9 +67,13 @@ public final class DnsServerAddressStreamProviders {
                     throw (Throwable) maybeProvider;
                 }
             } catch (Throwable cause) {
-                LOGGER.warn(
-                        "Unable to load {}, fallback to system defaults. {}", MACOS_PROVIDER_CLASS_NAME,
-                        "This may result in incorrect DNS resolutions on MacOS.", cause);
+                if (cause instanceof ClassNotFoundException) {
+                    LOGGER.warn("Unable to load {}, fallback to system defaults. {}", MACOS_PROVIDER_CLASS_NAME,
+                            "This may result in incorrect DNS resolutions on MacOS.");
+                } else {
+                    LOGGER.error("Unable to load {}, fallback to system defaults. {}", MACOS_PROVIDER_CLASS_NAME,
+                            "This may result in incorrect DNS resolutions on MacOS.", cause);
+                }
                 constructor = null;
             }
         }


### PR DESCRIPTION
Motivation:

It is not uncommon to run Netty on OS X without the specific
`MacOSDnsServerAddressStreamProvider`. The current log message is too
verbose because it prints a full stack trace on the console while a
simple logging message would have been enough.

Modifications:

- Print a `WARN` message when `MacOSDnsServerAddressStreamProvider`
class is not found;
- Print a `ERROR` message with a stack trace when the class was found
but could not be loaded due to some other reasons;

Result:

Less noise in logs.

See https://github.com/netty/netty/pull/10848#issuecomment-781499060