### PR TITLE
Change asterisk to 'x' in FQDN of SelfSignedCertificate

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -332,7 +332,8 @@ public final class SelfSignedCertificate {
             wrappedBuf.release();
         }
 
-        fqdn = fqdn.replaceFirst("\\*", "X"); // Change asterisk to 'X'
+        // Change asterisk to 'x' for file name safety.
+        fqdn = fqdn.replaceFirst("[^\\w.-]", "x");
 
         File keyFile = PlatformDependent.createTempFile("keyutil_" + fqdn + '_', ".key", null);
         keyFile.deleteOnExit();

--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -332,8 +332,8 @@ public final class SelfSignedCertificate {
             wrappedBuf.release();
         }
 
-        // Change asterisk to 'x' for file name safety.
-        fqdn = fqdn.replaceFirst("[^\\w.-]", "x");
+        // Change all asterisk to 'x' for file name safety.
+        fqdn = fqdn.replaceAll("[^\\w.-]", "x");
 
         File keyFile = PlatformDependent.createTempFile("keyutil_" + fqdn + '_', ".key", null);
         keyFile.deleteOnExit();

--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -332,6 +332,8 @@ public final class SelfSignedCertificate {
             wrappedBuf.release();
         }
 
+        fqdn = fqdn.replaceFirst("\\*", "X"); // Change asterisk to 'X'
+
         File keyFile = PlatformDependent.createTempFile("keyutil_" + fqdn + '_', ".key", null);
         keyFile.deleteOnExit();
 

--- a/handler/src/test/java/io/netty/handler/ssl/util/SelfSignedCertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/SelfSignedCertificateTest.java
@@ -1,0 +1,35 @@
+package io.netty.handler.ssl.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.security.cert.CertificateException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelfSignedCertificateTest {
+
+    @Test
+    void fqdnAsteriskDoesNotThrowTest() {
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new SelfSignedCertificate("*.netty.io", "EC", 256);
+            }
+        });
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new SelfSignedCertificate("*.netty.io", "RSA", 2048);
+            }
+        });
+    }
+
+    @Test
+    void fqdnAsteriskFileNameTest() throws CertificateException {
+        SelfSignedCertificate ssc = new SelfSignedCertificate("*.netty.io", "EC", 256);
+        assertFalse(ssc.certificate().getName().contains("*"));
+        assertFalse(ssc.privateKey().getName().contains("*"));
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/util/SelfSignedCertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/SelfSignedCertificateTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.ssl.util;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Motivation:

`SelfSignedCertificate` creates a certificate and private key files and store them in a temporary directory. However, if the certificate uses a wildcard hostname that uses asterisk *, e.g. `*.shieldblaze.com`, it'll throw an error because * is not a valid character in the file system.

Modification:
Replace the asterisk with 'X'

Result:
Fixes #11240