### PR TITLE
Migrate codec-mqtt to junit5

### DIFF
--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttConnectPayloadTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttConnectPayloadTest.java
@@ -16,10 +16,10 @@
 
 package io.netty.handler.codec.mqtt;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersPacketIdTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersPacketIdTest.java
@@ -16,21 +16,16 @@
 
 package io.netty.handler.codec.mqtt;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(value = Parameterized.class)
 public class MqttMessageBuildersPacketIdTest {
-    @Parameterized.Parameter
-    public Integer id;
 
-    @Parameterized.Parameters(name = "{index}: {0}")
-    public static Iterable<Integer> data() {
+    static Iterable<Integer> data() {
         // we take a subset of valid packetIds
         return Arrays.asList(
                 0x0001,
@@ -41,8 +36,9 @@ public class MqttMessageBuildersPacketIdTest {
         );
     }
 
-    @Test
-    public void testUnsubAckMessageIdAsShort() {
+    @ParameterizedTest()
+    @MethodSource("data")
+    public void testUnsubAckMessageIdAsShort(Integer id) {
         final MqttUnsubAckMessage msg = MqttMessageBuilders.unsubAck()
                 .packetId(id.shortValue())
                 .build();
@@ -53,8 +49,9 @@ public class MqttMessageBuildersPacketIdTest {
         );
     }
 
-    @Test
-    public void testSubAckMessageIdAsShort() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSubAckMessageIdAsShort(Integer id) {
         final MqttSubAckMessage msg = MqttMessageBuilders.subAck()
                 .packetId(id.shortValue())
                 .build();
@@ -65,8 +62,9 @@ public class MqttMessageBuildersPacketIdTest {
         );
     }
 
-    @Test
-    public void testPubAckMessageIdAsShort() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testPubAckMessageIdAsShort(Integer id) {
         final MqttMessage msg = MqttMessageBuilders.pubAck()
                 .packetId(id.shortValue())
                 .build();
@@ -77,8 +75,9 @@ public class MqttMessageBuildersPacketIdTest {
         );
     }
 
-    @Test
-    public void testUnsubAckMessageIdAsInt() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUnsubAckMessageIdAsInt(Integer id) {
         final MqttUnsubAckMessage msg = MqttMessageBuilders.unsubAck()
                 .packetId(id)
                 .build();
@@ -89,8 +88,9 @@ public class MqttMessageBuildersPacketIdTest {
         );
     }
 
-    @Test
-    public void testSubAckMessageIdAsInt() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSubAckMessageIdAsInt(Integer id) {
         final MqttSubAckMessage msg = MqttMessageBuilders.subAck()
                 .packetId(id)
                 .build();
@@ -101,8 +101,9 @@ public class MqttMessageBuildersPacketIdTest {
         );
     }
 
-    @Test
-    public void testPubAckMessageIdAsInt() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testPubAckMessageIdAsInt(Integer id) {
         final MqttMessage msg = MqttMessageBuilders.pubAck()
                 .packetId(id)
                 .build();

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageBuildersTest.java
@@ -17,9 +17,9 @@
 package io.netty.handler.codec.mqtt;
 
 import io.netty.handler.codec.mqtt.MqttMessageBuilders.PropertiesInitializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MqttMessageBuildersTest {
 

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageFactoryTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttMessageFactoryTest.java
@@ -16,14 +16,14 @@
 
 package io.netty.handler.codec.mqtt;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_LEAST_ONCE;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static io.netty.handler.codec.mqtt.MqttTestUtils.validateProperties;
 import static io.netty.handler.codec.mqtt.MqttTestUtils.validateSubscribePayload;
 import static io.netty.handler.codec.mqtt.MqttTestUtils.validateUnsubscribePayload;
@@ -41,14 +41,14 @@ public class MqttMessageFactoryTest {
 
         MqttMessage unsuback = MqttMessageFactory.newMessage(fixedHeader, variableHeader, null);
 
-        assertEquals("Message type mismatch", MqttMessageType.UNSUBACK, unsuback.fixedHeader().messageType());
+        assertEquals(MqttMessageType.UNSUBACK, unsuback.fixedHeader().messageType());
         MqttMessageIdAndPropertiesVariableHeader actualVariableHeader =
                 (MqttMessageIdAndPropertiesVariableHeader) unsuback.variableHeader();
-        assertEquals("MessageId mismatch", SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
+        assertEquals(SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
         validateProperties(MqttProperties.NO_PROPERTIES, actualVariableHeader.properties());
         MqttUnsubAckPayload actualPayload = (MqttUnsubAckPayload) unsuback.payload();
-        assertNotNull("payload", actualPayload);
-        assertEquals("reason codes size", 0, actualPayload.unsubscribeReasonCodes().size());
+        assertNotNull(actualPayload);
+        assertEquals(0, actualPayload.unsubscribeReasonCodes().size());
     }
 
     @Test
@@ -66,15 +66,13 @@ public class MqttMessageFactoryTest {
 
         MqttMessage unsuback = MqttMessageFactory.newMessage(fixedHeader, variableHeader, payload);
 
-        assertEquals("Message type mismatch", MqttMessageType.UNSUBACK, unsuback.fixedHeader().messageType());
+        assertEquals(MqttMessageType.UNSUBACK, unsuback.fixedHeader().messageType());
         MqttMessageIdAndPropertiesVariableHeader actualVariableHeader =
                 (MqttMessageIdAndPropertiesVariableHeader) unsuback.variableHeader();
-        assertEquals("MessageId mismatch", SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
+        assertEquals(SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
         validateProperties(properties, actualVariableHeader.properties());
         MqttUnsubAckPayload actualPayload = (MqttUnsubAckPayload) unsuback.payload();
-        assertEquals("Reason code list doesn't match",
-                payload.unsubscribeReasonCodes(),
-                actualPayload.unsubscribeReasonCodes());
+        assertEquals(payload.unsubscribeReasonCodes(), actualPayload.unsubscribeReasonCodes());
     }
 
     @Test
@@ -89,10 +87,10 @@ public class MqttMessageFactoryTest {
 
         MqttMessage subscribe = MqttMessageFactory.newMessage(fixedHeader, variableHeader, payload);
 
-        assertEquals("Message type mismatch", MqttMessageType.SUBSCRIBE, subscribe.fixedHeader().messageType());
+        assertEquals(MqttMessageType.SUBSCRIBE, subscribe.fixedHeader().messageType());
         MqttMessageIdAndPropertiesVariableHeader actualVariableHeader =
                 (MqttMessageIdAndPropertiesVariableHeader) subscribe.variableHeader();
-        assertEquals("MessageId mismatch", SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
+        assertEquals(SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
         validateProperties(MqttProperties.NO_PROPERTIES, actualVariableHeader.properties());
         MqttSubscribePayload actualPayload = (MqttSubscribePayload) subscribe.payload();
         validateSubscribePayload(payload, actualPayload);
@@ -113,10 +111,10 @@ public class MqttMessageFactoryTest {
 
         MqttMessage subscribe = MqttMessageFactory.newMessage(fixedHeader, variableHeader, payload);
 
-        assertEquals("Message type mismatch", MqttMessageType.SUBSCRIBE, subscribe.fixedHeader().messageType());
+        assertEquals(MqttMessageType.SUBSCRIBE, subscribe.fixedHeader().messageType());
         MqttMessageIdAndPropertiesVariableHeader actualVariableHeader =
                 (MqttMessageIdAndPropertiesVariableHeader) subscribe.variableHeader();
-        assertEquals("MessageId mismatch", SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
+        assertEquals(SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
         validateProperties(properties, actualVariableHeader.properties());
         MqttSubscribePayload actualPayload = (MqttSubscribePayload) subscribe.payload();
         validateSubscribePayload(payload, actualPayload);
@@ -134,10 +132,10 @@ public class MqttMessageFactoryTest {
 
         MqttMessage unsubscribe = MqttMessageFactory.newMessage(fixedHeader, variableHeader, payload);
 
-        assertEquals("Message type mismatch", MqttMessageType.UNSUBSCRIBE, unsubscribe.fixedHeader().messageType());
+        assertEquals(MqttMessageType.UNSUBSCRIBE, unsubscribe.fixedHeader().messageType());
         MqttMessageIdAndPropertiesVariableHeader actualVariableHeader =
                 (MqttMessageIdAndPropertiesVariableHeader) unsubscribe.variableHeader();
-        assertEquals("MessageId mismatch", SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
+        assertEquals(SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
         validateProperties(MqttProperties.NO_PROPERTIES, actualVariableHeader.properties());
         MqttUnsubscribePayload actualPayload = (MqttUnsubscribePayload) unsubscribe.payload();
         validateUnsubscribePayload(payload, actualPayload);
@@ -158,10 +156,10 @@ public class MqttMessageFactoryTest {
 
         MqttMessage unsubscribe = MqttMessageFactory.newMessage(fixedHeader, variableHeader, payload);
 
-        assertEquals("Message type mismatch", MqttMessageType.UNSUBSCRIBE, unsubscribe.fixedHeader().messageType());
+        assertEquals(MqttMessageType.UNSUBSCRIBE, unsubscribe.fixedHeader().messageType());
         MqttMessageIdAndPropertiesVariableHeader actualVariableHeader =
                 (MqttMessageIdAndPropertiesVariableHeader) unsubscribe.variableHeader();
-        assertEquals("MessageId mismatch", SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
+        assertEquals(SAMPLE_MESSAGE_ID, actualVariableHeader.messageId());
         validateProperties(properties, actualVariableHeader.properties());
         MqttUnsubscribePayload actualPayload = (MqttUnsubscribePayload) unsubscribe.payload();
         validateUnsubscribePayload(payload, actualPayload);

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttPropertiesTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttPropertiesTest.java
@@ -16,7 +16,8 @@
 
 package io.netty.handler.codec.mqtt;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,7 +27,7 @@ import static io.netty.handler.codec.mqtt.MqttProperties.MqttPropertyType.CONTEN
 import static io.netty.handler.codec.mqtt.MqttProperties.MqttPropertyType.PAYLOAD_FORMAT_INDICATOR;
 import static io.netty.handler.codec.mqtt.MqttProperties.MqttPropertyType.SUBSCRIPTION_IDENTIFIER;
 import static io.netty.handler.codec.mqtt.MqttProperties.MqttPropertyType.USER_PROPERTY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MqttPropertiesTest {
 
@@ -46,10 +47,10 @@ public class MqttPropertiesTest {
     public void testGetProperty() {
         MqttProperties props = createSampleProperties();
 
-        assertEquals("getProperty Content Type",
+        assertEquals(
                 "text/plain",
                 ((MqttProperties.StringProperty) props.getProperty(CONTENT_TYPE.value())).value);
-        assertEquals("getProperty Subscription ID",
+        assertEquals(
                 10,
                 ((MqttProperties.IntegerProperty) props.getProperty(SUBSCRIPTION_IDENTIFIER.value())).value.intValue());
 
@@ -59,21 +60,21 @@ public class MqttPropertiesTest {
         expectedUserProps.add(new MqttProperties.StringPair("tag", "secondTag"));
         List<MqttProperties.StringPair> actualUserProps =
                 ((MqttProperties.UserProperties) props.getProperty(USER_PROPERTY.value())).value;
-        assertEquals("getProperty User Properties", expectedUserProps, actualUserProps);
+        assertEquals(expectedUserProps, actualUserProps);
     }
 
     @Test
     public void testGetProperties() {
         MqttProperties props = createSampleProperties();
 
-        assertEquals("getProperties Content Type",
+        assertEquals(
                 Collections.singletonList(new MqttProperties.StringProperty(CONTENT_TYPE.value(), "text/plain")),
                 props.getProperties(CONTENT_TYPE.value()));
 
         List<MqttProperties.IntegerProperty> expectedSubscriptionIds = new ArrayList<MqttProperties.IntegerProperty>();
         expectedSubscriptionIds.add(new MqttProperties.IntegerProperty(SUBSCRIPTION_IDENTIFIER.value(), 10));
         expectedSubscriptionIds.add(new MqttProperties.IntegerProperty(SUBSCRIPTION_IDENTIFIER.value(), 20));
-        assertEquals("getProperties Subscription ID",
+        assertEquals(
                 expectedSubscriptionIds,
                props.getProperties(SUBSCRIPTION_IDENTIFIER.value()));
 
@@ -83,7 +84,7 @@ public class MqttPropertiesTest {
         expectedUserProps.add(new MqttProperties.UserProperty("tag", "secondTag"));
         List<MqttProperties.UserProperty> actualUserProps =
                 (List<MqttProperties.UserProperty>) props.getProperties(USER_PROPERTY.value());
-        assertEquals("getProperty User Properties", expectedUserProps, actualUserProps);
+        assertEquals(expectedUserProps, actualUserProps);
     }
 
     @Test
@@ -104,9 +105,7 @@ public class MqttPropertiesTest {
 
         expectedProperties.add(expectedUserProperties);
 
-        assertEquals("listAll",
-                expectedProperties,
-                props.listAll());
+        assertEquals(expectedProperties, props.listAll());
     }
 
 }


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust codec-mqtt tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757