### PR TITLE
absolute paths are not considered as SNI hostnames

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -462,7 +462,8 @@ final class SslUtils {
                hostname.indexOf('.') > 0 &&
                !hostname.endsWith(".") &&
                !NetUtil.isValidIpV4Address(hostname) &&
-               !NetUtil.isValidIpV6Address(hostname);
+               !NetUtil.isValidIpV6Address(hostname) &&
+               !hostname.startsWith("/");
     }
 
     /**


### PR DESCRIPTION
Motivation:

I have a use case where many workloads, communicating through UNIX Domain Sockets, use mutual TLS for authentication.

Before this suggested change, Netty considers absolute paths as valid SNI names. (For example: `/run/service/service.S` would be considered as a valid SNI hostname by Netty.) After doing this validation, Netty ends up [calling](https://github.com/netty/netty/blob/7d4aaa268b8a536f61fbc7711365147c58238745/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java#L63) the SNIHostName constructor which in turn calls IDN.toASCII which in turns throws an exception because foward slash `/` should not be present in a hostname.

Modification:
Netty does not consider hostnames starting with forward slash `/` as valid SNI hostnames.

Result:
TLS over UDS works.
