### PR TITLE
Make CompositeByteBuf throw IllegalStateException when components are missing

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1601,6 +1601,10 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         for (int low = 0, high = componentCount; low <= high;) {
             int mid = low + high >>> 1;
             Component c = components[mid];
+            if (c == null) {
+                throw new IllegalStateException("No component found for offset. " +
+                        "Composite buffer layout might be outdated, e.g. from a discardReadBytes call.");
+            }
             if (offset >= c.endOffset) {
                 low = mid + 1;
             } else if (offset < c.offset) {

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -1614,4 +1614,24 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
             compositeByteBuf.release();
         }
     }
+
+    @Test
+    public void sliceOfCompositeBufferMustThrowISEAfterDiscardBytes() {
+        CompositeByteBuf composite = compositeBuffer();
+        composite.addComponent(true, buffer(8).writeZero(8));
+
+        ByteBuf slice = composite.retainedSlice();
+        composite.skipBytes(slice.readableBytes());
+        composite.discardSomeReadBytes();
+
+        try {
+            slice.readByte();
+            fail("Expected readByte of discarded slice to throw.");
+        } catch (IllegalStateException ignore) {
+            // Good.
+        } finally {
+            slice.release();
+            composite.release();
+        }
+    }
 }


### PR DESCRIPTION
Motivation:
Components in a composite buffer can "go missing" if the composite is a slice of another composite and the parent has changed its layout.

Modification:
Where we would previously have thrown a NullPointerException, we now have a null-check for the component, and we instead throw an IllegalStateException with a more descriptive message.

Result:
It's now a bit easier to understand what is going on in these situations.

Fixes #10908