### PR TITLE
Fix ServerCookieDecoder javadoc

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
@@ -60,8 +60,8 @@ public final class ServerCookieDecoder extends CookieDecoder {
     }
 
     /**
-     * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.  Unlike {@link #decode(String)}, this
-     * includes all cookie values present, even if they have the same name.
+     * Decodes the specified {@code Cookie} HTTP header value into a {@link Cookie}. Unlike {@link #decode(String)},
+     * this includes all cookie values present, even if they have the same name.
      *
      * @return the decoded {@link Cookie}
      */
@@ -72,7 +72,7 @@ public final class ServerCookieDecoder extends CookieDecoder {
     }
 
     /**
-     * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.
+     * Decodes the specified {@code Cookie} HTTP header value into a {@link Cookie}.
      *
      * @return the decoded {@link Cookie}
      */
@@ -83,9 +83,7 @@ public final class ServerCookieDecoder extends CookieDecoder {
     }
 
     /**
-     * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.
-     *
-     * @return the decoded {@link Cookie}
+     * Decodes the specified {@code Cookie} HTTP header value into a {@link Cookie}.
      */
     private void decode(Collection<? super Cookie> cookies, String header) {
         final int headerLen = checkNotNull(header, "header").length();


### PR DESCRIPTION
Motivation:
When decoding the cookies on the server, the `Cookie` HTTP request header value should be considered.
The `Set-Cookie` HTTP response header is used to send cookies from the server to the user agent.

Modification:
- Specify in javadoc that the `Cookie` HTTP request header value should be considered and
not the `Set-Cookie` HTTP response header value.

Result:
Correct `ServerCookieDecoder` javadoc
