### PR TITLE
Migrate resolver to junit5

### DIFF
--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -16,8 +16,7 @@
 package io.netty.resolver;
 
 import io.netty.util.NetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -27,10 +26,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DefaultHostsFileEntriesResolverTest {
 
@@ -56,7 +56,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 new DefaultHostsFileEntriesResolver(new HostsFileEntriesProvider(inet4Entries, inet6Entries));
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV6_ONLY);
-        assertNull("Should pick an IPv6 address", address);
+        assertNull(address, "Should pick an IPv6 address");
     }
 
     @Test
@@ -71,7 +71,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 new DefaultHostsFileEntriesResolver(new HostsFileEntriesProvider(inet4Entries, inet6Entries));
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV4_PREFERRED);
-        assertTrue("Should pick an IPv4 address", address instanceof Inet4Address);
+        assertThat("Should pick an IPv4 address", address, instanceOf(Inet4Address.class));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 new DefaultHostsFileEntriesResolver(new HostsFileEntriesProvider(inet4Entries, inet6Entries));
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV6_PREFERRED);
-        assertTrue("Should pick an IPv6 address", address instanceof Inet6Address);
+        assertThat("Should pick an IPv6 address", address, instanceOf(Inet6Address.class));
     }
 
     @Test
@@ -100,7 +100,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 new DefaultHostsFileEntriesResolver(new HostsFileEntriesProvider(inet4Entries, inet6Entries));
 
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV6_ONLY);
-        assertNull("Should pick an IPv6 address", addresses);
+        assertNull(addresses, "Should pick an IPv6 address");
     }
 
     @Test
@@ -117,8 +117,8 @@ public class DefaultHostsFileEntriesResolverTest {
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV4_PREFERRED);
         assertNotNull(addresses);
         assertEquals(2, addresses.size());
-        assertTrue("Should pick an IPv4 address", addresses.get(0) instanceof Inet4Address);
-        assertTrue("Should pick an IPv6 address", addresses.get(1) instanceof Inet6Address);
+        assertThat("Should pick an IPv4 address", addresses.get(0), instanceOf(Inet4Address.class));
+        assertThat("Should pick an IPv6 address", addresses.get(1), instanceOf(Inet6Address.class));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class DefaultHostsFileEntriesResolverTest {
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV6_PREFERRED);
         assertNotNull(addresses);
         assertEquals(2, addresses.size());
-        assertTrue("Should pick an IPv6 address", addresses.get(0) instanceof Inet6Address);
-        assertTrue("Should pick an IPv4 address", addresses.get(1) instanceof Inet4Address);
+        assertThat("Should pick an IPv6 address", addresses.get(0), instanceOf(Inet6Address.class));
+        assertThat("Should pick an IPv4 address", addresses.get(1), instanceOf(Inet4Address.class));
     }
 }

--- a/resolver/src/test/java/io/netty/resolver/HostsFileParserTest.java
+++ b/resolver/src/test/java/io/netty/resolver/HostsFileParserTest.java
@@ -17,8 +17,7 @@ package io.netty.resolver;
 
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.ResourcesUtil;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,7 +28,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class HostsFileParserTest {
 
@@ -53,15 +53,15 @@ public class HostsFileParserTest {
         Map<String, Inet4Address> inet4Entries = entries.inet4Entries();
         Map<String, Inet6Address> inet6Entries = entries.inet6Entries();
 
-        assertEquals("Expected 7 IPv4 entries", 7, inet4Entries.size());
-        assertEquals("Expected 1 IPv6 entries", 1, inet6Entries.size());
+        assertEquals(7, inet4Entries.size(), "Expected 7 IPv4 entries");
+        assertEquals(1, inet6Entries.size(), "Expected 1 IPv6 entries");
         assertEquals("127.0.0.1", inet4Entries.get("host1").getHostAddress());
         assertEquals("192.168.0.1", inet4Entries.get("host2").getHostAddress());
         assertEquals("192.168.0.2", inet4Entries.get("host3").getHostAddress());
         assertEquals("192.168.0.3", inet4Entries.get("host4").getHostAddress());
         assertEquals("192.168.0.3", inet4Entries.get("host5").getHostAddress());
         assertEquals("192.168.0.3", inet4Entries.get("host6").getHostAddress());
-        assertNotNull("uppercase host doesn't resolve", inet4Entries.get("host7"));
+        assertNotNull(inet4Entries.get("host7"), "uppercase host doesn't resolve");
         assertEquals("192.168.0.5", inet4Entries.get("host7").getHostAddress());
         assertEquals("0:0:0:0:0:0:0:1", inet6Entries.get("host1").getHostAddress());
     }
@@ -72,7 +72,6 @@ public class HostsFileParserTest {
         try {
             unicodeCharset = Charset.forName("unicode");
         } catch (UnsupportedCharsetException e) {
-            Assume.assumeNoException(e);
             return;
         }
         testParseFile(HostsFileParser.parse(
@@ -85,7 +84,6 @@ public class HostsFileParserTest {
         try {
             unicodeCharset = Charset.forName("unicode");
         } catch (UnsupportedCharsetException e) {
-            Assume.assumeNoException(e);
             return;
         }
         testParseFile(HostsFileParser.parse(ResourcesUtil.getFile(getClass(),  "hosts-unicode"),
@@ -96,8 +94,8 @@ public class HostsFileParserTest {
         Map<String, Inet4Address> inet4Entries = entries.inet4Entries();
         Map<String, Inet6Address> inet6Entries = entries.inet6Entries();
 
-        assertEquals("Expected 2 IPv4 entries", 2, inet4Entries.size());
-        assertEquals("Expected 1 IPv6 entries", 1, inet6Entries.size());
+        assertEquals(2, inet4Entries.size(), "Expected 2 IPv4 entries");
+        assertEquals(1, inet6Entries.size(), "Expected 1 IPv6 entries");
         assertEquals("127.0.0.1", inet4Entries.get("localhost").getHostAddress());
         assertEquals("255.255.255.255", inet4Entries.get("broadcasthost").getHostAddress());
         assertEquals("0:0:0:0:0:0:0:1", inet6Entries.get("localhost").getHostAddress());

--- a/resolver/src/test/java/io/netty/resolver/InetSocketAddressResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/InetSocketAddressResolverTest.java
@@ -16,11 +16,13 @@
 package io.netty.resolver;
 
 import io.netty.util.concurrent.ImmediateEventExecutor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class InetSocketAddressResolverTest {
 


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust resolver tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757