### PR TITLE
Migrate codec-stomp tests to JUnit 5

### DIFF
--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
@@ -16,12 +16,12 @@
 package io.netty.handler.codec.stomp;
 
 import io.netty.util.AsciiString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultStompFrameTest {
 

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompCommandDecodeTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompCommandDecodeTest.java
@@ -20,42 +20,36 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.Arrays;
 import java.util.Collection;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static io.netty.util.CharsetUtil.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Parameterized.class)
 public class StompCommandDecodeTest {
-
-    private final String rawCommand;
-    private final StompCommand expectedCommand;
-    private final Boolean valid;
 
     private EmbeddedChannel channel;
 
-    public StompCommandDecodeTest(String rawCommand, StompCommand expectedCommand, Boolean valid) {
-        this.rawCommand = rawCommand;
-        this.expectedCommand = expectedCommand;
-        this.valid = valid;
-    }
-
-    @Before
+    @BeforeEach
     public void setUp() {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         assertFalse(channel.finish());
     }
 
-    @Test
-    public void testDecodeCommand() {
+    @ParameterizedTest(name = "{index}: testDecodeCommand({0}) = {1}")
+    @MethodSource("stompCommands")
+    public void testDecodeCommand(String rawCommand, StompCommand expectedCommand, Boolean valid) {
         byte[] frameContent = String.format("%s\n\n\0", rawCommand).getBytes(UTF_8);
         ByteBuf incoming = Unpooled.wrappedBuffer(frameContent);
         assertTrue(channel.writeInbound(incoming));
@@ -77,7 +71,6 @@ public class StompCommandDecodeTest {
         }
     }
 
-    @Parameterized.Parameters(name = "{index}: testDecodeCommand({0}) = {1}")
     public static Collection<Object[]> stompCommands() {
         return Arrays.asList(new Object[][] {
                 { "STOMP", StompCommand.STOMP, true },

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompHeadersTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompHeadersTest.java
@@ -16,10 +16,10 @@
 package io.netty.handler.codec.stomp;
 
 import io.netty.util.AsciiString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class StompHeadersTest {
     @Test

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeAggregatorTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeAggregatorTest.java
@@ -20,23 +20,28 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StompSubframeAggregatorTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder(), new StompSubframeAggregator(100000));
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
-        Assert.assertFalse(channel.finish());
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -48,7 +53,7 @@ public class StompSubframeAggregatorTest {
         StompFrame frame = channel.readInbound();
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -58,12 +63,12 @@ public class StompSubframeAggregatorTest {
         channel.writeInbound(incoming);
 
         StompFrame frame = channel.readInbound();
-        Assert.assertNotNull(frame);
-        Assert.assertEquals(StompCommand.SEND, frame.command());
-        Assert.assertEquals("hello, queue a!!!", frame.content().toString(CharsetUtil.UTF_8));
+        assertNotNull(frame);
+        assertEquals(StompCommand.SEND, frame.command());
+        assertEquals("hello, queue a!!!", frame.content().toString(CharsetUtil.UTF_8));
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -73,12 +78,12 @@ public class StompSubframeAggregatorTest {
         channel.writeInbound(incoming);
 
         StompFrame frame = channel.readInbound();
-        Assert.assertNotNull(frame);
-        Assert.assertEquals(StompCommand.SEND, frame.command());
-        Assert.assertEquals("body", frame.content().toString(CharsetUtil.UTF_8));
+        assertNotNull(frame);
+        assertEquals(StompCommand.SEND, frame.command());
+        assertEquals("body", frame.content().toString(CharsetUtil.UTF_8));
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -91,12 +96,12 @@ public class StompSubframeAggregatorTest {
         }
 
         StompFrame frame = channel.readInbound();
-        Assert.assertNotNull(frame);
-        Assert.assertEquals(StompCommand.SEND, frame.command());
-        Assert.assertEquals("first part of body\nsecond part of body", frame.content().toString(CharsetUtil.UTF_8));
+        assertNotNull(frame);
+        assertEquals(StompCommand.SEND, frame.command());
+        assertEquals("first part of body\nsecond part of body", frame.content().toString(CharsetUtil.UTF_8));
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -108,11 +113,11 @@ public class StompSubframeAggregatorTest {
         channel.writeInbound(incoming);
 
         StompFrame frame = channel.readInbound();
-        Assert.assertNotNull(frame);
-        Assert.assertEquals(StompCommand.SEND, frame.command());
+        assertNotNull(frame);
+        assertEquals(StompCommand.SEND, frame.command());
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -124,23 +129,24 @@ public class StompSubframeAggregatorTest {
         channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes()));
 
         StompFrame frame = channel.readInbound();
-        Assert.assertEquals(StompCommand.CONNECT, frame.command());
+        assertEquals(StompCommand.CONNECT, frame.command());
         frame.release();
 
         frame = channel.readInbound();
-        Assert.assertEquals(StompCommand.CONNECTED, frame.command());
+        assertEquals(StompCommand.CONNECTED, frame.command());
         frame.release();
 
         frame = channel.readInbound();
-        Assert.assertEquals(StompCommand.SEND, frame.command());
+        assertEquals(StompCommand.SEND, frame.command());
         frame.release();
 
-        Assert.assertNull(channel.readInbound());
+        assertNull(channel.readInbound());
     }
 
-    @Test(expected = TooLongFrameException.class)
+    @Test
     public void testTooLongFrameException() {
         EmbeddedChannel channel = new EmbeddedChannel(new StompSubframeDecoder(), new StompSubframeAggregator(10));
-        channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes()));
+        assertThrows(TooLongFrameException.class,
+            () -> channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes())));
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -18,24 +18,29 @@ package io.netty.handler.codec.stomp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.stomp.StompTestConstants.*;
 import static io.netty.util.CharsetUtil.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StompSubframeDecoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         assertFalse(channel.finish());
     }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
@@ -20,23 +20,27 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.codec.stomp.StompTestConstants.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StompSubframeEncoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeEncoder());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         assertFalse(channel.finish());
     }


### PR DESCRIPTION
https://github.com/netty/netty/issues/10757#issuecomment-848445551