### PR TITLE
[Feature] Add zstd encoder

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -125,6 +125,14 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
+This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+and decompression library, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.zstd-jni.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/luben/zstd-jni
+
 This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -204,7 +204,7 @@ non-blocking XML processor, which can be obtained at:
   * LICENSE:
     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
   * HOMEPAGE:
-    * http://wiki.fasterxml.com/AaltoHome
+    * https://wiki.fasterxml.com/AaltoHome
 
 This product contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -84,6 +84,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.aayushatharva.brotli4j</groupId>
       <artifactId>brotli4j</artifactId>
       <optional>true</optional>

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdConstants.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+final class ZstdConstants {
+
+    static final int DEFAULT_COMPRESSION_LEVEL = 10;
+
+    /**
+     * Max block size
+     */
+    static final int MAX_BLOCK_SIZE = 1 << DEFAULT_COMPRESSION_LEVEL + 0x0F;   //  32 M
+    /**
+     * Default block size
+     */
+    static final int DEFAULT_BLOCK_SIZE = 1 << 16;  // 64 KB
+
+    private ZstdConstants() { }
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import com.github.luben.zstd.Zstd;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.util.internal.ObjectUtil;
+import java.nio.ByteBuffer;
+
+import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_COMPRESSION_LEVEL;
+import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_BLOCK_SIZE;
+import static io.netty.handler.codec.compression.ZstdConstants.MAX_BLOCK_SIZE;
+
+/**
+ *  Compresses a {@link ByteBuf} using the Zstandard algorithm.
+ *  See <a href="https://facebook.github.io/zstd">Zstandard</a>.
+ */
+public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
+
+    private final int blockSize;
+    private final int compressionLevel;
+    private final int maxEncodeSize;
+    private ByteBuf buffer;
+
+    /**
+     * Creates a new Zstd encoder.
+     *
+     * Please note that if you use the default constructor, the default BLOCK_SIZE and MAX_BLOCK_SIZE
+     * will be used. If you want to specify BLOCK_SIZE and MAX_BLOCK_SIZE yourself,
+     * please use {@link ZstdEncoder(int,int)} constructor
+     */
+    public ZstdEncoder() {
+        this(DEFAULT_COMPRESSION_LEVEL, DEFAULT_BLOCK_SIZE, MAX_BLOCK_SIZE);
+    }
+
+    /**
+     * Creates a new Zstd encoder.
+     *  @param  compressionLevel
+     *            specifies the level of the compression
+     */
+    public ZstdEncoder(int compressionLevel) {
+        this(compressionLevel, DEFAULT_BLOCK_SIZE, MAX_BLOCK_SIZE);
+    }
+
+    /**
+     * Creates a new Zstd encoder.
+     *  @param  blockSize
+     *            is used to calculate the compressionLevel
+     *  @param  maxEncodeSize
+     *            specifies the size of the largest compressed object
+     */
+    public ZstdEncoder(int blockSize, int maxEncodeSize) {
+        this(DEFAULT_COMPRESSION_LEVEL, blockSize, maxEncodeSize);
+    }
+
+    /**
+     * @param  blockSize
+     *           is used to calculate the compressionLevel
+     * @param  maxEncodeSize
+     *           specifies the size of the largest compressed object
+     * @param  compressionLevel
+     *           specifies the level of the compression
+     */
+    public ZstdEncoder(int compressionLevel, int blockSize, int maxEncodeSize) {
+        super(true);
+        this.compressionLevel = ObjectUtil.checkPositive(compressionLevel, "compressionLevel");
+        this.blockSize = ObjectUtil.checkPositive(blockSize, "blockSize");
+        this.maxEncodeSize = ObjectUtil.checkPositive(maxEncodeSize, "maxEncodeSize");
+    }
+
+    @Override
+    protected ByteBuf allocateBuffer(ChannelHandlerContext ctx, ByteBuf msg, boolean preferDirect) {
+        if (buffer == null) {
+            throw new IllegalStateException("not added to a pipeline," +
+                    "or has been removed,buffer is null");
+        }
+
+        int remaining = msg.readableBytes() + buffer.readableBytes();
+
+        // quick overflow check
+        if (remaining < 0) {
+            throw new EncoderException("too much data to allocate a buffer for compression");
+        }
+
+        long bufferSize = 0;
+        while (remaining > 0) {
+            int curSize = Math.min(blockSize, remaining);
+            remaining -= curSize;
+            bufferSize += Zstd.compressBound(curSize);
+        }
+
+        if (bufferSize > maxEncodeSize || 0 > bufferSize) {
+            throw new EncoderException("requested encode buffer size (" + bufferSize + " bytes) exceeds " +
+                    "the maximum allowable size (" + maxEncodeSize + " bytes)");
+        }
+
+        return ctx.alloc().directBuffer((int) bufferSize);
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) {
+        if (buffer == null) {
+            throw new IllegalStateException("not added to a pipeline," +
+                    "or has been removed,buffer is null");
+        }
+
+        final ByteBuf buffer = this.buffer;
+        int length;
+        while ((length = in.readableBytes()) > 0) {
+            final int nextChunkSize = Math.min(length, buffer.writableBytes());
+            in.readBytes(buffer, nextChunkSize);
+
+            if (!buffer.isWritable()) {
+                flushBufferedData(out);
+            }
+        }
+    }
+
+    private void flushBufferedData(ByteBuf out) {
+        final int flushableBytes = buffer.readableBytes();
+        if (flushableBytes == 0) {
+            return;
+        }
+
+        final int bufSize = (int) Zstd.compressBound(flushableBytes);
+        out.ensureWritable(bufSize);
+        final int idx = out.writerIndex();
+        int compressedLength;
+        try {
+            ByteBuffer outNioBuffer = out.internalNioBuffer(idx, out.writableBytes());
+            compressedLength = Zstd.compress(
+                    outNioBuffer,
+                    buffer.internalNioBuffer(buffer.readerIndex(), flushableBytes),
+                    compressionLevel);
+        } catch (Exception e) {
+            throw new CompressionException(e);
+        }
+
+        out.writerIndex(idx + compressedLength);
+        buffer.clear();
+    }
+
+    @Override
+    public void flush(final ChannelHandlerContext ctx) {
+        if (buffer != null && buffer.isReadable()) {
+            final ByteBuf buf = allocateBuffer(ctx, Unpooled.EMPTY_BUFFER, isPreferDirect());
+            flushBufferedData(buf);
+            ctx.write(buf);
+        }
+        ctx.flush();
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) {
+        buffer = ctx.alloc().directBuffer(blockSize);
+        buffer.clear();
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        super.handlerRemoved(ctx);
+        if (buffer != null) {
+            buffer.release();
+            buffer = null;
+        }
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import com.github.luben.zstd.ZstdInputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.InputStream;
+
+
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ZstdEncoderTest extends AbstractEncoderTest {
+
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
+    }
+
+    @Override
+    public EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(new ZstdEncoder());
+    }
+
+    @Override
+    public void testCompressionOfBatchedFlow(final ByteBuf data) throws Exception {
+        final int dataLength = data.readableBytes();
+        int written = 0;
+
+        ByteBuf in = data.retainedSlice(written, 65535);
+        assertTrue(channel.writeOutbound(in));
+
+        ByteBuf in2 = data.retainedSlice(65535, dataLength - 65535);
+        assertTrue(channel.writeOutbound(in2));
+
+        assertTrue(channel.finish());
+
+        ByteBuf decompressed = readDecompressed(dataLength);
+        assertEquals(data, decompressed);
+
+        decompressed.release();
+        data.release();
+    }
+
+    @Override
+    protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
+        InputStream is = new ByteBufInputStream(compressed, true);
+        ZstdInputStream zstdIs = null;
+        byte[] decompressed = new byte[originalLength];
+        try {
+            zstdIs = new ZstdInputStream(is);
+            int remaining = originalLength;
+            while (remaining > 0) {
+                int read = zstdIs.read(decompressed, originalLength - remaining, remaining);
+                if (read > 0) {
+                    remaining -= read;
+                } else {
+                    break;
+                }
+            }
+            assertEquals(-1, zstdIs.read());
+        } finally {
+            if (zstdIs != null) {
+                zstdIs.close();
+            } else {
+                is.close();
+            }
+        }
+
+        return Unpooled.wrappedBuffer(decompressed);
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -72,6 +72,12 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
         data.release();
     }
 
+    @ParameterizedTest
+    @MethodSource("smallData")
+    public void testCompressionOfSmallBatchedFlow(final ByteBuf data) throws Exception {
+        testCompressionOfBatchedFlow(data);
+    }
+
     @Override
     protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
         InputStream is = new ByteBufInputStream(compressed, true);

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -23,6 +23,8 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -49,8 +51,9 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
         return new EmbeddedChannel(new ZstdEncoder());
     }
 
-    @Override
-    public void testCompressionOfBatchedFlow(final ByteBuf data) throws Exception {
+    @ParameterizedTest
+    @MethodSource("largeData")
+    public void testCompressionOfLargeBatchedFlow(final ByteBuf data) throws Exception {
         final int dataLength = data.readableBytes();
         int written = 0;
 

--- a/license/LICENSE.zstd-jni.txt
+++ b/license/LICENSE.zstd-jni.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -678,6 +678,12 @@
         <version>1.3</version>
       </dependency>
       <dependency>
+        <groupId>com.github.luben</groupId>
+        <artifactId>zstd-jni</artifactId>
+        <version>1.5.0-2</version>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j</artifactId>
         <version>${brotli4j.version}</version>


### PR DESCRIPTION
Motivation:

As discussed in https://github.com/netty/netty/pull/10422, ZstdEncoder can be added separately

Modification:

Add ZstdEncoder separately

Result:

netty supports ZSTD with ZstdEncoder
