### PR TITLE
Added short circuit for method:io.netty.buffer.AbstractByteBuf#compareTo

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1344,7 +1344,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || (o instanceof ByteBuf && ByteBufUtil.equals(this, (ByteBuf) o));
+        return o instanceof ByteBuf && ByteBufUtil.equals(this, (ByteBuf) o);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -299,6 +299,9 @@ public final class ByteBufUtil {
      * This method is useful when implementing a new buffer type.
      */
     public static boolean equals(ByteBuf bufferA, ByteBuf bufferB) {
+        if (bufferA == bufferB) {
+            return true;
+        }
         final int aLen = bufferA.readableBytes();
         if (aLen != bufferB.readableBytes()) {
             return false;
@@ -311,6 +314,9 @@ public final class ByteBufUtil {
      * This method is useful when implementing a new buffer type.
      */
     public static int compare(ByteBuf bufferA, ByteBuf bufferB) {
+        if (bufferA == bufferB) {
+            return 0;
+        }
         final int aLen = bufferA.readableBytes();
         final int bLen = bufferB.readableBytes();
         final int minLength = Math.min(aLen, bLen);

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -1048,9 +1048,6 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
         if (obj instanceof ByteBuf) {
             return ByteBufUtil.equals(this, (ByteBuf) obj);
         }


### PR DESCRIPTION
Motivation:

When object-references are both same, the method should return 0 directly with no necessary go loop&compare the content of the ByteBuf.

Modification:

Added short circuit when both object-references are the same.

Result:

Added short circuit code.