### PR TITLE
Migrate codec-http to junit5

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/EmptyHttpHeadersInitializationTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/EmptyHttpHeadersInitializationTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.handler.codec.http;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * A test to validate that either order of initialization of the {@link EmptyHttpHeaders#INSTANCE} and

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderDateFormatTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderDateFormatTest.java
@@ -15,12 +15,13 @@
  */
 package io.netty.handler.codec.http;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.util.Date;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class HttpHeaderDateFormatTest {
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
@@ -20,7 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.CharsetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -20,8 +20,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerExpectContinueHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerExpectContinueHandlerTest.java
@@ -17,7 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -18,8 +18,6 @@ package io.netty.handler.codec.http;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.junit.Test;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
@@ -33,6 +31,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodecFactory;
 import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpServerUpgradeHandlerTest {
 
-    private class TestUpgradeCodec implements UpgradeCodec {
+    private static class TestUpgradeCodec implements UpgradeCodec {
         @Override
         public Collection<CharSequence> requiredUpgradeHeaders() {
             return Collections.<CharSequence>emptyList();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -17,7 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.net.InetAddress;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersTest.java
@@ -18,11 +18,9 @@ package io.netty.handler.codec.http;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -39,17 +37,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
-@RunWith(Parameterized.class)
 public class MultipleContentLengthHeadersTest {
 
-    private final boolean allowDuplicateContentLengths;
-    private final boolean sameValue;
-    private final boolean singleField;
-
-    private EmbeddedChannel channel;
-
-    @Parameters
-    public static Collection<Object[]> parameters() {
+    static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
                 { false, false, false },
                 { false, false, true },
@@ -62,15 +52,7 @@ public class MultipleContentLengthHeadersTest {
         });
     }
 
-    public MultipleContentLengthHeadersTest(
-            boolean allowDuplicateContentLengths, boolean sameValue, boolean singleField) {
-        this.allowDuplicateContentLengths = allowDuplicateContentLengths;
-        this.sameValue = sameValue;
-        this.singleField = singleField;
-    }
-
-    @Before
-    public void setUp() {
+    private static EmbeddedChannel newChannel(boolean allowDuplicateContentLengths) {
         HttpRequestDecoder decoder = new HttpRequestDecoder(
                 DEFAULT_MAX_INITIAL_LINE_LENGTH,
                 DEFAULT_MAX_HEADER_SIZE,
@@ -78,12 +60,15 @@ public class MultipleContentLengthHeadersTest {
                 DEFAULT_VALIDATE_HEADERS,
                 DEFAULT_INITIAL_BUFFER_SIZE,
                 allowDuplicateContentLengths);
-        channel = new EmbeddedChannel(decoder);
+        return new EmbeddedChannel(decoder);
     }
 
-    @Test
-    public void testMultipleContentLengthHeadersBehavior() {
-        String requestStr = setupRequestString();
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testMultipleContentLengthHeadersBehavior(boolean allowDuplicateContentLengths,
+                                                         boolean sameValue, boolean singleField) {
+        EmbeddedChannel channel = newChannel(allowDuplicateContentLengths);
+        String requestStr = setupRequestString(sameValue, singleField);
         assertThat(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)), is(true));
         HttpRequest request = channel.readInbound();
 
@@ -104,7 +89,7 @@ public class MultipleContentLengthHeadersTest {
         assertThat(channel.finish(), is(false));
     }
 
-    private String setupRequestString() {
+    private static String setupRequestString(boolean sameValue, boolean singleField) {
         String firstValue = "1";
         String secondValue = sameValue ? firstValue : "2";
         String contentLength;
@@ -121,6 +106,7 @@ public class MultipleContentLengthHeadersTest {
 
     @Test
     public void testDanglingComma() {
+        EmbeddedChannel channel = newChannel(false);
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                             "Content-Length: 1,\r\n" +
                             "Connection: close\n\n" +

--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
@@ -15,16 +15,17 @@
  */
 package io.netty.handler.codec.rtsp;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test cases for RTSP decoder.

--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspEncoderTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.rtsp;
 
-import static org.junit.Assert.assertEquals;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -27,8 +26,9 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test cases for RTSP encoder.

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/DefaultSpdyHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/DefaultSpdyHeadersTest.java
@@ -15,10 +15,10 @@
  */
 package io.netty.handler.codec.spdy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DefaultSpdyHeadersTest {
 

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
@@ -17,17 +17,23 @@ package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.Random;
 
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_HEADER_SIZE;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class SpdyFrameDecoderTest {
 
@@ -37,12 +43,12 @@ public class SpdyFrameDecoderTest {
     private final TestSpdyFrameDecoderDelegate testDelegate = new TestSpdyFrameDecoderDelegate();
     private SpdyFrameDecoder decoder;
 
-    @Before
+    @BeforeEach
     public void createDecoder() {
         decoder = new SpdyFrameDecoder(SpdyVersion.SPDY_3_1, testDelegate);
     }
 
-    @After
+    @AfterEach
     public void releaseBuffers() {
         testDelegate.releaseAll();
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoderTest.java
@@ -18,13 +18,13 @@ package io.netty.handler.codec.spdy;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SpdyHeaderBlockRawDecoderTest {
 
@@ -38,13 +38,13 @@ public class SpdyHeaderBlockRawDecoderTest {
     private SpdyHeaderBlockRawDecoder decoder;
     private SpdyHeadersFrame frame;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         decoder = new SpdyHeaderBlockRawDecoder(SpdyVersion.SPDY_3_1, maxHeaderSize);
         frame = new DefaultSpdyHeadersFrame(1);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         decoder.end();
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecoderTest.java
@@ -18,13 +18,15 @@ package io.netty.handler.codec.spdy;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SpdyHeaderBlockZlibDecoderTest {
 
@@ -42,13 +44,13 @@ public class SpdyHeaderBlockZlibDecoderTest {
     private SpdyHeaderBlockZlibDecoder decoder;
     private SpdyHeadersFrame frame;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         decoder = new SpdyHeaderBlockZlibDecoder(SpdyVersion.SPDY_3_1, maxHeaderSize);
         frame = new DefaultSpdyHeadersFrame(1);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         decoder.end();
     }
@@ -170,9 +172,9 @@ public class SpdyHeaderBlockZlibDecoderTest {
         headerBlock.release();
     }
 
-    @Test(expected = SpdyProtocolException.class)
+    @Test
     public void testHeaderBlockExtraData() throws Exception {
-        ByteBuf headerBlock = Unpooled.buffer(37);
+        final ByteBuf headerBlock = Unpooled.buffer(37);
         headerBlock.writeBytes(zlibHeader);
         headerBlock.writeByte(0); // Non-compressed block
         headerBlock.writeByte(0x15); // little-endian length (21)
@@ -189,14 +191,20 @@ public class SpdyHeaderBlockZlibDecoderTest {
         headerBlock.writeByte(0x03); // adler-32 checksum
         headerBlock.writeByte(0xc9); // adler-32 checksum
         headerBlock.writeByte(0); // Data following zlib stream
-        decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+
+        assertThrows(SpdyProtocolException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+            }
+        });
 
         headerBlock.release();
     }
 
-    @Test(expected = SpdyProtocolException.class)
+    @Test
     public void testHeaderBlockInvalidDictionary() throws Exception {
-        ByteBuf headerBlock = Unpooled.buffer(7);
+        final ByteBuf headerBlock = Unpooled.buffer(7);
         headerBlock.writeByte(0x78);
         headerBlock.writeByte(0x3f);
         headerBlock.writeByte(0x01); // Unknown dictionary
@@ -204,21 +212,33 @@ public class SpdyHeaderBlockZlibDecoderTest {
         headerBlock.writeByte(0x03); // Unknown dictionary
         headerBlock.writeByte(0x04); // Unknown dictionary
         headerBlock.writeByte(0); // Non-compressed block
-        decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+
+        assertThrows(SpdyProtocolException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+            }
+        });
 
         headerBlock.release();
     }
 
-    @Test(expected = SpdyProtocolException.class)
+    @Test
     public void testHeaderBlockInvalidDeflateBlock() throws Exception {
-        ByteBuf headerBlock = Unpooled.buffer(11);
+        final ByteBuf headerBlock = Unpooled.buffer(11);
         headerBlock.writeBytes(zlibHeader);
         headerBlock.writeByte(0); // Non-compressed block
         headerBlock.writeByte(0x00); // little-endian length (0)
         headerBlock.writeByte(0x00); // little-endian length (0)
         headerBlock.writeByte(0x00); // invalid one's compliment
         headerBlock.writeByte(0x00); // invalid one's compliment
-        decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+
+        assertThrows(SpdyProtocolException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+            }
+        });
 
         headerBlock.release();
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
@@ -20,12 +20,15 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SpdySessionHandlerTest {
 


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust codec-http tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757