### PR TITLE
Add support for UDP_SEGMENT (GSO) when using sendmmsg

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -96,7 +96,7 @@ public final class Native {
 
     public static final boolean IS_SUPPORTING_SENDMMSG = isSupportingSendmmsg();
     static final boolean IS_SUPPORTING_RECVMMSG = isSupportingRecvmmsg();
-
+    static final boolean IS_SUPPORTING_UDP_SEGMENT = isSupportingUdpSegment();
     public static final boolean IS_SUPPORTING_TCP_FASTOPEN = isSupportingTcpFastopen();
     public static final int TCP_MD5SIG_MAXKEYLEN = tcpMd5SigMaxKeyLen();
     public static final String KERNEL_VERSION = kernelVersion();
@@ -109,6 +109,7 @@ public final class Native {
         return new FileDescriptor(timerFd());
     }
 
+    private static native boolean isSupportingUdpSegment();
     private static native int eventFd();
     private static native int timerFd();
     public static native void eventFdWrite(int fd, long value);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
@@ -55,10 +55,10 @@ final class NativeDatagramPacketArray {
     }
 
     boolean addWritable(ByteBuf buf, int index, int len) {
-        return add0(buf, index, len, null);
+        return add0(buf, index, len, 0, null);
     }
 
-    private boolean add0(ByteBuf buf, int index, int len, InetSocketAddress recipient) {
+    private boolean add0(ByteBuf buf, int index, int len, int segmentLen, InetSocketAddress recipient) {
         if (count == packets.length) {
             // We already filled up to UIO_MAX_IOV messages. This is the max allowed per
             // recvmmsg(...) / sendmmsg(...) call, we will try again later.
@@ -73,7 +73,7 @@ final class NativeDatagramPacketArray {
             return false;
         }
         NativeDatagramPacket p = packets[count];
-        p.init(iovArray.memoryAddress(offset), iovArray.count() - offset, recipient);
+        p.init(iovArray.memoryAddress(offset), iovArray.count() - offset, segmentLen, recipient);
 
         count++;
         return true;
@@ -115,11 +115,20 @@ final class NativeDatagramPacketArray {
             if (msg instanceof DatagramPacket) {
                 DatagramPacket packet = (DatagramPacket) msg;
                 ByteBuf buf = packet.content();
-                return add0(buf, buf.readerIndex(), buf.readableBytes(), packet.recipient());
+                int segmentSize = 0;
+                if (packet instanceof SegmentedDatagramPacket) {
+                    int seg = ((SegmentedDatagramPacket) packet).segmentSize();
+                    // We only need to tell the kernel that we want to use UDP_SEGMENT if there are multiple
+                    // segments in the packet.
+                    if (buf.readableBytes() > seg) {
+                        segmentSize = seg;
+                    }
+                }
+                return add0(buf, buf.readerIndex(), buf.readableBytes(), segmentSize, packet.recipient());
             }
             if (msg instanceof ByteBuf && connected) {
                 ByteBuf buf = (ByteBuf) msg;
-                return add0(buf, buf.readerIndex(), buf.readableBytes(), null);
+                return add0(buf, buf.readerIndex(), buf.readableBytes(), 0, null);
             }
             return false;
         }
@@ -137,13 +146,15 @@ final class NativeDatagramPacketArray {
 
         private final byte[] addr = new byte[16];
 
+        private int segmentSize;
         private int addrLen;
         private int scopeId;
         private int port;
 
-        private void init(long memoryAddress, int count, InetSocketAddress recipient) {
+        private void init(long memoryAddress, int count, int segmentSize, InetSocketAddress recipient) {
             this.memoryAddress = memoryAddress;
             this.count = count;
+            this.segmentSize = segmentSize;
 
             if (recipient == null) {
                 this.scopeId = 0;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/SegmentedDatagramPacket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/SegmentedDatagramPacket.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.util.internal.ObjectUtil;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Allows to use <a href="https://blog.cloudflare.com/accelerating-udp-packet-transmission-for-quic/">GSO</a>
+ * if the underlying OS supports it. Before instance and use this class you should check {@link #isSupported()}.
+ */
+public final class SegmentedDatagramPacket extends DatagramPacket {
+
+    private final int segmentSize;
+
+    /**
+     * Create a new instance.
+     *
+     * @param data          the {@link ByteBuf} which must be continguous.
+     * @param segmentSize   the segment size.
+     * @param recipient     the recipient.
+     */
+    public SegmentedDatagramPacket(ByteBuf data, int segmentSize, InetSocketAddress recipient) {
+        super(checkByteBuf(data), recipient);
+        checkIsSupported();
+        this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param data          the {@link ByteBuf} which must be continguous.
+     * @param segmentSize   the segment size.
+     * @param recipient     the recipient.
+     */
+    public SegmentedDatagramPacket(ByteBuf data, int segmentSize,
+                                   InetSocketAddress recipient, InetSocketAddress sender) {
+        super(checkByteBuf(data), recipient, sender);
+        checkIsSupported();
+        this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
+    }
+
+    /**
+     * Returns {@code true} if the underlying system supports GSO.
+     */
+    public static boolean isSupported() {
+        return Epoll.isAvailable() &&
+                // We only support it together with sendmmsg(...)
+                Native.IS_SUPPORTING_SENDMMSG && Native.IS_SUPPORTING_UDP_SEGMENT;
+    }
+
+    /**
+     * Return the size of each segment (the last segment can be smaller).
+     *
+     * @return size of segments.
+     */
+    public int segmentSize() {
+        return segmentSize;
+    }
+
+    @Override
+    public SegmentedDatagramPacket copy() {
+        return new SegmentedDatagramPacket(content().copy(), segmentSize, recipient(), sender());
+    }
+
+    @Override
+    public SegmentedDatagramPacket duplicate() {
+        return new SegmentedDatagramPacket(content().duplicate(), segmentSize, recipient(), sender());
+    }
+
+    @Override
+    public SegmentedDatagramPacket retainedDuplicate() {
+        return new SegmentedDatagramPacket(content().retainedDuplicate(), segmentSize, recipient(), sender());
+    }
+
+    @Override
+    public SegmentedDatagramPacket replace(ByteBuf content) {
+        return new SegmentedDatagramPacket(content, segmentSize, recipient(), sender());
+    }
+
+    @Override
+    public SegmentedDatagramPacket retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public SegmentedDatagramPacket retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public SegmentedDatagramPacket touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public SegmentedDatagramPacket touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
+
+    private static ByteBuf checkByteBuf(ByteBuf buffer) {
+        if (!buffer.isContiguous()) {
+            throw new IllegalArgumentException("Buffer needs to be continguous");
+        }
+        return buffer;
+    }
+
+    private static void checkIsSupported() {
+        if (!isSupported()) {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
@@ -16,11 +16,26 @@
 package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramUnicastTest;
+import org.junit.Assume;
+import org.junit.Test;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.fail;
 
 public class EpollDatagramUnicastTest extends DatagramUnicastTest {
     @Override
@@ -33,5 +48,65 @@ public class EpollDatagramUnicastTest extends DatagramUnicastTest {
         sb.option(EpollChannelOption.IP_RECVORIGDSTADDR, true);
         super.testSimpleSendWithConnect(sb, cb);
         sb.option(EpollChannelOption.IP_RECVORIGDSTADDR, false);
+    }
+
+    @Test
+    public void testSendSegmentedDatagramPacket() throws Throwable {
+        run();
+    }
+
+    public void testSendSegmentedDatagramPacket(Bootstrap sb, Bootstrap cb)
+            throws Throwable {
+        if (!(cb.group() instanceof EpollEventLoopGroup)) {
+            // Only supported for the native epoll transport.
+            return;
+        }
+        Assume.assumeTrue(SegmentedDatagramPacket.isSupported());
+        Channel sc = null;
+        Channel cc = null;
+
+        try {
+            cb.handler(new SimpleChannelInboundHandler() {
+                @Override
+                public void channelRead0(ChannelHandlerContext ctx, Object msgs) throws Exception {
+                    // Nothing will be sent.
+                }
+            });
+
+            final SocketAddress sender;
+            cc = cb.bind(newSocketAddress()).sync().channel();
+
+            final int segmentSize = 512;
+            int bufferCapacity = 16 * segmentSize;
+            final CountDownLatch latch = new CountDownLatch(bufferCapacity / segmentSize);
+            AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
+            sc = sb.handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+                @Override
+                public void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+                    if (packet.content().readableBytes() == segmentSize) {
+                        latch.countDown();
+                    }
+                }
+            }).bind(newSocketAddress()).sync().channel();
+
+            InetSocketAddress addr = sendToAddress((InetSocketAddress) sc.localAddress());
+            ByteBuf buffer = Unpooled.directBuffer(bufferCapacity).writeZero(bufferCapacity);
+            cc.writeAndFlush(new SegmentedDatagramPacket(buffer, segmentSize, addr)).sync();
+
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                Throwable error = errorRef.get();
+                if (error != null) {
+                    throw error;
+                }
+                fail();
+            }
+        } finally {
+            if (cc != null) {
+                cc.close().sync();
+            }
+            if (sc != null) {
+                sc.close().sync();
+            }
+        }
     }
 }

--- a/transport/src/main/java/io/netty/channel/socket/DatagramPacket.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramPacket.java
@@ -24,7 +24,7 @@ import java.net.InetSocketAddress;
 /**
  * The message container that is used for {@link DatagramChannel} to communicate with the remote peer.
  */
-public final class DatagramPacket
+public class DatagramPacket
         extends DefaultAddressedEnvelope<ByteBuf, InetSocketAddress> implements ByteBufHolder {
 
     /**


### PR DESCRIPTION
Motivation:

For protocols like QUIC using UDP_SEGMENT (GSO) can help to reduce the
overhead quite a bit. We should support it.

Modifications:

- Add a SegmentedDatagramPacket which can be used to use UDP_SEGMENT
- Add unit test

Result:

Be able to make use of UDP_SEGMENT