### PR TITLE
Use the same maven cache for all

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,15 +25,13 @@ jobs:
       - uses: actions/checkout@v2
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
-        env:
-          cache-name: build-${{ matrix.setup }}-cache-m2-repository
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-maven-
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -28,15 +28,13 @@ jobs:
       - uses: actions/checkout@v2
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
-        env:
-          cache-name: staging-${{ matrix.setup }}-cache-m2-repository
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-staging-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-staging-${{ env.cache-name }}-
-            ${{ runner.os }}-staging-
+            ${{ runner.os }}-maven-
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11
@@ -77,15 +75,13 @@ jobs:
           java-version: 8
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
-        env:
-          cache-name: deploy-staging-cache-m2-repository
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-deploy-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-deploy-${{ env.cache-name }}-
-            ${{ runner.os }}-deploy-
+            ${{ runner.os }}-maven-
 
       # Setup some env to re-use later.
       - name: Prepare enviroment variables

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,15 +17,13 @@ jobs:
         with:
           java-version: 8
       # Cache .m2/repository
-      - uses: actions/cache@v2
-        env:
-          cache-name: verify-cache-m2-repository
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-${{ env.cache-name }}-
-            ${{ runner.os }}-pr-
+            ${{ runner.os }}-maven-
       - name: Verify with Maven
         run: mvn verify -B --file pom.xml -Pci -DskipTests=true
 
@@ -38,15 +36,13 @@ jobs:
       - uses: actions/checkout@v2
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
-        env:
-          cache-name: build-pr-aarch64-cache-m2-repository
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-${{ env.cache-name }}-
-            ${{ runner.os }}-pr-
+            ${{ runner.os }}-maven-
 
       - uses: uraimo/run-on-arch-action@v2.0.9
         name: Run commands
@@ -99,15 +95,13 @@ jobs:
       - uses: actions/checkout@v2
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
-        env:
-          cache-name: build-${{ matrix.setup }}-cache-m2-repository
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-${{ env.cache-name }}-
-            ${{ runner.os }}-pr-
+            ${{ runner.os }}-maven-
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.11

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -30,15 +30,13 @@ jobs:
           known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
       # Cache .m2/repository
-      - uses: actions/cache@v2
-        env:
-          cache-name: release-cache-m2-repository
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-pr-${{ env.cache-name }}-
-            ${{ runner.os }}-pr-
+            ${{ runner.os }}-maven-
 
       - name: Prepare release with Maven
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,15 +37,13 @@ jobs:
         fetch-depth: 2
 
     # Cache .m2/repository
-    - uses: actions/cache@v2
-      env:
-        cache-name: verify-cache-m2-repository
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-pr-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-pr-${{ env.cache-name }}-
-          ${{ runner.os }}-pr-
+          ${{ runner.os }}-maven-
 
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.


### PR DESCRIPTION
Motivation:

We should use the same maven cache for all builds so we can re-use as much of the downloaded maven dependencies as possible

Modifications:

- Just use the same cache for all

Result:

Hopefully be able to re-use most of the dependencies

