### PR TITLE
Skip the windows tests when there is an entry for localhost in the hosts file

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -39,6 +39,7 @@ import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.handler.codec.dns.DnsResponseCode;
 import io.netty.handler.codec.dns.DnsSection;
+import io.netty.resolver.HostsFileEntriesProvider;
 import io.netty.resolver.HostsFileEntriesResolver;
 import io.netty.resolver.ResolvedAddressTypes;
 import io.netty.util.CharsetUtil;
@@ -79,6 +80,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -331,16 +333,32 @@ public class DnsNameResolverTest {
                 StringUtil.EMPTY_STRING);
     }
 
-    private static final String HOST_NAME;
+    private static final String WINDOWS_HOST_NAME;
+    private static final boolean WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS;
 
     static {
-        String hostName;
+        String windowsHostName;
+        boolean windowsHostsFileLocalhostEntryExists;
         try {
-            hostName = PlatformDependent.isWindows() ? InetAddress.getLocalHost().getHostName() : null;
+            if (PlatformDependent.isWindows()) {
+                windowsHostName = InetAddress.getLocalHost().getHostName();
+
+                HostsFileEntriesProvider provider =
+                        HostsFileEntriesProvider.parser()
+                                .parseSilently(Charset.defaultCharset(), CharsetUtil.UTF_16, CharsetUtil.UTF_8);
+                windowsHostsFileLocalhostEntryExists =
+                        provider.ipv4Entries().get("localhost") != null ||
+                                provider.ipv6Entries().get("localhost") != null;
+            } else {
+                windowsHostName = null;
+                windowsHostsFileLocalhostEntryExists = false;
+            }
         } catch (Exception ignore) {
-            hostName = null;
+            windowsHostName = null;
+            windowsHostsFileLocalhostEntryExists = false;
         }
-        HOST_NAME = hostName;
+        WINDOWS_HOST_NAME = windowsHostName;
+        WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS = windowsHostsFileLocalhostEntryExists;
     }
 
     private static final TestDnsServer dnsServer = new TestDnsServer(DOMAINS_ALL);
@@ -768,6 +786,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveLocalhostIpv4() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
+        assumeThat(WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolve0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, "localhost");
     }
@@ -775,6 +794,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveLocalhostIpv6() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
+        assumeThat(WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolve0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, "localhost");
     }
@@ -783,14 +803,14 @@ public class DnsNameResolverTest {
     public void testResolveHostNameIpv4() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolve0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, HOST_NAME);
+        testResolve0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, WINDOWS_HOST_NAME);
     }
 
     @Test
     public void testResolveHostNameIpv6() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolve0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, HOST_NAME);
+        testResolve0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
     }
 
     @Test
@@ -829,6 +849,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveAllLocalhostIpv4() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
+        assumeThat(WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolveAll0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, "localhost");
     }
@@ -836,6 +857,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveAllLocalhostIpv6() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
+        assumeThat(WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolveAll0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, "localhost");
     }
@@ -844,14 +866,14 @@ public class DnsNameResolverTest {
     public void testResolveAllHostNameIpv4() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolveAll0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, HOST_NAME);
+        testResolveAll0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, WINDOWS_HOST_NAME);
     }
 
     @Test
     public void testResolveAllHostNameIpv6() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
-        testResolveAll0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, HOST_NAME);
+        testResolveAll0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
     }
 
     @Test

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -335,10 +335,12 @@ public class DnsNameResolverTest {
 
     private static final String WINDOWS_HOST_NAME;
     private static final boolean WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS;
+    private static final boolean WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS;
 
     static {
         String windowsHostName;
         boolean windowsHostsFileLocalhostEntryExists;
+        boolean windowsHostsFileHostNameEntryExists;
         try {
             if (PlatformDependent.isWindows()) {
                 windowsHostName = InetAddress.getLocalHost().getHostName();
@@ -349,16 +351,22 @@ public class DnsNameResolverTest {
                 windowsHostsFileLocalhostEntryExists =
                         provider.ipv4Entries().get("localhost") != null ||
                                 provider.ipv6Entries().get("localhost") != null;
+                windowsHostsFileHostNameEntryExists =
+                        provider.ipv4Entries().get(windowsHostName) != null ||
+                                provider.ipv6Entries().get(windowsHostName) != null;
             } else {
                 windowsHostName = null;
                 windowsHostsFileLocalhostEntryExists = false;
+                windowsHostsFileHostNameEntryExists = false;
             }
         } catch (Exception ignore) {
             windowsHostName = null;
             windowsHostsFileLocalhostEntryExists = false;
+            windowsHostsFileHostNameEntryExists = false;
         }
         WINDOWS_HOST_NAME = windowsHostName;
         WINDOWS_HOSTS_FILE_LOCALHOST_ENTRY_EXISTS = windowsHostsFileLocalhostEntryExists;
+        WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS = windowsHostsFileHostNameEntryExists;
     }
 
     private static final TestDnsServer dnsServer = new TestDnsServer(DOMAINS_ALL);
@@ -802,6 +810,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveHostNameIpv4() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
+        assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolve0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, WINDOWS_HOST_NAME);
     }
@@ -809,6 +818,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveHostNameIpv6() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
+        assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolve0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
     }
@@ -865,6 +875,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveAllHostNameIpv4() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
+        assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isNotEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolveAll0(ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, WINDOWS_HOST_NAME);
     }
@@ -872,6 +883,7 @@ public class DnsNameResolverTest {
     @Test
     public void testResolveAllHostNameIpv6() {
         assumeThat(PlatformDependent.isWindows()).isTrue();
+        assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolveAll0(ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
     }


### PR DESCRIPTION
Motivation:

The tests must be executed only when there is no hosts file or
there is no entry for localhost in the hosts file. The tested functionality
is relevant only in these use cases.

Modifications:

Skip the windows tests when there is an entry for localhost in the hosts file.

Result:

Fix failing tests on Windows CI when using GitHub Actions
Related to #11384

