### PR TITLE
Add additional doc to the method io.netty.buffer.EmptyByteBuf#isDirect

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -59,7 +59,7 @@ public abstract class InternalLoggerFactory {
 
     private static InternalLoggerFactory useSlf4JLoggerFactory(String name) {
         try {
-            InternalLoggerFactory f = Slf4JLoggerFactory.INSTANCE_WITH_NOP_CHECK;
+            InternalLoggerFactory f = Slf4JLoggerFactory.getInstanceWithNopCheck();
             f.newInstance(name).debug("Using SLF4J as the default logging framework");
             return f;
         } catch (LinkageError ignore) {

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -30,8 +30,6 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
     @SuppressWarnings("deprecation")
     public static final InternalLoggerFactory INSTANCE = new Slf4JLoggerFactory();
 
-    static final InternalLoggerFactory INSTANCE_WITH_NOP_CHECK = new Slf4JLoggerFactory(true);
-
     /**
      * @deprecated Use {@link #INSTANCE} instead.
      */
@@ -55,5 +53,13 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
     static InternalLogger wrapLogger(Logger logger) {
         return logger instanceof LocationAwareLogger ?
                 new LocationAwareSlf4JLogger((LocationAwareLogger) logger) : new Slf4JLogger(logger);
+    }
+
+    static InternalLoggerFactory getInstanceWithNopCheck() {
+        return NopInstanceHolder.INSTANCE_WITH_NOP_CHECK;
+    }
+
+    private static class NopInstanceHolder {
+        private static final InternalLoggerFactory INSTANCE_WITH_NOP_CHECK = new Slf4JLoggerFactory(true);
     }
 }


### PR DESCRIPTION
Motivation:

Add additional explanation to the doc of method `io.netty.buffer.EmptyByteBuf#isDirect`, to make it more clear to understand.

Modification:

Add additional explanation to the doc of method `io.netty.buffer.EmptyByteBuf#isDirect`.

Result:

Fixes #11354. 
