### PR TITLE
Fix deprecated GC logging switch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
     <argLine.leak>-D_</argLine.leak> <!-- Overridden when 'leak' profile is active -->
     <argLine.noUnsafe>-D_</argLine.noUnsafe> <!-- Overridden when 'noUnsafe' profile is active -->
     <argLine.coverage>-D_</argLine.coverage> <!-- Overridden when 'coverage' profile is active -->
-    <argLine.printGC>-XX:+PrintGCDetails</argLine.printGC>
+    <argLine.printGC>-Xlog:gc</argLine.printGC>
     <argLine.java9 /> <!-- Overridden when 'java9' profile is active -->
     <argLine.javaProperties>-D_</argLine.javaProperties>
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->


### PR DESCRIPTION
Motivation:

This caused test failures due to the deprecation warning and produced a
dumpstream.

Modification:

Replace deprecated flag with recommended one.

Result:
Fix deprecation and cause of test failure in codec project.