### PR TITLE
Add ALPN Buffering to support HTTP/2 Prior Knowledge

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -151,7 +151,6 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
     private void removeSelfIfPresent(ChannelHandlerContext ctx) {
         ChannelPipeline pipeline = ctx.pipeline();
         if (pipeline.context(this) != null) {
-            fireBufferedMessages();
             pipeline.remove(this);
         }
     }


### PR DESCRIPTION
Motivation:
Currently, Netty cannot handle HTTP/2 Preface messages if the client used the Prior knowledge technique. In Prior knowledge, the client sends an HTTP/2 preface message immediately after finishing TLS Handshake. But in Netty, when TLS Handshake is finished, ALPNHandler is triggered to configure the pipeline. And between these 2 operations, if an HTTP/2 preface message arrives, it gets dropped. Here is some log:
```
21 Jun 2021 07:11:30.257 [epollEventLoopGroup-25-1] DEBUG i.n.c.DefaultChannelPipeline - Discarded inbound message PooledUnsafeDirectByteBuf(ridx: 0, widx: 121, cap: 249) that reached at the tail of the pipeline. Please check your pipeline configuration.
21 Jun 2021 07:11:30.257 [epollEventLoopGroup-25-1] DEBUG i.n.c.DefaultChannelPipeline - Discarded message pipeline : [ConnectionTracker#0, ConnectionTimeoutHandler#0, TLSHandler, ALPNHandler#0, DefaultChannelPipeline$TailContext#0]. Channel : [id: 0xad9d65dd, L:/127.0.0.1:9110 - R:/127.0.0.1:47036].
```

Modification:
Added buffering in ALPN Handler.

Result:
Fixes #11403. 