### PR TITLE
Fixed #11379, validate fixed header bits.

### DIFF
--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -141,6 +141,81 @@ public class MqttCodecTest {
     }
 
     @Test
+    public void testConnectMessageNonZeroReservedBit0Mqtt311() throws Exception {
+        final MqttConnectMessage message = createConnectMessage(MqttVersion.MQTT_3_1_1);
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+        byte firstByte = byteBuf.getByte(0);
+        byteBuf.setByte(0, (byte) (firstByte | 1)); // set bit 0 to 1
+        final List<Object> out = new LinkedList<Object>();
+        mqttDecoder.decode(ctx, byteBuf, out);
+        checkForSingleDecoderException(out);
+    }
+
+    @Test
+    public void testConnectMessageNonZeroReservedBit1Mqtt311() throws Exception {
+        final MqttConnectMessage message = createConnectMessage(MqttVersion.MQTT_3_1_1);
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+        byte firstByte = byteBuf.getByte(0);
+        byteBuf.setByte(0, (byte) (firstByte | 2)); // set bit 1 to 1
+        final List<Object> out = new LinkedList<Object>();
+        mqttDecoder.decode(ctx, byteBuf, out);
+        checkForSingleDecoderException(out);
+    }
+
+    @Test
+    public void testConnectMessageNonZeroReservedBit2Mqtt311() throws Exception {
+        final MqttConnectMessage message = createConnectMessage(MqttVersion.MQTT_3_1_1);
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+        byte firstByte = byteBuf.getByte(0);
+        byteBuf.setByte(0, (byte) (firstByte | 4)); // set bit 2 to 1
+        final List<Object> out = new LinkedList<Object>();
+        mqttDecoder.decode(ctx, byteBuf, out);
+        checkForSingleDecoderException(out);
+    }
+
+    @Test
+    public void testConnectMessageNonZeroReservedBit3Mqtt311() throws Exception {
+        final MqttConnectMessage message = createConnectMessage(MqttVersion.MQTT_3_1_1);
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+        byte firstByte = byteBuf.getByte(0);
+        byteBuf.setByte(0, (byte) (firstByte | 8)); // set bit 3 to 1
+        final List<Object> out = new LinkedList<Object>();
+        mqttDecoder.decode(ctx, byteBuf, out);
+        checkForSingleDecoderException(out);
+    }
+
+    @Test
+    public void testSubscribeMessageNonZeroReservedBit0Mqtt311() throws Exception {
+        final MqttSubscribeMessage message = createSubscribeMessage();
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+        byte firstByte = byteBuf.getByte(0);
+        byteBuf.setByte(0, (byte) (firstByte | 1)); // set bit 1 to 0
+        final List<Object> out = new LinkedList<Object>();
+        mqttDecoder.decode(ctx, byteBuf, out);
+        checkForSingleDecoderException(out);
+    }
+
+    @Test
+    public void testSubscribeMessageZeroReservedBit1Mqtt311() throws Exception {
+        final MqttSubscribeMessage message = createSubscribeMessage();
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+        byte firstByte = byteBuf.getByte(0);
+        byteBuf.setByte(0, (byte) (firstByte & ~2)); // set bit 1 to 0
+        final List<Object> out = new LinkedList<Object>();
+        mqttDecoder.decode(ctx, byteBuf, out);
+        checkForSingleDecoderException(out);
+    }
+
+    private void checkForSingleDecoderException(final List<Object> out) {
+        assertEquals("Expected one object but got " + out.size(), 1, out.size());
+        assertFalse("Message should not be an MqttConnectMessage",
+                MqttConnectMessage.class.isAssignableFrom(out.get(0).getClass()));
+        MqttMessage result = (MqttMessage) out.get(0);
+        assertTrue("Decoding should have resulted in a DecoderException",
+                result.decoderResult().cause() instanceof DecoderException);
+    }
+
+    @Test
     public void testConnectMessageNoPassword() throws Exception {
         final MqttConnectMessage message = createConnectMessage(
                 MqttVersion.MQTT_3_1_1,
@@ -922,7 +997,7 @@ public class MqttCodecTest {
 
     private static MqttSubscribeMessage createSubscribeMessage() {
         MqttFixedHeader mqttFixedHeader =
-                new MqttFixedHeader(MqttMessageType.SUBSCRIBE, false, MqttQoS.AT_LEAST_ONCE, true, 0);
+                new MqttFixedHeader(MqttMessageType.SUBSCRIBE, false, MqttQoS.AT_LEAST_ONCE, false, 0);
         MqttMessageIdVariableHeader mqttMessageIdVariableHeader = MqttMessageIdVariableHeader.from(12345);
 
         List<MqttTopicSubscription> topicSubscriptions = new LinkedList<MqttTopicSubscription>();
@@ -948,7 +1023,7 @@ public class MqttCodecTest {
 
     private static MqttUnsubscribeMessage createUnsubscribeMessage() {
         MqttFixedHeader mqttFixedHeader =
-                new MqttFixedHeader(MqttMessageType.UNSUBSCRIBE, false, MqttQoS.AT_LEAST_ONCE, true, 0);
+                new MqttFixedHeader(MqttMessageType.UNSUBSCRIBE, false, MqttQoS.AT_LEAST_ONCE, false, 0);
         MqttMessageIdVariableHeader mqttMessageIdVariableHeader = MqttMessageIdVariableHeader.from(12345);
 
         List<String> topics = new LinkedList<String>();


### PR DESCRIPTION
Motivation:
The MQTT spec states that the bits in the fixed header must be set to specific values depending on message type. If a client sends a message with the wrong bits, the server must treat the message as malformed. Netty did not check the value of the reserved bits in the fixed header.

See:
MQTT3.1.1: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180835
MQTT 5.0: https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901023


Modification:
Add validation checks to MqttDecoder.java
Add unit tests to MqttCodecTest.java 
Fixed two instances where messages were generated for other unit tests with an incorrect fixed header.

Result:
Fixes #11379. 
