### PR TITLE
Fix java version for java16

### DIFF
--- a/docker/docker-compose.centos-6.116.yaml
+++ b/docker/docker-compose.centos-6.116.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.16
     build:
       args:
-        java_version : "adopt-openj9@1.16.0-1"
+        java_version : "adopt@1.16.0-1"
 
   build:
     image: netty:centos-6-1.16

--- a/pom.xml
+++ b/pom.xml
@@ -800,7 +800,7 @@
       <dependency>
         <groupId>io.projectreactor.tools</groupId>
         <artifactId>blockhound</artifactId>
-        <version>1.0.3.RELEASE</version>
+        <version>1.0.6.RELEASE</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,8 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <!-- doesn't work with java16 -->
+        <skipJapicmp>true</skipJapicmp>
       </properties>
     </profile>
 


### PR DESCRIPTION
Motivation:

When trying to compile with java16 we should use adopt@1.16*

Modifications:

Use adopt@1.16.0-1

Result:

Use correct java version / flavor
