### PR TITLE
Don't include netty-examples as dependency for netty-all

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -476,11 +476,6 @@
       <artifactId>netty-transport-udt</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>netty-example</artifactId>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 </project>
 


### PR DESCRIPTION
Motivation:

We shouldn't include netty-examples as dependency for netty-all as this will try to pull in all sorts of dependencies which are optional.

Modifications:

Remove dependency on netty-examples

Result:

Related to https://github.com/netty/netty/issues/11272

