### PR TITLE
Utilize i.n.u.internal.ObjectUtil Preconditions (buffer) (#11170)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -15,6 +15,8 @@
  */
 package io.netty.buffer;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 import io.netty.util.ReferenceCounted;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
@@ -108,7 +110,7 @@ public class ByteBufInputStream extends InputStream implements DataInput {
             if (releaseOnClose) {
                 buffer.release();
             }
-            throw new IllegalArgumentException("length: " + length);
+            checkPositiveOrZero(length, "length");
         }
         if (length > buffer.readableBytes()) {
             if (releaseOnClose) {

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -250,9 +250,13 @@ public final class ByteBufUtil {
      * {@code a[aStartIndex : aStartIndex + length] == b[bStartIndex : bStartIndex + length]}
      */
     public static boolean equals(ByteBuf a, int aStartIndex, ByteBuf b, int bStartIndex, int length) {
-        if (aStartIndex < 0 || bStartIndex < 0 || length < 0) {
-            throw new IllegalArgumentException("All indexes and lengths must be non-negative");
-        }
+        checkNotNull(a, "a");
+        checkNotNull(b, "b");
+        // All indexes and lengths must be non-negative
+        checkPositiveOrZero(aStartIndex, "aStartIndex");
+        checkPositiveOrZero(bStartIndex, "bStartIndex");
+        checkPositiveOrZero(length, "length");
+
         if (a.writerIndex() - length < aStartIndex || b.writerIndex() - length < bStartIndex) {
             return false;
         }


### PR DESCRIPTION
Motivation:

NullChecks resulting in a NullPointerException or IllegalArgumentException, numeric ranges (>0, >=0) checks, not empty strings/arrays checks must never be anonymous but with the parameter or variable name which is checked. They must be specific and should not be done with an "OR-Logic" (if a == null || b == null) throw new NullPointerEx.

Modifications:

* import static relevant checks
* Replace manual checks with ObjectUtil methods

Result:

All checks needed are done with ObjectUtil, some exception texts are improved.

Fixes #11170
One PR for each subproject to ease review.