### PR TITLE
Fix build for aarch64

### DIFF
--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -247,7 +247,7 @@
         <jni.classifier>${os.detected.name}-aarch_64</jni.classifier>
         <jni.platform>linux</jni.platform>
         <exe.compiler>aarch64-none-linux-gnu-gcc</exe.compiler>
-        <exe.archiver>arch64-none-linux-gnu-ar</exe.archiver>
+        <exe.archiver>aarch64-none-linux-gnu-ar</exe.archiver>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Motivation:

We had a typo and so the build for aarch64 failed before

Modifications:

Fix typo

Result:

Build for aarch64 works again