### PR TITLE
EventExecutorGroup lightweight progress metrics (continue PR #9080)

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/ObservableTaskConsumer.java
+++ b/common/src/main/java/io/netty/util/concurrent/ObservableTaskConsumer.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/common/src/main/java/io/netty/util/concurrent/ObservableTaskConsumer.java
+++ b/common/src/main/java/io/netty/util/concurrent/ObservableTaskConsumer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface ObservableTaskConsumer {
+
+    long UNSUPPORTED = -1;
+
+    /**
+     * Returns the number of submitted tasks: it's safe to be read by different threads.<br>
+     * <p>
+     * If {@code this} don't support this metrics it returns a negative value, likely {@link #UNSUPPORTED}.
+     */
+    long submittedTasks();
+
+    /**
+     * Returns the number of completed tasks: it's safe to be read by different threads.<br>
+     * <p>
+     * If {@code this} don't support this metrics it returns a negative value, likely {@link #UNSUPPORTED}.
+     */
+    long completedTasks();
+}

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -47,7 +47,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  * Abstract base class for {@link OrderedEventExecutor}'s that execute all its submitted tasks in a single thread.
  *
  */
-public abstract class SingleThreadEventExecutor extends AbstractScheduledEventExecutor implements OrderedEventExecutor {
+public abstract class SingleThreadEventExecutor extends AbstractScheduledEventExecutor
+        implements OrderedEventExecutor, ObservableTaskConsumer {
 
     static final int DEFAULT_MAX_PENDING_EXECUTOR_TASKS = Math.max(16,
             SystemPropertyUtil.getInt("io.netty.eventexecutor.maxPendingTasks", Integer.MAX_VALUE));
@@ -1067,6 +1068,16 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
             }
         }
         return numTasks;
+    }
+
+    @Override
+    public long submittedTasks() {
+        return PlatformDependent.currentProducerIndex(taskQueue);
+    }
+
+    @Override
+    public long completedTasks() {
+        return PlatformDependent.currentConsumerIndex(taskQueue);
     }
 
     private static final class DefaultThreadProperties implements ThreadProperties {

--- a/common/src/main/java/io/netty/util/internal/ObservableTaskConsumerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObservableTaskConsumerUtil.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -35,6 +35,6 @@ public final class ObservableTaskConsumerUtil {
             return ObservableTaskConsumer.UNSUPPORTED;
         }
         final ObservableTaskConsumer consumer = (ObservableTaskConsumer) obj;
-        return consumer.completedTasks();
+        return consumer.submittedTasks();
     }
 }

--- a/common/src/main/java/io/netty/util/internal/ObservableTaskConsumerUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObservableTaskConsumerUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import io.netty.util.concurrent.ObservableTaskConsumer;
+
+public final class ObservableTaskConsumerUtil {
+
+    private ObservableTaskConsumerUtil() {
+    }
+
+    public static long completedTasks(Object obj) {
+        if (!(obj instanceof ObservableTaskConsumer)) {
+            return ObservableTaskConsumer.UNSUPPORTED;
+        }
+        final ObservableTaskConsumer consumer = (ObservableTaskConsumer) obj;
+        return consumer.completedTasks();
+    }
+
+    public static long submittedTasks(Object obj) {
+        if (!(obj instanceof ObservableTaskConsumer)) {
+            return ObservableTaskConsumer.UNSUPPORTED;
+        }
+        final ObservableTaskConsumer consumer = (ObservableTaskConsumer) obj;
+        return consumer.completedTasks();
+    }
+}


### PR DESCRIPTION
This PR aims to continue work on PR https://github.com/netty/netty/pull/9080 by @franz1981 
I rebased it on latest commits (resolved merge conflict) and fixed a typo in the code. I can add tests, if it is required
I hope that it is OK to open new PR and if you decide to merge it, old one can be closed

@normanmaurer as you were last active person in origin PR I mark you here