### PR TITLE
Disable TLSv1 and TLSv1.1 by default

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -297,6 +297,11 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             int options = SSLContext.getOptions(ctx) |
                           SSL.SSL_OP_NO_SSLv2 |
                           SSL.SSL_OP_NO_SSLv3 |
+                          // Disable TLSv1 and TLSv1.1 by default as these are not considered secure anymore
+                          // and the JDK is doing the same:
+                          // https://www.oracle.com/java/technologies/javase/8u291-relnotes.html
+                          SSL.SSL_OP_NO_TLSv1 |
+                          SSL.SSL_OP_NO_TLSv1_1 |
 
                           SSL.SSL_OP_CIPHER_SERVER_PREFERENCE |
 


### PR DESCRIPTION
Motivation:

TLSv1 and TLSv1.1 is considered insecure. Let's follow the JDK and disable these by default

Modifications:

Disable TLSv1 and TLSv1.1 by default when using OpenSSL.

Result:

Use only strong TLS versions by default when using OpenSSL