### PR TITLE
Log fewer stack traces from initialisation code

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -125,7 +125,11 @@ final class PlatformDependent0 {
             if (maybeUnsafe instanceof Throwable) {
                 unsafe = null;
                 unsafeUnavailabilityCause = (Throwable) maybeUnsafe;
-                logger.debug("sun.misc.Unsafe.theUnsafe: unavailable", (Throwable) maybeUnsafe);
+                if (logger.isTraceEnabled()) {
+                    logger.debug("sun.misc.Unsafe.theUnsafe: unavailable", (Throwable) maybeUnsafe);
+                } else {
+                    logger.debug("sun.misc.Unsafe.theUnsafe: unavailable: {}", ((Throwable) maybeUnsafe).getMessage());
+                }
             } else {
                 unsafe = (Unsafe) maybeUnsafe;
                 logger.debug("sun.misc.Unsafe.theUnsafe: available");
@@ -157,7 +161,12 @@ final class PlatformDependent0 {
                     // Unsafe.copyMemory(Object, long, Object, long, long) unavailable.
                     unsafe = null;
                     unsafeUnavailabilityCause = (Throwable) maybeException;
-                    logger.debug("sun.misc.Unsafe.copyMemory: unavailable", (Throwable) maybeException);
+                    if (logger.isTraceEnabled()) {
+                        logger.debug("sun.misc.Unsafe.copyMemory: unavailable", (Throwable) maybeException);
+                    } else {
+                        logger.debug("sun.misc.Unsafe.copyMemory: unavailable: {}",
+                                ((Throwable) maybeException).getMessage());
+                    }
                 }
             }
 
@@ -193,7 +202,12 @@ final class PlatformDependent0 {
                     logger.debug("java.nio.Buffer.address: available");
                 } else {
                     unsafeUnavailabilityCause = (Throwable) maybeAddressField;
-                    logger.debug("java.nio.Buffer.address: unavailable", (Throwable) maybeAddressField);
+                    if (logger.isTraceEnabled()) {
+                        logger.debug("java.nio.Buffer.address: unavailable", (Throwable) maybeAddressField);
+                    } else {
+                        logger.debug("java.nio.Buffer.address: unavailable: {}",
+                                ((Throwable) maybeAddressField).getMessage());
+                    }
 
                     // If we cannot access the address of a direct buffer, there's no point of using unsafe.
                     // Let's just pretend unsafe is unavailable for overall simplicity.
@@ -264,9 +278,13 @@ final class PlatformDependent0 {
                         directBufferConstructor = null;
                     }
                 } else {
-                    logger.debug(
-                            "direct buffer constructor: unavailable",
-                            (Throwable) maybeDirectBufferConstructor);
+                    if (logger.isTraceEnabled()) {
+                        logger.debug("direct buffer constructor: unavailable",
+                                (Throwable) maybeDirectBufferConstructor);
+                    } else {
+                        logger.debug("direct buffer constructor: unavailable: {}",
+                                ((Throwable) maybeDirectBufferConstructor).getMessage());
+                    }
                     directBufferConstructor = null;
                 }
             } finally {
@@ -335,7 +353,11 @@ final class PlatformDependent0 {
                 //noinspection DynamicRegexReplaceableByCompiledPattern
                 unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64)$");
                 Throwable t = (Throwable) maybeUnaligned;
-                logger.debug("java.nio.Bits.unaligned: unavailable {}", unaligned, t);
+                if (logger.isTraceEnabled()) {
+                    logger.debug("java.nio.Bits.unaligned: unavailable, {}", unaligned, t);
+                } else {
+                    logger.debug("java.nio.Bits.unaligned: unavailable, {}, {}", unaligned, t.getMessage());
+                }
             }
 
             UNALIGNED = unaligned;
@@ -388,8 +410,13 @@ final class PlatformDependent0 {
                 }
 
                 if (maybeException instanceof Throwable) {
-                    logger.debug("jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable",
-                            (Throwable) maybeException);
+                    if (logger.isTraceEnabled()) {
+                        logger.debug("jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable",
+                                (Throwable) maybeException);
+                    } else {
+                        logger.debug("jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable: {}",
+                                ((Throwable) maybeException).getMessage());
+                    }
                 } else {
                     logger.debug("jdk.internal.misc.Unsafe.allocateUninitializedArray(int): available");
                 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslMasterKeyHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslMasterKeyHandler.java
@@ -71,7 +71,11 @@ public abstract class SslMasterKeyHandler extends ChannelInboundHandlerAdapter {
             cause = ReflectionUtil.trySetAccessible(field, true);
         } catch (Throwable e) {
             cause = e;
-            logger.debug("sun.security.ssl.SSLSessionImpl is unavailable.", e);
+            if (logger.isTraceEnabled()) {
+                logger.debug("sun.security.ssl.SSLSessionImpl is unavailable.", e);
+            } else {
+                logger.debug("sun.security.ssl.SSLSessionImpl is unavailable: {}", e.getMessage());
+            }
         }
         UNAVAILABILITY_CAUSE = cause;
         SSL_SESSIONIMPL_CLASS = clazz;


### PR DESCRIPTION
Motivation:
We are increasingly running in environments where Unsafe, setAccessible, etc. are not available.
When debug logging is enabled, we log a complete stack trace every time one of these initialisations fail.
Seeing these stack traces can cause people unnecessary concern.
For instance, people might have alerts that are triggered by a stack trace showing up in logs, regardless of its log level.

Modification:
We continue to print debug log messages on the result of our initialisations, but now we only include the full stack trace is _trace_ logging (or FINEST, or equivalent in whatever logging framework is configured) is enabled.

Result:
We now only log these initialisation stack traces when the lowest possible log level is enabled.

Fixes #7817