### PR TITLE
[HttpObjectDecoder] Include hex-value of illegal whitespace char

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -905,7 +905,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             } else if (validateOWS && !isOWS(c)) {
                 // Only OWS is supported for whitespace
                 throw new IllegalArgumentException("Invalid separator, only a single space or horizontal tab allowed," +
-                        " but received a '" + c + "'");
+                        " but received a '" + c + "' (0x" + Integer.toHexString(c) + ")");
             }
         }
         return sb.length();


### PR DESCRIPTION
`HttpObjectDecoder` may throw an `IllegalArgumentException` if it encounters a character that `Character.isWhitespace()` returns `true` for, but is not one of the two valid `OWS` (optional whitespace) values. Such values may not have friendly or readable `toString()` values. We should include the hex value so that the illegal character can always be determined.