### PR TITLE
Preload classes before calling native OnLoad function to prevent clas…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
@@ -33,6 +33,7 @@ public final class ClassInitializerUtil {
             tryLoadClass(classLoader, className);
         }
     }
+
     /**
      * Preload the given classes and so ensure the {@link ClassLoader} has these loaded after this method call.
      *

--- a/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
@@ -25,12 +25,13 @@ public final class ClassInitializerUtil {
     /**
      * Preload the given classes and so ensure the {@link ClassLoader} has these loaded after this method call.
      *
-     * @param classLoader   the {@link ClassLoader}
-     * @param classes    the classes to load.
+     * @param loadingClass      the {@link Class} that wants to load the classes.
+     * @param classes           the classes to load.
      */
-    public static void tryLoadClasses(ClassLoader classLoader, Class<?>... classes) {
+    public static void tryLoadClasses(Class<?> loadingClass, Class<?>... classes) {
+        ClassLoader loader = PlatformDependent.getClassLoader(loadingClass);
         for (Class<?> clazz: classes) {
-            tryLoadClass(classLoader, clazz.getName());
+            tryLoadClass(loader, clazz.getName());
         }
     }
 

--- a/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
@@ -50,8 +50,8 @@ public final class ClassInitializerUtil {
         try {
             // Load the class and also ensure we init it which means its linked etc.
             Class.forName(className, true, classLoader);
-        } catch (Throwable ignore) {
-            // ignore
+        } catch (Exception e) {
+            throw new RuntimeException("Error during loading class " + className, e);
         }
     }
 }

--- a/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
@@ -26,18 +26,6 @@ public final class ClassInitializerUtil {
      * Preload the given classes and so ensure the {@link ClassLoader} has these loaded after this method call.
      *
      * @param classLoader   the {@link ClassLoader}
-     * @param classNames    the classes to load.
-     */
-    public static void tryLoadClasses(ClassLoader classLoader, String... classNames) {
-        for (String className: classNames) {
-            tryLoadClass(classLoader, className);
-        }
-    }
-
-    /**
-     * Preload the given classes and so ensure the {@link ClassLoader} has these loaded after this method call.
-     *
-     * @param classLoader   the {@link ClassLoader}
      * @param classes    the classes to load.
      */
     public static void tryLoadClasses(ClassLoader classLoader, Class<?>... classes) {

--- a/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
@@ -50,8 +50,10 @@ public final class ClassInitializerUtil {
         try {
             // Load the class and also ensure we init it which means its linked etc.
             Class.forName(className, true, classLoader);
-        } catch (Exception e) {
-            throw new RuntimeException("Error during loading class " + className, e);
+        } catch (ClassNotFoundException ignore) {
+            // Ignore
+        } catch (SecurityException ignore) {
+            // Ignore
         }
     }
 }

--- a/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ClassInitializerUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+/**
+ * Utility which ensures that classes are loaded by the {@link ClassLoader}.
+ */
+public final class ClassInitializerUtil {
+
+    private ClassInitializerUtil() { }
+
+    /**
+     * Preload the given classes and so ensure the {@link ClassLoader} has these loaded after this method call.
+     *
+     * @param classLoader   the {@link ClassLoader}
+     * @param classNames    the classes to load.
+     */
+    public static void tryLoadClasses(ClassLoader classLoader, String... classNames) {
+        for (String className: classNames) {
+            tryLoadClass(classLoader, className);
+        }
+    }
+    /**
+     * Preload the given classes and so ensure the {@link ClassLoader} has these loaded after this method call.
+     *
+     * @param classLoader   the {@link ClassLoader}
+     * @param classes    the classes to load.
+     */
+    public static void tryLoadClasses(ClassLoader classLoader, Class<?>... classes) {
+        for (Class<?> clazz: classes) {
+            tryLoadClass(classLoader, clazz.getName());
+        }
+    }
+
+    private static void tryLoadClass(ClassLoader classLoader, String className) {
+        try {
+            // Load the class and also ensure we init it which means its linked etc.
+            Class.forName(className, true, classLoader);
+        } catch (Throwable ignore) {
+            // ignore
+        }
+    }
+}

--- a/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
@@ -162,6 +162,8 @@ static void netty_resolver_dns_native_macos_JNI_OnUnLoad(JNIEnv* env) {
     }
 }
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            MacOSDnsServerAddressStreamProvider.preloadClasses() to reflect that.
 static jint netty_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     int providerRegistered = 0;

--- a/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
@@ -163,7 +163,7 @@ static void netty_resolver_dns_native_macos_JNI_OnUnLoad(JNIEnv* env) {
 }
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            MacOSDnsServerAddressStreamProvider.preloadClasses() to reflect that.
+//            MacOSDnsServerAddressStreamProvider to reflect that.
 static jint netty_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     int providerRegistered = 0;

--- a/resolver-dns-native-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
+++ b/resolver-dns-native-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
@@ -57,7 +57,7 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
 
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
         // NETTY_JNI_UTIL_FIND_CLASS.
-        ClassInitializerUtil.tryLoadClasses(PlatformDependent.getClassLoader(MacOSDnsServerAddressStreamProvider.class),
+        ClassInitializerUtil.tryLoadClasses(MacOSDnsServerAddressStreamProvider.class,
                 // netty_resolver_dns_macos
                 byte[].class, String.class
         );

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -746,6 +746,8 @@ error:
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Native.preloadClasses() to reflect that.
 jint netty_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     char* nettyClassName = NULL;

--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -747,7 +747,7 @@ error:
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Native.preloadClasses() to reflect that.
+//            Native to reflect that.
 jint netty_epoll_linuxsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     char* nettyClassName = NULL;

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -727,6 +727,8 @@ error:
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Native.preloadClasses() to reflect that.
 static jint netty_epoll_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     int staticallyRegistered = 0;

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -728,7 +728,7 @@ error:
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Native.preloadClasses() to reflect that.
+//            Native to reflect that.
 static jint netty_epoll_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     int staticallyRegistered = 0;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -71,7 +71,7 @@ public final class Native {
 
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
         // NETTY_JNI_UTIL_FIND_CLASS.
-        ClassInitializerUtil.tryLoadClasses(PlatformDependent.getClassLoader(Native.class),
+        ClassInitializerUtil.tryLoadClasses(Native.class,
                 // netty_epoll_linuxsocket
                 PeerCredentials.class, DefaultFileRegion.class, FileChannel.class, java.io.FileDescriptor.class,
                 // netty_epoll_native

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -238,6 +238,8 @@ error:
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Native.preloadClasses() to reflect that.
 jint netty_kqueue_bsdsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     char* nettyClassName = NULL;

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -239,7 +239,7 @@ error:
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Native.preloadClasses() to reflect that.
+//            Native to reflect that.
 jint netty_kqueue_bsdsocket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     char* nettyClassName = NULL;

--- a/transport-native-kqueue/src/main/c/netty_kqueue_eventarray.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_eventarray.c
@@ -38,6 +38,8 @@ static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Native.preloadClasses() to reflect that.
 jint netty_kqueue_eventarray_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_jni_util_register_natives(env,
             packagePrefix,

--- a/transport-native-kqueue/src/main/c/netty_kqueue_eventarray.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_eventarray.c
@@ -39,7 +39,7 @@ static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Native.preloadClasses() to reflect that.
+//            Native to reflect that.
 jint netty_kqueue_eventarray_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     if (netty_jni_util_register_natives(env,
             packagePrefix,

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -282,7 +282,7 @@ static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Native.preloadClasses() to reflect that.
+//            Native to reflect that.
 static jint netty_kqueue_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int staticallyRegistered = 0;
     int nativeRegistered = 0;

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -281,6 +281,8 @@ static const JNINativeMethod fixed_method_table[] = {
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Native.preloadClasses() to reflect that.
 static jint netty_kqueue_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int staticallyRegistered = 0;
     int nativeRegistered = 0;

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -60,7 +60,7 @@ final class Native {
 
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
         // NETTY_JNI_UTIL_FIND_CLASS.
-        ClassInitializerUtil.tryLoadClasses(PlatformDependent.getClassLoader(Native.class),
+        ClassInitializerUtil.tryLoadClasses(Native.class,
                 // netty_kqueue_bsdsocket
                 PeerCredentials.class, DefaultFileRegion.class, FileChannel.class, java.io.FileDescriptor.class
         );

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -16,10 +16,10 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.DefaultFileRegion;
-import io.netty.channel.unix.DatagramSocketAddress;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Unix;
+import io.netty.util.internal.ClassInitializerUtil;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -28,12 +28,8 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.PortUnreachableException;
-import java.nio.channels.ClosedChannelException;
-import java.util.HashSet;
+import java.nio.channels.FileChannel;
 import java.util.Locale;
-import java.util.Set;
 
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evAdd;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evClear;
@@ -57,10 +53,17 @@ import static io.netty.channel.unix.Errors.newIOException;
  */
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
-    private static final Set<Class<?>> PRELOADED_CLASSES = new HashSet<Class<?>>();
 
     static {
-        preloadClasses();
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
+
+        // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
+        // NETTY_JNI_UTIL_FIND_CLASS.
+        ClassInitializerUtil.tryLoadClasses(PlatformDependent.getClassLoader(Native.class),
+                // netty_kqueue_bsdsocket
+                PeerCredentials.class, DefaultFileRegion.class, FileChannel.class, java.io.FileDescriptor.class
+        );
 
         try {
             // First, try calling a side-effect free JNI method to see if the library was already
@@ -76,24 +79,6 @@ final class Native {
                 registerUnix();
             }
         });
-    }
-
-    // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
-    // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
-    private static void preloadClasses() {
-        // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
-        // NETTY_JNI_UTIL_FIND_CLASS.
-
-        // netty_kqueue_bsdsocket
-        PRELOADED_CLASSES.add(DefaultFileRegion.class);
-        try {
-            PRELOADED_CLASSES.add(Class.forName("sun.nio.ch.FileChannelImpl"));
-        } catch (ClassNotFoundException ignore) {
-            // ignore
-        }
-        PRELOADED_CLASSES.add(java.io.FileDescriptor.class);
-        PRELOADED_CLASSES.add(PeerCredentials.class);
-        PRELOADED_CLASSES.add(String.class);
     }
 
     private static native int registerUnix();

--- a/transport-native-unix-common/src/main/c/netty_unix.c
+++ b/transport-native-unix-common/src/main/c/netty_unix.c
@@ -22,6 +22,8 @@
 #include "netty_unix_socket.h"
 #include "netty_unix_util.h"
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Unix.preloadClasses() to reflect that.
 jint netty_unix_register(JNIEnv* env, const char* packagePrefix) {
     int limitsOnLoadCalled = 0;
     int errorsOnLoadCalled = 0;

--- a/transport-native-unix-common/src/main/c/netty_unix.c
+++ b/transport-native-unix-common/src/main/c/netty_unix.c
@@ -23,7 +23,7 @@
 #include "netty_unix_util.h"
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Unix.preloadClasses() to reflect that.
+//            Unix to reflect that.
 jint netty_unix_register(JNIEnv* env, const char* packagePrefix) {
     int limitsOnLoadCalled = 0;
     int errorsOnLoadCalled = 0;

--- a/transport-native-unix-common/src/main/c/netty_unix_buffer.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_buffer.c
@@ -40,7 +40,7 @@ static const jint statically_referenced_fixed_method_table_size = sizeof(statica
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Unix.preloadClasses() to reflect that.
+//            Unix to reflect that.
 jint netty_unix_buffer_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     // We must register the statically referenced methods first!
     if (netty_jni_util_register_natives(env,

--- a/transport-native-unix-common/src/main/c/netty_unix_buffer.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_buffer.c
@@ -39,6 +39,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Unix.preloadClasses() to reflect that.
 jint netty_unix_buffer_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     // We must register the statically referenced methods first!
     if (netty_jni_util_register_natives(env,

--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -213,7 +213,7 @@ static const jint statically_referenced_fixed_method_table_size = sizeof(statica
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Unix.preloadClasses() to reflect that.
+//            Unix to reflect that.
 jint netty_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     char* nettyClassName = NULL;
     // We must register the statically referenced methods first!

--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -212,6 +212,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Unix.preloadClasses() to reflect that.
 jint netty_unix_errors_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     char* nettyClassName = NULL;
     // We must register the statically referenced methods first!

--- a/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
@@ -279,7 +279,7 @@ static const jint method_table_size = sizeof(method_table) / sizeof(method_table
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Unix.preloadClasses() to reflect that.
+//            Unix to reflect that.
 jint netty_unix_filedescriptor_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     void* mem = NULL;

--- a/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
@@ -278,6 +278,8 @@ static const JNINativeMethod method_table[] = {
 static const jint method_table_size = sizeof(method_table) / sizeof(method_table[0]);
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Unix.preloadClasses() to reflect that.
 jint netty_unix_filedescriptor_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     void* mem = NULL;

--- a/transport-native-unix-common/src/main/c/netty_unix_limits.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_limits.c
@@ -70,7 +70,7 @@ static const jint statically_referenced_fixed_method_table_size = sizeof(statica
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Unix.preloadClasses() to reflect that.
+//            Unix to reflect that.
 jint netty_unix_limits_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     // We must register the statically referenced methods first!
     if (netty_jni_util_register_natives(env,

--- a/transport-native-unix-common/src/main/c/netty_unix_limits.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_limits.c
@@ -69,6 +69,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Unix.preloadClasses() to reflect that.
 jint netty_unix_limits_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     // We must register the statically referenced methods first!
     if (netty_jni_util_register_natives(env,

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -1011,6 +1011,8 @@ error:
 
 // JNI Method Registration Table End
 
+// IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
+//            Unix.preloadClasses() to reflect that.
 jint netty_unix_socket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     char* nettyClassName = NULL;

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -1012,7 +1012,7 @@ error:
 // JNI Method Registration Table End
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
-//            Unix.preloadClasses() to reflect that.
+//            Unix to reflect that.
 jint netty_unix_socket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
     int ret = JNI_ERR;
     char* nettyClassName = NULL;

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
@@ -16,7 +16,6 @@
 package io.netty.channel.unix;
 
 import io.netty.util.internal.ClassInitializerUtil;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -38,7 +37,7 @@ public final class Unix {
 
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
         // NETTY_JNI_UTIL_FIND_CLASS.
-        ClassInitializerUtil.tryLoadClasses(PlatformDependent.getClassLoader(Unix.class),
+        ClassInitializerUtil.tryLoadClasses(Unix.class,
                 // netty_unix_errors
                 OutOfMemoryError.class, RuntimeException.class, ClosedChannelException.class,
                 IOException.class, PortUnreachableException.class,

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
@@ -15,15 +15,14 @@
  */
 package io.netty.channel.unix;
 
+import io.netty.util.internal.ClassInitializerUtil;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.PortUnreachableException;
 import java.nio.channels.ClosedChannelException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -32,28 +31,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class Unix {
     private static final AtomicBoolean registered = new AtomicBoolean();
-    private static final Set<Class<?>> PRELOADED_CLASSES = new HashSet<Class<?>>();
 
     static {
-        preloadClasses();
-    }
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
 
-    // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
-    // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
-    private static void preloadClasses() {
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via
         // NETTY_JNI_UTIL_FIND_CLASS.
+        ClassInitializerUtil.tryLoadClasses(PlatformDependent.getClassLoader(Unix.class),
+                // netty_unix_errors
+                OutOfMemoryError.class, RuntimeException.class, ClosedChannelException.class,
+                IOException.class, PortUnreachableException.class,
 
-        // netty_unix_errors
-        PRELOADED_CLASSES.add(OutOfMemoryError.class);
-        PRELOADED_CLASSES.add(RuntimeException.class);
-        PRELOADED_CLASSES.add(ClosedChannelException.class);
-        PRELOADED_CLASSES.add(IOException.class);
-        PRELOADED_CLASSES.add(PortUnreachableException.class);
-
-        // netty_unix_socket
-        PRELOADED_CLASSES.add(DatagramSocketAddress.class);
-        PRELOADED_CLASSES.add(InetSocketAddress.class);
+                // netty_unix_socket
+                DatagramSocketAddress.class, InetSocketAddress.class
+        );
     }
 
     /**


### PR DESCRIPTION
…sloader deadlock

Motivation:

It turns out it is quite easy to cause a classloader deadlock in more recent java updates if you cause classloading while you are in native code. Because of this we should just workaround this issue by pre-load all the classes that needs to be accessed in the OnLoad function.

Modifications:

- Preload all classes that would otherwise be loaded by native OnLoad functions.

Result:

Workaround for https://github.com/netty/netty/issues/11209 and https://bugs.openjdk.java.net/browse/JDK-8266310