### PR TITLE
Add Event loop queue latency telemetry

### DIFF
--- a/common/src/main/java/io/netty/util/internal/QueueFactory.java
+++ b/common/src/main/java/io/netty/util/internal/QueueFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import java.util.Queue;
+
+@UnstableApi
+public interface QueueFactory {
+    /**
+     * Returns a new {@link Queue} to use.
+     * @return the new queue.
+     */
+    <E> Queue<E> newQueue();
+}

--- a/common/src/main/java/io/netty/util/internal/telemetry/CycleBufferQueueEliminationStrategy.java
+++ b/common/src/main/java/io/netty/util/internal/telemetry/CycleBufferQueueEliminationStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.telemetry;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@UnstableApi
+public class CycleBufferQueueEliminationStrategy implements QueueEliminationStrategy {
+    private static final long EMPTY_VALUE = -1L;
+
+    private final long[] latencies;
+    private final AtomicInteger pointer;
+
+    public CycleBufferQueueEliminationStrategy(int bufferSize) {
+        latencies = new long[bufferSize];
+        Arrays.fill(latencies, EMPTY_VALUE);
+        pointer = new AtomicInteger();
+    }
+
+    public long[] getLatencies() {
+        if (latencies[latencies.length - 1] == EMPTY_VALUE) {
+            // First iteration of array insertion is not finished, return only actual latencies
+            return Arrays.copyOf(latencies, pointer.get());
+        } else {
+            // We have second or later iteration, all array values contains actial latencies
+            long[] latenciesCopy = new long[latencies.length];
+            int ptr = pointer.get();
+            // Return elements according their order. Old ones in the array beginning, new in the end
+            System.arraycopy(latencies, ptr, latenciesCopy, 0, latencies.length - ptr);
+            System.arraycopy(latencies, 0, latenciesCopy, latencies.length - ptr, ptr);
+            return latenciesCopy;
+        }
+    }
+
+    @Override
+    public void handleElemination(EleminationHookQueueEntry<?> queueEntry) {
+        final long dequeueTimeNanos = System.nanoTime();
+        while (true) {
+            int ptr = pointer.get();
+            int nextVal = ptr >= latencies.length - 1 ? 0 : ptr + 1;
+            if (pointer.compareAndSet(ptr, nextVal)) {
+                latencies[ptr] = dequeueTimeNanos - queueEntry.getEnqueueTimeNanos();
+                return;
+            }
+        }
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/telemetry/EleminationHookQueueEntry.java
+++ b/common/src/main/java/io/netty/util/internal/telemetry/EleminationHookQueueEntry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.telemetry;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public class EleminationHookQueueEntry<E> {
+    private final E entry;
+    private final long enqueueTimeNanos;
+
+    public EleminationHookQueueEntry(E entry) {
+        this.entry = entry;
+        enqueueTimeNanos = System.nanoTime();
+    }
+
+    public EleminationHookQueueEntry(E entry, long enqueueTimeNanos) {
+        this.entry = entry;
+        this.enqueueTimeNanos = enqueueTimeNanos;
+    }
+
+    public E getEntry() {
+        return entry;
+    }
+
+    public long getEnqueueTimeNanos() {
+        return enqueueTimeNanos;
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/telemetry/EliminationHookQueue.java
+++ b/common/src/main/java/io/netty/util/internal/telemetry/EliminationHookQueue.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.telemetry;
+
+import io.netty.util.internal.QueueFactory;
+import io.netty.util.internal.UnstableApi;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.Queue;
+
+@UnstableApi
+public class EliminationHookQueue<E> extends AbstractQueue<E> {
+    private final Queue<EleminationHookQueueEntry<E>> queue;
+    private final QueueEliminationStrategy eliminationStrategy;
+
+    public EliminationHookQueue(QueueFactory queueFactory,
+                                QueueEliminationStrategy eliminationStrategy) {
+        queue = queueFactory.newQueue();
+        this.eliminationStrategy = eliminationStrategy;
+    }
+
+    public QueueEliminationStrategy getEliminationStrategy() {
+        return eliminationStrategy;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        final Iterator<EleminationHookQueueEntry<E>> iterator = queue.iterator();
+        return new Iterator<E>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public E next() {
+                return iterator.next().getEntry();
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return queue.size();
+    }
+
+    @Override
+    public boolean offer(E e) {
+        return queue.offer(new EleminationHookQueueEntry<E>(e));
+    }
+
+    @Override
+    public E poll() {
+        final EleminationHookQueueEntry<E> polled = queue.poll();
+        if (polled == null) {
+            return null;
+        }
+        eliminationStrategy.handleElemination(polled);
+        return polled.getEntry();
+    }
+
+    @Override
+    public E peek() {
+        final EleminationHookQueueEntry<E> peek = queue.peek();
+        return peek == null ? null : peek.getEntry();
+    }
+}
+

--- a/common/src/main/java/io/netty/util/internal/telemetry/QueueEliminationStrategy.java
+++ b/common/src/main/java/io/netty/util/internal/telemetry/QueueEliminationStrategy.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.telemetry;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface QueueEliminationStrategy {
+    void handleElemination(EleminationHookQueueEntry<?> queueEntry);
+}

--- a/common/src/main/java/io/netty/util/internal/telemetry/package-info.java
+++ b/common/src/main/java/io/netty/util/internal/telemetry/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Classes for telemetry of Event Executors (Event Loops)
+ */
+package io.netty.util.internal.telemetry;

--- a/common/src/test/java/io/netty/util/internal/telemetry/CycleBufferQueueEliminationStrategyTest.java
+++ b/common/src/test/java/io/netty/util/internal/telemetry/CycleBufferQueueEliminationStrategyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.telemetry;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CycleBufferQueueEliminationStrategyTest {
+    private static final int ROUGH_THRESHOLD_NANOS = 100000000;
+
+    @Test
+    public void partialOccupancyTest() {
+        final CycleBufferQueueEliminationStrategy cycleBufferQueueEliminationStrategy =
+                new CycleBufferQueueEliminationStrategy(5);
+        cycleBufferQueueEliminationStrategy.handleElemination(new EleminationHookQueueEntry<Integer>(1));
+        assertEquals(1, cycleBufferQueueEliminationStrategy.getLatencies().length);
+        assertTrue(cycleBufferQueueEliminationStrategy.getLatencies()[0] < ROUGH_THRESHOLD_NANOS);
+        cycleBufferQueueEliminationStrategy.handleElemination(new EleminationHookQueueEntry<Integer>(1));
+        assertEquals(2, cycleBufferQueueEliminationStrategy.getLatencies().length);
+    }
+
+    @Test
+    public void fullOccupancyTest() {
+        final int bufferSize = 5;
+        final CycleBufferQueueEliminationStrategy cycleBufferQueueEliminationStrategy =
+                new CycleBufferQueueEliminationStrategy(bufferSize);
+        for (int i = 1; i <= 2 * bufferSize; i++) {
+            cycleBufferQueueEliminationStrategy.handleElemination(new EleminationHookQueueEntry<Integer>(i));
+            assertEquals(Math.min(i, bufferSize), cycleBufferQueueEliminationStrategy.getLatencies().length);
+        }
+        assertEquals(bufferSize, cycleBufferQueueEliminationStrategy.getLatencies().length);
+        int bufferOverflowSize = 2;
+        for (int i = 0; i < 2; i++) {
+            cycleBufferQueueEliminationStrategy.handleElemination(new EleminationHookQueueEntry<Integer>(0, 0));
+        }
+        assertEquals(bufferSize, cycleBufferQueueEliminationStrategy.getLatencies().length);
+        for (int i = 0; i < bufferSize - bufferOverflowSize; i++) {
+            assertTrue(cycleBufferQueueEliminationStrategy.getLatencies()[i] < 100000000);
+        }
+        for (int i = bufferSize - bufferOverflowSize; i < bufferSize; i++) {
+            assertTrue(cycleBufferQueueEliminationStrategy.getLatencies()[i] > 100000000);
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/EventLoopTasksLatencyMonitorFactory.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopTasksLatencyMonitorFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.QueueFactory;
+import io.netty.util.internal.UnstableApi;
+import io.netty.util.internal.telemetry.CycleBufferQueueEliminationStrategy;
+import io.netty.util.internal.telemetry.EliminationHookQueue;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@UnstableApi
+public class EventLoopTasksLatencyMonitorFactory implements EventLoopTaskQueueFactory {
+    private final int bufferSize;
+    private final Queue<EliminationHookQueue<Runnable>> instances =
+            new ConcurrentLinkedQueue<EliminationHookQueue<Runnable>>();
+
+    public EventLoopTasksLatencyMonitorFactory(int bufferSize) {
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public EliminationHookQueue<Runnable> newTaskQueue(final int maxCapacity) {
+        final EliminationHookQueue<Runnable> queue = new EliminationHookQueue<Runnable>(
+                new QueueFactory() {
+                    @Override
+                    public <E> Queue<E> newQueue() {
+                        return maxCapacity == Integer.MAX_VALUE? PlatformDependent.<E>newMpscQueue()
+                                : PlatformDependent.<E>newMpscQueue(maxCapacity);
+                    }
+                },
+                new CycleBufferQueueEliminationStrategy(bufferSize)
+        );
+        instances.add(queue);
+        return queue;
+    }
+
+    public Collection<EliminationHookQueue<Runnable>> getInstances() {
+        return Collections.unmodifiableCollection(instances);
+    }
+}


### PR DESCRIPTION
Motivation:
Monitoring event loop and its performance is important to understand the app's behaviour and how it performs under load. Currently there is no way to understand how many time tasks spend in the event loop queue.

Modifications:
Introduce queue wrapper, which performs additional operation on elimination from queue and sample code which measures latencies for tasks in queue.

Result:
Users may monitor latencies for tasks in event loop queue


I have thought about implementation details and didn't manage to find an optimal solution which will satisfy me entirely. Maybe you can help with it.
My main concerns are about `EventLoopTasksLatencyMonitorFactory`. To produce opportunity to receive latencies list, I ought to declare field with all created instances. On EventLoop creation factory are called twice: for `taskQueue` and `tailTasks`. So it is hard to distinguish latencies for them (for example if we want to look only at `taskQueue` latencies). We cannot rely on even/odd position in the list, as with concurrent creations it may be mixed.
As a sample of another implementation of `QueueEliminationStrategy` I can offer a class which will build histogram with latencies distribution (for example using https://github.com/HdrHistogram/HdrHistogram library).
We can introduce type of `QueueEliminationStrategy` as a generic type parameter to `EliminationHookQueue`, it will be typesafe and allow to avoid extra typecasts, but it makes type declarations really wordy.

Main benefits is that users may monitor latencies and it is fully optional and can be pretty easily setup if such telemetry is required.

Very basic example of usage is as follows:
```
 // Configure the server.
EventLoopGroup bossGroup = new NioEventLoopGroup(1);
final EventLoopTasksLatencyMonitorFactory taskQueueFactory = new EventLoopTasksLatencyMonitorFactory(100);
EventLoopGroup workerGroup = new NioEventLoopGroup(
        2, (Executor) null, DefaultEventExecutorChooserFactory.INSTANCE, SelectorProvider.provider(),
        DefaultSelectStrategyFactory.INSTANCE, RejectedExecutionHandlers.reject(), taskQueueFactory);

Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(new Runnable() {
    @Override
    public void run() {
        System.out.println("Latencies:");
        for (EliminationHookQueue<Runnable> instance : taskQueueFactory.getInstances()) {
            final CycleBufferQueueEliminationStrategy eliminationStrategy =
                    (CycleBufferQueueEliminationStrategy) instance.getEliminationStrategy();
            System.out.println('\t' + Arrays.toString(eliminationStrategy.getLatencies()));
        }
    }
}, 10, 10, TimeUnit.SECONDS);
```