### PR TITLE
Return correct result for Futures that are returned from UnorderedThr…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/PromiseTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseTask.java
@@ -90,7 +90,7 @@ class PromiseTask<V> extends DefaultPromise<V> implements RunnableFuture<V> {
     }
 
     @SuppressWarnings("unchecked")
-    V runTask() throws Exception {
+    V runTask() throws Throwable {
         final Object task = this.task;
         if (task instanceof Callable) {
             return ((Callable<V>) task).call();

--- a/common/src/main/java/io/netty/util/concurrent/PromiseTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseTask.java
@@ -90,7 +90,7 @@ class PromiseTask<V> extends DefaultPromise<V> implements RunnableFuture<V> {
     }
 
     @SuppressWarnings("unchecked")
-    final V runTask() throws Exception {
+    V runTask() throws Exception {
         final Object task = this.task;
         if (task instanceof Callable) {
             return ((Callable<V>) task).call();

--- a/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -76,7 +76,7 @@ public class UnorderedThreadPoolEventExecutorTest {
     }
 
     @Test
-    public void testGetReturnsCorrectValue() throws Exception {
+    public void testGetReturnsCorrectValueOnSuccess() throws Exception {
         UnorderedThreadPoolEventExecutor executor = new UnorderedThreadPoolEventExecutor(1);
         try {
             final String expected = "expected";
@@ -88,6 +88,24 @@ public class UnorderedThreadPoolEventExecutorTest {
             });
 
             Assert.assertEquals(expected, f.get());
+        } finally {
+            executor.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testGetReturnsCorrectValueOnFailure() throws Exception {
+        UnorderedThreadPoolEventExecutor executor = new UnorderedThreadPoolEventExecutor(1);
+        try {
+            final RuntimeException cause = new RuntimeException();
+            Future<String> f = executor.submit(new Callable<String>() {
+                @Override
+                public String call() {
+                    throw cause;
+                }
+            });
+
+            Assert.assertSame(cause, f.await().cause());
         } finally {
             executor.shutdownGracefully();
         }

--- a/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -18,6 +18,7 @@ package io.netty.util.concurrent;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -70,6 +71,24 @@ public class UnorderedThreadPoolEventExecutorTest {
             latch.await();
         } finally {
             future.cancel(true);
+            executor.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testGetReturnsCorrectValue() throws Exception {
+        UnorderedThreadPoolEventExecutor executor = new UnorderedThreadPoolEventExecutor(1);
+        try {
+            final String expected = "expected";
+            Future<String> f = executor.submit(new Callable<String>() {
+                @Override
+                public String call() {
+                    return expected;
+                }
+            });
+
+            Assert.assertEquals(expected, f.get());
+        } finally {
             executor.shutdownGracefully();
         }
     }


### PR DESCRIPTION
…eadPoolExecutor

Motivation:

Due a regression in fd8c1874b4e24a18c562c7013efabcb155395459 we did not correctly set the result for the returned Future if it was build for a Callable.

Modifications:

- Adjust code to call get() to retrieve the correct result for notification of the future.
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/11072
