### PR TITLE
Fix test-error which was introduced by porting tests to junit5

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
@@ -241,6 +241,17 @@ public class WrappedUnpooledUnsafeByteBufTest extends BigEndianUnsafeDirectByteB
 
     @Test
     @Override
+    public void testGetBytesByteBuffer() {
+        assertThrows(IndexOutOfBoundsException.class, new Executable() {
+            @Override
+            public void execute() {
+                WrappedUnpooledUnsafeByteBufTest.super.testGetBytesByteBuffer();
+            }
+        });
+    }
+
+    @Test
+    @Override
     public void testForEachByteDesc2() {
         // Ignore
     }


### PR DESCRIPTION
Motivation:

b89a807d15fd925c21d3c875836145cd5302c8c9 moved the buffer tests to junit5 but introduced a small error which could lead to test-failure

Modifications:

Correctly override the method and assert that super throws (as we can not expand the buffer).

Result:

No more test failures
