### PR TITLE
BouncyCastle support

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastle.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastle.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SSLEngine;
+
+/**
+ * Contains methods that can be used to detect if BouncyCastle is usable.
+ */
+final class BouncyCastle {
+
+    private static final boolean BOUNCY_CASTLE_ON_CLASSPATH;
+
+    static {
+        boolean bcOnClasspath = false;
+        try {
+            Class.forName("org.bouncycastle.jsse.provider.BouncyCastleJsseProvider");
+            bcOnClasspath = true;
+        } catch (Throwable ignore) {
+            // ignore
+        }
+        BOUNCY_CASTLE_ON_CLASSPATH = bcOnClasspath;
+    }
+
+    /**
+     * Indicates whether or not BouncyCastle is available on the current system.
+     */
+    static boolean isAvailable() {
+        return BOUNCY_CASTLE_ON_CLASSPATH;
+    }
+
+    /**
+     * Indicates whether or not BouncyCastle is the underlying SSLEngine.
+     */
+    static boolean isInUse(SSLEngine engine) {
+        return engine.getClass().getPackage().getName().startsWith("org.bouncycastle.jsse.provider");
+    }
+
+    private BouncyCastle() {
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslEngine.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.util.internal.SuppressJava6Requirement;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import javax.net.ssl.SSLEngine;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+@SuppressJava6Requirement(reason = "Usage guarded by java version check")
+final class BouncyCastleAlpnSslEngine extends JdkAlpnSslEngine {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(BouncyCastleAlpnSslEngine.class);
+
+    BouncyCastleAlpnSslEngine(SSLEngine engine,
+                     @SuppressWarnings("deprecation") JdkApplicationProtocolNegotiator applicationNegotiator,
+                     boolean isServer) {
+        super(engine, applicationNegotiator, isServer,
+                new BiConsumer<SSLEngine, AlpnSelector>() {
+                    @Override
+                    public void accept(SSLEngine e, AlpnSelector s) {
+                        BouncyCastleAlpnSslUtils.setHandshakeApplicationProtocolSelector(e, s);
+                    }
+                },
+                new BiConsumer<SSLEngine, List<String>>() {
+                    @Override
+                    public void accept(SSLEngine e, List<String> p) {
+                        BouncyCastleAlpnSslUtils.setApplicationProtocols(e, p);
+                    }
+                });
+    }
+
+    public String getApplicationProtocol() {
+        return BouncyCastleAlpnSslUtils.getApplicationProtocol(getWrappedEngine());
+    }
+
+    public String getHandshakeApplicationProtocol() {
+        return BouncyCastleAlpnSslUtils.getHandshakeApplicationProtocol(getWrappedEngine());
+    }
+
+    public void setHandshakeApplicationProtocolSelector(BiFunction<SSLEngine, List<String>, String> selector) {
+        BouncyCastleAlpnSslUtils.setHandshakeApplicationProtocolSelector(getWrappedEngine(), selector);
+    }
+
+    public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
+        return BouncyCastleAlpnSslUtils.getHandshakeApplicationProtocolSelector(getWrappedEngine());
+    }
+
+}

--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslUtils.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.SuppressJava6Requirement;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.util.List;
+import java.util.function.BiFunction;
+
+@SuppressJava6Requirement(reason = "Usage guarded by java version check")
+final class BouncyCastleAlpnSslUtils {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(BouncyCastleAlpnSslUtils.class);
+    private static final Class BC_SSL_PARAMETERS;
+    private static final Method SET_PARAMETERS;
+    private static final Method SET_APPLICATION_PROTOCOLS;
+    private static final Method GET_APPLICATION_PROTOCOL;
+    private static final Method GET_HANDSHAKE_APPLICATION_PROTOCOL;
+    private static final Method SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR;
+    private static final Method GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR;
+    private static final Class BC_APPLICATION_PROTOCOL_SELECTOR;
+    private static final Method BC_APPLICATION_PROTOCOL_SELECTOR_SELECT;
+
+    static {
+        Class bcSslEngine;
+        Class bcSslParameters;
+        Method setParameters;
+        Method setApplicationProtocols;
+        Method getApplicationProtocol;
+        Method getHandshakeApplicationProtocol;
+        Method setHandshakeApplicationProtocolSelector;
+        Method getHandshakeApplicationProtocolSelector;
+        Method bcApplicationProtocolSelectorSelect;
+        Class bcApplicationProtocolSelector;
+
+        try {
+            bcSslEngine = Class.forName("org.bouncycastle.jsse.BCSSLEngine");
+            final Class testBCSslEngine = bcSslEngine;
+
+            bcSslParameters = Class.forName("org.bouncycastle.jsse.BCSSLParameters");
+            Object bcSslParametersInstance = bcSslParameters.newInstance();
+            final Class testBCSslParameters = bcSslParameters;
+
+            bcApplicationProtocolSelector =
+                    Class.forName("org.bouncycastle.jsse.BCApplicationProtocolSelector");
+
+            final Class testBCApplicationProtocolSelector = bcApplicationProtocolSelector;
+
+            bcApplicationProtocolSelectorSelect = AccessController.doPrivileged(
+                    new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return testBCApplicationProtocolSelector.getMethod("select", Object.class, List.class);
+                }
+            });
+
+            SSLContext context = SSLContext.getInstance("TLSV1.2", "BCJSSE");
+            context.init(null, null, null);
+            SSLEngine engine = context.createSSLEngine();
+            setParameters = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return testBCSslEngine.getMethod("setParameters", testBCSslParameters);
+                }
+            });
+            setParameters.invoke(engine, bcSslParametersInstance);
+
+            setApplicationProtocols = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return testBCSslParameters.getMethod("setApplicationProtocols", String[].class);
+                }
+            });
+            setApplicationProtocols.invoke(bcSslParametersInstance, new Object[]{EmptyArrays.EMPTY_STRINGS});
+
+            getApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return testBCSslEngine.getMethod("getApplicationProtocol");
+                }
+            });
+            getApplicationProtocol.invoke(engine);
+
+            getHandshakeApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return testBCSslEngine.getMethod("getHandshakeApplicationProtocol");
+                }
+            });
+            getHandshakeApplicationProtocol.invoke(engine);
+
+            setHandshakeApplicationProtocolSelector =
+                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                        @Override
+                        public Method run() throws Exception {
+                            return testBCSslEngine.getMethod("setBCHandshakeApplicationProtocolSelector",
+                                    testBCApplicationProtocolSelector);
+                        }
+                    });
+
+            getHandshakeApplicationProtocolSelector =
+                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                        @Override
+                        public Method run() throws Exception {
+                            return testBCSslEngine.getMethod("getBCHandshakeApplicationProtocolSelector");
+                        }
+                    });
+            getHandshakeApplicationProtocolSelector.invoke(engine);
+
+        } catch (Throwable t) {
+            logger.error("Unable to initialize BouncyCastleAlpnSslUtils.", t);
+            bcSslParameters = null;
+            setParameters = null;
+            setApplicationProtocols = null;
+            getApplicationProtocol = null;
+            getHandshakeApplicationProtocol = null;
+            setHandshakeApplicationProtocolSelector = null;
+            getHandshakeApplicationProtocolSelector = null;
+            bcApplicationProtocolSelectorSelect = null;
+            bcApplicationProtocolSelector = null;
+        }
+        BC_SSL_PARAMETERS = bcSslParameters;
+        SET_PARAMETERS = setParameters;
+        SET_APPLICATION_PROTOCOLS = setApplicationProtocols;
+        GET_APPLICATION_PROTOCOL = getApplicationProtocol;
+        GET_HANDSHAKE_APPLICATION_PROTOCOL = getHandshakeApplicationProtocol;
+        SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR = setHandshakeApplicationProtocolSelector;
+        GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR = getHandshakeApplicationProtocolSelector;
+        BC_APPLICATION_PROTOCOL_SELECTOR_SELECT = bcApplicationProtocolSelectorSelect;
+        BC_APPLICATION_PROTOCOL_SELECTOR = bcApplicationProtocolSelector;
+    }
+
+    private BouncyCastleAlpnSslUtils() {
+    }
+
+    static String getApplicationProtocol(SSLEngine sslEngine) {
+        try {
+            return (String) GET_APPLICATION_PROTOCOL.invoke(sslEngine);
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    static void setApplicationProtocols(SSLEngine engine, List<String> supportedProtocols) {
+        SSLParameters parameters = engine.getSSLParameters();
+
+        String[] protocolArray = supportedProtocols.toArray(EmptyArrays.EMPTY_STRINGS);
+        try {
+            Object bcSslParameters = BC_SSL_PARAMETERS.newInstance();
+            SET_APPLICATION_PROTOCOLS.invoke(bcSslParameters, new Object[]{protocolArray});
+            SET_PARAMETERS.invoke(engine, bcSslParameters);
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+        engine.setSSLParameters(parameters);
+    }
+
+    static String getHandshakeApplicationProtocol(SSLEngine sslEngine) {
+        try {
+            return (String) GET_HANDSHAKE_APPLICATION_PROTOCOL.invoke(sslEngine);
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    static void setHandshakeApplicationProtocolSelector(
+            SSLEngine engine, final BiFunction<SSLEngine, List<String>, String> selector) {
+        try {
+            Object selectorProxyInstance = Proxy.newProxyInstance(
+                    BouncyCastleAlpnSslUtils.class.getClassLoader(),
+                    new Class[]{BC_APPLICATION_PROTOCOL_SELECTOR},
+                    new InvocationHandler() {
+                        @Override
+                        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                            if (method.getName().equals("select")) {
+                                try {
+                                    return selector.apply((SSLEngine) args[0], (List<String>) args[1]);
+                                } catch (ClassCastException e) {
+                                    throw new RuntimeException("BCApplicationProtocolSelector select method " +
+                                            "parameter of invalid type.", e);
+                                }
+                            } else {
+                                throw new UnsupportedOperationException(String.format("Method '%s' not supported.",
+                                        method.getName()));
+                            }
+                        }
+                    });
+
+            SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invoke(engine, selectorProxyInstance);
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector(SSLEngine engine) {
+        try {
+            final Object selector = GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invoke(engine);
+            return new BiFunction<SSLEngine, List<String>, String>() {
+
+                @Override
+                public String apply(SSLEngine sslEngine, List<String> strings) {
+                    try {
+                        return (String) BC_APPLICATION_PROTOCOL_SELECTOR_SELECT.invoke(selector, sslEngine,
+                                strings);
+                    } catch (Exception e) {
+                        throw new RuntimeException("Could not call getHandshakeApplicationProtocolSelector", e);
+                    }
+                }
+            };
+
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+}

--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.PlatformDependent;
 
 import javax.net.ssl.SSLEngine;
 
@@ -28,7 +29,8 @@ import javax.net.ssl.SSLEngine;
 public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicationProtocolNegotiator {
     private static final boolean AVAILABLE = Conscrypt.isAvailable() ||
                                              JdkAlpnSslUtils.supportsAlpn() ||
-                                             JettyAlpnSslEngine.isAvailable();
+                                             JettyAlpnSslEngine.isAvailable() ||
+                                             BouncyCastle.isAvailable();
 
     private static final SslEngineWrapperFactory ALPN_WRAPPER = AVAILABLE ? new AlpnWrapper() : new FailureWrapper();
 
@@ -132,6 +134,9 @@ public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicati
             if (Conscrypt.isEngineSupported(engine)) {
                 return isServer ? ConscryptAlpnSslEngine.newServerEngine(engine, alloc, applicationNegotiator)
                         : ConscryptAlpnSslEngine.newClientEngine(engine, alloc, applicationNegotiator);
+            }
+            if (BouncyCastle.isInUse(engine)) {
+                return new BouncyCastleAlpnSslEngine(engine, applicationNegotiator, isServer);
             }
             // ALPN support was recently backported to Java8 as
             // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8230977.

--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -16,7 +16,6 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.internal.PlatformDependent;
 
 import javax.net.ssl.SSLEngine;
 


### PR DESCRIPTION
Motivation:

I experienced an [issue](https://github.com/chhsiao90/nitmproxy/issues/7) under Android not being able to load a web page. It might be related to ALPN of the internal TLS implementation. I was trying BouncyCastle as a replacement but this was not supported by Netty. So I added this.
Also BouncyCastle is a pure Java solution, all the other providers (OpenSSL, Conscrypt) require native libraries which are not available under Android at least.

Modification:

I added a `BouncyCastleAlpnSslEngine.java` and support classes. It is relying on the JDK code, hence I had to open some classes to prevent code duplication.

Maybe you can point be to some test cases to reuse.

Result:

BouncyCastle can be used as TLS provider with:

~~~java
                Security.insertProviderAt(new BouncyCastleJsseProvider(), 1);
                Security.addProvider(new BouncyCastleProvider());
                Security.addProvider(new SecureRandomProvider());
~~~

SecureRandomProvider is a necessary fix for BouncyCastle otherwise a `Caused by: java.lang.IllegalStateException: unable to create JcaTlsCrypto: DEFAULT SecureRandom not available` exception is thrown. This problem is BC related.

~~~java
/**
 * A JCE security provider for fixing: Caused by: java.lang.IllegalStateException: unable to create JcaTlsCrypto: DEFAULT SecureRandom not available for BouncyCastle when using bctls.
 */
public class SecureRandomProvider extends Provider {
    public static final String PROVIDER_NAME = "SecureRandom";

    public SecureRandomProvider() {
        super(PROVIDER_NAME, 1.0, "SecureRandom provider.");

        putService(new Service(this, "SecureRandom", "DEFAULT",
                SecureRandom.class.getName(), null, null));

    }

    public static class SecureRandom extends SecureRandomSpi {

        private final java.security.SecureRandom SECURE_RANDOM = new java.security.SecureRandom();

        @Override
        protected void engineSetSeed(byte[] seed) {
            SECURE_RANDOM.setSeed(seed);
        }

        @Override
        protected void engineNextBytes(byte[] bytes) {
            SECURE_RANDOM.nextBytes(bytes);
        }

        @Override
        protected byte[] engineGenerateSeed(int numBytes) {
            return SECURE_RANDOM.generateSeed(numBytes);
        }
    }
}
~~~



