### PR TITLE
Upgrade logback dependency due CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -811,7 +811,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.1.7</version>
+        <version>1.2.3</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Motivation:

Older version of logback are affected by [CVE-2017-5929]. While its an optional dependency we should upgrade

Modifications:

Upgrade to 1.2.3

Result:

No more reports about using affected logback version