### PR TITLE
Add ChannelFuture which will notify about handshaking process

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -305,5 +305,4 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         super.setForceCloseTimeoutMillis(forceCloseTimeoutMillis);
         return this;
     }
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -324,6 +324,7 @@ public abstract class WebSocketClientHandshakerTest {
                     protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
                         handshaker.finishHandshake(ctx.channel(), msg);
                         ctx.pipeline().remove(this);
+                        assertTrue(handshaker.handshakeFuture().isSuccess());
                     }
                 });
         if (codec) {


### PR DESCRIPTION
Motivation:
Currently, there is no automated way to know if the handshake of the WebSocket client has completed or not. We can indeed call `WebSocketClientHandshaker#isHandshakeComplete` to know if the handshake is completed or not but this is not a very scalable and async way of doing things.

Modification:
Added `ChannelPromise` to notify listeners back on handshake completion or failure.

Result:
Fixes #11208
