### PR TITLE
Migrate rest of epoll module to junit5

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -30,11 +30,13 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -190,7 +192,8 @@ public class EpollSpliceTest {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void spliceToFile() throws Throwable {
         EventLoopGroup group = new EpollEventLoopGroup(1);
         File file = PlatformDependent.createTempFile("netty-splice", null, null);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -29,8 +29,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,7 +37,8 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EpollSpliceTest {
 
@@ -238,8 +238,8 @@ public class EpollSpliceTest {
         FileInputStream in = new FileInputStream(file);
 
         try {
-            Assert.assertEquals(written.length, in.read(written));
-            Assert.assertArrayEquals(data, written);
+            assertEquals(written.length, in.read(written));
+            assertArrayEquals(data, written);
         } finally {
             in.close();
             group.shutdownGracefully();


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust missing epoll tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757