### PR TITLE
Add a new HTTP/2 pseudo header `:protocol`

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -55,7 +55,13 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
         /**
          * {@code :status}.
          */
-        STATUS(":status", false);
+        STATUS(":status", false),
+
+        /**
+         * {@code :protocol}, as defined in <a href="https://datatracker.ietf.org/doc/rfc8441/">RFC 8441,
+         * Bootstrapping WebSockets with HTTP/2</a>.
+         */
+        PROTOCOL(":protocol", true);
 
         private static final char PSEUDO_HEADER_PREFIX = ':';
         private static final byte PSEUDO_HEADER_PREFIX_BYTE = (byte) PSEUDO_HEADER_PREFIX;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -180,6 +180,7 @@ public class DefaultHttp2HeadersTest {
         headers.authority(of("netty.io"));
         headers.add(of("name3"), of("value4"));
         headers.scheme(of("https"));
+        headers.add(of(":protocol"), of("websocket"));
         return headers;
     }
 }


### PR DESCRIPTION
Motivation:

RFC 8411 defines a new HTTP/2 pseudo header called `:protocol`:

- https://datatracker.ietf.org/doc/rfc8441/

Netty currently raises an exception when validating an `Http2Headers`.

Modifications:

- Added `Http2Headers.PseudoHeaderNames.PROTOCOL` so that `:protocol`
  pseudo header is not rejected.

Result:

- A user can implement WebSockets with HTTP/2.