### PR TITLE
Migrate common to junit5 (#11431)

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/ScheduledFutureTaskTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/ScheduledFutureTaskTest.java
@@ -15,13 +15,13 @@
  */
 package io.netty.util.concurrent;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class ScheduledFutureTaskTest {
 
     @Test
     public void testDeadlineNanosNotOverflow() {
-        Assert.assertEquals(Long.MAX_VALUE, ScheduledFutureTask.deadlineNanos(Long.MAX_VALUE));
+        Assertions.assertEquals(Long.MAX_VALUE, ScheduledFutureTask.deadlineNanos(Long.MAX_VALUE));
     }
 }

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -15,10 +15,11 @@
  */
 package io.netty.util.concurrent;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.netty.util.concurrent.AbstractEventExecutor.LazyRunnable;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.Collections;
 import java.util.Set;
@@ -36,7 +37,11 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SingleThreadEventExecutorTest {
 
@@ -44,7 +49,8 @@ public class SingleThreadEventExecutorTest {
     public void testWrappedExecutorIsShutdown() {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
 
-        SingleThreadEventExecutor executor = new SingleThreadEventExecutor(null, executorService, false) {
+       final SingleThreadEventExecutor executor =
+               new SingleThreadEventExecutor(null, executorService, false) {
             @Override
             protected void run() {
                 while (!confirmShutdown()) {
@@ -59,27 +65,27 @@ public class SingleThreadEventExecutorTest {
         executorService.shutdownNow();
         executeShouldFail(executor);
         executeShouldFail(executor);
-        try {
-            executor.shutdownGracefully().syncUninterruptibly();
-            Assert.fail();
-        } catch (RejectedExecutionException expected) {
-            // expected
-        }
-        Assert.assertTrue(executor.isShutdown());
+        assertThrows(RejectedExecutionException.class, new Executable() {
+            @Override
+            public void execute() {
+                executor.shutdownGracefully().syncUninterruptibly();
+            }
+        });
+        assertTrue(executor.isShutdown());
     }
 
-    private static void executeShouldFail(Executor executor) {
-        try {
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    // Noop.
-                }
-            });
-            Assert.fail();
-        } catch (RejectedExecutionException expected) {
-            // expected
-        }
+    private static void executeShouldFail(final Executor executor) {
+        assertThrows(RejectedExecutionException.class, new Executable() {
+            @Override
+            public void execute() {
+                executor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        // Noop.
+                    }
+                });
+            }
+        });
     }
 
     @Test
@@ -101,31 +107,35 @@ public class SingleThreadEventExecutorTest {
         ThreadProperties threadProperties = executor.threadProperties();
 
         Thread thread = threadRef.get();
-        Assert.assertEquals(thread.getId(), threadProperties.id());
-        Assert.assertEquals(thread.getName(), threadProperties.name());
-        Assert.assertEquals(thread.getPriority(), threadProperties.priority());
-        Assert.assertEquals(thread.isAlive(), threadProperties.isAlive());
-        Assert.assertEquals(thread.isDaemon(), threadProperties.isDaemon());
-        Assert.assertTrue(threadProperties.stackTrace().length > 0);
+        assertEquals(thread.getId(), threadProperties.id());
+        assertEquals(thread.getName(), threadProperties.name());
+        assertEquals(thread.getPriority(), threadProperties.priority());
+        assertEquals(thread.isAlive(), threadProperties.isAlive());
+        assertEquals(thread.isDaemon(), threadProperties.isDaemon());
+        assertTrue(threadProperties.stackTrace().length > 0);
         executor.shutdownGracefully();
     }
 
-    @Test(expected = RejectedExecutionException.class, timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testInvokeAnyInEventLoop() {
         testInvokeInEventLoop(true, false);
     }
 
-    @Test(expected = RejectedExecutionException.class, timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testInvokeAnyInEventLoopWithTimeout() {
         testInvokeInEventLoop(true, true);
     }
 
-    @Test(expected = RejectedExecutionException.class, timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testInvokeAllInEventLoop() {
         testInvokeInEventLoop(false, false);
     }
 
-    @Test(expected = RejectedExecutionException.class, timeout = 3000)
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testInvokeAllInEventLoopWithTimeout() {
         testInvokeInEventLoop(false, true);
     }
@@ -144,38 +154,44 @@ public class SingleThreadEventExecutorTest {
             }
         };
         try {
-            final Promise<Void> promise = executor.newPromise();
-            executor.execute(new Runnable() {
+            assertThrows(RejectedExecutionException.class, new Executable() {
                 @Override
-                public void run() {
-                    try {
-                        Set<Callable<Boolean>> set = Collections.<Callable<Boolean>>singleton(new Callable<Boolean>() {
-                            @Override
-                            public Boolean call() throws Exception {
-                                promise.setFailure(new AssertionError("Should never execute the Callable"));
-                                return Boolean.TRUE;
-                            }
-                        });
-                        if (any) {
-                            if (timeout) {
-                                executor.invokeAny(set, 10, TimeUnit.SECONDS);
-                            } else {
-                                executor.invokeAny(set);
-                            }
-                        } else {
-                            if (timeout) {
-                                executor.invokeAll(set, 10, TimeUnit.SECONDS);
-                            } else {
-                                executor.invokeAll(set);
+                public void execute() throws Throwable {
+                    final Promise<Void> promise = executor.newPromise();
+                    executor.execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                Set<Callable<Boolean>> set = Collections.<Callable<Boolean>>singleton(
+                                        new Callable<Boolean>() {
+                                    @Override
+                                    public Boolean call() throws Exception {
+                                        promise.setFailure(new AssertionError("Should never execute the Callable"));
+                                        return Boolean.TRUE;
+                                    }
+                                });
+                                if (any) {
+                                    if (timeout) {
+                                        executor.invokeAny(set, 10, TimeUnit.SECONDS);
+                                    } else {
+                                        executor.invokeAny(set);
+                                    }
+                                } else {
+                                    if (timeout) {
+                                        executor.invokeAll(set, 10, TimeUnit.SECONDS);
+                                    } else {
+                                        executor.invokeAll(set);
+                                    }
+                                }
+                                promise.setFailure(new AssertionError("Should never reach here"));
+                            } catch (Throwable cause) {
+                                promise.setFailure(cause);
                             }
                         }
-                        promise.setFailure(new AssertionError("Should never reach here"));
-                    } catch (Throwable cause) {
-                        promise.setFailure(cause);
-                    }
+                    });
+                    promise.syncUninterruptibly();
                 }
             });
-            promise.syncUninterruptibly();
         } finally {
             executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
         }
@@ -210,7 +226,7 @@ public class SingleThreadEventExecutorTest {
                         runAllTasks();
                     } catch (Exception e) {
                         e.printStackTrace();
-                        Assert.fail(e.toString());
+                        fail(e.toString());
                     }
                 }
             }
@@ -322,7 +338,8 @@ public class SingleThreadEventExecutorTest {
         }
     }
 
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testTakeTask() throws Exception {
         final SingleThreadEventExecutor executor =
                 new SingleThreadEventExecutor(null, Executors.defaultThreadFactory(), true) {
@@ -356,7 +373,8 @@ public class SingleThreadEventExecutorTest {
         assertThat(afterTask.ran.get(), is(true));
     }
 
-    @Test(timeout = 5000)
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     public void testTakeTaskAlwaysHasTask() throws Exception {
         //for https://github.com/netty/netty/issues/1614
 

--- a/common/src/test/templates/io/netty/util/collection/KObjectHashMapTest.template
+++ b/common/src/test/templates/io/netty/util/collection/KObjectHashMapTest.template
@@ -15,8 +15,9 @@
 package io.netty.util.collection;
 
 import io.netty.util.collection.@K@ObjectMap.PrimitiveEntry;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,7 +27,13 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
  * Tests for {@link @K@ObjectHashMap}.
@@ -73,13 +80,13 @@ public class @K@ObjectHashMapTest {
 
     private @K@ObjectHashMap<Value> map;
 
-    @Before
+    @BeforeEach
     public void setup() {
         map = new @K@ObjectHashMap<Value>();
     }
 
     @Test
-    public void iteartorRemoveShouldNotNPE() {
+    public void iteratorRemoveShouldNotNPE() {
         map = new @K@ObjectHashMap<Value>(4, 1);
         map.put((@O@)(@k@) 0, new Value("A"));
         map.put((@O@)(@k@) 1, new Value("B"));


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust common tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757