### PR TITLE
Utilize i.n.u.internal.ObjectUtil to assert Preconditions (codec*) (#11170)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -32,6 +32,7 @@ import static io.netty.handler.codec.CharSequenceValueConverter.*;
 import static io.netty.handler.codec.http2.DefaultHttp2Headers.*;
 import static io.netty.util.AsciiString.*;
 import static io.netty.util.internal.EmptyArrays.*;
+import static io.netty.util.internal.ObjectUtil.checkNotNullArrayParam;
 
 /**
  * A variant of {@link Http2Headers} which only supports read-only methods.
@@ -132,9 +133,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
         // We are only validating values... so start at 1 and go until end.
         for (int i = 1; i < pseudoHeaders.length; i += 2) {
             // pseudoHeaders names are only set internally so they are assumed to be valid.
-            if (pseudoHeaders[i] == null) {
-                throw new IllegalArgumentException("pseudoHeaders value at index " + i + " is null");
-            }
+            checkNotNullArrayParam(pseudoHeaders[i], i, "pseudoHeaders");
         }
 
         boolean seenNonPseudoHeader = false;
@@ -148,9 +147,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
                 throw new IllegalArgumentException(
                      "otherHeaders name at index " + i + " is a pseudo header that appears after non-pseudo headers.");
             }
-            if (otherHeaders[i + 1] == null) {
-                throw new IllegalArgumentException("otherHeaders value at index " + (i + 1) + " is null");
-            }
+            checkNotNullArrayParam(otherHeaders[i + 1], i + 1, "otherHeaders");
         }
     }
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.mqtt;
 
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttProperties.MqttPropertyType;
@@ -433,10 +435,7 @@ public final class MqttMessageBuilders {
         }
 
         public ConnAckPropertiesBuilder receiveMaximum(int value) {
-            if (value <= 0) {
-                throw new IllegalArgumentException("receive maximum property must be > 0");
-            }
-            this.receiveMaximum = value;
+            this.receiveMaximum = checkPositive(value, "value");
             return this;
         }
 
@@ -454,10 +453,7 @@ public final class MqttMessageBuilders {
         }
 
         public ConnAckPropertiesBuilder maximumPacketSize(long size) {
-            if (size <= 0) {
-                throw new IllegalArgumentException("maximum packet size property must be > 0");
-            }
-            this.maximumPacketSize = size;
+            this.maximumPacketSize = checkPositive(size, "size");
             return this;
         }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialRequest.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.socksx.v5;
 
+import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
+
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
@@ -41,11 +43,7 @@ public class DefaultSocks5InitialRequest extends AbstractSocks5Message implement
             list.add(m);
         }
 
-        if (list.isEmpty()) {
-            throw new IllegalArgumentException("authMethods is empty");
-        }
-
-        this.authMethods = Collections.unmodifiableList(list);
+        this.authMethods = Collections.unmodifiableList(checkNonEmpty(list, "list"));
     }
 
     public DefaultSocks5InitialRequest(Iterable<Socks5AuthMethod> authMethods) {
@@ -59,11 +57,7 @@ public class DefaultSocks5InitialRequest extends AbstractSocks5Message implement
             list.add(m);
         }
 
-        if (list.isEmpty()) {
-            throw new IllegalArgumentException("authMethods is empty");
-        }
-
-        this.authMethods = Collections.unmodifiableList(list);
+        this.authMethods = Collections.unmodifiableList(checkNonEmpty(list, "list"));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

NullChecks resulting in a NullPointerException or IllegalArgumentException, numeric ranges (>0, >=0) checks, not empty strings/arrays checks must never be anonymous but with the parameter or variable name which is checked. They must be specific and should not be done with an "OR-Logic" (if a == null || b == null) throw new NullPointerEx.

Modifications:

* import static relevant checks
* Replace manual checks with ObjectUtil methods

Result:

All checks needed are done with ObjectUtil, some exception texts are improved.

Fixes #11170
One PR for each subproject to ease review.
Here
codec-http2
codec-mqtt
codec-socks