### PR TITLE
Migrate buffer tests to JUnit 5

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -16,11 +16,11 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllocator> extends ByteBufAllocatorTest {
 
@@ -108,7 +108,7 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
         // Double the size of the buffer
         buffer.capacity(capacity << 1);
         capacity = buffer.capacity();
-        assertEquals(buffer.toString(), expectedUsedMemory(allocator, capacity), metric.usedDirectMemory());
+        assertEquals(expectedUsedMemory(allocator, capacity), metric.usedDirectMemory(), buffer.toString());
 
         buffer.release();
         assertEquals(expectedUsedMemoryAfterRelease(allocator, capacity), metric.usedDirectMemory());

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -19,9 +19,10 @@ import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -60,15 +61,16 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * An abstract test class for channel buffers
@@ -93,14 +95,14 @@ public abstract class AbstractByteBufTest {
         return true;
     }
 
-    @Before
+    @BeforeEach
     public void init() {
         buffer = newBuffer(CAPACITY);
         seed = System.currentTimeMillis();
         random = new Random(seed);
     }
 
-    @After
+    @AfterEach
     public void dispose() {
         if (buffer != null) {
             assertThat(buffer.release(), is(true));
@@ -139,34 +141,34 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, buffer.readerIndex());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void readerIndexBoundaryCheck1() {
         try {
             buffer.writerIndex(0);
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.readerIndex(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void readerIndexBoundaryCheck2() {
         try {
             buffer.writerIndex(buffer.capacity());
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.readerIndex(buffer.capacity() + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(buffer.capacity() + 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void readerIndexBoundaryCheck3() {
         try {
             buffer.writerIndex(CAPACITY / 2);
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.readerIndex(CAPACITY * 3 / 2);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(CAPACITY * 3 / 2));
     }
 
     @Test
@@ -177,12 +179,12 @@ public abstract class AbstractByteBufTest {
         buffer.readerIndex(buffer.capacity());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void writerIndexBoundaryCheck1() {
-        buffer.writerIndex(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void writerIndexBoundaryCheck2() {
         try {
             buffer.writerIndex(CAPACITY);
@@ -190,10 +192,10 @@ public abstract class AbstractByteBufTest {
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.writerIndex(buffer.capacity() + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(buffer.capacity() + 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void writerIndexBoundaryCheck3() {
         try {
             buffer.writerIndex(CAPACITY);
@@ -201,7 +203,7 @@ public abstract class AbstractByteBufTest {
         } catch (IndexOutOfBoundsException e) {
             fail();
         }
-        buffer.writerIndex(CAPACITY / 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.writerIndex(CAPACITY / 4));
     }
 
     @Test
@@ -213,74 +215,74 @@ public abstract class AbstractByteBufTest {
         buffer.writeBytes(ByteBuffer.wrap(EMPTY_BYTES));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getBooleanBoundaryCheck1() {
-        buffer.getBoolean(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBoolean(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getBooleanBoundaryCheck2() {
-        buffer.getBoolean(buffer.capacity());
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBoolean(buffer.capacity()));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteBoundaryCheck1() {
-        buffer.getByte(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getByte(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteBoundaryCheck2() {
-        buffer.getByte(buffer.capacity());
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getByte(buffer.capacity()));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getShortBoundaryCheck1() {
-        buffer.getShort(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getShort(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getShortBoundaryCheck2() {
-        buffer.getShort(buffer.capacity() - 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getShort(buffer.capacity() - 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getMediumBoundaryCheck1() {
-        buffer.getMedium(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getMedium(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getMediumBoundaryCheck2() {
-        buffer.getMedium(buffer.capacity() - 2);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getMedium(buffer.capacity() - 2));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getIntBoundaryCheck1() {
-        buffer.getInt(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getInt(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getIntBoundaryCheck2() {
-        buffer.getInt(buffer.capacity() - 3);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getInt(buffer.capacity() - 3));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getLongBoundaryCheck1() {
-        buffer.getLong(-1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getLong(-1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getLongBoundaryCheck2() {
-        buffer.getLong(buffer.capacity() - 7);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getLong(buffer.capacity() - 7));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteArrayBoundaryCheck1() {
-        buffer.getBytes(-1, EMPTY_BYTES);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(-1, EMPTY_BYTES));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteArrayBoundaryCheck2() {
-        buffer.getBytes(-1, EMPTY_BYTES, 0, 0);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(-1, EMPTY_BYTES, 0, 0));
     }
 
     @Test
@@ -319,44 +321,44 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, dst[3]);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getByteBufferBoundaryCheck() {
-        buffer.getBytes(-1, ByteBuffer.allocate(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(-1, ByteBuffer.allocate(0)));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void copyBoundaryCheck1() {
-        buffer.copy(-1, 0);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.copy(-1, 0));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void copyBoundaryCheck2() {
-        buffer.copy(0, buffer.capacity() + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.copy(0, buffer.capacity() + 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void copyBoundaryCheck3() {
-        buffer.copy(buffer.capacity() + 1, 0);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.copy(buffer.capacity() + 1, 0));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void copyBoundaryCheck4() {
-        buffer.copy(buffer.capacity(), 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.copy(buffer.capacity(), 1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void setIndexBoundaryCheck1() {
-        buffer.setIndex(-1, CAPACITY);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.setIndex(-1, CAPACITY));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void setIndexBoundaryCheck2() {
-        buffer.setIndex(CAPACITY / 2, CAPACITY / 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.setIndex(CAPACITY / 2, CAPACITY / 4));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void setIndexBoundaryCheck3() {
-        buffer.setIndex(0, CAPACITY + 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.setIndex(0, CAPACITY + 1));
     }
 
     @Test
@@ -381,9 +383,9 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, dst.get(3));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void getDirectByteBufferBoundaryCheck() {
-        buffer.getBytes(-1, ByteBuffer.allocateDirect(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(-1, ByteBuffer.allocateDirect(0)));
     }
 
     @Test
@@ -2081,7 +2083,8 @@ public abstract class AbstractByteBufTest {
         copied.release();
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void testToStringMultipleThreads() throws Throwable {
         buffer.clear();
         buffer.writeBytes("Hello, World!".getBytes(CharsetUtil.ISO_8859_1));
@@ -2559,13 +2562,15 @@ public abstract class AbstractByteBufTest {
         buffer.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void readByteThrowsIndexOutOfBoundsException() {
         final ByteBuf buffer = newBuffer(8);
         try {
-            buffer.writeByte(0);
-            assertEquals((byte) 0, buffer.readByte());
-            buffer.readByte();
+            assertThrows(IndexOutOfBoundsException.class, () -> {
+                buffer.writeByte(0);
+                assertEquals((byte) 0, buffer.readByte());
+                buffer.readByte();
+            });
         } finally {
             buffer.release();
         }
@@ -2626,718 +2631,742 @@ public abstract class AbstractByteBufTest {
         return buffer;
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testDiscardReadBytesAfterRelease() {
-        releasedBuffer().discardReadBytes();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().discardReadBytes());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testDiscardSomeReadBytesAfterRelease() {
-        releasedBuffer().discardSomeReadBytes();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().discardSomeReadBytes());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testEnsureWritableAfterRelease() {
-        releasedBuffer().ensureWritable(16);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().ensureWritable(16));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBooleanAfterRelease() {
-        releasedBuffer().getBoolean(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBoolean(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetByteAfterRelease() {
-        releasedBuffer().getByte(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getByte(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedByteAfterRelease() {
-        releasedBuffer().getUnsignedByte(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedByte(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetShortAfterRelease() {
-        releasedBuffer().getShort(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getShort(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetShortLEAfterRelease() {
-        releasedBuffer().getShortLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getShortLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedShortAfterRelease() {
-        releasedBuffer().getUnsignedShort(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedShort(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedShortLEAfterRelease() {
-        releasedBuffer().getUnsignedShortLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedShortLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetMediumAfterRelease() {
-        releasedBuffer().getMedium(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getMedium(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetMediumLEAfterRelease() {
-        releasedBuffer().getMediumLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getMediumLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedMediumAfterRelease() {
-        releasedBuffer().getUnsignedMedium(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedMedium(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetIntAfterRelease() {
-        releasedBuffer().getInt(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getInt(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetIntLEAfterRelease() {
-        releasedBuffer().getIntLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getIntLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedIntAfterRelease() {
-        releasedBuffer().getUnsignedInt(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedInt(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetUnsignedIntLEAfterRelease() {
-        releasedBuffer().getUnsignedIntLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getUnsignedIntLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetLongAfterRelease() {
-        releasedBuffer().getLong(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getLong(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetLongLEAfterRelease() {
-        releasedBuffer().getLongLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getLongLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetCharAfterRelease() {
-        releasedBuffer().getChar(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getChar(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetFloatAfterRelease() {
-        releasedBuffer().getFloat(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getFloat(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetFloatLEAfterRelease() {
-        releasedBuffer().getFloatLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getFloatLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetDoubleAfterRelease() {
-        releasedBuffer().getDouble(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getDouble(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetDoubleLEAfterRelease() {
-        releasedBuffer().getDoubleLE(0);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getDoubleLE(0));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().getBytes(0, buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease2() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().getBytes(0, buffer, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, buffer, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease3() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().getBytes(0, buffer, 0, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, buffer, 0, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease4() {
-        releasedBuffer().getBytes(0, new byte[8]);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, new byte[8]));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease5() {
-        releasedBuffer().getBytes(0, new byte[8], 0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, new byte[8], 0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testGetBytesAfterRelease6() {
-        releasedBuffer().getBytes(0, ByteBuffer.allocate(8));
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().getBytes(0, ByteBuffer.allocate(8)));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testGetBytesAfterRelease7() throws IOException {
-        releasedBuffer().getBytes(0, new ByteArrayOutputStream(), 1);
+    @Test
+    public void testGetBytesAfterRelease7() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().getBytes(0, new ByteArrayOutputStream(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testGetBytesAfterRelease8() throws IOException {
-        releasedBuffer().getBytes(0, new DevNullGatheringByteChannel(), 1);
+    @Test
+    public void testGetBytesAfterRelease8() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().getBytes(0, new DevNullGatheringByteChannel(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBooleanAfterRelease() {
-        releasedBuffer().setBoolean(0, true);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBoolean(0, true));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetByteAfterRelease() {
-        releasedBuffer().setByte(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setByte(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetShortAfterRelease() {
-        releasedBuffer().setShort(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setShort(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetShortLEAfterRelease() {
-        releasedBuffer().setShortLE(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setShortLE(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetMediumAfterRelease() {
-        releasedBuffer().setMedium(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setMedium(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetMediumLEAfterRelease() {
-        releasedBuffer().setMediumLE(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setMediumLE(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetIntAfterRelease() {
-        releasedBuffer().setInt(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setInt(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetIntLEAfterRelease() {
-        releasedBuffer().setIntLE(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setIntLE(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetLongAfterRelease() {
-        releasedBuffer().setLong(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setLong(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetLongLEAfterRelease() {
-        releasedBuffer().setLongLE(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setLongLE(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetCharAfterRelease() {
-        releasedBuffer().setChar(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setChar(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetFloatAfterRelease() {
-        releasedBuffer().setFloat(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setFloat(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetDoubleAfterRelease() {
-        releasedBuffer().setDouble(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setDouble(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().setBytes(0, buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease2() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().setBytes(0, buffer, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, buffer, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease3() {
         ByteBuf buffer = buffer();
         try {
-            releasedBuffer().setBytes(0, buffer, 0, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, buffer, 0, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetUsAsciiCharSequenceAfterRelease() {
-        testSetCharSequenceAfterRelease0(CharsetUtil.US_ASCII);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testSetCharSequenceAfterRelease0(CharsetUtil.US_ASCII));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetIso88591CharSequenceAfterRelease() {
-        testSetCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testSetCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetUtf8CharSequenceAfterRelease() {
-        testSetCharSequenceAfterRelease0(CharsetUtil.UTF_8);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testSetCharSequenceAfterRelease0(CharsetUtil.UTF_8));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetUtf16CharSequenceAfterRelease() {
-        testSetCharSequenceAfterRelease0(CharsetUtil.UTF_16);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testSetCharSequenceAfterRelease0(CharsetUtil.UTF_16));
     }
 
     private void testSetCharSequenceAfterRelease0(Charset charset) {
         releasedBuffer().setCharSequence(0, "x", charset);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease4() {
-        releasedBuffer().setBytes(0, new byte[8]);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, new byte[8]));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease5() {
-        releasedBuffer().setBytes(0, new byte[8], 0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, new byte[8], 0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetBytesAfterRelease6() {
-        releasedBuffer().setBytes(0, ByteBuffer.allocate(8));
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setBytes(0, ByteBuffer.allocate(8)));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testSetBytesAfterRelease7() throws IOException {
-        releasedBuffer().setBytes(0, new ByteArrayInputStream(new byte[8]), 1);
+    @Test
+    public void testSetBytesAfterRelease7() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().setBytes(0, new ByteArrayInputStream(new byte[8]), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testSetBytesAfterRelease8() throws IOException {
-        releasedBuffer().setBytes(0, new TestScatteringByteChannel(), 1);
+    @Test
+    public void testSetBytesAfterRelease8() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().setBytes(0, new TestScatteringByteChannel(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSetZeroAfterRelease() {
-        releasedBuffer().setZero(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().setZero(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBooleanAfterRelease() {
-        releasedBuffer().readBoolean();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBoolean());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadByteAfterRelease() {
-        releasedBuffer().readByte();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readByte());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedByteAfterRelease() {
-        releasedBuffer().readUnsignedByte();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedByte());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadShortAfterRelease() {
-        releasedBuffer().readShort();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readShort());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadShortLEAfterRelease() {
-        releasedBuffer().readShortLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readShortLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedShortAfterRelease() {
-        releasedBuffer().readUnsignedShort();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedShort());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedShortLEAfterRelease() {
-        releasedBuffer().readUnsignedShortLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedShortLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadMediumAfterRelease() {
-        releasedBuffer().readMedium();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readMedium());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadMediumLEAfterRelease() {
-        releasedBuffer().readMediumLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readMediumLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedMediumAfterRelease() {
-        releasedBuffer().readUnsignedMedium();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedMedium());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedMediumLEAfterRelease() {
-        releasedBuffer().readUnsignedMediumLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedMediumLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadIntAfterRelease() {
-        releasedBuffer().readInt();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readInt());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadIntLEAfterRelease() {
-        releasedBuffer().readIntLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readIntLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedIntAfterRelease() {
-        releasedBuffer().readUnsignedInt();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedInt());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadUnsignedIntLEAfterRelease() {
-        releasedBuffer().readUnsignedIntLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readUnsignedIntLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadLongAfterRelease() {
-        releasedBuffer().readLong();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readLong());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadLongLEAfterRelease() {
-        releasedBuffer().readLongLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readLongLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadCharAfterRelease() {
-        releasedBuffer().readChar();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readChar());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadFloatAfterRelease() {
-        releasedBuffer().readFloat();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readFloat());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadFloatLEAfterRelease() {
-        releasedBuffer().readFloatLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readFloatLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadDoubleAfterRelease() {
-        releasedBuffer().readDouble();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readDouble());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadDoubleLEAfterRelease() {
-        releasedBuffer().readDoubleLE();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readDoubleLE());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease() {
-        releasedBuffer().readBytes(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease2() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().readBytes(buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease3() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().readBytes(buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease4() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().readBytes(buffer, 0, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(buffer, 0, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease5() {
-        releasedBuffer().readBytes(new byte[8]);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(new byte[8]));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease6() {
-        releasedBuffer().readBytes(new byte[8], 0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(new byte[8], 0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReadBytesAfterRelease7() {
-        releasedBuffer().readBytes(ByteBuffer.allocate(8));
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().readBytes(ByteBuffer.allocate(8)));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testReadBytesAfterRelease8() throws IOException {
-        releasedBuffer().readBytes(new ByteArrayOutputStream(), 1);
+    @Test
+    public void testReadBytesAfterRelease8() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().readBytes(new ByteArrayOutputStream(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testReadBytesAfterRelease9() throws IOException {
-        releasedBuffer().readBytes(new ByteArrayOutputStream(), 1);
+    @Test
+    public void testReadBytesAfterRelease9() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().readBytes(new ByteArrayOutputStream(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testReadBytesAfterRelease10() throws IOException {
-        releasedBuffer().readBytes(new DevNullGatheringByteChannel(), 1);
+    @Test
+    public void testReadBytesAfterRelease10() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().readBytes(new DevNullGatheringByteChannel(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBooleanAfterRelease() {
-        releasedBuffer().writeBoolean(true);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBoolean(true));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteByteAfterRelease() {
-        releasedBuffer().writeByte(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeByte(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteShortAfterRelease() {
-        releasedBuffer().writeShort(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeShort(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteShortLEAfterRelease() {
-        releasedBuffer().writeShortLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeShortLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteMediumAfterRelease() {
-        releasedBuffer().writeMedium(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeMedium(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteMediumLEAfterRelease() {
-        releasedBuffer().writeMediumLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeMediumLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteIntAfterRelease() {
-        releasedBuffer().writeInt(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeInt(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteIntLEAfterRelease() {
-        releasedBuffer().writeIntLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeIntLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteLongAfterRelease() {
-        releasedBuffer().writeLong(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeLong(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteLongLEAfterRelease() {
-        releasedBuffer().writeLongLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeLongLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteCharAfterRelease() {
-        releasedBuffer().writeChar(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeChar(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteFloatAfterRelease() {
-        releasedBuffer().writeFloat(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeFloat(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteFloatLEAfterRelease() {
-        releasedBuffer().writeFloatLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeFloatLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteDoubleAfterRelease() {
-        releasedBuffer().writeDouble(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeDouble(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteDoubleLEAfterRelease() {
-        releasedBuffer().writeDoubleLE(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeDoubleLE(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().writeBytes(buffer);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(buffer));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease2() {
         ByteBuf buffer = copiedBuffer(new byte[8]);
         try {
-            releasedBuffer().writeBytes(buffer, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(buffer, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease3() {
         ByteBuf buffer = buffer(8);
         try {
-            releasedBuffer().writeBytes(buffer, 0, 1);
+            assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(buffer, 0, 1));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease4() {
-        releasedBuffer().writeBytes(new byte[8]);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(new byte[8]));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease5() {
-        releasedBuffer().writeBytes(new byte[8], 0 , 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(new byte[8], 0 , 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteBytesAfterRelease6() {
-        releasedBuffer().writeBytes(ByteBuffer.allocate(8));
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeBytes(ByteBuffer.allocate(8)));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testWriteBytesAfterRelease7() throws IOException {
-        releasedBuffer().writeBytes(new ByteArrayInputStream(new byte[8]), 1);
+    @Test
+    public void testWriteBytesAfterRelease7() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().writeBytes(new ByteArrayInputStream(new byte[8]), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
-    public void testWriteBytesAfterRelease8() throws IOException {
-        releasedBuffer().writeBytes(new TestScatteringByteChannel(), 1);
+    @Test
+    public void testWriteBytesAfterRelease8() {
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().writeBytes(new TestScatteringByteChannel(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteZeroAfterRelease() throws IOException {
-        releasedBuffer().writeZero(1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().writeZero(1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteUsAsciiCharSequenceAfterRelease() {
-        testWriteCharSequenceAfterRelease0(CharsetUtil.US_ASCII);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testWriteCharSequenceAfterRelease0(CharsetUtil.US_ASCII));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteIso88591CharSequenceAfterRelease() {
-        testWriteCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testWriteCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteUtf8CharSequenceAfterRelease() {
-        testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_8);
+        assertThrows(IllegalReferenceCountException.class, () -> testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_8));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testWriteUtf16CharSequenceAfterRelease() {
-        testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_16);
+        assertThrows(IllegalReferenceCountException.class,
+            () -> testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_16));
     }
 
     private void testWriteCharSequenceAfterRelease0(Charset charset) {
         releasedBuffer().writeCharSequence("x", charset);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testForEachByteAfterRelease() {
-        releasedBuffer().forEachByte(new TestByteProcessor());
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().forEachByte(new TestByteProcessor()));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testForEachByteAfterRelease1() {
-        releasedBuffer().forEachByte(0, 1, new TestByteProcessor());
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().forEachByte(0, 1, new TestByteProcessor()));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testForEachByteDescAfterRelease() {
-        releasedBuffer().forEachByteDesc(new TestByteProcessor());
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().forEachByteDesc(new TestByteProcessor()));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testForEachByteDescAfterRelease1() {
-        releasedBuffer().forEachByteDesc(0, 1, new TestByteProcessor());
+        assertThrows(IllegalReferenceCountException.class,
+            () -> releasedBuffer().forEachByteDesc(0, 1, new TestByteProcessor()));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testCopyAfterRelease() {
-        releasedBuffer().copy();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().copy());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testCopyAfterRelease1() {
-        releasedBuffer().copy();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().copy());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testNioBufferAfterRelease() {
-        releasedBuffer().nioBuffer();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().nioBuffer());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testNioBufferAfterRelease1() {
-        releasedBuffer().nioBuffer(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().nioBuffer(0, 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testInternalNioBufferAfterRelease() {
+        testInternalNioBufferAfterRelease0(IllegalReferenceCountException.class);
+    }
+
+    protected void testInternalNioBufferAfterRelease0(final Class<? extends Throwable> expectedException) {
         ByteBuf releasedBuffer = releasedBuffer();
-        releasedBuffer.internalNioBuffer(releasedBuffer.readerIndex(), 1);
+        assertThrows(expectedException, () -> releasedBuffer.internalNioBuffer(releasedBuffer.readerIndex(), 1));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testNioBuffersAfterRelease() {
-        releasedBuffer().nioBuffers();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().nioBuffers());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testNioBuffersAfterRelease2() {
-        releasedBuffer().nioBuffers(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().nioBuffers(0, 1));
     }
 
     @Test
@@ -3366,14 +3395,14 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSliceAfterRelease() {
-        releasedBuffer().slice();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().slice());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testSliceAfterRelease2() {
-        releasedBuffer().slice(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().slice(0, 1));
     }
 
     private static void assertSliceFailAfterRelease(ByteBuf... bufs) {
@@ -3431,14 +3460,14 @@ public abstract class AbstractByteBufTest {
         assertSliceFailAfterRelease(buf, buf2, buf3);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainedSliceAfterRelease() {
-        releasedBuffer().retainedSlice();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().retainedSlice());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainedSliceAfterRelease2() {
-        releasedBuffer().retainedSlice(0, 1);
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().retainedSlice(0, 1));
     }
 
     private static void assertRetainedSliceFailAfterRelease(ByteBuf... bufs) {
@@ -3496,14 +3525,14 @@ public abstract class AbstractByteBufTest {
         assertRetainedSliceFailAfterRelease(buf, buf2, buf3);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testDuplicateAfterRelease() {
-        releasedBuffer().duplicate();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().duplicate());
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainedDuplicateAfterRelease() {
-        releasedBuffer().retainedDuplicate();
+        assertThrows(IllegalReferenceCountException.class, () -> releasedBuffer().retainedDuplicate());
     }
 
     private static void assertDuplicateFailAfterRelease(ByteBuf... bufs) {
@@ -3592,14 +3621,14 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, buf.refCnt());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testReadSliceOutOfBounds() {
-        testReadSliceOutOfBounds(false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testReadSliceOutOfBounds(false));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testReadRetainedSliceOutOfBounds() {
-        testReadSliceOutOfBounds(true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testReadSliceOutOfBounds(true));
     }
 
     private void testReadSliceOutOfBounds(boolean retainedSlice) {
@@ -3648,24 +3677,24 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetUsAsciiCharSequenceNoExpand() {
-        testSetCharSequenceNoExpand(CharsetUtil.US_ASCII);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSetCharSequenceNoExpand(CharsetUtil.US_ASCII));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetUtf8CharSequenceNoExpand() {
-        testSetCharSequenceNoExpand(CharsetUtil.UTF_8);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSetCharSequenceNoExpand(CharsetUtil.UTF_8));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetIso88591CharSequenceNoExpand() {
-        testSetCharSequenceNoExpand(CharsetUtil.ISO_8859_1);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSetCharSequenceNoExpand(CharsetUtil.ISO_8859_1));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetUtf16CharSequenceNoExpand() {
-        testSetCharSequenceNoExpand(CharsetUtil.UTF_16);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSetCharSequenceNoExpand(CharsetUtil.UTF_16));
     }
 
     private void testSetCharSequenceNoExpand(Charset charset) {
@@ -3748,44 +3777,44 @@ public abstract class AbstractByteBufTest {
         buf.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testRetainedSliceIndexOutOfBounds() {
-        testSliceOutOfBounds(true, true, true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(true, true, true));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testRetainedSliceLengthOutOfBounds() {
-        testSliceOutOfBounds(true, true, false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(true, true, false));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMixedSliceAIndexOutOfBounds() {
-        testSliceOutOfBounds(true, false, true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(true, false, true));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMixedSliceALengthOutOfBounds() {
-        testSliceOutOfBounds(true, false, false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(true, false, false));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMixedSliceBIndexOutOfBounds() {
-        testSliceOutOfBounds(false, true, true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(false, true, true));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMixedSliceBLengthOutOfBounds() {
-        testSliceOutOfBounds(false, true, false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(false, true, false));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSliceIndexOutOfBounds() {
-        testSliceOutOfBounds(false, false, true);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(false, false, true));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSliceLengthOutOfBounds() {
-        testSliceOutOfBounds(false, false, false);
+        assertThrows(IndexOutOfBoundsException.class, () -> testSliceOutOfBounds(false, false, false));
     }
 
     @Test
@@ -4041,14 +4070,14 @@ public abstract class AbstractByteBufTest {
         testDuplicateCapacityChange(true);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSliceCapacityChange() {
-        testSliceCapacityChange(false);
+        assertThrows(UnsupportedOperationException.class, () -> testSliceCapacityChange(false));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testRetainedSliceCapacityChange() {
-        testSliceCapacityChange(true);
+        assertThrows(UnsupportedOperationException.class, () -> testSliceCapacityChange(true));
     }
 
     @Test
@@ -4674,7 +4703,7 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is in the ByteBuf.
@@ -4682,7 +4711,7 @@ public abstract class AbstractByteBufTest {
         ByteBuf buffer = newBuffer(bytes.length);
         try {
             buffer.writeBytes(bytes);
-            buffer.getBytes(buffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(buffer.readerIndex(), nioBuffer));
         } finally {
             buffer.release();
         }
@@ -4840,25 +4869,25 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCapacityEnforceMaxCapacity() {
         ByteBuf buffer = newBuffer(3, 13);
         assertEquals(13, buffer.maxCapacity());
         assertEquals(3, buffer.capacity());
         try {
-            buffer.capacity(14);
+            assertThrows(IllegalArgumentException.class, () -> buffer.capacity(14));
         } finally {
             buffer.release();
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCapacityNegative() {
         ByteBuf buffer = newBuffer(3, 13);
         assertEquals(13, buffer.maxCapacity());
         assertEquals(3, buffer.capacity());
         try {
-            buffer.capacity(-1);
+            assertThrows(IllegalArgumentException.class, () -> buffer.capacity(-1));
         } finally {
             buffer.release();
         }
@@ -4892,7 +4921,7 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testReaderIndexLargerThanWriterIndex() {
         String content1 = "hello";
         String content2 = "world";
@@ -4906,7 +4935,7 @@ public abstract class AbstractByteBufTest {
         assertTrue(buffer.readerIndex() <= buffer.writerIndex());
 
         try {
-            buffer.readerIndex(buffer.writerIndex() + 1);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.readerIndex(buffer.writerIndex() + 1));
         } finally {
             buffer.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -16,8 +16,8 @@
 package io.netty.buffer;
 
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -39,14 +39,15 @@ import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * An abstract test class for composite channel buffers
@@ -63,7 +64,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
     @Override
     protected ByteBuf newBuffer(int length, int maxCapacity) {
-        Assume.assumeTrue(maxCapacity == Integer.MAX_VALUE);
+        Assumptions.assumeTrue(maxCapacity == Integer.MAX_VALUE);
 
         List<ByteBuf> buffers = new ArrayList<>();
         for (int i = 0; i < length + 45; i += 45) {
@@ -1243,7 +1244,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         cbuf.release();
     }
 
-    @Test(expected = ConcurrentModificationException.class)
+    @Test
     public void testIteratorConcurrentModificationAdd() {
         CompositeByteBuf cbuf = newCompositeBuffer();
         cbuf.addComponent(EMPTY_BUFFER);
@@ -1253,13 +1254,13 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
         assertTrue(it.hasNext());
         try {
-            it.next();
+            assertThrows(ConcurrentModificationException.class, it::next);
         } finally {
             cbuf.release();
         }
     }
 
-    @Test(expected = ConcurrentModificationException.class)
+    @Test
     public void testIteratorConcurrentModificationRemove() {
         CompositeByteBuf cbuf = newCompositeBuffer();
         cbuf.addComponent(EMPTY_BUFFER);
@@ -1269,7 +1270,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
         assertTrue(it.hasNext());
         try {
-            it.next();
+            assertThrows(ConcurrentModificationException.class, it::next);
         } finally {
             cbuf.release();
         }
@@ -1554,52 +1555,58 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertTrue(cbuf.release());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOverflowWhileAddingComponent() {
         int capacity = 1024 * 1024; // 1MB
         ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
         CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
 
         try {
-            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
-                ByteBuf duplicate = buffer.duplicate();
-                compositeByteBuf.addComponent(duplicate);
-                duplicate.retain();
-            }
+            assertThrows(IllegalArgumentException.class, () -> {
+                for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                    ByteBuf duplicate = buffer.duplicate();
+                    compositeByteBuf.addComponent(duplicate);
+                    duplicate.retain();
+                }
+            });
         } finally {
             compositeByteBuf.release();
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOverflowWhileAddingComponentsViaVarargs() {
         int capacity = 1024 * 1024; // 1MB
         ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
         CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
 
         try {
-            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
-                ByteBuf duplicate = buffer.duplicate();
-                compositeByteBuf.addComponents(duplicate);
-                duplicate.retain();
-            }
+            assertThrows(IllegalArgumentException.class, () -> {
+                for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                    ByteBuf duplicate = buffer.duplicate();
+                    compositeByteBuf.addComponents(duplicate);
+                    duplicate.retain();
+                }
+            });
         } finally {
             compositeByteBuf.release();
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOverflowWhileAddingComponentsViaIterable() {
         int capacity = 1024 * 1024; // 1MB
         ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
         CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
 
         try {
-            for (int i = 0; i >= 0; i += buffer.readableBytes()) {
-                ByteBuf duplicate = buffer.duplicate();
-                compositeByteBuf.addComponents(Collections.singletonList(duplicate));
-                duplicate.retain();
-            }
+            assertThrows(IllegalArgumentException.class, () -> {
+                for (int i = 0; i >= 0; i += buffer.readableBytes()) {
+                    ByteBuf duplicate = buffer.duplicate();
+                    compositeByteBuf.addComponents(Collections.singletonList(duplicate));
+                    duplicate.retain();
+                }
+            });
         } finally {
             compositeByteBuf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
@@ -15,15 +15,15 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
 
@@ -47,12 +47,11 @@ public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
         buf.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void ensureWritableWithNotEnoughSpaceShouldThrow() {
         ByteBuf buf = newBuffer(1, 10);
         try {
-            buf.ensureWritable(11);
-            fail();
+            assertThrows(IndexOutOfBoundsException.class, () -> buf.ensureWritable(11));
         } finally {
             buf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractReferenceCountedByteBufTest.java
@@ -16,7 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.IllegalReferenceCountException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,33 +27,34 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AbstractReferenceCountedByteBufTest {
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainOverflow() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         referenceCounted.setRefCnt(Integer.MAX_VALUE);
         assertEquals(Integer.MAX_VALUE, referenceCounted.refCnt());
-        referenceCounted.retain();
+        assertThrows(IllegalReferenceCountException.class, referenceCounted::retain);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainOverflow2() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         assertEquals(1, referenceCounted.refCnt());
-        referenceCounted.retain(Integer.MAX_VALUE);
+        assertThrows(IllegalReferenceCountException.class, () -> referenceCounted.retain(Integer.MAX_VALUE));
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testReleaseOverflow() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         referenceCounted.setRefCnt(0);
         assertEquals(0, referenceCounted.refCnt());
-        referenceCounted.release(Integer.MAX_VALUE);
+        assertThrows(IllegalReferenceCountException.class, () -> referenceCounted.release(Integer.MAX_VALUE));
     }
 
     @Test
@@ -68,20 +69,20 @@ public class AbstractReferenceCountedByteBufTest {
         }
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainResurrect() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         assertTrue(referenceCounted.release());
         assertEquals(0, referenceCounted.refCnt());
-        referenceCounted.retain();
+        assertThrows(IllegalReferenceCountException.class, referenceCounted::retain);
     }
 
-    @Test(expected = IllegalReferenceCountException.class)
+    @Test
     public void testRetainResurrect2() {
         AbstractReferenceCountedByteBuf referenceCounted = newReferenceCounted();
         assertTrue(referenceCounted.release());
         assertEquals(0, referenceCounted.refCnt());
-        referenceCounted.retain(2);
+        assertThrows(IllegalReferenceCountException.class, () -> referenceCounted.retain(2));
     }
 
     private static AbstractReferenceCountedByteBuf newReferenceCounted() {

--- a/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareByteBufTest.java
@@ -16,9 +16,9 @@
 package io.netty.buffer;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.netty.util.CharsetUtil;
 import io.netty.util.ResourceLeakTracker;

--- a/buffer/src/test/java/io/netty/buffer/BigEndianCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianCompositeByteBufTest.java
@@ -15,8 +15,7 @@
  */
 package io.netty.buffer;
 
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests big-endian composite channel buffers
@@ -27,9 +26,9 @@ public class BigEndianCompositeByteBufTest extends AbstractCompositeByteBufTest 
     }
 
     @Override
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testInternalNioBufferAfterRelease() {
-        super.testInternalNioBufferAfterRelease();
+        testInternalNioBufferAfterRelease0(UnsupportedOperationException.class);
     }
 
 }

--- a/buffer/src/test/java/io/netty/buffer/BigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianDirectByteBufTest.java
@@ -15,11 +15,13 @@
  */
 package io.netty.buffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteOrder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests big-endian direct channel buffers

--- a/buffer/src/test/java/io/netty/buffer/BigEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianHeapByteBufTest.java
@@ -15,9 +15,10 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests big-endian heap channel buffers
@@ -31,13 +32,14 @@ public class BigEndianHeapByteBufTest extends AbstractByteBufTest {
         return buffer;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor1() {
-        new UnpooledHeapByteBuf(null, new byte[1], 0);
+        assertThrows(NullPointerException.class, () -> new UnpooledHeapByteBuf(null, new byte[1], 0));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor2() {
-        new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, null, 0);
+        assertThrows(NullPointerException.class,
+            () -> new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, null, 0));
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeDirectByteBufTest.java
@@ -17,15 +17,15 @@ package io.netty.buffer;
 
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class BigEndianUnsafeDirectByteBufTest extends BigEndianDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assumptions.assumeTrue(PlatformDependent.hasUnsafe(), "sun.misc.Unsafe not found, skip tests");
         super.init();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -15,18 +15,17 @@
  */
 package io.netty.buffer;
 
-
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class BigEndianUnsafeNoCleanerDirectByteBufTest extends BigEndianDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests",
-                PlatformDependent.useDirectBufferNoCleaner());
+        Assumptions.assumeTrue(PlatformDependent.useDirectBufferNoCleaner(),
+                "java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests");
         super.init();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufAllocatorTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class ByteBufAllocatorTest {
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
@@ -16,7 +16,7 @@
 
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 import java.util.Random;

--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -15,13 +15,20 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
 import java.nio.charset.Charset;
 
 import static io.netty.util.internal.EmptyArrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests channel buffer streams
@@ -279,7 +286,7 @@ public class ByteBufStreamTest {
         in2.close();
     }
 
-    @Test(expected = EOFException.class)
+    @Test
     public void testReadByteLengthRespected() throws Exception {
         // case1
         ByteBuf buf = Unpooled.buffer(16);
@@ -287,7 +294,7 @@ public class ByteBufStreamTest {
 
         ByteBufInputStream in = new ByteBufInputStream(buf, 0);
         try {
-            in.readByte();
+            assertThrows(EOFException.class, in::readByte);
         } finally {
             buf.release();
             in.close();

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -17,9 +17,9 @@ package io.netty.buffer;
 
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
@@ -35,23 +35,22 @@ import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@RunWith(Parameterized.class)
 public class ByteBufUtilTest {
+    private static final String PARAMETERIZED_NAME = "bufferType = {0}";
 
     private enum BufferType {
         DIRECT_UNPOOLED, DIRECT_POOLED, HEAP_POOLED, HEAP_UNPOOLED
     }
 
-    private final BufferType bufferType;
-
-    public ByteBufUtilTest(BufferType bufferType) {
-        this.bufferType = bufferType;
-    }
-
-    private ByteBuf buffer(int capacity) {
+    private ByteBuf buffer(BufferType bufferType, int capacity) {
         switch (bufferType) {
 
         case DIRECT_UNPOOLED:
@@ -67,7 +66,6 @@ public class ByteBufUtilTest {
         }
     }
 
-    @Parameterized.Parameters(name = "bufferType = {0}")
     public static Collection<Object[]> noUnsafe() {
         return Arrays.asList(new Object[][] {
                 { BufferType.DIRECT_POOLED },
@@ -99,14 +97,14 @@ public class ByteBufUtilTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void decodeHexDumpWithOddLength() {
-        ByteBufUtil.decodeHexDump("abc");
+        assertThrows(IllegalArgumentException.class, () -> ByteBufUtil.decodeHexDump("abc"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void decodeHexDumpWithInvalidChar() {
-        ByteBufUtil.decodeHexDump("fg");
+        assertThrows(IllegalArgumentException.class, () -> ByteBufUtil.decodeHexDump("fg"));
     }
 
     @Test
@@ -160,7 +158,7 @@ public class ByteBufUtilTest {
                 Math.max(b1.length, b2.length) * 2));
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void notEqualsBufferUnderflow() {
         byte[] b1 = new byte[8];
         byte[] b2 = new byte[16];
@@ -171,23 +169,24 @@ public class ByteBufUtilTest {
         final int iB2 = iB1 + b1.length;
         final int length = b1.length - iB1;
         System.arraycopy(b1, iB1, b2, iB2, length - 1);
-        assertFalse(ByteBufUtil.equals(Unpooled.wrappedBuffer(b1), iB1, Unpooled.wrappedBuffer(b2), iB2,
-                -1));
+        assertThrows(IllegalArgumentException.class,
+            () -> ByteBufUtil.equals(Unpooled.wrappedBuffer(b1), iB1, Unpooled.wrappedBuffer(b2), iB2, -1));
     }
 
     @SuppressWarnings("deprecation")
-    @Test
-    public void writeShortBE() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void writeShortBE(BufferType bufferType) {
         int expected = 0x1234;
 
-        ByteBuf buf = buffer(2).order(ByteOrder.BIG_ENDIAN);
+        ByteBuf buf = buffer(bufferType, 2).order(ByteOrder.BIG_ENDIAN);
         ByteBufUtil.writeShortBE(buf, expected);
         assertEquals(expected, buf.readShort());
         buf.readerIndex(0);
         assertEquals(ByteBufUtil.swapShort((short) expected), buf.readShortLE());
         buf.release();
 
-        buf = buffer(2).order(ByteOrder.LITTLE_ENDIAN);
+        buf = buffer(bufferType, 2).order(ByteOrder.LITTLE_ENDIAN);
         ByteBufUtil.writeShortBE(buf, expected);
         assertEquals(ByteBufUtil.swapShort((short) expected), buf.readShortLE());
         buf.readerIndex(0);
@@ -216,18 +215,19 @@ public class ByteBufUtilTest {
     }
 
     @SuppressWarnings("deprecation")
-    @Test
-    public void writeMediumBE() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void writeMediumBE(BufferType bufferType) {
         int mediumValue = 0x123456;
 
-        ByteBuf buf = buffer(4).order(ByteOrder.BIG_ENDIAN);
+        ByteBuf buf = buffer(bufferType, 4).order(ByteOrder.BIG_ENDIAN);
         ByteBufUtil.writeMediumBE(buf, mediumValue);
         assertEquals(mediumValue, buf.readMedium());
         buf.readerIndex(0);
         assertEquals(ByteBufUtil.swapMedium(mediumValue), buf.readMediumLE());
         buf.release();
 
-        buf = buffer(4).order(ByteOrder.LITTLE_ENDIAN);
+        buf = buffer(bufferType, 4).order(ByteOrder.LITTLE_ENDIAN);
         ByteBufUtil.writeMediumBE(buf, mediumValue);
         assertEquals(ByteBufUtil.swapMedium(mediumValue), buf.readMediumLE());
         buf.readerIndex(0);
@@ -235,12 +235,13 @@ public class ByteBufUtilTest {
         buf.release();
     }
 
-    @Test
-    public void testWriteUsAscii() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUsAscii(BufferType bufferType) {
         String usAscii = "NettyRocks";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeAscii(buf2, usAscii);
 
         assertEquals(buf, buf2);
@@ -249,12 +250,13 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUsAsciiSwapped() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUsAsciiSwapped(BufferType bufferType) {
         String usAscii = "NettyRocks";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
-        SwappedByteBuf buf2 = new SwappedByteBuf(buffer(16));
+        SwappedByteBuf buf2 = new SwappedByteBuf(buffer(bufferType, 16));
         ByteBufUtil.writeAscii(buf2, usAscii);
 
         assertEquals(buf, buf2);
@@ -263,13 +265,14 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUsAsciiWrapped() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUsAsciiWrapped(BufferType bufferType) {
         String usAscii = "NettyRocks";
-        ByteBuf buf = unreleasableBuffer(buffer(16));
+        ByteBuf buf = unreleasableBuffer(buffer(bufferType, 16));
         assertWrapped(buf);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
-        ByteBuf buf2 = unreleasableBuffer(buffer(16));
+        ByteBuf buf2 = unreleasableBuffer(buffer(bufferType, 16));
         assertWrapped(buf2);
         ByteBufUtil.writeAscii(buf2, usAscii);
 
@@ -279,13 +282,14 @@ public class ByteBufUtilTest {
         buf2.unwrap().release();
     }
 
-    @Test
-    public void testWriteUsAsciiComposite() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUsAsciiComposite(BufferType bufferType) {
         String usAscii = "NettyRocks";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
         ByteBuf buf2 = Unpooled.compositeBuffer().addComponent(
-                buffer(8)).addComponent(buffer(24));
+                buffer(bufferType, 8)).addComponent(buffer(bufferType, 24));
         // write some byte so we start writing with an offset.
         buf2.writeByte(1);
         ByteBufUtil.writeAscii(buf2, usAscii);
@@ -297,13 +301,14 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUsAsciiCompositeWrapped() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUsAsciiCompositeWrapped(BufferType bufferType) {
         String usAscii = "NettyRocks";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
         ByteBuf buf2 = new WrappedCompositeByteBuf(Unpooled.compositeBuffer().addComponent(
-                buffer(8)).addComponent(buffer(24)));
+                buffer(bufferType, 8)).addComponent(buffer(bufferType, 24)));
         // write some byte so we start writing with an offset.
         buf2.writeByte(1);
         ByteBufUtil.writeAscii(buf2, usAscii);
@@ -315,12 +320,13 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8(BufferType bufferType) {
         String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, usAscii);
 
         assertEquals(buf, buf2);
@@ -329,13 +335,14 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8Composite() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8Composite(BufferType bufferType) {
         String utf8 = "Some UTF-8 like äÄ∏ŒŒ";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(utf8.getBytes(CharsetUtil.UTF_8));
         ByteBuf buf2 = Unpooled.compositeBuffer().addComponent(
-                buffer(8)).addComponent(buffer(24));
+                buffer(bufferType, 8)).addComponent(buffer(bufferType, 24));
         // write some byte so we start writing with an offset.
         buf2.writeByte(1);
         ByteBufUtil.writeUtf8(buf2, utf8);
@@ -347,13 +354,14 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8CompositeWrapped() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8CompositeWrapped(BufferType bufferType) {
         String utf8 = "Some UTF-8 like äÄ∏ŒŒ";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(utf8.getBytes(CharsetUtil.UTF_8));
         ByteBuf buf2 = new WrappedCompositeByteBuf(Unpooled.compositeBuffer().addComponent(
-                buffer(8)).addComponent(buffer(24)));
+                buffer(bufferType, 8)).addComponent(buffer(bufferType, 24)));
         // write some byte so we start writing with an offset.
         buf2.writeByte(1);
         ByteBufUtil.writeUtf8(buf2, utf8);
@@ -365,8 +373,9 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8Surrogates() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8Surrogates(BufferType bufferType) {
         // leading surrogate + trailing surrogate
         String surrogateString = new StringBuilder(2)
                                 .append('a')
@@ -374,9 +383,9 @@ public class ByteBufUtilTest {
                                 .append('\uDC00')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
@@ -386,16 +395,17 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8InvalidOnlyTrailingSurrogate() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8InvalidOnlyTrailingSurrogate(BufferType bufferType) {
         String surrogateString = new StringBuilder(2)
                                 .append('a')
                                 .append('\uDC00')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
@@ -405,16 +415,17 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8InvalidOnlyLeadingSurrogate() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8InvalidOnlyLeadingSurrogate(BufferType bufferType) {
         String surrogateString = new StringBuilder(2)
                                 .append('a')
                                 .append('\uD800')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
@@ -424,17 +435,18 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8InvalidSurrogatesSwitched() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8InvalidSurrogatesSwitched(BufferType bufferType) {
         String surrogateString = new StringBuilder(2)
                                 .append('a')
                                 .append('\uDC00')
                                 .append('\uD800')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
@@ -444,17 +456,18 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8InvalidTwoLeadingSurrogates() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8InvalidTwoLeadingSurrogates(BufferType bufferType) {
         String surrogateString = new StringBuilder(2)
                                 .append('a')
                                 .append('\uD800')
                                 .append('\uD800')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
@@ -463,17 +476,18 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8InvalidTwoTrailingSurrogates() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8InvalidTwoTrailingSurrogates(BufferType bufferType) {
         String surrogateString = new StringBuilder(2)
                                 .append('a')
                                 .append('\uDC00')
                                 .append('\uDC00')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
@@ -483,14 +497,15 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8InvalidEndOnLeadingSurrogate() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8InvalidEndOnLeadingSurrogate(BufferType bufferType) {
         String surrogateString = new StringBuilder(2)
                                 .append('\uD800')
                                 .toString();
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
@@ -500,14 +515,15 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8InvalidEndOnTrailingSurrogate() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8InvalidEndOnTrailingSurrogate(BufferType bufferType) {
         String surrogateString = new StringBuilder(2)
                                 .append('\uDC00')
                                 .toString();
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
@@ -517,13 +533,14 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUsAsciiString() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUsAsciiString(BufferType bufferType) {
         AsciiString usAscii = new AsciiString("NettyRocks");
         int expectedCapacity = usAscii.length();
-        ByteBuf buf = buffer(expectedCapacity);
+        ByteBuf buf = buffer(bufferType, expectedCapacity);
         buf.writeBytes(usAscii.toString().getBytes(CharsetUtil.US_ASCII));
-        ByteBuf buf2 = buffer(expectedCapacity);
+        ByteBuf buf2 = buffer(bufferType, expectedCapacity);
         ByteBufUtil.writeAscii(buf2, usAscii);
 
         assertEquals(buf, buf2);
@@ -532,13 +549,14 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8Wrapped() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8Wrapped(BufferType bufferType) {
         String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
-        ByteBuf buf = unreleasableBuffer(buffer(16));
+        ByteBuf buf = unreleasableBuffer(buffer(bufferType, 16));
         assertWrapped(buf);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = unreleasableBuffer(buffer(16));
+        ByteBuf buf2 = unreleasableBuffer(buffer(bufferType, 16));
         assertWrapped(buf2);
         ByteBufUtil.writeUtf8(buf2, usAscii);
 
@@ -552,12 +570,13 @@ public class ByteBufUtilTest {
         assertTrue(buf instanceof WrappedByteBuf);
     }
 
-    @Test
-    public void testWriteUtf8Subsequence() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8Subsequence(BufferType bufferType) {
         String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.substring(5, 18).getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, usAscii, 5, 18);
 
         assertEquals(buf, buf2);
@@ -566,12 +585,13 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testWriteUtf8SubsequenceSplitSurrogate() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8SubsequenceSplitSurrogate(BufferType bufferType) {
         String usAscii = "\uD800\uDC00"; // surrogate pair: one code point, two chars
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.substring(0, 1).getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         ByteBufUtil.writeUtf8(buf2, usAscii, 0, 1);
 
         assertEquals(buf, buf2);
@@ -580,12 +600,13 @@ public class ByteBufUtilTest {
         buf2.release();
     }
 
-    @Test
-    public void testReserveAndWriteUtf8Subsequence() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testReserveAndWriteUtf8Subsequence(BufferType bufferType) {
         String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
-        ByteBuf buf = buffer(16);
+        ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.substring(5, 18).getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = buffer(16);
+        ByteBuf buf2 = buffer(bufferType, 16);
         int count = ByteBufUtil.reserveAndWriteUtf8(buf2, usAscii, 5, 18, 16);
 
         assertEquals(buf, buf2);
@@ -610,9 +631,9 @@ public class ByteBufUtilTest {
         int invoke(Object... args);
     }
 
-    private void testInvalidSubsequences(TestMethod method) {
+    private void testInvalidSubsequences(BufferType bufferType, TestMethod method) {
         for (int [] range : INVALID_RANGES) {
-            ByteBuf buf = buffer(16);
+            ByteBuf buf = buffer(bufferType, 16);
             try {
                 method.invoke(buf, "Some UTF-8 like äÄ∏ŒŒ", range[0], range[1]);
                 fail("Did not throw IndexOutOfBoundsException for range (" + range[0] + ", " + range[1] + ")");
@@ -625,21 +646,25 @@ public class ByteBufUtilTest {
         }
     }
 
-    @Test
-    public void testWriteUtf8InvalidSubsequences() {
-        testInvalidSubsequences(args -> ByteBufUtil.writeUtf8((ByteBuf) args[0], (String) args[1],
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8InvalidSubsequences(BufferType bufferType) {
+        testInvalidSubsequences(bufferType, args -> ByteBufUtil.writeUtf8((ByteBuf) args[0], (String) args[1],
                 (Integer) args[2], (Integer) args[3]));
     }
 
-    @Test
-    public void testReserveAndWriteUtf8InvalidSubsequences() {
-        testInvalidSubsequences(args -> ByteBufUtil.reserveAndWriteUtf8((ByteBuf) args[0], (String) args[1],
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testReserveAndWriteUtf8InvalidSubsequences(BufferType bufferType) {
+        testInvalidSubsequences(bufferType, args -> ByteBufUtil.reserveAndWriteUtf8((ByteBuf) args[0], (String) args[1],
                 (Integer) args[2], (Integer) args[3], 32));
     }
 
-    @Test
-    public void testUtf8BytesInvalidSubsequences() {
-        testInvalidSubsequences(args -> ByteBufUtil.utf8Bytes((String) args[1], (Integer) args[2], (Integer) args[3]));
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testUtf8BytesInvalidSubsequences(BufferType bufferType) {
+        testInvalidSubsequences(bufferType,
+            args -> ByteBufUtil.utf8Bytes((String) args[1], (Integer) args[2], (Integer) args[3]));
     }
 
     @Test
@@ -658,21 +683,23 @@ public class ByteBufUtilTest {
         buffer.release();
     }
 
-    @Test
-    public void testToStringDoesNotThrowIndexOutOfBounds() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testToStringDoesNotThrowIndexOutOfBounds(BufferType bufferType) {
         CompositeByteBuf buffer = Unpooled.compositeBuffer();
         try {
             byte[] bytes = "1234".getBytes(CharsetUtil.UTF_8);
-            buffer.addComponent(buffer(bytes.length).writeBytes(bytes));
-            buffer.addComponent(buffer(bytes.length).writeBytes(bytes));
+            buffer.addComponent(buffer(bufferType, bytes.length).writeBytes(bytes));
+            buffer.addComponent(buffer(bufferType, bytes.length).writeBytes(bytes));
             assertEquals("1234", buffer.toString(bytes.length, bytes.length, CharsetUtil.UTF_8));
         } finally {
             buffer.release();
         }
     }
 
-    @Test
-    public void testIsTextWithUtf8() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testIsTextWithUtf8(BufferType bufferType) {
         byte[][] validUtf8Bytes = {
                 "netty".getBytes(CharsetUtil.UTF_8),
                 {(byte) 0x24},
@@ -685,7 +712,7 @@ public class ByteBufUtilTest {
                         (byte) 0xF0, (byte) 0x90, (byte) 0x8D, (byte) 0x88} // multiple characters
         };
         for (byte[] bytes : validUtf8Bytes) {
-            assertIsText(bytes, true, CharsetUtil.UTF_8);
+            assertIsText(bufferType, bytes, true, CharsetUtil.UTF_8);
         }
         byte[][] invalidUtf8Bytes = {
                 {(byte) 0x80},
@@ -701,31 +728,34 @@ public class ByteBufUtilTest {
                 {(byte) 0xED, (byte) 0xAF, (byte) 0x80}               // out of upper bound
         };
         for (byte[] bytes : invalidUtf8Bytes) {
-            assertIsText(bytes, false, CharsetUtil.UTF_8);
+            assertIsText(bufferType, bytes, false, CharsetUtil.UTF_8);
         }
     }
 
-    @Test
-    public void testIsTextWithoutOptimization() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testIsTextWithoutOptimization(BufferType bufferType) {
         byte[] validBytes = {(byte) 0x01, (byte) 0xD8, (byte) 0x37, (byte) 0xDC};
         byte[] invalidBytes = {(byte) 0x01, (byte) 0xD8};
 
-        assertIsText(validBytes, true, CharsetUtil.UTF_16LE);
-        assertIsText(invalidBytes, false, CharsetUtil.UTF_16LE);
+        assertIsText(bufferType, validBytes, true, CharsetUtil.UTF_16LE);
+        assertIsText(bufferType, invalidBytes, false, CharsetUtil.UTF_16LE);
     }
 
-    @Test
-    public void testIsTextWithAscii() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testIsTextWithAscii(BufferType bufferType) {
         byte[] validBytes = {(byte) 0x00, (byte) 0x01, (byte) 0x37, (byte) 0x7F};
         byte[] invalidBytes = {(byte) 0x80, (byte) 0xFF};
 
-        assertIsText(validBytes, true, CharsetUtil.US_ASCII);
-        assertIsText(invalidBytes, false, CharsetUtil.US_ASCII);
+        assertIsText(bufferType, validBytes, true, CharsetUtil.US_ASCII);
+        assertIsText(bufferType, invalidBytes, false, CharsetUtil.US_ASCII);
     }
 
-    @Test
-    public void testIsTextWithInvalidIndexAndLength() {
-        ByteBuf buffer = buffer(4);
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testIsTextWithInvalidIndexAndLength(BufferType bufferType) {
+        ByteBuf buffer = buffer(bufferType, 4);
         try {
             buffer.writeBytes(new byte[4]);
             int[][] validIndexLengthPairs = {
@@ -757,33 +787,37 @@ public class ByteBufUtilTest {
         }
     }
 
-    @Test
-    public void testUtf8Bytes() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testUtf8Bytes(BufferType bufferType) {
         final String s = "Some UTF-8 like äÄ∏ŒŒ";
-        checkUtf8Bytes(s);
+        checkUtf8Bytes(bufferType, s);
     }
 
-    @Test
-    public void testUtf8BytesWithSurrogates() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testUtf8BytesWithSurrogates(BufferType bufferType) {
         final String s = "a\uD800\uDC00b";
-        checkUtf8Bytes(s);
+        checkUtf8Bytes(bufferType, s);
     }
 
-    @Test
-    public void testUtf8BytesWithNonSurrogates3Bytes() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testUtf8BytesWithNonSurrogates3Bytes(BufferType bufferType) {
         final String s = "a\uE000b";
-        checkUtf8Bytes(s);
+        checkUtf8Bytes(bufferType, s);
     }
 
-    @Test
-    public void testUtf8BytesWithNonSurrogatesNonAscii() {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testUtf8BytesWithNonSurrogatesNonAscii(BufferType bufferType) {
         final char nonAscii = (char) 0x81;
         final String s = "a" + nonAscii + "b";
-        checkUtf8Bytes(s);
+        checkUtf8Bytes(bufferType, s);
     }
 
-    private void checkUtf8Bytes(final CharSequence charSequence) {
-        final ByteBuf buf = buffer(ByteBufUtil.utf8MaxBytes(charSequence));
+    private void checkUtf8Bytes(BufferType bufferType, final CharSequence charSequence) {
+        final ByteBuf buf = buffer(bufferType, ByteBufUtil.utf8MaxBytes(charSequence));
         try {
             final int writtenBytes = ByteBufUtil.writeUtf8(buf, charSequence);
             final int utf8Bytes = ByteBufUtil.utf8Bytes(charSequence);
@@ -793,8 +827,8 @@ public class ByteBufUtilTest {
         }
     }
 
-    private void assertIsText(byte[] bytes, boolean expected, Charset charset) {
-        ByteBuf buffer = buffer(bytes.length);
+    private void assertIsText(BufferType bufferType, byte[] bytes, boolean expected, Charset charset) {
+        ByteBuf buffer = buffer(bufferType, bytes.length);
         try {
             buffer.writeBytes(bytes);
             assertEquals(expected, ByteBufUtil.isText(buffer, charset));
@@ -803,9 +837,10 @@ public class ByteBufUtilTest {
         }
     }
 
-    @Test
-    public void testIsTextMultiThreaded() throws Throwable {
-        assumeThat(bufferType, is(BufferType.HEAP_UNPOOLED));
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testIsTextMultiThreaded(BufferType bufferType) throws Throwable {
+        assumeTrue(bufferType == BufferType.HEAP_UNPOOLED);
         final ByteBuf buffer = Unpooled.copiedBuffer("Hello, World!", CharsetUtil.ISO_8859_1);
 
         try {
@@ -841,9 +876,10 @@ public class ByteBufUtilTest {
         }
     }
 
-    @Test
-    public void testGetBytes() {
-        final ByteBuf buf = buffer(4);
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testGetBytes(BufferType bufferType) {
+        final ByteBuf buf = buffer(bufferType, 4);
         try {
             checkGetBytes(buf);
         } finally {
@@ -851,10 +887,11 @@ public class ByteBufUtilTest {
         }
     }
 
-    @Test
-    public void testGetBytesHeapWithNonZeroArrayOffset() {
-        assumeThat(bufferType, is(BufferType.HEAP_UNPOOLED));
-        final ByteBuf buf = buffer(5);
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testGetBytesHeapWithNonZeroArrayOffset(BufferType bufferType) {
+        assumeTrue(bufferType == BufferType.HEAP_UNPOOLED);
+        final ByteBuf buf = buffer(bufferType, 5);
         try {
             buf.setByte(0, 0x05);
 
@@ -871,10 +908,11 @@ public class ByteBufUtilTest {
         }
     }
 
-    @Test
-    public void testGetBytesHeapWithArrayLengthGreaterThanCapacity() {
-        assumeThat(bufferType, is(BufferType.HEAP_UNPOOLED));
-        final ByteBuf buf = buffer(5);
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testGetBytesHeapWithArrayLengthGreaterThanCapacity(BufferType bufferType) {
+        assumeTrue(bufferType == BufferType.HEAP_UNPOOLED);
+        final ByteBuf buf = buffer(bufferType, 5);
         try {
             buf.setByte(4, 0x05);
 

--- a/buffer/src/test/java/io/netty/buffer/ByteProcessorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteProcessorTest.java
@@ -16,11 +16,11 @@
 
 package io.netty.buffer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ByteProcessorTest {
     @Test

--- a/buffer/src/test/java/io/netty/buffer/ConsolidationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ConsolidationTest.java
@@ -16,10 +16,10 @@
 package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests buffer consolidation

--- a/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
@@ -15,9 +15,12 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultByteBufHolderTest {
 

--- a/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
@@ -15,9 +15,10 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests duplicated channel buffers
@@ -40,9 +41,9 @@ public class DuplicatedByteBufTest extends AbstractByteBufTest {
         buf.release();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor() {
-        new DuplicatedByteBuf(null);
+        assertThrows(NullPointerException.class, () -> new DuplicatedByteBuf(null));
     }
 
     // See https://github.com/netty/netty/issues/1800

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -12,14 +12,18 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- */package io.netty.buffer;
+ */
+package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class EmptyByteBufTest {
 

--- a/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
@@ -15,9 +15,8 @@
  */
 package io.netty.buffer;
 
-
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -28,7 +27,12 @@ import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FixedCompositeByteBufTest {
 
@@ -36,63 +40,64 @@ public class FixedCompositeByteBufTest {
         return new FixedCompositeByteBuf(UnpooledByteBufAllocator.DEFAULT, buffers);
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBoolean() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setBoolean(0, true);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBoolean(0, true));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetByte() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setByte(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setByte(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesWithByteBuf() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         ByteBuf src = wrappedBuffer(new byte[4]);
         try {
-            buf.setBytes(0, src);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, src));
         } finally {
             buf.release();
             src.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesWithByteBuffer() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setBytes(0, ByteBuffer.wrap(new byte[4]));
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, ByteBuffer.wrap(new byte[4])));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetBytesWithInputStream() throws IOException {
+    @Test
+    public void testSetBytesWithInputStream() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setBytes(0, new ByteArrayInputStream(new byte[4]), 4);
+            assertThrows(ReadOnlyBufferException.class,
+                () -> buf.setBytes(0, new ByteArrayInputStream(new byte[4]), 4));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetBytesWithChannel() throws IOException {
+    @Test
+    public void testSetBytesWithChannel() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setBytes(0, new ScatteringByteChannel() {
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, new ScatteringByteChannel() {
                 @Override
                 public long read(ByteBuffer[] dsts, int offset, int length) {
                     return 0;
@@ -116,67 +121,67 @@ public class FixedCompositeByteBufTest {
                 @Override
                 public void close() {
                 }
-            }, 4);
+            }, 4));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetChar() throws IOException {
+    @Test
+    public void testSetChar() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setChar(0, 'b');
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setChar(0, 'b'));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetDouble() throws IOException {
+    @Test
+    public void testSetDouble() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setDouble(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setDouble(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetFloat() throws IOException {
+    @Test
+    public void testSetFloat() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setFloat(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setFloat(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetInt() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setInt(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setInt(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetLong() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setLong(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setLong(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetMedium() throws IOException {
+    @Test
+    public void testSetMedium() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
         try {
-            buf.setMedium(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setMedium(0, 1));
         } finally {
             buf.release();
         }
@@ -394,7 +399,7 @@ public class FixedCompositeByteBufTest {
 
     @Test
     public void testHasMemoryAddressWhenEmpty() {
-        Assume.assumeTrue(EMPTY_BUFFER.hasMemoryAddress());
+        Assumptions.assumeTrue(EMPTY_BUFFER.hasMemoryAddress());
         ByteBuf buf = newBuffer(new ByteBuf[0]);
         assertTrue(buf.hasMemoryAddress());
         assertEquals(EMPTY_BUFFER.memoryAddress(), buf.memoryAddress());
@@ -441,15 +446,14 @@ public class FixedCompositeByteBufTest {
         buf.release();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testHasNoArrayWhenMultipleBuffers() {
         ByteBuf buf1 = buffer(10);
         ByteBuf buf2 = buffer(10);
         ByteBuf buf = newBuffer(buf1, buf2);
         assertFalse(buf.hasArray());
         try {
-            buf.array();
-            fail();
+            assertThrows(UnsupportedOperationException.class, buf::array);
         } finally {
             buf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianDirectByteBufTest.java
@@ -15,7 +15,8 @@
  */
 package io.netty.buffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.nio.ByteOrder;
 

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianHeapByteBufTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.buffer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteOrder;
 

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeDirectByteBufTest.java
@@ -16,15 +16,15 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class LittleEndianUnsafeDirectByteBufTest extends LittleEndianDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assumptions.assumeTrue(PlatformDependent.hasUnsafe(), "sun.misc.Unsafe not found, skip tests");
         super.init();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -16,16 +16,16 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class LittleEndianUnsafeNoCleanerDirectByteBufTest extends LittleEndianDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests",
-                PlatformDependent.useDirectBufferNoCleaner());
+        Assumptions.assumeTrue(PlatformDependent.useDirectBufferNoCleaner(),
+          "java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests");
         super.init();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/LongPriorityQueueTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LongPriorityQueueTest.java
@@ -16,7 +16,6 @@
 package io.netty.buffer;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,12 +29,7 @@ class LongPriorityQueueTest {
     @Test
     public void mustThrowWhenAddingNoValue() {
         final LongPriorityQueue pq = new LongPriorityQueue();
-        assertThrows(IllegalArgumentException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                pq.offer(LongPriorityQueue.NO_VALUE);
-            }
-        });
+        assertThrows(IllegalArgumentException.class, () -> pq.offer(LongPriorityQueue.NO_VALUE));
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -17,13 +17,13 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PoolArenaTest {
 
@@ -38,7 +38,7 @@ public class PoolArenaTest {
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {16, 16, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
-            Assert.assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
+            assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
         }
     }
 
@@ -48,7 +48,7 @@ public class PoolArenaTest {
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {16, 64, 512, 1024, 1024, 1280};
         for (int i = 0; i < reqCapacities.length; i ++) {
-            Assert.assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
+            assertEquals(expectedResult[i], arena.sizeIdx2size(arena.size2SizeIdx(reqCapacities[i])));
         }
     }
 
@@ -58,9 +58,9 @@ public class PoolArenaTest {
 
         for (int sz = 0; sz <= CHUNK_SIZE; sz++) {
             int sizeIdx = arena.size2SizeIdx(sz);
-            Assert.assertTrue(sz <= arena.sizeIdx2size(sizeIdx));
+            assertTrue(sz <= arena.sizeIdx2size(sizeIdx));
             if (sizeIdx > 0) {
-                Assert.assertTrue(sz > arena.sizeIdx2size(sizeIdx - 1));
+                assertTrue(sz > arena.sizeIdx2size(sizeIdx - 1));
             }
         }
     }
@@ -74,15 +74,15 @@ public class PoolArenaTest {
         int maxPages = CHUNK_SIZE >> pageShifts;
         for (int pages = 1; pages <= maxPages; pages++) {
             int pageIdxFloor = arena.pages2pageIdxFloor(pages);
-            Assert.assertTrue(pages << pageShifts >= arena.pageIdx2size(pageIdxFloor));
+            assertTrue(pages << pageShifts >= arena.pageIdx2size(pageIdxFloor));
             if (pageIdxFloor > 0 && pages < maxPages) {
-                Assert.assertTrue(pages << pageShifts < arena.pageIdx2size(pageIdxFloor + 1));
+                assertTrue(pages << pageShifts < arena.pageIdx2size(pageIdxFloor + 1));
             }
 
             int pageIdxCeiling = arena.pages2pageIdx(pages);
-            Assert.assertTrue(pages << pageShifts <= arena.pageIdx2size(pageIdxCeiling));
+            assertTrue(pages << pageShifts <= arena.pageIdx2size(pageIdxCeiling));
             if (pageIdxCeiling > 0) {
-                Assert.assertTrue(pages << pageShifts > arena.pageIdx2size(pageIdxCeiling - 1));
+                assertTrue(pages << pageShifts > arena.pageIdx2size(pageIdxCeiling - 1));
             }
         }
     }
@@ -122,24 +122,24 @@ public class PoolArenaTest {
         // create normal buffer
         final ByteBuf b2 = allocator.directBuffer(8192 * 5);
 
-        Assert.assertNotNull(b1);
-        Assert.assertNotNull(b2);
+        assertNotNull(b1);
+        assertNotNull(b2);
 
         // then release buffer to deallocated memory while threadlocal cache has been disabled
         // allocations counter value must equals deallocations counter value
-        Assert.assertTrue(b1.release());
-        Assert.assertTrue(b2.release());
+        assertTrue(b1.release());
+        assertTrue(b2.release());
 
-        Assert.assertTrue(allocator.directArenas().size() >= 1);
+        assertTrue(allocator.directArenas().size() >= 1);
         final PoolArenaMetric metric = allocator.directArenas().get(0);
 
-        Assert.assertEquals(2, metric.numDeallocations());
-        Assert.assertEquals(2, metric.numAllocations());
+        assertEquals(2, metric.numDeallocations());
+        assertEquals(2, metric.numAllocations());
 
-        Assert.assertEquals(1, metric.numSmallDeallocations());
-        Assert.assertEquals(1, metric.numSmallAllocations());
-        Assert.assertEquals(1, metric.numNormalDeallocations());
-        Assert.assertEquals(1, metric.numNormalAllocations());
+        assertEquals(1, metric.numSmallDeallocations());
+        assertEquals(1, metric.numSmallAllocations());
+        assertEquals(1, metric.numNormalDeallocations());
+        assertEquals(1, metric.numNormalAllocations());
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/PooledAlignedBigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledAlignedBigEndianDirectByteBufTest.java
@@ -15,18 +15,18 @@
  */
 package io.netty.buffer;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class PooledAlignedBigEndianDirectByteBufTest extends PooledBigEndianDirectByteBufTest {
     private static final int directMemoryCacheAlignment = 1;
     private static PooledByteBufAllocator allocator;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpAllocator() {
         allocator = new PooledByteBufAllocator(
                 true,
@@ -40,7 +40,7 @@ public class PooledAlignedBigEndianDirectByteBufTest extends PooledBigEndianDire
                 directMemoryCacheAlignment);
     }
 
-    @AfterClass
+    @AfterAll
     public static void releaseAllocator() {
         allocator = null;
     }

--- a/buffer/src/test/java/io/netty/buffer/PooledBigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledBigEndianDirectByteBufTest.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Tests big-endian direct channel buffers

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -20,8 +20,8 @@ import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -32,14 +32,15 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
+import org.junit.jupiter.api.Timeout;
 
 import static io.netty.buffer.PoolChunk.runOffset;
 import static io.netty.buffer.PoolChunk.runPages;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<PooledByteBufAllocator> {
 
@@ -144,13 +145,13 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     public void testArenaMetricsNoCacheAlign() {
-        Assume.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
+        Assumptions.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 0, 0, 0, true, 64), 100, 0, 100, 100);
     }
 
     @Test
     public void testArenaMetricsCacheAlign() {
-        Assume.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
+        Assumptions.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 1000, 1000, 1000, true, 64), 100, 1, 1, 0);
     }
 
@@ -338,12 +339,14 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         }
     }
 
-    @Test (timeout = 4000)
+    @Test
+    @Timeout(value = 4000, unit = MILLISECONDS)
     public void testThreadCacheDestroyedByThreadCleaner() throws InterruptedException {
         testThreadCacheDestroyed(false);
     }
 
-    @Test (timeout = 4000)
+    @Test
+    @Timeout(value = 4000, unit = MILLISECONDS)
     public void testThreadCacheDestroyedAfterExitRun() throws InterruptedException {
         testThreadCacheDestroyed(true);
     }
@@ -400,7 +403,8 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         assertTrue(threadCachesCreated.get());
     }
 
-    @Test(timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = MILLISECONDS)
     public void testNumThreadCachesWithNoDirectArenas() throws InterruptedException {
         int numHeapArenas = 1;
         final PooledByteBufAllocator allocator =
@@ -419,7 +423,8 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         assertEquals(0, allocator.metric().numThreadLocalCaches());
     }
 
-    @Test(timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = MILLISECONDS)
     public void testThreadCacheToArenaMappings() throws InterruptedException {
         int numArenas = 2;
         final PooledByteBufAllocator allocator =

--- a/buffer/src/test/java/io/netty/buffer/PooledLittleEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledLittleEndianDirectByteBufTest.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Tests little-endian direct channel buffers

--- a/buffer/src/test/java/io/netty/buffer/PooledLittleEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledLittleEndianHeapByteBufTest.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Tests little-endian heap channel buffers

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,11 +31,11 @@ import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.buffer.Unpooled.LITTLE_ENDIAN;
 import static io.netty.buffer.Unpooled.buffer;
 import static io.netty.buffer.Unpooled.unmodifiableBuffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,9 +44,9 @@ import static org.mockito.Mockito.when;
  */
 public class ReadOnlyByteBufTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor() {
-        new ReadOnlyByteBuf(null);
+        assertThrows(NullPointerException.class, () -> new ReadOnlyByteBuf(null));
     }
 
     @Test
@@ -127,59 +127,65 @@ public class ReadOnlyByteBufTest {
         assertEquals(27, roBuf.capacity());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectDiscardReadBytes() {
-        unmodifiableBuffer(EMPTY_BUFFER).discardReadBytes();
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).discardReadBytes());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetByte() {
-        unmodifiableBuffer(EMPTY_BUFFER).setByte(0, (byte) 0);
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).setByte(0, (byte) 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetShort() {
-        unmodifiableBuffer(EMPTY_BUFFER).setShort(0, (short) 0);
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setShort(0, (short) 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetMedium() {
-        unmodifiableBuffer(EMPTY_BUFFER).setMedium(0, 0);
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).setMedium(0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetInt() {
-        unmodifiableBuffer(EMPTY_BUFFER).setInt(0, 0);
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).setInt(0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetLong() {
-        unmodifiableBuffer(EMPTY_BUFFER).setLong(0, 0);
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableBuffer(EMPTY_BUFFER).setLong(0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldRejectSetBytes1() throws IOException {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (InputStream) null, 0);
+    @Test
+    public void shouldRejectSetBytes1() {
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (InputStream) null, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldRejectSetBytes2() throws IOException {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ScatteringByteChannel) null, 0);
+    @Test
+    public void shouldRejectSetBytes2() {
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ScatteringByteChannel) null, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetBytes3() {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (byte[]) null, 0, 0);
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (byte[]) null, 0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetBytes4() {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuf) null, 0, 0);
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuf) null, 0, 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldRejectSetBytes5() {
-        unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuffer) null);
+        assertThrows(UnsupportedOperationException.class,
+            () -> unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuffer) null));
     }
 
     @Test
@@ -211,13 +217,12 @@ public class ReadOnlyByteBufTest {
         readOnly.release();
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void ensureWritableShouldThrow() {
         ByteBuf buf = buffer(1);
         ByteBuf readOnly = buf.asReadOnly();
         try {
-            readOnly.ensureWritable(1);
-            fail();
+            assertThrows(ReadOnlyBufferException.class, () -> readOnly.ensureWritable(1));
         } finally {
             buf.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufferBufTest.java
@@ -15,12 +15,12 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReadOnlyByteBufferBufTest extends ReadOnlyDirectByteBufferBufTest {
     @Override

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -16,8 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -27,6 +26,12 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ReadOnlyDirectByteBufferBufTest {
 
@@ -41,20 +46,20 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void testIsContiguous() {
         ByteBuf buf = buffer(allocate(4).asReadOnlyBuffer());
-        Assert.assertTrue(buf.isContiguous());
+        assertTrue(buf.isContiguous());
         buf.release();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructWithWritable() {
-        buffer(allocate(1));
+        assertThrows(IllegalArgumentException.class, () -> buffer(allocate(1)));
     }
 
     @Test
     public void shouldIndicateNotWritable() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
-            Assert.assertFalse(buf.isWritable());
+            assertFalse(buf.isWritable());
         } finally {
             buf.release();
         }
@@ -64,7 +69,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void shouldIndicateNotWritableAnyNumber() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
-            Assert.assertFalse(buf.isWritable(1));
+            assertFalse(buf.isWritable(1));
         } finally {
             buf.release();
         }
@@ -75,7 +80,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
             int result = buf.ensureWritable(1, false);
-            Assert.assertEquals(1, result);
+            assertEquals(1, result);
         } finally {
             buf.release();
         }
@@ -86,99 +91,100 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
             int result = buf.ensureWritable(1, true);
-            Assert.assertEquals(1, result);
+            assertEquals(1, result);
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void ensureWritableShouldThrow() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
         try {
-            buf.ensureWritable(1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.ensureWritable(1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetByte() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setByte(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setByte(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetInt() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setInt(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setInt(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetShort() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setShort(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setShort(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetMedium() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setMedium(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setMedium(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetLong() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setLong(0, 1);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setLong(0, 1));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesViaArray() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            buf.setBytes(0, "test".getBytes());
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, "test".getBytes()));
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesViaBuffer() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         ByteBuf copy = Unpooled.copyInt(1);
         try {
-            buf.setBytes(0, copy);
+            assertThrows(ReadOnlyBufferException.class, () -> buf.setBytes(0, copy));
         } finally {
             buf.release();
             copy.release();
         }
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
+    @Test
     public void testSetBytesViaStream() throws IOException {
         ByteBuf buf = buffer(ByteBuffer.allocateDirect(8).asReadOnlyBuffer());
         try {
-            buf.setBytes(0, new ByteArrayInputStream("test".getBytes()), 2);
+            assertThrows(ReadOnlyBufferException.class,
+                () -> buf.setBytes(0, new ByteArrayInputStream("test".getBytes()), 2));
         } finally {
             buf.release();
         }
@@ -189,12 +195,12 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(
                 ((ByteBuffer) allocate(2).put(new byte[] { (byte) 1, (byte) 2 }).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.getByte(0));
-        Assert.assertEquals(2, buf.getByte(1));
+        assertEquals(1, buf.getByte(0));
+        assertEquals(2, buf.getByte(1));
 
-        Assert.assertEquals(1, buf.readByte());
-        Assert.assertEquals(2, buf.readByte());
-        Assert.assertFalse(buf.isReadable());
+        assertEquals(1, buf.readByte());
+        assertEquals(2, buf.readByte());
+        assertFalse(buf.isReadable());
 
         buf.release();
     }
@@ -203,12 +209,12 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void testGetReadInt() {
         ByteBuf buf = buffer(((ByteBuffer) allocate(8).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.getInt(0));
-        Assert.assertEquals(2, buf.getInt(4));
+        assertEquals(1, buf.getInt(0));
+        assertEquals(2, buf.getInt(4));
 
-        Assert.assertEquals(1, buf.readInt());
-        Assert.assertEquals(2, buf.readInt());
-        Assert.assertFalse(buf.isReadable());
+        assertEquals(1, buf.readInt());
+        assertEquals(2, buf.readInt());
+        assertFalse(buf.isReadable());
 
         buf.release();
     }
@@ -218,12 +224,12 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(((ByteBuffer) allocate(8)
                 .putShort((short) 1).putShort((short) 2).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.getShort(0));
-        Assert.assertEquals(2, buf.getShort(2));
+        assertEquals(1, buf.getShort(0));
+        assertEquals(2, buf.getShort(2));
 
-        Assert.assertEquals(1, buf.readShort());
-        Assert.assertEquals(2, buf.readShort());
-        Assert.assertFalse(buf.isReadable());
+        assertEquals(1, buf.readShort());
+        assertEquals(2, buf.readShort());
+        assertFalse(buf.isReadable());
 
         buf.release();
     }
@@ -233,17 +239,17 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(((ByteBuffer) allocate(16)
                 .putLong(1).putLong(2).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.getLong(0));
-        Assert.assertEquals(2, buf.getLong(8));
+        assertEquals(1, buf.getLong(0));
+        assertEquals(2, buf.getLong(8));
 
-        Assert.assertEquals(1, buf.readLong());
-        Assert.assertEquals(2, buf.readLong());
-        Assert.assertFalse(buf.isReadable());
+        assertEquals(1, buf.readLong());
+        assertEquals(2, buf.readLong());
+        assertFalse(buf.isReadable());
 
         buf.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is in the ByteBuf.
@@ -251,7 +257,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buffer = buffer(((ByteBuffer) allocate(bytes.length)
                 .put(bytes).flip()).asReadOnlyBuffer());
         try {
-            buffer.getBytes(buffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.getBytes(buffer.readerIndex(), nioBuffer));
         } finally {
             buffer.release();
         }
@@ -262,7 +268,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
         ByteBuf copy = buf.copy();
 
-        Assert.assertEquals(buf, copy);
+        assertEquals(buf, copy);
 
         buf.release();
         copy.release();
@@ -273,7 +279,7 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
         ByteBuf copy = buf.copy(1, 9);
 
-        Assert.assertEquals(buf.slice(1, 9), copy);
+        assertEquals(buf.slice(1, 9), copy);
 
         buf.release();
         copy.release();
@@ -286,7 +292,7 @@ public class ReadOnlyDirectByteBufferBufTest {
                 .putLong(1).flip().position(1)).asReadOnlyBuffer());
 
         ByteBuf slice = buf.slice();
-        Assert.assertEquals(buf, slice);
+        assertEquals(buf, slice);
 
         buf.release();
     }
@@ -295,12 +301,12 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void testWrapBufferRoundTrip() {
         ByteBuf buf = buffer(((ByteBuffer) allocate(16).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
 
-        Assert.assertEquals(1, buf.readInt());
+        assertEquals(1, buf.readInt());
 
         ByteBuffer nioBuffer = buf.nioBuffer();
 
         // Ensure this can be accessed without throwing a BufferUnderflowException
-        Assert.assertEquals(2, nioBuffer.getInt());
+        assertEquals(2, nioBuffer.getInt());
 
         buf.release();
     }
@@ -330,7 +336,7 @@ public class ReadOnlyDirectByteBufferBufTest {
 
             b2 = buffer(dup);
 
-            Assert.assertEquals(b2, b1.slice(2, 2));
+            assertEquals(b2, b1.slice(2, 2));
         } finally {
             if (b1 != null) {
                 b1.release();
@@ -352,10 +358,10 @@ public class ReadOnlyDirectByteBufferBufTest {
     public void testMemoryAddress() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            Assert.assertFalse(buf.hasMemoryAddress());
+            assertFalse(buf.hasMemoryAddress());
             try {
                 buf.memoryAddress();
-                Assert.fail();
+                fail();
             } catch (UnsupportedOperationException expected) {
                 // expected
             }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
@@ -16,22 +16,22 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ReadOnlyUnsafeDirectByteBufferBufTest extends ReadOnlyDirectByteBufferBufTest {
 
     /**
      * Needs unsafe to run
      */
-    @BeforeClass
+    @BeforeAll
     public static void assumeConditions() {
-        assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        assumeTrue(PlatformDependent.hasUnsafe(), "sun.misc.Unsafe not found, skip tests");
     }
 
     @Override
@@ -44,7 +44,7 @@ public class ReadOnlyUnsafeDirectByteBufferBufTest extends ReadOnlyDirectByteBuf
     public void testMemoryAddress() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
         try {
-            Assert.assertTrue(buf.hasMemoryAddress());
+            assertTrue(buf.hasMemoryAddress());
             buf.memoryAddress();
         } finally {
             buf.release();

--- a/buffer/src/test/java/io/netty/buffer/RetainedDuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/RetainedDuplicatedByteBufTest.java
@@ -16,7 +16,7 @@
 
 package io.netty.buffer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RetainedDuplicatedByteBufTest extends DuplicatedByteBufTest {
     @Override

--- a/buffer/src/test/java/io/netty/buffer/RetainedSlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/RetainedSlicedByteBufTest.java
@@ -16,8 +16,7 @@
 
 package io.netty.buffer;
 
-
-import org.junit.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RetainedSlicedByteBufTest extends SlicedByteBufTest {
 
@@ -25,7 +24,7 @@ public class RetainedSlicedByteBufTest extends SlicedByteBufTest {
     protected ByteBuf newSlice(ByteBuf buffer, int offset, int length) {
         ByteBuf slice = buffer.retainedSlice(offset, length);
         buffer.release();
-        Assert.assertEquals(buffer.refCnt(), slice.refCnt());
+        assertEquals(buffer.refCnt(), slice.refCnt());
         return slice;
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareByteBufTest.java
@@ -16,15 +16,15 @@
 package io.netty.buffer;
 
 import io.netty.util.ResourceLeakTracker;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleLeakAwareByteBufTest extends BigEndianHeapByteBufTest {
     private final Class<? extends ByteBuf> clazz = leakClass();
@@ -46,14 +46,14 @@ public class SimpleLeakAwareByteBufTest extends BigEndianHeapByteBufTest {
         return new SimpleLeakAwareByteBuf(buffer, tracker);
     }
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
         super.init();
         trackers.clear();
     }
 
-    @After
+    @AfterEach
     @Override
     public void dispose() {
         super.dispose();

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
@@ -17,17 +17,17 @@ package io.netty.buffer;
 
 import io.netty.util.ResourceLeakTracker;
 import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleLeakAwareCompositeByteBufTest extends WrappedCompositeByteBufTest {
 
@@ -46,14 +46,14 @@ public class SimpleLeakAwareCompositeByteBufTest extends WrappedCompositeByteBuf
         return new SimpleLeakAwareCompositeByteBuf(buffer, tracker);
     }
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
         super.init();
         trackers.clear();
     }
 
-    @After
+    @AfterEach
     @Override
     public void dispose() {
         super.dispose();

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -15,17 +15,17 @@
  */
 package io.netty.buffer;
 
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests sliced channel buffers
@@ -34,7 +34,7 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
 
     @Override
     protected final ByteBuf newBuffer(int length, int maxCapacity) {
-        Assume.assumeTrue(maxCapacity == Integer.MAX_VALUE);
+        Assumptions.assumeTrue(maxCapacity == Integer.MAX_VALUE);
         int offset = length == 0 ? 0 : ThreadLocalRandom.current().nextInt(length);
         ByteBuf buffer = Unpooled.buffer(length * 2);
         ByteBuf slice = newSlice(buffer, offset, length);
@@ -54,69 +54,69 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         buf.release();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInConstructor() {
-        new SlicedByteBuf(null, 0, 0);
+        assertThrows(NullPointerException.class, () -> new SlicedByteBuf(null, 0, 0));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testInternalNioBuffer() {
-        super.testInternalNioBuffer();
+        assertThrows(IndexOutOfBoundsException.class, super::testInternalNioBuffer);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateReadGatheringByteChannelMultipleThreads() throws Exception {
-        super.testDuplicateReadGatheringByteChannelMultipleThreads();
+    public void testDuplicateReadGatheringByteChannelMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateReadGatheringByteChannelMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceReadGatheringByteChannelMultipleThreads() throws Exception {
-        super.testSliceReadGatheringByteChannelMultipleThreads();
+    public void testSliceReadGatheringByteChannelMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceReadGatheringByteChannelMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateReadOutputStreamMultipleThreads() throws Exception {
-        super.testDuplicateReadOutputStreamMultipleThreads();
+    public void testDuplicateReadOutputStreamMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateReadOutputStreamMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceReadOutputStreamMultipleThreads() throws Exception {
-        super.testSliceReadOutputStreamMultipleThreads();
+    public void testSliceReadOutputStreamMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceReadOutputStreamMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateBytesInArrayMultipleThreads() throws Exception {
-        super.testDuplicateBytesInArrayMultipleThreads();
+    public void testDuplicateBytesInArrayMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateBytesInArrayMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceBytesInArrayMultipleThreads() throws Exception {
-        super.testSliceBytesInArrayMultipleThreads();
+    public void testSliceBytesInArrayMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceBytesInArrayMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testNioBufferExposeOnlyRegion() {
-        super.testNioBufferExposeOnlyRegion();
+        assertThrows(IndexOutOfBoundsException.class, super::testNioBufferExposeOnlyRegion);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testGetReadOnlyDirectDst() {
-        super.testGetReadOnlyDirectDst();
+        assertThrows(IndexOutOfBoundsException.class, super::testGetReadOnlyDirectDst);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testGetReadOnlyHeapDst() {
-        super.testGetReadOnlyHeapDst();
+        assertThrows(IndexOutOfBoundsException.class, super::testGetReadOnlyHeapDst);
     }
 
     @Test
@@ -143,12 +143,12 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         // Ignore for SlicedByteBuf
     }
 
-    @Ignore("Sliced ByteBuf objects don't allow the capacity to change. So this test would fail and shouldn't be run")
+    @Disabled("Sliced ByteBuf objects don't allow the capacity to change. So this test would fail and shouldn't be run")
     @Override
     public void testDuplicateCapacityChange() {
     }
 
-    @Ignore("Sliced ByteBuf objects don't allow the capacity to change. So this test would fail and shouldn't be run")
+    @Disabled("Sliced ByteBuf objects don't allow the capacity to change. So this test would fail and shouldn't be run")
     @Override
     public void testRetainedDuplicateCapacityChange() {
     }
@@ -199,41 +199,42 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
     }
 
     @Override
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is wrapped in the ByteBuf.
         ByteBuffer nioBuffer = ByteBuffer.allocate(bytes.length + 1);
         ByteBuf wrappedBuffer = Unpooled.wrappedBuffer(bytes).slice(0, bytes.length - 1);
         try {
-            wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class,
+                () -> wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer));
         } finally {
             wrappedBuffer.release();
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUsAsciiCharSequenceExpand() {
-        super.testWriteUsAsciiCharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUsAsciiCharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUtf8CharSequenceExpand() {
-        super.testWriteUtf8CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUtf8CharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteIso88591CharSequenceExpand() {
-        super.testWriteIso88591CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteIso88591CharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUtf16CharSequenceExpand() {
-        super.testWriteUtf16CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUtf16CharSequenceExpand);
     }
 
     @Test
@@ -252,14 +253,13 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         slice.release();
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void ensureWritableWithNotEnoughSpaceShouldThrow() {
         ByteBuf slice = newBuffer(10);
         ByteBuf unwrapped = slice.unwrap();
         unwrapped.writerIndex(unwrapped.writerIndex() + 5);
         try {
-            slice.ensureWritable(1);
-            fail();
+            assertThrows(IndexOutOfBoundsException.class, () -> slice.ensureWritable(1));
         } finally {
             slice.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
@@ -16,7 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.InputStream;
@@ -31,7 +31,12 @@ import java.util.Map.Entry;
 
 import static io.netty.buffer.Unpooled.*;
 import static io.netty.util.internal.EmptyArrays.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests channel buffers
@@ -694,11 +699,11 @@ public class UnpooledTest {
         wrapped.release();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void skipBytesNegativeLength() {
         ByteBuf buf = buffer(8);
         try {
-            buf.skipBytes(-1);
+            assertThrows(IllegalArgumentException.class, () -> buf.skipBytes(-1));
         } finally {
             buf.release();
         }
@@ -722,27 +727,29 @@ public class UnpooledTest {
         assertEquals(0, wrapped.refCnt());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is wrapped in the ByteBuf.
         ByteBuffer nioBuffer = ByteBuffer.allocate(bytes.length + 1);
         ByteBuf wrappedBuffer = wrappedBuffer(bytes);
         try {
-            wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class,
+                () -> wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer));
         } finally {
             wrappedBuffer.release();
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testGetBytesByteBuffer2() {
         byte[] bytes = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         // Ensure destination buffer is bigger then what is wrapped in the ByteBuf.
         ByteBuffer nioBuffer = ByteBuffer.allocate(bytes.length + 1);
         ByteBuf wrappedBuffer = wrappedBuffer(bytes, 0, bytes.length);
         try {
-            wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer);
+            assertThrows(IndexOutOfBoundsException.class,
+                () -> wrappedBuffer.getBytes(wrappedBuffer.readerIndex(), nioBuffer));
         } finally {
             wrappedBuffer.release();
         }

--- a/buffer/src/test/java/io/netty/buffer/UnreleaseableByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnreleaseableByteBufTest.java
@@ -15,13 +15,13 @@
  */
 package io.netty.buffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.buffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UnreleaseableByteBufTest {
 

--- a/buffer/src/test/java/io/netty/buffer/UnsafeByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnsafeByteBufUtilTest.java
@@ -16,21 +16,22 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 import static io.netty.util.internal.PlatformDependent.directBufferAddress;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnsafeByteBufUtilTest {
-    @Before
+    @BeforeEach
     public void checkHasUnsafe() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assumptions.assumeTrue(PlatformDependent.hasUnsafe(), "sun.misc.Unsafe not found, skip tests");
     }
 
     @Test
@@ -49,7 +50,7 @@ public class UnsafeByteBufUtilTest {
             byte[] check = new byte[length];
             targetBuffer.getBytes(0, check, 0, length);
 
-            assertArrayEquals("The byte array's copy does not equal the original", testData, check);
+            assertArrayEquals(testData, check, "The byte array's copy does not equal the original");
         } finally {
             targetBuffer.release();
         }
@@ -82,7 +83,7 @@ public class UnsafeByteBufUtilTest {
             byte[] check = new byte[length];
             targetBuffer.getBytes(0, check, 0, length);
 
-            assertArrayEquals("The byte array's copy does not equal the original", testData, check);
+            assertArrayEquals(testData, check, "The byte array's copy does not equal the original");
         } finally {
             targetBuffer.release();
             b1.release();
@@ -105,7 +106,7 @@ public class UnsafeByteBufUtilTest {
             final byte[] check = new byte[length];
             targetBuffer.getBytes(0, check, 0, length);
 
-            assertArrayEquals("The byte array's copy does not equal the original", testData, check);
+            assertArrayEquals(testData, check, "The byte array's copy does not equal the original");
         } finally {
             targetBuffer.release();
         }
@@ -135,60 +136,74 @@ public class UnsafeByteBufUtilTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetBytesWithNullByteArray() {
 
         final UnpooledByteBufAllocator alloc = new UnpooledByteBufAllocator(true);
         final UnpooledDirectByteBuf targetBuffer = new UnpooledDirectByteBuf(alloc, 8, 8);
 
         try {
-            UnsafeByteBufUtil.setBytes(targetBuffer,
-                    directBufferAddress(targetBuffer.nioBuffer()), 0, (byte[]) null, 0, 8);
+            assertThrows(NullPointerException.class, () -> UnsafeByteBufUtil.setBytes(targetBuffer,
+                    directBufferAddress(targetBuffer.nioBuffer()), 0, (byte[]) null, 0, 8));
         } finally {
             targetBuffer.release();
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds() {
-        // negative index
-        testSetBytesOutOfBounds0(4, 4, -1, 0, 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // negative index
+            testSetBytesOutOfBounds0(4, 4, -1, 0, 4);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds2() {
-        // negative length
-        testSetBytesOutOfBounds0(4, 4, 0, 0, -1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // negative length
+            testSetBytesOutOfBounds0(4, 4, 0, 0, -1);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds3() {
-        // buffer length oversize
-        testSetBytesOutOfBounds0(4, 8, 0, 0, 5);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // buffer length oversize
+            testSetBytesOutOfBounds0(4, 8, 0, 0, 5);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds4() {
-        // buffer length oversize
-        testSetBytesOutOfBounds0(4, 4, 3, 0, 3);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // buffer length oversize
+            testSetBytesOutOfBounds0(4, 4, 3, 0, 3);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds5() {
-        // negative srcIndex
-        testSetBytesOutOfBounds0(4, 4, 0, -1, 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // negative srcIndex
+            testSetBytesOutOfBounds0(4, 4, 0, -1, 4);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds6() {
-        // src length oversize
-        testSetBytesOutOfBounds0(8, 4, 0, 0, 5);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // src length oversize
+            testSetBytesOutOfBounds0(8, 4, 0, 0, 5);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testSetBytesOutOfBounds7() {
-        // src length oversize
-        testSetBytesOutOfBounds0(4, 4, 0, 1, 4);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            // src length oversize
+            testSetBytesOutOfBounds0(4, 4, 0, 1, 4);
+        });
     }
 
     private static void testSetBytesOutOfBounds0(int lengthOfBuffer,

--- a/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
@@ -16,134 +16,136 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class WrappedUnpooledUnsafeByteBufTest extends BigEndianUnsafeDirectByteBufTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void init() {
-        Assume.assumeTrue("PlatformDependent.useDirectBufferNoCleaner() returned false, skip tests",
-                PlatformDependent.useDirectBufferNoCleaner());
+        Assumptions.assumeTrue(PlatformDependent.useDirectBufferNoCleaner(),
+                "PlatformDependent.useDirectBufferNoCleaner() returned false, skip tests");
         super.init();
     }
 
     @Override
     protected ByteBuf newBuffer(int length, int maxCapacity) {
-        Assume.assumeTrue(maxCapacity == Integer.MAX_VALUE);
+        Assumptions.assumeTrue(maxCapacity == Integer.MAX_VALUE);
 
         return new WrappedUnpooledUnsafeDirectByteBuf(UnpooledByteBufAllocator.DEFAULT,
                 PlatformDependent.allocateMemory(length), length, true);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testInternalNioBuffer() {
-        super.testInternalNioBuffer();
+        assertThrows(IndexOutOfBoundsException.class, super::testInternalNioBuffer);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateReadGatheringByteChannelMultipleThreads() throws Exception {
-        super.testDuplicateReadGatheringByteChannelMultipleThreads();
+    public void testDuplicateReadGatheringByteChannelMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateReadGatheringByteChannelMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceReadGatheringByteChannelMultipleThreads() throws Exception {
-        super.testSliceReadGatheringByteChannelMultipleThreads();
+    public void testSliceReadGatheringByteChannelMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceReadGatheringByteChannelMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateReadOutputStreamMultipleThreads() throws Exception {
-        super.testDuplicateReadOutputStreamMultipleThreads();
+    public void testDuplicateReadOutputStreamMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateReadOutputStreamMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceReadOutputStreamMultipleThreads() throws Exception {
-        super.testSliceReadOutputStreamMultipleThreads();
+    public void testSliceReadOutputStreamMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceReadOutputStreamMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testDuplicateBytesInArrayMultipleThreads() throws Exception {
-        super.testDuplicateBytesInArrayMultipleThreads();
+    public void testDuplicateBytesInArrayMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testDuplicateBytesInArrayMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
-    public void testSliceBytesInArrayMultipleThreads() throws Exception {
-        super.testSliceBytesInArrayMultipleThreads();
+    public void testSliceBytesInArrayMultipleThreads() {
+        assertThrows(IndexOutOfBoundsException.class, super::testSliceBytesInArrayMultipleThreads);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testNioBufferExposeOnlyRegion() {
-        super.testNioBufferExposeOnlyRegion();
+        assertThrows(IndexOutOfBoundsException.class, super::testNioBufferExposeOnlyRegion);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testGetReadOnlyDirectDst() {
-        super.testGetReadOnlyDirectDst();
+        assertThrows(IndexOutOfBoundsException.class, super::testGetReadOnlyDirectDst);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testGetReadOnlyHeapDst() {
-        super.testGetReadOnlyHeapDst();
+        assertThrows(IndexOutOfBoundsException.class, super::testGetReadOnlyHeapDst);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testReadBytes() {
-        super.testReadBytes();
+        assertThrows(IndexOutOfBoundsException.class, super::testReadBytes);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     @Override
     public void testDuplicateCapacityChange() {
-        super.testDuplicateCapacityChange();
+        assertThrows(IllegalArgumentException.class, super::testDuplicateCapacityChange);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     @Override
     public void testRetainedDuplicateCapacityChange() {
-        super.testRetainedDuplicateCapacityChange();
+        assertThrows(IllegalArgumentException.class, super::testRetainedDuplicateCapacityChange);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testLittleEndianWithExpand() {
-        super.testLittleEndianWithExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testLittleEndianWithExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUsAsciiCharSequenceExpand() {
-        super.testWriteUsAsciiCharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUsAsciiCharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUtf8CharSequenceExpand() {
-        super.testWriteUtf8CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUtf8CharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteIso88591CharSequenceExpand() {
-        super.testWriteIso88591CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteIso88591CharSequenceExpand);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     @Override
     public void testWriteUtf16CharSequenceExpand() {
-        super.testWriteUtf16CharSequenceExpand();
+        assertThrows(IndexOutOfBoundsException.class, super::testWriteUtf16CharSequenceExpand);
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/search/BitapSearchProcessorFactoryTest.java
+++ b/buffer/src/test/java/io/netty/buffer/search/BitapSearchProcessorFactoryTest.java
@@ -15,7 +15,9 @@
  */
 package io.netty.buffer.search;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BitapSearchProcessorFactoryTest {
 
@@ -24,9 +26,9 @@ public class BitapSearchProcessorFactoryTest {
         new BitapSearchProcessorFactory(new byte[64]);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRejectTooLongNeedle() {
-        new BitapSearchProcessorFactory(new byte[65]);
+        assertThrows(IllegalArgumentException.class, () -> new BitapSearchProcessorFactory(new byte[65]));
     }
 
 }

--- a/buffer/src/test/java/io/netty/buffer/search/MultiSearchProcessorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/search/MultiSearchProcessorTest.java
@@ -18,9 +18,9 @@ package io.netty.buffer.search;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiSearchProcessorTest {
 

--- a/buffer/src/test/java/io/netty/buffer/search/SearchProcessorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/search/SearchProcessorTest.java
@@ -18,17 +18,13 @@ package io.netty.buffer.search;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(Parameterized.class)
 public class SearchProcessorTest {
 
     private enum Algorithm {
@@ -53,54 +49,48 @@ public class SearchProcessorTest {
         abstract SearchProcessorFactory newFactory(byte[] needle);
     }
 
-    @Parameters(name = "{0} algorithm")
-    public static Object[] algorithms() {
-        return Algorithm.values();
-    }
-
-    @Parameter
-    public Algorithm algorithm;
-
-    @Test
-    public void testSearch() {
+    @ParameterizedTest
+    @EnumSource(Algorithm.class)
+    public void testSearch(Algorithm algorithm) {
         final ByteBuf haystack = Unpooled.copiedBuffer("abc☺", CharsetUtil.UTF_8);
 
-        assertEquals(0, haystack.forEachByte(factory("a").newSearchProcessor()));
-        assertEquals(1, haystack.forEachByte(factory("ab").newSearchProcessor()));
-        assertEquals(2, haystack.forEachByte(factory("abc").newSearchProcessor()));
-        assertEquals(5, haystack.forEachByte(factory("abc☺").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("abc☺☺").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("abc☺x").newSearchProcessor()));
+        assertEquals(0, haystack.forEachByte(factory(algorithm, "a").newSearchProcessor()));
+        assertEquals(1, haystack.forEachByte(factory(algorithm, "ab").newSearchProcessor()));
+        assertEquals(2, haystack.forEachByte(factory(algorithm, "abc").newSearchProcessor()));
+        assertEquals(5, haystack.forEachByte(factory(algorithm, "abc☺").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "abc☺☺").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "abc☺x").newSearchProcessor()));
 
-        assertEquals(1, haystack.forEachByte(factory("b").newSearchProcessor()));
-        assertEquals(2, haystack.forEachByte(factory("bc").newSearchProcessor()));
-        assertEquals(5, haystack.forEachByte(factory("bc☺").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("bc☺☺").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("bc☺x").newSearchProcessor()));
+        assertEquals(1, haystack.forEachByte(factory(algorithm, "b").newSearchProcessor()));
+        assertEquals(2, haystack.forEachByte(factory(algorithm, "bc").newSearchProcessor()));
+        assertEquals(5, haystack.forEachByte(factory(algorithm, "bc☺").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "bc☺☺").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "bc☺x").newSearchProcessor()));
 
-        assertEquals(2, haystack.forEachByte(factory("c").newSearchProcessor()));
-        assertEquals(5, haystack.forEachByte(factory("c☺").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("c☺☺").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("c☺x").newSearchProcessor()));
+        assertEquals(2, haystack.forEachByte(factory(algorithm, "c").newSearchProcessor()));
+        assertEquals(5, haystack.forEachByte(factory(algorithm, "c☺").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "c☺☺").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "c☺x").newSearchProcessor()));
 
-        assertEquals(5, haystack.forEachByte(factory("☺").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("☺☺").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("☺x").newSearchProcessor()));
+        assertEquals(5, haystack.forEachByte(factory(algorithm, "☺").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "☺☺").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "☺x").newSearchProcessor()));
 
-        assertEquals(-1, haystack.forEachByte(factory("z").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("aa").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("ba").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("abcd").newSearchProcessor()));
-        assertEquals(-1, haystack.forEachByte(factory("abcde").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "z").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "aa").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "ba").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "abcd").newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, "abcde").newSearchProcessor()));
 
         haystack.release();
     }
 
-    @Test
-    public void testRepeating() {
+    @ParameterizedTest
+    @EnumSource(Algorithm.class)
+    public void testRepeating(Algorithm algorithm) {
         final ByteBuf haystack = Unpooled.copiedBuffer("abcababc", CharsetUtil.UTF_8);
         final int length = haystack.readableBytes();
-        SearchProcessor processor = factory("ab").newSearchProcessor();
+        SearchProcessor processor = factory(algorithm, "ab").newSearchProcessor();
 
         assertEquals(1,  haystack.forEachByte(processor));
         assertEquals(4,  haystack.forEachByte(2, length - 2, processor));
@@ -110,11 +100,12 @@ public class SearchProcessorTest {
         haystack.release();
     }
 
-    @Test
-    public void testOverlapping() {
+    @ParameterizedTest
+    @EnumSource(Algorithm.class)
+    public void testOverlapping(Algorithm algorithm) {
         final ByteBuf haystack = Unpooled.copiedBuffer("ababab", CharsetUtil.UTF_8);
         final int length = haystack.readableBytes();
-        SearchProcessor processor = factory("bab").newSearchProcessor();
+        SearchProcessor processor = factory(algorithm, "bab").newSearchProcessor();
 
         assertEquals(3,  haystack.forEachByte(processor));
         assertEquals(5,  haystack.forEachByte(4, length - 4, processor));
@@ -123,8 +114,9 @@ public class SearchProcessorTest {
         haystack.release();
     }
 
-    @Test
-    public void testLongInputs() {
+    @ParameterizedTest
+    @EnumSource(Algorithm.class)
+    public void testLongInputs(Algorithm algorithm) {
         final int haystackLen = 1024;
         final int needleLen = 64;
 
@@ -133,21 +125,22 @@ public class SearchProcessorTest {
         final ByteBuf haystack = Unpooled.copiedBuffer(haystackBytes); // 00000...00001
 
         final byte[] needleBytes = new byte[needleLen]; // 000...000
-        assertEquals(needleLen - 1, haystack.forEachByte(factory(needleBytes).newSearchProcessor()));
+        assertEquals(needleLen - 1, haystack.forEachByte(factory(algorithm, needleBytes).newSearchProcessor()));
 
         needleBytes[needleLen - 1] = 1; // 000...001
-        assertEquals(haystackLen - 1, haystack.forEachByte(factory(needleBytes).newSearchProcessor()));
+        assertEquals(haystackLen - 1, haystack.forEachByte(factory(algorithm, needleBytes).newSearchProcessor()));
 
         needleBytes[needleLen - 1] = 2; // 000...002
-        assertEquals(-1, haystack.forEachByte(factory(needleBytes).newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, needleBytes).newSearchProcessor()));
 
         needleBytes[needleLen - 1] = 0;
         needleBytes[0] = 1; // 100...000
-        assertEquals(-1, haystack.forEachByte(factory(needleBytes).newSearchProcessor()));
+        assertEquals(-1, haystack.forEachByte(factory(algorithm, needleBytes).newSearchProcessor()));
     }
 
-    @Test
-    public void testUniqueLen64Substrings() {
+    @ParameterizedTest
+    @EnumSource(Algorithm.class)
+    public void testUniqueLen64Substrings(Algorithm algorithm) {
         final byte[] haystackBytes = new byte[32 * 65]; // 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, ...
         int pos = 0;
         for (int i = 1; i <= 64; i++) {
@@ -159,16 +152,16 @@ public class SearchProcessorTest {
 
         for (int start = 0; start < haystackBytes.length - 64; start++) {
             final byte[] needle = Arrays.copyOfRange(haystackBytes, start, start + 64);
-            assertEquals(start + 63, haystack.forEachByte(factory(needle).newSearchProcessor()));
+            assertEquals(start + 63, haystack.forEachByte(factory(algorithm, needle).newSearchProcessor()));
         }
     }
 
-    private SearchProcessorFactory factory(byte[] needle) {
+    private SearchProcessorFactory factory(Algorithm algorithm, byte[] needle) {
         return algorithm.newFactory(needle);
     }
 
-    private SearchProcessorFactory factory(String needle) {
-        return factory(needle.getBytes(CharsetUtil.UTF_8));
+    private SearchProcessorFactory factory(Algorithm algorithm, String needle) {
+        return factory(algorithm, needle.getBytes(CharsetUtil.UTF_8));
     }
 
 }


### PR DESCRIPTION
https://github.com/netty/netty/issues/10757#issuecomment-848445551

- [x] `io.netty.buffer.ByteBufUtilTest`
- [x] `io.netty.buffer.search.SearchProcessorTest`