### PR TITLE
Add tests verifying channel configure/initialisation order

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -275,10 +275,11 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
     ChannelFuture init(Channel channel) {
         ChannelPromise promise = channel.newPromise();
         ChannelPipeline p = channel.pipeline();
-        p.addLast(config.handler());
 
         setChannelOptions(channel, newOptionsArray(), logger);
         setAttributes(channel, newAttributesArray());
+
+        p.addLast(config.handler());
 
         return promise.setSuccess();
     }

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -257,10 +257,10 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         private void initChild(final Channel child) {
             assert child.eventLoop().inEventLoop();
             try {
-                child.pipeline().addLast(childHandler);
-
                 setChannelOptions(child, childOptions, logger);
                 setAttributes(child, childAttrs);
+
+                child.pipeline().addLast(childHandler);
 
                 child.register().addListener((ChannelFutureListener) future -> {
                     if (!future.isSuccess()) {

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -106,6 +106,25 @@ public class BootstrapTest {
         assertEquals(value, attributesArray[0].getValue());
     }
 
+    @Test
+    public void optionsAndAttributesMustBeAvailableOnChannelInit() throws InterruptedException {
+        final AttributeKey<String> key = AttributeKey.valueOf(UUID.randomUUID().toString());
+        new Bootstrap()
+                .group(groupA)
+                .channel(LocalChannel.class)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4242)
+                .attr(key, "value")
+                .handler(new ChannelInitializer<LocalChannel>() {
+                    @Override
+                    protected void initChannel(LocalChannel ch) throws Exception {
+                        Integer option = ch.config().getOption(ChannelOption.CONNECT_TIMEOUT_MILLIS);
+                        assertEquals(4242, (int) option);
+                        assertEquals("value", ch.attr(key).get());
+                    }
+                })
+                .bind(LocalAddress.ANY).sync();
+    }
+
     @Test(timeout = 10000)
     public void testBindDeadLock() throws Exception {
         final Bootstrap bootstrapA = new Bootstrap();

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -17,20 +17,26 @@ package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalHandler;
 import io.netty.channel.local.LocalServerChannel;
+import io.netty.util.AttributeKey;
 import org.junit.Test;
 
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -134,5 +140,38 @@ public class ServerBootstrapTest {
             }
             group.shutdownGracefully();
         }
+    }
+
+    @Test
+    public void optionsAndAttributesMustBeAvailableOnChildChannelInit() throws InterruptedException {
+        EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalHandler.newFactory());
+        LocalAddress addr = new LocalAddress(UUID.randomUUID().toString());
+        final AttributeKey<String> key = AttributeKey.valueOf(UUID.randomUUID().toString());
+        final AtomicBoolean requestServed = new AtomicBoolean();
+        ServerBootstrap sb = new ServerBootstrap()
+                .group(group)
+                .channel(LocalServerChannel.class)
+                .childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4242)
+                .childAttr(key, "value")
+                .childHandler(new ChannelInitializer<LocalChannel>() {
+                    @Override
+                    protected void initChannel(LocalChannel ch) throws Exception {
+                        Integer option = ch.config().getOption(ChannelOption.CONNECT_TIMEOUT_MILLIS);
+                        assertEquals(4242, (int) option);
+                        assertEquals("value", ch.attr(key).get());
+                        requestServed.set(true);
+                    }
+                });
+        Channel serverChannel = sb.bind(addr).syncUninterruptibly().channel();
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(group)
+                .channel(LocalChannel.class)
+                .handler(new ChannelHandler() { });
+        Channel clientChannel = cb.connect(addr).syncUninterruptibly().channel();
+        serverChannel.close().syncUninterruptibly();
+        clientChannel.close().syncUninterruptibly();
+        group.shutdownGracefully();
+        assertTrue(requestServed.get());
     }
 }


### PR DESCRIPTION
Motivation:
Channels need to have their configurations applied before we can call out to user-code via handlerAdded and initChannel.

Modification:
This adds tests for this behaviour, and fixes their failures.

Result:
Channel initialisers now have access to channel configuration and attributes.

Netty companion to #11050
