### PR TITLE
Migrate codec tests to JUnit 5

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageCodecTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageCodecTest.java
@@ -20,20 +20,23 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ByteToMessageCodecTest {
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testSharable() {
-        new InvalidByteToMessageCodec();
+        assertThrows(IllegalStateException.class, InvalidByteToMessageCodec::new);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testSharable2() {
-        new InvalidByteToMessageCodec2();
+        assertThrows(IllegalStateException.class, InvalidByteToMessageCodec2::new);
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -27,7 +27,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.netty.channel.socket.ChannelInputShutdownEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -35,12 +35,12 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ByteToMessageDecoderTest {
 
@@ -163,8 +163,8 @@ public class ByteToMessageDecoderTest {
     }
 
     private static void assertCumulationReleased(ByteBuf byteBuf) {
-        assertTrue("unexpected value: " + byteBuf,
-                byteBuf == null || byteBuf == Unpooled.EMPTY_BUFFER || byteBuf.refCnt() == 0);
+        assertTrue(byteBuf == null || byteBuf == Unpooled.EMPTY_BUFFER || byteBuf.refCnt() == 0,
+                "unexpected value: " + byteBuf);
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/CharSequenceValueConverterTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/CharSequenceValueConverterTest.java
@@ -15,11 +15,12 @@
 package io.netty.handler.codec;
 
 import io.netty.util.AsciiString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CharSequenceValueConverterTest {
 
@@ -36,9 +37,9 @@ public class CharSequenceValueConverterTest {
         assertEquals(127, converter.convertToByte(AsciiString.of("127")));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void testByteFromEmptyAsciiString() {
-        converter.convertToByte(AsciiString.EMPTY_STRING);
+        assertThrows(NumberFormatException.class, () ->converter.convertToByte(AsciiString.EMPTY_STRING));
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/CodecOutputListTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/CodecOutputListTest.java
@@ -15,10 +15,11 @@
  */
 package io.netty.handler.codec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CodecOutputListTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/DatagramPacketDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DatagramPacketDecoderTest.java
@@ -23,29 +23,29 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.SocketUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DatagramPacketDecoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(
                 new DatagramPacketDecoder(
                         new StringDecoder(CharsetUtil.UTF_8)));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(channel.finish());
     }

--- a/codec/src/test/java/io/netty/handler/codec/DatagramPacketEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DatagramPacketEncoderTest.java
@@ -24,27 +24,27 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.string.StringEncoder;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.SocketUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DatagramPacketEncoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(
                 new DatagramPacketEncoder<String>(
                         new StringEncoder(CharsetUtil.UTF_8)));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(channel.finish());
     }

--- a/codec/src/test/java/io/netty/handler/codec/DateFormatterTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DateFormatterTest.java
@@ -15,13 +15,14 @@
  */
 package io.netty.handler.codec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Calendar;
 import java.util.Date;
 
-import static org.junit.Assert.*;
 import static io.netty.handler.codec.DateFormatter.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DateFormatterTest {
     /**

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -16,7 +16,7 @@ package io.netty.handler.codec;
 
 import io.netty.util.AsciiString;
 import io.netty.util.HashingStrategy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -30,13 +30,14 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link DefaultHeaders}.
@@ -165,13 +166,13 @@ public class DefaultHeadersTest {
         assertFalse(itr.hasNext());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void valuesItrRemoveThrowsWhenEmpty() {
         TestDefaultHeaders headers = newInstance();
         assertEquals(0, headers.size());
         assertTrue(headers.isEmpty());
         Iterator<CharSequence> itr = headers.valueIterator(of("name"));
-        itr.remove();
+        assertThrows(IllegalStateException.class, itr::remove);
     }
 
     @Test
@@ -462,11 +463,11 @@ public class DefaultHeadersTest {
         assertEquals(h2, h2);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void iterateEmptyHeadersShouldThrow() {
         Iterator<Map.Entry<CharSequence, CharSequence>> iterator = newInstance().iterator();
         assertFalse(iterator.hasNext());
-        iterator.next();
+        assertThrows(NoSuchElementException.class, iterator::next);
     }
 
     @Test
@@ -569,10 +570,10 @@ public class DefaultHeadersTest {
         assertEquals(headers1, expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAddSelf() {
         TestDefaultHeaders headers = newInstance();
-        headers.add(headers);
+        assertThrows(IllegalArgumentException.class, () -> headers.add(headers));
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DelimiterBasedFrameDecoderTest.java
@@ -20,11 +20,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DelimiterBasedFrameDecoderTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/EmptyHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/EmptyHeadersTest.java
@@ -14,149 +14,150 @@
  */
 package io.netty.handler.codec;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EmptyHeadersTest {
 
     private static final TestEmptyHeaders HEADERS = new TestEmptyHeaders();
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddStringValue() {
-        HEADERS.add("name", "value");
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.add("name", "value"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddStringValues() {
-        HEADERS.add("name", "value1", "value2");
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.add("name", "value1", "value2"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddStringValuesIterable() {
-        HEADERS.add("name", Arrays.asList("value1", "value2"));
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.add("name", Arrays.asList("value1", "value2")));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddBoolean() {
-        HEADERS.addBoolean("name", true);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addBoolean("name", true));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddByte() {
-        HEADERS.addByte("name", (byte) 1);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addByte("name", (byte) 1));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddChar() {
-        HEADERS.addChar("name", 'a');
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addChar("name", 'a'));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddDouble() {
-        HEADERS.addDouble("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addDouble("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddFloat() {
-        HEADERS.addFloat("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addFloat("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddInt() {
-        HEADERS.addInt("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addInt("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddLong() {
-        HEADERS.addLong("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addLong("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddShort() {
-        HEADERS.addShort("name", (short) 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addShort("name", (short) 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testAddTimeMillis() {
-        HEADERS.addTimeMillis("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.addTimeMillis("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetStringValue() {
-        HEADERS.set("name", "value");
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.set("name", "value"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetStringValues() {
-        HEADERS.set("name", "value1", "value2");
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.set("name", "value1", "value2"));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetStringValuesIterable() {
-        HEADERS.set("name", Arrays.asList("value1", "value2"));
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.set("name", Arrays.asList("value1", "value2")));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetBoolean() {
-        HEADERS.setBoolean("name", true);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setBoolean("name", true));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetByte() {
-        HEADERS.setByte("name", (byte) 1);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setByte("name", (byte) 1));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetChar() {
-        HEADERS.setChar("name", 'a');
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setChar("name", 'a'));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetDouble() {
-        HEADERS.setDouble("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setDouble("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetFloat() {
-        HEADERS.setFloat("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setFloat("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetInt() {
-        HEADERS.setInt("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setInt("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetLong() {
-        HEADERS.setLong("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setLong("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetShort() {
-        HEADERS.setShort("name", (short) 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setShort("name", (short) 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetTimeMillis() {
-        HEADERS.setTimeMillis("name", 0);
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setTimeMillis("name", 0));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetAll() {
-        HEADERS.setAll(new TestEmptyHeaders());
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.setAll(new TestEmptyHeaders()));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSet() {
-        HEADERS.set(new TestEmptyHeaders());
+        assertThrows(UnsupportedOperationException.class, () -> HEADERS.set(new TestEmptyHeaders()));
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
@@ -18,9 +18,12 @@ package io.netty.handler.codec;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldBasedFrameDecoderTest {
 
@@ -36,19 +39,19 @@ public class LengthFieldBasedFrameDecoderTest {
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
         try {
             channel.writeInbound(buf);
-            Assert.fail();
+            fail();
         } catch (TooLongFrameException e) {
             // expected
         }
-        Assert.assertTrue(channel.finish());
+        assertTrue(channel.finish());
 
         ByteBuf b = channel.readInbound();
-        Assert.assertEquals(5, b.readableBytes());
-        Assert.assertEquals(1, b.readInt());
-        Assert.assertEquals('a', b.readByte());
+        assertEquals(5, b.readableBytes());
+        assertEquals(1, b.readInt());
+        assertEquals('a', b.readByte());
         b.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
         channel.finish();
     }
 
@@ -64,21 +67,21 @@ public class LengthFieldBasedFrameDecoderTest {
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
         try {
             channel.writeInbound(buf.readRetainedSlice(14));
-            Assert.fail();
+            fail();
         } catch (TooLongFrameException e) {
             // expected
         }
-        Assert.assertTrue(channel.writeInbound(buf.readRetainedSlice(buf.readableBytes())));
+        assertTrue(channel.writeInbound(buf.readRetainedSlice(buf.readableBytes())));
 
-        Assert.assertTrue(channel.finish());
+        assertTrue(channel.finish());
 
         ByteBuf b = channel.readInbound();
-        Assert.assertEquals(5, b.readableBytes());
-        Assert.assertEquals(1, b.readInt());
-        Assert.assertEquals('a', b.readByte());
+        assertEquals(5, b.readableBytes());
+        assertEquals(1, b.readInt());
+        assertEquals('a', b.readByte());
         b.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
         channel.finish();
 
         buf.release();

--- a/codec/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
@@ -19,12 +19,16 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LineBasedFrameDecoderTest {
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
@@ -17,9 +17,11 @@
 package io.netty.handler.codec;
 
 import io.netty.channel.ChannelHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import io.netty.buffer.ByteBuf;

--- a/codec/src/test/java/io/netty/handler/codec/MessageToMessageEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/MessageToMessageEncoderTest.java
@@ -20,18 +20,20 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
-
 
 public class MessageToMessageEncoderTest {
 
     /**
      * Test-case for https://github.com/netty/netty/issues/1656
      */
-    @Test(expected = EncoderException.class)
+    @Test
     public void testException() {
         EmbeddedChannel channel = new EmbeddedChannel(new MessageToMessageEncoder<Object>() {
             @Override
@@ -39,7 +41,7 @@ public class MessageToMessageEncoderTest {
                 throw new Exception();
             }
         });
-        channel.writeOutbound(new Object());
+        assertThrows(EncoderException.class, () -> channel.writeOutbound(new Object()));
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
@@ -19,9 +19,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.netty.util.Signal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReplayingDecoderByteBufTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
@@ -21,14 +21,17 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReplayingDecoderTest {
 
@@ -119,7 +122,7 @@ public class ReplayingDecoderTest {
         buf.release();
         buf2.release();
 
-        assertNull("Must be null as it must only decode one frame", ch.readInbound());
+        assertNull(ch.readInbound(), "Must be null as it must only decode one frame");
 
         ch.read();
         ch.finish();
@@ -176,7 +179,7 @@ public class ReplayingDecoderTest {
         channel.writeInbound(buf.copy());
         ByteBuf b = channel.readInbound();
 
-        assertEquals("Expect to have still all bytes in the buffer", b, buf);
+        assertEquals(b, buf, "Expect to have still all bytes in the buffer");
         b.release();
         buf.release();
     }
@@ -309,7 +312,7 @@ public class ReplayingDecoderTest {
     }
 
     private static void assertCumulationReleased(ByteBuf byteBuf) {
-        assertTrue("unexpected value: " + byteBuf,
-                byteBuf == null || byteBuf == Unpooled.EMPTY_BUFFER || byteBuf.refCnt() == 0);
+        assertTrue(byteBuf == null || byteBuf == Unpooled.EMPTY_BUFFER || byteBuf.refCnt() == 0,
+                "unexpected value: " + byteBuf);
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/base64/Base64Test.java
+++ b/codec/src/test/java/io/netty/handler/codec/base64/Base64Test.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteOrder;
@@ -29,7 +29,9 @@ import java.security.cert.X509Certificate;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class Base64Test {
 
@@ -149,8 +151,9 @@ public class Base64Test {
         ByteBuf decoded = Base64.decode(encoded);
         ByteBuf expectedBuf = Unpooled.wrappedBuffer(bytes);
         try {
-            assertEquals(StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(expectedBuf) +
-                         StringUtil.NEWLINE + "actual--: " + ByteBufUtil.hexDump(decoded), expectedBuf, decoded);
+            assertEquals(expectedBuf, decoded,
+                        StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(expectedBuf) +
+                         StringUtil.NEWLINE + "actual--: " + ByteBufUtil.hexDump(decoded));
         } finally {
             src.release();
             encoded.release();

--- a/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
@@ -17,8 +17,8 @@ package io.netty.handler.codec.bytes;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
@@ -30,7 +30,7 @@ public class ByteArrayDecoderTest {
 
     private EmbeddedChannel ch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ch = new EmbeddedChannel(new ByteArrayDecoder());
     }

--- a/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
@@ -18,9 +18,9 @@ package io.netty.handler.codec.bytes;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
@@ -32,12 +32,12 @@ public class ByteArrayEncoderTest {
 
     private EmbeddedChannel ch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ch = new EmbeddedChannel(new ByteArrayEncoder());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertThat(ch.finish(), is(false));
     }

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
@@ -19,18 +19,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Theories.class)
 public abstract class AbstractEncoderTest extends AbstractCompressionTest {
 
     protected EmbeddedChannel channel;
@@ -40,10 +36,14 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
      */
     protected abstract ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception;
 
-    @Before
-    public abstract void initChannel();
+    @BeforeEach
+    public final void initChannel() {
+        channel = createChannel();
+    }
 
-    @After
+    protected abstract EmbeddedChannel createChannel();
+
+    @AfterEach
     public void destroyChannel() {
         if (channel != null) {
             channel.finishAndReleaseAll();
@@ -51,7 +51,6 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         }
     }
 
-    @DataPoints("smallData")
     public static ByteBuf[] smallData() {
         ByteBuf heap = Unpooled.wrappedBuffer(BYTES_SMALL);
         ByteBuf direct = Unpooled.directBuffer(BYTES_SMALL.length);
@@ -59,7 +58,6 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         return new ByteBuf[] {heap, direct};
     }
 
-    @DataPoints("largeData")
     public static ByteBuf[] largeData() {
         ByteBuf heap = Unpooled.wrappedBuffer(BYTES_LARGE);
         ByteBuf direct = Unpooled.directBuffer(BYTES_LARGE.length);
@@ -67,18 +65,21 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         return new ByteBuf[] {heap, direct};
     }
 
-    @Theory
-    public void testCompressionOfSmallChunkOfData(@FromDataPoints("smallData") ByteBuf data) throws Exception {
+    @ParameterizedTest
+    @MethodSource("smallData")
+    public void testCompressionOfSmallChunkOfData(ByteBuf data) throws Exception {
         testCompression(data);
     }
 
-    @Theory
-    public void testCompressionOfLargeChunkOfData(@FromDataPoints("largeData") ByteBuf data) throws Exception {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testCompressionOfLargeChunkOfData(ByteBuf data) throws Exception {
         testCompression(data);
     }
 
-    @Theory
-    public void testCompressionOfBatchedFlowOfData(@FromDataPoints("largeData") ByteBuf data) throws Exception {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testCompressionOfBatchedFlowOfData(ByteBuf data) throws Exception {
         testCompressionOfBatchedFlow(data);
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -22,16 +22,18 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractIntegrationTest {
 
@@ -43,13 +45,13 @@ public abstract class AbstractIntegrationTest {
     protected abstract EmbeddedChannel createEncoder();
     protected abstract EmbeddedChannel createDecoder();
 
-    @Before
+    @BeforeEach
     public void initChannels() throws Exception {
         encoder = createEncoder();
         decoder = createDecoder();
     }
 
-    @After
+    @AfterEach
     public void closeChannels() throws Exception {
         encoder.close();
         for (;;) {

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -21,22 +21,18 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.experimental.theories.DataPoints;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theories;
-import org.junit.experimental.theories.Theory;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Theories.class)
 public class BrotliDecoderTest {
 
     private static final Random RANDOM;
@@ -78,12 +74,12 @@ public class BrotliDecoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void initChannel() {
         channel = new EmbeddedChannel(new BrotliDecoder());
     }
 
-    @After
+    @AfterEach
     public void destroyChannel() {
         if (channel != null) {
             channel.finishAndReleaseAll();
@@ -91,7 +87,6 @@ public class BrotliDecoderTest {
         }
     }
 
-    @DataPoints("smallData")
     public static ByteBuf[] smallData() {
         ByteBuf heap = Unpooled.wrappedBuffer(COMPRESSED_BYTES_SMALL);
         ByteBuf direct = Unpooled.directBuffer(COMPRESSED_BYTES_SMALL.length);
@@ -99,7 +94,6 @@ public class BrotliDecoderTest {
         return new ByteBuf[]{heap, direct};
     }
 
-    @DataPoints("largeData")
     public static ByteBuf[] largeData() {
         ByteBuf heap = Unpooled.wrappedBuffer(COMPRESSED_BYTES_LARGE);
         ByteBuf direct = Unpooled.directBuffer(COMPRESSED_BYTES_LARGE.length);
@@ -107,18 +101,21 @@ public class BrotliDecoderTest {
         return new ByteBuf[]{heap, direct};
     }
 
-    @Theory
-    public void testDecompressionOfSmallChunkOfData(@FromDataPoints("smallData") ByteBuf data) {
+    @ParameterizedTest
+    @MethodSource("smallData")
+    public void testDecompressionOfSmallChunkOfData(ByteBuf data) {
         testDecompression(WRAPPED_BYTES_SMALL, data);
     }
 
-    @Theory
-    public void testDecompressionOfLargeChunkOfData(@FromDataPoints("largeData") ByteBuf data) {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testDecompressionOfLargeChunkOfData(ByteBuf data) {
         testDecompression(WRAPPED_BYTES_LARGE, data);
     }
 
-    @Theory
-    public void testDecompressionOfBatchedFlowOfData(@FromDataPoints("largeData") ByteBuf data) {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testDecompressionOfBatchedFlowOfData(ByteBuf data) {
         testDecompressionOfBatchedFlow(WRAPPED_BYTES_LARGE, data);
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/ByteBufChecksumTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ByteBufChecksumTest.java
@@ -18,8 +18,8 @@ package io.netty.handler.codec.compression;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import net.jpountz.xxhash.XXHashFactory;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 import java.util.zip.Adler32;
@@ -27,13 +27,13 @@ import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
 import static io.netty.handler.codec.compression.Lz4Constants.DEFAULT_SEED;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ByteBufChecksumTest {
 
     private static final byte[] BYTE_ARRAY = new byte[1024];
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         new Random().nextBytes(BYTE_ARRAY);
     }

--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
@@ -24,13 +24,13 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import java.io.InputStream;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Bzip2EncoderTest extends AbstractEncoderTest {
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new Bzip2Encoder(MIN_BLOCK_SIZE));
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new Bzip2Encoder(MIN_BLOCK_SIZE));
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2IntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2IntegrationTest.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Bzip2IntegrationTest extends AbstractIntegrationTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
@@ -22,7 +22,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class FastLzIntegrationTest extends AbstractIntegrationTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
@@ -19,12 +19,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import net.jpountz.lz4.LZ4BlockOutputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
 import static io.netty.handler.codec.compression.Lz4Constants.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Lz4FrameDecoderTest extends AbstractDecoderTest {
 
@@ -42,91 +43,71 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
     }
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new Lz4FrameDecoder(true));
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new Lz4FrameDecoder(true));
     }
 
     @Test
-    public void testUnexpectedBlockIdentifier() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("unexpected block identifier");
-
+    public void testUnexpectedBlockIdentifier() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[1] = 0x00;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected block identifier");
     }
 
     @Test
-    public void testInvalidCompressedLength() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("invalid compressedLength");
-
+    public void testInvalidCompressedLength() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[12] = (byte) 0xFF;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "invalid compressedLength");
     }
 
     @Test
-    public void testInvalidDecompressedLength() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("invalid decompressedLength");
-
+    public void testInvalidDecompressedLength() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[16] = (byte) 0xFF;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "invalid decompressedLength");
     }
 
     @Test
-    public void testDecompressedAndCompressedLengthMismatch() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("mismatch");
-
+    public void testDecompressedAndCompressedLengthMismatch() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[13] = 0x01;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "mismatch");
     }
 
     @Test
-    public void testUnexpectedBlockType() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("unexpected blockType");
-
+    public void testUnexpectedBlockType() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[8] = 0x36;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected blockType");
     }
 
     @Test
-    public void testMismatchingChecksum() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("mismatching checksum");
-
+    public void testMismatchingChecksum() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[17] = 0x01;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "mismatching checksum");
     }
 
     @Test
-    public void testChecksumErrorOfLastBlock() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("checksum error");
-
+    public void testChecksumErrorOfLastBlock() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[44] = 0x01;
 
-        tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data));
+        assertThrows(DecompressionException.class,
+            () -> tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data)), "checksum error");
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -33,12 +33,13 @@ import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.EncoderException;
+import java.util.concurrent.TimeUnit;
 import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.xxhash.XXHashFactory;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -53,9 +54,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 public class Lz4FrameEncoderTest extends AbstractEncoderTest {
@@ -75,15 +78,15 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     @Mock
     private ByteBuf buffer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
         when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
     }
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new Lz4FrameEncoder());
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new Lz4FrameEncoder());
     }
 
     @Override
@@ -139,11 +142,11 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         try {
             Lz4FrameEncoder encoder = newEncoder(blockSize, Lz4FrameEncoder.DEFAULT_MAX_ENCODE_SIZE);
             out = encoder.allocateBuffer(ctx, in, preferDirect);
-            Assert.assertNotNull(out);
+            assertNotNull(out);
             if (NONALLOCATABLE_SIZE == bufSize) {
-                Assert.assertFalse(out.isWritable());
+                assertFalse(out.isWritable());
             } else {
-                Assert.assertTrue(out.writableBytes() > 0);
+                assertTrue(out.writableBytes() > 0);
                 if (!preferDirect) {
                     // Only check if preferDirect is not true as if a direct buffer is returned or not depends on
                     // if sun.misc.Unsafe is present.
@@ -158,7 +161,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         }
     }
 
-    @Test (expected = EncoderException.class)
+    @Test
     public void testAllocateDirectBufferExceedMaxEncodeSize() {
         final int maxEncodeSize = 1024;
         Lz4FrameEncoder encoder = newEncoder(Lz4Constants.DEFAULT_BLOCK_SIZE, maxEncodeSize);
@@ -166,7 +169,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(inputBufferSize, inputBufferSize);
         try {
             buf.writerIndex(inputBufferSize);
-            encoder.allocateBuffer(ctx, buf, false);
+            assertThrows(EncoderException.class, () -> encoder.allocateBuffer(ctx, buf, false));
         } finally {
             buf.release();
         }
@@ -187,13 +190,13 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
      * {@link Lz4FrameEncoder#allocateBuffer(ChannelHandlerContext, ByteBuf, boolean)}, but this is safest way
      * of testing the overflow conditions as allocating the huge buffers fails in many CI environments.
      */
-    @Test (expected = EncoderException.class)
+    @Test
     public void testAllocateOnHeapBufferOverflowsOutputSize() {
         final int maxEncodeSize = Integer.MAX_VALUE;
         Lz4FrameEncoder encoder = newEncoder(Lz4Constants.DEFAULT_BLOCK_SIZE, maxEncodeSize);
         when(buffer.readableBytes()).thenReturn(maxEncodeSize);
         buffer.writerIndex(maxEncodeSize);
-        encoder.allocateBuffer(ctx, buffer, false);
+        assertThrows(EncoderException.class, () -> encoder.allocateBuffer(ctx, buffer, false));
     }
 
     @Test
@@ -203,14 +206,14 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         int size = 27;
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(size, size);
         buf.writerIndex(size);
-        Assert.assertEquals(0, encoder.getBackingBuffer().readableBytes());
+        assertEquals(0, encoder.getBackingBuffer().readableBytes());
         channel.write(buf);
-        Assert.assertTrue(channel.outboundMessages().isEmpty());
-        Assert.assertEquals(size, encoder.getBackingBuffer().readableBytes());
+        assertTrue(channel.outboundMessages().isEmpty());
+        assertEquals(size, encoder.getBackingBuffer().readableBytes());
         channel.flush();
-        Assert.assertTrue(channel.finish());
-        Assert.assertTrue(channel.releaseOutbound());
-        Assert.assertFalse(channel.releaseInbound());
+        assertTrue(channel.finish());
+        assertTrue(channel.releaseOutbound());
+        assertFalse(channel.releaseInbound());
     }
 
     @Test
@@ -222,24 +225,25 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         int size = blockSize - 1;
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(size, size);
         buf.writerIndex(size);
-        Assert.assertEquals(0, encoder.getBackingBuffer().readableBytes());
+        assertEquals(0, encoder.getBackingBuffer().readableBytes());
         channel.write(buf);
-        Assert.assertEquals(size, encoder.getBackingBuffer().readableBytes());
+        assertEquals(size, encoder.getBackingBuffer().readableBytes());
 
         int nextSize = size - 1;
         buf = ByteBufAllocator.DEFAULT.buffer(nextSize, nextSize);
         buf.writerIndex(nextSize);
         channel.write(buf);
-        Assert.assertEquals(size + nextSize - blockSize, encoder.getBackingBuffer().readableBytes());
+        assertEquals(size + nextSize - blockSize, encoder.getBackingBuffer().readableBytes());
 
         channel.flush();
-        Assert.assertEquals(0, encoder.getBackingBuffer().readableBytes());
-        Assert.assertTrue(channel.finish());
-        Assert.assertTrue(channel.releaseOutbound());
-        Assert.assertFalse(channel.releaseInbound());
+        assertEquals(0, encoder.getBackingBuffer().readableBytes());
+        assertTrue(channel.finish());
+        assertTrue(channel.releaseOutbound());
+        assertFalse(channel.releaseInbound());
     }
 
-    @Test(timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void writingAfterClosedChannelDoesNotNPE() throws InterruptedException {
         EventLoopGroup group = new MultithreadEventLoopGroup(2, NioHandler.newFactory());
         Channel serverChannel = null;

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
@@ -19,9 +19,10 @@ import com.ning.compress.lzf.LZFEncoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.ning.compress.lzf.LZFChunk.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LzfDecoderTest extends AbstractDecoderTest {
 
@@ -29,35 +30,29 @@ public class LzfDecoderTest extends AbstractDecoderTest {
     }
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new LzfDecoder());
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new LzfDecoder());
     }
 
     @Test
-    public void testUnexpectedBlockIdentifier() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("unexpected block identifier");
-
+    public void testUnexpectedBlockIdentifier() {
         ByteBuf in = Unpooled.buffer();
         in.writeShort(0x1234);  //random value
         in.writeByte(BLOCK_TYPE_NON_COMPRESSED);
         in.writeShort(0);
 
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected block identifier");
     }
 
     @Test
-    public void testUnknownTypeOfChunk() throws Exception {
-        expected.expect(DecompressionException.class);
-        expected.expectMessage("unknown type of chunk");
-
+    public void testUnknownTypeOfChunk() {
         ByteBuf in = Unpooled.buffer();
         in.writeByte(BYTE_Z);
         in.writeByte(BYTE_V);
         in.writeByte(0xFF);   //random value
         in.writeInt(0);
 
-        channel.writeInbound(in);
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unknown type of chunk");
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfEncoderTest.java
@@ -23,8 +23,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 public class LzfEncoderTest extends AbstractEncoderTest {
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new LzfEncoder());
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new LzfEncoder());
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzmaFrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzmaFrameEncoderTest.java
@@ -22,26 +22,27 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import lzma.sdk.lzma.Decoder;
 import lzma.streams.LzmaInputStream;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.experimental.theories.Theory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LzmaFrameEncoderTest extends AbstractEncoderTest {
 
     @Override
-    public void initChannel() {
-        channel = new EmbeddedChannel(new LzmaFrameEncoder());
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new LzmaFrameEncoder());
     }
 
-    @Theory
+    @ParameterizedTest
+    @MethodSource("smallData")
     @Override
-    public void testCompressionOfBatchedFlowOfData(@FromDataPoints("smallData") ByteBuf data) throws Exception {
+    public void testCompressionOfBatchedFlowOfData(ByteBuf data) throws Exception {
         testCompressionOfBatchedFlow(data);
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameEncoderTest.java
@@ -19,15 +19,15 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SnappyFrameEncoderTest {
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(new SnappyFrameEncoder());
     }

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
@@ -18,18 +18,19 @@ package io.netty.handler.codec.compression;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.compression.Snappy.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.CharBuffer;
 
 public class SnappyTest {
     private final Snappy snappy = new Snappy();
 
-    @After
+    @AfterEach
     public void resetSnappy() {
         snappy.reset();
     }
@@ -48,7 +49,7 @@ public class SnappyTest {
         ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
             0x6e, 0x65, 0x74, 0x74, 0x79
         });
-        assertEquals("Literal was not decoded correctly", expected, out);
+        assertEquals(expected, out, "Literal was not decoded correctly");
 
         in.release();
         out.release();
@@ -71,15 +72,15 @@ public class SnappyTest {
         ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
             0x6e, 0x65, 0x74, 0x74, 0x79, 0x6e, 0x65, 0x74, 0x74, 0x79
         });
-        assertEquals("Copy was not decoded correctly", expected, out);
+        assertEquals(expected, out, "Copy was not decoded correctly");
 
         in.release();
         out.release();
         expected.release();
     }
 
-    @Test(expected = DecompressionException.class)
-    public void testDecodeCopyWithTinyOffset() throws Exception {
+    @Test
+    public void testDecodeCopyWithTinyOffset() {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
             0x0b, // preamble length
             0x04 << 2, // literal tag + length
@@ -89,15 +90,15 @@ public class SnappyTest {
         });
         ByteBuf out = Unpooled.buffer(10);
         try {
-            snappy.decode(in, out);
+            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
         } finally {
             in.release();
             out.release();
         }
     }
 
-    @Test(expected = DecompressionException.class)
-    public void testDecodeCopyWithOffsetBeforeChunk() throws Exception {
+    @Test
+    public void testDecodeCopyWithOffsetBeforeChunk() {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
             0x0a, // preamble length
             0x04 << 2, // literal tag + length
@@ -107,15 +108,15 @@ public class SnappyTest {
         });
         ByteBuf out = Unpooled.buffer(10);
         try {
-            snappy.decode(in, out);
+            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
         } finally {
             in.release();
             out.release();
         }
     }
 
-    @Test(expected = DecompressionException.class)
-    public void testDecodeWithOverlyLongPreamble() throws Exception {
+    @Test
+    public void testDecodeWithOverlyLongPreamble() {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
             -0x80, -0x80, -0x80, -0x80, 0x7f, // preamble length
             0x04 << 2, // literal tag + length
@@ -123,7 +124,7 @@ public class SnappyTest {
         });
         ByteBuf out = Unpooled.buffer(10);
         try {
-            snappy.decode(in, out);
+            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
         } finally {
             in.release();
             out.release();
@@ -143,7 +144,7 @@ public class SnappyTest {
             0x04 << 2, // literal tag + length
             0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
         });
-        assertEquals("Encoded literal was invalid", expected, out);
+        assertEquals(expected, out, "Encoded literal was invalid");
 
         in.release();
         out.release();
@@ -216,7 +217,7 @@ public class SnappyTest {
             0x11, 0x4c,
         });
 
-        assertEquals("Encoded result was incorrect", expected, out);
+        assertEquals(expected, out, "Encoded result was incorrect");
 
         // Decode
         ByteBuf outDecoded = Unpooled.buffer();
@@ -260,13 +261,13 @@ public class SnappyTest {
         input.release();
     }
 
-    @Test(expected = DecompressionException.class)
+    @Test
     public void testValidateChecksumFails() {
         ByteBuf input = Unpooled.wrappedBuffer(new byte[] {
                 'y', 't', 't', 'e', 'n'
         });
         try {
-            validateChecksum(maskChecksum(0xd6cb8b55), input);
+            assertThrows(DecompressionException.class, () -> validateChecksum(maskChecksum(0xd6cb8b55), input));
         } finally {
             input.release();
         }
@@ -290,7 +291,7 @@ public class SnappyTest {
                 encodeLiteral(in, encoded, len);
                 byte tag = encoded.readByte();
                 decodeLiteral(tag, encoded, decoded);
-                assertEquals("Encoded or decoded literal was incorrect", expected, decoded);
+                assertEquals(expected, decoded, "Encoded or decoded literal was incorrect");
             } finally {
                 in.release();
                 encoded.release();

--- a/codec/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
@@ -23,9 +23,11 @@ import io.netty.handler.codec.DelimiterBasedFrameDecoder;
 import io.netty.handler.codec.Delimiters;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DelimiterBasedFrameDecoderTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
@@ -22,9 +22,12 @@ import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldBasedFrameDecoderTest {
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
@@ -20,19 +20,22 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.util.CharsetUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldPrependerTest {
 
     private ByteBuf msg;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         msg = copiedBuffer("A", CharsetUtil.ISO_8859_1);
     }
@@ -107,7 +110,7 @@ public class LengthFieldPrependerTest {
         buf = ch.readOutbound();
         assertSame(buf, msg);
         buf.release();
-        assertFalse("The channel must have been completely read", ch.finish());
+        assertFalse(ch.finish(), "The channel must have been completely read");
     }
 
 }

--- a/codec/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
@@ -22,9 +22,13 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonObjectDecoderTest {
     @Test
@@ -248,19 +252,18 @@ public class JsonObjectDecoderTest {
         assertFalse(ch.finish());
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test
     public void testNonJsonContent1() {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         try {
-            ch.writeInbound(Unpooled.copiedBuffer("  b [1,2,3]", CharsetUtil.UTF_8));
+            assertThrows(CorruptedFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer("  b [1,2,3]", CharsetUtil.UTF_8)));
         } finally {
             assertFalse(ch.finish());
         }
-
-        fail();
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test
     public void testNonJsonContent2() {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         ch.writeInbound(Unpooled.copiedBuffer("  [1,2,3]  ", CharsetUtil.UTF_8));
@@ -270,24 +273,22 @@ public class JsonObjectDecoderTest {
         res.release();
 
         try {
-            ch.writeInbound(Unpooled.copiedBuffer(" a {\"key\" : 10}", CharsetUtil.UTF_8));
+            assertThrows(CorruptedFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer(" a {\"key\" : 10}", CharsetUtil.UTF_8)));
         } finally {
             assertFalse(ch.finish());
         }
-
-        fail();
     }
 
-    @Test (expected = TooLongFrameException.class)
+    @Test
     public void testMaxObjectLength() {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder(6));
         try {
-            ch.writeInbound(Unpooled.copiedBuffer("[2,4,5]", CharsetUtil.UTF_8));
+            assertThrows(TooLongFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer("[2,4,5]", CharsetUtil.UTF_8)));
         } finally {
             assertFalse(ch.finish());
         }
-
-        fail();
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingDecoderTest.java
@@ -23,15 +23,15 @@ import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractCompatibleMarshallingDecoderTest extends AbstractMarshallingTest {
     @SuppressWarnings("RedundantStringConstructorCall")

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingEncoderTest.java
@@ -22,9 +22,11 @@ import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.Unmarshaller;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractCompatibleMarshallingEncoderTest extends AbstractMarshallingTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractMarshallingTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractMarshallingTest.java
@@ -17,15 +17,16 @@ package io.netty.handler.codec.marshalling;
 
 import io.netty.util.internal.PlatformDependent;
 import org.jboss.marshalling.Marshalling;
-import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public abstract class AbstractMarshallingTest {
 
     static final String SERIAL_FACTORY = "serial";
     static final String RIVER_FACTORY = "river";
 
-    @BeforeClass
+    @BeforeAll
     public static void checkSupported() throws Throwable {
         Throwable error = null;
         try {
@@ -37,6 +38,6 @@ public abstract class AbstractMarshallingTest {
             }
             error = cause;
         }
-        Assume.assumeNoException(error);
+        assumeTrue(error == null, error + " was not null");
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/RiverMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/RiverMarshallingDecoderTest.java
@@ -22,7 +22,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.TooLongFrameException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RiverMarshallingDecoderTest extends RiverCompatibleMarshallingDecoderTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/SerialMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/SerialMarshallingDecoderTest.java
@@ -22,7 +22,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.TooLongFrameException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SerialMarshallingDecoderTest extends SerialCompatibleMarshallingDecoderTest {
 

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
@@ -17,20 +17,21 @@ package io.netty.handler.codec.protobuf;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsNull.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProtobufVarint32FrameDecoderTest {
 
     private EmbeddedChannel ch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ch = new EmbeddedChannel(new ProtobufVarint32FrameDecoder());
     }

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -17,19 +17,20 @@ package io.netty.handler.codec.protobuf;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProtobufVarint32LengthFieldPrependerTest {
 
     private EmbeddedChannel ch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ch = new EmbeddedChannel(new ProtobufVarint32LengthFieldPrepender());
     }

--- a/codec/src/test/java/io/netty/handler/codec/serialization/CompactObjectSerializationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/serialization/CompactObjectSerializationTest.java
@@ -19,8 +19,8 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CompactObjectSerializationTest {
 
@@ -31,6 +31,6 @@ public class CompactObjectSerializationTest {
         CompactObjectOutputStream out = new CompactObjectOutputStream(pipeOut);
         CompactObjectInputStream in = new CompactObjectInputStream(pipeIn, ClassResolvers.cacheDisabled(null));
         out.writeObject(List.class);
-        Assert.assertSame(List.class, in.readObject());
+        Assertions.assertSame(List.class, in.readObject());
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
@@ -18,14 +18,14 @@ package io.netty.handler.codec.serialization;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class CompatibleObjectEncoderTest {
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/string/LineEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/string/LineEncoderTest.java
@@ -18,11 +18,12 @@ package io.netty.handler.codec.string;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LineEncoderTest {
 
@@ -41,8 +42,8 @@ public class LineEncoderTest {
             byte[] data = new byte[buf.readableBytes()];
             buf.readBytes(data);
             byte[] expected = (msg + lineSeparator.value()).getBytes(CharsetUtil.UTF_8);
-            Assert.assertArrayEquals(expected, data);
-            Assert.assertNull(channel.readOutbound());
+            assertArrayEquals(expected, data);
+            assertNull(channel.readOutbound());
         } finally {
             buf.release();
             assertFalse(channel.finish());

--- a/codec/src/test/java/io/netty/handler/codec/string/StringEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/string/StringEncoderTest.java
@@ -18,8 +18,8 @@ package io.netty.handler.codec.string;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StringEncoderTest {
 
@@ -27,13 +27,13 @@ public class StringEncoderTest {
     public void testEncode() {
         String msg = "Test";
         EmbeddedChannel channel = new EmbeddedChannel(new StringEncoder());
-        Assert.assertTrue(channel.writeOutbound(msg));
-        Assert.assertTrue(channel.finish());
+        Assertions.assertTrue(channel.writeOutbound(msg));
+        Assertions.assertTrue(channel.finish());
         ByteBuf buf = channel.readOutbound();
         byte[] data = new byte[buf.readableBytes()];
         buf.readBytes(data);
-        Assert.assertArrayEquals(msg.getBytes(CharsetUtil.UTF_8), data);
-        Assert.assertNull(channel.readOutbound());
+        Assertions.assertArrayEquals(msg.getBytes(CharsetUtil.UTF_8), data);
+        Assertions.assertNull(channel.readOutbound());
         buf.release();
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
@@ -22,7 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -38,6 +38,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class XmlFrameDecoderTest {
 
@@ -50,35 +51,38 @@ public class XmlFrameDecoderTest {
         );
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithIllegalArgs01() {
-        new XmlFrameDecoder(0);
+        assertThrows(IllegalArgumentException.class, () -> new XmlFrameDecoder(0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructorWithIllegalArgs02() {
-        new XmlFrameDecoder(-23);
+        assertThrows(IllegalArgumentException.class, () -> new XmlFrameDecoder(-23));
     }
 
-    @Test(expected = TooLongFrameException.class)
+    @Test
     public void testDecodeWithFrameExceedingMaxLength() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(3);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8));
+        assertThrows(TooLongFrameException.class,
+            () -> ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8)));
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test
     public void testDecodeWithInvalidInput() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        ch.writeInbound(Unpooled.copiedBuffer("invalid XML", CharsetUtil.UTF_8));
+        assertThrows(CorruptedFrameException.class,
+            () -> ch.writeInbound(Unpooled.copiedBuffer("invalid XML", CharsetUtil.UTF_8)));
     }
 
-    @Test(expected = CorruptedFrameException.class)
+    @Test
     public void testDecodeWithInvalidContentBeforeXml() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        ch.writeInbound(Unpooled.copiedBuffer("invalid XML<foo/>", CharsetUtil.UTF_8));
+        assertThrows(CorruptedFrameException.class,
+            () -> ch.writeInbound(Unpooled.copiedBuffer("invalid XML<foo/>", CharsetUtil.UTF_8)));
     }
 
     @Test


### PR DESCRIPTION
https://github.com/netty/netty/issues/10757#issuecomment-848445551

- [x] `io.netty.handler.codec.marshalling.AbstractMarshallingTest`