### PR TITLE
Migrate transport-udt to junit5

### DIFF
--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtByteAcceptorChannelTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtByteAcceptorChannelTest.java
@@ -17,9 +17,9 @@
 package io.netty.test.udt.nio;
 
 import io.netty.channel.udt.nio.NioUdtByteAcceptorChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class NioUdtByteAcceptorChannelTest extends AbstractUdtTest {
 

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtByteConnectorChannelTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtByteConnectorChannelTest.java
@@ -17,9 +17,9 @@
 package io.netty.test.udt.nio;
 
 import io.netty.channel.udt.nio.NioUdtByteConnectorChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class NioUdtByteConnectorChannelTest extends AbstractUdtTest {
 

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtByteRendezvousChannelTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtByteRendezvousChannelTest.java
@@ -27,13 +27,16 @@ import io.netty.test.udt.util.EchoByteHandler;
 import io.netty.test.udt.util.UnitHelp;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NioUdtByteRendezvousChannelTest extends AbstractUdtTest {
 
@@ -50,7 +53,8 @@ public class NioUdtByteRendezvousChannelTest extends AbstractUdtTest {
     /**
      * verify basic echo byte rendezvous
      */
-    @Test(timeout = 10 * 1000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void basicEcho() throws Exception {
 
         final int messageSize = 64 * 1024;

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtMessageAcceptorChannelTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtMessageAcceptorChannelTest.java
@@ -17,9 +17,9 @@
 package io.netty.test.udt.nio;
 
 import io.netty.channel.udt.nio.NioUdtMessageAcceptorChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class NioUdtMessageAcceptorChannelTest extends AbstractUdtTest {
 

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtMessageConnectorChannelTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtMessageConnectorChannelTest.java
@@ -17,9 +17,9 @@
 package io.netty.test.udt.nio;
 
 import io.netty.channel.udt.nio.NioUdtMessageConnectorChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class NioUdtMessageConnectorChannelTest extends AbstractUdtTest {
 

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtMessageRendezvousChannelTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtMessageRendezvousChannelTest.java
@@ -27,14 +27,17 @@ import io.netty.test.udt.util.EchoMessageHandler;
 import io.netty.test.udt.util.UnitHelp;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NioUdtMessageRendezvousChannelTest extends AbstractUdtTest {
 
@@ -54,8 +57,9 @@ public class NioUdtMessageRendezvousChannelTest extends AbstractUdtTest {
      * FIXME: Re-enable after making it pass on Windows without unncessary tight loop.
      *        https://github.com/netty/netty/issues/2853
      */
-    @Test(timeout = 10 * 1000)
-    @Ignore
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @Disabled
     public void basicEcho() throws Exception {
 
         final int messageSize = 64 * 1024;

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtProviderTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtProviderTest.java
@@ -24,10 +24,11 @@ import io.netty.channel.udt.nio.NioUdtProvider;
 import io.netty.channel.udt.nio.NioUdtMessageAcceptorChannel;
 import io.netty.channel.udt.nio.NioUdtMessageConnectorChannel;
 import io.netty.channel.udt.nio.NioUdtMessageRendezvousChannel;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class NioUdtProviderTest extends AbstractUdtTest {
 
@@ -68,7 +69,7 @@ public class NioUdtProviderTest extends AbstractUdtTest {
         assertNotNull(NioUdtProvider.channelUDT(nioUdtMessageRendezvousChannel));
 
         // acceptor types
-        assertTrue(NioUdtProvider.BYTE_ACCEPTOR.newChannel() instanceof UdtServerChannel);
-        assertTrue(NioUdtProvider.MESSAGE_ACCEPTOR.newChannel() instanceof UdtServerChannel);
+        assertThat(NioUdtProvider.BYTE_ACCEPTOR.newChannel(), instanceOf(UdtServerChannel.class));
+        assertThat(NioUdtProvider.MESSAGE_ACCEPTOR.newChannel(), instanceOf(UdtServerChannel.class));
     }
 }


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust transport-udt tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757
