### PR TITLE
Fix typo in word `accelerating`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,7 @@
         <optional>true</optional>
       </dependency>
 
-      <!-- Conscrypt - needed for running tests, used for acclerating SSL with OpenSSL. -->
+      <!-- Conscrypt - needed for running tests, used for accelerating SSL with OpenSSL. -->
       <dependency>
         <groupId>${conscrypt.groupId}</groupId>
         <artifactId>${conscrypt.artifactId}</artifactId>


### PR DESCRIPTION
Motivation:
There is a small typo in `pom.xml`. Typo is: `acclerating`, however it should be `accelerating`.

Modification:
Corrected the typo.

Result:
Typo-free `pom.xml`.
