### PR TITLE
Migrate some tests to JUnit 5

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -16,11 +16,11 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllocator> extends ByteBufAllocatorTest {
 
@@ -108,7 +108,7 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
         // Double the size of the buffer
         buffer.capacity(capacity << 1);
         capacity = buffer.capacity();
-        assertEquals(buffer.toString(), expectedUsedMemory(allocator, capacity), metric.usedDirectMemory());
+        assertEquals(expectedUsedMemory(allocator, capacity), metric.usedDirectMemory(), buffer.toString());
 
         buffer.release();
         assertEquals(expectedUsedMemoryAfterRelease(allocator, capacity), metric.usedDirectMemory());

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -19,9 +19,10 @@ import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -60,15 +61,16 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * An abstract test class for channel buffers
@@ -93,14 +95,14 @@ public abstract class AbstractByteBufTest {
         return true;
     }
 
-    @Before
+    @BeforeEach
     public void init() {
         buffer = newBuffer(CAPACITY);
         seed = System.currentTimeMillis();
         random = new Random(seed);
     }
 
-    @After
+    @AfterEach
     public void dispose() {
         if (buffer != null) {
             assertThat(buffer.release(), is(true));
@@ -139,34 +141,34 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, buffer.readerIndex());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void readerIndexBoundaryCheck1() {
         try {
             buffer.writerIndex(0);
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.readerIndex(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void readerIndexBoundaryCheck2() {
         try {
             buffer.writerIndex(buffer.capacity());
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.readerIndex(buffer.capacity() + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(buffer.capacity() + 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void readerIndexBoundaryCheck3() {
         try {
             buffer.writerIndex(CAPACITY / 2);
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.readerIndex(CAPACITY * 3 / 2);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(CAPACITY * 3 / 2));
     }
 
     @Test
@@ -177,12 +179,12 @@ public abstract class AbstractByteBufTest {
         buffer.readerIndex(buffer.capacity());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void writerIndexBoundaryCheck1() {
-        buffer.writerIndex(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void writerIndexBoundaryCheck2() {
         try {
             buffer.writerIndex(CAPACITY);
@@ -190,10 +192,10 @@ public abstract class AbstractByteBufTest {
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.writerIndex(buffer.capacity() + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(buffer.capacity() + 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void writerIndexBoundaryCheck3() {
         try {
             buffer.writerIndex(CAPACITY);
@@ -201,7 +203,7 @@ public abstract class AbstractByteBufTest {
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.writerIndex(CAPACITY / 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(CAPACITY / 4));
     }
 
     @Test
@@ -213,74 +215,74 @@ public abstract class AbstractByteBufTest {
         buffer.writeBytes(ByteBuffer.wrap(EMPTY_BYTES));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getBooleanBoundaryCheck1() {
-        buffer.getBoolean(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBoolean(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getBooleanBoundaryCheck2() {
-        buffer.getBoolean(buffer.capacity());
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBoolean(buffer.capacity()));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteBoundaryCheck1() {
-        buffer.getByte(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getByte(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteBoundaryCheck2() {
-        buffer.getByte(buffer.capacity());
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getByte(buffer.capacity()));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getShortBoundaryCheck1() {
-        buffer.getShort(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getShort(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getShortBoundaryCheck2() {
-        buffer.getShort(buffer.capacity() - 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getShort(buffer.capacity() - 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getMediumBoundaryCheck1() {
-        buffer.getMedium(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getMedium(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getMediumBoundaryCheck2() {
-        buffer.getMedium(buffer.capacity() - 2);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getMedium(buffer.capacity() - 2));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getIntBoundaryCheck1() {
-        buffer.getInt(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getInt(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getIntBoundaryCheck2() {
-        buffer.getInt(buffer.capacity() - 3);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getInt(buffer.capacity() - 3));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getLongBoundaryCheck1() {
-        buffer.getLong(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getLong(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getLongBoundaryCheck2() {
-        buffer.getLong(buffer.capacity() - 7);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getLong(buffer.capacity() - 7));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteArrayBoundaryCheck1() {
-        buffer.getBytes(-1, EMPTY_BYTES);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(-1, EMPTY_BYTES));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteArrayBoundaryCheck2() {
-        buffer.getBytes(-1, EMPTY_BYTES, 0, 0);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(-1, EMPTY_BYTES, 0, 0));
     }
 
     @Test
@@ -319,44 +321,44 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, dst[3]);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteBufferBoundaryCheck() {
-        buffer.getBytes(-1, ByteBuffer.allocate(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(-1, ByteBuffer.allocate(0)));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void copyBoundaryCheck1() {
-        buffer.copy(-1, 0);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.copy(-1, 0));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void copyBoundaryCheck2() {
-        buffer.copy(0, buffer.capacity() + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.copy(0, buffer.capacity() + 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void copyBoundaryCheck3() {
-        buffer.copy(buffer.capacity() + 1, 0);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.copy(buffer.capacity() + 1, 0));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void copyBoundaryCheck4() {
-        buffer.copy(buffer.capacity(), 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.copy(buffer.capacity(), 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void setIndexBoundaryCheck1() {
-        buffer.setIndex(-1, CAPACITY);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.setIndex(-1, CAPACITY));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void setIndexBoundaryCheck2() {
-        buffer.setIndex(CAPACITY / 2, CAPACITY / 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.setIndex(CAPACITY / 2, CAPACITY / 4));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void setIndexBoundaryCheck3() {
-        buffer.setIndex(0, CAPACITY + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.setIndex(0, CAPACITY + 1));
     }
 
     @Test
@@ -381,9 +383,9 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, dst.get(3));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getDirectByteBufferBoundaryCheck() {
-        buffer.getBytes(-1, ByteBuffer.allocateDirect(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(-1, ByteBuffer.allocateDirect(0)));
     }
 
     @Test
@@ -2081,7 +2083,8 @@ public abstract class AbstractByteBufTest {
         copied.release();
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void testToStringMultipleThreads() throws Throwable {
         buffer.clear();
         buffer.writeBytes("Hello, World!".getBytes(CharsetUtil.ISO_8859_1));
@@ -2559,13 +2562,15 @@ public abstract class AbstractByteBufTest {
         buffer.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void readByteThrowsIndexOutOfBoundsException() {
         final ByteBuf buffer = newBuffer(8);
         try {
-            buffer.writeByte(0);
-            assertEquals((byte) 0, buffer.readByte());
-            buffer.readByte();
+            assertThrows(IndexOutOfBoundsException.class, () -> {
+                buffer.writeByte(0);
+                assertEquals((byte) 0, buffer.readByte());
+                buffer.readByte();
+            });
         } finally {
             buffer.release();
         }
@@ -2626,718 +2631,742 @@ public abstract class AbstractByteBufTest {
         return buffer;
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testDiscardReadBytesAfterRelease() {
-        releasedBuffer().discardReadBytes();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().discardReadBytes());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testDiscardSomeReadBytesAfterRelease() {
-        releasedBuffer().discardSomeReadBytes();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().discardSomeReadBytes());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testEnsureWritableAfterRelease() {
-        releasedBuffer().ensureWritable(16);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().ensureWritable(16));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBooleanAfterRelease() {
-        releasedBuffer().getBoolean(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBoolean(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetByteAfterRelease() {
-        releasedBuffer().getByte(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getByte(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedByteAfterRelease() {
-        releasedBuffer().getUnsignedByte(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedByte(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetShortAfterRelease() {
-        releasedBuffer().getShort(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getShort(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetShortLEAfterRelease() {
-        releasedBuffer().getShortLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getShortLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedShortAfterRelease() {
-        releasedBuffer().getUnsignedShort(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedShort(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedShortLEAfterRelease() {
-        releasedBuffer().getUnsignedShortLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedShortLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetMediumAfterRelease() {
-        releasedBuffer().getMedium(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getMedium(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetMediumLEAfterRelease() {
-        releasedBuffer().getMediumLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getMediumLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedMediumAfterRelease() {
-        releasedBuffer().getUnsignedMedium(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedMedium(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetIntAfterRelease() {
-        releasedBuffer().getInt(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getInt(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetIntLEAfterRelease() {
-        releasedBuffer().getIntLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getIntLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedIntAfterRelease() {
-        releasedBuffer().getUnsignedInt(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedInt(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedIntLEAfterRelease() {
-        releasedBuffer().getUnsignedIntLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedIntLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetLongAfterRelease() {
-        releasedBuffer().getLong(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getLong(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetLongLEAfterRelease() {
-        releasedBuffer().getLongLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getLongLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetCharAfterRelease() {
-        releasedBuffer().getChar(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getChar(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetFloatAfterRelease() {
-        releasedBuffer().getFloat(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getFloat(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetFloatLEAfterRelease() {
-        releasedBuffer().getFloatLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getFloatLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetDoubleAfterRelease() {
-        releasedBuffer().getDouble(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getDouble(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetDoubleLEAfterRelease() {
-        releasedBuffer().getDoubleLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getDoubleLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().getBytes(0, buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease2() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().getBytes(0, buffer, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, buffer, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease3() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().getBytes(0, buffer, 0, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, buffer, 0, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease4() {
-        releasedBuffer().getBytes(0, new byte[8]);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, new byte[8]));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease5() {
-        releasedBuffer().getBytes(0, new byte[8], 0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, new byte[8], 0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease6() {
-        releasedBuffer().getBytes(0, ByteBuffer.allocate(8));
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, ByteBuffer.allocate(8)));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testGetBytesAfterRelease7() throws IOException {
-        releasedBuffer().getBytes(0, new ByteArrayOutputStream(), 1);
+    @Test
+    public void testGetBytesAfterRelease7() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().getBytes(0, new ByteArrayOutputStream(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testGetBytesAfterRelease8() throws IOException {
-        releasedBuffer().getBytes(0, new DevNullGatheringByteChannel(), 1);
+    @Test
+    public void testGetBytesAfterRelease8() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().getBytes(0, new DevNullGatheringByteChannel(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBooleanAfterRelease() {
-        releasedBuffer().setBoolean(0, true);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBoolean(0, true));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetByteAfterRelease() {
-        releasedBuffer().setByte(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setByte(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetShortAfterRelease() {
-        releasedBuffer().setShort(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setShort(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetShortLEAfterRelease() {
-        releasedBuffer().setShortLE(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setShortLE(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetMediumAfterRelease() {
-        releasedBuffer().setMedium(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setMedium(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetMediumLEAfterRelease() {
-        releasedBuffer().setMediumLE(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setMediumLE(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetIntAfterRelease() {
-        releasedBuffer().setInt(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setInt(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetIntLEAfterRelease() {
-        releasedBuffer().setIntLE(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setIntLE(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetLongAfterRelease() {
-        releasedBuffer().setLong(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setLong(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetLongLEAfterRelease() {
-        releasedBuffer().setLongLE(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setLongLE(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetCharAfterRelease() {
-        releasedBuffer().setChar(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setChar(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetFloatAfterRelease() {
-        releasedBuffer().setFloat(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setFloat(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetDoubleAfterRelease() {
-        releasedBuffer().setDouble(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setDouble(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().setBytes(0, buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease2() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().setBytes(0, buffer, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, buffer, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease3() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().setBytes(0, buffer, 0, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, buffer, 0, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetUsAsciiCharSequenceAfterRelease() {
-        testSetCharSequenceAfterRelease0(CharsetUtil.US_ASCII);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testSetCharSequenceAfterRelease0(CharsetUtil.US_ASCII));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetIso88591CharSequenceAfterRelease() {
-        testSetCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testSetCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetUtf8CharSequenceAfterRelease() {
-        testSetCharSequenceAfterRelease0(CharsetUtil.UTF_8);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testSetCharSequenceAfterRelease0(CharsetUtil.UTF_8));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetUtf16CharSequenceAfterRelease() {
-        testSetCharSequenceAfterRelease0(CharsetUtil.UTF_16);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testSetCharSequenceAfterRelease0(CharsetUtil.UTF_16));
     }
 
     private void testSetCharSequenceAfterRelease0(Charset charset) {
         releasedBuffer().setCharSequence(0, "x", charset);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease4() {
-        releasedBuffer().setBytes(0, new byte[8]);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, new byte[8]));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease5() {
-        releasedBuffer().setBytes(0, new byte[8], 0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, new byte[8], 0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease6() {
-        releasedBuffer().setBytes(0, ByteBuffer.allocate(8));
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, ByteBuffer.allocate(8)));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testSetBytesAfterRelease7() throws IOException {
-        releasedBuffer().setBytes(0, new ByteArrayInputStream(new byte[8]), 1);
+    @Test
+    public void testSetBytesAfterRelease7() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().setBytes(0, new ByteArrayInputStream(new byte[8]), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testSetBytesAfterRelease8() throws IOException {
-        releasedBuffer().setBytes(0, new TestScatteringByteChannel(), 1);
+    @Test
+    public void testSetBytesAfterRelease8() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().setBytes(0, new TestScatteringByteChannel(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetZeroAfterRelease() {
-        releasedBuffer().setZero(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setZero(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBooleanAfterRelease() {
-        releasedBuffer().readBoolean();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBoolean());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadByteAfterRelease() {
-        releasedBuffer().readByte();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readByte());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedByteAfterRelease() {
-        releasedBuffer().readUnsignedByte();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedByte());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadShortAfterRelease() {
-        releasedBuffer().readShort();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readShort());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadShortLEAfterRelease() {
-        releasedBuffer().readShortLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readShortLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedShortAfterRelease() {
-        releasedBuffer().readUnsignedShort();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedShort());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedShortLEAfterRelease() {
-        releasedBuffer().readUnsignedShortLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedShortLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadMediumAfterRelease() {
-        releasedBuffer().readMedium();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readMedium());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadMediumLEAfterRelease() {
-        releasedBuffer().readMediumLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readMediumLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedMediumAfterRelease() {
-        releasedBuffer().readUnsignedMedium();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedMedium());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedMediumLEAfterRelease() {
-        releasedBuffer().readUnsignedMediumLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedMediumLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadIntAfterRelease() {
-        releasedBuffer().readInt();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readInt());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadIntLEAfterRelease() {
-        releasedBuffer().readIntLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readIntLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedIntAfterRelease() {
-        releasedBuffer().readUnsignedInt();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedInt());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedIntLEAfterRelease() {
-        releasedBuffer().readUnsignedIntLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedIntLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadLongAfterRelease() {
-        releasedBuffer().readLong();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readLong());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadLongLEAfterRelease() {
-        releasedBuffer().readLongLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readLongLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadCharAfterRelease() {
-        releasedBuffer().readChar();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readChar());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadFloatAfterRelease() {
-        releasedBuffer().readFloat();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readFloat());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadFloatLEAfterRelease() {
-        releasedBuffer().readFloatLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readFloatLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadDoubleAfterRelease() {
-        releasedBuffer().readDouble();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readDouble());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadDoubleLEAfterRelease() {
-        releasedBuffer().readDoubleLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readDoubleLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease() {
-        releasedBuffer().readBytes(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease2() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().readBytes(buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease3() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().readBytes(buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease4() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().readBytes(buffer, 0, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(buffer, 0, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease5() {
-        releasedBuffer().readBytes(new byte[8]);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(new byte[8]));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease6() {
-        releasedBuffer().readBytes(new byte[8], 0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(new byte[8], 0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease7() {
-        releasedBuffer().readBytes(ByteBuffer.allocate(8));
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(ByteBuffer.allocate(8)));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testReadBytesAfterRelease8() throws IOException {
-        releasedBuffer().readBytes(new ByteArrayOutputStream(), 1);
+    @Test
+    public void testReadBytesAfterRelease8() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().readBytes(new ByteArrayOutputStream(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testReadBytesAfterRelease9() throws IOException {
-        releasedBuffer().readBytes(new ByteArrayOutputStream(), 1);
+    @Test
+    public void testReadBytesAfterRelease9() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().readBytes(new ByteArrayOutputStream(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testReadBytesAfterRelease10() throws IOException {
-        releasedBuffer().readBytes(new DevNullGatheringByteChannel(), 1);
+    @Test
+    public void testReadBytesAfterRelease10() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().readBytes(new DevNullGatheringByteChannel(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBooleanAfterRelease() {
-        releasedBuffer().writeBoolean(true);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBoolean(true));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteByteAfterRelease() {
-        releasedBuffer().writeByte(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeByte(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteShortAfterRelease() {
-        releasedBuffer().writeShort(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeShort(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteShortLEAfterRelease() {
-        releasedBuffer().writeShortLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeShortLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteMediumAfterRelease() {
-        releasedBuffer().writeMedium(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeMedium(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteMediumLEAfterRelease() {
-        releasedBuffer().writeMediumLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeMediumLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteIntAfterRelease() {
-        releasedBuffer().writeInt(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeInt(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteIntLEAfterRelease() {
-        releasedBuffer().writeIntLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeIntLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteLongAfterRelease() {
-        releasedBuffer().writeLong(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeLong(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteLongLEAfterRelease() {
-        releasedBuffer().writeLongLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeLongLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteCharAfterRelease() {
-        releasedBuffer().writeChar(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeChar(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteFloatAfterRelease() {
-        releasedBuffer().writeFloat(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeFloat(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteFloatLEAfterRelease() {
-        releasedBuffer().writeFloatLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeFloatLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteDoubleAfterRelease() {
-        releasedBuffer().writeDouble(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeDouble(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteDoubleLEAfterRelease() {
-        releasedBuffer().writeDoubleLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeDoubleLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().writeBytes(buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease2() {
         ByteBuf buffer = copiedBuffer(new byte[8]);
         try {
-            releasedBuffer().writeBytes(buffer, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(buffer, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease3() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().writeBytes(buffer, 0, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(buffer, 0, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease4() {
-        releasedBuffer().writeBytes(new byte[8]);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(new byte[8]));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease5() {
-        releasedBuffer().writeBytes(new byte[8], 0 , 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(new byte[8], 0 , 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease6() {
-        releasedBuffer().writeBytes(ByteBuffer.allocate(8));
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(ByteBuffer.allocate(8)));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testWriteBytesAfterRelease7() throws IOException {
-        releasedBuffer().writeBytes(new ByteArrayInputStream(new byte[8]), 1);
+    @Test
+    public void testWriteBytesAfterRelease7() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().writeBytes(new ByteArrayInputStream(new byte[8]), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testWriteBytesAfterRelease8() throws IOException {
-        releasedBuffer().writeBytes(new TestScatteringByteChannel(), 1);
+    @Test
+    public void testWriteBytesAfterRelease8() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().writeBytes(new TestScatteringByteChannel(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteZeroAfterRelease() throws IOException {
-        releasedBuffer().writeZero(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeZero(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteUsAsciiCharSequenceAfterRelease() {
-        testWriteCharSequenceAfterRelease0(CharsetUtil.US_ASCII);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testWriteCharSequenceAfterRelease0(CharsetUtil.US_ASCII));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteIso88591CharSequenceAfterRelease() {
-        testWriteCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testWriteCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteUtf8CharSequenceAfterRelease() {
-        testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_8);
+        assertThrows(IllegalReferenceCountException.class, () -> testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_8));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteUtf16CharSequenceAfterRelease() {
-        testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_16);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_16));
     }
 
     private void testWriteCharSequenceAfterRelease0(Charset charset) {
         releasedBuffer().writeCharSequence("x", charset);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testForEachByteAfterRelease() {
-        releasedBuffer().forEachByte(new TestByteProcessor());
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().forEachByte(new TestByteProcessor()));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testForEachByteAfterRelease1() {
-        releasedBuffer().forEachByte(0, 1, new TestByteProcessor());
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().forEachByte(0, 1, new TestByteProcessor()));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testForEachByteDescAfterRelease() {
-        releasedBuffer().forEachByteDesc(new TestByteProcessor());
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().forEachByteDesc(new TestByteProcessor()));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testForEachByteDescAfterRelease1() {
-        releasedBuffer().forEachByteDesc(0, 1, new TestByteProcessor());
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().forEachByteDesc(0, 1, new TestByteProcessor()));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testCopyAfterRelease() {
-        releasedBuffer().copy();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().copy());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testCopyAfterRelease1() {
-        releasedBuffer().copy();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().copy());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testNioBufferAfterRelease() {
-        releasedBuffer().nioBuffer();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().nioBuffer());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testNioBufferAfterRelease1() {
-        releasedBuffer().nioBuffer(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().nioBuffer(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testInternalNioBufferAfterRelease() {
+        testInternalNioBufferAfterRelease0(IllegalReferenceCountException.class);
+    }
+
+    protected void testInternalNioBufferAfterRelease0(final Class<? extends Throwable> expectedException) {
         ByteBuf releasedBuffer = releasedBuffer();
-        releasedBuffer.internalNioBuffer(releasedBuffer.readerIndex(), 1);
+        assertThrows(expectedException, () -> releasedBuffer.internalNioBuffer(releasedBuffer.readerIndex(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testNioBuffersAfterRelease() {
-        releasedBuffer().nioBuffers();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().nioBuffers());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testNioBuffersAfterRelease2() {
-        releasedBuffer().nioBuffers(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().nioBuffers(0, 1));
     }
 
     @Test
@@ -3366,14 +3395,14 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSliceAfterRelease() {
-        releasedBuffer().slice();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().slice());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSliceAfterRelease2() {
-        releasedBuffer().slice(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().slice(0, 1));
     }
 
     private static void assertSliceFailAfterRelease(ByteBuf... bufs) {
@@ -3431,14 +3460,14 @@ public abstract class AbstractByteBufTest {
         assertSliceFailAfterRelease(buf, buf2, buf3);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainedSliceAfterRelease() {
-        releasedBuffer().retainedSlice();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().retainedSlice());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainedSliceAfterRelease2() {
-        releasedBuffer().retainedSlice(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().retainedSlice(0, 1));
     }
 
     private static void assertRetainedSliceFailAfterRelease(ByteBuf... bufs) {
@@ -3496,14 +3525,14 @@ public abstract class AbstractByteBufTest {
         assertRetainedSliceFailAfterRelease(buf, buf2, buf3);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testDuplicateAfterRelease() {
-        releasedBuffer().duplicate();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().duplicate());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainedDuplicateAfterRelease() {
-        releasedBuffer().retainedDuplicate();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().retainedDuplicate());
     }
 
     private static void assertDuplicateFailAfterRelease(ByteBuf... bufs) {
@@ -3592,14 +3621,14 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, buf.refCnt());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testReadSliceOutOfBounds() {
-        testReadSliceOutOfBounds(false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testReadSliceOutOfBounds(false));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testReadRetainedSliceOutOfBounds() {
-        testReadSliceOutOfBounds(true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testReadSliceOutOfBounds(true));
     }
 
     private void testReadSliceOutOfBounds(boolean retainedSlice) {
@@ -3648,24 +3677,24 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetUsAsciiCharSequenceNoExpand() {
-        testSetCharSequenceNoExpand(CharsetUtil.US_ASCII);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSetCharSequenceNoExpand(CharsetUtil.US_ASCII));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetUtf8CharSequenceNoExpand() {
-        testSetCharSequenceNoExpand(CharsetUtil.UTF_8);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSetCharSequenceNoExpand(CharsetUtil.UTF_8));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetIso88591CharSequenceNoExpand() {
-        testSetCharSequenceNoExpand(CharsetUtil.ISO_8859_1);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSetCharSequenceNoExpand(CharsetUtil.ISO_8859_1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetUtf16CharSequenceNoExpand() {
-        testSetCharSequenceNoExpand(CharsetUtil.UTF_16);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSetCharSequenceNoExpand(CharsetUtil.UTF_16));
     }
 
     private void testSetCharSequenceNoExpand(Charset charset) {
@@ -3748,44 +3777,44 @@ public abstract class AbstractByteBufTest {
         buf.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testRetainedSliceIndexOutOfBounds() {
-        testSliceOutOfBounds(true, true, true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(true, true, true));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testRetainedSliceLengthOutOfBounds() {
-        testSliceOutOfBounds(true, true, false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(true, true, false));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMixedSliceAIndexOutOfBounds() {
-        testSliceOutOfBounds(true, false, true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(true, false, true));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMixedSliceALengthOutOfBounds() {
-        testSliceOutOfBounds(true, false, false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(true, false, false));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMixedSliceBIndexOutOfBounds() {
-        testSliceOutOfBounds(false, true, true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(false, true, true));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMixedSliceBLengthOutOfBounds() {
-        testSliceOutOfBounds(false, true, false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(false, true, false));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSliceIndexOutOfBounds() {
-        testSliceOutOfBounds(false, false, true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(false, false, true));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSliceLengthOutOfBounds() {
-        testSliceOutOfBounds(false, false, false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(false, false, false));
     }
 
     @Test
@@ -4041,14 +4070,14 @@ public abstract class AbstractByteBufTest {
         testDuplicateCapacityChange(true);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSliceCapacityChange() {
-        testSliceCapacityChange(false);
+        assertThrows(UnsupportedOperationException.class, () -> testSliceCapacityChange(false));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRetainedSliceCapacityChange() {
-        testSliceCapacityChange(true);
+        assertThrows(UnsupportedOperationException.class, () -> testSliceCapacityChange(true));
     }
 
     @Test
@@ -4674,7 +4703,7 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is in the ByteBuf.
@@ -4682,7 +4711,7 @@ public abstract class AbstractByteBufTest {
         ByteBuf buffer = newBuffer(bytes.length);
         try {
             buffer.writeBytes(bytes);
-            buffer.getBytes(buffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(buffer.readerIndex(), nioBuffer));
         } finally {
             buffer.release();
         }
@@ -4840,25 +4869,25 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCapacityEnforceMaxCapacity() {
         ByteBuf buffer = newBuffer(3, 13);
         assertEquals(13, buffer.maxCapacity());
         assertEquals(3, buffer.capacity());
         try {
-            buffer.capacity(14);
+            assertThrows(IllegalArgumentException.class, () -> buffer.capacity(14));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCapacityNegative() {
         ByteBuf buffer = newBuffer(3, 13);
         assertEquals(13, buffer.maxCapacity());
         assertEquals(3, buffer.capacity());
         try {
-            buffer.capacity(-1);
+            assertThrows(IllegalArgumentException.class, () -> buffer.capacity(-1));
         } finally {
             buffer.release();
         }
@@ -4892,7 +4921,7 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testReaderIndexLargerThanWriterIndex() {
         String content1 = "hello";
         String content2 = "world";
@@ -4906,7 +4935,7 @@ public abstract class AbstractByteBufTest {
         assertTrue(buffer.readerIndex() <= buffer.writerIndex());
 
         try {
-            buffer.readerIndex(buffer.writerIndex() + 1);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(buffer.writerIndex() + 1));
         } finally {
             buffer.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -16,8 +16,8 @@
 package io.netty.buffer;
 
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -39,14 +39,15 @@ import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * An abstract test class for composite channel buffers
@@ -63,7 +64,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
     @Override
     protected ByteBuf newBuffer(int length, int maxCapacity) {
-        Assume.assumeTrue(maxCapacity == Integer.MAX_VALUE);
+        Assumptions.assumeTrue(maxCapacity == Integer.MAX_VALUE);
 
         List<ByteBuf> buffers = new ArrayList<>();
         for (int i = 0; i < length + 45; i += 45) {
@@ -1243,7 +1244,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         cbuf.release();
     }
 
-    @Test(expected = ConcurrentModificationException.class)
+    @Test
     public void testIteratorConcurrentModificationAdd() {
         CompositeByteBuf cbuf = newCompositeBuffer();
         cbuf.addComponent(EMPTY_BUFFER);
@@ -1253,13 +1254,13 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
         assertTrue(it.hasNext());
         try {
-            it.next();
+            assertThrows(ConcurrentModificationException.class, it::next);
         } finally {
             cbuf.release();
         }
     }
 
-    @Test(expected = ConcurrentModificationException.class)
+    @Test
     public void testIteratorConcurrentModificationRemove() {
         CompositeByteBuf cbuf = newCompositeBuffer();
         cbuf.addComponent(EMPTY_BUFFER);
@@ -1269,7 +1270,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
         assertTrue(it.hasNext());
         try {
-            it.next();
+            assertThrows(ConcurrentModificationException.class, it::next);
         } finally {
             cbuf.release();
         }
@@ -1554,52 +1555,58 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertTrue(cbuf.release());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOverflowWhileAddingComponent() {
         int capacity = 1024 * 1024; // 1MB
         ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
         CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
 
         try {
-            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
-                ByteBuf duplicate = buffer.duplicate();
-                compositeByteBuf.addComponent(duplicate);
-                duplicate.retain();
-            }
+            assertThrows(IllegalArgumentException.class, () -> {
+                for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                    ByteBuf duplicate = buffer.duplicate();
+                    compositeByteBuf.addComponent(duplicate);
+                    duplicate.retain();
+                }
+            });
         } finally {
             compositeByteBuf.release();
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOverflowWhileAddingComponentsViaVarargs() {
         int capacity = 1024 * 1024; // 1MB
         ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
         CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
 
         try {
-            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
-                ByteBuf duplicate = buffer.duplicate();
-                compositeByteBuf.addComponents(duplicate);
-                duplicate.retain();
-            }
+            assertThrows(IllegalArgumentException.class, () -> {
+                for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                    ByteBuf duplicate = buffer.duplicate();
+                    compositeByteBuf.addComponents(duplicate);
+                    duplicate.retain();
+                }
+            });
         } finally {
             compositeByteBuf.release();
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOverflowWhileAddingComponentsViaIterable() {
         int capacity = 1024 * 1024; // 1MB
         ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
         CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
 
         try {
-            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
-                ByteBuf duplicate = buffer.duplicate();
-                compositeByteBuf.addComponents(Collections.singletonList(duplicate));
-                duplicate.retain();
-            }
+            assertThrows(IllegalArgumentException.class, () -> {
+                for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                    ByteBuf duplicate = buffer.duplicate();
+                    compositeByteBuf.addComponents(Collections.singletonList(duplicate));
+                    duplicate.retain();
+                }
+            });
         } finally {
             compositeByteBuf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
@@ -15,15 +15,15 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
 
@@ -47,12 +47,11 @@ public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
         buf.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void ensureWritableWithNotEnoughSpaceShouldThrow() {
         ByteBuf buf = newBuffer(1, 10);
         try {
-            buf.ensureWritable(11);
-            fail();
+            assertThrows(IndexOutOfBoundsException.class, () -> buf.ensureWritable(11));
         } finally {
             buf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
@@ -16,7 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.IllegalReferenceCountException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,33 +27,34 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AbstractReferenceCountedByteBufTest {
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainOverflow() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         referenceCounted.setRefCnt(Integer.MAX_VALUE);
         assertEquals(Integer.MAX_VALUE, referenceCounted.refCnt());
-        referenceCounted.retain();
+        assertThrows(IllegalReferenceCountException.class, referenceCounted::retain);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainOverflow2() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         assertEquals(1, referenceCounted.refCnt());
-        referenceCounted.retain(Integer.MAX_VALUE);
+        assertThrows(IllegalReferenceCountException.class, () -> referenceCounted.retain(Integer.MAX_VALUE));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReleaseOverflow() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         referenceCounted.setRefCnt(0);
         assertEquals(0, referenceCounted.refCnt());
-        referenceCounted.release(Integer.MAX_VALUE);
+        assertThrows(IllegalReferenceCountException.class, () -> referenceCounted.release(Integer.MAX_VALUE));
     }
 
     @Test
@@ -68,20 +69,20 @@ public class AbstractReferenceCountedByteBufTest {
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainResurrect() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         assertTrue(referenceCounted.release());
         assertEquals(0, referenceCounted.refCnt());
-        referenceCounted.retain();
+        assertThrows(IllegalReferenceCountException.class, referenceCounted::retain);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainResurrect2() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         assertTrue(referenceCounted.release());
         assertEquals(0, referenceCounted.refCnt());
-        referenceCounted.retain(2);
+        assertThrows(IllegalReferenceCountException.class, () -> referenceCounted.retain(2));
     }
 
     private static AbstractReferenceCountedByteBuf newReferenceCounted() {

--- a/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareByteBufTest.java
@@ -16,9 +16,9 @@
 package io.netty.buffer;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.netty.util.CharsetUtil;
 import io.netty.util.ResourceLeakTracker;

--- a/buffer/src/test/java/io/netty/buffer/BigEndianCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianCompositeByteBufTest.java
@@ -15,8 +15,7 @@
  */
 package io.netty.buffer;
 
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests big-endian composite channel buffers
@@ -27,9 +26,9 @@ public class BigEndianCompositeByteBufTest extends AbstractCompositeByteBufTest 
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testInternalNioBufferAfterRelease() {
-        super.testInternalNioBufferAfterRelease();
+        testInternalNioBufferAfterRelease0(UnsupportedOperationException.class);
     }
 
 }

--- a/buffer/src/test/java/io/netty/buffer/BigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianDirectByteBufTest.java
@@ -15,11 +15,13 @@
  */
 package io.netty.buffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteOrder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests big-endian direct channel buffers

--- a/buffer/src/test/java/io/netty/buffer/BigEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianHeapByteBufTest.java
@@ -15,9 +15,10 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests big-endian heap channel buffers
@@ -31,13 +32,14 @@ public class BigEndianHeapByteBufTest extends AbstractByteBufTest {
         return buffer;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor1() {
-        new UnpooledHeapByteBuf(null, new byte[1], 0);
+        assertThrows(NullPointerException.class, () -> new UnpooledHeapByteBuf(null, new byte[1], 0));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor2() {
-        new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, null, 0);
+        assertThrows(NullPointerException.class,
+            () -> new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, null, 0));
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeDirectByteBufTest.java
@@ -17,15 +17,15 @@ package io.netty.buffer;
 
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class BigEndianUnsafeDirectByteBufTest extends BigEndianDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assumptions.assumeTrue(PlatformDependent.hasUnsafe(), "sun.misc.Unsafe not found, skip tests");
         super.init();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -15,18 +15,17 @@
  */
 package io.netty.buffer;
 
-
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class BigEndianUnsafeNoCleanerDirectByteBufTest extends BigEndianDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests",
-                PlatformDependent.useDirectBufferNoCleaner());
+        Assumptions.assumeTrue(PlatformDependent.useDirectBufferNoCleaner(),
+                "java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests");
         super.init();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufAllocatorTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class ByteBufAllocatorTest {
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
@@ -16,7 +16,7 @@
 
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 import java.util.Random;

--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -15,13 +15,20 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
 import java.nio.charset.Charset;
 
 import static io.netty.util.internal.EmptyArrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests channel buffer streams
@@ -279,7 +286,7 @@ public class ByteBufStreamTest {
         in2.close();
     }
 
-    @Test(expected = EOFException.class)
+    @Test
     public void testReadByteLengthRespected() throws Exception {
         // case1
         ByteBuf buf = Unpooled.buffer(16);
@@ -287,7 +294,7 @@ public class ByteBufStreamTest {
 
         ByteBufInputStream in = new ByteBufInputStream(buf, 0);
         try {
-            in.readByte();
+            assertThrows(EOFException.class, in::readByte);
         } finally {
             buf.release();
             in.close();

--- a/buffer/src/test/java/io/netty/buffer/ByteProcessorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteProcessorTest.java
@@ -16,11 +16,11 @@
 
 package io.netty.buffer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ByteProcessorTest {
     @Test

--- a/buffer/src/test/java/io/netty/buffer/ConsolidationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ConsolidationTest.java
@@ -16,10 +16,10 @@
 package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests buffer consolidation

--- a/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
@@ -15,9 +15,12 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultByteBufHolderTest {
 

--- a/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
@@ -15,9 +15,10 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests duplicated channel buffers
@@ -40,9 +41,9 @@ public class DuplicatedByteBufTest extends AbstractByteBufTest {
         buf.release();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor() {
-        new DuplicatedByteBuf(null);
+        assertThrows(NullPointerException.class, () -> new DuplicatedByteBuf(null));
     }
 
     // See https://github.com/netty/netty/issues/1800

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -12,14 +12,18 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- */package io.netty.buffer;
+ */
+package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class EmptyByteBufTest {
 

--- a/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
@@ -15,9 +15,8 @@
  */
 package io.netty.buffer;
 
-
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -28,7 +27,12 @@ import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FixedCompositeByteBufTest {
 
@@ -36,63 +40,64 @@ public class FixedCompositeByteBufTest {
         return new FixedCompositeByteBuf(UnpooledByteBufAllocator.DEFAULT, buffers);
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBoolean() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setBoolean(0, true);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBoolean(0, true));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetByte() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setByte(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setByte(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesWithByteBuf() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         ByteBuf src = wrappedBuffer(new byte[4]);
         try {
-            buf.setBytes(0, src);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, src));
         } finally {
             buf.release();
             src.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesWithByteBuffer() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setBytes(0, ByteBuffer.wrap(new byte[4]));
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, ByteBuffer.wrap(new byte[4])));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetBytesWithInputStream() throws IOException {
+    @Test
+    public void testSetBytesWithInputStream() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setBytes(0, new ByteArrayInputStream(new byte[4]), 4);
+            assertThrows(ReadOnlyBufferException.class,
+                () -> buf.setBytes(0, new ByteArrayInputStream(new byte[4]), 4));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetBytesWithChannel() throws IOException {
+    @Test
+    public void testSetBytesWithChannel() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setBytes(0, new ScatteringByteChannel() {
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, new ScatteringByteChannel() {
                 @Override
                 public long read(ByteBuffer[] dsts, int offset, int length) {
                     return 0;
@@ -116,67 +121,67 @@ public class FixedCompositeByteBufTest {
                 @Override
                 public void close() {
                 }
-            }, 4);
+            }, 4));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetChar() throws IOException {
+    @Test
+    public void testSetChar() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setChar(0, 'b');
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setChar(0, 'b'));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetDouble() throws IOException {
+    @Test
+    public void testSetDouble() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setDouble(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setDouble(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetFloat() throws IOException {
+    @Test
+    public void testSetFloat() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setFloat(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setFloat(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetInt() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setInt(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setInt(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetLong() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setLong(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setLong(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetMedium() throws IOException {
+    @Test
+    public void testSetMedium() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setMedium(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setMedium(0, 1));
         } finally {
             buf.release();
         }
@@ -394,7 +399,7 @@ public class FixedCompositeByteBufTest {
 
     @Test
     public void testHasMemoryAddressWhenEmpty() {
-        Assume.assumeTrue(EMPTY_BUFFER.hasMemoryAddress());
+        Assumptions.assumeTrue(EMPTY_BUFFER.hasMemoryAddress());
         ByteBuf buf = newBuffer(new ByteBuf[0]);
         assertTrue(buf.hasMemoryAddress());
         assertEquals(EMPTY_BUFFER.memoryAddress(), buf.memoryAddress());
@@ -441,15 +446,14 @@ public class FixedCompositeByteBufTest {
         buf.release();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testHasNoArrayWhenMultipleBuffers() {
         ByteBuf buf1 = buffer(10);
         ByteBuf buf2 = buffer(10);
         ByteBuf buf = newBuffer(buf1, buf2);
         assertFalse(buf.hasArray());
         try {
-            buf.array();
-            fail();
+            assertThrows(UnsupportedOperationException.class, buf::array);
         } finally {
             buf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianDirectByteBufTest.java
@@ -15,7 +15,8 @@
  */
 package io.netty.buffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.nio.ByteOrder;
 

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianHeapByteBufTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.buffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteOrder;
 

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeDirectByteBufTest.java
@@ -16,15 +16,15 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class LittleEndianUnsafeDirectByteBufTest extends LittleEndianDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assumptions.assumeTrue(PlatformDependent.hasUnsafe(), "sun.misc.Unsafe not found, skip tests");
         super.init();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -16,16 +16,16 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class LittleEndianUnsafeNoCleanerDirectByteBufTest extends LittleEndianDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests",
-                PlatformDependent.useDirectBufferNoCleaner());
+        Assumptions.assumeTrue(PlatformDependent.useDirectBufferNoCleaner(),
+          "java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests");
         super.init();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/LongPriorityQueueTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LongPriorityQueueTest.java
@@ -16,7 +16,6 @@
 package io.netty.buffer;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,12 +29,7 @@ class LongPriorityQueueTest {
     @Test
     public void mustThrowWhenAddingNoValue() {
         final LongPriorityQueue pq = new LongPriorityQueue();
-        assertThrows(IllegalArgumentException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                pq.offer(LongPriorityQueue.NO_VALUE);
-            }
-        });
+        assertThrows(IllegalArgumentException.class, () -> pq.offer(LongPriorityQueue.NO_VALUE));
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -17,13 +17,13 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PoolArenaTest {
 
@@ -38,7 +38,7 @@ public class PoolArenaTest {
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {16, 16, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
-            Assert.assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
+            assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
         }
     }
 
@@ -48,7 +48,7 @@ public class PoolArenaTest {
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {16, 64, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
-            Assert.assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
+            assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
         }
     }
 
@@ -58,9 +58,9 @@ public class PoolArenaTest {
 
         for (int sz = 0; sz <= CHUNK_SIZE; sz++) {
             int sizeIdx = arena.size2SizeIdx(sz);
-            Assert.assertTrue(sz <= arena.sizeIdx2size(sizeIdx));
+            assertTrue(sz <= arena.sizeIdx2size(sizeIdx));
             if (sizeIdx > 0) {
-                Assert.assertTrue(sz > arena.sizeIdx2size(sizeIdx - 1));
+                assertTrue(sz > arena.sizeIdx2size(sizeIdx - 1));
             }
         }
     }
@@ -74,15 +74,15 @@ public class PoolArenaTest {
         int maxPages = CHUNK_SIZE >> pageShifts;
         for (int pages = 1; pages <= maxPages; pages++) {
             int pageIdxFloor = arena.pages2pageIdxFloor(pages);
-            Assert.assertTrue(pages << pageShifts >= arena.pageIdx2size(pageIdxFloor));
+            assertTrue(pages << pageShifts >= arena.pageIdx2size(pageIdxFloor));
             if (pageIdxFloor > 0 && pages < maxPages) {
-                Assert.assertTrue(pages << pageShifts < arena.pageIdx2size(pageIdxFloor + 1));
+                assertTrue(pages << pageShifts < arena.pageIdx2size(pageIdxFloor + 1));
             }
 
             int pageIdxCeiling = arena.pages2pageIdx(pages);
-            Assert.assertTrue(pages << pageShifts <= arena.pageIdx2size(pageIdxCeiling));
+            assertTrue(pages << pageShifts <= arena.pageIdx2size(pageIdxCeiling));
             if (pageIdxCeiling > 0) {
-                Assert.assertTrue(pages << pageShifts > arena.pageIdx2size(pageIdxCeiling - 1));
+                assertTrue(pages << pageShifts > arena.pageIdx2size(pageIdxCeiling - 1));
             }
         }
     }
@@ -122,24 +122,24 @@ public class PoolArenaTest {
         // create normal buffer
         final ByteBuf b2 = allocator.directBuffer(8192 * 5);
 
-        Assert.assertNotNull(b1);
-        Assert.assertNotNull(b2);
+        assertNotNull(b1);
+        assertNotNull(b2);
 
         // then release buffer to deallocated memory while threadlocal cache has been disabled
         // allocations counter value must equals deallocations counter value
-        Assert.assertTrue(b1.release());
-        Assert.assertTrue(b2.release());
+        assertTrue(b1.release());
+        assertTrue(b2.release());
 
-        Assert.assertTrue(allocator.directArenas().size() >= 1);
+        assertTrue(allocator.directArenas().size() >= 1);
         final PoolArenaMetric metric = allocator.directArenas().get(0);
 
-        Assert.assertEquals(2, metric.numDeallocations());
-        Assert.assertEquals(2, metric.numAllocations());
+        assertEquals(2, metric.numDeallocations());
+        assertEquals(2, metric.numAllocations());
 
-        Assert.assertEquals(1, metric.numSmallDeallocations());
-        Assert.assertEquals(1, metric.numSmallAllocations());
-        Assert.assertEquals(1, metric.numNormalDeallocations());
-        Assert.assertEquals(1, metric.numNormalAllocations());
+        assertEquals(1, metric.numSmallDeallocations());
+        assertEquals(1, metric.numSmallAllocations());
+        assertEquals(1, metric.numNormalDeallocations());
+        assertEquals(1, metric.numNormalAllocations());
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/PooledAlignedBigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledAlignedBigEndianDirectByteBufTest.java
@@ -15,18 +15,18 @@
  */
 package io.netty.buffer;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class PooledAlignedBigEndianDirectByteBufTest extends PooledBigEndianDirectByteBufTest {
     private static final int directMemoryCacheAlignment = 1;
     private static PooledByteBufAllocator allocator;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpAllocator() {
         allocator = new PooledByteBufAllocator(
                 true,
@@ -40,7 +40,7 @@ public class PooledAlignedBigEndianDirectByteBufTest extends PooledBigEndianDire
                 directMemoryCacheAlignment);
     }
 
-    @AfterClass
+    @AfterAll
     public static void releaseAllocator() {
         allocator = null;
     }

--- a/buffer/src/test/java/io/netty/buffer/PooledBigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledBigEndianDirectByteBufTest.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Tests big-endian direct channel buffers

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -20,8 +20,8 @@ import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -32,14 +32,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
+import org.junit.jupiter.api.Timeout;
 
 import static io.netty.buffer.PoolChunk.runOffset;
 import static io.netty.buffer.PoolChunk.runPages;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<PooledByteBufAllocator> {
 
@@ -144,13 +145,13 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     public void testArenaMetricsNoCacheAlign() {
-        Assume.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
+        Assumptions.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 0, 0, 0, true, 64), 100, 0, 100, 100);
     }
 
     @Test
     public void testArenaMetricsCacheAlign() {
-        Assume.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
+        Assumptions.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 1000, 1000, 1000, true, 64), 100, 1, 1, 0);
     }
 
@@ -338,12 +339,14 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         }
     }
 
-    @Test (timeout = 4000)
+    @Test
+    @Timeout(value = 4000, unit = MILLISECONDS)
     public void testThreadCacheDestroyedByThreadCleaner() throws InterruptedException {
         testThreadCacheDestroyed(false);
     }
 
-    @Test (timeout = 4000)
+    @Test
+    @Timeout(value = 4000, unit = MILLISECONDS)
     public void testThreadCacheDestroyedAfterExitRun() throws InterruptedException {
         testThreadCacheDestroyed(true);
     }
@@ -400,7 +403,8 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         assertTrue(threadCachesCreated.get());
     }
 
-    @Test(timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = MILLISECONDS)
     public void testNumThreadCachesWithNoDirectArenas() throws InterruptedException {
         int numHeapArenas = 1;
         final PooledByteBufAllocator allocator =
@@ -419,7 +423,8 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         assertEquals(0, allocator.metric().numThreadLocalCaches());
     }
 
-    @Test(timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = MILLISECONDS)
     public void testThreadCacheToArenaMappings() throws InterruptedException {
         int numArenas = 2;
         final PooledByteBufAllocator allocator =

--- a/buffer/src/test/java/io/netty/buffer/PooledLittleEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledLittleEndianDirectByteBufTest.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Tests little-endian direct channel buffers

--- a/buffer/src/test/java/io/netty/buffer/PooledLittleEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledLittleEndianHeapByteBufTest.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Tests little-endian heap channel buffers

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,11 +31,11 @@ import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.buffer.Unpooled.LITTLE_ENDIAN;
 import static io.netty.buffer.Unpooled.buffer;
 import static io.netty.buffer.Unpooled.unmodifiableBuffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,9 +44,9 @@ import static org.mockito.Mockito.when;
  */
 public class ReadOnlyByteBufTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor() {
-        new ReadOnlyByteBuf(null);
+        assertThrows(NullPointerException.class, () -> new ReadOnlyByteBuf(null));
     }
 
     @Test
@@ -127,59 +127,65 @@ public class ReadOnlyByteBufTest {
         assertEquals(27, roBuf.capacity());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectDiscardReadBytes() {
-        unmodifiableBuffer(EMPTY_BUFFER).discardReadBytes();
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).discardReadBytes());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetByte() {
-        unmodifiableBuffer(EMPTY_BUFFER).setByte(0, (byte) 0);
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).setByte(0, (byte) 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetShort() {
-        unmodifiableBuffer(EMPTY_BUFFER).setShort(0, (short) 0);
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setShort(0, (short) 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetMedium() {
-        unmodifiableBuffer(EMPTY_BUFFER).setMedium(0, 0);
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).setMedium(0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetInt() {
-        unmodifiableBuffer(EMPTY_BUFFER).setInt(0, 0);
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).setInt(0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetLong() {
-        unmodifiableBuffer(EMPTY_BUFFER).setLong(0, 0);
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).setLong(0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldRejectSetBytes1() throws IOException {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (InputStream) null, 0);
+    @Test
+    public void shouldRejectSetBytes1() {
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (InputStream) null, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldRejectSetBytes2() throws IOException {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ScatteringByteChannel) null, 0);
+    @Test
+    public void shouldRejectSetBytes2() {
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ScatteringByteChannel) null, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetBytes3() {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (byte[]) null, 0, 0);
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (byte[]) null, 0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetBytes4() {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuf) null, 0, 0);
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuf) null, 0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetBytes5() {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuffer) null);
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuffer) null));
     }
 
     @Test
@@ -211,13 +217,12 @@ public class ReadOnlyByteBufTest {
         readOnly.release();
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void ensureWritableShouldThrow() {
         ByteBuf buf = buffer(1);
         ByteBuf readOnly = buf.asReadOnly();
         try {
-            readOnly.ensureWritable(1);
-            fail();
+            assertThrows(ReadOnlyBufferException.class, () -> readOnly.ensureWritable(1));
         } finally {
             buf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufferBufTest.java
@@ -15,12 +15,12 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReadOnlyByteBufferBufTest extends ReadOnlyDirectByteBufferBufTest {
     @Override

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -16,8 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -27,6 +26,12 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ReadOnlyDirectByteBufferBufTest {
 
@@ -41,20 +46,20 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void testIsContiguous() {
         ByteBuf buf = buffer(allocate(4).asReadOnlyBuffer());
-        Assert.assertTrue(buf.isContiguous());
+        assertTrue(buf.isContiguous());
         buf.release();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructWithWritable() {
-        buffer(allocate(1));
+        assertThrows(IllegalArgumentException.class, () -> buffer(allocate(1)));
     }
 
     @Test
     public void shouldIndicateNotWritable() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
-            Assert.assertFalse(buf.isWritable());
+            assertFalse(buf.isWritable());
         } finally {
             buf.release();
         }
@@ -64,7 +69,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void shouldIndicateNotWritableAnyNumber() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
-            Assert.assertFalse(buf.isWritable(1));
+            assertFalse(buf.isWritable(1));
         } finally {
             buf.release();
         }
@@ -75,7 +80,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
             int result = buf.ensureWritable(1, false);
-            Assert.assertEquals(1, result);
+            assertEquals(1, result);
         } finally {
             buf.release();
         }
@@ -86,99 +91,100 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
             int result = buf.ensureWritable(1, true);
-            Assert.assertEquals(1, result);
+            assertEquals(1, result);
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void ensureWritableShouldThrow() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
-            buf.ensureWritable(1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.ensureWritable(1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetByte() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setByte(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setByte(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetInt() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setInt(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setInt(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetShort() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setShort(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setShort(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetMedium() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setMedium(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setMedium(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetLong() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setLong(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setLong(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesViaArray() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setBytes(0, "test".getBytes());
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, "test".getBytes()));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesViaBuffer() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         ByteBuf copy = Unpooled.copyInt(1);
         try {
-            buf.setBytes(0, copy);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, copy));
         } finally {
             buf.release();
             copy.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesViaStream() throws IOException {
         ByteBuf buf = buffer(ByteBuffer.allocateDirect(8).asReadOnlyBuffer());
         try {
-            buf.setBytes(0, new ByteArrayInputStream("test".getBytes()), 2);
+            assertThrows(ReadOnlyBufferException.class,
+                () -> buf.setBytes(0, new ByteArrayInputStream("test".getBytes()), 2));
         } finally {
             buf.release();
         }
@@ -189,12 +195,12 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(
                 ((ByteBuffer) allocate(2).put(new byte[] { (byte) 1, (byte) 2 }).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.getByte(0));
-        Assert.assertEquals(2, buf.getByte(1));
+        assertEquals(1, buf.getByte(0));
+        assertEquals(2, buf.getByte(1));
 
-        Assert.assertEquals(1, buf.readByte());
-        Assert.assertEquals(2, buf.readByte());
-        Assert.assertFalse(buf.isReadable());
+        assertEquals(1, buf.readByte());
+        assertEquals(2, buf.readByte());
+        assertFalse(buf.isReadable());
 
         buf.release();
     }
@@ -203,12 +209,12 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void testGetReadInt() {
         ByteBuf buf = buffer(((ByteBuffer) allocate(8).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.getInt(0));
-        Assert.assertEquals(2, buf.getInt(4));
+        assertEquals(1, buf.getInt(0));
+        assertEquals(2, buf.getInt(4));
 
-        Assert.assertEquals(1, buf.readInt());
-        Assert.assertEquals(2, buf.readInt());
-        Assert.assertFalse(buf.isReadable());
+        assertEquals(1, buf.readInt());
+        assertEquals(2, buf.readInt());
+        assertFalse(buf.isReadable());
 
         buf.release();
     }
@@ -218,12 +224,12 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(((ByteBuffer) allocate(8)
                 .putShort((short) 1).putShort((short) 2).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.getShort(0));
-        Assert.assertEquals(2, buf.getShort(2));
+        assertEquals(1, buf.getShort(0));
+        assertEquals(2, buf.getShort(2));
 
-        Assert.assertEquals(1, buf.readShort());
-        Assert.assertEquals(2, buf.readShort());
-        Assert.assertFalse(buf.isReadable());
+        assertEquals(1, buf.readShort());
+        assertEquals(2, buf.readShort());
+        assertFalse(buf.isReadable());
 
         buf.release();
     }
@@ -233,17 +239,17 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(((ByteBuffer) allocate(16)
                 .putLong(1).putLong(2).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.getLong(0));
-        Assert.assertEquals(2, buf.getLong(8));
+        assertEquals(1, buf.getLong(0));
+        assertEquals(2, buf.getLong(8));
 
-        Assert.assertEquals(1, buf.readLong());
-        Assert.assertEquals(2, buf.readLong());
-        Assert.assertFalse(buf.isReadable());
+        assertEquals(1, buf.readLong());
+        assertEquals(2, buf.readLong());
+        assertFalse(buf.isReadable());
 
         buf.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is in the ByteBuf.
@@ -251,7 +257,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buffer = buffer(((ByteBuffer) allocate(bytes.length)
                 .put(bytes).flip()).asReadOnlyBuffer());
         try {
-            buffer.getBytes(buffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(buffer.readerIndex(), nioBuffer));
         } finally {
             buffer.release();
         }
@@ -262,7 +268,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
         ByteBuf copy = buf.copy();
 
-        Assert.assertEquals(buf, copy);
+        assertEquals(buf, copy);
 
         buf.release();
         copy.release();
@@ -273,7 +279,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
         ByteBuf copy = buf.copy(1, 9);
 
-        Assert.assertEquals(buf.slice(1, 9), copy);
+        assertEquals(buf.slice(1, 9), copy);
 
         buf.release();
         copy.release();
@@ -286,7 +292,7 @@ public class ReadOnlyDirectByteBufferBufTest {
                 .putLong(1).flip().position(1)).asReadOnlyBuffer());
 
         ByteBuf slice = buf.slice();
-        Assert.assertEquals(buf, slice);
+        assertEquals(buf, slice);
 
         buf.release();
     }
@@ -295,12 +301,12 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void testWrapBufferRoundTrip() {
         ByteBuf buf = buffer(((ByteBuffer) allocate(16).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.readInt());
+        assertEquals(1, buf.readInt());
 
         ByteBuffer nioBuffer = buf.nioBuffer();
 
         // Ensure this can be accessed without throwing a BufferUnderflowException
-        Assert.assertEquals(2, nioBuffer.getInt());
+        assertEquals(2, nioBuffer.getInt());
 
         buf.release();
     }
@@ -330,7 +336,7 @@ public class ReadOnlyDirectByteBufferBufTest {
 
             b2 = buffer(dup);
 
-            Assert.assertEquals(b2, b1.slice(2, 2));
+            assertEquals(b2, b1.slice(2, 2));
         } finally {
             if (b1 != null) {
                 b1.release();
@@ -352,10 +358,10 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void testMemoryAddress() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            Assert.assertFalse(buf.hasMemoryAddress());
+            assertFalse(buf.hasMemoryAddress());
             try {
                 buf.memoryAddress();
-                Assert.fail();
+                fail();
             } catch (UnsupportedOperationException expected) {
                 // expected
             }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
@@ -16,22 +16,22 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ReadOnlyUnsafeDirectByteBufferBufTest extends ReadOnlyDirectByteBufferBufTest {
 
     /**
      * Needs unsafe to run
      */
-    @BeforeClass
+    @BeforeAll
     public static void assumeConditions() {
-        assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        assumeTrue(PlatformDependent.hasUnsafe(), "sun.misc.Unsafe not found, skip tests");
     }
 
     @Override
@@ -44,7 +44,7 @@ public class ReadOnlyUnsafeDirectByteBufferBufTest extends ReadOnlyDirectByteBuf
     public void testMemoryAddress() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            Assert.assertTrue(buf.hasMemoryAddress());
+            assertTrue(buf.hasMemoryAddress());
             buf.memoryAddress();
         } finally {
             buf.release();

--- a/buffer/src/test/java/io/netty/buffer/RetainedDuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/RetainedDuplicatedByteBufTest.java
@@ -16,7 +16,7 @@
 
 package io.netty.buffer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RetainedDuplicatedByteBufTest extends DuplicatedByteBufTest {
     @Override

--- a/buffer/src/test/java/io/netty/buffer/RetainedSlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/RetainedSlicedByteBufTest.java
@@ -16,8 +16,7 @@
 
 package io.netty.buffer;
 
-
-import org.junit.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RetainedSlicedByteBufTest extends SlicedByteBufTest {
 
@@ -25,7 +24,7 @@ public class RetainedSlicedByteBufTest extends SlicedByteBufTest {
     protected ByteBuf newSlice(ByteBuf buffer, int offset, int length) {
         ByteBuf slice = buffer.retainedSlice(offset, length);
         buffer.release();
-        Assert.assertEquals(buffer.refCnt(), slice.refCnt());
+        assertEquals(buffer.refCnt(), slice.refCnt());
         return slice;
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareByteBufTest.java
@@ -16,15 +16,15 @@
 package io.netty.buffer;
 
 import io.netty.util.ResourceLeakTracker;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleLeakAwareByteBufTest extends BigEndianHeapByteBufTest {
     private final Class<? extends ByteBuf> clazz = leakClass();
@@ -46,14 +46,14 @@ public class SimpleLeakAwareByteBufTest extends BigEndianHeapByteBufTest {
         return new SimpleLeakAwareByteBuf(buffer, tracker);
     }
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
         super.init();
         trackers.clear();
     }
 
-    @After
+    @AfterEach
     @Override
     public void dispose() {
         super.dispose();

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
@@ -17,17 +17,17 @@ package io.netty.buffer;
 
 import io.netty.util.ResourceLeakTracker;
 import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleLeakAwareCompositeByteBufTest extends WrappedCompositeByteBufTest {
 
@@ -46,14 +46,14 @@ public class SimpleLeakAwareCompositeByteBufTest extends WrappedCompositeByteBuf
         return new SimpleLeakAwareCompositeByteBuf(buffer, tracker);
     }
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
         super.init();
         trackers.clear();
     }
 
-    @After
+    @AfterEach
     @Override
     public void dispose() {
         super.dispose();

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -15,17 +15,17 @@
  */
 package io.netty.buffer;
 
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests sliced channel buffers
@@ -34,7 +34,7 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
 
     @Override
     protected final ByteBuf newBuffer(int length, int maxCapacity) {
-        Assume.assumeTrue(maxCapacity == Integer.MAX_VALUE);
+        Assumptions.assumeTrue(maxCapacity == Integer.MAX_VALUE);
         int offset = length == 0 ? 0 : ThreadLocalRandom.current().nextInt(length);
         ByteBuf buffer = Unpooled.buffer(length * 2);
         ByteBuf slice = newSlice(buffer, offset, length);
@@ -54,69 +54,69 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         buf.release();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor() {
-        new SlicedByteBuf(null, 0, 0);
+        assertThrows(NullPointerException.class, () -> new SlicedByteBuf(null, 0, 0));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testInternalNioBuffer() {
-        super.testInternalNioBuffer();
+        assertThrows(IndexOutOfBoundsException.class, super::testInternalNioBuffer);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateReadGatheringByteChannelMultipleThreads() throws Exception {
-        super.testDuplicateReadGatheringByteChannelMultipleThreads();
+    public void testDuplicateReadGatheringByteChannelMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateReadGatheringByteChannelMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceReadGatheringByteChannelMultipleThreads() throws Exception {
-        super.testSliceReadGatheringByteChannelMultipleThreads();
+    public void testSliceReadGatheringByteChannelMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceReadGatheringByteChannelMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateReadOutputStreamMultipleThreads() throws Exception {
-        super.testDuplicateReadOutputStreamMultipleThreads();
+    public void testDuplicateReadOutputStreamMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateReadOutputStreamMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceReadOutputStreamMultipleThreads() throws Exception {
-        super.testSliceReadOutputStreamMultipleThreads();
+    public void testSliceReadOutputStreamMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceReadOutputStreamMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateBytesInArrayMultipleThreads() throws Exception {
-        super.testDuplicateBytesInArrayMultipleThreads();
+    public void testDuplicateBytesInArrayMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateBytesInArrayMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceBytesInArrayMultipleThreads() throws Exception {
-        super.testSliceBytesInArrayMultipleThreads();
+    public void testSliceBytesInArrayMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceBytesInArrayMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testNioBufferExposeOnlyRegion() {
-        super.testNioBufferExposeOnlyRegion();
+        assertThrows(IndexOutOfBoundsException.class, super::testNioBufferExposeOnlyRegion);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testGetReadOnlyDirectDst() {
-        super.testGetReadOnlyDirectDst();
+        assertThrows(IndexOutOfBoundsException.class, super::testGetReadOnlyDirectDst);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testGetReadOnlyHeapDst() {
-        super.testGetReadOnlyHeapDst();
+        assertThrows(IndexOutOfBoundsException.class, super::testGetReadOnlyHeapDst);
     }
 
     @Test
@@ -143,12 +143,12 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         // Ignore for SlicedByteBuf
     }
 
-    @Ignore("Sliced ByteBuf objects don't allow the capacity to change. So this test would fail and shouldn't be run")
+    @Disabled("Sliced ByteBuf objects don't allow the capacity to change. So this test would fail and shouldn't be run")
     @Override
     public void testDuplicateCapacityChange() {
     }
 
-    @Ignore("Sliced ByteBuf objects don't allow the capacity to change. So this test would fail and shouldn't be run")
+    @Disabled("Sliced ByteBuf objects don't allow the capacity to change. So this test would fail and shouldn't be run")
     @Override
     public void testRetainedDuplicateCapacityChange() {
     }
@@ -199,41 +199,42 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
     }
 
     @Override
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is wrapped in the ByteBuf.
         ByteBuffer nioBuffer = ByteBuffer.allocate(bytes.length + 1);
         ByteBuf wrappedBuffer = Unpooled.wrappedBuffer(bytes).slice(0, bytes.length - 1);
         try {
-            wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class,
+                () -> wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer));
         } finally {
             wrappedBuffer.release();
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUsAsciiCharSequenceExpand() {
-        super.testWriteUsAsciiCharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUsAsciiCharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUtf8CharSequenceExpand() {
-        super.testWriteUtf8CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUtf8CharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteIso88591CharSequenceExpand() {
-        super.testWriteIso88591CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteIso88591CharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUtf16CharSequenceExpand() {
-        super.testWriteUtf16CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUtf16CharSequenceExpand);
     }
 
     @Test
@@ -252,14 +253,13 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         slice.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void ensureWritableWithNotEnoughSpaceShouldThrow() {
         ByteBuf slice = newBuffer(10);
         ByteBuf unwrapped = slice.unwrap();
         unwrapped.writerIndex(unwrapped.writerIndex() + 5);
         try {
-            slice.ensureWritable(1);
-            fail();
+            assertThrows(IndexOutOfBoundsException.class, () -> slice.ensureWritable(1));
         } finally {
             slice.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
@@ -16,7 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.InputStream;
@@ -31,7 +31,12 @@ import java.util.Map.Entry;
 
 import static io.netty.buffer.Unpooled.*;
 import static io.netty.util.internal.EmptyArrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests channel buffers
@@ -694,11 +699,11 @@ public class UnpooledTest {
         wrapped.release();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void skipBytesNegativeLength() {
         ByteBuf buf = buffer(8);
         try {
-            buf.skipBytes(-1);
+            assertThrows(IllegalArgumentException.class, () -> buf.skipBytes(-1));
         } finally {
             buf.release();
         }
@@ -722,27 +727,29 @@ public class UnpooledTest {
         assertEquals(0, wrapped.refCnt());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is wrapped in the ByteBuf.
         ByteBuffer nioBuffer = ByteBuffer.allocate(bytes.length + 1);
         ByteBuf wrappedBuffer = wrappedBuffer(bytes);
         try {
-            wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class,
+                () -> wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer));
         } finally {
             wrappedBuffer.release();
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer2() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is wrapped in the ByteBuf.
         ByteBuffer nioBuffer = ByteBuffer.allocate(bytes.length + 1);
         ByteBuf wrappedBuffer = wrappedBuffer(bytes, 0, bytes.length);
         try {
-            wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class,
+                () -> wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer));
         } finally {
             wrappedBuffer.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/UnreleaseableByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnreleaseableByteBufTest.java
@@ -15,13 +15,13 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.buffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UnreleaseableByteBufTest {
 

--- a/buffer/src/test/java/io/netty/buffer/UnsafeByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnsafeByteBufUtilTest.java
@@ -16,21 +16,22 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 import static io.netty.util.internal.PlatformDependent.directBufferAddress;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnsafeByteBufUtilTest {
-    @Before
+    @BeforeEach
     public void checkHasUnsafe() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assumptions.assumeTrue(PlatformDependent.hasUnsafe(), "sun.misc.Unsafe not found, skip tests");
     }
 
     @Test
@@ -49,7 +50,7 @@ public class UnsafeByteBufUtilTest {
             byte[] check = new byte[length];
             targetBuffer.getBytes(0, check, 0, length);
 
-            assertArrayEquals("The byte array's copy does not equal the original", testData, check);
+            assertArrayEquals(testData, check, "The byte array's copy does not equal the original");
         } finally {
             targetBuffer.release();
         }
@@ -82,7 +83,7 @@ public class UnsafeByteBufUtilTest {
             byte[] check = new byte[length];
             targetBuffer.getBytes(0, check, 0, length);
 
-            assertArrayEquals("The byte array's copy does not equal the original", testData, check);
+            assertArrayEquals(testData, check, "The byte array's copy does not equal the original");
         } finally {
             targetBuffer.release();
             b1.release();
@@ -105,7 +106,7 @@ public class UnsafeByteBufUtilTest {
             final byte[] check = new byte[length];
             targetBuffer.getBytes(0, check, 0, length);
 
-            assertArrayEquals("The byte array's copy does not equal the original", testData, check);
+            assertArrayEquals(testData, check, "The byte array's copy does not equal the original");
         } finally {
             targetBuffer.release();
         }
@@ -135,60 +136,74 @@ public class UnsafeByteBufUtilTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetBytesWithNullByteArray() {
 
         final UnpooledByteBufAllocator alloc = new UnpooledByteBufAllocator(true);
         final UnpooledDirectByteBuf targetBuffer = new UnpooledDirectByteBuf(alloc, 8, 8);
 
         try {
-            UnsafeByteBufUtil.setBytes(targetBuffer,
-                    directBufferAddress(targetBuffer.nioBuffer()), 0, (byte[]) null, 0, 8);
+            assertThrows(NullPointerException.class, () -> UnsafeByteBufUtil.setBytes(targetBuffer,
+                    directBufferAddress(targetBuffer.nioBuffer()), 0, (byte[]) null, 0, 8));
         } finally {
             targetBuffer.release();
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds() {
-        // negative index
-        testSetBytesOutOfBounds0(4, 4, -1, 0, 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // negative index
+            testSetBytesOutOfBounds0(4, 4, -1, 0, 4);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds2() {
-        // negative length
-        testSetBytesOutOfBounds0(4, 4, 0, 0, -1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // negative length
+            testSetBytesOutOfBounds0(4, 4, 0, 0, -1);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds3() {
-        // buffer length oversize
-        testSetBytesOutOfBounds0(4, 8, 0, 0, 5);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // buffer length oversize
+            testSetBytesOutOfBounds0(4, 8, 0, 0, 5);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds4() {
-        // buffer length oversize
-        testSetBytesOutOfBounds0(4, 4, 3, 0, 3);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // buffer length oversize
+            testSetBytesOutOfBounds0(4, 4, 3, 0, 3);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds5() {
-        // negative srcIndex
-        testSetBytesOutOfBounds0(4, 4, 0, -1, 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // negative srcIndex
+            testSetBytesOutOfBounds0(4, 4, 0, -1, 4);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds6() {
-        // src length oversize
-        testSetBytesOutOfBounds0(8, 4, 0, 0, 5);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // src length oversize
+            testSetBytesOutOfBounds0(8, 4, 0, 0, 5);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds7() {
-        // src length oversize
-        testSetBytesOutOfBounds0(4, 4, 0, 1, 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // src length oversize
+            testSetBytesOutOfBounds0(4, 4, 0, 1, 4);
+        });
     }
 
     private static void testSetBytesOutOfBounds0(int lengthOfBuffer,

--- a/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
@@ -16,134 +16,136 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class WrappedUnpooledUnsafeByteBufTest extends BigEndianUnsafeDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("PlatformDependent.useDirectBufferNoCleaner() returned false, skip tests",
-                PlatformDependent.useDirectBufferNoCleaner());
+        Assumptions.assumeTrue(PlatformDependent.useDirectBufferNoCleaner(),
+                "PlatformDependent.useDirectBufferNoCleaner() returned false, skip tests");
         super.init();
     }
 
     @Override
     protected ByteBuf newBuffer(int length, int maxCapacity) {
-        Assume.assumeTrue(maxCapacity == Integer.MAX_VALUE);
+        Assumptions.assumeTrue(maxCapacity == Integer.MAX_VALUE);
 
         return new WrappedUnpooledUnsafeDirectByteBuf(UnpooledByteBufAllocator.DEFAULT,
                 PlatformDependent.allocateMemory(length), length, true);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testInternalNioBuffer() {
-        super.testInternalNioBuffer();
+        assertThrows(IndexOutOfBoundsException.class, super::testInternalNioBuffer);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateReadGatheringByteChannelMultipleThreads() throws Exception {
-        super.testDuplicateReadGatheringByteChannelMultipleThreads();
+    public void testDuplicateReadGatheringByteChannelMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateReadGatheringByteChannelMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceReadGatheringByteChannelMultipleThreads() throws Exception {
-        super.testSliceReadGatheringByteChannelMultipleThreads();
+    public void testSliceReadGatheringByteChannelMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceReadGatheringByteChannelMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateReadOutputStreamMultipleThreads() throws Exception {
-        super.testDuplicateReadOutputStreamMultipleThreads();
+    public void testDuplicateReadOutputStreamMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateReadOutputStreamMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceReadOutputStreamMultipleThreads() throws Exception {
-        super.testSliceReadOutputStreamMultipleThreads();
+    public void testSliceReadOutputStreamMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceReadOutputStreamMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateBytesInArrayMultipleThreads() throws Exception {
-        super.testDuplicateBytesInArrayMultipleThreads();
+    public void testDuplicateBytesInArrayMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateBytesInArrayMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceBytesInArrayMultipleThreads() throws Exception {
-        super.testSliceBytesInArrayMultipleThreads();
+    public void testSliceBytesInArrayMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceBytesInArrayMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testNioBufferExposeOnlyRegion() {
-        super.testNioBufferExposeOnlyRegion();
+        assertThrows(IndexOutOfBoundsException.class, super::testNioBufferExposeOnlyRegion);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testGetReadOnlyDirectDst() {
-        super.testGetReadOnlyDirectDst();
+        assertThrows(IndexOutOfBoundsException.class, super::testGetReadOnlyDirectDst);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testGetReadOnlyHeapDst() {
-        super.testGetReadOnlyHeapDst();
+        assertThrows(IndexOutOfBoundsException.class, super::testGetReadOnlyHeapDst);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testReadBytes() {
-        super.testReadBytes();
+        assertThrows(IndexOutOfBoundsException.class, super::testReadBytes);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     @Override
     public void testDuplicateCapacityChange() {
-        super.testDuplicateCapacityChange();
+        assertThrows(IllegalArgumentException.class, super::testDuplicateCapacityChange);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     @Override
     public void testRetainedDuplicateCapacityChange() {
-        super.testRetainedDuplicateCapacityChange();
+        assertThrows(IllegalArgumentException.class, super::testRetainedDuplicateCapacityChange);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testLittleEndianWithExpand() {
-        super.testLittleEndianWithExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testLittleEndianWithExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUsAsciiCharSequenceExpand() {
-        super.testWriteUsAsciiCharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUsAsciiCharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUtf8CharSequenceExpand() {
-        super.testWriteUtf8CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUtf8CharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteIso88591CharSequenceExpand() {
-        super.testWriteIso88591CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteIso88591CharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUtf16CharSequenceExpand() {
-        super.testWriteUtf16CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUtf16CharSequenceExpand);
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/search/BitapSearchProcessorFactoryTest.java
+++ b/buffer/src/test/java/io/netty/buffer/search/BitapSearchProcessorFactoryTest.java
@@ -15,7 +15,9 @@
  */
 package io.netty.buffer.search;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BitapSearchProcessorFactoryTest {
 
@@ -24,9 +26,9 @@ public class BitapSearchProcessorFactoryTest {
         new BitapSearchProcessorFactory(new byte[64]);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRejectTooLongNeedle() {
-        new BitapSearchProcessorFactory(new byte[65]);
+        assertThrows(IllegalArgumentException.class, () -> new BitapSearchProcessorFactory(new byte[65]));
     }
 
 }

--- a/buffer/src/test/java/io/netty/buffer/search/MultiSearchProcessorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/search/MultiSearchProcessorTest.java
@@ -18,9 +18,9 @@ package io.netty.buffer.search;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiSearchProcessorTest {
 

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/AbstractDnsRecordTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/AbstractDnsRecordTest.java
@@ -15,8 +15,10 @@
  */
 package io.netty.handler.codec.dns;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AbstractDnsRecordTest {
 
@@ -24,39 +26,39 @@ public class AbstractDnsRecordTest {
     public void testValidDomainName() {
         String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
-        Assert.assertEquals(name + '.', record.name());
+        assertEquals(name + '.', record.name());
     }
 
     @Test
     public void testValidDomainNameUmlaut() {
         String name = "ä";
         AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
-        Assert.assertEquals("xn--4ca.", record.name());
+        assertEquals("xn--4ca.", record.name());
     }
 
     @Test
     public void testValidDomainNameTrailingDot() {
         String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.";
         AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
-        Assert.assertEquals(name, record.name());
+        assertEquals(name, record.name());
     }
 
     @Test
     public void testValidDomainNameUmlautTrailingDot() {
         String name = "ä.";
         AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
-        Assert.assertEquals("xn--4ca.", record.name());
+        assertEquals("xn--4ca.", record.name());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidDomainNameLength() {
         String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        assertThrows(IllegalArgumentException.class, () -> new AbstractDnsRecord(name, DnsRecordType.A, 0) { });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidDomainNameUmlautLength() {
         String name = "äaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        assertThrows(IllegalArgumentException.class, () -> new AbstractDnsRecord(name, DnsRecordType.A, 0) { });
     }
 }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoderTest.java
@@ -18,9 +18,10 @@ package io.netty.handler.codec.dns;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DefaultDnsRecordDecoderTest {
 
@@ -145,13 +146,13 @@ public class DefaultDnsRecordDecoderTest {
         try {
             cnameRecord = (DefaultDnsRawRecord) decoder.decodeRecord(
                     "netty.github.io", DnsRecordType.CNAME, DnsRecord.CLASS_IN, 60, buffer, 10, 2);
-            assertEquals("The rdata of CNAME-type record should be decompressed in advance",
-                         0, ByteBufUtil.compare(buffer.duplicate().setIndex(0, 10), cnameRecord.content()));
+            assertEquals(0, ByteBufUtil.compare(buffer.duplicate().setIndex(0, 10), cnameRecord.content()),
+                "The rdata of CNAME-type record should be decompressed in advance");
             assertEquals("netty.io.", DnsCodecUtil.decodeDomainName(cnameRecord.content()));
             nsRecord = (DefaultDnsRawRecord) decoder.decodeRecord(
                     "netty.github.io", DnsRecordType.NS, DnsRecord.CLASS_IN, 60, buffer, 10, 2);
-            assertEquals("The rdata of NS-type record should be decompressed in advance",
-                         0, ByteBufUtil.compare(buffer.duplicate().setIndex(0, 10), nsRecord.content()));
+            assertEquals(0, ByteBufUtil.compare(buffer.duplicate().setIndex(0, 10), nsRecord.content()),
+                        "The rdata of NS-type record should be decompressed in advance");
             assertEquals("netty.io.", DnsCodecUtil.decodeDomainName(nsRecord.content()));
         } finally {
             buffer.release();

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
@@ -20,12 +20,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.StringUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DefaultDnsRecordEncoderTest {
 

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
@@ -19,8 +19,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.internal.SocketUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -28,6 +27,8 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DnsQueryTest {
 
@@ -61,9 +62,9 @@ public class DnsQueryTest {
             embedder.writeOutbound(query);
 
             DatagramPacket packet = embedder.readOutbound();
-            Assert.assertTrue(packet.content().isReadable());
+            assertTrue(packet.content().isReadable());
             packet.release();
-            Assert.assertNull(embedder.readOutbound());
+            assertNull(embedder.readOutbound());
         }
     }
 }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsRecordTypeTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsRecordTypeTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.codec.dns;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -23,7 +23,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class DnsRecordTypeTest {
 
@@ -40,8 +43,8 @@ public class DnsRecordTypeTest {
 
     @Test
     public void testSanity() throws Exception {
-        assertEquals("More than one type has the same int value",
-                allTypes().size(), new HashSet<>(allTypes()).size());
+        assertEquals(allTypes().size(), new HashSet<>(allTypes()).size(),
+                "More than one type has the same int value");
     }
 
     /**
@@ -77,7 +80,7 @@ public class DnsRecordTypeTest {
             DnsRecordType found = DnsRecordType.valueOf(t.intValue());
             assertSame(t, found);
             found = DnsRecordType.valueOf(t.name());
-            assertSame(t.name(), t, found);
+            assertSame(t, found, t.name());
         }
     }
 }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
@@ -21,16 +21,14 @@ import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.CorruptedFrameException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DnsResponseTest {
 
@@ -95,16 +93,13 @@ public class DnsResponseTest {
         assertFalse(embedder.finish());
     }
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
     public void readMalformedResponseTest() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new DatagramDnsResponseDecoder());
         ByteBuf packet = embedder.alloc().buffer(512).writeBytes(malformedLoopPacket);
-        exception.expect(CorruptedFrameException.class);
         try {
-            embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
+            assertThrows(CorruptedFrameException.class,
+                () -> embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0))));
         } finally {
             assertFalse(embedder.finish());
         }
@@ -114,9 +109,9 @@ public class DnsResponseTest {
     public void readIncompleteResponseTest() {
         EmbeddedChannel embedder = new EmbeddedChannel(new DatagramDnsResponseDecoder());
         ByteBuf packet = embedder.alloc().buffer(512);
-        exception.expect(CorruptedFrameException.class);
         try {
-            embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
+            assertThrows(CorruptedFrameException.class,
+                () -> embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0))));
         } finally {
             assertFalse(embedder.finish());
         }

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -28,13 +28,14 @@ import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalHandler;
 import io.netty.channel.local.LocalServerChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HAProxyIntegrationTest {
 

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxySSLTLVTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxySSLTLVTest.java
@@ -17,11 +17,12 @@
 package io.netty.handler.codec.haproxy;
 
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HAProxySSLTLVTest {
 

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -23,7 +23,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.haproxy.HAProxyTLV.Type;
 import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,7 +31,11 @@ import java.util.List;
 
 import static io.netty.handler.codec.haproxy.HAProxyConstants.*;
 import static io.netty.handler.codec.haproxy.HAProxyMessageEncoder.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HaProxyMessageEncoderTest {
 
@@ -356,49 +360,49 @@ public class HaProxyMessageEncoderTest {
         assertFalse(ch.finish());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidIpV4Address() {
         String invalidIpv4Address = "192.168.0.1234";
-        new HAProxyMessage(
+        assertThrows(IllegalArgumentException.class, () -> new HAProxyMessage(
                 HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
-                invalidIpv4Address, "192.168.0.11", 56324, 443);
+                invalidIpv4Address, "192.168.0.11", 56324, 443));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidIpV6Address() {
         String invalidIpv6Address = "2001:0db8:85a3:0000:0000:8a2e:0370:73345";
-        new HAProxyMessage(
+        assertThrows(IllegalArgumentException.class, () -> new HAProxyMessage(
                 HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP6,
-                invalidIpv6Address, "1050:0:0:0:5:600:300c:326b", 56324, 443);
+                invalidIpv6Address, "1050:0:0:0:5:600:300c:326b", 56324, 443));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidUnixAddress() {
         String invalidUnixAddress = new String(new byte[UNIX_ADDRESS_BYTES_LENGTH + 1]);
-        new HAProxyMessage(
+        assertThrows(IllegalArgumentException.class, () -> new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
-                invalidUnixAddress, "/var/run/dst.sock", 0, 0);
+                invalidUnixAddress, "/var/run/dst.sock", 0, 0));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullUnixAddress() {
-        new HAProxyMessage(
+        assertThrows(NullPointerException.class, () -> new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
-                null, null, 0, 0);
+                null, null, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLongUnixAddress() {
         String longUnixAddress = new String(new char[109]).replace("\0", "a");
-        new HAProxyMessage(
+        assertThrows(IllegalArgumentException.class, () -> new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
-                "source", longUnixAddress, 0, 0);
+                "source", longUnixAddress, 0, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidUnixPort() {
-        new HAProxyMessage(
+        assertThrows(IllegalArgumentException.class, () -> new HAProxyMessage(
                 HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
-                "/var/run/src.sock", "/var/run/dst.sock", 80, 443);
+                "/var/run/src.sock", "/var/run/dst.sock", 80, 443));
     }
 }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
@@ -22,15 +22,15 @@ import io.netty.handler.codec.memcache.LastMemcacheContent;
 import io.netty.handler.codec.memcache.MemcacheContent;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCounted;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies the correct functionality of the {@link AbstractBinaryMemcacheDecoder}.
@@ -69,12 +69,12 @@ public class BinaryMemcacheDecoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new BinaryMemcacheRequestDecoder());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         channel.finishAndReleaseAll();
     }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
@@ -22,13 +22,14 @@ import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.memcache.DefaultLastMemcacheContent;
 import io.netty.handler.codec.memcache.DefaultMemcacheContent;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Verifies the correct functionality of the {@link AbstractBinaryMemcacheEncoder}.
@@ -39,12 +40,12 @@ public class BinaryMemcacheEncoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new BinaryMemcacheRequestEncoder());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         channel.finishAndReleaseAll();
     }
@@ -153,9 +154,9 @@ public class BinaryMemcacheEncoderTest {
         written.release();
     }
 
-    @Test(expected = EncoderException.class)
+    @Test
     public void shouldFailWithoutLastContent() {
         channel.writeOutbound(new DefaultMemcacheContent(Unpooled.EMPTY_BUFFER));
-        channel.writeOutbound(new DefaultBinaryMemcacheRequest());
+        assertThrows(EncoderException.class, () -> channel.writeOutbound(new DefaultBinaryMemcacheRequest()));
     }
 }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessageTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessageTest.java
@@ -18,9 +18,9 @@ package io.netty.handler.codec.memcache.binary;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BinaryMemcacheMessageTest {
 

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
@@ -21,14 +21,14 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.memcache.DefaultLastMemcacheContent;
 import io.netty.handler.codec.memcache.DefaultMemcacheContent;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies the correct functionality of the {@link BinaryMemcacheObjectAggregator}.

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequestTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequestTest.java
@@ -18,17 +18,17 @@ package io.netty.handler.codec.memcache.binary;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 public class DefaultFullBinaryMemcacheRequestTest {
 
     private DefaultFullBinaryMemcacheRequest request;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         request = new DefaultFullBinaryMemcacheRequest(
                 Unpooled.copiedBuffer("key", CharsetUtil.UTF_8),

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponseTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponseTest.java
@@ -18,17 +18,17 @@ package io.netty.handler.codec.memcache.binary;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 public class DefaultFullBinaryMemcacheResponseTest {
 
     private DefaultFullBinaryMemcacheResponse response;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         response = new DefaultFullBinaryMemcacheResponse(
                 Unpooled.copiedBuffer("key", CharsetUtil.UTF_8),

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/FullMemcacheMessageRequestTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/FullMemcacheMessageRequestTest.java
@@ -19,17 +19,19 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FullMemcacheMessageRequestTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(
                 new BinaryMemcacheRequestEncoder(),
@@ -37,7 +39,7 @@ public class FullMemcacheMessageRequestTest {
                 new BinaryMemcacheObjectAggregator(1024));
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         assertFalse(channel.finish());
     }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/FullMemcacheMessageResponseTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/FullMemcacheMessageResponseTest.java
@@ -19,19 +19,19 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FullMemcacheMessageResponseTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(
                 new BinaryMemcacheResponseEncoder(),
@@ -39,7 +39,7 @@ public class FullMemcacheMessageResponseTest {
                 new BinaryMemcacheObjectAggregator(1024));
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         assertFalse(channel.finish());
     }

--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpCommandTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpCommandTest.java
@@ -15,9 +15,13 @@
  */
 package io.netty.handler.codec.smtp;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SmtpCommandTest {
     @Test

--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpRequestEncoderTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpRequestEncoderTest.java
@@ -20,11 +20,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.EncoderException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SmtpRequestEncoderTest {
 
@@ -106,12 +107,12 @@ public class SmtpRequestEncoderTest {
         assertEquals("DATA\r\nSubject: Test\r\n\r\nTest\r\n.\r\n", getWrittenString(channel));
     }
 
-    @Test(expected = EncoderException.class)
+    @Test
     public void testThrowsIfContentExpected() {
         EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
         try {
             assertTrue(channel.writeOutbound(SmtpRequests.data()));
-            channel.writeOutbound(SmtpRequests.noop());
+            assertThrows(EncoderException.class, () ->channel.writeOutbound(SmtpRequests.noop()));
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpResponseDecoderTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpResponseDecoderTest.java
@@ -20,11 +20,15 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SmtpResponseDecoderTest {
 
@@ -106,22 +110,22 @@ public class SmtpResponseDecoderTest {
         assertNull(channel.readInbound());
     }
 
-    @Test(expected = DecoderException.class)
+    @Test
     public void testDecodeInvalidSeparator() {
         EmbeddedChannel channel = newChannel();
-        assertTrue(channel.writeInbound(newBuffer("200:Ok\r\n")));
+        assertThrows(DecoderException.class, () -> channel.writeInbound(newBuffer("200:Ok\r\n")));
     }
 
-    @Test(expected = DecoderException.class)
+    @Test
     public void testDecodeInvalidCode() {
         EmbeddedChannel channel = newChannel();
-        assertTrue(channel.writeInbound(newBuffer("xyz Ok\r\n")));
+        assertThrows(DecoderException.class, () -> channel.writeInbound(newBuffer("xyz Ok\r\n")));
     }
 
-    @Test(expected = DecoderException.class)
+    @Test
     public void testDecodeInvalidLine() {
         EmbeddedChannel channel = newChannel();
-        assertTrue(channel.writeInbound(newBuffer("Ok\r\n")));
+        assertThrows(DecoderException.class, () -> channel.writeInbound(newBuffer("Ok\r\n")));
     }
 
     private static EmbeddedChannel newChannel() {

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthRequestDecoderTest.java
@@ -18,9 +18,11 @@ package io.netty.handler.codec.socks;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SocksAuthRequestDecoderTest {
 

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthRequestTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.socks;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocksAuthRequestTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthResponseDecoderTest.java
@@ -18,9 +18,10 @@ package io.netty.handler.codec.socks;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SocksAuthResponseDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SocksAuthResponseDecoderTest.class);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthResponseTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.socks;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocksAuthResponseTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestDecoderTest.java
@@ -19,11 +19,14 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.UnknownHostException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocksCmdRequestDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SocksCmdRequestDecoderTest.class);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestTest.java
@@ -18,12 +18,14 @@ package io.netty.handler.codec.socks;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
 import java.nio.CharBuffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocksCmdRequestTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdResponseDecoderTest.java
@@ -18,9 +18,12 @@ package io.netty.handler.codec.socks;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocksCmdResponseDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SocksCmdResponseDecoderTest.class);
@@ -60,9 +63,11 @@ public class SocksCmdResponseDecoderTest {
     /**
      * Verifies that invalid bound host will fail with IllegalArgumentException during encoding.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidAddress() {
-        testSocksCmdResponseDecoderWithDifferentParams(SocksCmdStatus.SUCCESS, SocksAddressType.IPv4, "1", 80);
+        assertThrows(IllegalArgumentException.class,
+            () -> testSocksCmdResponseDecoderWithDifferentParams(
+                SocksCmdStatus.SUCCESS, SocksAddressType.IPv4, "1", 80));
     }
 
     /**

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdResponseTest.java
@@ -18,12 +18,17 @@ package io.netty.handler.codec.socks;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
 import java.nio.CharBuffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocksCmdResponseTest {
     @Test
@@ -161,16 +166,17 @@ public class SocksCmdResponseTest {
     /**
      * Verifies that Response cannot be constructed with invalid IP.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidBoundAddress() {
-        new SocksCmdResponse(SocksCmdStatus.SUCCESS, SocksAddressType.IPv4, "127.0.0", 1000);
+        assertThrows(IllegalArgumentException.class,
+            () -> new SocksCmdResponse(SocksCmdStatus.SUCCESS, SocksAddressType.IPv4, "127.0.0", 1000));
     }
 
     private static void assertByteBufEquals(byte[] expected, ByteBuf actual) {
         byte[] actualBytes = new byte[actual.readableBytes()];
         actual.readBytes(actualBytes);
-        assertEquals("Generated response has incorrect length", expected.length, actualBytes.length);
-        assertArrayEquals("Generated response differs from expected", expected, actualBytes);
+        assertEquals(expected.length, actualBytes.length, "Generated response has incorrect length");
+        assertArrayEquals(expected, actualBytes, "Generated response differs from expected");
     }
 
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksInitRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksInitRequestTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.socks;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocksInitRequestTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksInitResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksInitResponseTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.socks;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocksInitResponseTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoderTest.java
@@ -16,11 +16,12 @@
 package io.netty.handler.codec.socksx.v4;
 
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class Socks4ClientDecoderTest {
     private static final Logger logger = LoggerFactory.getLogger(Socks4ClientDecoderTest.class);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoderTest.java
@@ -18,11 +18,13 @@ package io.netty.handler.codec.socksx.v4;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class Socks4ServerDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Socks4ServerDecoderTest.class);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequestTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.handler.codec.socksx.v5;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DefaultSocks5CommandRequestTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
@@ -16,9 +16,13 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.buffer.ByteBuf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultSocks5CommandResponseTest {
     @Test
@@ -113,17 +117,17 @@ public class DefaultSocks5CommandResponseTest {
     /**
      * Verifies that Response cannot be constructed with invalid IP.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidBoundAddress() {
-        new DefaultSocks5CommandResponse(
-                Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "127.0.0", 1000);
+        assertThrows(IllegalArgumentException.class, () -> new DefaultSocks5CommandResponse(
+                Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "127.0.0", 1000));
     }
 
     private static void assertByteBufEquals(byte[] expected, ByteBuf actual) {
         byte[] actualBytes = new byte[actual.readableBytes()];
         actual.readBytes(actualBytes);
-        assertEquals("Generated response has incorrect length", expected.length, actualBytes.length);
-        assertArrayEquals("Generated response differs from expected", expected, actualBytes);
+        assertEquals(expected.length, actualBytes.length, "Generated response has incorrect length");
+        assertArrayEquals(expected, actualBytes, "Generated response differs from expected");
     }
 
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialRequestTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.socksx.v5;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultSocks5InitialRequestTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialResponseTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.socksx.v5;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultSocks5InitialResponseTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthRequestTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.socksx.v5;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultSocks5PasswordAuthRequestTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponseTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.socksx.v5;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultSocks5PasswordAuthResponseTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoderTest.java
@@ -20,13 +20,15 @@ import io.netty.util.NetUtil;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class Socks5CommandRequestDecoderTest {
     private static final InternalLogger logger =

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoderTest.java
@@ -18,12 +18,13 @@ package io.netty.handler.codec.socksx.v5;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Socks5CommandResponseDecoderTest {
 
@@ -75,9 +76,10 @@ public class Socks5CommandResponseDecoderTest {
     /**
      * Verifies that invalid bound host will fail with IllegalArgumentException during encoding.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidAddress() {
-        test(Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "1", 80);
+        assertThrows(IllegalArgumentException.class,
+            () -> test(Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "1", 80));
     }
 
     /**

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
@@ -18,9 +18,11 @@ package io.netty.handler.codec.socksx.v5;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Socks5InitialRequestDecoderTest {
     @Test

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoderTest.java
@@ -16,9 +16,10 @@
 package io.netty.handler.codec.socksx.v5;
 
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class Socks5PasswordAuthRequestDecoderTest {
 

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoderTest.java
@@ -18,9 +18,10 @@ package io.netty.handler.codec.socksx.v5;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class Socks5PasswordAuthResponseDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
@@ -16,12 +16,12 @@
 package io.netty.handler.codec.stomp;
 
 import io.netty.util.AsciiString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultStompFrameTest {
 

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompCommandDecodeTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompCommandDecodeTest.java
@@ -20,42 +20,36 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.Arrays;
 import java.util.Collection;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static io.netty.util.CharsetUtil.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Parameterized.class)
 public class StompCommandDecodeTest {
-
-    private final String rawCommand;
-    private final StompCommand expectedCommand;
-    private final Boolean valid;
 
     private EmbeddedChannel channel;
 
-    public StompCommandDecodeTest(String rawCommand, StompCommand expectedCommand, Boolean valid) {
-        this.rawCommand = rawCommand;
-        this.expectedCommand = expectedCommand;
-        this.valid = valid;
-    }
-
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(channel.finish());
     }
 
-    @Test
-    public void testDecodeCommand() {
+    @ParameterizedTest(name = "{index}: testDecodeCommand({0}) = {1}")
+    @MethodSource("stompCommands")
+    public void testDecodeCommand(String rawCommand, StompCommand expectedCommand, Boolean valid) {
         byte[] frameContent = String.format("%s\n\n\0", rawCommand).getBytes(UTF_8);
         ByteBuf incoming = Unpooled.wrappedBuffer(frameContent);
         assertTrue(channel.writeInbound(incoming));
@@ -77,7 +71,6 @@ public class StompCommandDecodeTest {
         }
     }
 
-    @Parameterized.Parameters(name = "{index}: testDecodeCommand({0}) = {1}")
     public static Collection<Object[]> stompCommands() {
         return Arrays.asList(new Object[][] {
                 { "STOMP", StompCommand.STOMP, true },

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompHeadersTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompHeadersTest.java
@@ -16,10 +16,10 @@
 package io.netty.handler.codec.stomp;
 
 import io.netty.util.AsciiString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class StompHeadersTest {
     @Test

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeAggregatorTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeAggregatorTest.java
@@ -20,23 +20,28 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StompSubframeAggregatorTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder(), new StompSubframeAggregator(100000));
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
-        Assert.assertFalse(channel.finish());
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -48,7 +53,7 @@ public class StompSubframeAggregatorTest {
         StompFrame frame = channel.readInbound();
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -58,12 +63,12 @@ public class StompSubframeAggregatorTest {
         channel.writeInbound(incoming);
 
         StompFrame frame = channel.readInbound();
-        Assert.assertNotNull(frame);
-        Assert.assertEquals(StompCommand.SEND, frame.command());
-        Assert.assertEquals("hello, queue a!!!", frame.content().toString(CharsetUtil.UTF_8));
+        assertNotNull(frame);
+        assertEquals(StompCommand.SEND, frame.command());
+        assertEquals("hello, queue a!!!", frame.content().toString(CharsetUtil.UTF_8));
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -73,12 +78,12 @@ public class StompSubframeAggregatorTest {
         channel.writeInbound(incoming);
 
         StompFrame frame = channel.readInbound();
-        Assert.assertNotNull(frame);
-        Assert.assertEquals(StompCommand.SEND, frame.command());
-        Assert.assertEquals("body", frame.content().toString(CharsetUtil.UTF_8));
+        assertNotNull(frame);
+        assertEquals(StompCommand.SEND, frame.command());
+        assertEquals("body", frame.content().toString(CharsetUtil.UTF_8));
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -91,12 +96,12 @@ public class StompSubframeAggregatorTest {
         }
 
         StompFrame frame = channel.readInbound();
-        Assert.assertNotNull(frame);
-        Assert.assertEquals(StompCommand.SEND, frame.command());
-        Assert.assertEquals("first part of body\nsecond part of body", frame.content().toString(CharsetUtil.UTF_8));
+        assertNotNull(frame);
+        assertEquals(StompCommand.SEND, frame.command());
+        assertEquals("first part of body\nsecond part of body", frame.content().toString(CharsetUtil.UTF_8));
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -108,11 +113,11 @@ public class StompSubframeAggregatorTest {
         channel.writeInbound(incoming);
 
         StompFrame frame = channel.readInbound();
-        Assert.assertNotNull(frame);
-        Assert.assertEquals(StompCommand.SEND, frame.command());
+        assertNotNull(frame);
+        assertEquals(StompCommand.SEND, frame.command());
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -124,23 +129,24 @@ public class StompSubframeAggregatorTest {
         channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes()));
 
         StompFrame frame = channel.readInbound();
-        Assert.assertEquals(StompCommand.CONNECT, frame.command());
+        assertEquals(StompCommand.CONNECT, frame.command());
         frame.release();
 
         frame = channel.readInbound();
-        Assert.assertEquals(StompCommand.CONNECTED, frame.command());
+        assertEquals(StompCommand.CONNECTED, frame.command());
         frame.release();
 
         frame = channel.readInbound();
-        Assert.assertEquals(StompCommand.SEND, frame.command());
+        assertEquals(StompCommand.SEND, frame.command());
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
-    @Test(expected = TooLongFrameException.class)
+    @Test
     public void testTooLongFrameException() {
         EmbeddedChannel channel = new EmbeddedChannel(new StompSubframeDecoder(), new StompSubframeAggregator(10));
-        channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes()));
+        assertThrows(TooLongFrameException.class,
+            () -> channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes())));
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -18,24 +18,29 @@ package io.netty.handler.codec.stomp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.stomp.StompTestConstants.*;
 import static io.netty.util.CharsetUtil.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StompSubframeDecoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         assertFalse(channel.finish());
     }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
@@ -20,23 +20,27 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.stomp.StompTestConstants.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StompSubframeEncoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeEncoder());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         assertFalse(channel.finish());
     }

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlDecoderTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlDecoderTest.java
@@ -18,9 +18,9 @@ package io.netty.handler.codec.xml;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
@@ -52,12 +52,12 @@ public class XmlDecoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new XmlDecoder());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         channel.finish();
     }

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageCodecTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageCodecTest.java
@@ -20,20 +20,23 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ByteToMessageCodecTest {
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testSharable() {
-        new InvalidByteToMessageCodec();
+        assertThrows(IllegalStateException.class, InvalidByteToMessageCodec::new);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testSharable2() {
-        new InvalidByteToMessageCodec2();
+        assertThrows(IllegalStateException.class, InvalidByteToMessageCodec2::new);
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -27,7 +27,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.netty.channel.socket.ChannelInputShutdownEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -35,12 +35,12 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ByteToMessageDecoderTest {
 
@@ -163,8 +163,8 @@ public class ByteToMessageDecoderTest {
     }
 
     private static void assertCumulationReleased(ByteBuf byteBuf) {
-        assertTrue("unexpected value: " + byteBuf,
-                byteBuf == null || byteBuf == Unpooled.EMPTY_BUFFER || byteBuf.refCnt() == 0);
+        assertTrue(byteBuf == null || byteBuf == Unpooled.EMPTY_BUFFER || byteBuf.refCnt() == 0,
+                "unexpected value: " + byteBuf);
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/CharSequenceValueConverterTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/CharSequenceValueConverterTest.java
@@ -15,11 +15,12 @@
 package io.netty.handler.codec;
 
 import io.netty.util.AsciiString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CharSequenceValueConverterTest {
 
@@ -36,9 +37,9 @@ public class CharSequenceValueConverterTest {
         assertEquals(127, converter.convertToByte(AsciiString.of("127")));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void testByteFromEmptyAsciiString() {
-        converter.convertToByte(AsciiString.EMPTY_STRING);
+        assertThrows(NumberFormatException.class, () ->converter.convertToByte(AsciiString.EMPTY_STRING));
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/CodecOutputListTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/CodecOutputListTest.java
@@ -15,10 +15,11 @@
  */
 package io.netty.handler.codec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CodecOutputListTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/DatagramPacketDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DatagramPacketDecoderTest.java
@@ -23,29 +23,29 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.SocketUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DatagramPacketDecoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(
                 new DatagramPacketDecoder(
                         new StringDecoder(CharsetUtil.UTF_8)));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(channel.finish());
     }

--- a/codec/src/test/java/io/netty/handler/codec/DatagramPacketEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DatagramPacketEncoderTest.java
@@ -24,27 +24,27 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.string.StringEncoder;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.SocketUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DatagramPacketEncoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(
                 new DatagramPacketEncoder<String>(
                         new StringEncoder(CharsetUtil.UTF_8)));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(channel.finish());
     }

--- a/codec/src/test/java/io/netty/handler/codec/DateFormatterTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DateFormatterTest.java
@@ -15,13 +15,14 @@
  */
 package io.netty.handler.codec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Calendar;
 import java.util.Date;
 
-import static org.junit.Assert.*;
 import static io.netty.handler.codec.DateFormatter.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DateFormatterTest {
     /**

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -16,7 +16,7 @@ package io.netty.handler.codec;
 
 import io.netty.util.AsciiString;
 import io.netty.util.HashingStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -30,13 +30,14 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link DefaultHeaders}.
@@ -165,13 +166,13 @@ public class DefaultHeadersTest {
         assertFalse(itr.hasNext());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void valuesItrRemoveThrowsWhenEmpty() {
         TestDefaultHeaders headers = newInstance();
         assertEquals(0, headers.size());
         assertTrue(headers.isEmpty());
         Iterator<CharSequence> itr = headers.valueIterator(of("name"));
-        itr.remove();
+        assertThrows(IllegalStateException.class, itr::remove);
     }
 
     @Test
@@ -462,11 +463,11 @@ public class DefaultHeadersTest {
         assertEquals(h2, h2);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iterateEmptyHeadersShouldThrow() {
         Iterator<Map.Entry<CharSequence, CharSequence>> iterator = newInstance().iterator();
         assertFalse(iterator.hasNext());
-        iterator.next();
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -569,10 +570,10 @@ public class DefaultHeadersTest {
         assertEquals(headers1, expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAddSelf() {
         TestDefaultHeaders headers = newInstance();
-        headers.add(headers);
+        assertThrows(IllegalArgumentException.class, () -> headers.add(headers));
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DelimiterBasedFrameDecoderTest.java
@@ -20,11 +20,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DelimiterBasedFrameDecoderTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/EmptyHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/EmptyHeadersTest.java
@@ -14,149 +14,150 @@
  */
 package io.netty.handler.codec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EmptyHeadersTest {
 
     private static final TestEmptyHeaders HEADERS = new TestEmptyHeaders();
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddStringValue() {
-        HEADERS.add("name", "value");
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.add("name", "value"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddStringValues() {
-        HEADERS.add("name", "value1", "value2");
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.add("name", "value1", "value2"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddStringValuesIterable() {
-        HEADERS.add("name", Arrays.asList("value1", "value2"));
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.add("name", Arrays.asList("value1", "value2")));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddBoolean() {
-        HEADERS.addBoolean("name", true);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addBoolean("name", true));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddByte() {
-        HEADERS.addByte("name", (byte) 1);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addByte("name", (byte) 1));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddChar() {
-        HEADERS.addChar("name", 'a');
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addChar("name", 'a'));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddDouble() {
-        HEADERS.addDouble("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addDouble("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddFloat() {
-        HEADERS.addFloat("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addFloat("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddInt() {
-        HEADERS.addInt("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addInt("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddLong() {
-        HEADERS.addLong("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addLong("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddShort() {
-        HEADERS.addShort("name", (short) 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addShort("name", (short) 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddTimeMillis() {
-        HEADERS.addTimeMillis("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addTimeMillis("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetStringValue() {
-        HEADERS.set("name", "value");
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.set("name", "value"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetStringValues() {
-        HEADERS.set("name", "value1", "value2");
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.set("name", "value1", "value2"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetStringValuesIterable() {
-        HEADERS.set("name", Arrays.asList("value1", "value2"));
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.set("name", Arrays.asList("value1", "value2")));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetBoolean() {
-        HEADERS.setBoolean("name", true);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setBoolean("name", true));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetByte() {
-        HEADERS.setByte("name", (byte) 1);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setByte("name", (byte) 1));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetChar() {
-        HEADERS.setChar("name", 'a');
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setChar("name", 'a'));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetDouble() {
-        HEADERS.setDouble("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setDouble("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetFloat() {
-        HEADERS.setFloat("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setFloat("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetInt() {
-        HEADERS.setInt("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setInt("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetLong() {
-        HEADERS.setLong("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setLong("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetShort() {
-        HEADERS.setShort("name", (short) 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setShort("name", (short) 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetTimeMillis() {
-        HEADERS.setTimeMillis("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setTimeMillis("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetAll() {
-        HEADERS.setAll(new TestEmptyHeaders());
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setAll(new TestEmptyHeaders()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSet() {
-        HEADERS.set(new TestEmptyHeaders());
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.set(new TestEmptyHeaders()));
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
@@ -18,9 +18,12 @@ package io.netty.handler.codec;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldBasedFrameDecoderTest {
 
@@ -36,19 +39,19 @@ public class LengthFieldBasedFrameDecoderTest {
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
         try {
             channel.writeInbound(buf);
-            Assert.fail();
+            fail();
         } catch (TooLongFrameException e) {
             // expected
         }
-        Assert.assertTrue(channel.finish());
+        assertTrue(channel.finish());
 
         ByteBuf b = channel.readInbound();
-        Assert.assertEquals(5, b.readableBytes());
-        Assert.assertEquals(1, b.readInt());
-        Assert.assertEquals('a', b.readByte());
+        assertEquals(5, b.readableBytes());
+        assertEquals(1, b.readInt());
+        assertEquals('a', b.readByte());
         b.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
         channel.finish();
     }
 
@@ -64,21 +67,21 @@ public class LengthFieldBasedFrameDecoderTest {
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
         try {
             channel.writeInbound(buf.readRetainedSlice(14));
-            Assert.fail();
+            fail();
         } catch (TooLongFrameException e) {
             // expected
         }
-        Assert.assertTrue(channel.writeInbound(buf.readRetainedSlice(buf.readableBytes())));
+        assertTrue(channel.writeInbound(buf.readRetainedSlice(buf.readableBytes())));
 
-        Assert.assertTrue(channel.finish());
+        assertTrue(channel.finish());
 
         ByteBuf b = channel.readInbound();
-        Assert.assertEquals(5, b.readableBytes());
-        Assert.assertEquals(1, b.readInt());
-        Assert.assertEquals('a', b.readByte());
+        assertEquals(5, b.readableBytes());
+        assertEquals(1, b.readInt());
+        assertEquals('a', b.readByte());
         b.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
         channel.finish();
 
         buf.release();

--- a/codec/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
@@ -19,12 +19,16 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LineBasedFrameDecoderTest {
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
@@ -17,9 +17,11 @@
 package io.netty.handler.codec;
 
 import io.netty.channel.ChannelHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import io.netty.buffer.ByteBuf;

--- a/codec/src/test/java/io/netty/handler/codec/MessageToMessageEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/MessageToMessageEncoderTest.java
@@ -20,18 +20,20 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
-
 
 public class MessageToMessageEncoderTest {
 
     /**
      * Test-case for https://github.com/netty/netty/issues/1656
      */
-    @Test(expected = EncoderException.class)
+    @Test
     public void testException() {
         EmbeddedChannel channel = new EmbeddedChannel(new MessageToMessageEncoder<Object>() {
             @Override
@@ -39,7 +41,7 @@ public class MessageToMessageEncoderTest {
                 throw new Exception();
             }
         });
-        channel.writeOutbound(new Object());
+        assertThrows(EncoderException.class, () -> channel.writeOutbound(new Object()));
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
@@ -19,9 +19,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.netty.util.Signal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReplayingDecoderByteBufTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
@@ -21,14 +21,17 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReplayingDecoderTest {
 
@@ -119,7 +122,7 @@ public class ReplayingDecoderTest {
         buf.release();
         buf2.release();
 
-        assertNull("Must be null as it must only decode one frame", ch.readInbound());
+        assertNull(ch.readInbound(), "Must be null as it must only decode one frame");
 
         ch.read();
         ch.finish();
@@ -176,7 +179,7 @@ public class ReplayingDecoderTest {
         channel.writeInbound(buf.copy());
         ByteBuf b = channel.readInbound();
 
-        assertEquals("Expect to have still all bytes in the buffer", b, buf);
+        assertEquals(b, buf, "Expect to have still all bytes in the buffer");
         b.release();
         buf.release();
     }
@@ -309,7 +312,7 @@ public class ReplayingDecoderTest {
     }
 
     private static void assertCumulationReleased(ByteBuf byteBuf) {
-        assertTrue("unexpected value: " + byteBuf,
-                byteBuf == null || byteBuf == Unpooled.EMPTY_BUFFER || byteBuf.refCnt() == 0);
+        assertTrue(byteBuf == null || byteBuf == Unpooled.EMPTY_BUFFER || byteBuf.refCnt() == 0,
+                "unexpected value: " + byteBuf);
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/base64/Base64Test.java
+++ b/codec/src/test/java/io/netty/handler/codec/base64/Base64Test.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteOrder;
@@ -29,7 +29,9 @@ import java.security.cert.X509Certificate;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class Base64Test {
 
@@ -149,8 +151,9 @@ public class Base64Test {
         ByteBuf decoded = Base64.decode(encoded);
         ByteBuf expectedBuf = Unpooled.wrappedBuffer(bytes);
         try {
-            assertEquals(StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(expectedBuf) +
-                         StringUtil.NEWLINE + "actual--: " + ByteBufUtil.hexDump(decoded), expectedBuf, decoded);
+            assertEquals(expectedBuf, decoded,
+                        StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(expectedBuf) +
+                         StringUtil.NEWLINE + "actual--: " + ByteBufUtil.hexDump(decoded));
         } finally {
             src.release();
             encoded.release();

--- a/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
@@ -17,8 +17,8 @@ package io.netty.handler.codec.bytes;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
@@ -30,7 +30,7 @@ public class ByteArrayDecoderTest {
 
     private EmbeddedChannel ch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ch = new EmbeddedChannel(new ByteArrayDecoder());
     }

--- a/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
@@ -18,9 +18,9 @@ package io.netty.handler.codec.bytes;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
@@ -32,12 +32,12 @@ public class ByteArrayEncoderTest {
 
     private EmbeddedChannel ch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ch = new EmbeddedChannel(new ByteArrayEncoder());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertThat(ch.finish(), is(false));
     }

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
@@ -19,18 +19,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Theories.class)
 public abstract class AbstractEncoderTest extends AbstractCompressionTest {
 
     protected EmbeddedChannel channel;
@@ -40,10 +36,14 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
      */
     protected abstract ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception;
 
-    @Before
-    public abstract void initChannel();
+    @BeforeEach
+    public final void initChannel() {
+        channel = createChannel();
+    }
 
-    @After
+    protected abstract EmbeddedChannel createChannel();
+
+    @AfterEach
     public void destroyChannel() {
         if (channel != null) {
             channel.finishAndReleaseAll();
@@ -51,7 +51,6 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         }
     }
 
-    @DataPoints("smallData")
     public static ByteBuf[] smallData() {
         ByteBuf heap = Unpooled.wrappedBuffer(BYTES_SMALL);
         ByteBuf direct = Unpooled.directBuffer(BYTES_SMALL.length);
@@ -59,7 +58,6 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         return new ByteBuf[] {heap, direct};
     }
 
-    @DataPoints("largeData")
     public static ByteBuf[] largeData() {
         ByteBuf heap = Unpooled.wrappedBuffer(BYTES_LARGE);
         ByteBuf direct = Unpooled.directBuffer(BYTES_LARGE.length);
@@ -67,18 +65,21 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         return new ByteBuf[] {heap, direct};
     }
 
-    @Theory
-    public void testCompressionOfSmallChunkOfData(@FromDataPoints("smallData") ByteBuf data) throws Exception {
+    @ParameterizedTest
+    @MethodSource("smallData")
+    public void testCompressionOfSmallChunkOfData(ByteBuf data) throws Exception {
         testCompression(data);
     }
 
-    @Theory
-    public void testCompressionOfLargeChunkOfData(@FromDataPoints("largeData") ByteBuf data) throws Exception {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testCompressionOfLargeChunkOfData(ByteBuf data) throws Exception {
         testCompression(data);
     }
 
-    @Theory
-    public void testCompressionOfBatchedFlowOfData(@FromDataPoints("largeData") ByteBuf data) throws Exception {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testCompressionOfBatchedFlowOfData(ByteBuf data) throws Exception {
         testCompressionOfBatchedFlow(data);
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -22,16 +22,18 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractIntegrationTest {
 
@@ -43,13 +45,13 @@ public abstract class AbstractIntegrationTest {
     protected abstract EmbeddedChannel createEncoder();
     protected abstract EmbeddedChannel createDecoder();
 
-    @Before
+    @BeforeEach
     public void initChannels() throws Exception {
         encoder = createEncoder();
         decoder = createDecoder();
     }
 
-    @After
+    @AfterEach
     public void closeChannels() throws Exception {
         encoder.close();
         for (;;) {

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -21,22 +21,18 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Theories.class)
 public class BrotliDecoderTest {
 
     private static final Random RANDOM;
@@ -78,12 +74,12 @@ public class BrotliDecoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void initChannel() {
         channel = new EmbeddedChannel(new BrotliDecoder());
     }
 
-    @After
+    @AfterEach
     public void destroyChannel() {
         if (channel != null) {
             channel.finishAndReleaseAll();
@@ -91,7 +87,6 @@ public class BrotliDecoderTest {
         }
     }
 
-    @DataPoints("smallData")
     public static ByteBuf[] smallData() {
         ByteBuf heap = Unpooled.wrappedBuffer(COMPRESSED_BYTES_SMALL);
         ByteBuf direct = Unpooled.directBuffer(COMPRESSED_BYTES_SMALL.length);
@@ -99,7 +94,6 @@ public class BrotliDecoderTest {
         return new ByteBuf[]{heap, direct};
     }
 
-    @DataPoints("largeData")
     public static ByteBuf[] largeData() {
         ByteBuf heap = Unpooled.wrappedBuffer(COMPRESSED_BYTES_LARGE);
         ByteBuf direct = Unpooled.directBuffer(COMPRESSED_BYTES_LARGE.length);
@@ -107,18 +101,21 @@ public class BrotliDecoderTest {
         return new ByteBuf[]{heap, direct};
     }
 
-    @Theory
-    public void testDecompressionOfSmallChunkOfData(@FromDataPoints("smallData") ByteBuf data) {
+    @ParameterizedTest
+    @MethodSource("smallData")
+    public void testDecompressionOfSmallChunkOfData(ByteBuf data) {
         testDecompression(WRAPPED_BYTES_SMALL, data);
     }
 
-    @Theory
-    public void testDecompressionOfLargeChunkOfData(@FromDataPoints("largeData") ByteBuf data) {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testDecompressionOfLargeChunkOfData(ByteBuf data) {
         testDecompression(WRAPPED_BYTES_LARGE, data);
     }
 
-    @Theory
-    public void testDecompressionOfBatchedFlowOfData(@FromDataPoints("largeData") ByteBuf data) {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testDecompressionOfBatchedFlowOfData(ByteBuf data) {
         testDecompressionOfBatchedFlow(WRAPPED_BYTES_LARGE, data);
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/ByteBufChecksumTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ByteBufChecksumTest.java
@@ -18,8 +18,8 @@ package io.netty.handler.codec.compression;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import net.jpountz.xxhash.XXHashFactory;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 import java.util.zip.Adler32;
@@ -27,13 +27,13 @@ import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
 import static io.netty.handler.codec.compression.Lz4Constants.DEFAULT_SEED;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ByteBufChecksumTest {
 
     private static final byte[] BYTE_ARRAY = new byte[1024];
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         new Random().nextBytes(BYTE_ARRAY);
     }

--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
@@ -24,13 +24,13 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import java.io.InputStream;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Bzip2EncoderTest extends AbstractEncoderTest {
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new Bzip2Encoder(MIN_BLOCK_SIZE));
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new Bzip2Encoder(MIN_BLOCK_SIZE));
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2IntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2IntegrationTest.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Bzip2IntegrationTest extends AbstractIntegrationTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
@@ -22,7 +22,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class FastLzIntegrationTest extends AbstractIntegrationTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
@@ -19,12 +19,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import net.jpountz.lz4.LZ4BlockOutputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
 import static io.netty.handler.codec.compression.Lz4Constants.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Lz4FrameDecoderTest extends AbstractDecoderTest {
 
@@ -42,91 +43,71 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
     }
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new Lz4FrameDecoder(true));
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new Lz4FrameDecoder(true));
     }
 
     @Test
-    public void testUnexpectedBlockIdentifier() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("unexpected block identifier");
-
+    public void testUnexpectedBlockIdentifier() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[1] = 0x00;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected block identifier");
     }
 
     @Test
-    public void testInvalidCompressedLength() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("invalid compressedLength");
-
+    public void testInvalidCompressedLength() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[12] = (byte) 0xFF;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "invalid compressedLength");
     }
 
     @Test
-    public void testInvalidDecompressedLength() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("invalid decompressedLength");
-
+    public void testInvalidDecompressedLength() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[16] = (byte) 0xFF;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "invalid decompressedLength");
     }
 
     @Test
-    public void testDecompressedAndCompressedLengthMismatch() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("mismatch");
-
+    public void testDecompressedAndCompressedLengthMismatch() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[13] = 0x01;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "mismatch");
     }
 
     @Test
-    public void testUnexpectedBlockType() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("unexpected blockType");
-
+    public void testUnexpectedBlockType() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[8] = 0x36;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected blockType");
     }
 
     @Test
-    public void testMismatchingChecksum() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("mismatching checksum");
-
+    public void testMismatchingChecksum() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[17] = 0x01;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "mismatching checksum");
     }
 
     @Test
-    public void testChecksumErrorOfLastBlock() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("checksum error");
-
+    public void testChecksumErrorOfLastBlock() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[44] = 0x01;
 
-        tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data));
+        assertThrows(DecompressionException.class,
+            () -> tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data)), "checksum error");
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -33,12 +33,13 @@ import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.EncoderException;
+import java.util.concurrent.TimeUnit;
 import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.xxhash.XXHashFactory;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -53,9 +54,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 public class Lz4FrameEncoderTest extends AbstractEncoderTest {
@@ -75,15 +78,15 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     @Mock
     private ByteBuf buffer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
         when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
     }
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new Lz4FrameEncoder());
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new Lz4FrameEncoder());
     }
 
     @Override
@@ -139,11 +142,11 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         try {
             Lz4FrameEncoder encoder = newEncoder(blockSize, Lz4FrameEncoder.DEFAULT_MAX_ENCODE_SIZE);
             out = encoder.allocateBuffer(ctx, in, preferDirect);
-            Assert.assertNotNull(out);
+            assertNotNull(out);
             if (NONALLOCATABLE_SIZE == bufSize) {
-                Assert.assertFalse(out.isWritable());
+                assertFalse(out.isWritable());
             } else {
-                Assert.assertTrue(out.writableBytes() > 0);
+                assertTrue(out.writableBytes() > 0);
                 if (!preferDirect) {
                     // Only check if preferDirect is not true as if a direct buffer is returned or not depends on
                     // if sun.misc.Unsafe is present.
@@ -158,7 +161,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         }
     }
 
-    @Test (expected = EncoderException.class)
+    @Test
     public void testAllocateDirectBufferExceedMaxEncodeSize() {
         final int maxEncodeSize = 1024;
         Lz4FrameEncoder encoder = newEncoder(Lz4Constants.DEFAULT_BLOCK_SIZE, maxEncodeSize);
@@ -166,7 +169,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(inputBufferSize, inputBufferSize);
         try {
             buf.writerIndex(inputBufferSize);
-            encoder.allocateBuffer(ctx, buf, false);
+            assertThrows(EncoderException.class, () -> encoder.allocateBuffer(ctx, buf, false));
         } finally {
             buf.release();
         }
@@ -187,13 +190,13 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
      * {@link Lz4FrameEncoder#allocateBuffer(ChannelHandlerContext, ByteBuf, boolean)}, but this is safest way
      * of testing the overflow conditions as allocating the huge buffers fails in many CI environments.
      */
-    @Test (expected = EncoderException.class)
+    @Test
     public void testAllocateOnHeapBufferOverflowsOutputSize() {
         final int maxEncodeSize = Integer.MAX_VALUE;
         Lz4FrameEncoder encoder = newEncoder(Lz4Constants.DEFAULT_BLOCK_SIZE, maxEncodeSize);
         when(buffer.readableBytes()).thenReturn(maxEncodeSize);
         buffer.writerIndex(maxEncodeSize);
-        encoder.allocateBuffer(ctx, buffer, false);
+        assertThrows(EncoderException.class, () -> encoder.allocateBuffer(ctx, buffer, false));
     }
 
     @Test
@@ -203,14 +206,14 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         int size = 27;
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(size, size);
         buf.writerIndex(size);
-        Assert.assertEquals(0, encoder.getBackingBuffer().readableBytes());
+        assertEquals(0, encoder.getBackingBuffer().readableBytes());
         channel.write(buf);
-        Assert.assertTrue(channel.outboundMessages().isEmpty());
-        Assert.assertEquals(size, encoder.getBackingBuffer().readableBytes());
+        assertTrue(channel.outboundMessages().isEmpty());
+        assertEquals(size, encoder.getBackingBuffer().readableBytes());
         channel.flush();
-        Assert.assertTrue(channel.finish());
-        Assert.assertTrue(channel.releaseOutbound());
-        Assert.assertFalse(channel.releaseInbound());
+        assertTrue(channel.finish());
+        assertTrue(channel.releaseOutbound());
+        assertFalse(channel.releaseInbound());
     }
 
     @Test
@@ -222,24 +225,25 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         int size = blockSize - 1;
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(size, size);
         buf.writerIndex(size);
-        Assert.assertEquals(0, encoder.getBackingBuffer().readableBytes());
+        assertEquals(0, encoder.getBackingBuffer().readableBytes());
         channel.write(buf);
-        Assert.assertEquals(size, encoder.getBackingBuffer().readableBytes());
+        assertEquals(size, encoder.getBackingBuffer().readableBytes());
 
         int nextSize = size - 1;
         buf = ByteBufAllocator.DEFAULT.buffer(nextSize, nextSize);
         buf.writerIndex(nextSize);
         channel.write(buf);
-        Assert.assertEquals(size + nextSize - blockSize, encoder.getBackingBuffer().readableBytes());
+        assertEquals(size + nextSize - blockSize, encoder.getBackingBuffer().readableBytes());
 
         channel.flush();
-        Assert.assertEquals(0, encoder.getBackingBuffer().readableBytes());
-        Assert.assertTrue(channel.finish());
-        Assert.assertTrue(channel.releaseOutbound());
-        Assert.assertFalse(channel.releaseInbound());
+        assertEquals(0, encoder.getBackingBuffer().readableBytes());
+        assertTrue(channel.finish());
+        assertTrue(channel.releaseOutbound());
+        assertFalse(channel.releaseInbound());
     }
 
-    @Test(timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void writingAfterClosedChannelDoesNotNPE() throws InterruptedException {
         EventLoopGroup group = new MultithreadEventLoopGroup(2, NioHandler.newFactory());
         Channel serverChannel = null;

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
@@ -19,9 +19,10 @@ import com.ning.compress.lzf.LZFEncoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.ning.compress.lzf.LZFChunk.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LzfDecoderTest extends AbstractDecoderTest {
 
@@ -29,35 +30,29 @@ public class LzfDecoderTest extends AbstractDecoderTest {
     }
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new LzfDecoder());
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new LzfDecoder());
     }
 
     @Test
-    public void testUnexpectedBlockIdentifier() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("unexpected block identifier");
-
+    public void testUnexpectedBlockIdentifier() {
         ByteBuf in = Unpooled.buffer();
         in.writeShort(0x1234);  //random value
         in.writeByte(BLOCK_TYPE_NON_COMPRESSED);
         in.writeShort(0);
 
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected block identifier");
     }
 
     @Test
-    public void testUnknownTypeOfChunk() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("unknown type of chunk");
-
+    public void testUnknownTypeOfChunk() {
         ByteBuf in = Unpooled.buffer();
         in.writeByte(BYTE_Z);
         in.writeByte(BYTE_V);
         in.writeByte(0xFF);   //random value
         in.writeInt(0);
 
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unknown type of chunk");
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfEncoderTest.java
@@ -23,8 +23,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 public class LzfEncoderTest extends AbstractEncoderTest {
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new LzfEncoder());
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new LzfEncoder());
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzmaFrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzmaFrameEncoderTest.java
@@ -22,26 +22,27 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import lzma.sdk.lzma.Decoder;
 import lzma.streams.LzmaInputStream;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LzmaFrameEncoderTest extends AbstractEncoderTest {
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new LzmaFrameEncoder());
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new LzmaFrameEncoder());
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("smallData")
     @Override
-    public void testCompressionOfBatchedFlowOfData(@FromDataPoints("smallData") ByteBuf data) throws Exception {
+    public void testCompressionOfBatchedFlowOfData(ByteBuf data) throws Exception {
         testCompressionOfBatchedFlow(data);
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameEncoderTest.java
@@ -19,15 +19,15 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SnappyFrameEncoderTest {
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(new SnappyFrameEncoder());
     }

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
@@ -18,18 +18,19 @@ package io.netty.handler.codec.compression;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.compression.Snappy.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.CharBuffer;
 
 public class SnappyTest {
     private final Snappy snappy = new Snappy();
 
-    @After
+    @AfterEach
     public void resetSnappy() {
         snappy.reset();
     }
@@ -48,7 +49,7 @@ public class SnappyTest {
         ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
             0x6e, 0x65, 0x74, 0x74, 0x79
         });
-        assertEquals("Literal was not decoded correctly", expected, out);
+        assertEquals(expected, out, "Literal was not decoded correctly");
 
         in.release();
         out.release();
@@ -71,15 +72,15 @@ public class SnappyTest {
         ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
             0x6e, 0x65, 0x74, 0x74, 0x79, 0x6e, 0x65, 0x74, 0x74, 0x79
         });
-        assertEquals("Copy was not decoded correctly", expected, out);
+        assertEquals(expected, out, "Copy was not decoded correctly");
 
         in.release();
         out.release();
         expected.release();
     }
 
-    @Test(expected = DecompressionException.class)
-    public void testDecodeCopyWithTinyOffset() throws Exception {
+    @Test
+    public void testDecodeCopyWithTinyOffset() {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
             0x0b, // preamble length
             0x04 << 2, // literal tag + length
@@ -89,15 +90,15 @@ public class SnappyTest {
         });
         ByteBuf out = Unpooled.buffer(10);
         try {
-            snappy.decode(in, out);
+            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
         } finally {
             in.release();
             out.release();
         }
     }
 
-    @Test(expected = DecompressionException.class)
-    public void testDecodeCopyWithOffsetBeforeChunk() throws Exception {
+    @Test
+    public void testDecodeCopyWithOffsetBeforeChunk() {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
             0x0a, // preamble length
             0x04 << 2, // literal tag + length
@@ -107,15 +108,15 @@ public class SnappyTest {
         });
         ByteBuf out = Unpooled.buffer(10);
         try {
-            snappy.decode(in, out);
+            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
         } finally {
             in.release();
             out.release();
         }
     }
 
-    @Test(expected = DecompressionException.class)
-    public void testDecodeWithOverlyLongPreamble() throws Exception {
+    @Test
+    public void testDecodeWithOverlyLongPreamble() {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
             -0x80, -0x80, -0x80, -0x80, 0x7f, // preamble length
             0x04 << 2, // literal tag + length
@@ -123,7 +124,7 @@ public class SnappyTest {
         });
         ByteBuf out = Unpooled.buffer(10);
         try {
-            snappy.decode(in, out);
+            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
         } finally {
             in.release();
             out.release();
@@ -143,7 +144,7 @@ public class SnappyTest {
             0x04 << 2, // literal tag + length
             0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
         });
-        assertEquals("Encoded literal was invalid", expected, out);
+        assertEquals(expected, out, "Encoded literal was invalid");
 
         in.release();
         out.release();
@@ -216,7 +217,7 @@ public class SnappyTest {
             0x11, 0x4c,
         });
 
-        assertEquals("Encoded result was incorrect", expected, out);
+        assertEquals(expected, out, "Encoded result was incorrect");
 
         // Decode
         ByteBuf outDecoded = Unpooled.buffer();
@@ -260,13 +261,13 @@ public class SnappyTest {
         input.release();
     }
 
-    @Test(expected = DecompressionException.class)
+    @Test
     public void testValidateChecksumFails() {
         ByteBuf input = Unpooled.wrappedBuffer(new byte[] {
                 'y', 't', 't', 'e', 'n'
         });
         try {
-            validateChecksum(maskChecksum(0xd6cb8b55), input);
+            assertThrows(DecompressionException.class, () -> validateChecksum(maskChecksum(0xd6cb8b55), input));
         } finally {
             input.release();
         }
@@ -290,7 +291,7 @@ public class SnappyTest {
                 encodeLiteral(in, encoded, len);
                 byte tag = encoded.readByte();
                 decodeLiteral(tag, encoded, decoded);
-                assertEquals("Encoded or decoded literal was incorrect", expected, decoded);
+                assertEquals(expected, decoded, "Encoded or decoded literal was incorrect");
             } finally {
                 in.release();
                 encoded.release();

--- a/codec/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
@@ -23,9 +23,11 @@ import io.netty.handler.codec.DelimiterBasedFrameDecoder;
 import io.netty.handler.codec.Delimiters;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DelimiterBasedFrameDecoderTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
@@ -22,9 +22,12 @@ import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldBasedFrameDecoderTest {
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
@@ -20,19 +20,22 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.util.CharsetUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldPrependerTest {
 
     private ByteBuf msg;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         msg = copiedBuffer("A", CharsetUtil.ISO_8859_1);
     }
@@ -107,7 +110,7 @@ public class LengthFieldPrependerTest {
         buf = ch.readOutbound();
         assertSame(buf, msg);
         buf.release();
-        assertFalse("The channel must have been completely read", ch.finish());
+        assertFalse(ch.finish(), "The channel must have been completely read");
     }
 
 }

--- a/codec/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
@@ -22,9 +22,13 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonObjectDecoderTest {
     @Test
@@ -248,19 +252,18 @@ public class JsonObjectDecoderTest {
         assertFalse(ch.finish());
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test
     public void testNonJsonContent1() {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         try {
-            ch.writeInbound(Unpooled.copiedBuffer("  b [1,2,3]", CharsetUtil.UTF_8));
+            assertThrows(CorruptedFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer("  b [1,2,3]", CharsetUtil.UTF_8)));
         } finally {
             assertFalse(ch.finish());
         }
-
-        fail();
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test
     public void testNonJsonContent2() {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         ch.writeInbound(Unpooled.copiedBuffer("  [1,2,3]  ", CharsetUtil.UTF_8));
@@ -270,24 +273,22 @@ public class JsonObjectDecoderTest {
         res.release();
 
         try {
-            ch.writeInbound(Unpooled.copiedBuffer(" a {\"key\" : 10}", CharsetUtil.UTF_8));
+            assertThrows(CorruptedFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer(" a {\"key\" : 10}", CharsetUtil.UTF_8)));
         } finally {
             assertFalse(ch.finish());
         }
-
-        fail();
     }
 
-    @Test (expected = TooLongFrameException.class)
+    @Test
     public void testMaxObjectLength() {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder(6));
         try {
-            ch.writeInbound(Unpooled.copiedBuffer("[2,4,5]", CharsetUtil.UTF_8));
+            assertThrows(TooLongFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer("[2,4,5]", CharsetUtil.UTF_8)));
         } finally {
             assertFalse(ch.finish());
         }
-
-        fail();
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingDecoderTest.java
@@ -23,15 +23,15 @@ import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractCompatibleMarshallingDecoderTest extends AbstractMarshallingTest {
     @SuppressWarnings("RedundantStringConstructorCall")

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingEncoderTest.java
@@ -22,9 +22,11 @@ import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.Unmarshaller;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractCompatibleMarshallingEncoderTest extends AbstractMarshallingTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractMarshallingTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractMarshallingTest.java
@@ -18,14 +18,14 @@ package io.netty.handler.codec.marshalling;
 import io.netty.util.internal.PlatformDependent;
 import org.jboss.marshalling.Marshalling;
 import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public abstract class AbstractMarshallingTest {
 
     static final String SERIAL_FACTORY = "serial";
     static final String RIVER_FACTORY = "river";
 
-    @BeforeClass
+    @BeforeAll
     public static void checkSupported() throws Throwable {
         Throwable error = null;
         try {
@@ -37,6 +37,6 @@ public abstract class AbstractMarshallingTest {
             }
             error = cause;
         }
-        Assume.assumeNoException(error);
+        Assume.assumeNoException(error); // todo: no replacement in junit 5
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/RiverMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/RiverMarshallingDecoderTest.java
@@ -22,7 +22,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.TooLongFrameException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RiverMarshallingDecoderTest extends RiverCompatibleMarshallingDecoderTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/SerialMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/SerialMarshallingDecoderTest.java
@@ -22,7 +22,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.TooLongFrameException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SerialMarshallingDecoderTest extends SerialCompatibleMarshallingDecoderTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
@@ -17,20 +17,21 @@ package io.netty.handler.codec.protobuf;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsNull.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProtobufVarint32FrameDecoderTest {
 
     private EmbeddedChannel ch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ch = new EmbeddedChannel(new ProtobufVarint32FrameDecoder());
     }

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -17,19 +17,20 @@ package io.netty.handler.codec.protobuf;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProtobufVarint32LengthFieldPrependerTest {
 
     private EmbeddedChannel ch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ch = new EmbeddedChannel(new ProtobufVarint32LengthFieldPrepender());
     }

--- a/codec/src/test/java/io/netty/handler/codec/serialization/CompactObjectSerializationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/serialization/CompactObjectSerializationTest.java
@@ -19,8 +19,8 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CompactObjectSerializationTest {
 
@@ -31,6 +31,6 @@ public class CompactObjectSerializationTest {
         CompactObjectOutputStream out = new CompactObjectOutputStream(pipeOut);
         CompactObjectInputStream in = new CompactObjectInputStream(pipeIn, ClassResolvers.cacheDisabled(null));
         out.writeObject(List.class);
-        Assert.assertSame(List.class, in.readObject());
+        Assertions.assertSame(List.class, in.readObject());
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
@@ -18,14 +18,14 @@ package io.netty.handler.codec.serialization;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class CompatibleObjectEncoderTest {
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/string/LineEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/string/LineEncoderTest.java
@@ -18,11 +18,12 @@ package io.netty.handler.codec.string;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LineEncoderTest {
 
@@ -41,8 +42,8 @@ public class LineEncoderTest {
             byte[] data = new byte[buf.readableBytes()];
             buf.readBytes(data);
             byte[] expected = (msg + lineSeparator.value()).getBytes(CharsetUtil.UTF_8);
-            Assert.assertArrayEquals(expected, data);
-            Assert.assertNull(channel.readOutbound());
+            assertArrayEquals(expected, data);
+            assertNull(channel.readOutbound());
         } finally {
             buf.release();
             assertFalse(channel.finish());

--- a/codec/src/test/java/io/netty/handler/codec/string/StringEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/string/StringEncoderTest.java
@@ -18,8 +18,8 @@ package io.netty.handler.codec.string;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StringEncoderTest {
 
@@ -27,13 +27,13 @@ public class StringEncoderTest {
     public void testEncode() {
         String msg = "Test";
         EmbeddedChannel channel = new EmbeddedChannel(new StringEncoder());
-        Assert.assertTrue(channel.writeOutbound(msg));
-        Assert.assertTrue(channel.finish());
+        Assertions.assertTrue(channel.writeOutbound(msg));
+        Assertions.assertTrue(channel.finish());
         ByteBuf buf = channel.readOutbound();
         byte[] data = new byte[buf.readableBytes()];
         buf.readBytes(data);
-        Assert.assertArrayEquals(msg.getBytes(CharsetUtil.UTF_8), data);
-        Assert.assertNull(channel.readOutbound());
+        Assertions.assertArrayEquals(msg.getBytes(CharsetUtil.UTF_8), data);
+        Assertions.assertNull(channel.readOutbound());
         buf.release();
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
@@ -22,7 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -38,6 +38,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class XmlFrameDecoderTest {
 
@@ -50,35 +51,38 @@ public class XmlFrameDecoderTest {
         );
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithIllegalArgs01() {
-        new XmlFrameDecoder(0);
+        assertThrows(IllegalArgumentException.class, () -> new XmlFrameDecoder(0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithIllegalArgs02() {
-        new XmlFrameDecoder(-23);
+        assertThrows(IllegalArgumentException.class, () -> new XmlFrameDecoder(-23));
     }
 
-    @Test(expected = TooLongFrameException.class)
+    @Test
     public void testDecodeWithFrameExceedingMaxLength() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(3);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8));
+        assertThrows(TooLongFrameException.class,
+            () -> ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8)));
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test
     public void testDecodeWithInvalidInput() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        ch.writeInbound(Unpooled.copiedBuffer("invalid XML", CharsetUtil.UTF_8));
+        assertThrows(CorruptedFrameException.class,
+            () -> ch.writeInbound(Unpooled.copiedBuffer("invalid XML", CharsetUtil.UTF_8)));
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test
     public void testDecodeWithInvalidContentBeforeXml() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        ch.writeInbound(Unpooled.copiedBuffer("invalid XML<foo/>", CharsetUtil.UTF_8));
+        assertThrows(CorruptedFrameException.class,
+            () -> ch.writeInbound(Unpooled.copiedBuffer("invalid XML<foo/>", CharsetUtil.UTF_8)));
     }
 
     @Test

--- a/common/src/test/java/io/netty/util/AttributeKeyTest.java
+++ b/common/src/test/java/io/netty/util/AttributeKeyTest.java
@@ -15,9 +15,13 @@
  */
 package io.netty.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AttributeKeyTest {
 

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
@@ -43,12 +43,15 @@ import io.netty.handler.proxy.HttpProxyHandler.HttpProxyConnectException;
 import io.netty.util.NetUtil;
 
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class HttpProxyHandlerTest {

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -48,13 +48,11 @@ import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -70,9 +68,8 @@ import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class ProxyHandlerTest {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ProxyHandlerTest.class);
@@ -138,7 +135,6 @@ public class ProxyHandlerTest {
     // look for "Seed used: *" debug message in test logs
     private static final long reproducibleSeed = 0L;
 
-    @Parameters(name = "{index}: {0}")
     public static List<Object[]> testItems() {
 
         List<TestItem> items = Arrays.asList(
@@ -425,32 +421,27 @@ public class ProxyHandlerTest {
         return params;
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopServers() {
         for (ProxyServer p: allProxies) {
             p.stop();
         }
     }
 
-    private final TestItem testItem;
-
-    public ProxyHandlerTest(TestItem testItem) {
-        this.testItem = testItem;
-    }
-
-    @Before
+    @BeforeEach
     public void clearServerExceptions() throws Exception {
         for (ProxyServer p: allProxies) {
             p.clearExceptions();
         }
     }
 
-    @Test
-    public void test() throws Exception {
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("testItems")
+    public void test(TestItem testItem) throws Exception {
         testItem.test();
     }
 
-    @After
+    @AfterEach
     public void checkServerExceptions() throws Exception {
         for (ProxyServer p: allProxies) {
             p.checkExceptions();

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -85,6 +85,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
I had some free time so I thought I would start work towards completing #10757.

The following modules have been moved over, with some exceptions:

- [ ] all
- [ ] bom
- [x] buffer
  - [ ] `io.netty.buffer.ByteBufUtilTest`
  - [ ] `io.netty.buffer.search.SearchProcessorTest`
- [x] codec
  - [ ] `io.netty.handler.codec.marshalling.AbstractMarshallingTest`
- [x] codec-dns
- [x] codec-haproxy
- [ ] codec-http
- [ ] codec-http2
- [x] codec-memcache
- [ ] codec-mqtt
- [ ] codec-redis
- [x] codec-smtp
- [x] codec-socks
- [x] codec-stomp
- [x] codec-xml
- [ ] common
- [ ] dev-tools
- [ ] example
- [ ] handler
- [x] handler-proxy
- [ ] microbench
- [ ] resolver
- [ ] resolver-dns
- [ ] resolver-dns-native-macos
- [ ] tarball
- [ ] testsuite
- [ ] testsuite-autobahn
- [ ] testsuite-http2
- [ ] testsuite-native
- [ ] testsuite-native-image
- [ ] testsuite-native-image-client
- [ ] testsuite-native-image-client-runtime-init
- [ ] testsuite-osgi
- [ ] testsuite-shading
- [ ] transport
- [ ] transport-blockhound-tests
- [ ] transport-native-epoll
- [ ] transport-native-kqueue
- [ ] transport-native-unix-common
- [ ] transport-native-unix-common-tests
- [ ] transport-sctp