### PR TITLE
Run `os-maven-plugin` as a maven plugin (not as an extension)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -938,15 +938,20 @@
   </dependencies>
 
   <build>
-    <extensions>
-      <extension>
+    <plugins>
+      <plugin>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
         <version>${osmaven.version}</version>
-      </extension>
-    </extensions>
-
-    <plugins>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>detect</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>


### PR DESCRIPTION
Motivation:

When used as a maven extension in the parent pom, the properties set by `os-maven-plugin` aren't available in projects that use that parent pom.
By using `os-maven-plugin` as a plugin instead, those properties are available within child project poms.

Modification:

Removed `os-maven-plugin` as a maven extension, configured it instead to run as a maven plugin.

Result:

Fixes #11272