### PR TITLE
Migrate transport to junit5 (#11431)

### DIFF
--- a/transport/src/test/java/io/netty/channel/ThreadPerChannelEventLoopGroupTest.java
+++ b/transport/src/test/java/io/netty/channel/ThreadPerChannelEventLoopGroupTest.java
@@ -25,12 +25,13 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThreadPerChannelEventLoopGroupTest {
 

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest3.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest3.java
@@ -29,11 +29,11 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.EventExecutorGroup;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Deque;
 import java.util.LinkedList;
@@ -41,6 +41,10 @@ import java.util.Queue;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LocalTransportThreadModelTest3 {
 
@@ -60,7 +64,7 @@ public class LocalTransportThreadModelTest3 {
     private static EventLoopGroup group;
     private static LocalAddress localAddr;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         // Configure a test server
         group = new DefaultEventLoopGroup();
@@ -83,35 +87,39 @@ public class LocalTransportThreadModelTest3 {
         localAddr = (LocalAddress) sb.bind(LocalAddress.ANY).syncUninterruptibly().channel().localAddress();
     }
 
-    @AfterClass
+    @AfterAll
     public static void destroy() throws Exception {
         group.shutdownGracefully().sync();
     }
 
-    @Test(timeout = 60000)
-    @Ignore("regression test")
+    @Test
+    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+    @Disabled("regression test")
     public void testConcurrentAddRemoveInboundEventsMultiple() throws Throwable {
         for (int i = 0; i < 50; i ++) {
             testConcurrentAddRemoveInboundEvents();
         }
     }
 
-    @Test(timeout = 60000)
-    @Ignore("regression test")
+    @Test
+    @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+    @Disabled("regression test")
     public void testConcurrentAddRemoveOutboundEventsMultiple() throws Throwable {
         for (int i = 0; i < 50; i ++) {
             testConcurrentAddRemoveOutboundEvents();
         }
     }
 
-    @Test(timeout = 30000)
-    @Ignore("needs a fix")
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    @Disabled("needs a fix")
     public void testConcurrentAddRemoveInboundEvents() throws Throwable {
         testConcurrentAddRemove(true);
     }
 
-    @Test(timeout = 30000)
-    @Ignore("needs a fix")
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    @Disabled("needs a fix")
     public void testConcurrentAddRemoveOutboundEvents() throws Throwable {
         testConcurrentAddRemove(false);
     }
@@ -211,10 +219,10 @@ public class LocalTransportThreadModelTest3 {
             for (;;) {
                 EventType event = events.poll();
                 if (event == null) {
-                    Assert.assertTrue("Missing events:" + expectedEvents, expectedEvents.isEmpty());
+                    assertTrue(expectedEvents.isEmpty(), "Missing events:" + expectedEvents);
                     break;
                 }
-                Assert.assertEquals(event, expectedEvents.poll());
+                assertEquals(event, expectedEvents.poll());
             }
         } finally {
             l.shutdownGracefully();

--- a/transport/src/test/java/io/netty/channel/oio/OioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/oio/OioEventLoopTest.java
@@ -26,13 +26,15 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.oio.OioServerSocketChannel;
 import io.netty.channel.socket.oio.OioSocketChannel;
 import io.netty.util.NetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.concurrent.CountDownLatch;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class OioEventLoopTest {

--- a/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
@@ -26,19 +26,22 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.net.ConnectException;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AbstractChannelPoolMapTest {
-    @Test(expected = ConnectException.class)
+    @Test
     public void testMap() throws Exception {
         EventLoopGroup group = new LocalEventLoopGroup();
         LocalAddress addr = new LocalAddress(getLocalAddrId());
@@ -60,7 +63,7 @@ public class AbstractChannelPoolMapTest {
         assertFalse(poolMap.iterator().hasNext());
         assertEquals(0, poolMap.size());
 
-        SimpleChannelPool pool = poolMap.get(loop);
+        final SimpleChannelPool pool = poolMap.get(loop);
         assertEquals(1, poolMap.size());
         assertTrue(poolMap.iterator().hasNext());
 
@@ -71,7 +74,12 @@ public class AbstractChannelPoolMapTest {
         assertFalse(poolMap.iterator().hasNext());
         assertEquals(0, poolMap.size());
 
-        pool.acquire().syncUninterruptibly();
+        assertThrows(ConnectException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                pool.acquire().syncUninterruptibly();
+            }
+        });
         poolMap.close();
     }
 

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolMapDeadlockTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolMapDeadlockTest.java
@@ -23,14 +23,14 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.util.concurrent.Future;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * This is a test case for the deadlock scenario described in https://github.com/netty/netty/issues/8238.


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust transport tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757
