### PR TITLE
Update run-on-arch-action

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -48,7 +48,7 @@ jobs:
             ${{ runner.os }}-pr-${{ env.cache-name }}-
             ${{ runner.os }}-pr-
 
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2.0.9
         name: Run commands
         id: runcmd
         with:


### PR DESCRIPTION
Motivation:

In the past we did see problems sometime when run-on-arch-action was used. We are multiple releases behind, lets update and so maybe fix the problems.

Modifications:

Update to latest release

Result:

Use latest run-on-arch-action release
