### PR TITLE
adjust validation logic when websocket server check starts with '/'(#…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -117,7 +117,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         String websocketPath = serverConfig.websocketPath();
         String uri = req.uri();
         boolean checkStartUri = uri.startsWith(websocketPath);
-        boolean checkNextUri = checkNextUri(uri, websocketPath);
+        boolean checkNextUri = "/".equals(websocketPath) ? true : checkNextUri(uri, websocketPath);
         return serverConfig.checkStartsWith() ? (checkStartUri && checkNextUri) : uri.equals(websocketPath);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -117,7 +117,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         String websocketPath = serverConfig.websocketPath();
         String uri = req.uri();
         boolean checkStartUri = uri.startsWith(websocketPath);
-        boolean checkNextUri = "/".equals(websocketPath) ? true : checkNextUri(uri, websocketPath);
+        boolean checkNextUri = "/".equals(websocketPath) || checkNextUri(uri, websocketPath);
         return serverConfig.checkStartsWith() ? (checkStartUri && checkNextUri) : uri.equals(websocketPath);
     }
 


### PR DESCRIPTION
…11190)

Motivation:

When create a WebSocketServerProtocolConfig to check URI path starts from '/',
only '/' or '//subPath' can be passed by the checker,but '/subPath' should be
passed as well

Modifications:

in `WebSocketServerProtocolHandshakeHandler.isWebSocketPath()` treat '/' a special case

Result:
'/subPath' can be passed

Fixes #11190. 
