### PR TITLE
Make EpollSocketConnectTest correctly configure TFO

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketConnectTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketConnectTest.java
@@ -32,7 +32,7 @@ public class EpollSocketConnectTest extends SocketConnectTest {
 
     @Override
     protected void enableTcpFastOpen(ServerBootstrap sb, Bootstrap cb) {
-        sb.childOption(EpollChannelOption.TCP_FASTOPEN, 5);
+        sb.option(EpollChannelOption.TCP_FASTOPEN, 5);
         cb.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
     }
 }


### PR DESCRIPTION
Motivation:
The EpollSocketConnectTest was not correctly configuring TCP Fast Open on the server socket.
It's an option, not a child option.

Modification:
EpollSocketConnectTest now correctly enables TCP Fast Open on the server side, when available, for the test that needs it.

Result:
Test covers what it was intended to.
