### PR TITLE
 Migrate testsuite, transport-native-epoll, transport-native-kqueue, and transport-native-unix-common-tests tests to JUnit 5

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -85,6 +85,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>compile</scope>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractComboTestsuiteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractComboTestsuiteTest.java
@@ -21,25 +21,15 @@ import io.netty.testsuite.util.TestUtils;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Rule;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.TestInfo;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.List;
 
 public abstract class AbstractComboTestsuiteTest<SB extends AbstractBootstrap<?, ?, ?>,
         CB extends AbstractBootstrap<?, ?, ?>> {
-    private final Class<SB> sbClazz;
-    private final Class<CB> cbClazz;
     protected final InternalLogger logger = InternalLoggerFactory.getInstance(getClass());
     protected volatile CB cb;
     protected volatile SB sb;
-
-    protected AbstractComboTestsuiteTest(Class<SB> sbClazz, Class<CB> cbClazz) {
-        this.sbClazz = sbClazz;
-        this.cbClazz = cbClazz;
-    }
 
     protected abstract List<TestsuitePermutation.BootstrapComboFactory<SB, CB>> newFactories();
 
@@ -47,11 +37,9 @@ public abstract class AbstractComboTestsuiteTest<SB extends AbstractBootstrap<?,
         return TestsuitePermutation.allocator();
     }
 
-    @Rule
-    public final TestName testName = new TestName();
-
-    protected void run() throws Throwable {
+    protected void run(TestInfo testInfo, Runner<SB, CB> runner) throws Throwable {
         List<TestsuitePermutation.BootstrapComboFactory<SB, CB>> combos = newFactories();
+        String methodName = TestUtils.testMethodName(testInfo);
         for (ByteBufAllocator allocator: newAllocators()) {
             int i = 0;
             for (TestsuitePermutation.BootstrapComboFactory<SB, CB> e: combos) {
@@ -60,17 +48,15 @@ public abstract class AbstractComboTestsuiteTest<SB extends AbstractBootstrap<?,
                 configure(sb, cb, allocator);
                 logger.info(String.format(
                         "Running: %s %d of %d (%s + %s) with %s",
-                        testName.getMethodName(), ++ i, combos.size(), sb, cb, StringUtil.simpleClassName(allocator)));
-                try {
-                    Method m = getClass().getMethod(
-                            TestUtils.testMethodName(testName), sbClazz, cbClazz);
-                    m.invoke(this, sb, cb);
-                } catch (InvocationTargetException ex) {
-                    throw ex.getCause();
-                }
+                        methodName, ++ i, combos.size(), sb, cb, StringUtil.simpleClassName(allocator)));
+                runner.run(sb, cb);
             }
         }
     }
 
     protected abstract void configure(SB sb, CB cb, ByteBufAllocator allocator);
+
+    public interface Runner<SB extends AbstractBootstrap<?, ?, ?>, CB extends AbstractBootstrap<?, ?, ?>> {
+        void run(SB sb, CB cb) throws Throwable;
+    }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -15,28 +15,28 @@
  */
 package io.netty.testsuite.transport;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.IoHandlerFactory;
-import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.Test;
-
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractSingleThreadEventLoopTest {
 
@@ -56,7 +56,8 @@ public abstract class AbstractSingleThreadEventLoopTest {
     }
 
     // Copied from AbstractEventLoopTest
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testShutdownGracefullyNoQuietPeriod() throws Exception {
         EventLoopGroup loop = new MultithreadEventLoopGroup(newIoHandlerFactory());
         ServerBootstrap b = new ServerBootstrap();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractTestsuiteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractTestsuiteTest.java
@@ -21,21 +21,13 @@ import io.netty.testsuite.util.TestUtils;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Rule;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.TestInfo;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.List;
 
 public abstract class AbstractTestsuiteTest<T extends AbstractBootstrap<?, ?, ?>> {
-    private final Class<T> clazz;
     protected final InternalLogger logger = InternalLoggerFactory.getInstance(getClass());
     protected volatile T cb;
-
-    protected AbstractTestsuiteTest(Class<T> clazz) {
-        this.clazz = clazz;
-    }
 
     protected abstract List<TestsuitePermutation.BootstrapFactory<T>> newFactories();
 
@@ -43,11 +35,9 @@ public abstract class AbstractTestsuiteTest<T extends AbstractBootstrap<?, ?, ?>
         return TestsuitePermutation.allocator();
     }
 
-    @Rule
-    public final TestName testName = new TestName();
-
-    protected void run() throws Throwable {
+    protected void run(TestInfo testInfo, Runner<T> runner) throws Throwable {
         List<TestsuitePermutation.BootstrapFactory<T>> combos = newFactories();
+        String methodName = TestUtils.testMethodName(testInfo);
         for (ByteBufAllocator allocator: newAllocators()) {
             int i = 0;
             for (TestsuitePermutation.BootstrapFactory<T> e: combos) {
@@ -55,17 +45,15 @@ public abstract class AbstractTestsuiteTest<T extends AbstractBootstrap<?, ?, ?>
                 configure(cb, allocator);
                 logger.info(String.format(
                         "Running: %s %d of %d with %s",
-                        testName.getMethodName(), ++ i, combos.size(), StringUtil.simpleClassName(allocator)));
-                try {
-                    Method m = getClass().getMethod(
-                            TestUtils.testMethodName(testName), clazz);
-                    m.invoke(this, cb);
-                } catch (InvocationTargetException ex) {
-                    throw ex.getCause();
-                }
+                        methodName, ++ i, combos.size(), StringUtil.simpleClassName(allocator)));
+                runner.run(cb);
             }
         }
     }
 
     protected abstract void configure(T bootstrap, ByteBufAllocator allocator);
+
+    public interface Runner<CB extends AbstractBootstrap<?, ?, ?>> {
+        void run(CB cb) throws Throwable;
+    }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/AbstractSctpTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/AbstractSctpTest.java
@@ -27,11 +27,6 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 public abstract class AbstractSctpTest extends AbstractComboTestsuiteTest<ServerBootstrap, Bootstrap> {
-
-    protected AbstractSctpTest() {
-        super(ServerBootstrap.class, Bootstrap.class);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return SctpTestPermutation.sctpChannel();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
@@ -28,14 +28,15 @@ import io.netty.handler.codec.sctp.SctpInboundByteStreamHandler;
 import io.netty.handler.codec.sctp.SctpMessageCompletionHandler;
 import io.netty.handler.codec.sctp.SctpOutboundByteStreamHandler;
 import io.netty.testsuite.util.TestUtils;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.TestInfo;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SctpEchoTest extends AbstractSctpTest {
 
@@ -47,9 +48,9 @@ public class SctpEchoTest extends AbstractSctpTest {
     }
 
     @Test
-    public void testSimpleEcho() throws Throwable {
-        Assume.assumeTrue(TestUtils.isSctpSupported());
-        run();
+    public void testSimpleEcho(TestInfo testInfo) throws Throwable {
+        assumeTrue(TestUtils.isSctpSupported());
+        run(testInfo, this::testSimpleEcho);
     }
 
     public void testSimpleEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -57,9 +58,9 @@ public class SctpEchoTest extends AbstractSctpTest {
     }
 
     @Test
-    public void testSimpleEchoUnordered() throws Throwable {
-        Assume.assumeTrue(TestUtils.isSctpSupported());
-        run();
+    public void testSimpleEchoUnordered(TestInfo testInfo) throws Throwable {
+        assumeTrue(TestUtils.isSctpSupported());
+        run(testInfo, this::testSimpleEchoUnordered);
     }
 
     public void testSimpleEchoUnordered(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractClientSocketTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractClientSocketTest.java
@@ -27,11 +27,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public abstract class AbstractClientSocketTest extends AbstractTestsuiteTest<Bootstrap> {
-
-    protected AbstractClientSocketTest() {
-        super(Bootstrap.class);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return SocketTestPermutation.INSTANCE.clientSocket();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractDatagramTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractDatagramTest.java
@@ -28,11 +28,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public abstract class AbstractDatagramTest extends AbstractComboTestsuiteTest<Bootstrap, Bootstrap> {
-
-    protected AbstractDatagramTest() {
-        super(Bootstrap.class, Bootstrap.class);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> newFactories() {
         return SocketTestPermutation.INSTANCE.datagram(socketInternetProtocalFamily());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractServerSocketTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractServerSocketTest.java
@@ -28,10 +28,6 @@ import java.util.List;
 
 public abstract class AbstractServerSocketTest extends AbstractTestsuiteTest<ServerBootstrap> {
 
-    protected AbstractServerSocketTest() {
-        super(ServerBootstrap.class);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<ServerBootstrap>> newFactories() {
         return SocketTestPermutation.INSTANCE.serverSocket();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -29,11 +29,14 @@ import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -44,9 +47,10 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
     @Override
     protected abstract List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories();
 
-    @Test(timeout = 60000)
-    public void testReuseFd() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+    public void testReuseFd(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testReuseFd);
     }
 
     public void testReuseFd(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
@@ -23,22 +23,28 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.DuplexChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends AbstractServerSocketTest {
 
-    @Test(timeout = 30000)
-    public void testShutdownOutput() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testShutdownOutput(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testShutdownOutput);
     }
 
     public void testShutdownOutput(ServerBootstrap sb) throws Throwable {
@@ -78,9 +84,10 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
         }
     }
 
-    @Test(timeout = 30000)
-    public void testShutdownOutputWithoutOption() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testShutdownOutputWithoutOption(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testShutdownOutputWithoutOption);
     }
 
     public void testShutdownOutputWithoutOption(ServerBootstrap sb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketTest.java
@@ -28,11 +28,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public abstract class AbstractSocketTest extends AbstractComboTestsuiteTest<ServerBootstrap, Bootstrap> {
-
-    protected AbstractSocketTest() {
-        super(ServerBootstrap.class, Bootstrap.class);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return SocketTestPermutation.INSTANCE.socket();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -28,21 +28,25 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
     private static final int EXPECTED_BYTES = 20;
 
-    @Test(timeout = 10000)
-    public void testSingleCompositeBufferWrite() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testSingleCompositeBufferWrite(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSingleCompositeBufferWrite);
     }
 
     public void testSingleCompositeBufferWrite(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -136,9 +140,10 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testCompositeBufferPartialWriteDoesNotCorruptData() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testCompositeBufferPartialWriteDoesNotCorruptData(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testCompositeBufferPartialWriteDoesNotCorruptData);
     }
 
     protected void compositeBufferPartialWriteDoesNotCorruptDataInitServerConfig(ChannelConfig config,

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastIPv6Test.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastIPv6Test.java
@@ -18,7 +18,8 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class DatagramMulticastIPv6Test extends DatagramMulticastTest {
 
@@ -26,7 +27,7 @@ public class DatagramMulticastIPv6Test extends DatagramMulticastTest {
     public void testMulticast(Bootstrap sb, Bootstrap cb) throws Throwable {
         // Not works on windows atm.
         // See https://github.com/netty/netty/issues/11285
-        Assume.assumeFalse(PlatformDependent.isWindows());
+        assumeFalse(PlatformDependent.isWindows());
         super.testMulticast(sb, cb);
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
@@ -25,8 +25,8 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.util.internal.SocketUtils;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -39,19 +39,23 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class DatagramMulticastTest extends AbstractDatagramTest {
 
     @Test
-    public void testMulticast() throws Throwable {
-        run();
+    public void testMulticast(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testMulticast);
     }
 
     public void testMulticast(Bootstrap sb, Bootstrap cb) throws Throwable {
         NetworkInterface iface = multicastNetworkInterface();
-        Assume.assumeNotNull("No NetworkInterface found that supports multicast and " +
-                             socketInternetProtocalFamily(), iface);
+        assumeTrue(iface != null, "No NetworkInterface found that supports multicast and " +
+                             socketInternetProtocalFamily());
 
         MulticastTestHandler mhandler = new MulticastTestHandler();
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6Test.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6Test.java
@@ -17,7 +17,7 @@ package io.netty.testsuite.transport.socket;
 
 import io.netty.channel.socket.InternetProtocolFamily;
 import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.net.StandardProtocolFamily;
@@ -26,7 +26,7 @@ import java.nio.channels.spi.SelectorProvider;
 
 public class DatagramUnicastIPv6Test extends DatagramUnicastTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void assumeIpv6Supported() {
         try {
             Channel channel = SelectorProvider.provider().openDatagramChannel(StandardProtocolFamily.INET6);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -29,7 +29,8 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.NetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -42,7 +43,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DatagramUnicastTest extends AbstractDatagramTest {
 
@@ -52,8 +58,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     @Test
-    public void testBindWithPortOnly() throws Throwable {
-        run();
+    public void testBindWithPortOnly(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testBindWithPortOnly);
     }
 
     public void testBindWithPortOnly(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -67,8 +73,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     @Test
-    public void testSimpleSendDirectByteBuf() throws Throwable {
-        run();
+    public void testSimpleSendDirectByteBuf(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleSendDirectByteBuf);
     }
 
     public void testSimpleSendDirectByteBuf(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -77,8 +83,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     @Test
-    public void testSimpleSendHeapByteBuf() throws Throwable {
-        run();
+    public void testSimpleSendHeapByteBuf(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleSendHeapByteBuf);
     }
 
     public void testSimpleSendHeapByteBuf(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -87,8 +93,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     @Test
-    public void testSimpleSendCompositeDirectByteBuf() throws Throwable {
-        run();
+    public void testSimpleSendCompositeDirectByteBuf(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleSendCompositeDirectByteBuf);
     }
 
     public void testSimpleSendCompositeDirectByteBuf(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -104,8 +110,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     @Test
-    public void testSimpleSendCompositeHeapByteBuf() throws Throwable {
-        run();
+    public void testSimpleSendCompositeHeapByteBuf(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleSendCompositeHeapByteBuf);
     }
 
     public void testSimpleSendCompositeHeapByteBuf(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -121,8 +127,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     @Test
-    public void testSimpleSendCompositeMixedByteBuf() throws Throwable {
-        run();
+    public void testSimpleSendCompositeMixedByteBuf(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleSendCompositeMixedByteBuf);
     }
 
     public void testSimpleSendCompositeMixedByteBuf(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -138,8 +144,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     @Test
-    public void testSimpleSendWithoutBind() throws Throwable {
-        run();
+    public void testSimpleSendWithoutBind(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleSendWithoutBind);
     }
 
     public void testSimpleSendWithoutBind(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -156,8 +162,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     @Test
-    public void testSimpleSendWithConnect() throws Throwable {
-        run();
+    public void testSimpleSendWithConnect(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleSendWithConnect);
     }
 
     public void testSimpleSendWithConnect(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -325,8 +331,8 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
 
             ChannelFuture future = cc.writeAndFlush(
                     buf.retain().duplicate()).awaitUninterruptibly();
-            assertTrue("NotYetConnectedException expected, got: " + future.cause(),
-                    future.cause() instanceof NotYetConnectedException);
+            assertTrue(future.cause() instanceof NotYetConnectedException,
+                "NotYetConnectedException expected, got: " + future.cause());
         } finally {
             // release as we used buf.retain() before
             buf.release();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/ServerSocketSuspendTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/ServerSocketSuspendTest.java
@@ -21,15 +21,16 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.util.internal.SocketUtils;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServerSocketSuspendTest extends AbstractServerSocketTest {
 
@@ -37,9 +38,9 @@ public class ServerSocketSuspendTest extends AbstractServerSocketTest {
     private static final long TIMEOUT = 3000000000L;
 
     @Test
-    @Ignore("Need to investigate why it fails on osx")
-    public void testSuspendAndResumeAccept() throws Throwable {
-        run();
+    @Disabled("Need to investigate why it fails on osx")
+    public void testSuspendAndResumeAccept(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSuspendAndResumeAccept);
     }
 
     public void testSuspendAndResumeAccept(ServerBootstrap sb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -29,19 +29,20 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.UncheckedBooleanSupplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketAutoReadTest extends AbstractSocketTest {
     @Test
-    public void testAutoReadOffDuringReadOnlyReadsOneTime() throws Throwable {
-        run();
+    public void testAutoReadOffDuringReadOnlyReadsOneTime(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testAutoReadOffDuringReadOnlyReadsOneTime);
     }
 
     public void testAutoReadOffDuringReadOnlyReadsOneTime(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -28,12 +28,13 @@ import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SocketBufReleaseTest extends AbstractSocketTest {
 
@@ -41,8 +42,8 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
             new DefaultEventExecutorGroup(1, new DefaultThreadFactory(SocketBufReleaseTest.class, true)).next();
 
     @Test
-    public void testBufRelease() throws Throwable {
-        run();
+    public void testBufRelease(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testBufRelease);
     }
 
     public void testBufRelease(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -23,19 +23,23 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import org.junit.Test;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketCancelWriteTest extends AbstractSocketTest {
 
-    @Test(timeout = 30000)
-    public void testCancelWrite() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testCancelWrite(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testCancelWrite);
     }
 
     public void testCancelWrite(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -18,17 +18,21 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.socket.SocketChannel;
-import org.junit.Test;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
 
 import java.net.SocketException;
 import java.nio.channels.NotYetConnectedException;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
-    @Test(timeout = 30000)
-    public void testShutdownNotYetConnected() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testShutdownNotYetConnected(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testShutdownNotYetConnected);
     }
 
     public void testShutdownNotYetConnected(Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
@@ -21,13 +21,14 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.SocketChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 public class SocketCloseForciblyTest extends AbstractSocketTest {
 
     @Test
-    public void testCloseForcibly() throws Throwable {
-        run();
+    public void testCloseForcibly(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testCloseForcibly);
     }
 
     public void testCloseForcibly(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -25,14 +25,18 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class SocketConditionalWritabilityTest extends AbstractSocketTest {
-    @Test(timeout = 30000)
-    public void testConditionalWritability() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testConditionalWritability(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testConditionalWritability);
     }
 
     public void testConditionalWritability(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
@@ -30,8 +30,10 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.StringUtil;
-import org.junit.AssumptionViolatedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.opentest4j.TestAbortedException;
 
 import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
@@ -39,21 +41,23 @@ import java.net.SocketAddress;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.buffer.UnpooledByteBufAllocator.DEFAULT;
 import static io.netty.util.CharsetUtil.US_ASCII;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketConnectTest extends AbstractSocketTest {
 
-    @Test(timeout = 30000)
-    public void testLocalAddressAfterConnect() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testLocalAddressAfterConnect(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testLocalAddressAfterConnect);
     }
 
     public void testLocalAddressAfterConnect(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -88,9 +92,10 @@ public class SocketConnectTest extends AbstractSocketTest {
         }
     }
 
-    @Test(timeout = 3000)
-    public void testChannelEventsFiredWhenClosedDirectly() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    public void testChannelEventsFiredWhenClosedDirectly(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testChannelEventsFiredWhenClosedDirectly);
     }
 
     public void testChannelEventsFiredWhenClosedDirectly(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -128,9 +133,10 @@ public class SocketConnectTest extends AbstractSocketTest {
         }
     }
 
-    @Test(timeout = 3000)
-    public void testWriteWithFastOpenBeforeConnect() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteWithFastOpenBeforeConnect(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testWriteWithFastOpenBeforeConnect);
     }
 
     public void testWriteWithFastOpenBeforeConnect(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -169,7 +175,7 @@ public class SocketConnectTest extends AbstractSocketTest {
     }
 
     protected void enableTcpFastOpen(ServerBootstrap sb, Bootstrap cb) {
-        throw new AssumptionViolatedException(
+        throw new TestAbortedException(
                 "Support for testing TCP_FASTOPEN not enabled for " + StringUtil.simpleClassName(this));
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -25,27 +25,31 @@ import io.netty.util.NetUtil;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.Socket;
+import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_HOST;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_PORT;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
 
     // See /etc/services
     private static final int UNASSIGNED_PORT = 4;
 
-    @Test(timeout = 30000)
-    public void testConnectTimeout() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testConnectTimeout(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testConnectTimeout);
     }
 
     public void testConnectTimeout(Bootstrap cb) throws Throwable {
@@ -58,18 +62,20 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         }
     }
 
-    @Test(timeout = 30000)
-    public void testConnectRefused() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testConnectRefused(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testConnectRefused);
     }
 
     public void testConnectRefused(Bootstrap cb) throws Throwable {
         testConnectRefused0(cb, false);
     }
 
-    @Test(timeout = 30000)
-    public void testConnectRefusedHalfClosure() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testConnectRefusedHalfClosure(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testConnectRefusedHalfClosure);
     }
 
     public void testConnectRefusedHalfClosure(Bootstrap cb) throws Throwable {
@@ -93,7 +99,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
     }
 
     @Test
-    public void testConnectCancellation() throws Throwable {
+    public void testConnectCancellation(TestInfo testInfo) throws Throwable {
         // Check if the test can be executed or should be skipped because of no network/internet connection
         // See https://github.com/netty/netty/issues/1474
         boolean badHostTimedOut = true;
@@ -113,10 +119,9 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
             }
         }
 
-        assumeThat("The connection attempt to " + BAD_HOST + " does not time out.",
-                badHostTimedOut, is(true));
+        assumeTrue(badHostTimedOut, "The connection attempt to " + BAD_HOST + " does not time out.");
 
-        run();
+        run(testInfo, this::testConnectCancellation);
     }
 
     public void testConnectCancellation(Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -23,19 +23,23 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.SimpleChannelInboundHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.channel.ChannelOption.AUTO_READ;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SocketDataReadInitialStateTest extends AbstractSocketTest {
-    @Test(timeout = 10000)
-    public void testAutoReadOffNoDataReadUntilReadCalled() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testAutoReadOffNoDataReadUntilReadCalled(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testAutoReadOffNoDataReadUntilReadCalled);
     }
 
     public void testAutoReadOffNoDataReadUntilReadCalled(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -127,9 +131,10 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testAutoReadOnDataReadImmediately() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testAutoReadOnDataReadImmediately(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testAutoReadOnDataReadImmediately);
     }
 
     public void testAutoReadOnDataReadImmediately(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -24,13 +24,17 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
-import org.junit.Test;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class SocketEchoTest extends AbstractSocketTest {
 
@@ -41,18 +45,20 @@ public class SocketEchoTest extends AbstractSocketTest {
         random.nextBytes(data);
     }
 
-    @Test(timeout = 30000)
-    public void testSimpleEcho() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testSimpleEcho(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleEcho);
     }
 
     public void testSimpleEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         testSimpleEcho0(sb, cb, false, true);
     }
 
-    @Test(timeout = 30000)
-    public void testSimpleEchoNotAutoRead() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testSimpleEchoNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleEchoNotAutoRead);
     }
 
     public void testSimpleEchoNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -60,8 +66,8 @@ public class SocketEchoTest extends AbstractSocketTest {
     }
 
     @Test//(timeout = 30000)
-    public void testSimpleEchoWithVoidPromise() throws Throwable {
-        run();
+    public void testSimpleEchoWithVoidPromise(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleEchoWithVoidPromise);
     }
 
     public void testSimpleEchoWithVoidPromise(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -69,8 +75,8 @@ public class SocketEchoTest extends AbstractSocketTest {
     }
 
     @Test//(timeout = 30000)
-    public void testSimpleEchoWithVoidPromiseNotAutoRead() throws Throwable {
-        run();
+    public void testSimpleEchoWithVoidPromiseNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSimpleEchoWithVoidPromiseNotAutoRead);
     }
 
     public void testSimpleEchoWithVoidPromiseNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -25,19 +25,20 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.TestInfo;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketExceptionHandlingTest extends AbstractSocketTest {
     @Test
-    public void testReadPendingIsResetAfterEachRead() throws Throwable {
-        run();
+    public void testReadPendingIsResetAfterEachRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testReadPendingIsResetAfterEachRead);
     }
 
     public void testReadPendingIsResetAfterEachRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -59,9 +60,9 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
             assertTrue(serverInitializer.exceptionHandler.latch1.await(5, TimeUnit.SECONDS));
 
             // After we get the first exception, we should get no more, this is expected to timeout.
-            assertFalse("Encountered " + serverInitializer.exceptionHandler.count.get() +
-                            " exceptions when 1 was expected",
-                        serverInitializer.exceptionHandler.latch2.await(1, TimeUnit.SECONDS));
+            assertFalse(serverInitializer.exceptionHandler.latch2.await(1, TimeUnit.SECONDS),
+                "Encountered " + serverInitializer.exceptionHandler.count.get() +
+                                        " exceptions when 1 was expected");
         } finally {
             if (serverChannel != null) {
                 serverChannel.close().syncUninterruptibly();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -28,7 +28,8 @@ import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.internal.PlatformDependent;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -41,7 +42,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class SocketFileRegionTest extends AbstractSocketTest {
 
@@ -52,33 +54,33 @@ public class SocketFileRegionTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testFileRegion() throws Throwable {
-        run();
+    public void testFileRegion(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testFileRegion);
     }
 
     @Test
-    public void testCustomFileRegion() throws Throwable {
-        run();
+    public void testCustomFileRegion(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testCustomFileRegion);
     }
 
     @Test
-    public void testFileRegionNotAutoRead() throws Throwable {
-        run();
+    public void testFileRegionNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testFileRegionNotAutoRead);
     }
 
     @Test
-    public void testFileRegionVoidPromise() throws Throwable {
-        run();
+    public void testFileRegionVoidPromise(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testFileRegionVoidPromise);
     }
 
     @Test
-    public void testFileRegionVoidPromiseNotAutoRead() throws Throwable {
-        run();
+    public void testFileRegionVoidPromiseNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testFileRegionVoidPromiseNotAutoRead);
     }
 
     @Test
-    public void testFileRegionCountLargerThenFile() throws Throwable {
-        run();
+    public void testFileRegionCountLargerThenFile(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testFileRegionCountLargerThenFile);
     }
 
     public void testFileRegion(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -25,13 +25,14 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.FixedLengthFrameDecoder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SocketFixedLengthEchoTest extends AbstractSocketTest {
 
@@ -43,13 +44,13 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testFixedLengthEcho() throws Throwable {
-        run();
+    public void testFixedLengthEcho(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testFixedLengthEcho);
     }
 
     @Test
-    public void testFixedLengthEchoNotAutoRead() throws Throwable {
-        run();
+    public void testFixedLengthEchoNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testFixedLengthEchoNotAutoRead);
     }
 
     public void testFixedLengthEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -29,25 +29,24 @@ import io.netty.testsuite.util.TestUtils;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.StringUtil;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.buffer.Unpooled.compositeBuffer;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketGatheringWriteTest extends AbstractSocketTest {
-
-    @Rule
-    public final Timeout globalTimeout = new Timeout(120000);
+    private static final long TIMEOUT = 120000;
 
     private static final Random random = new Random();
     static final byte[] data = new byte[1048576];
@@ -56,14 +55,15 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         random.nextBytes(data);
     }
 
-    @AfterClass
+    @AfterAll
     public static void compressHeapDumps() throws Exception {
         TestUtils.compressHeapDumps();
     }
 
     @Test
-    public void testGatheringWrite() throws Throwable {
-        run();
+    @Timeout(value = TIMEOUT, unit = TimeUnit.MILLISECONDS)
+    public void testGatheringWrite(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testGatheringWrite);
     }
 
     public void testGatheringWrite(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -71,8 +71,9 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testGatheringWriteNotAutoRead() throws Throwable {
-        run();
+    @Timeout(value = TIMEOUT, unit = TimeUnit.MILLISECONDS)
+    public void testGatheringWriteNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testGatheringWriteNotAutoRead);
     }
 
     public void testGatheringWriteNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -80,27 +81,30 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testGatheringWriteWithComposite() throws Throwable {
-        run();
-    }
-
-    public void testGatheringWriteWithCompositeNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        testGatheringWrite0(sb, cb, data, true, false);
-    }
-
-    @Test
-    public void testGatheringWriteWithCompositeNotAutoRead() throws Throwable {
-        run();
+    @Timeout(value = TIMEOUT, unit = TimeUnit.MILLISECONDS)
+    public void testGatheringWriteWithComposite(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testGatheringWriteWithComposite);
     }
 
     public void testGatheringWriteWithComposite(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         testGatheringWrite0(sb, cb, data, true, true);
     }
 
+    @Test
+    @Timeout(value = TIMEOUT, unit = TimeUnit.MILLISECONDS)
+    public void testGatheringWriteWithCompositeNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testGatheringWriteWithCompositeNotAutoRead);
+    }
+
+    public void testGatheringWriteWithCompositeNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        testGatheringWrite0(sb, cb, data, true, false);
+    }
+
     // Test for https://github.com/netty/netty/issues/2647
     @Test
-    public void testGatheringWriteBig() throws Throwable {
-        run();
+    @Timeout(value = TIMEOUT, unit = TimeUnit.MILLISECONDS)
+    public void testGatheringWriteBig(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testGatheringWriteBig);
     }
 
     public void testGatheringWriteBig(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -34,8 +34,9 @@ import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.util.UncheckedBooleanSupplier;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -43,14 +44,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class SocketHalfClosedTest extends AbstractSocketTest {
-    @Test(timeout = 10000)
-    public void testHalfClosureOnlyOneEventWhenAutoRead() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 10000, unit = MILLISECONDS)
+    public void testHalfClosureOnlyOneEventWhenAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testHalfClosureOnlyOneEventWhenAutoRead);
     }
 
     public void testHalfClosureOnlyOneEventWhenAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -114,8 +117,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testAllDataReadAfterHalfClosure() throws Throwable {
-        run();
+    public void testAllDataReadAfterHalfClosure(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testAllDataReadAfterHalfClosure);
     }
 
     public void testAllDataReadAfterHalfClosure(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -207,8 +210,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             serverInitializedLatch.await();
             clientReadAllDataLatch.await();
             clientHalfClosedLatch.await();
-            assertTrue("too many read complete events: " + clientReadCompletes.get(),
-                    totalServerBytesWritten / numReadsPerReadLoop + 10 > clientReadCompletes.get());
+            assertTrue(totalServerBytesWritten / numReadsPerReadLoop + 10 > clientReadCompletes.get(),
+                "too many read complete events: " + clientReadCompletes.get());
         } finally {
             if (clientChannel != null) {
                 clientChannel.close().sync();
@@ -220,10 +223,10 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testAutoCloseFalseDoesShutdownOutput() throws Throwable {
+    public void testAutoCloseFalseDoesShutdownOutput(TestInfo testInfo) throws Throwable {
         // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
-        Assume.assumeFalse(PlatformDependent.isWindows());
-        run();
+        assumeFalse(PlatformDependent.isWindows());
+        run(testInfo, this::testAutoCloseFalseDoesShutdownOutput);
     }
 
     public void testAutoCloseFalseDoesShutdownOutput(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -411,8 +414,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testAllDataReadClosure() throws Throwable {
-        run();
+    public void testAllDataReadClosure(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testAllDataReadClosure);
     }
 
     public void testAllDataReadClosure(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -512,8 +515,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             serverInitializedLatch.await();
             clientReadAllDataLatch.await();
             clientHalfClosedLatch.await();
-            assertTrue("too many read complete events: " + clientReadCompletes.get(),
-                    totalServerBytesWritten / numReadsPerReadLoop + 10 > clientReadCompletes.get());
+            assertTrue(totalServerBytesWritten / numReadsPerReadLoop + 10 > clientReadCompletes.get(),
+                "too many read complete events: " + clientReadCompletes.get());
         } finally {
             if (clientChannel != null) {
                 clientChannel.close().sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -22,19 +22,23 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.util.NetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.channels.AlreadyConnectedException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketMultipleConnectTest extends AbstractSocketTest {
 
-    @Test(timeout = 30000)
-    public void testMultipleConnect() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testMultipleConnect(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testMultipleConnect);
     }
 
     public void testMultipleConnect(ServerBootstrap sb, Bootstrap cb) throws Exception {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
@@ -25,13 +25,14 @@ import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.serialization.ClassResolvers;
 import io.netty.handler.codec.serialization.ObjectDecoder;
 import io.netty.handler.codec.serialization.ObjectEncoder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SocketObjectEchoTest extends AbstractSocketTest {
 
@@ -51,8 +52,8 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testObjectEcho() throws Throwable {
-        run();
+    public void testObjectEcho(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testObjectEcho);
     }
 
     public void testObjectEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -60,8 +61,8 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
     }
 
     @Test
-    public void testObjectEchoNotAutoRead() throws Throwable {
-        run();
+    public void testObjectEchoNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testObjectEchoNotAutoRead);
     }
 
     public void testObjectEchoNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
@@ -29,20 +29,23 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.UncheckedBooleanSupplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketReadPendingTest extends AbstractSocketTest {
-    @Test(timeout = 60000)
-    public void testReadPendingIsResetAfterEachRead() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+    public void testReadPendingIsResetAfterEachRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testReadPendingIsResetAfterEachRead);
     }
 
     public void testReadPendingIsResetAfterEachRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
@@ -22,27 +22,31 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketRstTest extends AbstractSocketTest {
     protected void assertRstOnCloseException(IOException cause, Channel clientChannel) {
         if (Locale.getDefault() == Locale.US || Locale.getDefault() == Locale.UK) {
-            assertTrue("actual message: " + cause.getMessage(),
-                       cause.getMessage().contains("reset") || cause.getMessage().contains("closed"));
+            assertTrue(cause.getMessage().contains("reset") || cause.getMessage().contains("closed"),
+                "actual message: " + cause.getMessage());
         }
     }
 
-    @Test(timeout = 3000)
-    public void testSoLingerZeroCausesOnlyRstOnClose() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    public void testSoLingerZeroCausesOnlyRstOnClose(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSoLingerZeroCausesOnlyRstOnClose);
     }
 
     public void testSoLingerZeroCausesOnlyRstOnClose(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -89,15 +93,16 @@ public class SocketRstTest extends AbstractSocketTest {
 
         // Verify the client received a RST.
         Throwable cause = throwableRef.get();
-        assertTrue("actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]",
-                cause instanceof IOException);
+        assertTrue(cause instanceof IOException,
+            "actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]");
 
         assertRstOnCloseException((IOException) cause, cc);
     }
 
-    @Test(timeout = 3000)
-    public void testNoRstIfSoLingerOnClose() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    public void testNoRstIfSoLingerOnClose(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testNoRstIfSoLingerOnClose);
     }
 
     public void testNoRstIfSoLingerOnClose(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -25,8 +25,10 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.SocketChannel;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -38,17 +40,18 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
 
-    @Test(timeout = 30000)
-    public void testShutdownOutput() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testShutdownOutput(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testShutdownOutput);
     }
 
     public void testShutdownOutput(Bootstrap cb) throws Throwable {
@@ -94,9 +97,10 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         }
     }
 
-    @Test(timeout = 30000)
-    public void testShutdownOutputAfterClosed() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testShutdownOutputAfterClosed(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testShutdownOutputAfterClosed);
     }
 
     public void testShutdownOutputAfterClosed(Bootstrap cb) throws Throwable {
@@ -130,10 +134,11 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         }
     }
 
-    @Ignore
-    @Test(timeout = 30000)
-    public void testWriteAfterShutdownOutputNoWritabilityChange() throws Throwable {
-        run();
+    @Disabled
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteAfterShutdownOutputNoWritabilityChange(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testWriteAfterShutdownOutputNoWritabilityChange);
     }
 
     public void testWriteAfterShutdownOutputNoWritabilityChange(Bootstrap cb) throws Throwable {
@@ -193,18 +198,20 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         }
     }
 
-    @Test(timeout = 30000)
-    public void testShutdownOutputSoLingerNoAssertError() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testShutdownOutputSoLingerNoAssertError(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testShutdownOutputSoLingerNoAssertError);
     }
 
     public void testShutdownOutputSoLingerNoAssertError(Bootstrap cb) throws Throwable {
         testShutdownSoLingerNoAssertError0(cb, true);
     }
 
-    @Test(timeout = 30000)
-    public void testShutdownSoLingerNoAssertError() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testShutdownSoLingerNoAssertError(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testShutdownSoLingerNoAssertError);
     }
 
     public void testShutdownSoLingerNoAssertError(Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -40,11 +40,11 @@ import io.netty.testsuite.util.TestUtils;
 import io.netty.util.concurrent.Future;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +56,7 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -66,10 +67,9 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-@RunWith(Parameterized.class)
 public class SocketSslEchoTest extends AbstractSocketTest {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SocketSslEchoTest.class);
@@ -120,10 +120,6 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         }
     }
 
-    @Parameters(name =
-            "{index}: serverEngine = {0}, clientEngine = {1}, renegotiation = {2}, " +
-            "serverUsesDelegatedTaskExecutor = {3}, clientUsesDelegatedTaskExecutor = {4}, " +
-            "autoRead = {5}, useChunkedWriteHandler = {6}, useCompositeByteBuf = {7}")
     public static Collection<Object[]> data() throws Exception {
         List<SslContext> serverContexts = new ArrayList<>();
         serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
@@ -194,15 +190,6 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         return params;
     }
 
-    private final SslContext serverCtx;
-    private final SslContext clientCtx;
-    private final Renegotiation renegotiation;
-    private final boolean serverUsesDelegatedTaskExecutor;
-    private final boolean clientUsesDelegatedTaskExecutor;
-    private final boolean autoRead;
-    private final boolean useChunkedWriteHandler;
-    private final boolean useCompositeByteBuf;
-
     private final AtomicReference<Throwable> clientException = new AtomicReference<>();
     private final AtomicReference<Throwable> serverException = new AtomicReference<>();
 
@@ -225,10 +212,31 @@ public class SocketSslEchoTest extends AbstractSocketTest {
     private final EchoServerHandler serverHandler =
             new EchoServerHandler(serverRecvCounter, serverNegoCounter, serverException);
 
-    public SocketSslEchoTest(
+    private SslContext serverCtx;
+    private SslContext clientCtx;
+    private Renegotiation renegotiation;
+    private boolean serverUsesDelegatedTaskExecutor;
+    private boolean clientUsesDelegatedTaskExecutor;
+    private boolean autoRead;
+    private boolean useChunkedWriteHandler;
+    private boolean useCompositeByteBuf;
+
+    @AfterAll
+    public static void compressHeapDumps() throws Exception {
+        TestUtils.compressHeapDumps();
+    }
+
+    @ParameterizedTest(name =
+            "{index}: serverEngine = {0}, clientEngine = {1}, renegotiation = {2}, " +
+            "serverUsesDelegatedTaskExecutor = {3}, clientUsesDelegatedTaskExecutor = {4}, " +
+            "autoRead = {5}, useChunkedWriteHandler = {6}, useCompositeByteBuf = {7}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testSslEcho(
             SslContext serverCtx, SslContext clientCtx, Renegotiation renegotiation,
             boolean serverUsesDelegatedTaskExecutor, boolean clientUsesDelegatedTaskExecutor,
-            boolean autoRead, boolean useChunkedWriteHandler, boolean useCompositeByteBuf) {
+            boolean autoRead, boolean useChunkedWriteHandler, boolean useCompositeByteBuf,
+            TestInfo testInfo) throws Throwable {
         this.serverCtx = serverCtx;
         this.clientCtx = clientCtx;
         this.serverUsesDelegatedTaskExecutor = serverUsesDelegatedTaskExecutor;
@@ -237,16 +245,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         this.autoRead = autoRead;
         this.useChunkedWriteHandler = useChunkedWriteHandler;
         this.useCompositeByteBuf = useCompositeByteBuf;
-    }
-
-    @Test(timeout = 30000)
-    public void testSslEcho() throws Throwable {
-        run();
-    }
-
-    @AfterClass
-    public static void compressHeapDumps() throws Exception {
-        TestUtils.compressHeapDumps();
+        run(testInfo, this::testSslEcho);
     }
 
     public void testSslEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -36,10 +36,10 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -53,13 +53,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class SocketSslGreetingTest extends AbstractSocketTest {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SocketSslGreetingTest.class);
@@ -79,7 +79,6 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         KEY_FILE = ssc.privateKey();
     }
 
-    @Parameters(name = "{index}: serverEngine = {0}, clientEngine = {1}, delegate = {2}")
     public static Collection<Object[]> data() throws Exception {
         List<SslContext> serverContexts = new ArrayList<>();
         serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
@@ -107,16 +106,6 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         return params;
     }
 
-    private final SslContext serverCtx;
-    private final SslContext clientCtx;
-    private final boolean delegate;
-
-    public SocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        this.serverCtx = serverCtx;
-        this.clientCtx = clientCtx;
-        this.delegate = delegate;
-    }
-
     private static SslHandler newSslHandler(SslContext sslCtx, ByteBufAllocator allocator, Executor executor) {
         if (executor == null) {
             return sslCtx.newHandler(allocator);
@@ -126,12 +115,16 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
     }
 
     // Test for https://github.com/netty/netty/pull/2437
-    @Test(timeout = 30000)
-    public void testSslGreeting() throws Throwable {
-        run();
+    @ParameterizedTest(name = "{index}: serverEngine = {0}, clientEngine = {1}, delegate = {2}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testSslGreeting(SslContext serverCtx, SslContext clientCtx, boolean delegate,
+                                TestInfo testInfo) throws Throwable {
+        run(testInfo, (sb, cb) -> testSslGreeting(sb, cb, serverCtx, clientCtx, delegate));
     }
 
-    public void testSslGreeting(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testSslGreeting(ServerBootstrap sb, Bootstrap cb, SslContext serverCtx,
+                                SslContext clientCtx, boolean delegate) throws Throwable {
         final ServerHandler sh = new ServerHandler();
         final ClientHandler ch = new ClientHandler();
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -34,10 +34,10 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
@@ -51,11 +51,11 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(Parameterized.class)
 public class SocketSslSessionReuseTest extends AbstractSocketTest {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SocketSslSessionReuseTest.class);
@@ -74,7 +74,6 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         KEY_FILE = ssc.privateKey();
     }
 
-    @Parameters(name = "{index}: serverEngine = {0}, clientEngine = {1}")
     public static Collection<Object[]> data() throws Exception {
         return Collections.singletonList(new Object[] {
           SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build(),
@@ -82,20 +81,15 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         });
     }
 
-    private final SslContext serverCtx;
-    private final SslContext clientCtx;
-
-    public SocketSslSessionReuseTest(SslContext serverCtx, SslContext clientCtx) {
-        this.serverCtx = serverCtx;
-        this.clientCtx = clientCtx;
+    @ParameterizedTest(name = "{index}: serverEngine = {0}, clientEngine = {1}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testSslSessionReuse(SslContext serverCtx, SslContext clientCtx, TestInfo testInfo) throws Throwable {
+        run(testInfo, (sb, cb) -> this.testSslSessionReuse(sb, cb, serverCtx, clientCtx));
     }
 
-    @Test(timeout = 30000)
-    public void testSslSessionReuse() throws Throwable {
-        run();
-    }
-
-    public void testSslSessionReuse(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testSslSessionReuse(ServerBootstrap sb, Bootstrap cb,
+                                    SslContext serverCtx, SslContext clientCtx) throws Throwable {
         final ReadAndDiscardHandler sh = new ReadAndDiscardHandler(true, true);
         final ReadAndDiscardHandler ch = new ReadAndDiscardHandler(false, true);
         final String[] protocols = { "TLSv1", "TLSv1.1", "TLSv1.2" };
@@ -139,7 +133,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
             cc = cb.connect(sc.localAddress()).sync().channel();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
-            assertEquals("Expected no new sessions", sessions, sessionIdSet(clientSessionCtx.getIds()));
+            assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");
             rethrowHandlerExceptions(sh, ch);
         } finally {
             sc.close().awaitUninterruptibly();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
@@ -29,10 +29,13 @@ import io.netty.handler.codec.string.StringEncoder;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class SocketStringEchoTest extends AbstractSocketTest {
@@ -52,18 +55,20 @@ public class SocketStringEchoTest extends AbstractSocketTest {
         }
     }
 
-    @Test(timeout = 60000)
-    public void testStringEcho() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+    public void testStringEcho(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testStringEcho);
     }
 
     public void testStringEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         testStringEcho(sb, cb, true);
     }
 
-    @Test(timeout = 60000)
-    public void testStringEchoNotAutoRead() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+    public void testStringEchoNotAutoRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testStringEchoNotAutoRead);
     }
 
     public void testStringEchoNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -30,9 +30,11 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -42,7 +44,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TrafficShapingHandlerTest extends AbstractSocketTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(TrafficShapingHandlerTest.class);
@@ -70,7 +72,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         random.nextBytes(data);
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void createGroup() {
         logger.info("Bandwidth: " + minfactor + " <= " + bandwidthFactor + " <= " + maxfactor +
                     " StepMs: " + stepms + " MinMs: " + minimalms + " CheckMs: " + check);
@@ -78,7 +80,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         groupForGlobal = new DefaultEventExecutorGroup(8);
     }
 
-    @AfterClass
+    @AfterAll
     public static void destroyGroup() throws Exception {
         group.shutdownGracefully().sync();
         groupForGlobal.shutdownGracefully().sync();
@@ -127,11 +129,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         return minimalWaitBetween;
     }
 
-    @Test(timeout = 10000)
-    public void testNoTrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testNoTrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST NO TRAFFIC";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testNoTrafficShapping);
     }
 
     public void testNoTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -141,11 +144,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         testTrafficShapping0(sb, cb, false, false, false, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
-    @Test(timeout = 10000)
-    public void testWriteTrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteTrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST WRITE";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testWriteTrafficShapping);
     }
 
     public void testWriteTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -155,11 +159,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         testTrafficShapping0(sb, cb, false, false, true, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
-    @Test(timeout = 10000)
-    public void testReadTrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testReadTrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST READ";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testReadTrafficShapping);
     }
 
     public void testReadTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -169,11 +174,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         testTrafficShapping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
-    @Test(timeout = 10000)
-    public void testWrite1TrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testWrite1TrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST WRITE";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testWrite1TrafficShapping);
     }
 
     public void testWrite1TrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -183,11 +189,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         testTrafficShapping0(sb, cb, false, false, true, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
-    @Test(timeout = 10000)
-    public void testRead1TrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testRead1TrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST READ";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testRead1TrafficShapping);
     }
 
     public void testRead1TrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -197,11 +204,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         testTrafficShapping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
-    @Test(timeout = 10000)
-    public void testWriteGlobalTrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteGlobalTrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST GLOBAL WRITE";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testWriteGlobalTrafficShapping);
     }
 
     public void testWriteGlobalTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -211,11 +219,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         testTrafficShapping0(sb, cb, false, false, true, true, autoRead, minimalWaitBetween, multipleMessage);
     }
 
-    @Test(timeout = 10000)
-    public void testReadGlobalTrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testReadGlobalTrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST GLOBAL READ";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testReadGlobalTrafficShapping);
     }
 
     public void testReadGlobalTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -225,11 +234,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         testTrafficShapping0(sb, cb, false, true, false, true, autoRead, minimalWaitBetween, multipleMessage);
     }
 
-    @Test(timeout = 10000)
-    public void testAutoReadTrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testAutoReadTrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST AUTO READ";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testAutoReadTrafficShapping);
     }
 
     public void testAutoReadTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -240,11 +250,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         testTrafficShapping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
-    @Test(timeout = 10000)
-    public void testAutoReadGlobalTrafficShapping() throws Throwable {
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testAutoReadGlobalTrafficShapping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST AUTO READ GLOBAL";
         currentTestRun = 0;
-        run();
+        run(testInfo, this::testAutoReadGlobalTrafficShapping);
     }
 
     public void testAutoReadGlobalTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -339,7 +350,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
 
         promise.await();
         Long stop = TrafficCounter.milliSecondFromNano();
-        assertTrue("Error during execution of TrafficShapping: " + promise.cause(), promise.isSuccess());
+        assertTrue(promise.isSuccess(), "Error during execution of TrafficShapping: " + promise.cause());
 
         float average = (totalNb * messageSize) / (float) (stop - start);
         logger.info("TEST: " + currentTestName + " RUN: " + currentTestRun +
@@ -353,14 +364,14 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
 
         if (autoRead == null && minimalWaitBetween != null) {
-            assertTrue("Overall Traffic not ok since > " + maxfactor + ": " + average,
-                       average <= maxfactor);
+            assertTrue(average <= maxfactor,
+                "Overall Traffic not ok since > " + maxfactor + ": " + average);
             if (additionalExecutor) {
                 // Oio is not as good when using additionalExecutor
-                assertTrue("Overall Traffic not ok since < 0.25: " + average, average >= 0.25);
+                assertTrue(average >= 0.25, "Overall Traffic not ok since < 0.25: " + average);
             } else {
-                assertTrue("Overall Traffic not ok since < " + minfactor + ": " + average,
-                           average >= minfactor);
+                assertTrue(average >= minfactor,
+                    "Overall Traffic not ok since < " + minfactor + ": " + average);
             }
         }
         if (handler != null && globalLimit) {
@@ -426,8 +437,8 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
             }
             loggerClient.info("Step: " + step + " Interval: " + (lastTimestamp - currentLastTime) + " compareTo "
                               + minimalWait + " (" + ar + ')');
-            assertTrue("The interval of time is incorrect:" + (lastTimestamp - currentLastTime) + " not> "
-                       + minimalWait, lastTimestamp - currentLastTime >= minimalWait);
+            assertTrue(lastTimestamp - currentLastTime >= minimalWait,
+                    "The interval of time is incorrect:" + (lastTimestamp - currentLastTime) + " not> " + minimalWait);
             currentLastTime = lastTimestamp;
             step++;
             if (multipleMessage.length > step) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
@@ -20,13 +20,18 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.SocketChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
 
 public class WriteBeforeRegisteredTest extends AbstractClientSocketTest {
 
-    @Test(timeout = 30000)
-    public void testWriteBeforeConnect() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteBeforeConnect(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testWriteBeforeConnect);
     }
 
     public void testWriteBeforeConnect(Bootstrap cb) throws Throwable {

--- a/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
+++ b/testsuite/src/main/java/io/netty/testsuite/util/TestUtils.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.rules.TestName;
 import org.tukaani.xz.LZMA2Options;
 import org.tukaani.xz.XZOutputStream;
@@ -98,6 +99,17 @@ public final class TestUtils {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Returns the method name of the current test.
+     */
+    public static String testMethodName(TestInfo testInfo) {
+        String testMethodName = testInfo.getTestMethod().map(Method::getName).orElse("[unknown method]");
+        if (testMethodName.contains("[")) {
+            testMethodName = testMethodName.substring(0, testMethodName.indexOf('['));
+        }
+        return testMethodName;
     }
 
     /**

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollChannelConfigTest.java
@@ -18,9 +18,9 @@ package io.netty.channel.epoll;
 import io.netty.channel.ChannelException;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class EpollChannelConfigTest {
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelConfigTest.java
@@ -17,9 +17,9 @@ package io.netty.channel.epoll;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollDatagramChannelConfigTest {
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -23,23 +23,23 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.unix.Socket;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 import static io.netty.util.NetUtil.LOCALHOST;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollDatagramChannelTest {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Epoll.ensureAvailability();
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -25,9 +25,9 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractDatagramTest;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -38,16 +38,17 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
 
-    @BeforeClass
+    @BeforeAll
     public static void assumeRecvmmsgSupported() {
-        Assume.assumeTrue(Native.IS_SUPPORTING_RECVMMSG);
+        assumeTrue(Native.IS_SUPPORTING_RECVMMSG);
     }
 
     @Override
@@ -56,8 +57,8 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
     }
 
     @Test
-    public void testScatteringReadPartial() throws Throwable {
-        run();
+    public void testScatteringReadPartial(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testScatteringReadPartial);
     }
 
     public void testScatteringReadPartial(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -65,8 +66,8 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
     }
 
     @Test
-    public void testScatteringRead() throws Throwable {
-        run();
+    public void testScatteringRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testScatteringRead);
     }
 
     public void testScatteringRead(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -74,8 +75,8 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
     }
 
     @Test
-    public void testScatteringReadConnectedPartial() throws Throwable {
-        run();
+    public void testScatteringReadConnectedPartial(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testScatteringReadConnectedPartial);
     }
 
     public void testScatteringReadConnectedPartial(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -83,8 +84,8 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
     }
 
     @Test
-    public void testScatteringConnectedRead() throws Throwable {
-        run();
+    public void testScatteringConnectedRead(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testScatteringConnectedRead);
     }
 
     public void testScatteringConnectedRead(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -186,8 +187,8 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
     }
 
     @Test
-    public void testScatteringReadWithSmallBuffer() throws Throwable {
-        run();
+    public void testScatteringReadWithSmallBuffer(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testScatteringReadWithSmallBuffer);
     }
 
     public void testScatteringReadWithSmallBuffer(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -195,8 +196,8 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
     }
 
     @Test
-    public void testScatteringConnectedReadWithSmallBuffer() throws Throwable {
-        run();
+    public void testScatteringConnectedReadWithSmallBuffer(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testScatteringConnectedReadWithSmallBuffer);
     }
 
     public void testScatteringConnectedReadWithSmallBuffer(Bootstrap sb, Bootstrap cb) throws Throwable {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
@@ -28,8 +28,8 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramUnicastTest;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -37,8 +37,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class EpollDatagramUnicastTest extends DatagramUnicastTest {
     @Override
@@ -54,8 +55,8 @@ public class EpollDatagramUnicastTest extends DatagramUnicastTest {
     }
 
     @Test
-    public void testSendSegmentedDatagramPacket() throws Throwable {
-        run();
+    public void testSendSegmentedDatagramPacket(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendSegmentedDatagramPacket);
     }
 
     public void testSendSegmentedDatagramPacket(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -63,8 +64,8 @@ public class EpollDatagramUnicastTest extends DatagramUnicastTest {
     }
 
     @Test
-    public void testSendSegmentedDatagramPacketComposite() throws Throwable {
-        run();
+    public void testSendSegmentedDatagramPacketComposite(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendSegmentedDatagramPacketComposite);
     }
 
     public void testSendSegmentedDatagramPacketComposite(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -72,8 +73,8 @@ public class EpollDatagramUnicastTest extends DatagramUnicastTest {
     }
 
     @Test
-    public void testSendAndReceiveSegmentedDatagramPacket() throws Throwable {
-        run();
+    public void testSendAndReceiveSegmentedDatagramPacket(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendAndReceiveSegmentedDatagramPacket);
     }
 
     public void testSendAndReceiveSegmentedDatagramPacket(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -81,8 +82,8 @@ public class EpollDatagramUnicastTest extends DatagramUnicastTest {
     }
 
     @Test
-    public void testSendAndReceiveSegmentedDatagramPacketComposite() throws Throwable {
-        run();
+    public void testSendAndReceiveSegmentedDatagramPacketComposite(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendAndReceiveSegmentedDatagramPacketComposite);
     }
 
     public void testSendAndReceiveSegmentedDatagramPacketComposite(Bootstrap sb, Bootstrap cb) throws Throwable {
@@ -99,7 +100,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastTest {
             // Only supported for the native epoll transport.
             return;
         }
-        Assume.assumeTrue(EpollDatagramChannel.isSegmentedDatagramPacketSupported());
+        assumeTrue(EpollDatagramChannel.isSegmentedDatagramPacketSupported());
         Channel sc = null;
         Channel cc = null;
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -25,14 +25,19 @@ import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractSocketTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollDomainSocketFdTest extends AbstractSocketTest {
     @Override
@@ -45,9 +50,10 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
         return EpollSocketTestPermutation.INSTANCE.domainSocket();
     }
 
-    @Test(timeout = 30000)
-    public void testSendRecvFd() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testSendRecvFd(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendRecvFd);
     }
 
     public void testSendRecvFd(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -90,10 +96,10 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
 
         if (received instanceof FileDescriptor) {
             FileDescriptor fd = (FileDescriptor) received;
-            Assert.assertTrue(fd.isOpen());
+            assertTrue(fd.isOpen());
             fd.close();
-            Assert.assertFalse(fd.isOpen());
-            Assert.assertNull(queue.poll());
+            assertFalse(fd.isOpen());
+            assertNull(queue.poll());
         } else {
             throw (Throwable) received;
         }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslClientRenegotiateTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslClientRenegotiateTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslClientRenegotiateTest;
 
@@ -25,11 +24,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public class EpollDomainSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
-
-    public EpollDomainSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.domainSocket();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslEchoTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslEchoTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslEchoTest;
 
@@ -25,16 +24,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public class EpollDomainSocketSslEchoTest extends SocketSslEchoTest {
-    public EpollDomainSocketSslEchoTest(
-            SslContext serverCtx, SslContext clientCtx, Renegotiation renegotiation,
-            boolean serverUsesDelegatedTaskExecutor, boolean clientUsesDelegatedTaskExecutor,
-            boolean autoRead, boolean useChunkedWriteHandler, boolean useCompositeByteBuf) {
-
-        super(serverCtx, clientCtx, renegotiation,
-              serverUsesDelegatedTaskExecutor, clientUsesDelegatedTaskExecutor,
-              autoRead, useChunkedWriteHandler, useCompositeByteBuf);
-    }
-
     @Override
     protected SocketAddress newSocketAddress() {
         return EpollSocketTestPermutation.newSocketAddress();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslGreetingTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslGreetingTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslGreetingTest;
 
@@ -25,11 +24,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public class EpollDomainSocketSslGreetingTest extends SocketSslGreetingTest {
-
-    public EpollDomainSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
-
     @Override
     protected SocketAddress newSocketAddress() {
         return EpollSocketTestPermutation.newSocketAddress();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketStartTlsTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketStartTlsTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketStartTlsTest;
 
@@ -25,11 +24,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public class EpollDomainSocketStartTlsTest extends SocketStartTlsTest {
-
-    public EpollDomainSocketStartTlsTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
-    }
-
     @Override
     protected SocketAddress newSocketAddress() {
         return EpollSocketTestPermutation.newSocketAddress();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -26,17 +26,17 @@ import io.netty.testsuite.transport.AbstractSingleThreadEventLoopTest;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollKQueueIovArrayTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollKQueueIovArrayTest.java
@@ -16,12 +16,11 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.unix.tests.IovArrayTest;
-import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public class EpollKQueueIovArrayTest extends IovArrayTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void loadNative() {
         Epoll.ensureAvailability();
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
@@ -29,10 +29,9 @@ import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -42,7 +41,13 @@ import java.net.Socket;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class EpollReuseAddrTest {
     private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(EpollReuseAddrTest.class);
@@ -84,13 +89,13 @@ public class EpollReuseAddrTest {
 
     @Test
     public void testMultipleBindSocketChannelWithoutReusePortFails() {
-        Assume.assumeTrue(versionEqOrGt(3, 9, 0));
+        assumeTrue(versionEqOrGt(3, 9, 0));
         testMultipleBindDatagramChannelWithoutReusePortFails0(createServerBootstrap());
     }
 
     @Test
     public void testMultipleBindDatagramChannelWithoutReusePortFails() {
-        Assume.assumeTrue(versionEqOrGt(3, 9, 0));
+        assumeTrue(versionEqOrGt(3, 9, 0));
         testMultipleBindDatagramChannelWithoutReusePortFails0(createBootstrap());
     }
 
@@ -99,16 +104,17 @@ public class EpollReuseAddrTest {
         ChannelFuture future = bootstrap.bind().syncUninterruptibly();
         try {
             bootstrap.bind(future.channel().localAddress()).syncUninterruptibly();
-            Assert.fail();
+            fail();
         } catch (Exception e) {
-            Assert.assertTrue(e.getCause() instanceof IOException);
+            assertTrue(e.getCause() instanceof IOException);
         }
         future.channel().close().syncUninterruptibly();
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void testMultipleBindSocketChannel() throws Exception {
-        Assume.assumeTrue(versionEqOrGt(3, 9, 0));
+        assumeTrue(versionEqOrGt(3, 9, 0));
         ServerBootstrap bootstrap = createServerBootstrap();
         bootstrap.option(EpollChannelOption.SO_REUSEPORT, true);
         final AtomicBoolean accepted1 = new AtomicBoolean();
@@ -121,7 +127,7 @@ public class EpollReuseAddrTest {
         ChannelFuture future2 = bootstrap.bind(address1).syncUninterruptibly();
         InetSocketAddress address2 = (InetSocketAddress) future2.channel().localAddress();
 
-        Assert.assertEquals(address1, address2);
+        assertEquals(address1, address2);
         while (!accepted1.get() || !accepted2.get()) {
             Socket socket = new Socket(address1.getAddress(), address1.getPort());
             socket.setReuseAddress(true);
@@ -131,11 +137,12 @@ public class EpollReuseAddrTest {
         future2.channel().close().syncUninterruptibly();
     }
 
-    @Test(timeout = 10000)
-    @Ignore // TODO: Unignore after making it pass on centos6-1 and debian7-1
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @Disabled // TODO: Unignore after making it pass on centos6-1 and debian7-1
     public void testMultipleBindDatagramChannel() throws Exception {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.ADVANCED);
-        Assume.assumeTrue(versionEqOrGt(3, 9, 0));
+        assumeTrue(versionEqOrGt(3, 9, 0));
         Bootstrap bootstrap = createBootstrap();
         bootstrap.option(EpollChannelOption.SO_REUSEPORT, true);
         final AtomicBoolean received1 = new AtomicBoolean();
@@ -148,7 +155,7 @@ public class EpollReuseAddrTest {
         ChannelFuture future2 = bootstrap.bind(address1).syncUninterruptibly();
         final InetSocketAddress address2 = (InetSocketAddress) future2.channel().localAddress();
 
-        Assert.assertEquals(address1, address2);
+        assertEquals(address1, address2);
         final byte[] bytes = "data".getBytes();
 
         // fire up 16 Threads and send DatagramPackets to make sure we stress it enough to see DatagramPackets received
@@ -177,8 +184,8 @@ public class EpollReuseAddrTest {
         executor.shutdown();
         future.channel().close().syncUninterruptibly();
         future2.channel().close().syncUninterruptibly();
-        Assert.assertTrue(received1.get());
-        Assert.assertTrue(received2.get());
+        assertTrue(received1.get());
+        assertTrue(received2.get());
     }
 
     private static ServerBootstrap createServerBootstrap() {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -20,21 +20,23 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollServerSocketChannelConfigTest {
 
     private static EventLoopGroup group;
     private static EpollServerSocketChannel ch;
 
-    @BeforeClass
+    @BeforeAll
     public static void before() {
         group = new MultithreadEventLoopGroup(1, EpollHandler.newFactory());
         ServerBootstrap bootstrap = new ServerBootstrap();
@@ -44,7 +46,7 @@ public class EpollServerSocketChannelConfigTest {
                 .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() {
         try {
             ch.close().syncUninterruptibly();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -15,25 +15,28 @@
  */
 package io.netty.channel.epoll;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
 
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.Map;
 import java.util.Random;
 
-import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class EpollSocketChannelConfigTest {
 
@@ -41,18 +44,18 @@ public class EpollSocketChannelConfigTest {
     private static EpollSocketChannel ch;
     private static Random rand;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         rand = new Random();
         group = new MultithreadEventLoopGroup(1, EpollHandler.newFactory());
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         group.shutdownGracefully();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         Bootstrap bootstrap = new Bootstrap();
         ch = (EpollSocketChannel) bootstrap.group(group)
@@ -61,7 +64,7 @@ public class EpollSocketChannelConfigTest {
                 .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         ch.close().syncUninterruptibly();
     }
@@ -87,8 +90,7 @@ public class EpollSocketChannelConfigTest {
             ch.config().setTcpNotSentLowAt(expected);
             actual = ch.config().getTcpNotSentLowAt();
         } catch (RuntimeException e) {
-            assumeNoException(e);
-            return; // Needed to prevent compile error for final variables to be used below
+            throw new TestAbortedException("assumeNoException", e);
         }
         assertEquals(expected, actual);
     }
@@ -101,7 +103,7 @@ public class EpollSocketChannelConfigTest {
         } catch (IllegalArgumentException e) {
             return;
         } catch (RuntimeException e) {
-            assumeNoException(e);
+            throw new TestAbortedException("assumeNoException", e);
         }
         fail();
     }
@@ -114,7 +116,7 @@ public class EpollSocketChannelConfigTest {
         } catch (IllegalArgumentException e) {
             return;
         } catch (RuntimeException e) {
-            assumeNoException(e);
+            throw new TestAbortedException("assumeNoException", e);
         }
         fail();
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
@@ -20,10 +20,12 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollSocketChannelTest {
 
@@ -65,40 +67,40 @@ public class EpollSocketChannelTest {
     }
 
     private static void assertTcpInfo0(EpollTcpInfo info) throws Exception {
-        Assert.assertNotNull(info);
+        assertNotNull(info);
 
-        Assert.assertTrue(info.state() >= 0);
-        Assert.assertTrue(info.caState() >= 0);
-        Assert.assertTrue(info.retransmits() >= 0);
-        Assert.assertTrue(info.probes() >= 0);
-        Assert.assertTrue(info.backoff() >= 0);
-        Assert.assertTrue(info.options() >= 0);
-        Assert.assertTrue(info.sndWscale() >= 0);
-        Assert.assertTrue(info.rcvWscale() >= 0);
-        Assert.assertTrue(info.rto() >= 0);
-        Assert.assertTrue(info.ato() >= 0);
-        Assert.assertTrue(info.sndMss() >= 0);
-        Assert.assertTrue(info.rcvMss() >= 0);
-        Assert.assertTrue(info.unacked() >= 0);
-        Assert.assertTrue(info.sacked() >= 0);
-        Assert.assertTrue(info.lost() >= 0);
-        Assert.assertTrue(info.retrans() >= 0);
-        Assert.assertTrue(info.fackets() >= 0);
-        Assert.assertTrue(info.lastDataSent() >= 0);
-        Assert.assertTrue(info.lastAckSent() >= 0);
-        Assert.assertTrue(info.lastDataRecv() >= 0);
-        Assert.assertTrue(info.lastAckRecv() >= 0);
-        Assert.assertTrue(info.pmtu() >= 0);
-        Assert.assertTrue(info.rcvSsthresh() >= 0);
-        Assert.assertTrue(info.rtt() >= 0);
-        Assert.assertTrue(info.rttvar() >= 0);
-        Assert.assertTrue(info.sndSsthresh() >= 0);
-        Assert.assertTrue(info.sndCwnd() >= 0);
-        Assert.assertTrue(info.advmss() >= 0);
-        Assert.assertTrue(info.reordering() >= 0);
-        Assert.assertTrue(info.rcvRtt() >= 0);
-        Assert.assertTrue(info.rcvSpace() >= 0);
-        Assert.assertTrue(info.totalRetrans() >= 0);
+        assertTrue(info.state() >= 0);
+        assertTrue(info.caState() >= 0);
+        assertTrue(info.retransmits() >= 0);
+        assertTrue(info.probes() >= 0);
+        assertTrue(info.backoff() >= 0);
+        assertTrue(info.options() >= 0);
+        assertTrue(info.sndWscale() >= 0);
+        assertTrue(info.rcvWscale() >= 0);
+        assertTrue(info.rto() >= 0);
+        assertTrue(info.ato() >= 0);
+        assertTrue(info.sndMss() >= 0);
+        assertTrue(info.rcvMss() >= 0);
+        assertTrue(info.unacked() >= 0);
+        assertTrue(info.sacked() >= 0);
+        assertTrue(info.lost() >= 0);
+        assertTrue(info.retrans() >= 0);
+        assertTrue(info.fackets() >= 0);
+        assertTrue(info.lastDataSent() >= 0);
+        assertTrue(info.lastAckSent() >= 0);
+        assertTrue(info.lastDataRecv() >= 0);
+        assertTrue(info.lastAckRecv() >= 0);
+        assertTrue(info.pmtu() >= 0);
+        assertTrue(info.rcvSsthresh() >= 0);
+        assertTrue(info.rtt() >= 0);
+        assertTrue(info.rttvar() >= 0);
+        assertTrue(info.sndSsthresh() >= 0);
+        assertTrue(info.sndCwnd() >= 0);
+        assertTrue(info.advmss() >= 0);
+        assertTrue(info.reordering() >= 0);
+        assertTrue(info.rcvRtt() >= 0);
+        assertTrue(info.rcvSpace() >= 0);
+        assertTrue(info.totalRetrans() >= 0);
     }
 
     // See https://github.com/netty/netty/issues/7159

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketRstTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketRstTest.java
@@ -26,8 +26,8 @@ import io.netty.testsuite.transport.socket.SocketRstTest;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollSocketRstTest extends SocketRstTest {
     @Override
@@ -42,8 +42,8 @@ public class EpollSocketRstTest extends SocketRstTest {
             return;
         }
 
-        assertTrue("actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]",
-                   cause instanceof NativeIoException);
+        assertTrue(cause instanceof NativeIoException,
+            "actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]");
         assertEquals(Errors.ERRNO_ECONNRESET_NEGATIVE, ((NativeIoException) cause).expectedErr());
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslClientRenegotiateTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslClientRenegotiateTest.java
@@ -17,18 +17,12 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslClientRenegotiateTest;
 
 import java.util.List;
 
 public class EpollSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
-
-    public EpollSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslEchoTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslEchoTest.java
@@ -17,23 +17,12 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslEchoTest;
 
 import java.util.List;
 
 public class EpollSocketSslEchoTest extends SocketSslEchoTest {
-    public EpollSocketSslEchoTest(
-            SslContext serverCtx, SslContext clientCtx, Renegotiation renegotiation,
-            boolean serverUsesDelegatedTaskExecutor, boolean clientUsesDelegatedTaskExecutor,
-            boolean autoRead, boolean useChunkedWriteHandler, boolean useCompositeByteBuf) {
-
-        super(serverCtx, clientCtx, renegotiation,
-              serverUsesDelegatedTaskExecutor, clientUsesDelegatedTaskExecutor,
-              autoRead, useChunkedWriteHandler, useCompositeByteBuf);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslGreetingTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslGreetingTest.java
@@ -17,18 +17,12 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslGreetingTest;
 
 import java.util.List;
 
 public class EpollSocketSslGreetingTest extends SocketSslGreetingTest {
-
-    public EpollSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslSessionReuseTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketSslSessionReuseTest.java
@@ -17,18 +17,12 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslSessionReuseTest;
 
 import java.util.List;
 
 public class EpollSocketSslSessionReuseTest extends SocketSslSessionReuseTest {
-
-    public EpollSocketSslSessionReuseTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStartTlsTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStartTlsTest.java
@@ -17,18 +17,12 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketStartTlsTest;
 
 import java.util.List;
 
 public class EpollSocketStartTlsTest extends SocketStartTlsTest {
-
-    public EpollSocketStartTlsTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithFastOpen();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
@@ -15,16 +15,10 @@
  */
 package io.netty.channel.epoll;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.SelectStrategy;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.testsuite.transport.TestsuitePermutation;
@@ -33,18 +27,23 @@ import io.netty.testsuite.transport.TestsuitePermutation.BootstrapFactory;
 import io.netty.testsuite.transport.socket.SocketStringEchoTest;
 import io.netty.util.IntSupplier;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class EpollSocketStringEchoBusyWaitTest extends SocketStringEchoTest {
 
     private static EventLoopGroup EPOLL_LOOP;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws Exception {
         EPOLL_LOOP = new MultithreadEventLoopGroup(2, new DefaultThreadFactory("testsuite-epoll-busy-wait", true),
                 EpollHandler.newFactory(0, () -> (selectSupplier, hasTasks) -> SelectStrategy.BUSY_WAIT));
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown() throws Exception {
         if (EPOLL_LOOP != null) {
             EPOLL_LOOP.shutdownGracefully();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTest.java
@@ -19,17 +19,17 @@ import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.tests.SocketTest;
 import io.netty.channel.unix.tests.UnixTestUtils;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollSocketTest extends SocketTest<LinuxSocket> {
-    @BeforeClass
+    @BeforeAll
     public static void loadJNI() {
         Epoll.ensureAvailability();
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
@@ -16,13 +16,15 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.unix.FileDescriptor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EpollTest {
 
@@ -32,7 +34,8 @@ public class EpollTest {
     }
 
     // Testcase for https://github.com/netty/netty/issues/8444
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testEpollWaitWithTimeOutMinusOne() throws Exception  {
         final EpollEventArray eventArray = new EpollEventArray(8);
         try {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
@@ -15,36 +15,40 @@
  */
 package io.netty.channel.epoll;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LinuxSocketTest {
-    @BeforeClass
+    @BeforeAll
     public static void loadJNI() {
         Epoll.ensureAvailability();
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testBindNonIpv6SocketToInet6AddressThrows() throws Exception {
         LinuxSocket socket = LinuxSocket.newSocketStream(false);
         try {
-            socket.bind(new InetSocketAddress(InetAddress.getByAddress(
-                    new byte[]{'0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1'}), 0));
+            assertThrows(IOException.class, () -> socket.bind(new InetSocketAddress(InetAddress.getByAddress(
+                    new byte[]{'0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1'}), 0)));
         } finally {
             socket.close();
         }
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testConnectNonIpv6SocketToInet6AddressThrows() throws Exception {
         LinuxSocket socket = LinuxSocket.newSocketStream(false);
         try {
-            socket.connect(new InetSocketAddress(InetAddress.getByAddress(
-                    new byte[]{'0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1'}), 1234));
+            assertThrows(IOException.class,
+                () -> socket.connect(new InetSocketAddress(InetAddress.getByAddress(new byte[]{
+                    '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1'}), 1234)));
         } finally {
             socket.close();
         }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/NativeTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/NativeTest.java
@@ -16,14 +16,14 @@
 package io.netty.channel.epoll;
 
 import io.netty.util.NetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
 import static io.netty.channel.unix.NativeInetAddress.address;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NativeTest {
 
@@ -34,7 +34,7 @@ public class NativeTest {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         buffer.put(inetAddress.getAddress().getAddress());
         buffer.putInt(inetAddress.getPort());
-        Assert.assertEquals(inetAddress, address(buffer.array(), 0, bytes.length));
+        assertEquals(inetAddress, address(buffer.array(), 0, bytes.length));
     }
 
     @Test
@@ -46,6 +46,6 @@ public class NativeTest {
         buffer.put(address.getAddress());
         buffer.putInt(address.getScopeId());
         buffer.putInt(inetAddress.getPort());
-        Assert.assertEquals(inetAddress, address(buffer.array(), 0, bytes.length));
+        assertEquals(inetAddress, address(buffer.array(), 0, bytes.length));
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
@@ -21,15 +21,15 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class KQueueChannelConfigTest {
-    @Before
+    @BeforeEach
     public void before() {
         KQueue.ensureAvailability();
     }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -25,13 +25,19 @@ import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractSocketTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KQueueDomainSocketFdTest extends AbstractSocketTest {
     @Override
@@ -44,9 +50,10 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
         return KQueueSocketTestPermutation.INSTANCE.domainSocket();
     }
 
-    @Test(timeout = 30000)
-    public void testSendRecvFd() throws Throwable {
-        run();
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testSendRecvFd(TestInfo testInfo) throws Throwable {
+        run(testInfo, this::testSendRecvFd);
     }
 
     public void testSendRecvFd(ServerBootstrap sb, Bootstrap cb) throws Throwable {
@@ -89,10 +96,10 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
 
         if (received instanceof FileDescriptor) {
             FileDescriptor fd = (FileDescriptor) received;
-            Assert.assertTrue(fd.isOpen());
+            assertTrue(fd.isOpen());
             fd.close();
-            Assert.assertFalse(fd.isOpen());
-            Assert.assertNull(queue.poll());
+            assertFalse(fd.isOpen());
+            assertNull(queue.poll());
         } else {
             throw (Throwable) received;
         }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslClientRenegotiateTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslClientRenegotiateTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslClientRenegotiateTest;
 
@@ -25,11 +24,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public class KQueueDomainSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
-
-    public KQueueDomainSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return KQueueSocketTestPermutation.INSTANCE.domainSocket();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslEchoTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslEchoTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslEchoTest;
 
@@ -25,16 +24,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public class KQueueDomainSocketSslEchoTest extends SocketSslEchoTest {
-    public KQueueDomainSocketSslEchoTest(
-            SslContext serverCtx, SslContext clientCtx, Renegotiation renegotiation,
-            boolean serverUsesDelegatedTaskExecutor, boolean clientUsesDelegatedTaskExecutor,
-            boolean autoRead, boolean useChunkedWriteHandler, boolean useCompositeByteBuf) {
-
-        super(serverCtx, clientCtx, renegotiation,
-              serverUsesDelegatedTaskExecutor, clientUsesDelegatedTaskExecutor,
-              autoRead, useChunkedWriteHandler, useCompositeByteBuf);
-    }
-
     @Override
     protected SocketAddress newSocketAddress() {
         return KQueueSocketTestPermutation.newSocketAddress();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslGreetingTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketSslGreetingTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslGreetingTest;
 
@@ -25,11 +24,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public class KQueueDomainSocketSslGreetingTest extends SocketSslGreetingTest {
-
-    public KQueueDomainSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
-
     @Override
     protected SocketAddress newSocketAddress() {
         return KQueueSocketTestPermutation.newSocketAddress();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketStartTlsTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketStartTlsTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketStartTlsTest;
 
@@ -25,11 +24,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public class KQueueDomainSocketStartTlsTest extends SocketStartTlsTest {
-
-    public KQueueDomainSocketStartTlsTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
-    }
-
     @Override
     protected SocketAddress newSocketAddress() {
         return KQueueSocketTestPermutation.newSocketAddress();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
@@ -22,12 +22,12 @@ import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.testsuite.transport.AbstractSingleThreadEventLoopTest;
 import io.netty.util.concurrent.Future;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueIovArrayTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueIovArrayTest.java
@@ -16,11 +16,11 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.unix.tests.IovArrayTest;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public class KQueueIovArrayTest extends IovArrayTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void loadNative() {
         KQueue.ensureAvailability();
     }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueRcvAllocatorOverrideSocketSslEchoTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueRcvAllocatorOverrideSocketSslEchoTest.java
@@ -18,19 +18,8 @@ package io.netty.channel.kqueue;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.handler.ssl.SslContext;
 
 public class KQueueRcvAllocatorOverrideSocketSslEchoTest extends KQueueSocketSslEchoTest {
-    public KQueueRcvAllocatorOverrideSocketSslEchoTest(
-            SslContext serverCtx, SslContext clientCtx, Renegotiation renegotiation,
-            boolean serverUsesDelegatedTaskExecutor, boolean clientUsesDelegatedTaskExecutor,
-            boolean autoRead, boolean useChunkedWriteHandler, boolean useCompositeByteBuf) {
-
-        super(serverCtx, clientCtx, renegotiation,
-                serverUsesDelegatedTaskExecutor, clientUsesDelegatedTaskExecutor,
-                autoRead, useChunkedWriteHandler, useCompositeByteBuf);
-    }
-
     @Override
     protected void configure(ServerBootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
         super.configure(bootstrap, bootstrap2, allocator);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfigTest.java
@@ -19,24 +19,23 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class KQueueServerSocketChannelConfigTest {
 
     private static EventLoopGroup group;
     private static KQueueServerSocketChannel ch;
 
-    @BeforeClass
+    @BeforeAll
     public static void before() {
         group = new MultithreadEventLoopGroup(1, KQueueHandler.newFactory());
         ServerBootstrap bootstrap = new ServerBootstrap();
@@ -46,7 +45,7 @@ public class KQueueServerSocketChannelConfigTest {
                 .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
     }
 
-    @AfterClass
+    @AfterAll
     public static void after() {
         try {
             ch.close().syncUninterruptibly();
@@ -67,7 +66,7 @@ public class KQueueServerSocketChannelConfigTest {
     public void testAcceptFilter() {
         AcceptFilter currentFilter = ch.config().getAcceptFilter();
         // Not all platforms support this option (e.g. MacOS doesn't) so test if we support the option first.
-        assumeThat(currentFilter, not(AcceptFilter.PLATFORM_UNSUPPORTED));
+        assumeTrue(currentFilter != AcceptFilter.PLATFORM_UNSUPPORTED);
 
         AcceptFilter af = new AcceptFilter("test", "foo");
         ch.config().setAcceptFilter(af);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -20,22 +20,22 @@ import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
 
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.Random;
 
 import static io.netty.channel.kqueue.BsdSocket.BSD_SND_LOW_AT_MAX;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeNoException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class KQueueSocketChannelConfigTest {
 
@@ -43,18 +43,18 @@ public class KQueueSocketChannelConfigTest {
     private static KQueueSocketChannel ch;
     private static Random rand;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         rand = new Random();
         group = new MultithreadEventLoopGroup(1, KQueueHandler.newFactory());
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         group.shutdownGracefully();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         Bootstrap bootstrap = new Bootstrap();
         ch = (KQueueSocketChannel) bootstrap.group(group)
@@ -63,7 +63,7 @@ public class KQueueSocketChannelConfigTest {
                 .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         ch.close().syncUninterruptibly();
     }
@@ -76,8 +76,7 @@ public class KQueueSocketChannelConfigTest {
             ch.config().setSndLowAt(expected);
             actual = ch.config().getSndLowAt();
         } catch (RuntimeException e) {
-            assumeNoException(e);
-            return; // Needed to prevent compile error for final variables to be used below
+            throw new TestAbortedException("assumeNoException", e);
         }
         assertEquals(expected, actual);
     }
@@ -89,7 +88,7 @@ public class KQueueSocketChannelConfigTest {
         } catch (ChannelException e) {
             return;
         } catch (RuntimeException e) {
-            assumeNoException(e);
+            throw new TestAbortedException("assumeNoException", e);
         }
         fail();
     }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketRstTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketRstTest.java
@@ -26,8 +26,8 @@ import io.netty.testsuite.transport.socket.SocketRstTest;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KQueueSocketRstTest extends SocketRstTest {
     @Override
@@ -42,8 +42,8 @@ public class KQueueSocketRstTest extends SocketRstTest {
             return;
         }
 
-        assertTrue("actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]",
-                   cause instanceof NativeIoException);
+        assertTrue(cause instanceof NativeIoException,
+            "actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]");
         assertEquals(Errors.ERRNO_ECONNRESET_NEGATIVE, ((NativeIoException) cause).expectedErr());
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslClientRenegotiateTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslClientRenegotiateTest.java
@@ -17,18 +17,12 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslClientRenegotiateTest;
 
 import java.util.List;
 
 public class KQueueSocketSslClientRenegotiateTest extends SocketSslClientRenegotiateTest {
-
-    public KQueueSocketSslClientRenegotiateTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return KQueueSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslEchoTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslEchoTest.java
@@ -17,23 +17,12 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslEchoTest;
 
 import java.util.List;
 
 public class KQueueSocketSslEchoTest extends SocketSslEchoTest {
-    public KQueueSocketSslEchoTest(
-            SslContext serverCtx, SslContext clientCtx, Renegotiation renegotiation,
-            boolean serverUsesDelegatedTaskExecutor, boolean clientUsesDelegatedTaskExecutor,
-            boolean autoRead, boolean useChunkedWriteHandler, boolean useCompositeByteBuf) {
-
-        super(serverCtx, clientCtx, renegotiation,
-              serverUsesDelegatedTaskExecutor, clientUsesDelegatedTaskExecutor,
-              autoRead, useChunkedWriteHandler, useCompositeByteBuf);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return KQueueSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslGreetingTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslGreetingTest.java
@@ -17,18 +17,12 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketSslGreetingTest;
 
 import java.util.List;
 
 public class KQueueSocketSslGreetingTest extends SocketSslGreetingTest {
-
-    public KQueueSocketSslGreetingTest(SslContext serverCtx, SslContext clientCtx, boolean delegate) {
-        super(serverCtx, clientCtx, delegate);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return KQueueSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslSessionReuseTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketSslSessionReuseTest.java
@@ -24,11 +24,6 @@ import io.netty.testsuite.transport.socket.SocketSslSessionReuseTest;
 import java.util.List;
 
 public class KQueueSocketSslSessionReuseTest extends SocketSslSessionReuseTest {
-
-    public KQueueSocketSslSessionReuseTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return KQueueSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketStartTlsTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketStartTlsTest.java
@@ -17,18 +17,12 @@ package io.netty.channel.kqueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.handler.ssl.SslContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketStartTlsTest;
 
 import java.util.List;
 
 public class KQueueSocketStartTlsTest extends SocketStartTlsTest {
-
-    public KQueueSocketStartTlsTest(SslContext serverCtx, SslContext clientCtx) {
-        super(serverCtx, clientCtx);
-    }
-
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return KQueueSocketTestPermutation.INSTANCE.socket();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTest.java
@@ -19,15 +19,17 @@ import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.tests.SocketTest;
 import io.netty.channel.unix.tests.UnixTestUtils;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KQueueSocketTest extends SocketTest<BsdSocket> {
-    @BeforeClass
+    @BeforeAll
     public static void loadJNI() {
         KQueue.ensureAvailability();
     }

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -28,25 +28,29 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.SimpleChannelInboundHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class DetectPeerCloseWithoutReadTest {
     protected abstract EventLoopGroup newGroup();
     protected abstract Class<? extends ServerChannel> serverChannel();
     protected abstract Class<? extends Channel> clientChannel();
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void clientCloseWithoutServerReadIsDetectedNoExtraReadRequested() throws InterruptedException {
         clientCloseWithoutServerReadIsDetected0(false);
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void clientCloseWithoutServerReadIsDetectedExtraReadRequested() throws InterruptedException {
         clientCloseWithoutServerReadIsDetected0(true);
     }
@@ -103,12 +107,14 @@ public abstract class DetectPeerCloseWithoutReadTest {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void serverCloseWithoutClientReadIsDetectedNoExtraReadRequested() throws InterruptedException {
         serverCloseWithoutClientReadIsDetected0(false);
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void serverCloseWithoutClientReadIsDetectedExtraReadRequested() throws InterruptedException {
         serverCloseWithoutClientReadIsDetected0(true);
     }

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/IovArrayTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/IovArrayTest.java
@@ -20,11 +20,11 @@ import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.buffer.UnpooledDirectByteBuf;
 import io.netty.channel.unix.IovArray;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class IovArrayTest {
 

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/SocketTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/SocketTest.java
@@ -16,27 +16,27 @@
 package io.netty.channel.unix.tests;
 
 import io.netty.channel.unix.Socket;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class SocketTest<T extends Socket> {
     protected T socket;
 
     protected abstract T newSocket();
 
-    @Before
+    @BeforeEach
     public void setup() {
         socket = newSocket();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
         socket.close();
     }


### PR DESCRIPTION
https://github.com/netty/netty/issues/10757#issuecomment-848445551