### PR TITLE
Ensure we can load the native library or fail the build

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollKQueueIovArrayTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollKQueueIovArrayTest.java
@@ -23,6 +23,6 @@ public class EpollKQueueIovArrayTest extends IovArrayTest {
 
     @BeforeClass
     public static void loadNative() {
-        Assume.assumeTrue(Epoll.isAvailable());
+        Epoll.ensureAvailability();
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTest.java
@@ -27,12 +27,11 @@ import java.io.IOException;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 public class EpollSocketTest extends SocketTest<LinuxSocket> {
     @BeforeClass
     public static void loadJNI() {
-        assumeTrue(Epoll.isAvailable());
+        Epoll.ensureAvailability();
     }
 
     @Test

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
@@ -22,12 +22,10 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
-import static org.junit.Assume.assumeTrue;
-
 public class LinuxSocketTest {
     @BeforeClass
     public static void loadJNI() {
-        assumeTrue(Epoll.isAvailable());
+        Epoll.ensureAvailability();
     }
 
     @Test(expected = IOException.class)

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueIovArrayTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueIovArrayTest.java
@@ -16,13 +16,12 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.unix.tests.IovArrayTest;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 
 public class KQueueIovArrayTest extends IovArrayTest {
 
     @BeforeClass
     public static void loadNative() {
-        Assume.assumeTrue(KQueue.isAvailable());
+        KQueue.ensureAvailability();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTest.java
@@ -25,12 +25,11 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
 
 public class KQueueSocketTest extends SocketTest<BsdSocket> {
     @BeforeClass
     public static void loadJNI() {
-        assumeTrue(KQueue.isAvailable());
+        KQueue.ensureAvailability();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We used assumeTrue(...) in some places before to detect if we could load the native library but this could lead to the sitation that we not notice if we break native loading.

Modifications:

Always fail if we cant load the native library

Result:

Ensure we not cause any regression in the native loading code in the future
