### PR TITLE
HttpUtil.getCharset() fails for charset in double-quotes

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -395,10 +395,15 @@ public final class HttpUtil {
      */
     public static Charset getCharset(CharSequence contentTypeValue, Charset defaultCharset) {
         if (contentTypeValue != null) {
-            CharSequence charsetCharSequence = getCharsetAsSequence(contentTypeValue);
-            if (charsetCharSequence != null) {
+            CharSequence charsetRaw = getCharsetAsSequence(contentTypeValue);
+            if (charsetRaw != null) {
+                if (charsetRaw.length() > 2) { // at least contains 2 quotes(")
+                    if (charsetRaw.charAt(0) == '"' && charsetRaw.charAt(charsetRaw.length() - 1) == '"') {
+                        charsetRaw = charsetRaw.subSequence(1, charsetRaw.length() - 1);
+                    }
+                }
                 try {
-                    return Charset.forName(charsetCharSequence.toString());
+                    return Charset.forName(charsetRaw.toString());
                 } catch (IllegalCharsetNameException ignored) {
                     // just return the default charset
                 } catch (UnsupportedCharsetException ignored) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -76,17 +76,64 @@ public class HttpUtilTest {
 
     @Test
     public void testGetCharset() {
-        String NORMAL_CONTENT_TYPE = "text/html; charset=utf-8";
-        String UPPER_CASE_NORMAL_CONTENT_TYPE = "TEXT/HTML; CHARSET=UTF-8";
+        testGetCharsetUtf8("text/html; charset=utf-8");
+    }
+
+    @Test
+    public void testGetCharsetNoSpace() {
+        testGetCharsetUtf8("text/html;charset=utf-8");
+    }
+
+    @Test
+    public void testGetCharsetQuoted() {
+        HttpUtilTest.this.testGetCharsetUtf8("text/html; charset=\"utf-8\"");
+    }
+
+    @Test
+    public void testGetCharsetNoSpaceQuoted() {
+        HttpUtilTest.this.testGetCharsetUtf8("text/html;charset=\"utf-8\"");
+    }
+
+    private void testGetCharsetUtf8(String contentType) {
+        String UPPER_CASE_NORMAL_CONTENT_TYPE = contentType.toUpperCase();
 
         HttpMessage message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
-        message.headers().set(HttpHeaderNames.CONTENT_TYPE, NORMAL_CONTENT_TYPE);
+        message.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
         assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(message));
-        assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(NORMAL_CONTENT_TYPE));
+        assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(contentType));
 
         message.headers().set(HttpHeaderNames.CONTENT_TYPE, UPPER_CASE_NORMAL_CONTENT_TYPE);
         assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(message));
         assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(UPPER_CASE_NORMAL_CONTENT_TYPE));
+    }
+
+    @Test
+    public void testGetCharsetNoLeadingQuotes() {
+        testGetCharsetInvalidQuotes("text/html;charset=utf-8\"");
+    }
+
+    @Test
+    public void testGetCharsetNoTrailingQuotes() {
+        testGetCharsetInvalidQuotes("text/html;charset=\"utf-8");
+    }
+
+    @Test
+    public void testGetCharsetOnlyQuotes() {
+        testGetCharsetInvalidQuotes("text/html;charset=\"\"");
+    }
+
+    private void testGetCharsetInvalidQuotes(String contentType) {
+        String UPPER_CASE_NORMAL_CONTENT_TYPE = contentType.toUpperCase();
+
+        HttpMessage message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        assertEquals(CharsetUtil.ISO_8859_1, HttpUtil.getCharset(message, CharsetUtil.ISO_8859_1));
+        assertEquals(CharsetUtil.ISO_8859_1, HttpUtil.getCharset(contentType, CharsetUtil.ISO_8859_1));
+
+        message.headers().set(HttpHeaderNames.CONTENT_TYPE, UPPER_CASE_NORMAL_CONTENT_TYPE);
+        assertEquals(CharsetUtil.ISO_8859_1, HttpUtil.getCharset(message, CharsetUtil.ISO_8859_1));
+        assertEquals(CharsetUtil.ISO_8859_1, HttpUtil.getCharset(UPPER_CASE_NORMAL_CONTENT_TYPE,
+                CharsetUtil.ISO_8859_1));
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -86,12 +86,12 @@ public class HttpUtilTest {
 
     @Test
     public void testGetCharsetQuoted() {
-        HttpUtilTest.this.testGetCharsetUtf8("text/html; charset=\"utf-8\"");
+        testGetCharsetUtf8("text/html; charset=\"utf-8\"");
     }
 
     @Test
     public void testGetCharsetNoSpaceQuoted() {
-        HttpUtilTest.this.testGetCharsetUtf8("text/html;charset=\"utf-8\"");
+        testGetCharsetUtf8("text/html;charset=\"utf-8\"");
     }
 
     private void testGetCharsetUtf8(String contentType) {
@@ -122,7 +122,7 @@ public class HttpUtilTest {
         testGetCharsetInvalidQuotes("text/html;charset=\"\"");
     }
 
-    private void testGetCharsetInvalidQuotes(String contentType) {
+    private static void testGetCharsetInvalidQuotes(String contentType) {
         String UPPER_CASE_NORMAL_CONTENT_TYPE = contentType.toUpperCase();
 
         HttpMessage message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);


### PR DESCRIPTION
__Motivation__

As described in https://github.com/netty/netty/issues/11370 we should support quoted charset values

__Modification__

Modify `HttpUtil.getCharset(CharSequence contentTypeValue, Charset defaultCharset)` to trim the double-quotes if present.

__Result__
Fixes #11370:  `HttpUtil.getCharset()` now supports quoted charsets.