### PR TITLE
SslHandler#unwrap must send fireChannelRead event after a notification for a handshake success

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -33,6 +33,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -453,6 +453,7 @@ public class Http2MultiplexTransportTest {
 
     @Test(timeout = 5000L)
     public void testFireChannelReadAfterHandshakeSuccess_OPENSSL() throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
         assumeTrue(SslProvider.isAlpnSupported(SslProvider.OPENSSL));
         testFireChannelReadAfterHandshakeSuccess(SslProvider.OPENSSL);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -31,6 +31,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -437,6 +438,133 @@ public class Http2MultiplexTransportTest {
             if (error != null) {
                 throw error;
             }
+        } finally {
+            if (ssc != null) {
+                ssc.delete();
+            }
+        }
+    }
+
+    @Test(timeout = 5000L)
+    public void testFireChannelReadAfterHandshakeSuccess_JDK() throws Exception {
+        assumeTrue(SslProvider.isAlpnSupported(SslProvider.JDK));
+        testFireChannelReadAfterHandshakeSuccess(SslProvider.JDK);
+    }
+
+    @Test(timeout = 5000L)
+    public void testFireChannelReadAfterHandshakeSuccess_OPENSSL() throws Exception {
+        assumeTrue(SslProvider.isAlpnSupported(SslProvider.OPENSSL));
+        testFireChannelReadAfterHandshakeSuccess(SslProvider.OPENSSL);
+    }
+
+    private void testFireChannelReadAfterHandshakeSuccess(SslProvider provider) throws Exception {
+        SelfSignedCertificate ssc = null;
+        try {
+            ssc = new SelfSignedCertificate();
+            final SslContext serverCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                    .sslProvider(provider)
+                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                    .applicationProtocolConfig(new ApplicationProtocolConfig(
+                            ApplicationProtocolConfig.Protocol.ALPN,
+                            ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                            ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                            ApplicationProtocolNames.HTTP_2,
+                            ApplicationProtocolNames.HTTP_1_1))
+                    .build();
+
+            ServerBootstrap sb = new ServerBootstrap();
+            sb.group(eventLoopGroup);
+            sb.channel(NioServerSocketChannel.class);
+            sb.childHandler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) {
+                    ch.pipeline().addLast(serverCtx.newHandler(ch.alloc()));
+                    ch.pipeline().addLast(new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
+                        @Override
+                        protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
+                            ctx.pipeline().addLast(new Http2FrameCodecBuilder(true).build());
+                            ctx.pipeline().addLast(new Http2MultiplexHandler(new ChannelInboundHandlerAdapter() {
+                                @Override
+                                public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+                                    if (msg instanceof Http2HeadersFrame && ((Http2HeadersFrame) msg).isEndStream()) {
+                                        ctx.writeAndFlush(new DefaultHttp2HeadersFrame(
+                                                new DefaultHttp2Headers(), false))
+                                           .addListener(new ChannelFutureListener() {
+                                               @Override
+                                               public void operationComplete(ChannelFuture future) {
+                                                   ctx.writeAndFlush(new DefaultHttp2DataFrame(
+                                                           Unpooled.copiedBuffer("Hello World", CharsetUtil.US_ASCII),
+                                                           true));
+                                               }
+                                           });
+                                    }
+                                    ReferenceCountUtil.release(msg);
+                                }
+                            }));
+                        }
+                    });
+                }
+            });
+            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).syncUninterruptibly().channel();
+
+            final SslContext clientCtx = SslContextBuilder.forClient()
+                    .sslProvider(SslProvider.OPENSSL)
+                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .applicationProtocolConfig(new ApplicationProtocolConfig(
+                            ApplicationProtocolConfig.Protocol.ALPN,
+                            ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                            ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                            ApplicationProtocolNames.HTTP_2,
+                            ApplicationProtocolNames.HTTP_1_1))
+                    .build();
+
+            final CountDownLatch latch = new CountDownLatch(1);
+            Bootstrap bs = new Bootstrap();
+            bs.group(eventLoopGroup);
+            bs.channel(NioSocketChannel.class);
+            bs.handler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) {
+                    ch.pipeline().addLast(clientCtx.newHandler(ch.alloc()));
+                    ch.pipeline().addLast(new Http2FrameCodecBuilder(false).build());
+                    ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
+                    ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            if (evt instanceof SslHandshakeCompletionEvent) {
+                                SslHandshakeCompletionEvent handshakeCompletionEvent =
+                                        (SslHandshakeCompletionEvent) evt;
+                                if (handshakeCompletionEvent.isSuccess()) {
+                                    Http2StreamChannelBootstrap h2Bootstrap =
+                                            new Http2StreamChannelBootstrap(clientChannel);
+                                    h2Bootstrap.handler(new ChannelInboundHandlerAdapter() {
+                                        @Override
+                                        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                                            if (msg instanceof Http2DataFrame && ((Http2DataFrame) msg).isEndStream()) {
+                                                latch.countDown();
+                                            }
+                                            ReferenceCountUtil.release(msg);
+                                        }
+                                    });
+                                    h2Bootstrap.open().addListener(new FutureListener<Channel>() {
+                                        @Override
+                                        public void operationComplete(Future<Channel> future) {
+                                            if (future.isSuccess()) {
+                                                future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
+                                                        new DefaultHttp2Headers(), true));
+                                            }
+                                        }
+                                    });
+                                }
+                            }
+                        }
+                    });
+                }
+            });
+            clientChannel = bs.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+
+            latch.await();
         } finally {
             if (ssc != null) {
                 ssc.delete();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -510,7 +510,7 @@ public class Http2MultiplexTransportTest {
             serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).syncUninterruptibly().channel();
 
             final SslContext clientCtx = SslContextBuilder.forClient()
-                    .sslProvider(SslProvider.OPENSSL)
+                    .sslProvider(provider)
                     .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
                     .applicationProtocolConfig(new ApplicationProtocolConfig(

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -507,7 +507,7 @@ public class Http2MultiplexTransportTest {
                     });
                 }
             });
-            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).syncUninterruptibly().channel();
+            serverChannel = sb.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).sync().channel();
 
             final SslContext clientCtx = SslContextBuilder.forClient()
                     .sslProvider(provider)
@@ -564,7 +564,7 @@ public class Http2MultiplexTransportTest {
                     });
                 }
             });
-            clientChannel = bs.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            clientChannel = bs.connect(serverChannel.localAddress()).sync().channel();
 
             latch.await();
         } finally {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1359,7 +1359,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 // Dispatch decoded data after we have notified of handshake success. If this method has been invoked
                 // in a re-entry fashion we execute a task on the executor queue to process after the stack unwinds
                 // to preserve order of events.
-                if (decodeOut.isReadable()) {
+                if (decodeOut.isReadable() && handshakePromise.isDone()) {
                     setState(STATE_FIRE_CHANNEL_READ);
                     if (isStateSet(STATE_UNWRAP_REENTRY)) {
                         executedRead = true;

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1359,7 +1359,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 // Dispatch decoded data after we have notified of handshake success. If this method has been invoked
                 // in a re-entry fashion we execute a task on the executor queue to process after the stack unwinds
                 // to preserve order of events.
-                if (decodeOut.isReadable() && handshakePromise.isDone()) {
+                if (decodeOut.isReadable()) {
                     setState(STATE_FIRE_CHANNEL_READ);
                     if (isStateSet(STATE_UNWRAP_REENTRY)) {
                         executedRead = true;


### PR DESCRIPTION
Motivation:

In some use cases `SslHandler#unwrap` sends `fireChannelRead` event before a notification for a handshake success.
Such use case is a HTTP server that supports HTTP/1.1 and HTTP/2 via `ApplicationProtocolNegotiationHandler`,
in this case `fireChannelRead` is sent before `ApplicationProtocolNegotiationHandler` is able to setup properly the pipeline
depending on the negotiated protocol. The issue is visible when `SslProvider.OPENSSL` is configured.
This is a regression caused by #11156

Modifications:

- SslHandler#unwrap sends fireChannelRead event after a notification for a handshake success
- Add test

Result:

Fixes #11201
