### PR TITLE
Skip Brotli related tests on platforms which not support Brotli

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -21,8 +21,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -33,6 +35,7 @@ import java.util.Random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledIf(value = "isNotSupported", disabledReason = "Brotli is not supported on this platform")
 public class BrotliDecoderTest {
 
     private static final Random RANDOM;
@@ -56,6 +59,10 @@ public class BrotliDecoderTest {
         } catch (Throwable throwable) {
             throw new ExceptionInInitializerError(throwable);
         }
+    }
+
+    static boolean isNotSupported() {
+        return PlatformDependent.isOsx() && "aarch_64".equals(PlatformDependent.normalizedArch());
     }
 
     private static void fillArrayWithCompressibleData(byte[] array) {

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -62,7 +62,8 @@ public class BrotliDecoderTest {
     }
 
     static boolean isNotSupported() {
-        return PlatformDependent.isOsx() && "aarch_64".equals(PlatformDependent.normalizedArch());
+        return (PlatformDependent.isOsx() || PlatformDependent.isWindows())
+                && "aarch_64".equals(PlatformDependent.normalizedArch());
     }
 
     private static void fillArrayWithCompressibleData(byte[] array) {


### PR DESCRIPTION
Motivation:

The native module is not yet available on aarch64 Mac thus causing tests in codec/ to fail (specifically all the Brotli ones, since the module could not be loaded).

Modification:

Disable Brotli tests under Mac/aarch64 combo.

Result:

Tests under codec/ now pass under Mac/aarch64.
