### PR TITLE
make Slf4JLoggerFactory be singleton

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -59,7 +59,7 @@ public abstract class InternalLoggerFactory {
 
     private static InternalLoggerFactory useSlf4JLoggerFactory(String name) {
         try {
-            InternalLoggerFactory f = Slf4JLoggerFactory.INSTANCE;
+            InternalLoggerFactory f = Slf4JLoggerFactory.INSTANCE_WITH_NOP_CHECK;
             f.newInstance(name).debug("Using SLF4J as the default logging framework");
             return f;
         } catch (LinkageError ignore) {

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -59,7 +59,7 @@ public abstract class InternalLoggerFactory {
 
     private static InternalLoggerFactory useSlf4JLoggerFactory(String name) {
         try {
-            InternalLoggerFactory f = new Slf4JLoggerFactory(true);
+            InternalLoggerFactory f = Slf4JLoggerFactory.INSTANCE;
             f.newInstance(name).debug("Using SLF4J as the default logging framework");
             return f;
         } catch (LinkageError ignore) {

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -30,11 +30,17 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
     @SuppressWarnings("deprecation")
     public static final InternalLoggerFactory INSTANCE = new Slf4JLoggerFactory();
 
+    public static final InternalLoggerFactory INSTANCE_WITH_NOP_CHECK = new Slf4JLoggerFactory(true);
+
     /**
      * @deprecated Use {@link #INSTANCE} instead.
      */
     @Deprecated
     public Slf4JLoggerFactory() {
+    }
+
+    Slf4JLoggerFactory(boolean failIfNOP) {
+        assert failIfNOP; // Should be always called with true.
         if (LoggerFactory.getILoggerFactory() instanceof NOPLoggerFactory) {
             throw new NoClassDefFoundError("NOPLoggerFactory not supported");
         }

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -30,7 +30,7 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
     @SuppressWarnings("deprecation")
     public static final InternalLoggerFactory INSTANCE = new Slf4JLoggerFactory();
 
-    public static final InternalLoggerFactory INSTANCE_WITH_NOP_CHECK = new Slf4JLoggerFactory(true);
+    static final InternalLoggerFactory INSTANCE_WITH_NOP_CHECK = new Slf4JLoggerFactory(true);
 
     /**
      * @deprecated Use {@link #INSTANCE} instead.

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -35,15 +35,11 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
      */
     @Deprecated
     public Slf4JLoggerFactory() {
-    }
-
-    Slf4JLoggerFactory(boolean failIfNOP) {
-        assert failIfNOP; // Should be always called with true.
         if (LoggerFactory.getILoggerFactory() instanceof NOPLoggerFactory) {
             throw new NoClassDefFoundError("NOPLoggerFactory not supported");
         }
     }
-
+    
     @Override
     public InternalLogger newInstance(String name) {
         return wrapLogger(LoggerFactory.getLogger(name));

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -39,7 +39,7 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
             throw new NoClassDefFoundError("NOPLoggerFactory not supported");
         }
     }
-    
+
     @Override
     public InternalLogger newInstance(String name) {
         return wrapLogger(LoggerFactory.getLogger(name));


### PR DESCRIPTION
Motivation:

The current initialization of Slf4JLoggerFactory is not singleton.

Modification:

Use `Slf4JLoggerFactory.INSTANCE` to initialize `Slf4JLoggerFactory`.

Result:

The instance of Slf4JLoggerFactory became a singleton.
