### PR TITLE
Make build log output less chatty

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -44,7 +44,7 @@ jobs:
             ${{ runner.os }}-maven-verify-pr-
             ${{ runner.os }}-maven-
       - name: Verify with Maven
-        run: ./mvnw verify -B --file pom.xml -DskipTests=true
+        run: ./mvnw -B -ntp --file pom.xml verify -DskipTests=true
 
   build-pr-windows:
     runs-on: windows-2016
@@ -68,7 +68,7 @@ jobs:
             pr-windows-x86_64-maven-cache-
 
       - name: Build project
-        run: ./mvnw.cmd --file pom.xml clean package -Pboringssl -DskipHttp2Testsuite=true -DskipAutobahnTestsuite=true
+        run: ./mvnw.cmd -B -ntp --file pom.xml clean package -Pboringssl -DskipHttp2Testsuite=true -DskipAutobahnTestsuite=true
 
       - name: Upload Test Results
         if: always()
@@ -126,7 +126,7 @@ jobs:
           #
           # Use tcnative.classifier that is empty as we don't support using the shared lib version on ubuntu.
           run: |
-            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64 ./mvnw -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
+            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64 ./mvnw -B -ntp -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
 
   build-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -59,8 +59,8 @@ jobs:
 
       - name: Prepare release with Maven
         run: |
-          ./mvnw -B --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true
-          ./mvnw clean
+          ./mvnw -B -ntp --file pom.xml release:prepare -DpreparationGoals=clean -DskipTests=true
+          ./mvnw -B -ntp clean
 
       - name: Checkout tag
         run: ./.github/scripts/release_checkout_tag.sh release.properties
@@ -240,7 +240,7 @@ jobs:
       - name: Deploy local staged artifacts
         working-directory: ./prepare-release-workspace/
         # If we don't want to close the repository we can add -DskipStagingRepositoryClose=true
-        run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
+        run: ./mvnw -B -ntp --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/home/runner/local-staging -DskipStagingRepositoryClose=true
 
       - name: Rollback release on failure
         working-directory: ./prepare-release-workspace/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -92,7 +92,7 @@ jobs:
     #    uses a compiled language
 
     - name: Compile project
-      run: ./mvnw clean package -DskipTests=true -ntp -B
+      run: ./mvnw -B -ntp clean package -DskipTests=true
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -29,7 +29,7 @@ services:
 
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean deploy -DskipTests=true"
 
   cross-compile-aarch64-stage-snapshot:
     <<: *cross-compile-aarch64-common
@@ -39,7 +39,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   cross-compile-aarch64-stage-release:
     <<: *cross-compile-aarch64-common
@@ -48,7 +48,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}"
 
   cross-compile-aarch64-shell:
     <<: *cross-compile-aarch64-common
@@ -56,4 +56,4 @@ services:
 
   cross-compile-aarch64-build:
     <<: *cross-compile-aarch64-common
-    command: /bin/bash -cl "./mvnw -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll -am clean package -DskipTests=true"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,15 +25,15 @@ services:
 
   build-leak:
     <<: *common
-    command: /bin/bash -cl "./mvnw -Pleak clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora"
+    command: /bin/bash -cl "./mvnw -B -ntp -Pleak clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora"
 
   build:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora"
+    command: /bin/bash -cl "./mvnw -B -ntp clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora"
 
   deploy:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean deploy -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp clean deploy -DskipTests=true"
 
   stage-snapshot:
     <<: *common
@@ -43,7 +43,7 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "./mvnw clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
+    command: /bin/bash -cl "./mvnw -B -ntp clean package org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true"
 
   stage-release:
     <<: *common
@@ -52,15 +52,15 @@ services:
       - ~/.m2:/root/.m2
       - ~/local-staging:/root/local-staging
       - ..:/code
-    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} -Dtcnative.classifier=linux-x86_64-fedora"
+    command: /bin/bash -cl "cat <(echo -e \"${GPG_PRIVATE_KEY}\") | gpg --batch --import && ./mvnw -B -ntp clean javadoc:jar package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DaltStagingDirectory=/root/local-staging -DskipRemoteStaging=true -DskipTests=true -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME} -Dtcnative.classifier=linux-x86_64-fedora"
 
   build-boringssl-static:
     <<: *common
-    command: /bin/bash -cl "./mvnw -Pboringssl clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Pboringssl clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
 
   build-leak-boringssl-static:
     <<: *common
-    command: /bin/bash -cl "./mvnw -Pboringssl,leak clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
+    command: /bin/bash -cl "./mvnw -B -ntp -Pboringssl,leak clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
 
   shell:
     <<: *common


### PR DESCRIPTION
Motivation:
When Maven does not run in batch mode, it will continuously print its progress as it downloads dependencies.
This can produce a very large amount of log output, that makes it harder to debug build failures.

Modification:
Make all Maven builds run in batch mode by adding the `-B` command line flag, and have transfer progress suppressed with the `-ntp` flag.
Some builds were already running batch mode but had the flag in a different location – these have had their `-B` flag moved so all builds are consistent.

Result:
Much less output in our build logs where Maven is just downloading stuff.