### PR TITLE
Update conscrypt and add workaround for test failure

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -2040,6 +2040,15 @@ public abstract class SSLEngineTest {
         }
     }
 
+    private String[] nonContiguousProtocols(SslProvider provider) {
+        if (provider != null) {
+            // conscrypt not correctly filters out TLSv1 and TLSv1.1 which is required now by the JDK.
+            // https://github.com/google/conscrypt/issues/1013
+            return new String[] { PROTOCOL_TLS_V1_2 };
+        }
+        return new String[] {PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1};
+    }
+
     @Test
     public void testHandshakeCompletesWithNonContiguousProtocolsTLSv1_2CipherOnly() throws Exception {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
@@ -2049,14 +2058,14 @@ public abstract class SSLEngineTest {
         clientSslCtx = wrapContext(SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .ciphers(Collections.singletonList(sharedCipher))
-                .protocols(PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1)
+                .protocols(nonContiguousProtocols(sslClientProvider()))
                 .sslContextProvider(clientSslContextProvider())
                 .sslProvider(sslClientProvider())
                 .build());
 
         serverSslCtx = wrapContext(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .ciphers(Collections.singletonList(sharedCipher))
-                .protocols(PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1)
+                .protocols(nonContiguousProtocols(sslServerProvider()))
                 .sslContextProvider(serverSslContextProvider())
                 .sslProvider(sslServerProvider())
                 .build());
@@ -2082,14 +2091,14 @@ public abstract class SSLEngineTest {
         clientSslCtx = wrapContext(SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .ciphers(Collections.singletonList(sharedCipher), SupportedCipherSuiteFilter.INSTANCE)
-                .protocols(PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1)
+                .protocols(nonContiguousProtocols(sslClientProvider()))
                 .sslContextProvider(clientSslContextProvider())
                 .sslProvider(sslClientProvider())
                 .build());
 
         serverSslCtx = wrapContext(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .ciphers(Collections.singletonList(sharedCipher), SupportedCipherSuiteFilter.INSTANCE)
-                .protocols(PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1)
+                .protocols(nonContiguousProtocols(sslServerProvider()))
                 .sslContextProvider(serverSslContextProvider())
                 .sslProvider(sslServerProvider())
                 .build());

--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
-    <conscrypt.version>2.5.1</conscrypt.version>
+    <conscrypt.version>2.5.2</conscrypt.version>
     <conscrypt.classifier />
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

Conscrypt not correctly filters out non support TLS versions which may lead to test failures.

Related to https://github.com/google/conscrypt/issues/1013

Modifications:

- Bump up to latest patch release
- Add workaround

Result:

No more test failures caused by conscrypt
