### PR TITLE
DnsNameResolver must wait for future to complete before checking failure

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -498,7 +498,7 @@ public class DnsNameResolver extends InetNameResolver {
         } else {
             future = b.bind(localAddress);
         }
-        Throwable cause = future.cause();
+        Throwable cause = future.awaitUninterruptibly().cause();
         if (cause != null) {
             if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;


### PR DESCRIPTION
Motivation:
If a Future has not yet completed, calling `cause` on it will return `null`.
Thus, while it makes little sense to check the failure state of a future that hasn't completed, it also doesn't throw any exceptions at runtime.
However, if the future subsequently failed, this data race would mean the failure was missed.
This could lead us to construct a `DnsNameResolver` in an unpredictable state.

Modification:
Wait for the register/bind future to finish, before examening it for failures.

Result:
No data race in the event that register or bind fails in `DnsNameResolver`.
