### PR TITLE
Ensure removal from queue happens before writeAndFlush(...) is called

### DIFF
--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -261,11 +261,14 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                     message = Unpooled.EMPTY_BUFFER;
                 }
 
+                if (endOfInput) {
+                    // We meed to remove the element from the queue before we call writeAndFlush() as this operation
+                    // may cause an action that also touches the queue.
+                    queue.remove();
+                }
                 // Flush each chunk to conserve memory
                 ChannelFuture f = ctx.writeAndFlush(message);
                 if (endOfInput) {
-                    queue.remove();
-
                     if (f.isDone()) {
                         handleEndOfInputFuture(f, currentWrite);
                     } else {

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -262,7 +262,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                 }
 
                 if (endOfInput) {
-                    // We meed to remove the element from the queue before we call writeAndFlush() as this operation
+                    // We need to remove the element from the queue before we call writeAndFlush() as this operation
                     // may cause an action that also touches the queue.
                     queue.remove();
                 }


### PR DESCRIPTION
Motivation:

We need to ensure that we call queue.remove() before we cal writeAndFlush() as this operation may cause an event that also touches the queue and remove from it. If we miss to do so we may see NoSuchElementExceptions.

Modifications:

- Call queue.remove() before calling writeAndFlush(...)
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/11046