### PR TITLE
Update graal annotations dependencies GAV to allow license GPL2+CE

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -39,7 +39,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.oracle.substratevm</groupId>
+      <groupId>org.graalvm.nativeimage</groupId>
       <artifactId>svm</artifactId>
       <version>${graalvm.version}</version>
       <!-- Provided scope as it is only needed for compiling the SVM substitution classes -->

--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <skipJapicmp>false</skipJapicmp>
-    <graalvm.version>19.2.1</graalvm.version>
+    <graalvm.version>19.3.6</graalvm.version>
     <brotli4j.version>1.4.2</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -59,7 +59,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.oracle.substratevm</groupId>
+        <groupId>org.graalvm.nativeimage</groupId>
         <artifactId>native-image-maven-plugin</artifactId>
         <version>${graalvm.version}</version>
         <executions>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -65,7 +65,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.oracle.substratevm</groupId>
+        <groupId>org.graalvm.nativeimage</groupId>
         <artifactId>native-image-maven-plugin</artifactId>
         <version>${graalvm.version}</version>
         <executions>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -80,7 +80,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.oracle.substratevm</groupId>
+        <groupId>org.graalvm.nativeimage</groupId>
         <artifactId>native-image-maven-plugin</artifactId>
         <version>${graalvm.version}</version>
         <executions>


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fixes: #11398

Update all graalvm dependencies to new GAV which introduces a license change from GPL2 to GPL2 + CE

This also required a small bump on the general version from 19.2 to 19.3, which should be fine as 19.3 is an official maintained LTS version, while 19.2 wasn't.
