### PR TITLE
Decrease visibility of `Http2FrameCodecBuilder` default ctor to `protected`

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
@@ -29,7 +29,16 @@ public class Http2FrameCodecBuilder extends
 
     private Http2FrameWriter frameWriter;
 
-    public Http2FrameCodecBuilder() {
+    /**
+     * Allows overriding behavior of existing builder.
+     * <p>
+     * Users of this constructor are responsible for invoking {@link #server(boolean)} method or overriding
+     * {@link #isServer()} method to give the builder information if the {@link Http2Connection}(s) it creates are in
+     * server or client mode.
+     *
+     * @see AbstractHttp2ConnectionHandlerBuilder
+     */
+    protected Http2FrameCodecBuilder() {
     }
 
     Http2FrameCodecBuilder(boolean server) {


### PR DESCRIPTION
Motivation:

`Http2FrameCodecBuilder` defines static factory methods `forClient()`
and `forServer()` that should be used to create a new instance.
The default ctor is useful only when users need to override behavior
of the existing builder. Those users should define another way to create
an instance.

Modifications:

- Decrease visibility of `Http2FrameCodecBuilder` default ctor from
`public` to `protected`;
- Add javadoc to clarity responsibilities;

Result:

Users of `Http2FrameCodecBuilder` are not confused why
`new Http2FrameCodecBuilder().build()` works for the server-side, but
does not work for the client-side.

Follow-up for #11195.