### PR TITLE
Redirect Log4J 1.x to Log 2.x

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -64,8 +64,8 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -728,9 +728,9 @@
         <version>${log4j2.version}</version>
       </dependency>
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-1.2-api</artifactId>
+        <version>2.14.1</version>
         <exclusions>
           <exclusion>
             <artifactId>mail</artifactId>


### PR DESCRIPTION
Removes flag by Whitesource vulnerability scanner

Motivation:

WhiteSource vulnerability scan flags the Log4J 1.x stream as vulnerable.

Modification:

Replaced reference to `log4j` with `log4j-1.2-api`
Ran `mvn test` (on a Mac) successfully

Result:

Fixes #11263
