### PR TITLE
Automatically use netty-tcnative-boringssl-static on windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,15 @@
 
     <profile>
       <id>boringssl</id>
+      <activation>
+        <!--
+          Automatically active on windows as we only release static boringssl version of
+          netty-tcnative for windows.
+        -->
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
       <properties>
         <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
         <tcnative.classifier />


### PR DESCRIPTION
Motivation:

We only release a static compiled version of netty-tcnative for windows so we need to ensure we use it when on windows and not try to use a dynamic build version.

Modifications:

Automatically renable the boringssl profile when on windows

Result:

Fixes https://github.com/netty/netty/issues/11302

