### PR TITLE
HttpPostMultipartRequestDecoder IndexOutOfBoundsException error

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostBodyUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostBodyUtil.java
@@ -233,13 +233,15 @@ final class HttpPostBodyUtil {
             newOffset += posDelimiter;
             toRead -= posDelimiter;
             // Now check for delimiter
-            delimiterNotFound = false;
-            for (int i = 0; i < delimiterLength; i++) {
-                if (buffer.getByte(newOffset + i) != delimiter[i]) {
-                    newOffset++;
-                    toRead--;
-                    delimiterNotFound = true;
-                    break;
+            if (toRead >= delimiterLength) {
+                delimiterNotFound = false;
+                for (int i = 0; i < delimiterLength; i++) {
+                    if (buffer.getByte(newOffset + i) != delimiter[i]) {
+                        newOffset++;
+                        toRead--;
+                        delimiterNotFound = true;
+                        break;
+                    }
                 }
             }
             if (!delimiterNotFound) {


### PR DESCRIPTION
Motivation:

When searching for the delimiter, the decoder part within HttpPostBodyUtil
was not checking the left space to check if it could be included or not,$
while it should.

Modifications:

Add a check on toRead being greater or equal than delimiterLength before
going within the loop. If the check is wrong, the delimiter is obviously not found.

Add a Junit test to preserve regression.

Result:

No more IndexOutOfBoundsException

Fixes #11334
