### PR TITLE
Utilize i.n.u.internal.ObjectUtil Preconditions (codec) (#1170)

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.compression;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
@@ -44,10 +46,7 @@ public abstract class ZlibDecoder extends ByteToMessageDecoder {
      *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      */
     public ZlibDecoder(int maxAllocation) {
-        if (maxAllocation < 0) {
-            throw new IllegalArgumentException("maxAllocation must be >= 0");
-        }
-        this.maxAllocation = maxAllocation;
+        this.maxAllocation = checkPositiveOrZero(maxAllocation, "maxAllocation");
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
@@ -16,6 +16,8 @@
 
 package io.netty.handler.codec.json;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
@@ -80,10 +82,7 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
      *
      */
     public JsonObjectDecoder(int maxObjectLength, boolean streamArrayElements) {
-        if (maxObjectLength < 1) {
-            throw new IllegalArgumentException("maxObjectLength must be a positive int");
-        }
-        this.maxObjectLength = maxObjectLength;
+        this.maxObjectLength = checkPositive(maxObjectLength, "maxObjectLength");
         this.streamArrayElements = streamArrayElements;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/marshalling/LimitingByteInput.java
+++ b/codec/src/main/java/io/netty/handler/codec/marshalling/LimitingByteInput.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.marshalling;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import org.jboss.marshalling.ByteInput;
 
 import java.io.IOException;
@@ -33,11 +35,8 @@ class LimitingByteInput implements ByteInput {
     private long read;
 
     LimitingByteInput(ByteInput input, long limit) {
-        if (limit <= 0) {
-            throw new IllegalArgumentException("The limit MUST be > 0");
-        }
         this.input = input;
-        this.limit = limit;
+        this.limit = checkPositive(limit, "limit");
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.serialization;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.channel.ChannelHandlerContext;
@@ -53,11 +55,7 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
      *        the long term.
      */
     public CompatibleObjectEncoder(int resetInterval) {
-        if (resetInterval < 0) {
-            throw new IllegalArgumentException(
-                    "resetInterval: " + resetInterval);
-        }
-        this.resetInterval = resetInterval;
+        this.resetInterval = checkPositiveOrZero(resetInterval, "resetInterval");
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/xml/XmlFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/xml/XmlFrameDecoder.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.xml;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -78,10 +80,7 @@ public class XmlFrameDecoder extends ByteToMessageDecoder {
     private final int maxFrameLength;
 
     public XmlFrameDecoder(int maxFrameLength) {
-        if (maxFrameLength < 1) {
-            throw new IllegalArgumentException("maxFrameLength must be a positive int");
-        }
-        this.maxFrameLength = maxFrameLength;
+        this.maxFrameLength = checkPositive(maxFrameLength, "maxFrameLength");
     }
 
     @Override


### PR DESCRIPTION
Motivation:

NullChecks resulting in a NullPointerException or IllegalArgumentException, numeric ranges (>0, >=0) checks, not empty strings/arrays checks must never be anonymous but with the parameter or variable name which is checked. They must be specific and should not be done with an "OR-Logic" (if a == null || b == null) throw new NullPointerEx.

Modifications:

* import static relevant checks
* Replace manual checks with ObjectUtil methods

Result:

All checks needed are done with ObjectUtil, some exception texts are improved.

Fixes #11170
One PR for each subproject to ease review.