### PR TITLE
Ensure we fail if native lib can not be loaded on macos

### DIFF
--- a/resolver-dns-native-macos/src/test/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns-native-macos/src/test/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProviderTest.java
@@ -18,24 +18,21 @@ package io.netty.resolver.dns.macos;
 import io.netty.resolver.dns.DnsServerAddressStream;
 import io.netty.resolver.dns.DnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsServerAddressStreamProviders;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class MacOSDnsServerAddressStreamProviderTest {
 
-    @BeforeClass
-    public static void assume() {
-        Assume.assumeTrue(MacOSDnsServerAddressStreamProvider.isAvailable());
-    }
-
     @Test
+    @EnabledOnOs(OS.MAC)
     public void testStream() {
+        MacOSDnsServerAddressStreamProvider.ensureAvailability();
         DnsServerAddressStreamProvider provider = new MacOSDnsServerAddressStreamProvider();
         DnsServerAddressStream stream = provider.nameServerAddressStream("netty.io");
         assertNotNull(stream);
@@ -47,7 +44,9 @@ public class MacOSDnsServerAddressStreamProviderTest {
     }
 
     @Test
+    @EnabledOnOs(OS.MAC)
     public void testDefaultUseCorrectInstance() {
+        MacOSDnsServerAddressStreamProvider.ensureAvailability();
         assertThat(DnsServerAddressStreamProviders.platformDefault(),
                 instanceOf(MacOSDnsServerAddressStreamProvider.class));
     }

--- a/resolver-dns-native-macos/src/test/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns-native-macos/src/test/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProviderTest.java
@@ -27,11 +27,11 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public class MacOSDnsServerAddressStreamProviderTest {
+@EnabledOnOs(OS.MAC)
+class MacOSDnsServerAddressStreamProviderTest {
 
     @Test
-    @EnabledOnOs(OS.MAC)
-    public void testStream() {
+    void testStream() {
         MacOSDnsServerAddressStreamProvider.ensureAvailability();
         DnsServerAddressStreamProvider provider = new MacOSDnsServerAddressStreamProvider();
         DnsServerAddressStream stream = provider.nameServerAddressStream("netty.io");
@@ -45,10 +45,9 @@ public class MacOSDnsServerAddressStreamProviderTest {
 
     @Test
     @EnabledOnOs(OS.MAC)
-    public void testDefaultUseCorrectInstance() {
+    void testDefaultUseCorrectInstance() {
         MacOSDnsServerAddressStreamProvider.ensureAvailability();
         assertThat(DnsServerAddressStreamProviders.platformDefault(),
                 instanceOf(MacOSDnsServerAddressStreamProvider.class));
     }
-
 }


### PR DESCRIPTION
Motivation:

ccca3959fd64b133edca855925fb68d077c3a8a2 fixed a regression which caused the native resolver code to not be loaded but this was not reported by the tests.

Modifications:

Adjust tests to actually fail the build if we cant load the native lib

Result:

Ensure we don't introduce another regression in the future
