### PR TITLE
Update java versions

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.11
     build:
       args:
-        java_version : "adopt@1.11.0-9"
+        java_version : "adopt@1.11.0-11"
 
   build:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.115.yaml
+++ b/docker/docker-compose.centos-6.115.yaml
@@ -8,7 +8,7 @@ services:
       args:
         # use zulu and not adoptjdk for now as adoptjdk15 does not support centos6
         # https://github.com/AdoptOpenJDK/openjdk-build/issues/2097
-        java_version : "zulu@1.15.0-1"
+        java_version : "zulu@1.15.0-2"
 
   build:
     image: netty:centos-6-1.15

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.8
     build:
       args:
-        java_version : "adopt@1.8.0-272"
+        java_version : "adopt@1.8.0-292"
 
   build:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.openj9111.yaml
+++ b/docker/docker-compose.centos-6.openj9111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-openj9-1.11
     build:
       args:
-        java_version : "adopt-openj9@1.11.0-9"
+        java_version : "adopt-openj9@1.11.0-11"
 
   build:
     image: netty:centos-6-openj9-1.11


### PR DESCRIPTION
Motivation:

We should use the latest java versions when compiling on the CI

Modifications:

Upgrade to latest versions

Result:

Use latest versions