### PR TITLE
Use netty-jni-util 0.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.2.Final</version>
+        <version>0.0.3.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>

--- a/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
@@ -36,6 +36,7 @@ static jclass dnsResolverClass = NULL;
 static jclass byteArrayClass = NULL;
 static jclass stringClass = NULL;
 static jmethodID dnsResolverMethodId = NULL;
+static char* staticPackagePrefix = NULL;
 
 // JNI Registered Methods Begin
 
@@ -150,10 +151,15 @@ static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
 
 // JNI Method Registration Table End
 
-static void netty_resolver_dns_native_macos_JNI_OnUnLoad(JNIEnv* env, const char* packagePrefix) {
+static void netty_resolver_dns_native_macos_JNI_OnUnLoad(JNIEnv* env) {
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, byteArrayClass);
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, stringClass);
-    netty_jni_util_unregister_natives(env, packagePrefix, STREAM_CLASSNAME);
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, STREAM_CLASSNAME);
+
+    if (staticPackagePrefix != NULL) {
+        free((void *) staticPackagePrefix);
+        staticPackagePrefix = NULL;
+    }
 }
 
 static jint netty_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
@@ -182,6 +188,10 @@ static jint netty_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, const char* 
 
     NETTY_JNI_UTIL_LOAD_CLASS(env, byteArrayClass, "[B", done);
     NETTY_JNI_UTIL_LOAD_CLASS(env, stringClass, "java/lang/String", done);
+
+    if (packagePrefix != NULL) {
+        staticPackagePrefix = strdup(packagePrefix);
+    }
 
     ret = NETTY_JNI_UTIL_JNI_VERSION;
 done:

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -722,13 +722,17 @@ done:
     return ret;
 }
 
-static void netty_epoll_native_JNI_OnUnload(JNIEnv* env, const char* packagePrefix) {
-    netty_epoll_linuxsocket_JNI_OnUnLoad(env, packagePrefix);
+static void netty_epoll_native_JNI_OnUnload(JNIEnv* env) {
+    netty_epoll_linuxsocket_JNI_OnUnLoad(env, staticPackagePrefix);
 
     if (register_unix_called == 1) {
         register_unix_called = 0;
         netty_unix_unregister(env, staticPackagePrefix);
     }
+
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, STATICALLY_CLASSNAME);
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, NATIVE_CLASSNAME);
+
     if (staticPackagePrefix != NULL) {
         free((void *) staticPackagePrefix);
         staticPackagePrefix = NULL;
@@ -741,9 +745,6 @@ static void netty_epoll_native_JNI_OnUnload(JNIEnv* env, const char* packagePref
     packetPortFieldId = NULL;
     packetMemoryAddressFieldId = NULL;
     packetCountFieldId = NULL;
-
-    netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
-    netty_jni_util_unregister_natives(env, packagePrefix, NATIVE_CLASSNAME);
 }
 
 // Invoked by the JVM when statically linked

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -341,21 +341,22 @@ error:
    return JNI_ERR;
 }
 
-static void netty_kqueue_native_JNI_OnUnload(JNIEnv* env, const char* packagePrefix) {
-    netty_kqueue_bsdsocket_JNI_OnUnLoad(env, packagePrefix);
-    netty_kqueue_eventarray_JNI_OnUnLoad(env, packagePrefix);
+static void netty_kqueue_native_JNI_OnUnload(JNIEnv* env) {
+    netty_kqueue_bsdsocket_JNI_OnUnLoad(env, staticPackagePrefix);
+    netty_kqueue_eventarray_JNI_OnUnLoad(env, staticPackagePrefix);
 
     if (register_unix_called == 1) {
         register_unix_called = 0;
         netty_unix_unregister(env, staticPackagePrefix);
     }
+
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, STATICALLY_CLASSNAME);
+    netty_jni_util_unregister_natives(env, staticPackagePrefix, NATIVE_CLASSNAME);
+
     if (staticPackagePrefix != NULL) {
         free((void *) staticPackagePrefix);
         staticPackagePrefix = NULL;
     }
-
-    netty_jni_util_unregister_natives(env, packagePrefix, STATICALLY_CLASSNAME);
-    netty_jni_util_unregister_natives(env, packagePrefix, NATIVE_CLASSNAME);
 }
 
 // We build with -fvisibility=hidden so ensure we mark everything that needs to be visible with JNIEXPORT


### PR DESCRIPTION
netty-jni-util 0.0.2.Final is incompatible with static linking. Before
the netty-jni-util dependency was introduced netty-tcnative supported
static linking via NETTY_BUILD_STATIC. netty-jni-util 0.0.3.Final adds
static linking compatibility.

Modifications:

Bump netty-jni-util to version 0.0.3.Final and update to its new API
which requires the caller to manage packagePrefix.

Result:

Using latest version of netty-jni-util and restored static linking
compatibility.

