### PR TITLE
`HttpUtil#normalizeAndGetContentLength()` should handle empty value

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -602,7 +602,7 @@ public final class HttpUtil {
         }
         // Ensure we not allow sign as part of the content-length:
         // See https://github.com/squid-cache/squid/security/advisories/GHSA-qf3v-rc95-96j5
-        if (!Character.isDigit(firstField.charAt(0))) {
+        if (firstField.isEmpty() || !Character.isDigit(firstField.charAt(0))) {
             // Reject the message as invalid
             throw new IllegalArgumentException(
                     "Content-Length value is not a number: " + firstField);


### PR DESCRIPTION
__Motivation__

`HttpUtil#normalizeAndGetContentLength()` throws `StringIndexOutOfBoundsException` for empty `content-length` values, it should instead throw `IllegalArgumentException` for all invalid values.

__Modification__

- Throw `IllegalArgumentException` if the `content-length` value is empty.
- Add tests

__Result__

Fixes https://github.com/netty/netty/issues/11408
