### PR TITLE
Log if the user tries to explicit set TLSv1.3 ciphers and using Borin…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -412,7 +412,7 @@ public final class OpenSsl {
             }
             if (ciphersNotMatch || !boringsslTlsv13Ciphers.isEmpty()) {
                 logger.info(
-                        "BoringSSL doesn't allow to explicit enable / disable TLSv1.3 ciphers." +
+                        "BoringSSL doesn't allow to enable or disable TLSv1.3 ciphers explicitly." +
                                 " The default TLSv1.3 ciphers will be used: '{}'.",
                         Arrays.toString(EXTRA_SUPPORTED_TLS_1_3_CIPHERS));
                 return EXTRA_SUPPORTED_TLS_1_3_CIPHERS_STRING;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -189,7 +189,7 @@ public final class OpenSsl {
                         "TLS_AES_256_GCM_SHA384" ,
                         "TLS_CHACHA20_POLY1305_SHA256" };
 
-                StringBuilder ciphersBuilder = new StringBuilder(64);
+                StringBuilder ciphersBuilder = new StringBuilder(128);
                 for (String cipher: EXTRA_SUPPORTED_TLS_1_3_CIPHERS) {
                     ciphersBuilder.append(cipher).append(",");
                 }
@@ -402,10 +402,15 @@ public final class OpenSsl {
             assert EXTRA_SUPPORTED_TLS_1_3_CIPHERS.length > 0;
             Set<String> boringsslTlsv13Ciphers = new HashSet<String>();
             Collections.addAll(boringsslTlsv13Ciphers, EXTRA_SUPPORTED_TLS_1_3_CIPHERS);
+            boolean ciphersNotMatch = false;
             for (String cipher: ciphers.split(",")) {
+                if (boringsslTlsv13Ciphers.isEmpty()) {
+                    ciphersNotMatch = true;
+                    break;
+                }
                 boringsslTlsv13Ciphers.remove(cipher);
             }
-            if (!boringsslTlsv13Ciphers.isEmpty()) {
+            if (ciphersNotMatch || !boringsslTlsv13Ciphers.isEmpty()) {
                 logger.info(
                         "BoringSSL doesn't allow to explicit enable / disable TLSv1.3 ciphers." +
                                 " The default TLSv1.3 ciphers will be used: '{}'.",

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -286,7 +286,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                     SSLContext.setCipherSuite(ctx, cipherBuilder.toString(), false);
                     if (tlsv13Supported) {
                         // Set TLSv1.3 ciphers.
-                        SSLContext.setCipherSuite(ctx, cipherTLSv13Builder.toString(), true);
+                        SSLContext.setCipherSuite(ctx,
+                                OpenSsl.checkTls13Ciphers(logger, cipherTLSv13Builder.toString()), true);
                     }
                 }
             } catch (SSLException e) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1598,7 +1598,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     SSL.setCipherSuites(ssl, cipherSuiteSpec, false);
                     if (OpenSsl.isTlsv13Supported()) {
                         // Set TLSv1.3 ciphers.
-                        SSL.setCipherSuites(ssl, cipherSuiteSpecTLSv13, true);
+                        SSL.setCipherSuites(ssl, OpenSsl.checkTls13Ciphers(logger, cipherSuiteSpecTLSv13), true);
                     }
 
                     // We also need to update the enabled protocols to ensure we disable the protocol if there are


### PR DESCRIPTION
…gSSL

Motivation:

At the moment BoringSSL doesnt support explicit set the TLSv1.3 ciphers that should be used. If TLSv1.3 should be used it just enables all ciphers. We should better log if the user tries to explicit set a specific ciphers and using BoringSSL to inform the user that what is tried doesnt really work.

Modifications:

Log if the user tries to not use all TLSv1.3 ciphers and use BoringSSL

Result:

Easier for the user to understand why always all TLSv1.3 ciphers are enabled when using BoringSSL
