### PR TITLE
Utilize i.n.u.internal.ObjectUtil Preconditions (misc) (#11170)

### DIFF
--- a/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
@@ -48,6 +48,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_UNSIGNED_BYTE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.handler.codec.http2.Http2CodecUtil.writeFrameHeaderInternal;
 import static io.netty.handler.codec.http2.Http2FrameTypes.DATA;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
@@ -124,7 +125,7 @@ public class Http2FrameWriterDataBenchmark extends AbstractMicrobenchmark {
             boolean needToReleaseHeaders = true;
             boolean needToReleaseData = true;
             try {
-                verifyStreamId(streamId, "Stream ID");
+                checkPositive(streamId, "streamId");
                 verifyPadding(padding);
 
                 boolean lastFrame;
@@ -173,12 +174,6 @@ public class Http2FrameWriterDataBenchmark extends AbstractMicrobenchmark {
                 return promiseAggregator;
             }
             return promiseAggregator.doneAllocatingPromises();
-        }
-
-        private static void verifyStreamId(int streamId, String argumentName) {
-            if (streamId <= 0) {
-                throw new IllegalArgumentException(argumentName + " must be > 0");
-            }
         }
 
         private static int paddingBytes(int padding) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
@@ -16,7 +16,8 @@
 
 package io.netty.resolver.dns;
 
-import io.netty.util.internal.ObjectUtil;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -148,7 +149,7 @@ public abstract class DnsServerAddresses {
      * Returns the {@link DnsServerAddresses} that yields only a single {@code address}.
      */
     public static DnsServerAddresses singleton(final InetSocketAddress address) {
-        ObjectUtil.checkNotNull(address, "address");
+        checkNotNull(address, "address");
         if (address.isUnresolved()) {
             throw new IllegalArgumentException("cannot use an unresolved DNS server address: " + address);
         }
@@ -157,7 +158,7 @@ public abstract class DnsServerAddresses {
     }
 
     private static List<InetSocketAddress> sanitize(Iterable<? extends InetSocketAddress> addresses) {
-        ObjectUtil.checkNotNull(addresses, "addresses");
+        checkNotNull(addresses, "addresses");
 
         final List<InetSocketAddress> list;
         if (addresses instanceof Collection) {
@@ -176,15 +177,11 @@ public abstract class DnsServerAddresses {
             list.add(a);
         }
 
-        if (list.isEmpty()) {
-            throw new IllegalArgumentException("empty addresses");
-        }
-
-        return list;
+        return checkNonEmpty(list, "list");
     }
 
     private static List<InetSocketAddress> sanitize(InetSocketAddress[] addresses) {
-        ObjectUtil.checkNotNull(addresses, "addresses");
+        checkNotNull(addresses, "addresses");
 
         List<InetSocketAddress> list = new ArrayList<InetSocketAddress>(addresses.length);
         for (InetSocketAddress a: addresses) {


### PR DESCRIPTION
Motivation:

NullChecks resulting in a NullPointerException or IllegalArgumentException, numeric ranges (>0, >=0) checks, not empty strings/arrays checks must never be anonymous but with the parameter or variable name which is checked. They must be specific and should not be done with an "OR-Logic" (if a == null || b == null) throw new NullPointerEx.

Modifications:

* import static relevant checks
* Replace manual checks with ObjectUtil methods

Result:

All checks needed are done with ObjectUtil, some exception texts are improved.

Fixes #11170
One PR for each subproject to ease review.
Here
microbench
resolver-dns