### PR TITLE
Delay initialization of io.netty.handler.codec.compression.BrotliDecoder to runtime

### DIFF
--- a/codec-http/src/main/resources/META-INF/native-image/io.netty/codec-http/native-image.properties
+++ b/codec-http/src/main/resources/META-INF/native-image/io.netty/codec-http/native-image.properties
@@ -13,4 +13,4 @@
 # under the License.
 
 Args = --initialize-at-build-time=io.netty \
-       --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder
+       --initialize-at-run-time=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder,io.netty.handler.codec.compression.BrotliDecoder


### PR DESCRIPTION
Motivation:
See #11427

Modification:
By delaying the initialization of `io.netty.handler.codec.compression.BrotliDecoder` to runtime, native-image will not try to eagerly initialize the class during the image build, avoiding the build failure described in the issue.

Fixes #11427