### PR TITLE
Fix read access using getByte(specificReadIndex) not checking that going over writerIndex

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -352,7 +352,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public byte getByte(int index) {
-        checkIndex(index);
+        checkReaderIndex(index);
         return _getByte(index);
     }
 
@@ -370,7 +370,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public short getShort(int index) {
-        checkIndex(index, 2);
+        checkReaderIndex(index, 2);
         return _getShort(index);
     }
 
@@ -378,7 +378,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public short getShortLE(int index) {
-        checkIndex(index, 2);
+        checkReaderIndex(index, 2);
         return _getShortLE(index);
     }
 
@@ -396,7 +396,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public int getUnsignedMedium(int index) {
-        checkIndex(index, 3);
+        checkReaderIndex(index, 3);
         return _getUnsignedMedium(index);
     }
 
@@ -404,7 +404,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public int getUnsignedMediumLE(int index) {
-        checkIndex(index, 3);
+        checkReaderIndex(index, 3);
         return _getUnsignedMediumLE(index);
     }
 
@@ -430,7 +430,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public int getInt(int index) {
-        checkIndex(index, 4);
+        checkReaderIndex(index, 4);
         return _getInt(index);
     }
 
@@ -438,7 +438,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public int getIntLE(int index) {
-        checkIndex(index, 4);
+        checkReaderIndex(index, 4);
         return _getIntLE(index);
     }
 
@@ -456,7 +456,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public long getLong(int index) {
-        checkIndex(index, 8);
+        checkReaderIndex(index, 8);
         return _getLong(index);
     }
 
@@ -464,7 +464,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public long getLongLE(int index) {
-        checkIndex(index, 8);
+        checkReaderIndex(index, 8);
         return _getLongLE(index);
     }
 
@@ -1287,7 +1287,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         try {
             return forEachByteAsc0(index, index + length, processor);
         } catch (Exception e) {
@@ -1319,7 +1319,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         try {
             return forEachByteDesc0(index + length - 1, index, processor);
         } catch (Exception e) {
@@ -1375,6 +1375,21 @@ public abstract class AbstractByteBuf extends ByteBuf {
         return buf.toString();
     }
 
+    protected final void checkReaderIndex(int index) {
+        checkReaderIndex(index, 1);
+    }
+
+    protected final void checkReaderIndex(int index, int fieldLength) {
+        ensureAccessible();
+        checkReaderIndex0(index, fieldLength);
+    }
+
+    final void checkReaderIndex0(int index, int fieldLength) {
+        if (checkBounds) {
+            checkRangeBounds("index", index, fieldLength, writerIndex());
+        }
+    }
+
     protected final void checkIndex(int index) {
         checkIndex(index, 1);
     }
@@ -1398,10 +1413,10 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
-    protected final void checkSrcIndex(int index, int length, int srcIndex, int srcCapacity) {
+    protected final void checkSrcIndex(int index, int length, int srcIndex, int srcMaxReadeable) {
         checkIndex(index, length);
         if (checkBounds) {
-            checkRangeBounds("srcIndex", srcIndex, length, srcCapacity);
+            checkRangeBounds("srcIndex", srcIndex, length, srcMaxReadeable);
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -221,7 +221,7 @@ abstract class AbstractPooledDerivedByteBuf extends AbstractReferenceCountedByte
 
         @Override
         public ByteBuf slice(int index, int length) {
-            checkIndex(index, length);
+            checkReaderIndex(index, length);
             return new PooledNonRetainedSlicedByteBuf(referenceCountDelegate, unwrap(), index, length);
         }
 
@@ -304,7 +304,7 @@ abstract class AbstractPooledDerivedByteBuf extends AbstractReferenceCountedByte
 
         @Override
         public ByteBuf slice(int index, int length) {
-            checkIndex(index, length);
+            checkReaderIndex(index, length);
             return new PooledNonRetainedSlicedByteBuf(referenceCountDelegate, unwrap(), idx(index), length);
         }
 

--- a/buffer/src/main/java/io/netty/buffer/AbstractUnpooledSlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractUnpooledSlicedByteBuf.java
@@ -116,7 +116,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public byte getByte(int index) {
-        checkIndex0(index, 1);
+        checkReaderIndex0(index, 1);
         return unwrap().getByte(idx(index));
     }
 
@@ -127,7 +127,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public short getShort(int index) {
-        checkIndex0(index, 2);
+        checkReaderIndex0(index, 2);
         return unwrap().getShort(idx(index));
     }
 
@@ -138,7 +138,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public short getShortLE(int index) {
-        checkIndex0(index, 2);
+        checkReaderIndex0(index, 2);
         return unwrap().getShortLE(idx(index));
     }
 
@@ -149,7 +149,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int getUnsignedMedium(int index) {
-        checkIndex0(index, 3);
+        checkReaderIndex0(index, 3);
         return unwrap().getUnsignedMedium(idx(index));
     }
 
@@ -160,7 +160,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int getUnsignedMediumLE(int index) {
-        checkIndex0(index, 3);
+        checkReaderIndex0(index, 3);
         return unwrap().getUnsignedMediumLE(idx(index));
     }
 
@@ -171,7 +171,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int getInt(int index) {
-        checkIndex0(index, 4);
+        checkReaderIndex0(index, 4);
         return unwrap().getInt(idx(index));
     }
 
@@ -182,7 +182,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int getIntLE(int index) {
-        checkIndex0(index, 4);
+        checkReaderIndex0(index, 4);
         return unwrap().getIntLE(idx(index));
     }
 
@@ -193,7 +193,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public long getLong(int index) {
-        checkIndex0(index, 8);
+        checkReaderIndex0(index, 8);
         return unwrap().getLong(idx(index));
     }
 
@@ -204,7 +204,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public long getLongLE(int index) {
-        checkIndex0(index, 8);
+        checkReaderIndex0(index, 8);
         return unwrap().getLongLE(idx(index));
     }
 
@@ -220,33 +220,33 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf copy(int index, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return unwrap().copy(idx(index), length);
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return unwrap().slice(idx(index), length);
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         unwrap().getBytes(idx(index), dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         unwrap().getBytes(idx(index), dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
-        checkIndex0(index, dst.remaining());
+        checkReaderIndex0(index, dst.remaining());
         unwrap().getBytes(idx(index), dst);
         return this;
     }
@@ -260,7 +260,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public CharSequence getCharSequence(int index, int length, Charset charset) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return unwrap().getCharSequence(idx(index), length, charset);
     }
 
@@ -388,20 +388,20 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         unwrap().getBytes(idx(index), out, length);
         return this;
     }
 
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return unwrap().getBytes(idx(index), out, length);
     }
 
     @Override
     public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return unwrap().getBytes(idx(index), out, position, length);
     }
 
@@ -442,7 +442,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         int ret = unwrap().forEachByte(idx(index), length, processor);
         if (ret >= adjustment) {
             return ret - adjustment;
@@ -453,7 +453,7 @@ abstract class AbstractUnpooledSlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         int ret = unwrap().forEachByteDesc(idx(index), length, processor);
         if (ret >= adjustment) {
             return ret - adjustment;

--- a/buffer/src/main/java/io/netty/buffer/AbstractUnsafeSwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractUnsafeSwappedByteBuf.java
@@ -37,7 +37,7 @@ abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
 
     @Override
     public final long getLong(int index) {
-        wrapped.checkIndex(index, 8);
+        wrapped.checkReaderIndex(index, 8);
         long v = _getLong(wrapped, index);
         return nativeByteOrder ? v : Long.reverseBytes(v);
     }
@@ -64,7 +64,7 @@ abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
 
     @Override
     public final int getInt(int index) {
-        wrapped.checkIndex(index, 4);
+        wrapped.checkReaderIndex(index, 4);
         int v = _getInt(wrapped, index);
         return nativeByteOrder ? v : Integer.reverseBytes(v);
     }
@@ -76,7 +76,7 @@ abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
 
     @Override
     public final short getShort(int index) {
-        wrapped.checkIndex(index, 2);
+        wrapped.checkReaderIndex(index, 2);
         short v = _getShort(wrapped, index);
         return nativeByteOrder ? v : Short.reverseBytes(v);
     }

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -468,7 +468,7 @@ public final class ByteBufUtil {
             return -1;
         }
         final int length = toIndex - fromIndex;
-        buffer.checkIndex(fromIndex, length);
+        buffer.checkReaderIndex(fromIndex, length);
         if (!PlatformDependent.isUnaligned()) {
             return linearFirstIndexOf(buffer, fromIndex, toIndex, value);
         }
@@ -602,7 +602,7 @@ public final class ByteBufUtil {
         if (fromIndex < 0 || capacity == 0) {
             return -1;
         }
-        buffer.checkIndex(toIndex, fromIndex - toIndex);
+        buffer.checkReaderIndex(toIndex, fromIndex - toIndex);
         for (int i = fromIndex - 1; i >= toIndex; i--) {
             if (buffer._getByte(i) == value) {
                 return i;

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -716,7 +716,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
      * Same with {@link #slice(int, int)} except that this method returns a list.
      */
     public List<ByteBuf> decompose(int offset, int length) {
-        checkIndex(offset, length);
+        checkReaderIndex(offset, length);
         if (length == 0) {
             return Collections.emptyList();
         }
@@ -1071,7 +1071,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         int limit = dst.limit();
         int length = dst.remaining();
 
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         if (length == 0) {
             return this;
         }
@@ -1149,7 +1149,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
 
     @Override
     public CompositeByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         if (length == 0) {
             return this;
         }
@@ -1368,7 +1368,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
 
     @Override
     public CompositeByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        checkSrcIndex(index, length, srcIndex, src.capacity());
+        checkSrcIndex(index, length, srcIndex, src.writerIndex());
         if (length == 0) {
             return this;
         }
@@ -1509,7 +1509,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
 
     @Override
     public ByteBuf copy(int index, int length) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         ByteBuf dst = allocBuffer(length);
         if (length != 0) {
             copyTo(index, length, toComponentIndex0(index), dst);

--- a/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
@@ -395,7 +395,7 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
         int limit = dst.limit();
         int length = dst.remaining();
 
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         if (length == 0) {
             return this;
         }
@@ -486,7 +486,7 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         if (length == 0) {
             return this;
         }
@@ -511,7 +511,7 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf copy(int index, int length) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         boolean release = true;
         ByteBuf buf = alloc().buffer(length);
         try {

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -160,7 +160,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     private void getBytes(int index, OutputStream out, int length, boolean internal) throws IOException {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         if (length == 0) {
             return;
         }
@@ -228,7 +228,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        checkSrcIndex(index, length, srcIndex, src.capacity());
+        checkSrcIndex(index, length, srcIndex, src.writerIndex());
         if (src.hasArray()) {
             setBytes(index, src.array(), src.arrayOffset() + srcIndex, length);
         } else if (src.nioBufferCount() > 0) {
@@ -281,7 +281,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     @Override
     public ByteBuf copy(int index, int length) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         ByteBuf copy = alloc().directBuffer(length, maxCapacity());
         return copy.writeBytes(this, index, length);
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -117,14 +117,14 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
     @Override
     public final ByteBuf getBytes(int index, ByteBuffer dst) {
         int length = dst.remaining();
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         dst.put(memory, idx(index), length);
         return this;
     }
 
     @Override
     public final ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         out.write(memory, idx(index), length);
         return this;
     }
@@ -176,7 +176,7 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
 
     @Override
     public final ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        checkSrcIndex(index, length, srcIndex, src.capacity());
+        checkSrcIndex(index, length, srcIndex, src.writerIndex());
         if (src.hasMemoryAddress()) {
             PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, memory, idx(index), length);
         } else if (src.hasArray()) {
@@ -210,7 +210,7 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
 
     @Override
     public final ByteBuf copy(int index, int length) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         ByteBuf copy = alloc().heapBuffer(length, maxCapacity());
         return copy.writeBytes(memory, idx(index), length);
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
@@ -97,19 +97,19 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public ByteBuf copy(int index, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return unwrap().copy(idx(index), length);
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return super.slice(idx(index), length);
     }
 
     @Override
     public ByteBuf retainedSlice(int index, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return PooledSlicedByteBuf.newInstance0(unwrap(), this, idx(index), length);
     }
 
@@ -125,7 +125,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public byte getByte(int index) {
-        checkIndex0(index, 1);
+        checkReaderIndex0(index, 1);
         return unwrap().getByte(idx(index));
     }
 
@@ -136,7 +136,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public short getShort(int index) {
-        checkIndex0(index, 2);
+        checkReaderIndex0(index, 2);
         return unwrap().getShort(idx(index));
     }
 
@@ -147,7 +147,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public short getShortLE(int index) {
-        checkIndex0(index, 2);
+        checkReaderIndex0(index, 2);
         return unwrap().getShortLE(idx(index));
     }
 
@@ -158,7 +158,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public int getUnsignedMedium(int index) {
-        checkIndex0(index, 3);
+        checkReaderIndex0(index, 3);
         return unwrap().getUnsignedMedium(idx(index));
     }
 
@@ -169,7 +169,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public int getUnsignedMediumLE(int index) {
-        checkIndex0(index, 3);
+        checkReaderIndex0(index, 3);
         return unwrap().getUnsignedMediumLE(idx(index));
     }
 
@@ -180,7 +180,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public int getInt(int index) {
-        checkIndex0(index, 4);
+        checkReaderIndex0(index, 4);
         return unwrap().getInt(idx(index));
     }
 
@@ -191,7 +191,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public int getIntLE(int index) {
-        checkIndex0(index, 4);
+        checkReaderIndex0(index, 4);
         return unwrap().getIntLE(idx(index));
     }
 
@@ -202,7 +202,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public long getLong(int index) {
-        checkIndex0(index, 8);
+        checkReaderIndex0(index, 8);
         return unwrap().getLong(idx(index));
     }
 
@@ -213,7 +213,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public long getLongLE(int index) {
-        checkIndex0(index, 8);
+        checkReaderIndex0(index, 8);
         return unwrap().getLongLE(idx(index));
     }
 
@@ -224,21 +224,21 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         unwrap().getBytes(idx(index), dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         unwrap().getBytes(idx(index), dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
-        checkIndex0(index, dst.remaining());
+        checkReaderIndex0(index, dst.remaining());
         unwrap().getBytes(idx(index), dst);
         return this;
     }
@@ -375,7 +375,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         unwrap().getBytes(idx(index), out, length);
         return this;
     }
@@ -383,14 +383,14 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length)
             throws IOException {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return unwrap().getBytes(idx(index), out, length);
     }
 
     @Override
     public int getBytes(int index, FileChannel out, long position, int length)
             throws IOException {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         return unwrap().getBytes(idx(index), out, position, length);
     }
 
@@ -417,7 +417,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         int ret = unwrap().forEachByte(idx(index), length, processor);
         if (ret < adjustment) {
             return -1;
@@ -427,7 +427,7 @@ final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf {
 
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
-        checkIndex0(index, length);
+        checkReaderIndex0(index, length);
         int ret = unwrap().forEachByteDesc(idx(index), length, processor);
         if (ret < adjustment) {
             return -1;

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -203,7 +203,7 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
-        checkIndex(index, dst.remaining());
+        checkReaderIndex(index, dst.remaining());
 
         ByteBuffer tmpBuf = internalNioBuffer();
         tmpBuf.clear().position(index).limit(index + dst.remaining());

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -62,7 +62,7 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         ObjectUtil.checkNotNull(dst, "dst");
         if (dstIndex < 0 || dstIndex > dst.capacity() - length) {
             throw new IndexOutOfBoundsException("dstIndex: " + dstIndex);
@@ -80,7 +80,7 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         ObjectUtil.checkNotNull(dst, "dst");
         if (dstIndex < 0 || dstIndex > dst.length - length) {
             throw new IndexOutOfBoundsException(String.format(
@@ -95,7 +95,7 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
 
     @Override
     public ByteBuf copy(int index, int length) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         ByteBuf copy = alloc().directBuffer(length, maxCapacity());
         if (length != 0) {
             if (copy.hasMemoryAddress()) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -326,7 +326,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     void getBytes(int index, ByteBuffer dst, boolean internal) {
-        checkIndex(index, dst.remaining());
+        checkReaderIndex(index, dst.remaining());
 
         ByteBuffer tmpBuf;
         if (internal) {
@@ -433,7 +433,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        checkSrcIndex(index, length, srcIndex, src.capacity());
+        checkSrcIndex(index, length, srcIndex, src.writerIndex());
         if (src.nioBufferCount() > 0) {
             for (ByteBuffer bb: src.nioBuffers(srcIndex, length)) {
                 int bbLen = bb.remaining();

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -244,7 +244,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        checkSrcIndex(index, length, srcIndex, src.capacity());
+        checkSrcIndex(index, length, srcIndex, src.writerIndex());
         if (src.hasMemoryAddress()) {
             PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, array, index, length);
         } else  if (src.hasArray()) {
@@ -531,7 +531,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuf copy(int index, int length) {
-        checkIndex(index, length);
+        checkReaderIndex(index, length);
         return alloc().heapBuffer(length, maxCapacity()).writeBytes(array, index, length);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -82,7 +82,7 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     public byte getByte(int index) {
-        checkIndex(index);
+        checkReaderIndex(index);
         return _getByte(index);
     }
 
@@ -93,7 +93,7 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     public short getShort(int index) {
-        checkIndex(index, 2);
+        checkReaderIndex(index, 2);
         return _getShort(index);
     }
 
@@ -109,7 +109,7 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     public int getUnsignedMedium(int index) {
-        checkIndex(index, 3);
+        checkReaderIndex(index, 3);
         return _getUnsignedMedium(index);
     }
 
@@ -125,7 +125,7 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     public int getInt(int index) {
-        checkIndex(index, 4);
+        checkReaderIndex(index, 4);
         return _getInt(index);
     }
 
@@ -141,7 +141,7 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     public long getLong(int index) {
-        checkIndex(index, 8);
+        checkReaderIndex(index, 8);
         return _getLong(index);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
@@ -41,7 +41,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public byte getByte(int index) {
-        checkIndex(index);
+        checkReaderIndex(index);
         return _getByte(index);
     }
 
@@ -52,7 +52,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public short getShort(int index) {
-        checkIndex(index, 2);
+        checkReaderIndex(index, 2);
         return _getShort(index);
     }
 
@@ -63,7 +63,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public short getShortLE(int index) {
-        checkIndex(index, 2);
+        checkReaderIndex(index, 2);
         return _getShortLE(index);
     }
 
@@ -74,7 +74,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public int getUnsignedMedium(int index) {
-        checkIndex(index, 3);
+        checkReaderIndex(index, 3);
         return _getUnsignedMedium(index);
     }
 
@@ -85,7 +85,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public int getUnsignedMediumLE(int index) {
-        checkIndex(index, 3);
+        checkReaderIndex(index, 3);
         return _getUnsignedMediumLE(index);
     }
 
@@ -96,7 +96,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public int getInt(int index) {
-        checkIndex(index, 4);
+        checkReaderIndex(index, 4);
         return _getInt(index);
     }
 
@@ -107,7 +107,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public int getIntLE(int index) {
-        checkIndex(index, 4);
+        checkReaderIndex(index, 4);
         return _getIntLE(index);
     }
 
@@ -118,7 +118,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public long getLong(int index) {
-        checkIndex(index, 8);
+        checkReaderIndex(index, 8);
         return _getLong(index);
     }
 
@@ -129,7 +129,7 @@ public class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     @Override
     public long getLongLE(int index) {
-        checkIndex(index, 8);
+        checkReaderIndex(index, 8);
         return _getLongLE(index);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -432,7 +432,7 @@ final class UnsafeByteBufUtil {
     }
 
     static ByteBuf copy(AbstractByteBuf buf, long addr, int index, int length) {
-        buf.checkIndex(index, length);
+        buf.checkReaderIndex(index, length);
         ByteBuf copy = buf.alloc().directBuffer(length, buf.maxCapacity());
         if (length != 0) {
             if (copy.hasMemoryAddress()) {
@@ -462,7 +462,7 @@ final class UnsafeByteBufUtil {
     }
 
     static void getBytes(AbstractByteBuf buf, long addr, int index, ByteBuf dst, int dstIndex, int length) {
-        buf.checkIndex(index, length);
+        buf.checkReaderIndex(index, length);
         checkNotNull(dst, "dst");
         if (isOutOfBounds(dstIndex, length, dst.capacity())) {
             throw new IndexOutOfBoundsException("dstIndex: " + dstIndex);
@@ -478,7 +478,7 @@ final class UnsafeByteBufUtil {
     }
 
     static void getBytes(AbstractByteBuf buf, long addr, int index, byte[] dst, int dstIndex, int length) {
-        buf.checkIndex(index, length);
+        buf.checkReaderIndex(index, length);
         checkNotNull(dst, "dst");
         if (isOutOfBounds(dstIndex, length, dst.length)) {
             throw new IndexOutOfBoundsException("dstIndex: " + dstIndex);
@@ -489,7 +489,7 @@ final class UnsafeByteBufUtil {
     }
 
     static void getBytes(AbstractByteBuf buf, long addr, int index, ByteBuffer dst) {
-        buf.checkIndex(index, dst.remaining());
+        buf.checkReaderIndex(index, dst.remaining());
         if (dst.remaining() == 0) {
             return;
         }
@@ -588,7 +588,7 @@ final class UnsafeByteBufUtil {
     }
 
     static void getBytes(AbstractByteBuf buf, long addr, int index, OutputStream out, int length) throws IOException {
-        buf.checkIndex(index, length);
+        buf.checkReaderIndex(index, length);
         if (length != 0) {
             int len = Math.min(length, ByteBufUtil.WRITE_CHUNK_SIZE);
             if (len <= ByteBufUtil.MAX_TL_ARRAY_LEN || !buf.alloc().isDirectBufferPooled()) {

--- a/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
@@ -768,4 +768,30 @@ public class UnpooledTest {
             wrappedBuffer.release();
         }
     }
+
+    @Test
+    public void testWrongAccessGetByteOverWriterIndex() {
+        final ByteBuf buffer = ByteBufAllocator.DEFAULT.directBuffer(100, 2048);
+        buffer.writeZero(100);
+        for (int i = 0; i < 100; i++) {
+            buffer.getByte(i);
+        }
+        try {
+            buffer.getByte(101);
+            fail("Should raized an exception");
+        } catch (IndexOutOfBoundsException e) {
+            // OK
+        }
+        final ByteBuf buffer2 = ByteBufAllocator.DEFAULT.directBuffer(1024, 2048);
+        buffer2.writeZero(100);
+        for (int i = 0; i < 100; i++) {
+            buffer2.getByte(i);
+        }
+        try {
+            buffer2.getByte(101);
+            fail("Should raized an exception");
+        } catch (IndexOutOfBoundsException e) {
+            // OK
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

While using a `ByteBuf` with a capacity greater than `writerIndex`, trying to access
a specific index position that is over `writerIndex` does not raized an exception such
as `IndexOutOfBoundsException`, while it should.

Modifications:

Add `checkReaderIndex` and related other methods to check against `writerIndex`.
Modify all get and related methods (slice, copy...) to use those new protected methods.

Add a Junit test to preserve regression.

Result:

Shall raized `IndexOutOfBoundsException`

Should fixes #11336

Notes:
- However that this could miss some
- Could impact greatly projects using Netty if they rely on bad usage of reading access
