### PR TITLE
Enable TLSv1.3 when using BouncyCastle ALPN support

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslEngine.java
@@ -16,8 +16,6 @@
 package io.netty.handler.ssl;
 
 import io.netty.util.internal.SuppressJava6Requirement;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import javax.net.ssl.SSLEngine;
 import java.util.List;
@@ -26,8 +24,6 @@ import java.util.function.BiFunction;
 
 @SuppressJava6Requirement(reason = "Usage guarded by java version check")
 final class BouncyCastleAlpnSslEngine extends JdkAlpnSslEngine {
-
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(BouncyCastleAlpnSslEngine.class);
 
     BouncyCastleAlpnSslEngine(SSLEngine engine,
                      @SuppressWarnings("deprecation") JdkApplicationProtocolNegotiator applicationNegotiator,

--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslUtils.java
@@ -25,13 +25,14 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.function.BiFunction;
+
+import static io.netty.handler.ssl.SslUtils.getSSLContext;
 
 @SuppressJava6Requirement(reason = "Usage guarded by java version check")
 final class BouncyCastleAlpnSslUtils {
@@ -79,8 +80,7 @@ final class BouncyCastleAlpnSslUtils {
                 }
             });
 
-            SSLContext context = SSLContext.getInstance("TLSV1.2", "BCJSSE");
-            context.init(null, null, null);
+            SSLContext context = getSSLContext("BCJSSE");
             SSLEngine engine = context.createSSLEngine();
             setParameters = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
                 @Override

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.base64.Base64;
 import io.netty.handler.codec.base64.Base64Dialect;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -30,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.Provider;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -193,6 +195,22 @@ final class SslUtils {
         }
         context.init(null, new TrustManager[0], null);
         return context;
+    }
+
+    static SSLContext getSSLContext(String provider)
+            throws NoSuchAlgorithmException, KeyManagementException, NoSuchProviderException {
+        final SSLContext context;
+        if (StringUtil.isNullOrEmpty(provider)) {
+            context = SSLContext.getInstance(getTlsVersion());
+        } else {
+            context = SSLContext.getInstance(getTlsVersion(), provider);
+        }
+        context.init(null, new TrustManager[0], null);
+        return context;
+    }
+
+    private static String getTlsVersion() {
+        return TLSV1_3_JDK_SUPPORTED ? PROTOCOL_TLS_V1_3 : PROTOCOL_TLS_V1_2;
     }
 
     static boolean arrayContains(String[] array, String value) {


### PR DESCRIPTION
Motivation:

In the latest version of BouncyCastle, BCJSSE:'TLSv1.3' is now a supported protocol for both client and server. So should consider enabling TLSv1.3 when TLSv1.3 is available

Modification:

This pr is to enable TLSv1.3 when using BouncyCastle ALPN support, please review this pr,thanks

Result:

Enable TLSv1.3 when using BouncyCastle ALPN support

