### PR TITLE
Use Two way algorithm to optimize ByteBufUtil.indexOf() method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -233,6 +233,10 @@ public final class ByteBufUtil {
             return -1;
         }
 
+        if (needle.readableBytes() > haystack.readableBytes()) {
+            return -1;
+        }
+
         int n = haystack.readableBytes();
         int m = needle.readableBytes();
         if (m == 0) {

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -254,21 +254,21 @@ public final class ByteBufUtil {
         }
 
         int i;
-        int j;
-        int startIndex = needle.readerIndex();
-        int[] suffixes =  maxSuf(needle, m, startIndex, true);
-        int[] prefixes = maxSuf(needle, m, startIndex, false);
+        int j = 0;
+        int aStartIndex = needle.readerIndex();
+        int bStartIndex = haystack.readerIndex();
+        int[] suffixes =  maxSuf(needle, m, aStartIndex, true);
+        int[] prefixes = maxSuf(needle, m, aStartIndex, false);
         int ell = Math.max(suffixes[0], prefixes[0]);
         int per = Math.max(suffixes[1], prefixes[1]);
         int memory;
         int length = Math.min(m - per, ell + 1);
 
-        if (equals(needle, startIndex, needle, startIndex + per,  length)) {
-            j = 0;
+        if (equals(needle, aStartIndex, needle, aStartIndex + per,  length)) {
             memory = -1;
             while (j <= n - m) {
                 i = Math.max(ell, memory) + 1;
-                while (i < m && needle.getByte(i) == haystack.getByte(i + j)) {
+                while (i < m && needle.getByte(i + aStartIndex) == haystack.getByte(i + j + bStartIndex)) {
                     ++i;
                 }
                 if (i > n) {
@@ -276,7 +276,7 @@ public final class ByteBufUtil {
                 }
                 if (i >= m) {
                     i = ell;
-                    while (i > memory && needle.getByte(i) == haystack.getByte(i + j)) {
+                    while (i > memory && needle.getByte(i + aStartIndex) == haystack.getByte(i + j + bStartIndex)) {
                         --i;
                     }
                     if (i <= memory) {
@@ -291,10 +291,9 @@ public final class ByteBufUtil {
             }
         } else {
             per = Math.max(ell + 1, m - ell - 1) + 1;
-            j = 0;
             while (j <= n - m) {
                 i = ell + 1;
-                while (i < m && needle.getByte(i) == haystack.getByte(i + j)) {
+                while (i < m && needle.getByte(i + aStartIndex) == haystack.getByte(i + j + bStartIndex)) {
                     ++i;
                 }
                 if (i > n) {
@@ -302,7 +301,7 @@ public final class ByteBufUtil {
                 }
                 if (i >= m) {
                     i = ell;
-                    while (i >= 0 && needle.getByte(i) == haystack.getByte(i + j)) {
+                    while (i >= 0 && needle.getByte(i + aStartIndex) == haystack.getByte(i + j + bStartIndex)) {
                         --i;
                     }
                     if (i < 0) {

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -227,9 +227,8 @@ public final class ByteBufUtil {
 
     /**
      * Returns the reader index of needle in haystack, or -1 if needle is not in haystack.
-     * The indexOf method uses the <a href="https://en.wikipedia.org/wiki/Two-way_string-matching_algorithm">Two-Way</a>
-     * string matching algorithm to optimize performance,
-     * because it uses the o(1) Space complexity and excellent performance
+     * This method uses the <a href="https://en.wikipedia.org/wiki/Two-way_string-matching_algorithm">Two-Way
+     * string matching algorithm</a>, which yields O(1) space complexity and excellent performance.
      */
     public static int indexOf(ByteBuf needle, ByteBuf haystack) {
         if (haystack == null || needle == null) {

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -227,6 +227,9 @@ public final class ByteBufUtil {
 
     /**
      * Returns the reader index of needle in haystack, or -1 if needle is not in haystack.
+     * The indexOf method uses the <a href="https://en.wikipedia.org/wiki/Two-way_string-matching_algorithm">Two-Way</a>
+     * string matching algorithm to optimize performance,
+     * because it uses the o(1) Space complexity and excellent performance
      */
     public static int indexOf(ByteBuf needle, ByteBuf haystack) {
         if (haystack == null || needle == null) {
@@ -243,13 +246,20 @@ public final class ByteBufUtil {
             return 0;
         }
 
-        int i = maxSuf(needle, m, true);
-        int j = maxSuf(needle, m, false);
-        int ell = Math.max(i, j);
-        int memory;
-        int per = 0;
+        // When the needle has only one byte that can be read,
+        // the firstIndexOf method needs to be called
+        if (m == 1) {
+           return firstIndexOf((AbstractByteBuf) haystack, haystack.readerIndex(),
+                   haystack.writerIndex(), needle.getByte(needle.readerIndex()));
+        }
 
-        if (equals(needle, 0, needle, per, per + ell + 1)) {
+        int i;
+        int j;
+        int ell = Math.max(maxSuf(needle, m, true), maxSuf(needle, m, false));
+        int memory;
+        int per = needle.readerIndex();
+
+        if (equals(needle, per, needle, per, per + ell + 1)) {
             j = 0;
             memory = -1;
             while (j <= n - m) {

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -261,8 +261,9 @@ public final class ByteBufUtil {
         int ell = Math.max(suffixes[0], prefixes[0]);
         int per = Math.max(suffixes[1], prefixes[1]);
         int memory;
+        int length = Math.min(m - per, ell + 1);
 
-        if (equals(needle, startIndex, needle, startIndex + per,  ell - startIndex + 1)) {
+        if (equals(needle, startIndex, needle, startIndex + per,  length)) {
             j = 0;
             memory = -1;
             while (j <= n - m) {

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -257,6 +257,9 @@ public final class ByteBufUtil {
                 while (i < m && needle.getByte(i) == haystack.getByte(i + j)) {
                     ++i;
                 }
+                if (i > n) {
+                    return -1;
+                }
                 if (i >= m) {
                     i = ell;
                     while (i > memory && needle.getByte(i) == haystack.getByte(i + j)) {
@@ -279,6 +282,9 @@ public final class ByteBufUtil {
                 i = ell + 1;
                 while (i < m && needle.getByte(i) == haystack.getByte(i + j)) {
                     ++i;
+                }
+                if (i > n) {
+                    return -1;
                 }
                 if (i >= m) {
                     i = ell;

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -230,12 +230,34 @@ public final class ByteBufUtil {
      */
     public static int indexOf(ByteBuf needle, ByteBuf haystack) {
         // TODO: maybe use Boyer Moore for efficiency.
-        int attempts = haystack.readableBytes() - needle.readableBytes() + 1;
-        for (int i = 0; i < attempts; i++) {
-            if (equals(needle, needle.readerIndex(),
-                       haystack, haystack.readerIndex() + i,
-                       needle.readableBytes())) {
-                return haystack.readerIndex() + i;
+        if (haystack == null || needle == null) {
+            return -1;
+        }
+
+        int n = haystack.readableBytes();
+        int m = needle.readableBytes();
+        if (m == 0) {
+            return 0;
+        }
+        int[] next = new int[m];
+        for (int i = 1, j = 0; i < m; i++) {
+            while (j > 0 && needle.getByte(i) != needle.getByte(j)) {
+                j = next[j - 1];
+            }
+            if (needle.getByte(i) == needle.getByte(j)) {
+                j++;
+            }
+            next[i] = j;
+        }
+        for (int i = 0, j = 0; i < n; i++) {
+            while (j > 0 && haystack.getByte(i) != needle.getByte(j)) {
+                j = next[j - 1];
+            }
+            if (haystack.getByte(i) == needle.getByte(j)) {
+                j++;
+            }
+            if (j == m) {
+                return i - m + 1;
             }
         }
         return -1;

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -249,15 +249,17 @@ public final class ByteBufUtil {
         // When the needle has only one byte that can be read,
         // the firstIndexOf method needs to be called
         if (m == 1) {
-           return firstIndexOf((AbstractByteBuf) haystack, haystack.readerIndex(),
-                   haystack.writerIndex(), needle.getByte(needle.readerIndex()));
+            return firstIndexOf((AbstractByteBuf) haystack, haystack.readerIndex(),
+                    haystack.writerIndex(), needle.getByte(needle.readerIndex()));
         }
 
         int i;
         int j;
-        int ell = Math.max(maxSuf(needle, m, true), maxSuf(needle, m, false));
+        int startIndex = needle.readerIndex();
+        int ell = Math.max(maxSuf(needle, m, startIndex, true),
+                maxSuf(needle, m, startIndex, false));
         int memory;
-        int per = needle.readerIndex();
+        int per = startIndex;
 
         if (equals(needle, per, needle, per, per + ell + 1)) {
             j = 0;
@@ -313,10 +315,10 @@ public final class ByteBufUtil {
         return -1;
     }
 
-    private static int maxSuf(ByteBuf x, int m, boolean isSuffix) {
+    private static int maxSuf(ByteBuf x, int m, int start, boolean isSuffix) {
         int p = 1;
         int ms = -1;
-        int j = 0;
+        int j = start;
         int k = 1;
         byte a;
         byte b;

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -256,12 +256,13 @@ public final class ByteBufUtil {
         int i;
         int j;
         int startIndex = needle.readerIndex();
-        int ell = Math.max(maxSuf(needle, m, startIndex, true),
-                maxSuf(needle, m, startIndex, false));
+        int[] suffixes =  maxSuf(needle, m, startIndex, true);
+        int[] prefixes = maxSuf(needle, m, startIndex, false);
+        int ell = Math.max(suffixes[0], prefixes[0]);
+        int per = Math.max(suffixes[1], prefixes[1]);
         int memory;
-        int per = startIndex;
 
-        if (equals(needle, per, needle, per, per + ell + 1)) {
+        if (equals(needle, startIndex, needle, startIndex + per,  ell - startIndex + 1)) {
             j = 0;
             memory = -1;
             while (j <= n - m) {
@@ -315,7 +316,7 @@ public final class ByteBufUtil {
         return -1;
     }
 
-    private static int maxSuf(ByteBuf x, int m, int start, boolean isSuffix) {
+    private static int[] maxSuf(ByteBuf x, int m, int start, boolean isSuffix) {
         int p = 1;
         int ms = -1;
         int j = start;
@@ -343,7 +344,7 @@ public final class ByteBufUtil {
                 k = p = 1;
             }
         }
-        return ms;
+        return new int[]{ms, p};
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -259,8 +259,8 @@ public final class ByteBufUtil {
         int bStartIndex = haystack.readerIndex();
         long suffixes =  maxSuf(needle, m, aStartIndex, true);
         long prefixes = maxSuf(needle, m, aStartIndex, false);
-        int ell = (int) Math.max(suffixes >>> 32, prefixes >>> 32);
-        int per = (int) Math.max(suffixes, prefixes);
+        int ell = Math.max((int) (suffixes >> 32), (int) (prefixes >> 32));
+        int per = Math.max((int) suffixes, (int) prefixes);
         int memory;
         int length = Math.min(m - per, ell + 1);
 

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -257,10 +257,10 @@ public final class ByteBufUtil {
         int j = 0;
         int aStartIndex = needle.readerIndex();
         int bStartIndex = haystack.readerIndex();
-        int[] suffixes =  maxSuf(needle, m, aStartIndex, true);
-        int[] prefixes = maxSuf(needle, m, aStartIndex, false);
-        int ell = Math.max(suffixes[0], prefixes[0]);
-        int per = Math.max(suffixes[1], prefixes[1]);
+        long suffixes =  maxSuf(needle, m, aStartIndex, true);
+        long prefixes = maxSuf(needle, m, aStartIndex, false);
+        int ell = (int) Math.max(suffixes >>> 32, prefixes >>> 32);
+        int per = (int) Math.max(suffixes, prefixes);
         int memory;
         int length = Math.min(m - per, ell + 1);
 
@@ -316,7 +316,7 @@ public final class ByteBufUtil {
         return -1;
     }
 
-    private static int[] maxSuf(ByteBuf x, int m, int start, boolean isSuffix) {
+    private static long maxSuf(ByteBuf x, int m, int start, boolean isSuffix) {
         int p = 1;
         int ms = -1;
         int j = start;
@@ -344,7 +344,7 @@ public final class ByteBufUtil {
                 k = p = 1;
             }
         }
-        return new int[]{ms, p};
+        return ((long) ms << 32) + p;
     }
 
     /**

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.buffer;
 
+import com.google.common.base.Charsets;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
@@ -116,6 +117,17 @@ public class ByteBufUtilTest {
                 ByteBufUtil.decodeHexDump("fg");
             }
         });
+    }
+
+    @Test
+    public void testIndexOf() {
+        final ByteBuf haystack = Unpooled.copiedBuffer("abc123", CharsetUtil.UTF_8);
+        assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("a", Charsets.UTF_8), haystack));
+        assertEquals(1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("bc".getBytes(Charsets.UTF_8)), haystack));
+        assertEquals(2, ByteBufUtil.indexOf(Unpooled.copiedBuffer("c".getBytes(Charsets.UTF_8)), haystack));
+        assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc12".getBytes(Charsets.UTF_8)), haystack));
+        assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abcdef".getBytes(Charsets.UTF_8)), haystack));
+        assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc12x".getBytes(Charsets.UTF_8)), haystack));
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -133,6 +133,12 @@ public class ByteBufUtilTest {
         haystack.readerIndex(1);
         needle.readerIndex(1);
         assertEquals(0, ByteBufUtil.indexOf(needle, haystack));
+        haystack.readerIndex(2);
+        needle.readerIndex(3);
+        assertEquals(1, ByteBufUtil.indexOf(needle, haystack));
+        haystack.readerIndex(1);
+        needle.readerIndex(2);
+        assertEquals(1, ByteBufUtil.indexOf(needle, haystack));
 
         haystack = Unpooled.copiedBuffer("123aab123", CharsetUtil.UTF_8);
         assertEquals(3, ByteBufUtil.indexOf(Unpooled.copiedBuffer("aab", CharsetUtil.UTF_8), haystack));

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-import com.google.common.base.Charsets;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
@@ -122,12 +121,17 @@ public class ByteBufUtilTest {
     @Test
     public void testIndexOf() {
         final ByteBuf haystack = Unpooled.copiedBuffer("abc123", CharsetUtil.UTF_8);
-        assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("a", Charsets.UTF_8), haystack));
-        assertEquals(1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("bc".getBytes(Charsets.UTF_8)), haystack));
-        assertEquals(2, ByteBufUtil.indexOf(Unpooled.copiedBuffer("c".getBytes(Charsets.UTF_8)), haystack));
-        assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc12".getBytes(Charsets.UTF_8)), haystack));
-        assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abcdef".getBytes(Charsets.UTF_8)), haystack));
-        assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc12x".getBytes(Charsets.UTF_8)), haystack));
+        assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("a", CharsetUtil.UTF_8), haystack));
+        assertEquals(1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("bc".getBytes(CharsetUtil.UTF_8)), haystack));
+        assertEquals(2, ByteBufUtil.indexOf(Unpooled.copiedBuffer("c".getBytes(CharsetUtil.UTF_8)), haystack));
+        assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc12".getBytes(CharsetUtil.UTF_8)), haystack));
+        assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abcdef".getBytes(CharsetUtil.UTF_8)), haystack));
+        assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc12x".getBytes(CharsetUtil.UTF_8)), haystack));
+
+        ByteBuf needle = Unpooled.copiedBuffer("abc12", CharsetUtil.UTF_8);
+        haystack.readerIndex(1);
+        needle.readerIndex(1);
+        assertEquals(0, ByteBufUtil.indexOf(needle, haystack));
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -120,18 +120,24 @@ public class ByteBufUtilTest {
 
     @Test
     public void testIndexOf() {
-        final ByteBuf haystack = Unpooled.copiedBuffer("abc123", CharsetUtil.UTF_8);
+        ByteBuf haystack = Unpooled.copiedBuffer("abc123", CharsetUtil.UTF_8);
         assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("a", CharsetUtil.UTF_8), haystack));
         assertEquals(1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("bc".getBytes(CharsetUtil.UTF_8)), haystack));
         assertEquals(2, ByteBufUtil.indexOf(Unpooled.copiedBuffer("c".getBytes(CharsetUtil.UTF_8)), haystack));
         assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc12".getBytes(CharsetUtil.UTF_8)), haystack));
         assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abcdef".getBytes(CharsetUtil.UTF_8)), haystack));
         assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc12x".getBytes(CharsetUtil.UTF_8)), haystack));
+        assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abc123def".getBytes(CharsetUtil.UTF_8)), haystack));
 
-        ByteBuf needle = Unpooled.copiedBuffer("abc12", CharsetUtil.UTF_8);
+        final ByteBuf needle = Unpooled.copiedBuffer("abc12", CharsetUtil.UTF_8);
         haystack.readerIndex(1);
         needle.readerIndex(1);
         assertEquals(0, ByteBufUtil.indexOf(needle, haystack));
+
+        haystack = Unpooled.copiedBuffer("123aab123", CharsetUtil.UTF_8);
+        assertEquals(3, ByteBufUtil.indexOf(Unpooled.copiedBuffer("aab", CharsetUtil.UTF_8), haystack));
+        haystack.release();
+        needle.release();
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -139,6 +139,7 @@ public class ByteBufUtilTest {
         haystack.readerIndex(1);
         needle.readerIndex(2);
         assertEquals(1, ByteBufUtil.indexOf(needle, haystack));
+        haystack.release();
 
         haystack = Unpooled.copiedBuffer("123aab123", CharsetUtil.UTF_8);
         assertEquals(3, ByteBufUtil.indexOf(Unpooled.copiedBuffer("aab", CharsetUtil.UTF_8), haystack));


### PR DESCRIPTION
Motivation:

ByteBufUtil.indexOf can be inefficient for substring search on
ByteBuf, in terms of algorithm complexity (O(needle.readableBytes * haystack.readableBytes)), consider using the Two Way  algorithm to optimize the ByteBufUtil.indexOf() method

Modification:

Use the Two Way algorithm to optimize ByteBufUtil.indexOf() method.

Result:

The performance of the ByteBufUtil.indexOf() method is higher than the original implementation
