### PR TITLE
Fix Buffer Overflow During Lz4FrameEncoder Close

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -315,6 +315,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
                 compressor.maxCompressedLength(buffer.readableBytes()) + HEADER_LENGTH);
         flushBufferedData(footer);
 
+        footer.ensureWritable(HEADER_LENGTH);
         final int idx = footer.writerIndex();
         footer.setLong(idx, MAGIC_NUMBER);
         footer.setByte(idx + TOKEN_OFFSET, (byte) (BLOCK_TYPE_NON_COMPRESSED | compressionLevel));


### PR DESCRIPTION
Motivation:

We failed to account for the last header when estimating the buffer
size. If the data does not compress enough to make space for the
last header we would exceed the ByteBuf's capacity.

Modifications:

Call #ensureWritable with appropriate capacity for footer ByteBuf
befor writing footer.

Result:

If there is not enough space left in the buffer, the buffer will be
expanded.

