### PR TITLE
Migrate microbenchmark to junit5 (#11440)

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -15,7 +15,6 @@
  */
 package io.netty.microbench.util;
 
-import static org.junit.Assert.assertNull;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.SystemPropertyUtil;
 
@@ -23,7 +22,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -32,6 +31,8 @@ import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Base class for all JMH benchmarks.


### PR DESCRIPTION
Motivation:

We should update to use junit5 in all modules.

Modifications:

Adjust microbenchmark to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757