### PR TITLE
Utilize i.n.u.internal.ObjectUtil Preconditions (transport*) (#11170)

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TcpMd5Util.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TcpMd5Util.java
@@ -15,7 +15,9 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.util.internal.ObjectUtil;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
+import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -29,20 +31,15 @@ final class TcpMd5Util {
 
     static Collection<InetAddress> newTcpMd5Sigs(AbstractEpollChannel channel, Collection<InetAddress> current,
                                          Map<InetAddress, byte[]> newKeys) throws IOException {
-        ObjectUtil.checkNotNull(channel, "channel");
-        ObjectUtil.checkNotNull(current, "current");
-        ObjectUtil.checkNotNull(newKeys, "newKeys");
+        checkNotNull(channel, "channel");
+        checkNotNull(current, "current");
+        checkNotNull(newKeys, "newKeys");
 
         // Validate incoming values
         for (Entry<InetAddress, byte[]> e : newKeys.entrySet()) {
             final byte[] key = e.getValue();
-            if (e.getKey() == null) {
-                throw new IllegalArgumentException("newKeys contains an entry with null address: " + newKeys);
-            }
-            ObjectUtil.checkNotNull(key, "newKeys[" + e.getKey() + ']');
-            if (key.length == 0) {
-                throw new IllegalArgumentException("newKeys[" + e.getKey() + "] has an empty key.");
-            }
+            checkNotNullWithIAE(e.getKey(), "e.getKey");
+            checkNonEmpty(key, e.getKey().toString());
             if (key.length > Native.TCP_MD5SIG_MAXKEYLEN) {
                 throw new IllegalArgumentException("newKeys[" + e.getKey() +
                     "] has a key with invalid length; should not exceed the maximum length (" +

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/NativeLongArray.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/NativeLongArray.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.PlatformDependent;
 import java.nio.ByteBuffer;
 
 import static io.netty.channel.unix.Limits.SIZEOF_JLONG;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 final class NativeLongArray {
     private ByteBuffer memory;
@@ -29,12 +30,9 @@ final class NativeLongArray {
     private int size;
 
     NativeLongArray(int capacity) {
-        if (capacity < 1) {
-            throw new IllegalArgumentException("capacity must be >= 1 but was " + capacity);
-        }
+        this.capacity = checkPositive(capacity, "capacity");
         memory = Buffer.allocateDirectWithNativeOrder(calculateBufferCapacity(capacity));
         memoryAddress = Buffer.memoryAddress(memory);
-        this.capacity = capacity;
     }
 
     private static int idx(int index) {

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/DefaultRxtxChannelConfig.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/DefaultRxtxChannelConfig.java
@@ -33,6 +33,7 @@ import static io.netty.channel.rxtx.RxtxChannelOption.READ_TIMEOUT;
 import static io.netty.channel.rxtx.RxtxChannelOption.RTS;
 import static io.netty.channel.rxtx.RxtxChannelOption.STOP_BITS;
 import static io.netty.channel.rxtx.RxtxChannelOption.WAIT_TIME;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * Default configuration class for RXTX device connections.
@@ -190,19 +191,13 @@ final class DefaultRxtxChannelConfig extends DefaultChannelConfig implements Rxt
 
     @Override
     public RxtxChannelConfig setWaitTimeMillis(final int waitTimeMillis) {
-        if (waitTimeMillis < 0) {
-            throw new IllegalArgumentException("Wait time must be >= 0");
-        }
-        waitTime = waitTimeMillis;
+        this.waitTime = checkPositiveOrZero(waitTimeMillis, "waitTimeMillis");
         return this;
     }
 
     @Override
     public RxtxChannelConfig setReadTimeout(int readTimeout) {
-        if (readTimeout < 0) {
-            throw new IllegalArgumentException("readTime must be >= 0");
-        }
-        this.readTimeout = readTimeout;
+        this.readTimeout = checkPositiveOrZero(readTimeout, "readTimeout");
         return this;
     }
 

--- a/transport-udt/src/test/java/io/netty/test/udt/util/TrafficControl.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/util/TrafficControl.java
@@ -16,6 +16,8 @@
 
 package io.netty.test.udt.util;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -62,9 +64,7 @@ public final class TrafficControl {
      * @param time - delay in milliseconds; use zero to remove delay.
      */
     public static void delay(final int time) throws Exception {
-        if (time < 0) {
-            throw new IllegalArgumentException("negative latency");
-        }
+        checkPositiveOrZero(time, "time");
         final int delay = time / 2;
         if (delay == 0) {
             UnitHelp.process(String.format(TC_RESET, "lo"));

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -321,10 +321,10 @@ public class DefaultChannelConfig implements ChannelConfig {
      * is of type {@link MaxMessagesRecvByteBufAllocator}.
      */
     private void setRecvByteBufAllocator(RecvByteBufAllocator allocator, ChannelMetadata metadata) {
+        checkNotNull(allocator, "allocator");
+        checkNotNull(metadata, "metadata");
         if (allocator instanceof MaxMessagesRecvByteBufAllocator) {
             ((MaxMessagesRecvByteBufAllocator) allocator).maxMessagesPerRead(metadata.defaultMaxMessagesPerRead());
-        } else if (allocator == null) {
-            throw new NullPointerException("allocator");
         }
         setRecvByteBufAllocator(allocator);
     }

--- a/transport/src/main/java/io/netty/channel/local/LocalAddress.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalAddress.java
@@ -15,8 +15,9 @@
  */
 package io.netty.channel.local;
 
+import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
+
 import io.netty.channel.Channel;
-import io.netty.util.internal.ObjectUtil;
 
 import java.net.SocketAddress;
 
@@ -51,13 +52,8 @@ public final class LocalAddress extends SocketAddress implements Comparable<Loca
      * Creates a new instance with the specified ID.
      */
     public LocalAddress(String id) {
-        ObjectUtil.checkNotNull(id, "id");
-        id = id.trim().toLowerCase();
-        if (id.isEmpty()) {
-            throw new IllegalArgumentException("empty id");
-        }
-        this.id = id;
-        strVal = "local:" + id;
+        this.id = checkNonEmptyAfterTrim(id, "id").toLowerCase();
+        this.strVal = "local:" + this.id;
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel.pool;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.util.concurrent.EventExecutor;
@@ -173,12 +175,8 @@ public class FixedChannelPool extends SimpleChannelPool {
                             int maxConnections, int maxPendingAcquires,
                             boolean releaseHealthCheck, boolean lastRecentUsed) {
         super(bootstrap, handler, healthCheck, releaseHealthCheck, lastRecentUsed);
-        if (maxConnections < 1) {
-            throw new IllegalArgumentException("maxConnections: " + maxConnections + " (expected: >= 1)");
-        }
-        if (maxPendingAcquires < 1) {
-            throw new IllegalArgumentException("maxPendingAcquires: " + maxPendingAcquires + " (expected: >= 1)");
-        }
+        checkPositive(maxConnections, "maxConnections");
+        checkPositive(maxPendingAcquires, "maxPendingAcquires");
         if (action == null && acquireTimeoutMillis == -1) {
             timeoutTask = null;
             acquireTimeoutNanos = -1;


### PR DESCRIPTION
Motivation:

NullChecks resulting in a NullPointerException or IllegalArgumentException, numeric ranges (>0, >=0) checks, not empty strings/arrays checks must never be anonymous but with the parameter or variable name which is checked. They must be specific and should not be done with an "OR-Logic" (if a == null || b == null) throw new NullPointerEx.

Modifications:

* import static relevant checks
* Replace manual checks with ObjectUtil methods

Result:

All checks needed are done with ObjectUtil, some exception texts are improved.

Fixes #11170
One PR for each subproject to ease review.