### PR TITLE
Bump initial timeouts in SSLEngineTest

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -595,7 +595,7 @@ public abstract class SSLEngineTest {
         // Client trusts server but server only trusts itself
         mySetupMutualAuth(serverCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
                           serverCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
-        assertTrue(serverLatch.await(2, TimeUnit.SECONDS));
+        assertTrue(serverLatch.await(10, TimeUnit.SECONDS));
         assertTrue(serverException instanceof SSLHandshakeException);
     }
 
@@ -610,7 +610,7 @@ public abstract class SSLEngineTest {
         // Server trusts client but client only trusts itself
         mySetupMutualAuth(clientCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
                           clientCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
-        assertTrue(clientLatch.await(2, TimeUnit.SECONDS));
+        assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
         assertTrue(clientException instanceof SSLHandshakeException);
     }
 
@@ -655,7 +655,7 @@ public abstract class SSLEngineTest {
 
         mySetupMutualAuth(serverKeyManagerFactory, commonCertChain, clientKeyManagerFactory, commonCertChain,
                 auth, false, false);
-        assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
         assertNull(clientException);
         assertTrue(serverLatch.await(5, TimeUnit.SECONDS));
         assertNull(serverException);
@@ -682,7 +682,7 @@ public abstract class SSLEngineTest {
 
         mySetupMutualAuth(serverKeyManagerFactory, commonCertChain, clientKeyManagerFactory, commonCertChain,
                           auth, true, serverInitEngine);
-        assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
         assertTrue("unexpected exception: " + clientException,
                 mySetupMutualAuthServerIsValidClientException(clientException));
         assertTrue(serverLatch.await(5, TimeUnit.SECONDS));
@@ -845,25 +845,25 @@ public abstract class SSLEngineTest {
     }
 
     @Test
-    public void testClientHostnameValidationSuccess() throws InterruptedException, SSLException {
+    public void testClientHostnameValidationSuccess() throws Exception {
         mySetupClientHostnameValidation(ResourcesUtil.getFile(getClass(),  "localhost_server.pem"),
                                         ResourcesUtil.getFile(getClass(), "localhost_server.key"),
                                         ResourcesUtil.getFile(getClass(), "mutual_auth_ca.pem"),
                                         false);
-        assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
         assertNull(clientException);
         assertTrue(serverLatch.await(5, TimeUnit.SECONDS));
         assertNull(serverException);
     }
 
     @Test
-    public void testClientHostnameValidationFail() throws InterruptedException, SSLException {
+    public void testClientHostnameValidationFail() throws Exception {
         Future<Void> clientWriteFuture =
             mySetupClientHostnameValidation(ResourcesUtil.getFile(getClass(),  "notlocalhost_server.pem"),
                                             ResourcesUtil.getFile(getClass(), "notlocalhost_server.key"),
                                             ResourcesUtil.getFile(getClass(), "mutual_auth_ca.pem"),
                                             true);
-        assertTrue(clientLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(clientLatch.await(10, TimeUnit.SECONDS));
         assertTrue("unexpected exception: " + clientException,
                 mySetupMutualAuthServerIsValidClientException(clientException));
         assertTrue(serverLatch.await(5, TimeUnit.SECONDS));
@@ -1218,7 +1218,7 @@ public abstract class SSLEngineTest {
                                                MessageReceiver receiver) throws Exception {
         List<ByteBuf> dataCapture = null;
         try {
-            assertTrue(sendChannel.writeAndFlush(message).await(5, TimeUnit.SECONDS));
+            assertTrue(sendChannel.writeAndFlush(message).await(10, TimeUnit.SECONDS));
             receiverLatch.await(5, TimeUnit.SECONDS);
             message.resetReaderIndex();
             ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
@@ -1366,8 +1366,7 @@ public abstract class SSLEngineTest {
     }
 
     @Test(timeout = 30000)
-    public void clientInitiatedRenegotiationWithFatalAlertDoesNotInfiniteLoopServer()
-            throws CertificateException, SSLException, InterruptedException, ExecutionException {
+    public void clientInitiatedRenegotiationWithFatalAlertDoesNotInfiniteLoopServer() throws Exception {
         assumeTrue(PlatformDependent.javaVersion() >= 11);
         final SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = wrapContext(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
@@ -3898,7 +3897,7 @@ public abstract class SSLEngineTest {
         }
     }
 
-    private KeyManagerFactory newKeyManagerFactory(SelfSignedCertificate ssc)
+    private static KeyManagerFactory newKeyManagerFactory(SelfSignedCertificate ssc)
             throws UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException,
             CertificateException, IOException {
         return SslContext.buildKeyManagerFactory(


### PR DESCRIPTION
Motivation:
We've seen (very rare) flaky test failures due to timeouts.
They are too rare to analyse properly, but a theory is that on overloaded, small cloud CI instances, it can sometimes take a surprising amount of time to start a thread.
It could be that the event loop thread is getting an unlucky schedule, and takes seconds to start, causing the timeouts to elapse.

Modification:
Increase the initial timeouts in the SSLEngineTest, that could end up waiting for the event loop thread to start.
Also fix a few simple warnings from Intellij.

Result:
Hopefully we will not see these tests be flaky again.
So, hopefully fixes the test failure we saw in https://github.com/netty/netty/pull/11068/checks?check_run_id=2063872643
