### PR TITLE
Fix HttpHeaderValue#XML_HTTP_REQUEST case

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -235,7 +235,7 @@ public final class HttpHeaderValues {
     /**
      * {@code "XmlHttpRequest"}
      */
-    public static final AsciiString XML_HTTP_REQUEST = AsciiString.cached("XmlHttpRequest");
+    public static final AsciiString XML_HTTP_REQUEST = AsciiString.cached("XMLHttpRequest");
 
     private HttpHeaderValues() { }
 }


### PR DESCRIPTION
Motivation:

HTTP header values are case sensitive. The expected value for `x-request-with` header is `XMLHttpRequest`, not `XmlHttpRequest`.

Modification:

Fix constant's case.

Result:

Correct `XMLHttpRequest` HTTP header value.