### PR TITLE
Let's use gcc10 when cross-compiling for LSE support

### DIFF
--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,6 +1,6 @@
 FROM centos:7.6.1810
 
-ARG gcc_version=4.9-2016.02
+ARG gcc_version=10.2-2020.11
 ENV GCC_VERSION $gcc_version
 
 # Install requirements
@@ -9,10 +9,9 @@ RUN yum install -y wget tar git make redhat-lsb-core autoconf automake libtool g
 # Install Java
 RUN yum install -y java-1.8.0-openjdk-devel
 
-# Install aarch64 gcc toolchain
-RUN set -x && \
-  wget https://releases.linaro.org/components/toolchain/binaries/$GCC_VERSION/aarch64-linux-gnu/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz && \
-  tar xvf gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu.tar.xz
+# Install aarch64 gcc 10.2 toolchain
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VERSION/binrel/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && \
+   tar xvf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && mv gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu /opt/
+ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
 
-ENV PATH="/gcc-linaro-$GCC_VERSION-x86_64_aarch64-linux-gnu/bin:${PATH}"
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk/"

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -9,7 +9,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.cross_compile_aarch64
       args:
-        gcc_version: "4.9-2016.02"
+        gcc_version: "10.2-2020.11"
         java_version: "adopt@1.8.0-272"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -307,6 +307,7 @@
                     <arg>${jni.compiler.args.cflags}</arg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                     <configureArg>--host=aarch64-linux-gnu</configureArg>
+                    <configureArg>CC=aarch64-none-linux-gnu-gcc</configureArg>
                   </configureArgs>
                 </configuration>
                 <goals>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -246,8 +246,8 @@
         <!-- use aarch_64 as this is also what os.detected.arch will use on an aarch64 system -->
         <jni.classifier>${os.detected.name}-aarch_64</jni.classifier>
         <jni.platform>linux</jni.platform>
-        <exe.compiler>aarch64-linux-gnu-gcc</exe.compiler>
-        <exe.archiver>aarch64-linux-gnu-ar</exe.archiver>
+        <exe.compiler>aarch64-none-linux-gnu-gcc</exe.compiler>
+        <exe.archiver>arch64-none-linux-gnu-ar</exe.archiver>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Motivation:

LSE (https://mysqlonarm.github.io/ARM-LSE-and-MySQL/) can have a huge performance difference. Let's ensure we use a compiler that can support it.

Modifications:

Update to gc10 when cross-compiling as it supports LSE and enables it by default

Result:

More optized builds for aarch64