### PR TITLE
Improve bounder check for method 'io.netty.util.internal.MathUtil#isOutOfBounds'

### DIFF
--- a/common/src/main/java/io/netty/util/internal/MathUtil.java
+++ b/common/src/main/java/io/netty/util/internal/MathUtil.java
@@ -57,11 +57,11 @@ public final class MathUtil {
      * @param index The starting index.
      * @param length The length which will be utilized (starting from {@code index}).
      * @param capacity The capacity that {@code index + length} is allowed to be within.
-     * @return {@code true} if the requested {@code index} and {@code length} will fit within {@code capacity}.
-     * {@code false} if this would result in an index out of bounds exception.
+     * @return {@code false} if the requested {@code index} and {@code length} will fit within {@code capacity}.
+     * {@code true} if this would result in an index out of bounds exception.
      */
     public static boolean isOutOfBounds(int index, int length, int capacity) {
-        return (index | length | (index + length) | (capacity - (index + length))) < 0;
+        return (index | length | capacity | (index + length) | (capacity - (index + length))) < 0;
     }
 
     /**

--- a/common/src/test/java/io/netty/util/internal/MathUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/MathUtilTest.java
@@ -68,6 +68,9 @@ public class MathUtilTest {
         assertTrue(isOutOfBounds(Integer.MAX_VALUE - 1, 1, Integer.MAX_VALUE - 1));
         assertTrue(isOutOfBounds(Integer.MAX_VALUE - 1, 2, Integer.MAX_VALUE));
         assertTrue(isOutOfBounds(1, Integer.MAX_VALUE, Integer.MAX_VALUE));
+        assertTrue(isOutOfBounds(0, 1, Integer.MIN_VALUE));
+        assertTrue(isOutOfBounds(0, 1, -1));
+        assertTrue(isOutOfBounds(0, Integer.MAX_VALUE, 0));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

1.The docs about the 'retun value' of the method `io.netty.util.internal.MathUtil#isOutOfBounds` is not correct.
2.The capacity parameter should be checked for overflowed case.

Modification:

1.Changed the doc to:

>  @return {@code false} if the requested {@code index} and {@code length} will fit within {@code capacity}.
>  {@code true} if this would result in an index out of bounds exception.

2.Improved the bounder checking logic.

Result:
Fixes #11279 
Fixes #11280