### PR TITLE
Add GraalVM to the PR build matrix

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -139,6 +139,9 @@ jobs:
           - setup: linux-x86_64-java11
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak"
+          - setup: linux-x86_64-java11-graal
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.graalvm111.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.graalvm111.yaml run build-leak"
           - setup: linux-x86_64-java16
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.116.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.116.yaml run build-leak"


### PR DESCRIPTION
Motivation:

Native image compatibility is fragile and breaks easily, so we need a PR build to tell us when this happens.

Modification:

Add a graalvm-based build to the PR build matrix.

Result:

Every PR is now also tested on Graal.

These changes were extracted from #11163
