### PR TITLE
Remove unnecessary checks in WebSocket08FrameDecoder (IDE highlighted)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -246,7 +246,7 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
                 }
 
                 // check opcode vs message fragmentation state 2/2
-                if (fragmentedFramesCount != 0 && frameOpcode != OPCODE_CONT && frameOpcode != OPCODE_PING) {
+                if (fragmentedFramesCount != 0 && frameOpcode != OPCODE_CONT) {
                     protocolViolation(ctx, in,
                                       "received non-continuation data frame while inside fragmented message");
                     return;
@@ -347,9 +347,7 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
                 if (frameFinalFlag) {
                     // Final frame of the sequence. Apparently ping frames are
                     // allowed in the middle of a fragmented message
-                    if (frameOpcode != OPCODE_PING) {
-                        fragmentedFramesCount = 0;
-                    }
+                    fragmentedFramesCount = 0;
                 } else {
                     // Increment counter
                     fragmentedFramesCount++;


### PR DESCRIPTION
First check `frameOpcode != OPCODE_PING` is removed because the code executed int the branch where` frameOpcode <= 7`, while `OPCODE_PING` is 9.

Second check `frameOpcode != OPCODE_PING` is removed because the above code has:

```
if (frameOpcode == OPCODE_PING) {
   ...
   return;
}
```