### PR TITLE
Migrate codec-redis to junit5

### DIFF
--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisEncoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisEncoderTest.java
@@ -19,18 +19,18 @@ package io.netty.handler.codec.redis;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-
 import static io.netty.handler.codec.redis.RedisCodecTestUtil.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Verifies the correct functionality of the {@link RedisEncoder}.
@@ -39,12 +39,12 @@ public class RedisEncoderTest {
 
     private EmbeddedChannel channel;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         channel = new EmbeddedChannel(new RedisEncoder());
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         assertFalse(channel.finish());
     }


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust codec-redis tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757