### PR TITLE
Delete obsolete javadoc warning about pendingTasks() method expensiveness

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -125,9 +125,6 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
 
     /**
      * Return the number of tasks that are pending for processing.
-     *
-     * <strong>Be aware that this operation may be expensive as it depends on the internal implementation of the
-     * SingleThreadEventExecutor. So use it was care!</strong>
      */
     public int pendingTasks() {
         return taskQueue.size();

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -329,9 +329,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     /**
      * Return the number of tasks that are pending for processing.
-     *
-     * <strong>Be aware that this operation may be expensive as it depends on the internal implementation of the
-     * SingleThreadEventExecutor. So use it with care!</strong>
      */
     public int pendingTasks() {
         return taskQueue.size();


### PR DESCRIPTION
Motivation:
Current javadoc for `SingleThreadEventExecutor#pendingTasks()` method declares:

> Return the number of tasks that are pending for processing. **Be aware that this operation may be expensive as it depends on the internal implementation of the SingleThreadEventExecutor. So use it with care!**

(https://netty.io/4.1/api/io/netty/util/concurrent/SingleThreadEventExecutor.html#pendingTasks--)

From the implementation side, Event Loop implementations use queue implementation from JCTools library, which provides the expected result very fast (can be considered as constant time). The default implementation, JDK's `LinkedBlockingQueue` also provides result in constant time.
Seems that this comment describes usage of `ConcurrentLinkedQueue`, which is not used for several years (it computes size in linear time).

Modification:
I suggest to remove this misleading note