### PR TITLE
Recycler.WeakOrderQueue drop Object hasBeenRecycled

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -399,12 +399,14 @@ public abstract class Recycler<T> {
             // While we also enforce the recycling ratio when we transfer objects from the WeakOrderQueue to the Stack
             // we better should enforce it as well early. Missing to do so may let the WeakOrderQueue grow very fast
             // without control
-            if (handleRecycleCount < interval) {
-                handleRecycleCount++;
-                // Drop the item to prevent recycling to aggressive.
-                return;
+            if (!handle.hasBeenRecycled) {
+                if (handleRecycleCount < interval) {
+                    handleRecycleCount++;
+                    // Drop the item to prevent recycling to aggressive.
+                    return;
+                }
+                handleRecycleCount = 0;
             }
-            handleRecycleCount = 0;
 
             Link tail = this.tail;
             int writeIndex;

--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -402,7 +402,7 @@ public abstract class Recycler<T> {
             if (!handle.hasBeenRecycled) {
                 if (handleRecycleCount < interval) {
                     handleRecycleCount++;
-                    // Drop the item to prevent recycling to aggressive.
+                    // Drop the item to prevent from recycling too aggressively.
                     return;
                 }
                 handleRecycleCount = 0;

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -379,7 +379,6 @@ public class RecyclerTest {
         });
         assertTrue(latch2.await(100, TimeUnit.MILLISECONDS));
 
-
         // It should be the same object, right?
         final HandledObject o3 = recycler.get();
         assertSame(o3, o);

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -367,7 +367,6 @@ public class RecyclerTest {
         // Always recycler the first object, that is Ok
         assertSame(o2, o);
 
-
         final CountDownLatch latch2 = new CountDownLatch(1);
         single.execute(new Runnable() {
             @Override

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -343,6 +345,45 @@ public class RecyclerTest {
 
         assertSame(recycler.get(), o);
         assertNotSame(recycler.get(), o2);
+    }
+
+    @Test
+    public void testRecycleAtTwoThreadsMulti() throws Exception {
+        final Recycler<HandledObject> recycler = newRecycler(256);
+        final HandledObject o = recycler.get();
+
+        ExecutorService single = Executors.newSingleThreadExecutor();
+
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        single.execute(new Runnable() {
+            @Override
+            public void run() {
+                o.recycle();
+                latch1.countDown();
+            }
+        });
+        assertTrue(latch1.await(100, TimeUnit.MILLISECONDS));
+        final HandledObject o2 = recycler.get();
+        // Always recycler the first object, that is Ok
+        assertSame(o2, o);
+
+
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        single.execute(new Runnable() {
+            @Override
+            public void run() {
+                //The object should be recycled
+                o2.recycle();
+                latch2.countDown();
+            }
+        });
+        assertTrue(latch2.await(100, TimeUnit.MILLISECONDS));
+
+
+        // It should be the same object, right?
+        final HandledObject o3 = recycler.get();
+        assertSame(o3, o);
+        single.shutdown();
     }
 
     @Test


### PR DESCRIPTION
WeakOrderQueue should check DefaultHandler.hasBeenRecycled field

Motivation:

WeakOrderQueue would drop object that has been recycle, event there has space for it.
WeakOrderQueue#add should check DefaultHandler.hasBeenRecycled field  first

Modifications:

WeakOrderQueue test the DefaultHandler.hasBeenRecycled first

Result:

WeakOrderQueue would not drop object that has been recycled when there have space