### PR TITLE
Add explicit null checks in OpenSslX509KeyManagerFactory

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactory.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -254,6 +255,7 @@ public final class OpenSslX509KeyManagerFactory extends KeyManagerFactory {
     public static OpenSslX509KeyManagerFactory newEngineBased(X509Certificate[] certificateChain, String password)
             throws CertificateException, IOException,
                    KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+        checkNotNull(certificateChain, "certificateChain");
         KeyStore store = new OpenSslKeyStore(certificateChain.clone(), false);
         store.load(null, null);
         OpenSslX509KeyManagerFactory factory = new OpenSslX509KeyManagerFactory();
@@ -286,6 +288,7 @@ public final class OpenSslX509KeyManagerFactory extends KeyManagerFactory {
     public static OpenSslX509KeyManagerFactory newKeyless(X509Certificate... certificateChain)
             throws CertificateException, IOException,
             KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+        checkNotNull(certificateChain, "certificateChain");
         KeyStore store = new OpenSslKeyStore(certificateChain.clone(), true);
         store.load(null, null);
         OpenSslX509KeyManagerFactory factory = new OpenSslX509KeyManagerFactory();

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -27,6 +27,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.util.AttributeMap;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ObjectUtil;
 
 import java.security.Provider;
 import javax.net.ssl.KeyManager;
@@ -1102,6 +1103,7 @@ public abstract class SslContext {
                                   char[] keyPasswordChars, String keyStoreType)
             throws KeyStoreException, NoSuchAlgorithmException,
                    CertificateException, IOException {
+        ObjectUtil.checkNotNull(certChain, "certChain");
         if (keyStoreType == null) {
             keyStoreType = KeyStore.getDefaultType();
         }

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -27,7 +27,6 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.util.AttributeMap;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.ObjectUtil;
 
 import java.security.Provider;
 import javax.net.ssl.KeyManager;
@@ -1103,7 +1102,6 @@ public abstract class SslContext {
                                   char[] keyPasswordChars, String keyStoreType)
             throws KeyStoreException, NoSuchAlgorithmException,
                    CertificateException, IOException {
-        ObjectUtil.checkNotNull(certChain, "certChain");
         if (keyStoreType == null) {
             keyStoreType = KeyStore.getDefaultType();
         }


### PR DESCRIPTION
Motivation:

The return value of io.netty.handler.ssl.SslContext.toX509Certificates() may be null, so the non-null check is required for the return value

Modification:

Should do the non-null check on the return value of io.netty.handler.ssl.SslContext.toX509Certificates() in SslContext and OpenSslX509KeyManagerFactory, thanks

Result:

Added a non-null check for the return value of io.netty.handler.ssl.SslContext.toX509Certificates()
