### PR TITLE
Use MAVEN_OPTS to setup timeouts for dependency downloads

### DIFF
--- a/.github/scripts/release_rollback.sh
+++ b/.github/scripts/release_rollback.sh
@@ -10,5 +10,5 @@ TAG=$(grep scm.tag= "$1" | cut -d'=' -f2)
 git remote set-url origin git@github.com:"$2".git
 git fetch
 git checkout "$3"
-mvn -B --file pom.xml release:rollback
+./mvnw -B --file pom.xml release:rollback
 git push origin :"$TAG"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
   build:

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   stage-snapshot:
     runs-on: ubuntu-latest
@@ -122,6 +125,4 @@ jobs:
             }]
 
       - name: Deploy local staged artifacts
-        env:
-          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
         run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
   stage-snapshot:

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -122,4 +122,6 @@ jobs:
             }]
 
       - name: Deploy local staged artifacts
-        run: mvn -B --file pom.xml -Pci org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR
+        env:
+          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=$LOCAL_STAGING_DIR

--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -4,6 +4,9 @@ on:
     workflows: [ "Build PR" ]
     types:
       - completed
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -5,7 +5,7 @@ on:
     types:
       - completed
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
   tests:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   verify-pr:
     runs-on: ubuntu-18.04
@@ -26,8 +29,6 @@ jobs:
             ${{ runner.os }}-maven-verify-pr-
             ${{ runner.os }}-maven-
       - name: Verify with Maven
-        env:
-          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
         run: ./mvnw verify -B --file pom.xml -DskipTests=true
 
   build-pr-aarch64:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,7 +26,9 @@ jobs:
             ${{ runner.os }}-maven-verify-pr-
             ${{ runner.os }}-maven-
       - name: Verify with Maven
-        run: mvn verify -B --file pom.xml -Pci -DskipTests=true
+        env:
+          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+        run: ./mvnw verify -B --file pom.xml -DskipTests=true
 
   build-pr-aarch64:
     name: linux-aarch64-verify-native
@@ -71,7 +73,7 @@ jobs:
           #
           # Use tcnative.classifier that is empty as we don't support using the shared lib version on ubuntu.
           run: |
-            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64 mvn -Pci -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
+            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64 ./mvnw -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
 
   build-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
   verify-pr:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -5,6 +5,9 @@ on:
   # Releases can only be triggered via the action tab
   workflow_dispatch:
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   prepare-release:
     runs-on: ubuntu-18.04
@@ -40,8 +43,6 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Prepare release with Maven
-        env:
-          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
         run: |
           ./mvnw -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true
           ./mvnw clean
@@ -223,8 +224,6 @@ jobs:
 
       - name: Deploy local staged artifacts
         working-directory: ./prepare-release-workspace/
-        env:
-          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
         # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
         run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
   prepare-release:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -40,9 +40,11 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Prepare release with Maven
+        env:
+          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
         run: |
-          mvn -B --file pom.xml -Pci release:prepare -DpreparationGoals=clean -DskipTests=true
-          mvn -Pci clean
+          ./mvnw -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true
+          ./mvnw clean
 
       - name: Checkout tag
         run: ./.github/scripts/release_checkout_tag.sh release.properties
@@ -161,6 +163,9 @@ jobs:
           name: prepare-release-workspace
           path: ./prepare-release-workspace/
 
+      - name: Adjust mvnw permissions
+        run: chmod 755 ./prepare-release-workspace/mvnw
+
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
@@ -218,8 +223,10 @@ jobs:
 
       - name: Deploy local staged artifacts
         working-directory: ./prepare-release-workspace/
+        env:
+          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
         # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
-        run: mvn -Pci -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
+        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
     - cron: '0 13 * * 3'
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,10 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: ./mvnw -Pci clean package -DskipTests=true -ntp -B
+    - name: Compile project
+      env:
+        MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+      run: ./mvnw clean package -DskipTests=true -ntp -B
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 13 * * 3'
 
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
 jobs:
   analyze:
     name: Analyze
@@ -74,8 +77,6 @@ jobs:
     #    uses a compiled language
 
     - name: Compile project
-      env:
-        MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
       run: ./mvnw clean package -DskipTests=true -ntp -B
 
     - name: Perform CodeQL Analysis

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-  <servers>
-    <server>
-      <id>sonatype-nexus-snapshots</id>
-      <username>${env.SANOTYPE_USER}</username>
-      <password>${env.SANOTYPE_PASSWORD}</password>
-    </server>
-  </servers>
-</settings>

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -15,6 +15,11 @@ services:
   cross-compile-aarch64-common: &cross-compile-aarch64-common
     depends_on: [ cross-compile-aarch64-runtime-setup ]
     image: netty:cross_compile_aarch64
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS=-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
@@ -24,7 +29,7 @@ services:
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -Pci,linux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean deploy -DskipTests=true"
 
   cross-compile-aarch64-stage-snapshot:
     <<: *cross-compile-aarch64-common
@@ -34,20 +39,16 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Pci,linux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
-    environment:
-      - GPG_KEYNAME
-      - GPG_PASSPHRASE
-      - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Pci,linux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-aarch64-shell:
     <<: *cross-compile-aarch64-common
@@ -55,4 +56,4 @@ services:
 
   cross-compile-aarch64-build:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -Pci,linux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package -DskipTests=true"

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -19,7 +19,7 @@ services:
       - GPG_KEYNAME
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
-      - MAVEN_OPTS=-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,6 +11,11 @@ services:
   common: &common
     image: netty:default
     depends_on: [runtime-setup]
+    environment:
+      - GPG_KEYNAME
+      - GPG_PASSPHRASE
+      - GPG_PRIVATE_KEY
+      - MAVEN_OPTS=-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
@@ -42,10 +47,6 @@ services:
 
   stage-release:
     <<: *common
-    environment:
-      - GPG_KEYNAME
-      - GPG_PASSPHRASE
-      - GPG_PRIVATE_KEY
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.m2:/root/.m2

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - GPG_KEYNAME
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
-      - MAVEN_OPTS=-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+      - MAVEN_OPTS
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,6 @@
   </developers>
 
   <profiles>
-    <profile>
-      <id>ci</id>
-      <properties>
-        <http.keepAlive>false</http.keepAlive>
-        <maven.wagon.http.pool>false</maven.wagon.http.pool>
-        <maven.wagon.httpconnectionManager.ttlSeconds>120</maven.wagon.httpconnectionManager.ttlSeconds>
-      </properties>
-    </profile>
     <!-- Detect if we use GraalVM and if so enable the native image testsuite -->
     <profile>
       <id>graal</id>


### PR DESCRIPTION
Motivation:

Just use MAVEN_OPTS to setup all the timeouts etc for dependency downloads. This way we at least can be sure these are applied.

Modifications:

- Use MAVEN_OPTS
- Remove ci profile
- Remove unused settings.xml file
- Always use ./mvnw

Result:

Build stability improvements