### PR TITLE
Less blocking in ChunkedStream

### DIFF
--- a/handler/src/main/java/io/netty/handler/stream/ChunkedStream.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedStream.java
@@ -79,6 +79,9 @@ public class ChunkedStream implements ChunkedInput<ByteBuf> {
         if (closed) {
             return true;
         }
+        if (in.available() > 0) {
+            return false;
+        }
 
         int b = in.read();
         if (b < 0) {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -155,7 +155,7 @@ public class EpollSocketChannelConfigTest {
             if (!(e.getCause() instanceof ClosedChannelException)) {
                 AssertionError error = new AssertionError(
                         "Expected the suppressed exception to be an instance of ClosedChannelException.");
-                error.addSuppressed(e.getCause());
+                error.addSuppressed(e);
                 throw error;
             }
         }


### PR DESCRIPTION
Motivation:
We should avoid blocking in the event loop as much as possible.
The InputStream.read() is a blocking method, and we don't need to call it if available() returns a positive number.

Modification:
Bypass calling InputStream.read() if available() returns a positive number.

Result:
Fewer blocking calls in the event loop, in general, when ChunkedStream is used.

Fixes #11147
