### PR TITLE
Accept smaller `server_max_window_bits` than requested

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
@@ -183,7 +183,7 @@ public final class PerMessageDeflateClientExtensionHandshaker implements WebSock
         }
 
         if ((requestedServerNoContext && !serverNoContext) ||
-                requestedServerWindowSize != serverWindowSize) {
+                requestedServerWindowSize < serverWindowSize) {
             succeed = false;
         }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -90,7 +90,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
 
         parameters = new HashMap<String, String>();
         parameters.put(CLIENT_MAX_WINDOW, "12");
-        parameters.put(SERVER_MAX_WINDOW, "10");
+        parameters.put(SERVER_MAX_WINDOW, "8");
         parameters.put(CLIENT_NO_CONTEXT, null);
         parameters.put(SERVER_NO_CONTEXT, null);
 


### PR DESCRIPTION
Motivation:

Netty will fail a handshake for the Per-Message Deflate WebSocket
extension if the server response contains a smaller
`server_max_window_bits` value than the client offered.

However, this is allowed by RFC 7692:

> A server accepts an extension negotiation offer with this parameter
> by including the “server_max_window_bits” extension parameter in the
> extension negotiation response to send back to the client with the
> same or smaller value as the offer.

Modifications:

- Allow the server to respond with a smaller value than offered.
- Change the unit tests to test for this.

Result:

The client will not fail when the server indicates it is using a
smaller window size than offered by the client.
