### PR TITLE
Utilize i.n.u.internal.ObjectUtil Preconditions (commons) (#11170)

### DIFF
--- a/common/src/main/java/io/netty/util/ConstantPool.java
+++ b/common/src/main/java/io/netty/util/ConstantPool.java
@@ -16,7 +16,9 @@
 
 package io.netty.util;
 
-import io.netty.util.internal.ObjectUtil;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
+
 import io.netty.util.internal.PlatformDependent;
 
 import java.util.concurrent.ConcurrentMap;
@@ -38,9 +40,9 @@ public abstract class ConstantPool<T extends Constant<T>> {
      */
     public T valueOf(Class<?> firstNameComponent, String secondNameComponent) {
         return valueOf(
-                ObjectUtil.checkNotNull(firstNameComponent, "firstNameComponent").getName() +
+                checkNotNull(firstNameComponent, "firstNameComponent").getName() +
                 '#' +
-                ObjectUtil.checkNotNull(secondNameComponent, "secondNameComponent"));
+                checkNotNull(secondNameComponent, "secondNameComponent"));
     }
 
     /**
@@ -52,8 +54,7 @@ public abstract class ConstantPool<T extends Constant<T>> {
      * @param name the name of the {@link Constant}
      */
     public T valueOf(String name) {
-        checkNotNullAndNotEmpty(name);
-        return getOrCreate(name);
+        return getOrCreate(checkNonEmpty(name, "name"));
     }
 
     /**
@@ -78,8 +79,7 @@ public abstract class ConstantPool<T extends Constant<T>> {
      * Returns {@code true} if a {@link AttributeKey} exists for the given {@code name}.
      */
     public boolean exists(String name) {
-        checkNotNullAndNotEmpty(name);
-        return constants.containsKey(name);
+        return constants.containsKey(checkNonEmpty(name, "name"));
     }
 
     /**
@@ -87,8 +87,7 @@ public abstract class ConstantPool<T extends Constant<T>> {
      * {@link IllegalArgumentException} if a {@link Constant} for the given {@code name} exists.
      */
     public T newInstance(String name) {
-        checkNotNullAndNotEmpty(name);
-        return createOrThrow(name);
+        return createOrThrow(checkNonEmpty(name, "name"));
     }
 
     /**
@@ -107,16 +106,6 @@ public abstract class ConstantPool<T extends Constant<T>> {
         }
 
         throw new IllegalArgumentException(String.format("'%s' is already in use", name));
-    }
-
-    private static String checkNotNullAndNotEmpty(String name) {
-        ObjectUtil.checkNotNull(name, "name");
-
-        if (name.isEmpty()) {
-            throw new IllegalArgumentException("empty name");
-        }
-
-        return name;
     }
 
     protected abstract T newConstant(int id, String name);

--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -15,7 +15,10 @@
  */
 package io.netty.util;
 
-import io.netty.util.internal.ObjectUtil;
+import static io.netty.util.internal.ObjectUtil.checkInRange;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -243,10 +246,10 @@ public class HashedWheelTimer implements Timer {
             long tickDuration, TimeUnit unit, int ticksPerWheel, boolean leakDetection,
             long maxPendingTimeouts) {
 
-        ObjectUtil.checkNotNull(threadFactory, "threadFactory");
-        ObjectUtil.checkNotNull(unit, "unit");
-        ObjectUtil.checkPositive(tickDuration, "tickDuration");
-        ObjectUtil.checkPositive(ticksPerWheel, "ticksPerWheel");
+        checkNotNull(threadFactory, "threadFactory");
+        checkNotNull(unit, "unit");
+        checkPositive(tickDuration, "tickDuration");
+        checkPositive(ticksPerWheel, "ticksPerWheel");
 
         // Normalize ticksPerWheel to power of two and initialize the wheel.
         wheel = createWheel(ticksPerWheel);
@@ -296,14 +299,8 @@ public class HashedWheelTimer implements Timer {
     }
 
     private static HashedWheelBucket[] createWheel(int ticksPerWheel) {
-        if (ticksPerWheel <= 0) {
-            throw new IllegalArgumentException(
-                    "ticksPerWheel must be greater than 0: " + ticksPerWheel);
-        }
-        if (ticksPerWheel > 1073741824) {
-            throw new IllegalArgumentException(
-                    "ticksPerWheel may not be greater than 2^30: " + ticksPerWheel);
-        }
+        //ticksPerWheel may not be greater than 2^30
+        checkInRange(ticksPerWheel, 1, 1073741824, "ticksPerWheel");
 
         ticksPerWheel = normalizeTicksPerWheel(ticksPerWheel);
         HashedWheelBucket[] wheel = new HashedWheelBucket[ticksPerWheel];
@@ -401,8 +398,8 @@ public class HashedWheelTimer implements Timer {
 
     @Override
     public Timeout newTimeout(TimerTask task, long delay, TimeUnit unit) {
-        ObjectUtil.checkNotNull(task, "task");
-        ObjectUtil.checkNotNull(unit, "unit");
+        checkNotNull(task, "task");
+        checkNotNull(unit, "unit");
 
         long pendingTimeoutsCount = pendingTimeouts.incrementAndGet();
 

--- a/common/src/main/java/io/netty/util/concurrent/DefaultProgressivePromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultProgressivePromise.java
@@ -16,6 +16,8 @@
 
 package io.netty.util.concurrent;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 public class DefaultProgressivePromise<V> extends DefaultPromise<V> implements ProgressivePromise<V> {
 
     /**
@@ -37,9 +39,7 @@ public class DefaultProgressivePromise<V> extends DefaultPromise<V> implements P
         if (total < 0) {
             // total unknown
             total = -1; // normalize
-            if (progress < 0) {
-                throw new IllegalArgumentException("progress: " + progress + " (expected: >= 0)");
-            }
+            checkPositiveOrZero(progress, "progress");
         } else if (progress < 0 || progress > total) {
             throw new IllegalArgumentException(
                     "progress: " + progress + " (expected: 0 <= progress <= total (" + total + "))");

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.concurrent;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -68,9 +70,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
      */
     protected MultithreadEventExecutorGroup(int nThreads, Executor executor,
                                             EventExecutorChooserFactory chooserFactory, Object... args) {
-        if (nThreads <= 0) {
-            throw new IllegalArgumentException(String.format("nThreads: %d (expected: > 0)", nThreads));
-        }
+        checkPositive(nThreads, "nThreads");
 
         if (executor == null) {
             executor = new ThreadPerTaskExecutor(newDefaultThreadFactory());

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -20,6 +20,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
 
 /**
  * {@link GenericFutureListener} implementation which takes other {@link Promise}s
@@ -54,9 +55,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
     public PromiseNotifier(boolean logNotifyFailure, Promise<? super V>... promises) {
         checkNotNull(promises, "promises");
         for (Promise<? super V> promise: promises) {
-            if (promise == null) {
-                throw new IllegalArgumentException("promises contains null Promise");
-            }
+            checkNotNullWithIAE(promise, "promise");
         }
         this.promises = promises.clone();
         this.logNotifyFailure = logNotifyFailure;

--- a/common/src/main/java/io/netty/util/internal/AppendableCharSequence.java
+++ b/common/src/main/java/io/netty/util/internal/AppendableCharSequence.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.internal;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
 
 import java.util.Arrays;
 
@@ -23,17 +25,11 @@ public final class AppendableCharSequence implements CharSequence, Appendable {
     private int pos;
 
     public AppendableCharSequence(int length) {
-        if (length < 1) {
-            throw new IllegalArgumentException("length: " + length + " (length: >= 1)");
-        }
-        chars = new char[length];
+        chars = new char[checkPositive(length, "length")];
     }
 
     private AppendableCharSequence(char[] chars) {
-        if (chars.length < 1) {
-            throw new IllegalArgumentException("length: " + chars.length + " (length: >= 1)");
-        }
-        this.chars = chars;
+        this.chars = checkNonEmpty(chars, "chars");
         pos = chars.length;
     }
 

--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -15,11 +15,17 @@
 package io.netty.util.internal;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * A grab-bag of useful utility methods.
  */
 public final class ObjectUtil {
+
+    private static final float FLOAT_ZERO = 0.0F;
+    private static final double DOUBLE_ZERO = 0.0D;
+    private static final long LONG_ZERO = 0L;
+    private static final int INT_ZERO = 0;
 
     private ObjectUtil() {
     }
@@ -36,12 +42,42 @@ public final class ObjectUtil {
     }
 
     /**
+     * Checks that the given argument is not null. If it is, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static <T> T checkNotNullWithIAE(final T arg, final String paramName) throws IllegalArgumentException {
+        if (arg == null) {
+            throw new IllegalArgumentException("Param '" + paramName + "' must not be null");
+        }
+        return arg;
+    }
+
+    /**
+     * Checks that the given argument is not null. If it is, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     *
+     * @param <T> type of the given argument value.
+     * @param name of the parameter, belongs to the exception message.
+     * @param index of the array, belongs to the exception message.
+     * @param value to check.
+     * @return the given argument value.
+     * @throws IllegalArgumentException if value is null.
+     */
+    public static <T> T checkNotNullArrayParam(T value, int index, String name) throws IllegalArgumentException {
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    "Array index " + index + " of parameter '" + name + "' must not be null");
+        }
+        return value;
+    }
+
+    /**
      * Checks that the given argument is strictly positive. If it is not, throws {@link IllegalArgumentException}.
      * Otherwise, returns the argument.
      */
     public static int checkPositive(int i, String name) {
-        if (i <= 0) {
-            throw new IllegalArgumentException(name + ": " + i + " (expected: > 0)");
+        if (i <= INT_ZERO) {
+            throw new IllegalArgumentException(name + " : " + i + " (expected: > 0)");
         }
         return i;
     }
@@ -51,10 +87,32 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static long checkPositive(long l, String name) {
-        if (l <= 0) {
-            throw new IllegalArgumentException(name + ": " + l + " (expected: > 0)");
+        if (l <= LONG_ZERO) {
+            throw new IllegalArgumentException(name + " : " + l + " (expected: > 0)");
         }
         return l;
+    }
+
+    /**
+     * Checks that the given argument is strictly positive. If it is not, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static double checkPositive(final double d, final String name) {
+        if (d <= DOUBLE_ZERO) {
+            throw new IllegalArgumentException(name + " : " + d + " (expected: > 0)");
+        }
+        return d;
+    }
+
+    /**
+     * Checks that the given argument is strictly positive. If it is not, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static float checkPositive(final float f, final String name) {
+        if (f <= FLOAT_ZERO) {
+            throw new IllegalArgumentException(name + " : " + f + " (expected: > 0)");
+        }
+        return f;
     }
 
     /**
@@ -62,8 +120,8 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static int checkPositiveOrZero(int i, String name) {
-        if (i < 0) {
-            throw new IllegalArgumentException(name + ": " + i + " (expected: >= 0)");
+        if (i < INT_ZERO) {
+            throw new IllegalArgumentException(name + " : " + i + " (expected: >= 0)");
         }
         return i;
     }
@@ -73,10 +131,32 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static long checkPositiveOrZero(long l, String name) {
-        if (l < 0) {
-            throw new IllegalArgumentException(name + ": " + l + " (expected: >= 0)");
+        if (l < LONG_ZERO) {
+            throw new IllegalArgumentException(name + " : " + l + " (expected: >= 0)");
         }
         return l;
+    }
+
+    /**
+     * Checks that the given argument is positive or zero. If it is not, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static double checkPositiveOrZero(final double d, final String name) {
+        if (d < DOUBLE_ZERO) {
+            throw new IllegalArgumentException(name + " : " + d + " (expected: >= 0)");
+        }
+        return d;
+    }
+
+    /**
+     * Checks that the given argument is positive or zero. If it is not, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static float checkPositiveOrZero(final float f, final String name) {
+        if (f < FLOAT_ZERO) {
+            throw new IllegalArgumentException(name + " : " + f + " (expected: >= 0)");
+        }
+        return f;
     }
 
     /**
@@ -107,8 +187,36 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static <T> T[] checkNonEmpty(T[] array, String name) {
-        checkNotNull(array, name);
-        checkPositive(array.length, name + ".length");
+        //No String concatenation for check
+        if (checkNotNull(array, name).length == 0) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        }
+        return array;
+    }
+
+    /**
+     * Checks that the given argument is neither null nor empty.
+     * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static byte[] checkNonEmpty(byte[] array, String name) {
+        //No String concatenation for check
+        if (checkNotNull(array, name).length == 0) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        }
+        return array;
+    }
+
+    /**
+     * Checks that the given argument is neither null nor empty.
+     * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static char[] checkNonEmpty(char[] array, String name) {
+        //No String concatenation for check
+        if (checkNotNull(array, name).length == 0) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        }
         return array;
     }
 
@@ -118,9 +226,63 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static <T extends Collection<?>> T checkNonEmpty(T collection, String name) {
-        checkNotNull(collection, name);
-        checkPositive(collection.size(), name + ".size");
+        //No String concatenation for check
+        if (checkNotNull(collection, name).size() == 0) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        }
         return collection;
+    }
+
+    /**
+     * Checks that the given argument is neither null nor empty.
+     * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static String checkNonEmpty(final String value, final String name) {
+        if (checkNotNull(value, name).isEmpty()) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        }
+        return value;
+    }
+
+    /**
+     * Checks that the given argument is neither null nor empty.
+     * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static <K, V, T extends Map<K, V>> T checkNonEmpty(T value, String name) {
+        if (checkNotNull(value, name).isEmpty()) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        }
+        return value;
+    }
+
+    /**
+     * Checks that the given argument is neither null nor empty.
+     * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static CharSequence checkNonEmpty(final CharSequence value, final String name) {
+        if (checkNotNull(value, name).length() == 0) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        }
+        return value;
+    }
+
+    /**
+     * Trims the the given argument and checks whether it is neither null nor empty.
+     * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
+     * Otherwise, returns the trimmed argument.
+     *
+     * @param value to trim and check.
+     * @param name of the parameter.
+     * @return the trimmed (not the original) value.
+     * @throws NullPointerException if value is null.
+     * @throws IllegalArgumentException if the trimmed value is empty.
+     */
+    public static String checkNonEmptyAfterTrim(final String value, final String name) {
+        String trimmed = checkNotNull(value, name).trim();
+        return checkNonEmpty(trimmed, name);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
+++ b/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.internal;
 
+import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
+
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -56,10 +58,7 @@ public final class SystemPropertyUtil {
      *         specified property is not allowed.
      */
     public static String get(final String key, String def) {
-        ObjectUtil.checkNotNull(key, "key");
-        if (key.isEmpty()) {
-            throw new IllegalArgumentException("key must not be empty.");
-        }
+        checkNonEmpty(key, "key");
 
         String value = null;
         try {

--- a/common/src/main/java/io/netty/util/internal/ThreadLocalRandom.java
+++ b/common/src/main/java/io/netty/util/internal/ThreadLocalRandom.java
@@ -22,6 +22,8 @@
 
 package io.netty.util.internal;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -312,9 +314,7 @@ public final class ThreadLocalRandom extends Random {
      * @throws IllegalArgumentException if n is not positive
      */
     public long nextLong(long n) {
-        if (n <= 0) {
-            throw new IllegalArgumentException("n must be positive");
-        }
+        checkPositive(n, "n");
 
         // Divide n by two until small enough for nextInt. On each
         // iteration (at most 31 of them but usually much less),
@@ -361,9 +361,7 @@ public final class ThreadLocalRandom extends Random {
      * @throws IllegalArgumentException if n is not positive
      */
     public double nextDouble(double n) {
-        if (n <= 0) {
-            throw new IllegalArgumentException("n must be positive");
-        }
+        checkPositive(n, "n");
         return nextDouble() * n;
     }
 

--- a/common/src/test/java/io/netty/util/internal/ObjectUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/ObjectUtilTest.java
@@ -1,0 +1,594 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.util.internal;
+
+import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Testcases for io.netty.util.internal.ObjectUtil.
+ *
+ * The tests for exceptions do not use a fail mimic. The tests evaluate the
+ * presence and type, to have really regression character.
+ *
+ */
+public class ObjectUtilTest {
+
+    private static final Object NULL_OBJECT = null;
+
+    private static final Object NON_NULL_OBJECT = "Object is not null";
+    private static final String NON_NULL_EMPTY_STRING = "";
+    private static final String NON_NULL_WHITESPACE_STRING = "  ";
+    private static final Object[] NON_NULL_EMPTY_OBJECT_ARRAY = {};
+    private static final Object[] NON_NULL_FILLED_OBJECT_ARRAY = { NON_NULL_OBJECT };
+    private static final CharSequence NULL_CHARSEQUENCE = (CharSequence) NULL_OBJECT;
+    private static final CharSequence NON_NULL_CHARSEQUENCE = (CharSequence) NON_NULL_OBJECT;
+    private static final CharSequence NON_NULL_EMPTY_CHARSEQUENCE = (CharSequence) NON_NULL_EMPTY_STRING;
+    private static final byte[] NON_NULL_EMPTY_BYTE_ARRAY = {};
+    private static final byte[] NON_NULL_FILLED_BYTE_ARRAY = { (byte) 0xa };
+    private static final char[] NON_NULL_EMPTY_CHAR_ARRAY = {};
+    private static final char[] NON_NULL_FILLED_CHAR_ARRAY = { 'A' };
+
+    private static final String NULL_NAME = "IS_NULL";
+    private static final String NON_NULL_NAME = "NOT_NULL";
+    private static final String NON_NULL_EMPTY_NAME = "NOT_NULL_BUT_EMPTY";
+
+    private static final String TEST_RESULT_NULLEX_OK = "Expected a NPE/IAE";
+    private static final String TEST_RESULT_NULLEX_NOK = "Expected no exception";
+    private static final String TEST_RESULT_EXTYPE_NOK = "Expected type not found";
+
+    private static final int ZERO_INT = 0;
+    private static final long ZERO_LONG = 0;
+    private static final double ZERO_DOUBLE = 0.0d;
+    private static final float ZERO_FLOAT = 0.0f;
+
+    private static final int POS_ONE_INT = 1;
+    private static final long POS_ONE_LONG = 1;
+    private static final double POS_ONE_DOUBLE = 1.0d;
+    private static final float POS_ONE_FLOAT = 1.0f;
+
+    private static final int NEG_ONE_INT = -1;
+    private static final long NEG_ONE_LONG = -1;
+    private static final double NEG_ONE_DOUBLE = -1.0d;
+    private static final float NEG_ONE_FLOAT = -1.0f;
+
+    private static final String NUM_POS_NAME = "NUMBER_POSITIVE";
+    private static final String NUM_ZERO_NAME = "NUMBER_ZERO";
+    private static final String NUM_NEG_NAME = "NUMBER_NEGATIVE";
+
+    @Test
+    public void testCheckNotNull() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkNotNull(NON_NULL_OBJECT, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNotNull(NULL_OBJECT, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof NullPointerException);
+    }
+
+    @Test
+    public void testCheckNotNullWithIAE() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkNotNullWithIAE(NON_NULL_OBJECT, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNotNullWithIAE(NULL_OBJECT, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckNotNullArrayParam() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkNotNullArrayParam(NON_NULL_OBJECT, 1, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNotNullArrayParam(NULL_OBJECT, 1, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckPositiveIntString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkPositive(POS_ONE_INT, NUM_POS_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositive(ZERO_INT, NUM_ZERO_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositive(NEG_ONE_INT, NUM_NEG_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckPositiveLongString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkPositive(POS_ONE_LONG, NUM_POS_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositive(ZERO_LONG, NUM_ZERO_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositive(NEG_ONE_LONG, NUM_NEG_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckPositiveDoubleString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkPositive(POS_ONE_DOUBLE, NUM_POS_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositive(ZERO_DOUBLE, NUM_ZERO_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositive(NEG_ONE_DOUBLE, NUM_NEG_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckPositiveFloatString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkPositive(POS_ONE_FLOAT, NUM_POS_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositive(ZERO_FLOAT, NUM_ZERO_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositive(NEG_ONE_FLOAT, NUM_NEG_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckPositiveOrZeroIntString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(POS_ONE_INT, NUM_POS_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(ZERO_INT, NUM_ZERO_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(NEG_ONE_INT, NUM_NEG_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckPositiveOrZeroLongString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(POS_ONE_LONG, NUM_POS_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(ZERO_LONG, NUM_ZERO_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(NEG_ONE_LONG, NUM_NEG_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckPositiveOrZeroDoubleString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(POS_ONE_DOUBLE, NUM_POS_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(ZERO_DOUBLE, NUM_ZERO_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(NEG_ONE_DOUBLE, NUM_NEG_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckPositiveOrZeroFloatString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(POS_ONE_FLOAT, NUM_POS_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(ZERO_FLOAT, NUM_ZERO_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkPositiveOrZero(NEG_ONE_FLOAT, NUM_NEG_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckNonEmptyTArrayString() {
+        Exception actualEx = null;
+
+        try {
+            ObjectUtil.checkNonEmpty((Object[]) NULL_OBJECT, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof NullPointerException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((Object[]) NON_NULL_FILLED_OBJECT_ARRAY, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((Object[]) NON_NULL_EMPTY_OBJECT_ARRAY, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckNonEmptyByteArrayString() {
+        Exception actualEx = null;
+
+        try {
+            ObjectUtil.checkNonEmpty((byte[]) NULL_OBJECT, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof NullPointerException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((byte[]) NON_NULL_FILLED_BYTE_ARRAY, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((byte[]) NON_NULL_EMPTY_BYTE_ARRAY, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckNonEmptyCharArrayString() {
+        Exception actualEx = null;
+
+        try {
+            ObjectUtil.checkNonEmpty((char[]) NULL_OBJECT, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof NullPointerException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((char[]) NON_NULL_FILLED_CHAR_ARRAY, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((char[]) NON_NULL_EMPTY_CHAR_ARRAY, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckNonEmptyTString() {
+        Exception actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((Object[]) NULL_OBJECT, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof NullPointerException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((Object[]) NON_NULL_FILLED_OBJECT_ARRAY, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((Object[]) NON_NULL_EMPTY_OBJECT_ARRAY, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testCheckNonEmptyStringString() {
+        Exception actualEx = null;
+
+        try {
+            ObjectUtil.checkNonEmpty((String) NULL_OBJECT, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof NullPointerException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((String) NON_NULL_OBJECT, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((String) NON_NULL_EMPTY_STRING, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((String) NON_NULL_WHITESPACE_STRING, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+    }
+
+    @Test
+    public void testCheckNonEmptyCharSequenceString() {
+        Exception actualEx = null;
+
+        try {
+            ObjectUtil.checkNonEmpty((CharSequence) NULL_CHARSEQUENCE, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof NullPointerException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((CharSequence) NON_NULL_CHARSEQUENCE, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((CharSequence) NON_NULL_EMPTY_CHARSEQUENCE, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmpty((CharSequence) NON_NULL_WHITESPACE_STRING, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+    }
+
+    @Test
+    public void testCheckNonEmptyAfterTrim() {
+        Exception actualEx = null;
+
+        try {
+            ObjectUtil.checkNonEmptyAfterTrim((String) NULL_OBJECT, NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof NullPointerException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmptyAfterTrim((String) NON_NULL_OBJECT, NON_NULL_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNull(TEST_RESULT_NULLEX_NOK, actualEx);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmptyAfterTrim(NON_NULL_EMPTY_STRING, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+
+        actualEx = null;
+        try {
+            ObjectUtil.checkNonEmptyAfterTrim(NON_NULL_WHITESPACE_STRING, NON_NULL_EMPTY_NAME);
+        } catch (Exception e) {
+            actualEx = e;
+        }
+        assertNotNull(TEST_RESULT_NULLEX_OK, actualEx);
+        assertTrue(TEST_RESULT_EXTYPE_NOK, actualEx instanceof IllegalArgumentException);
+    }
+}


### PR DESCRIPTION
Motivation:

NullChecks resulting in a NullPointerException or IllegalArgumentException, numeric ranges (>0, >=0) checks, not empty strings/arrays checks must never be anonymous but with the parameter or variable name which is checked. They must be specific and should not be done with an "OR-Logic" (if a == null || b == null) throw new NullPointerEx.

Modifications:

* Add some checks to ObjectUtil not present today but utilized in the code.
* Add unit test for ObjectUtil
* Update commmons internal usage with ObjectUtil

Result:

All checks needed are present, subsequent changes of usage of ObjectUtil are possible.

Fixes for https://github.com/netty/netty/issues/11170
One PR for each subproject to ease review.