### PR TITLE
Add TcpDnsQueryDecoder and TcpDnsResponseEncoder

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -51,8 +51,15 @@ public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPac
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, DatagramPacket packet, List<Object> out) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, final DatagramPacket packet, List<Object> out) throws Exception {
         final ByteBuf buf = packet.content();
+
+        DnsMessageUtil.decodeDnsQuery(recordDecoder, buf, new DnsMessageUtil.DnsQuerySupplier() {
+            @Override
+            public DnsQuery get(int id, DnsOpCode dnsOpCode) {
+                return new DatagramDnsQuery(packet.sender(), packet.recipient(), id, dnsOpCode);
+            }
+        });
 
         final DnsQuery query = newQuery(packet, buf);
         boolean success = false;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -54,9 +54,9 @@ public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPac
     protected void decode(ChannelHandlerContext ctx, final DatagramPacket packet, List<Object> out) throws Exception {
         final ByteBuf buf = packet.content();
 
-        DnsMessageUtil.decodeDnsQuery(recordDecoder, buf, new DnsMessageUtil.DnsQuerySupplier() {
+        DnsMessageUtil.decodeDnsQuery(recordDecoder, buf, new DnsMessageUtil.DnsQueryFactory() {
             @Override
-            public DnsQuery get(int id, DnsOpCode dnsOpCode) {
+            public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
                 return new DatagramDnsQuery(packet.sender(), packet.recipient(), id, dnsOpCode);
             }
         });

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
@@ -15,7 +15,9 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.AddressedEnvelope;
+import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.util.internal.StringUtil;
 
 import java.net.SocketAddress;
@@ -177,5 +179,121 @@ final class DnsMessageUtil {
         }
     }
 
-    private DnsMessageUtil() { }
+    static DnsQuery decodeDnsQuery(DnsRecordDecoder decoder, ByteBuf buf, DnsQuerySupplier supplier) throws Exception {
+        DnsQuery query = newQuery(buf, supplier);
+        boolean success = false;
+        try {
+            int questionCount = buf.readUnsignedShort();
+            int answerCount = buf.readUnsignedShort();
+            int authorityRecordCount = buf.readUnsignedShort();
+            int additionalRecordCount = buf.readUnsignedShort();
+            decodeQuestions(decoder, query, buf, questionCount);
+            decodeRecords(decoder, query, DnsSection.ANSWER, buf, answerCount);
+            decodeRecords(decoder, query, DnsSection.AUTHORITY, buf, authorityRecordCount);
+            decodeRecords(decoder, query, DnsSection.ADDITIONAL, buf, additionalRecordCount);
+            success = true;
+            return query;
+        } finally {
+            if (!success) {
+                query.release();
+            }
+        }
+    }
+
+    private static DnsQuery newQuery(ByteBuf buf, DnsQuerySupplier supplier) {
+        int id = buf.readUnsignedShort();
+        int flags = buf.readUnsignedShort();
+        if (flags >> 15 == 1) {
+            throw new CorruptedFrameException("not a query");
+        }
+
+        DnsQuery query = supplier.get(id, DnsOpCode.valueOf((byte) (flags >> 11 & 0xf)));
+        query.setRecursionDesired((flags >> 8 & 1) == 1);
+        query.setZ(flags >> 4 & 0x7);
+        return query;
+    }
+
+    private static void decodeQuestions(DnsRecordDecoder decoder, DnsQuery query, ByteBuf buf, int questionCount) throws Exception {
+        for (int i = questionCount; i > 0; --i) {
+            query.addRecord(DnsSection.QUESTION, decoder.decodeQuestion(buf));
+        }
+    }
+
+    private static void decodeRecords(DnsRecordDecoder decoder, DnsQuery query, DnsSection section, ByteBuf buf, int count) throws Exception {
+        for (int i = count; i > 0; --i) {
+            DnsRecord r = decoder.decodeRecord(buf);
+            if (r == null) {
+                break;
+            }
+            query.addRecord(section, r);
+        }
+    }
+
+    static void encodeDnsResponse(DnsRecordEncoder encoder, DnsResponse response, ByteBuf buf) throws Exception {
+        boolean success = false;
+        try {
+            encodeHeader(response, buf);
+            encodeQuestions(encoder, response, buf);
+            encodeRecords(encoder, response, DnsSection.ANSWER, buf);
+            encodeRecords(encoder, response, DnsSection.AUTHORITY, buf);
+            encodeRecords(encoder, response, DnsSection.ADDITIONAL, buf);
+            success = true;
+        } finally {
+            if (!success) {
+                buf.release();
+            }
+        }
+    }
+
+    /**
+     * Encodes the header that is always 12 bytes long.
+     *
+     * @param response the response header being encoded
+     * @param buf      the buffer the encoded data should be written to
+     */
+    private static void encodeHeader(DnsResponse response, ByteBuf buf) {
+        buf.writeShort(response.id());
+        int flags = 32768;
+        flags |= (response.opCode().byteValue() & 0xFF) << 11;
+        if (response.isAuthoritativeAnswer()) {
+            flags |= 1 << 10;
+        }
+        if (response.isTruncated()) {
+            flags |= 1 << 9;
+        }
+        if (response.isRecursionDesired()) {
+            flags |= 1 << 8;
+        }
+        if (response.isRecursionAvailable()) {
+            flags |= 1 << 7;
+        }
+        flags |= response.z() << 4;
+        flags |= response.code().intValue();
+        buf.writeShort(flags);
+        buf.writeShort(response.count(DnsSection.QUESTION));
+        buf.writeShort(response.count(DnsSection.ANSWER));
+        buf.writeShort(response.count(DnsSection.AUTHORITY));
+        buf.writeShort(response.count(DnsSection.ADDITIONAL));
+    }
+
+    private static void encodeQuestions(DnsRecordEncoder encoder, DnsResponse response, ByteBuf buf) throws Exception {
+        int count = response.count(DnsSection.QUESTION);
+        for (int i = 0; i < count; ++i) {
+            encoder.encodeQuestion(response.<DnsQuestion>recordAt(DnsSection.QUESTION, i), buf);
+        }
+    }
+
+    private static void encodeRecords(DnsRecordEncoder encoder, DnsResponse response, DnsSection section, ByteBuf buf) throws Exception {
+        int count = response.count(section);
+        for (int i = 0; i < count; ++i) {
+            encoder.encodeRecord(response.recordAt(section, i), buf);
+        }
+    }
+
+    public interface DnsQuerySupplier {
+        DnsQuery get(int id, DnsOpCode dnsOpCode);
+    }
+
+    private DnsMessageUtil() {
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
@@ -213,13 +213,15 @@ final class DnsMessageUtil {
         return query;
     }
 
-    private static void decodeQuestions(DnsRecordDecoder decoder, DnsQuery query, ByteBuf buf, int questionCount) throws Exception {
+    private static void decodeQuestions(DnsRecordDecoder decoder,
+                                        DnsQuery query, ByteBuf buf, int questionCount) throws Exception {
         for (int i = questionCount; i > 0; --i) {
             query.addRecord(DnsSection.QUESTION, decoder.decodeQuestion(buf));
         }
     }
 
-    private static void decodeRecords(DnsRecordDecoder decoder, DnsQuery query, DnsSection section, ByteBuf buf, int count) throws Exception {
+    private static void decodeRecords(DnsRecordDecoder decoder,
+                                      DnsQuery query, DnsSection section, ByteBuf buf, int count) throws Exception {
         for (int i = count; i > 0; --i) {
             DnsRecord r = decoder.decodeRecord(buf);
             if (r == null) {
@@ -283,7 +285,8 @@ final class DnsMessageUtil {
         }
     }
 
-    private static void encodeRecords(DnsRecordEncoder encoder, DnsResponse response, DnsSection section, ByteBuf buf) throws Exception {
+    private static void encodeRecords(DnsRecordEncoder encoder,
+                                      DnsResponse response, DnsSection section, ByteBuf buf) throws Exception {
         int count = response.count(section);
         for (int i = 0; i < count; ++i) {
             encoder.encodeRecord(response.recordAt(section, i), buf);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
@@ -179,7 +179,7 @@ final class DnsMessageUtil {
         }
     }
 
-    static DnsQuery decodeDnsQuery(DnsRecordDecoder decoder, ByteBuf buf, DnsQuerySupplier supplier) throws Exception {
+    static DnsQuery decodeDnsQuery(DnsRecordDecoder decoder, ByteBuf buf, DnsQueryFactory supplier) throws Exception {
         DnsQuery query = newQuery(buf, supplier);
         boolean success = false;
         try {
@@ -200,14 +200,14 @@ final class DnsMessageUtil {
         }
     }
 
-    private static DnsQuery newQuery(ByteBuf buf, DnsQuerySupplier supplier) {
+    private static DnsQuery newQuery(ByteBuf buf, DnsQueryFactory supplier) {
         int id = buf.readUnsignedShort();
         int flags = buf.readUnsignedShort();
         if (flags >> 15 == 1) {
             throw new CorruptedFrameException("not a query");
         }
 
-        DnsQuery query = supplier.get(id, DnsOpCode.valueOf((byte) (flags >> 11 & 0xf)));
+        DnsQuery query = supplier.newQuery(id, DnsOpCode.valueOf((byte) (flags >> 11 & 0xf)));
         query.setRecursionDesired((flags >> 8 & 1) == 1);
         query.setZ(flags >> 4 & 0x7);
         return query;
@@ -290,8 +290,8 @@ final class DnsMessageUtil {
         }
     }
 
-    interface DnsQuerySupplier {
-        DnsQuery get(int id, DnsOpCode dnsOpCode);
+    interface DnsQueryFactory {
+        DnsQuery newQuery(int id, DnsOpCode dnsOpCode);
     }
 
     private DnsMessageUtil() {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
@@ -290,7 +290,7 @@ final class DnsMessageUtil {
         }
     }
 
-    public interface DnsQuerySupplier {
+    interface DnsQuerySupplier {
         DnsQuery get(int id, DnsOpCode dnsOpCode);
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -1,0 +1,81 @@
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+
+public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
+    private final DnsRecordDecoder decoder;
+
+    public TcpDnsQueryDecoder() {
+        this(DnsRecordDecoder.DEFAULT, 64 * 1024);
+    }
+
+    public TcpDnsQueryDecoder(DnsRecordDecoder decoder, int maxFrameLength) {
+        super(maxFrameLength, 0, 2, 0, 2);
+        this.decoder = decoder;
+    }
+
+    @Override
+    protected Object decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+        ByteBuf frame = (ByteBuf) super.decode(ctx, in);
+        if (frame == null) {
+            return null;
+        }
+
+        ByteBuf buf = frame.slice();
+        DnsQuery query = newQuery(buf);
+        boolean success = false;
+        try {
+            int questionCount = buf.readUnsignedShort();
+            int answerCount = buf.readUnsignedShort();
+            int authorityRecordCount = buf.readUnsignedShort();
+            int additionalRecordCount = buf.readUnsignedShort();
+            this.decodeQuestions(query, buf, questionCount);
+            this.decodeRecords(query, DnsSection.ANSWER, buf, answerCount);
+            this.decodeRecords(query, DnsSection.AUTHORITY, buf, authorityRecordCount);
+            this.decodeRecords(query, DnsSection.ADDITIONAL, buf, additionalRecordCount);
+            success = true;
+            return query;
+        } finally {
+            if (!success) {
+                query.release();
+            }
+        }
+    }
+
+    @Override
+    protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
+        return buffer.copy(index, length);
+    }
+
+    private static DnsQuery newQuery(ByteBuf buf) {
+        int id = buf.readUnsignedShort();
+        int flags = buf.readUnsignedShort();
+        if (flags >> 15 == 1) {
+            throw new CorruptedFrameException("not a query");
+        }
+
+        DnsQuery query = new DefaultDnsQuery(id, DnsOpCode.valueOf((byte) (flags >> 11 & 0xf)));
+        query.setRecursionDesired((flags >> 8 & 1) == 1);
+        query.setZ(flags >> 4 & 0x7);
+        return query;
+    }
+
+    private void decodeQuestions(DnsQuery query, ByteBuf buf, int questionCount) throws Exception {
+        for (int i = questionCount; i > 0; --i) {
+            query.addRecord(DnsSection.QUESTION, this.decoder.decodeQuestion(buf));
+        }
+    }
+
+    private void decodeRecords(DnsQuery query, DnsSection section, ByteBuf buf, int count) throws Exception {
+        for (int i = count; i > 0; --i) {
+            DnsRecord r = this.decoder.decodeRecord(buf);
+            if (r == null) {
+                break;
+            }
+            query.addRecord(section, r);
+        }
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -45,9 +45,9 @@ public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
             return null;
         }
 
-        return DnsMessageUtil.decodeDnsQuery(decoder, frame.slice(), new DnsMessageUtil.DnsQuerySupplier() {
+        return DnsMessageUtil.decodeDnsQuery(decoder, frame.slice(), new DnsMessageUtil.DnsQueryFactory() {
             @Override
-            public DnsQuery get(int id, DnsOpCode dnsOpCode) {
+            public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
                 return new DefaultDnsQuery(id, dnsOpCode);
             }
         });

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.util.internal.ObjectUtil;
 
@@ -46,53 +45,11 @@ public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
             return null;
         }
 
-        ByteBuf buf = frame.slice();
-        DnsQuery query = newQuery(buf);
-        boolean success = false;
-        try {
-            int questionCount = buf.readUnsignedShort();
-            int answerCount = buf.readUnsignedShort();
-            int authorityRecordCount = buf.readUnsignedShort();
-            int additionalRecordCount = buf.readUnsignedShort();
-            decodeQuestions(query, buf, questionCount);
-            decodeRecords(query, DnsSection.ANSWER, buf, answerCount);
-            decodeRecords(query, DnsSection.AUTHORITY, buf, authorityRecordCount);
-            decodeRecords(query, DnsSection.ADDITIONAL, buf, additionalRecordCount);
-            success = true;
-            return query;
-        } finally {
-            if (!success) {
-                query.release();
+        return DnsMessageUtil.decodeDnsQuery(decoder, frame.slice(), new DnsMessageUtil.DnsQuerySupplier() {
+            @Override
+            public DnsQuery get(int id, DnsOpCode dnsOpCode) {
+                return new DefaultDnsQuery(id, dnsOpCode);
             }
-        }
-    }
-
-    private static DnsQuery newQuery(ByteBuf buf) {
-        int id = buf.readUnsignedShort();
-        int flags = buf.readUnsignedShort();
-        if (flags >> 15 == 1) {
-            throw new CorruptedFrameException("not a query");
-        }
-
-        DnsQuery query = new DefaultDnsQuery(id, DnsOpCode.valueOf((byte) (flags >> 11 & 0xf)));
-        query.setRecursionDesired((flags >> 8 & 1) == 1);
-        query.setZ(flags >> 4 & 0x7);
-        return query;
-    }
-
-    private void decodeQuestions(DnsQuery query, ByteBuf buf, int questionCount) throws Exception {
-        for (int i = questionCount; i > 0; --i) {
-            query.addRecord(DnsSection.QUESTION, decoder.decodeQuestion(buf));
-        }
-    }
-
-    private void decodeRecords(DnsQuery query, DnsSection section, ByteBuf buf, int count) throws Exception {
-        for (int i = count; i > 0; --i) {
-            DnsRecord r = decoder.decodeRecord(buf);
-            if (r == null) {
-                break;
-            }
-            query.addRecord(section, r);
-        }
+        });
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -24,10 +24,16 @@ import io.netty.util.internal.ObjectUtil;
 public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
     private final DnsRecordDecoder decoder;
 
+    /**
+     * Creates a new decoder with {@linkplain DnsRecordDecoder#DEFAULT the default record decoder}.
+     */
     public TcpDnsQueryDecoder() {
         this(DnsRecordDecoder.DEFAULT, 65535);
     }
 
+    /**
+     * Creates a new decoder with the specified {@code decoder}.
+     */
     public TcpDnsQueryDecoder(DnsRecordDecoder decoder, int maxFrameLength) {
         super(maxFrameLength, 0, 2, 0, 2);
         this.decoder = ObjectUtil.checkNotNull(decoder, "decoder");

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -25,7 +25,7 @@ public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
     private final DnsRecordDecoder decoder;
 
     public TcpDnsQueryDecoder() {
-        this(DnsRecordDecoder.DEFAULT, Integer.MAX_VALUE);
+        this(DnsRecordDecoder.DEFAULT, 65535);
     }
 
     public TcpDnsQueryDecoder(DnsRecordDecoder decoder, int maxFrameLength) {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.List;
 
@@ -16,7 +32,7 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
     }
 
     public TcpDnsResponseEncoder(DnsRecordEncoder encoder) {
-        this.encoder = encoder;
+        this.encoder = ObjectUtil.checkNotNull(encoder, "encoder");
     }
 
     @Override
@@ -26,10 +42,10 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
         try {
             buf.writerIndex(buf.writerIndex() + 2);
             encodeHeader(response, buf);
-            this.encodeQuestions(response, buf);
-            this.encodeRecords(response, DnsSection.ANSWER, buf);
-            this.encodeRecords(response, DnsSection.AUTHORITY, buf);
-            this.encodeRecords(response, DnsSection.ADDITIONAL, buf);
+            encodeQuestions(response, buf);
+            encodeRecords(response, DnsSection.ANSWER, buf);
+            encodeRecords(response, DnsSection.AUTHORITY, buf);
+            encodeRecords(response, DnsSection.ADDITIONAL, buf);
             buf.setShort(0, buf.readableBytes() - 2);
             success = true;
         } finally {
@@ -68,14 +84,14 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
     private void encodeQuestions(DnsResponse response, ByteBuf buf) throws Exception {
         int count = response.count(DnsSection.QUESTION);
         for (int i = 0; i < count; ++i) {
-            this.encoder.encodeQuestion(response.<DnsQuestion>recordAt(DnsSection.QUESTION, i), buf);
+            encoder.encodeQuestion(response.<DnsQuestion>recordAt(DnsSection.QUESTION, i), buf);
         }
     }
 
     private void encodeRecords(DnsResponse response, DnsSection section, ByteBuf buf) throws Exception {
         int count = response.count(section);
         for (int i = 0; i < count; ++i) {
-            this.encoder.encodeRecord(response.recordAt(section, i), buf);
+            encoder.encodeRecord(response.recordAt(section, i), buf);
         }
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -27,10 +27,16 @@ import java.util.List;
 public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
     private final DnsRecordEncoder encoder;
 
+    /**
+     * Creates a new encoder with {@linkplain DnsRecordEncoder#DEFAULT the default record encoder}.
+     */
     public TcpDnsResponseEncoder() {
         this(DnsRecordEncoder.DEFAULT);
     }
 
+    /**
+     * Creates a new encoder with the specified {@code encoder}.
+     */
     public TcpDnsResponseEncoder(DnsRecordEncoder encoder) {
         this.encoder = ObjectUtil.checkNotNull(encoder, "encoder");
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -1,0 +1,81 @@
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+import java.util.List;
+
+@ChannelHandler.Sharable
+public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
+    private final DnsRecordEncoder encoder;
+
+    public TcpDnsResponseEncoder() {
+        this(DnsRecordEncoder.DEFAULT);
+    }
+
+    public TcpDnsResponseEncoder(DnsRecordEncoder encoder) {
+        this.encoder = encoder;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, DnsResponse response, List<Object> out) throws Exception {
+        ByteBuf buf = ctx.alloc().ioBuffer(1024);
+        boolean success = false;
+        try {
+            buf.writerIndex(buf.writerIndex() + 2);
+            encodeHeader(response, buf);
+            this.encodeQuestions(response, buf);
+            this.encodeRecords(response, DnsSection.ANSWER, buf);
+            this.encodeRecords(response, DnsSection.AUTHORITY, buf);
+            this.encodeRecords(response, DnsSection.ADDITIONAL, buf);
+            buf.setShort(0, buf.readableBytes() - 2);
+            success = true;
+        } finally {
+            if (!success) {
+                buf.release();
+            }
+        }
+        out.add(buf);
+    }
+
+    private static void encodeHeader(DnsResponse response, ByteBuf buf) {
+        buf.writeShort(response.id());
+        int flags = 32768;
+        flags |= (response.opCode().byteValue() & 0xFF) << 11;
+        if (response.isAuthoritativeAnswer()) {
+            flags |= 1 << 10;
+        }
+        if (response.isTruncated()) {
+            flags |= 1 << 9;
+        }
+        if (response.isRecursionDesired()) {
+            flags |= 1 << 8;
+        }
+        if (response.isRecursionAvailable()) {
+            flags |= 1 << 7;
+        }
+        flags |= response.z() << 4;
+        flags |= response.code().intValue();
+        buf.writeShort(flags);
+        buf.writeShort(response.count(DnsSection.QUESTION));
+        buf.writeShort(response.count(DnsSection.ANSWER));
+        buf.writeShort(response.count(DnsSection.AUTHORITY));
+        buf.writeShort(response.count(DnsSection.ADDITIONAL));
+    }
+
+    private void encodeQuestions(DnsResponse response, ByteBuf buf) throws Exception {
+        int count = response.count(DnsSection.QUESTION);
+        for (int i = 0; i < count; ++i) {
+            this.encoder.encodeQuestion(response.<DnsQuestion>recordAt(DnsSection.QUESTION, i), buf);
+        }
+    }
+
+    private void encodeRecords(DnsResponse response, DnsSection section, ByteBuf buf) throws Exception {
+        int count = response.count(section);
+        for (int i = 0; i < count; ++i) {
+            this.encoder.encodeRecord(response.recordAt(section, i), buf);
+        }
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -44,60 +44,11 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
     @Override
     protected void encode(ChannelHandlerContext ctx, DnsResponse response, List<Object> out) throws Exception {
         ByteBuf buf = ctx.alloc().ioBuffer(1024);
-        boolean success = false;
-        try {
-            buf.writerIndex(buf.writerIndex() + 2);
-            encodeHeader(response, buf);
-            encodeQuestions(response, buf);
-            encodeRecords(response, DnsSection.ANSWER, buf);
-            encodeRecords(response, DnsSection.AUTHORITY, buf);
-            encodeRecords(response, DnsSection.ADDITIONAL, buf);
-            buf.setShort(0, buf.readableBytes() - 2);
-            success = true;
-        } finally {
-            if (!success) {
-                buf.release();
-            }
-        }
+
+        buf.writerIndex(buf.writerIndex() + 2);
+        DnsMessageUtil.encodeDnsResponse(encoder, response, buf);
+        buf.setShort(0, buf.readableBytes() - 2);
+
         out.add(buf);
-    }
-
-    private static void encodeHeader(DnsResponse response, ByteBuf buf) {
-        buf.writeShort(response.id());
-        int flags = 32768;
-        flags |= (response.opCode().byteValue() & 0xFF) << 11;
-        if (response.isAuthoritativeAnswer()) {
-            flags |= 1 << 10;
-        }
-        if (response.isTruncated()) {
-            flags |= 1 << 9;
-        }
-        if (response.isRecursionDesired()) {
-            flags |= 1 << 8;
-        }
-        if (response.isRecursionAvailable()) {
-            flags |= 1 << 7;
-        }
-        flags |= response.z() << 4;
-        flags |= response.code().intValue();
-        buf.writeShort(flags);
-        buf.writeShort(response.count(DnsSection.QUESTION));
-        buf.writeShort(response.count(DnsSection.ANSWER));
-        buf.writeShort(response.count(DnsSection.AUTHORITY));
-        buf.writeShort(response.count(DnsSection.ADDITIONAL));
-    }
-
-    private void encodeQuestions(DnsResponse response, ByteBuf buf) throws Exception {
-        int count = response.count(DnsSection.QUESTION);
-        for (int i = 0; i < count; ++i) {
-            encoder.encodeQuestion(response.<DnsQuestion>recordAt(DnsSection.QUESTION, i), buf);
-        }
-    }
-
-    private void encodeRecords(DnsResponse response, DnsSection section, ByteBuf buf) throws Exception {
-        int count = response.count(section);
-        for (int i = 0; i < count; ++i) {
-            encoder.encodeRecord(response.recordAt(section, i), buf);
-        }
     }
 }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -42,6 +42,7 @@ public class TcpDnsTest {
         assertThat(readQuery, is(query));
         assertThat(readQuery.recordAt(DnsSection.QUESTION), is(query.recordAt(DnsSection.QUESTION)));
         assertThat(readQuery.recordAt(DnsSection.QUESTION).name(), is(query.recordAt(DnsSection.QUESTION).name()));
+        assertFalse(channel.finish());
     }
 
     @Test

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -36,7 +36,7 @@ public class TcpDnsTest {
         int randomID = new Random().nextInt(60000 - 1000) + 1000;
         DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                 .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
-        channel.writeInbound(query);
+        assertTrue(channel.writeInbound(query));
 
         DnsQuery readQuery = channel.readInbound();
         assertThat(readQuery, is(query));

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class TcpDnsTest {
+    private static final String QUERY_DOMAIN = "www.example.com";
+    private static final long TTL = 600;
+    private static final byte[] QUERY_RESULT = new byte[]{(byte) 192, (byte) 168, 1, 1};
+
+    @Test
+    public void testQueryDecode() {
+        EmbeddedChannel channel = new EmbeddedChannel(new TcpDnsQueryDecoder());
+
+        int randomID = new Random().nextInt(60000 - 1000) + 1000;
+        DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
+                .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
+        channel.writeInbound(query);
+
+        DnsQuery readQuery = channel.readInbound();
+        assertThat(readQuery, is(query));
+        assertThat(readQuery.recordAt(DnsSection.QUESTION), is(query.recordAt(DnsSection.QUESTION)));
+        assertThat(readQuery.recordAt(DnsSection.QUESTION).name(), is(query.recordAt(DnsSection.QUESTION).name()));
+    }
+
+    @Test
+    public void testResponseEncode() {
+        EmbeddedChannel channel = new EmbeddedChannel(new TcpDnsResponseEncoder());
+
+        int randomID = new Random().nextInt(60000 - 1000) + 1000;
+        DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
+                .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
+
+        DnsQuestion question = query.recordAt(DnsSection.QUESTION);
+        channel.writeInbound(newResponse(query, question, QUERY_RESULT));
+
+        DnsResponse readResponse = channel.readInbound();
+        assertThat(readResponse.recordAt(DnsSection.QUESTION), is((DnsRecord) question));
+        DnsRawRecord record = new DefaultDnsRawRecord(question.name(),
+                DnsRecordType.A, TTL, Unpooled.wrappedBuffer(QUERY_RESULT));
+        assertThat(readResponse.recordAt(DnsSection.ANSWER), is((DnsRecord) record));
+        assertThat(readResponse.<DnsRawRecord>recordAt(DnsSection.ANSWER).content(), is(record.content()));
+    }
+
+    private DefaultDnsResponse newResponse(DnsQuery query, DnsQuestion question, byte[]... addresses) {
+        DefaultDnsResponse response = new DefaultDnsResponse(query.id());
+        response.addRecord(DnsSection.QUESTION, question);
+
+        for (byte[] address : addresses) {
+            DefaultDnsRawRecord queryAnswer = new DefaultDnsRawRecord(question.name(),
+                    DnsRecordType.A, TTL, Unpooled.wrappedBuffer(address));
+            response.addRecord(DnsSection.ANSWER, queryAnswer);
+        }
+        return response;
+    }
+}

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -17,12 +17,15 @@ package io.netty.handler.codec.dns;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TcpDnsTest {
     private static final String QUERY_DOMAIN = "www.example.com";
@@ -64,7 +67,7 @@ public class TcpDnsTest {
         assertThat(readResponse.<DnsRawRecord>recordAt(DnsSection.ANSWER).content(), is(record.content()));
         ReferenceCountUtil.release(readResponse);
         ReferenceCountUtil.release(record);
-         assertFalse(channel.finish());
+        assertFalse(channel.finish());
     }
 
     private static DefaultDnsResponse newResponse(DnsQuery query, DnsQuestion question, byte[]... addresses) {

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -62,6 +62,9 @@ public class TcpDnsTest {
                 DnsRecordType.A, TTL, Unpooled.wrappedBuffer(QUERY_RESULT));
         assertThat(readResponse.recordAt(DnsSection.ANSWER), is((DnsRecord) record));
         assertThat(readResponse.<DnsRawRecord>recordAt(DnsSection.ANSWER).content(), is(record.content()));
+        ReferenceCountUtil.release(readResponse);
+        ReferenceCountUtil.release(record);
+         assertFalse(channel.finish());
     }
 
     private DefaultDnsResponse newResponse(DnsQuery query, DnsQuestion question, byte[]... addresses) {

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -67,7 +67,7 @@ public class TcpDnsTest {
          assertFalse(channel.finish());
     }
 
-    private DefaultDnsResponse newResponse(DnsQuery query, DnsQuestion question, byte[]... addresses) {
+    private static DefaultDnsResponse newResponse(DnsQuery query, DnsQuestion question, byte[]... addresses) {
         DefaultDnsResponse response = new DefaultDnsResponse(query.id());
         response.addRecord(DnsSection.QUESTION, question);
 

--- a/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
@@ -57,7 +57,8 @@ public final class TcpDnsServer {
     private static final byte[] QUERY_RESULT = new byte[]{(byte) 192, (byte) 168, 1, 1};
 
     public static void main(String[] args) throws Exception {
-        final ServerBootstrap bootstrap = new ServerBootstrap().group(new NioEventLoopGroup(1), new NioEventLoopGroup())
+        ServerBootstrap bootstrap = new ServerBootstrap().group(new NioEventLoopGroup(1),
+                new NioEventLoopGroup())
                 .channel(NioServerSocketChannel.class)
                 .handler(new LoggingHandler(LogLevel.INFO))
                 .childHandler(new ChannelInitializer<Channel>() {
@@ -66,7 +67,8 @@ public final class TcpDnsServer {
                         ch.pipeline().addLast(new TcpDnsQueryDecoder(), new TcpDnsResponseEncoder(),
                                 new SimpleChannelInboundHandler<DnsQuery>() {
                                     @Override
-                                    protected void channelRead0(ChannelHandlerContext ctx, DnsQuery msg) throws Exception {
+                                    protected void channelRead0(ChannelHandlerContext ctx,
+                                                                DnsQuery msg) throws Exception {
                                         DnsQuestion question = msg.recordAt(DnsSection.QUESTION);
                                         System.out.println("Query domain: " + question);
 
@@ -74,13 +76,15 @@ public final class TcpDnsServer {
                                         ctx.writeAndFlush(newResponse(msg, question, 600, QUERY_RESULT));
                                     }
 
-                                    private DefaultDnsResponse newResponse(DnsQuery query, DnsQuestion question,
+                                    private DefaultDnsResponse newResponse(DnsQuery query,
+                                                                           DnsQuestion question,
                                                                            long ttl, byte[]... addresses) {
                                         DefaultDnsResponse response = new DefaultDnsResponse(query.id());
                                         response.addRecord(DnsSection.QUESTION, question);
 
                                         for (byte[] address : addresses) {
-                                            DefaultDnsRawRecord queryAnswer = new DefaultDnsRawRecord(question.name(),
+                                            DefaultDnsRawRecord queryAnswer = new DefaultDnsRawRecord(
+                                                    question.name(),
                                                     DnsRecordType.A, ttl, Unpooled.wrappedBuffer(address));
                                             response.addRecord(DnsSection.ANSWER, queryAnswer);
                                         }

--- a/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
@@ -1,0 +1,123 @@
+package io.netty.example.dns.tcp;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.dns.*;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.util.NetUtil;
+
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public final class TcpDnsServer {
+    private static final String QUERY_DOMAIN = "www.example.com";
+    private static final int DNS_SERVER_PORT = 53;
+    private static final String DNS_SERVER_HOST = "127.0.0.1";
+
+    public static void main(String[] args) throws Exception {
+        ServerBootstrap bootstrap = new ServerBootstrap().group(new NioEventLoopGroup(1), new NioEventLoopGroup())
+                .channel(NioServerSocketChannel.class)
+                .handler(new LoggingHandler(LogLevel.INFO))
+                .childHandler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) throws Exception {
+                        ch.pipeline().addLast(new TcpDnsQueryDecoder(), new TcpDnsResponseEncoder(), new SimpleChannelInboundHandler<DnsQuery>() {
+                            @Override
+                            protected void channelRead0(ChannelHandlerContext ctx, DnsQuery msg) throws Exception {
+                                DnsQuestion question = msg.recordAt(DnsSection.QUESTION);
+                                System.out.println("Query domain: " + question);
+
+                                ctx.writeAndFlush(newResponse(msg, question, 600, new byte[]{(byte) 192, (byte) 168, 1, 1}));
+                            }
+
+                            private DefaultDnsResponse newResponse(DnsQuery query, DnsQuestion question, long ttl, byte[]... addresses) {
+                                DefaultDnsResponse response = new DefaultDnsResponse(query.id());
+                                response.addRecord(DnsSection.QUESTION, question);
+
+                                for (byte[] address : addresses) {
+                                    DefaultDnsRawRecord queryAnswer = new DefaultDnsRawRecord(question.name(), DnsRecordType.A, ttl, Unpooled.wrappedBuffer(address));
+                                    response.addRecord(DnsSection.ANSWER, queryAnswer);
+                                }
+                                return response;
+                            }
+                        });
+                    }
+                });
+        Executors.newSingleThreadScheduledExecutor().schedule(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    clientQuery();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }, 2000, TimeUnit.MILLISECONDS);
+        bootstrap.bind(DNS_SERVER_PORT).channel().closeFuture().sync();
+    }
+
+    private static void clientQuery() throws Exception {
+        EventLoopGroup group = new NioEventLoopGroup();
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel ch) {
+                            ChannelPipeline p = ch.pipeline();
+                            p.addLast(new TcpDnsQueryEncoder())
+                                    .addLast(new TcpDnsResponseDecoder())
+                                    .addLast(new SimpleChannelInboundHandler<DefaultDnsResponse>() {
+                                        @Override
+                                        protected void channelRead0(ChannelHandlerContext ctx, DefaultDnsResponse msg) {
+                                            try {
+                                                handleQueryResp(msg);
+                                            } finally {
+                                                ctx.close();
+                                            }
+                                        }
+                                    });
+                        }
+                    });
+
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).sync().channel();
+
+            int randomID = new Random().nextInt(60000 - 1000) + 1000;
+            DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
+                    .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
+            ch.writeAndFlush(query).sync();
+            boolean success = ch.closeFuture().await(10, TimeUnit.SECONDS);
+            if (!success) {
+                System.err.println("dns query timeout!");
+                ch.close().sync();
+            }
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private static void handleQueryResp(DefaultDnsResponse msg) {
+        if (msg.count(DnsSection.QUESTION) > 0) {
+            DnsQuestion question = msg.recordAt(DnsSection.QUESTION, 0);
+            System.out.printf("name: %s%n", question.name());
+        }
+        for (int i = 0, count = msg.count(DnsSection.ANSWER); i < count; i++) {
+            DnsRecord record = msg.recordAt(DnsSection.ANSWER, i);
+            if (record.type() == DnsRecordType.A) {
+                //just print the IP after query
+                DnsRawRecord raw = (DnsRawRecord) record;
+                System.out.println(NetUtil.bytesToIpAddress(ByteBufUtil.getBytes(raw.content())));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add TcpDnsQueryDecoder and TcpDnsResponseEncoder for TcpDnsServer

Motivation:
There is no TcpDnsServer codec, I need to create a TcpDnsServer.

Result:
TcpDnsQueryDecoder, like DatagramDnsQueryDecoder
TcpDnsResponseEncoder, like DatagramDnsResponseEncoder

thx.
