### PR TITLE
Introduce HttpMessageDecoderResult to expose decoded header size

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageDecoderResult.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageDecoderResult.java
@@ -24,12 +24,12 @@ import io.netty.handler.codec.DecoderResult;
  * HttpMessageDecoderResult}. It may simply produce a regular {@link DecoderResult}. This result is intended for
  * successful {@link HttpMessage} decoder results.
  */
-public class HttpMessageDecoderResult extends DecoderResult {
+public final class HttpMessageDecoderResult extends DecoderResult {
 
     private final int initialLineLength;
     private final int headerSize;
 
-    protected HttpMessageDecoderResult(int initialLineLength, int headerSize) {
+    HttpMessageDecoderResult(int initialLineLength, int headerSize) {
         super(SIGNAL_SUCCESS);
         this.initialLineLength = initialLineLength;
         this.headerSize = headerSize;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageDecoderResult.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageDecoderResult.java
@@ -36,23 +36,23 @@ public final class HttpMessageDecoderResult extends DecoderResult {
     }
 
     /**
-     * The decoded initial line length, as controlled by {@code maxInitialLineLength}.
+     * The decoded initial line length (in bytes), as controlled by {@code maxInitialLineLength}.
      */
     public int initialLineLength() {
         return initialLineLength;
     }
 
     /**
-     * The decoded header size, as controlled by {@code maxHeaderSize}.
+     * The decoded header size (in bytes), as controlled by {@code maxHeaderSize}.
      */
     public int headerSize() {
         return headerSize;
     }
 
     /**
-     * The decoded initial line length plus the decoded header size.
+     * The decoded initial line length plus the decoded header size (in bytes).
      */
-    public int size() {
+    public int totalSize() {
         return initialLineLength + headerSize;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageDecoderResult.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMessageDecoderResult.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.DecoderResult;
+
+/**
+ * A {@link DecoderResult} for {@link HttpMessage}s as produced by an {@link HttpObjectDecoder}.
+ * <p>
+ * Please note that there is no guarantee that a {@link HttpObjectDecoder} will produce a {@link
+ * HttpMessageDecoderResult}. It may simply produce a regular {@link DecoderResult}. This result is intended for
+ * successful {@link HttpMessage} decoder results.
+ */
+public class HttpMessageDecoderResult extends DecoderResult {
+
+    private final int initialLineLength;
+    private final int headerSize;
+
+    protected HttpMessageDecoderResult(int initialLineLength, int headerSize) {
+        super(SIGNAL_SUCCESS);
+        this.initialLineLength = initialLineLength;
+        this.headerSize = headerSize;
+    }
+
+    /**
+     * The decoded initial line length, as controlled by {@code maxInitialLineLength}.
+     */
+    public int initialLineLength() {
+        return initialLineLength;
+    }
+
+    /**
+     * The decoded header size, as controlled by {@code maxHeaderSize}.
+     */
+    public int headerSize() {
+        return headerSize;
+    }
+
+    /**
+     * The decoded initial line length plus the decoded header size.
+     */
+    public int size() {
+        return initialLineLength + headerSize;
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -629,6 +629,10 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         name = null;
         value = null;
 
+        // Done parsing initial line and headers. Set decoder result.
+        HttpMessageDecoderResult decoderResult = new HttpMessageDecoderResult(lineParser.size, headerParser.size);
+        message.setDecoderResult(decoderResult);
+
         List<String> contentLengthFields = headers.getAll(HttpHeaderNames.CONTENT_LENGTH);
 
         if (!contentLengthFields.isEmpty()) {
@@ -927,7 +931,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     private static class HeaderParser implements ByteProcessor {
         private final AppendableCharSequence seq;
         private final int maxLength;
-        private int size;
+        protected int size;
 
         HeaderParser(AppendableCharSequence seq, int maxLength) {
             this.seq = seq;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -931,7 +931,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     private static class HeaderParser implements ByteProcessor {
         private final AppendableCharSequence seq;
         private final int maxLength;
-        protected int size;
+        int size;
 
         HeaderParser(AppendableCharSequence seq, int maxLength) {
             this.seq = seq;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -495,6 +495,7 @@ public class HttpRequestDecoderTest {
         assertThat(decoderResult.headerSize(), is(35));
         assertThat(decoderResult.totalSize(), is(58));
         HttpContent c = channel.readInbound();
+        c.release();
         assertFalse(channel.finish());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -17,12 +17,10 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.List;
@@ -495,7 +493,7 @@ public class HttpRequestDecoderTest {
         HttpMessageDecoderResult decoderResult = (HttpMessageDecoderResult) request.decoderResult();
         assertThat(decoderResult.initialLineLength(), is(23));
         assertThat(decoderResult.headerSize(), is(35));
-        assertThat(decoderResult.size(), is(58));
+        assertThat(decoderResult.totalSize(), is(58));
         HttpContent c = channel.readInbound();
         assertFalse(channel.finish());
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -496,6 +496,8 @@ public class HttpRequestDecoderTest {
         assertThat(decoderResult.initialLineLength(), is(23));
         assertThat(decoderResult.headerSize(), is(35));
         assertThat(decoderResult.size(), is(58));
+        HttpContent c = channel.readInbound();
+        assertFalse(channel.finish());
     }
 
     private static void testInvalidHeaders0(String requestStr) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -727,4 +727,21 @@ public class HttpResponseDecoderTest {
         assertEquals("netty.io", response.headers().get(HttpHeaderNames.HOST));
         assertFalse(channel.finish());
     }
+
+    @Test
+    public void testHttpMessageDecoderResult() {
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Content-Length: 11\r\n" +
+                "Connection: close\r\n\r\n" +
+                "Lorem ipsum";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertTrue(response.decoderResult().isSuccess());
+        assertThat(response.decoderResult(), instanceOf(HttpMessageDecoderResult.class));
+        HttpMessageDecoderResult decoderResult = (HttpMessageDecoderResult) response.decoderResult();
+        assertThat(decoderResult.initialLineLength(), is(15));
+        assertThat(decoderResult.headerSize(), is(35));
+        assertThat(decoderResult.size(), is(50));
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -743,5 +743,7 @@ public class HttpResponseDecoderTest {
         assertThat(decoderResult.initialLineLength(), is(15));
         assertThat(decoderResult.headerSize(), is(35));
         assertThat(decoderResult.size(), is(50));
+        HttpContent c = channel.readInbound();
+        assertFalse(channel.finish());
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -744,6 +744,7 @@ public class HttpResponseDecoderTest {
         assertThat(decoderResult.headerSize(), is(35));
         assertThat(decoderResult.totalSize(), is(50));
         HttpContent c = channel.readInbound();
+        c.release();
         assertFalse(channel.finish());
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -742,7 +742,7 @@ public class HttpResponseDecoderTest {
         HttpMessageDecoderResult decoderResult = (HttpMessageDecoderResult) response.decoderResult();
         assertThat(decoderResult.initialLineLength(), is(15));
         assertThat(decoderResult.headerSize(), is(35));
-        assertThat(decoderResult.size(), is(50));
+        assertThat(decoderResult.totalSize(), is(50));
         HttpContent c = channel.readInbound();
         assertFalse(channel.finish());
     }


### PR DESCRIPTION
## Motivation

The `HttpObjectDecoder` accepts input parameters for `maxInitialLineLength` and `maxHeaderSize`. These are important variables since both message components must be buffered in memory. As such, many decoders (like Netty and others) introduce constraints. Due to their importance, many users may wish to add instrumentation on the values of successful decoder results, or otherwise be able to access these values to enforce their own supplemental constraints.

While users can perhaps estimate the sizes today, they will not be exact, due to the decoder being responsible for consuming optional whitespace and the like.

## Modifications

* Add `HttpMessageDecoderResult` class. This class extends `DecoderResult` and is intended for `HttpMessage` objects successfully decoded by the `HttpObjectDecoder`. It exposes attributes for the decoded `initialLineLength` and `headerSize`.
* Modify `HttpObjectDecoder` to produce `HttpMessageDecoderResult`s upon successfully decoding the last HTTP header.
* Add corresponding tests to `HttpRequestDecoderTest` & `HttpResponseDecoderTest`.

## Result

Users will be given visibility into the successfully decoded `initialLineLength` and `headerSize`, allowing them to add instrumentation or other user-defined validation.