### PR TITLE
Disable Brotli tests on Apple silicon

### DIFF
--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -32,6 +32,31 @@
     <javaModuleName>io.netty.codec</javaModuleName>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>mac-aarch64</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <!-- Brotli native lib is not available for Apple M1 silicon yet -->
+                <exclude>BrotliDecoderTest.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Motivation:

The native module is not yet available on aarch64 Mac thus causing tests in codec/ to fail (specifically all the Brotli ones, since the module could not be loaded).

Modification:

Disable Brotli tests under Mac/aarch64 combo.

Result:

Tests under codec/ now pass under Mac/aarch64.