### PR TITLE
Use Junit5 for handler module

### DIFF
--- a/handler/src/test/java/io/netty/handler/address/DynamicAddressConnectHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/address/DynamicAddressConnectHandlerTest.java
@@ -19,14 +19,14 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.SocketAddress;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class DynamicAddressConnectHandlerTest {
     private static final SocketAddress LOCAL = new SocketAddress() { };

--- a/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
@@ -31,16 +31,19 @@ import io.netty.resolver.AddressResolver;
 import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Promise;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ResolveAddressHandlerTest {
 
@@ -50,12 +53,12 @@ public class ResolveAddressHandlerTest {
 
     private static EventLoopGroup group;
 
-    @BeforeClass
+    @BeforeAll
     public static void createEventLoop() {
         group = new DefaultEventLoopGroup();
     }
 
-    @AfterClass
+    @AfterAll
     public static void destroyEventLoop() {
         if (group != null) {
             group.shutdownGracefully();

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -37,9 +37,9 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.net.SocketAddress;
 import java.util.List;
@@ -50,17 +50,21 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FlowControlHandlerTest {
     private static EventLoopGroup GROUP;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         GROUP = new NioEventLoopGroup();
     }
 
-    @AfterClass
+    @AfterEach
     public static void destroy() {
         GROUP.shutdownGracefully();
     }

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -21,11 +21,15 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FlushConsolidationHandlerTest {
 
@@ -124,10 +128,10 @@ public class FlushConsolidationHandlerTest {
         assertFalse(channel.finish());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testFlushViaException() {
         final AtomicInteger flushCount = new AtomicInteger();
-        EmbeddedChannel channel = newChannel(flushCount, false);
+        final EmbeddedChannel channel = newChannel(flushCount, false);
         // Simulate read loop;
         channel.pipeline().fireChannelRead(1L);
         assertEquals(0, flushCount.get());
@@ -136,7 +140,12 @@ public class FlushConsolidationHandlerTest {
         assertEquals(1, flushCount.get());
         assertEquals(1L, channel.readOutbound());
         assertNull(channel.readOutbound());
-        channel.finish();
+        assertThrows(IllegalStateException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.finish();
+            }
+        });
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -22,16 +22,17 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.SocketUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class IpSubnetFilterTest {
 
@@ -109,16 +110,16 @@ public class IpSubnetFilterTest {
             protected ChannelFuture channelRejected(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) {
                 assertTrue(ctx.channel().isActive());
                 assertTrue(ctx.channel().isWritable());
-                Assert.assertEquals("192.168.57.1", remoteAddress.getHostName());
+                assertEquals("192.168.57.1", remoteAddress.getHostName());
 
                 return ctx.writeAndFlush(Unpooled.wrappedBuffer(message));
             }
         };
         EmbeddedChannel chDeny = newEmbeddedInetChannel("192.168.57.1", denyHandler);
         ByteBuf out = chDeny.readOutbound();
-        Assert.assertEquals(7, out.readableBytes());
+        assertEquals(7, out.readableBytes());
         for (byte i = 1; i <= 7; i++) {
-            Assert.assertEquals(i, out.readByte());
+            assertEquals(i, out.readByte());
         }
         assertFalse(chDeny.isActive());
         assertFalse(chDeny.isOpen());
@@ -126,7 +127,7 @@ public class IpSubnetFilterTest {
         RuleBasedIpFilter allowHandler = new RuleBasedIpFilter(filter0) {
             @Override
             protected ChannelFuture channelRejected(ChannelHandlerContext ctx, InetSocketAddress remoteAddress) {
-                Assert.fail();
+                fail();
                 return null;
             }
         };

--- a/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/UniqueIpFilterTest.java
@@ -18,8 +18,7 @@ package io.netty.handler.ipfilter;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.SocketUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.SocketAddress;
 import java.util.concurrent.Callable;
@@ -28,6 +27,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UniqueIpFilterTest {
 
@@ -42,8 +44,8 @@ public class UniqueIpFilterTest {
                 Future<EmbeddedChannel> future2 = newChannelAsync(barrier, executorService, ipFilter);
                 EmbeddedChannel ch1 = future1.get();
                 EmbeddedChannel ch2 = future2.get();
-                Assert.assertTrue(ch1.isActive() || ch2.isActive());
-                Assert.assertFalse(ch1.isActive() && ch2.isActive());
+                assertTrue(ch1.isActive() || ch2.isActive());
+                assertFalse(ch1.isActive() && ch2.isActive());
 
                 barrier.reset();
                 ch1.close().await();

--- a/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
@@ -26,11 +26,13 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +46,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 /**
@@ -64,7 +69,7 @@ public class LoggingHandlerTest {
      */
     private Appender<ILoggingEvent> appender;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         for (Iterator<Appender<ILoggingEvent>> i = rootLogger.iteratorForAppenders(); i.hasNext();) {
             Appender<ILoggingEvent> a = i.next();
@@ -75,29 +80,34 @@ public class LoggingHandlerTest {
         Unpooled.buffer();
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         for (Appender<ILoggingEvent> a: oldAppenders) {
             rootLogger.addAppender(a);
         }
     }
 
-    @Before
+    @BeforeEach
     @SuppressWarnings("unchecked")
     public void setup() {
         appender = mock(Appender.class);
         logger.addAppender(appender);
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         logger.detachAppender(appender);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAcceptNullLogLevel() {
-        LogLevel level = null;
-        new LoggingHandler(level);
+        assertThrows(NullPointerException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                LogLevel level = null;
+                new LoggingHandler(level);
+            }
+        });
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -29,14 +29,14 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PcapWriteHandlerTest {
 

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -21,7 +21,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,13 +32,13 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
 
 import static io.netty.handler.ssl.CloseNotifyTest.assertCloseNotify;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ApplicationProtocolNegotiationHandlerTest {
 
@@ -86,7 +87,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
         assertTrue(configureCalled.get());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testHandshakeSuccessButNoSslHandler() {
         ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
             @Override
@@ -94,13 +95,16 @@ public class ApplicationProtocolNegotiationHandlerTest {
                 fail();
             }
         };
-        EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
-        try {
-            channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
-        } finally {
-            assertNull(channel.pipeline().context(alpnHandler));
-            assertFalse(channel.finishAndReleaseAll());
-        }
+        final EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
+        channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
+        assertNull(channel.pipeline().context(alpnHandler));
+        assertThrows(IllegalStateException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                assertFalse(channel.finishAndReleaseAll());
+
+            }
+        });
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -101,7 +101,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
         assertThrows(IllegalStateException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                assertFalse(channel.finishAndReleaseAll());
+                channel.finishAndReleaseAll();
             }
         });
     }

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -102,7 +102,6 @@ public class ApplicationProtocolNegotiationHandlerTest {
             @Override
             public void execute() throws Throwable {
                 assertFalse(channel.finishAndReleaseAll());
-
             }
         });
     }

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
@@ -18,12 +18,13 @@ package io.netty.handler.ssl;
 
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CipherSuiteConverterTest {
 

--- a/handler/src/test/java/io/netty/handler/ssl/DelegatingSslContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/DelegatingSslContextTest.java
@@ -17,11 +17,12 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.UnpooledByteBufAllocator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class DelegatingSslContextTest {
     private static final String[] EXPECTED_PROTOCOLS = { SslUtils.PROTOCOL_TLS_V1_1 };
@@ -31,10 +32,10 @@ public class DelegatingSslContextTest {
         SslContext delegating = newDelegatingSslContext();
 
         SSLEngine engine = delegating.newEngine(UnpooledByteBufAllocator.DEFAULT);
-        Assert.assertArrayEquals(EXPECTED_PROTOCOLS, engine.getEnabledProtocols());
+        assertArrayEquals(EXPECTED_PROTOCOLS, engine.getEnabledProtocols());
 
         engine = delegating.newEngine(UnpooledByteBufAllocator.DEFAULT, "localhost", 9090);
-        Assert.assertArrayEquals(EXPECTED_PROTOCOLS, engine.getEnabledProtocols());
+        assertArrayEquals(EXPECTED_PROTOCOLS, engine.getEnabledProtocols());
     }
 
     @Test
@@ -42,10 +43,10 @@ public class DelegatingSslContextTest {
         SslContext delegating = newDelegatingSslContext();
 
         SslHandler handler = delegating.newHandler(UnpooledByteBufAllocator.DEFAULT);
-        Assert.assertArrayEquals(EXPECTED_PROTOCOLS, handler.engine().getEnabledProtocols());
+        assertArrayEquals(EXPECTED_PROTOCOLS, handler.engine().getEnabledProtocols());
 
         handler = delegating.newHandler(UnpooledByteBufAllocator.DEFAULT, "localhost", 9090);
-        Assert.assertArrayEquals(EXPECTED_PROTOCOLS, handler.engine().getEnabledProtocols());
+        assertArrayEquals(EXPECTED_PROTOCOLS, handler.engine().getEnabledProtocols());
     }
 
     private static SslContext newDelegatingSslContext() throws Exception {

--- a/handler/src/test/java/io/netty/handler/ssl/IdentityCipherSuiteFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/IdentityCipherSuiteFilterTest.java
@@ -15,14 +15,14 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class IdentityCipherSuiteFilterTest {
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
@@ -17,13 +17,15 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.UnpooledByteBufAllocator;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManagerFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialProviderTest {
 
@@ -40,7 +42,7 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
 
     @Override
     protected void assertRelease(OpenSslKeyMaterial material) {
-        Assert.assertFalse(material.release());
+        assertFalse(material.release());
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateExceptionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateExceptionTest.java
@@ -16,15 +16,18 @@
 package io.netty.handler.ssl;
 
 import io.netty.internal.tcnative.CertificateVerifier;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.lang.reflect.Field;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class OpenSslCertificateExceptionTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void ensureOpenSsl() {
         OpenSsl.ensureAvailability();
     }
@@ -36,14 +39,19 @@ public class OpenSslCertificateExceptionTest {
             if (field.isAccessible()) {
                 int errorCode = field.getInt(null);
                 OpenSslCertificateException exception = new OpenSslCertificateException(errorCode);
-                Assert.assertEquals(errorCode, exception.errorCode());
+                assertEquals(errorCode, exception.errorCode());
             }
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNonValidErrorCode() {
-        new OpenSslCertificateException(Integer.MIN_VALUE);
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new OpenSslCertificateException(Integer.MIN_VALUE);
+            }
+        });
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialManagerTest.java
@@ -18,9 +18,7 @@ package io.netty.handler.ssl;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.X509ExtendedKeyManager;
@@ -28,6 +26,8 @@ import java.net.Socket;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class OpenSslKeyMaterialManagerTest {
 
@@ -71,7 +71,7 @@ public class OpenSslKeyMaterialManagerTest {
                 new OpenSslKeyMaterialProvider(keyManager, null) {
             @Override
             OpenSslKeyMaterial chooseKeyMaterial(ByteBufAllocator allocator, String alias) throws Exception {
-                Assert.fail("Should not be called when alias is null");
+                fail("Should not be called when alias is null");
                 return null;
             }
         });

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialProviderTest.java
@@ -19,8 +19,8 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.internal.tcnative.SSL;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.X509KeyManager;
@@ -31,8 +31,11 @@ import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenSslKeyMaterialProviderTest {
 
@@ -40,8 +43,8 @@ public class OpenSslKeyMaterialProviderTest {
     static final String EXISTING_ALIAS = "1";
     private static final String NON_EXISTING_ALIAS = "nonexisting";
 
-    @BeforeClass
-    public static void checkOpenSsl() {
+    @BeforeAll
+    static void checkOpenSsl() {
         OpenSsl.ensureAvailability();
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -36,13 +36,11 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
 import org.hamcrest.Matchers;
-import org.junit.AfterClass;
 import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -67,27 +65,25 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Parameterized.class)
 public class OpenSslPrivateKeyMethodTest {
     private static final String RFC_CIPHER_NAME = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
     private static EventLoopGroup GROUP;
     private static SelfSignedCertificate CERT;
     private static ExecutorService EXECUTOR;
 
-    @Parameters(name = "{index}: delegate = {0}")
-    public static Collection<Object[]> parameters() {
+    static Collection<Object[]> parameters() {
         List<Object[]> dst = new ArrayList<Object[]>();
         dst.add(new Object[] { true });
         dst.add(new Object[] { false });
         return dst;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void init() throws Exception {
         checkShouldUseKeyManagerFactory();
 
@@ -107,19 +103,13 @@ public class OpenSslPrivateKeyMethodTest {
         });
     }
 
-    @AfterClass
+    @AfterAll
     public static void destroy() {
         if (OpenSsl.isBoringSSL()) {
             GROUP.shutdownGracefully();
             CERT.delete();
             EXECUTOR.shutdown();
         }
-    }
-
-    private final boolean delegate;
-
-    public OpenSslPrivateKeyMethodTest(boolean delegate) {
-        this.delegate = delegate;
     }
 
     private static void assumeCipherAvailable(SslProvider provider) throws NoSuchAlgorithmException {
@@ -170,11 +160,11 @@ public class OpenSslPrivateKeyMethodTest {
                 .build();
     }
 
-    private Executor delegateExecutor() {
+    private static Executor delegateExecutor(boolean delegate) {
        return delegate ? EXECUTOR : null;
     }
 
-    private void assertThread() {
+    private static void assertThread(boolean delegate) {
         if (delegate && OpenSslContext.USE_TASKS) {
             assertEquals(DelegateThread.class, Thread.currentThread().getClass());
         } else {
@@ -182,14 +172,15 @@ public class OpenSslPrivateKeyMethodTest {
         }
     }
 
-    @Test
-    public void testPrivateKeyMethod() throws Exception {
+    @ParameterizedTest(name = "{index}: delegate = {0}")
+    @MethodSource("parameters")
+    public void testPrivateKeyMethod(final boolean delegate) throws Exception {
         final AtomicBoolean signCalled = new AtomicBoolean();
         final SslContext sslServerContext = buildServerContext(new OpenSslPrivateKeyMethod() {
             @Override
             public byte[] sign(SSLEngine engine, int signatureAlgorithm, byte[] input) throws Exception {
                 signCalled.set(true);
-                assertThread();
+                assertThread(delegate);
 
                 assertEquals(CERT.cert().getPublicKey(),
                         engine.getSession().getLocalCertificates()[0].getPublicKey());
@@ -227,7 +218,7 @@ public class OpenSslPrivateKeyMethodTest {
                     @Override
                     protected void initChannel(Channel ch) {
                         ChannelPipeline pipeline = ch.pipeline();
-                        pipeline.addLast(newSslHandler(sslServerContext, ch.alloc(), delegateExecutor()));
+                        pipeline.addLast(newSslHandler(sslServerContext, ch.alloc(), delegateExecutor(delegate)));
 
                         pipeline.addLast(new SimpleChannelInboundHandler<Object>() {
                             @Override
@@ -263,7 +254,7 @@ public class OpenSslPrivateKeyMethodTest {
                         @Override
                         protected void initChannel(Channel ch) {
                             ChannelPipeline pipeline = ch.pipeline();
-                            pipeline.addLast(newSslHandler(sslClientContext, ch.alloc(), delegateExecutor()));
+                            pipeline.addLast(newSslHandler(sslClientContext, ch.alloc(), delegateExecutor(delegate)));
 
                             pipeline.addLast(new SimpleChannelInboundHandler<Object>() {
                                 @Override
@@ -293,8 +284,8 @@ public class OpenSslPrivateKeyMethodTest {
                         client.writeAndFlush(Unpooled.wrappedBuffer(new byte[] {'P', 'I', 'N', 'G'}))
                               .syncUninterruptibly();
 
-                        assertTrue("client timeout", clientPromise.await(5L, TimeUnit.SECONDS));
-                        assertTrue("server timeout", serverPromise.await(5L, TimeUnit.SECONDS));
+                        assertTrue(clientPromise.await(5L, TimeUnit.SECONDS), "client timeout");
+                        assertTrue(serverPromise.await(5L, TimeUnit.SECONDS), "server timeout");
 
                         clientPromise.sync();
                         serverPromise.sync();
@@ -313,20 +304,23 @@ public class OpenSslPrivateKeyMethodTest {
         }
     }
 
-    @Test
-    public void testPrivateKeyMethodFailsBecauseOfException() throws Exception {
-        testPrivateKeyMethodFails(false);
+    @ParameterizedTest(name = "{index}: delegate = {0}")
+    @MethodSource("parameters")
+    public void testPrivateKeyMethodFailsBecauseOfException(final boolean delegate) throws Exception {
+        testPrivateKeyMethodFails(delegate, false);
     }
 
-    @Test
-    public void testPrivateKeyMethodFailsBecauseOfNull() throws Exception {
-        testPrivateKeyMethodFails(true);
+    @ParameterizedTest(name = "{index}: delegate = {0}")
+    @MethodSource("parameters")
+    public void testPrivateKeyMethodFailsBecauseOfNull(final boolean delegate) throws Exception {
+        testPrivateKeyMethodFails(delegate, true);
     }
-    private void testPrivateKeyMethodFails(final boolean returnNull) throws Exception {
+
+    private void testPrivateKeyMethodFails(final boolean delegate, final boolean returnNull) throws Exception {
         final SslContext sslServerContext = buildServerContext(new OpenSslPrivateKeyMethod() {
             @Override
             public byte[] sign(SSLEngine engine, int signatureAlgorithm, byte[] input) throws Exception {
-                assertThread();
+                assertThread(delegate);
                 if (returnNull) {
                     return null;
                 }
@@ -341,9 +335,9 @@ public class OpenSslPrivateKeyMethodTest {
         final SslContext sslClientContext = buildClientContext();
 
         SslHandler serverSslHandler = newSslHandler(
-                sslServerContext, UnpooledByteBufAllocator.DEFAULT, delegateExecutor());
+                sslServerContext, UnpooledByteBufAllocator.DEFAULT, delegateExecutor(delegate));
         SslHandler clientSslHandler = newSslHandler(
-                sslClientContext, UnpooledByteBufAllocator.DEFAULT, delegateExecutor());
+                sslClientContext, UnpooledByteBufAllocator.DEFAULT, delegateExecutor(delegate));
 
         try {
             try {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslTest.java
@@ -15,15 +15,16 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenSslTest {
 
     @Test
     public void testDefaultCiphers() {
         if (!OpenSsl.isTlsv13Supported()) {
-            Assert.assertTrue(
+            assertTrue(
                     OpenSsl.DEFAULT_CIPHERS.size() <= SslUtils.DEFAULT_CIPHER_SUITES.length);
         }
     }

--- a/handler/src/test/java/io/netty/handler/ssl/OptionalSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OptionalSslHandlerTest.java
@@ -20,16 +20,17 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class OptionalSslHandlerTest {
 
     private static final String SSL_HANDLER_NAME = "sslhandler";
@@ -44,8 +45,9 @@ public class OptionalSslHandlerTest {
     @Mock
     private ChannelPipeline pipeline;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
         when(context.pipeline()).thenReturn(pipeline);
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -76,6 +76,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ParameterizedSslHandlerTest {
 
+    private static final String PARAMETERIZED_NAME = "{index}: clientProvider={0}, {index}: serverProvider={1}";
+
     static Collection<Object[]> data() {
         List<SslProvider> providers = new ArrayList<SslProvider>(3);
         if (OpenSsl.isAvailable()) {
@@ -94,7 +96,7 @@ public class ParameterizedSslHandlerTest {
         return params;
     }
 
-    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("data")
     @Timeout(value = 48000, unit = TimeUnit.MILLISECONDS)
     public void testCompositeBufSizeEstimationGuaranteesSynchronousWrite(
@@ -271,7 +273,7 @@ public class ParameterizedSslHandlerTest {
         }
     }
 
-    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("data")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testAlertProducedAndSend(SslProvider clientProvider, SslProvider serverProvider) throws Exception {
@@ -371,14 +373,14 @@ public class ParameterizedSslHandlerTest {
         }
     }
 
-    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("data")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testCloseNotify(SslProvider clientProvider, SslProvider serverProvider) throws Exception {
         testCloseNotify(clientProvider, serverProvider, 5000, false);
     }
 
-    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("data")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testCloseNotifyReceivedTimeout(SslProvider clientProvider, SslProvider serverProvider)
@@ -386,7 +388,7 @@ public class ParameterizedSslHandlerTest {
         testCloseNotify(clientProvider, serverProvider, 100, true);
     }
 
-    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("data")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testCloseNotifyNotWaitForResponse(SslProvider clientProvider, SslProvider serverProvider)
@@ -513,7 +515,7 @@ public class ParameterizedSslHandlerTest {
         }
     }
 
-    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("data")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void reentryOnHandshakeCompleteNioChannel(SslProvider clientProvider, SslProvider serverProvider)
@@ -536,7 +538,7 @@ public class ParameterizedSslHandlerTest {
         }
     }
 
-    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("data")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void reentryOnHandshakeCompleteLocalChannel(SslProvider clientProvider, SslProvider serverProvider)

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -47,9 +47,9 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ResourcesUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLException;
@@ -65,19 +65,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.util.internal.ThreadLocalRandom.current;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Parameterized.class)
 public class ParameterizedSslHandlerTest {
 
-    @Parameterized.Parameters(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
-    public static Collection<Object[]> data() {
+    static Collection<Object[]> data() {
         List<SslProvider> providers = new ArrayList<SslProvider>(3);
         if (OpenSsl.isAvailable()) {
             providers.add(SslProvider.OPENSSL);
@@ -95,16 +94,11 @@ public class ParameterizedSslHandlerTest {
         return params;
     }
 
-    private final SslProvider clientProvider;
-    private final SslProvider serverProvider;
-
-    public ParameterizedSslHandlerTest(SslProvider clientProvider, SslProvider serverProvider) {
-        this.clientProvider = clientProvider;
-        this.serverProvider = serverProvider;
-    }
-
-    @Test(timeout = 480000)
-    public void testCompositeBufSizeEstimationGuaranteesSynchronousWrite()
+    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @MethodSource("data")
+    @Timeout(value = 48000, unit = TimeUnit.MILLISECONDS)
+    public void testCompositeBufSizeEstimationGuaranteesSynchronousWrite(
+            SslProvider clientProvider, SslProvider serverProvider)
             throws CertificateException, SSLException, ExecutionException, InterruptedException {
         compositeBufSizeEstimationGuaranteesSynchronousWrite(serverProvider, clientProvider,
                 true, true, true);
@@ -277,8 +271,10 @@ public class ParameterizedSslHandlerTest {
         }
     }
 
-    @Test(timeout = 30000)
-    public void testAlertProducedAndSend() throws Exception {
+    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testAlertProducedAndSend(SslProvider clientProvider, SslProvider serverProvider) throws Exception {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
 
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
@@ -375,22 +371,31 @@ public class ParameterizedSslHandlerTest {
         }
     }
 
-    @Test(timeout = 30000)
-    public void testCloseNotify() throws Exception {
-        testCloseNotify(5000, false);
+    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testCloseNotify(SslProvider clientProvider, SslProvider serverProvider) throws Exception {
+        testCloseNotify(clientProvider, serverProvider, 5000, false);
     }
 
-    @Test(timeout = 30000)
-    public void testCloseNotifyReceivedTimeout() throws Exception {
-        testCloseNotify(100, true);
+    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testCloseNotifyReceivedTimeout(SslProvider clientProvider, SslProvider serverProvider)
+            throws Exception {
+        testCloseNotify(clientProvider, serverProvider, 100, true);
     }
 
-    @Test(timeout = 30000)
-    public void testCloseNotifyNotWaitForResponse() throws Exception {
-        testCloseNotify(0, false);
+    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testCloseNotifyNotWaitForResponse(SslProvider clientProvider, SslProvider serverProvider)
+            throws Exception {
+        testCloseNotify(clientProvider, serverProvider, 0, false);
     }
 
-    private void testCloseNotify(final long closeNotifyReadTimeout, final boolean timeout) throws Exception {
+    private void testCloseNotify(SslProvider clientProvider, SslProvider serverProvider,
+                                 final long closeNotifyReadTimeout, final boolean timeout) throws Exception {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
 
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
@@ -508,39 +513,54 @@ public class ParameterizedSslHandlerTest {
         }
     }
 
-    @Test(timeout = 30000)
-    public void reentryOnHandshakeCompleteNioChannel() throws Exception {
+    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void reentryOnHandshakeCompleteNioChannel(SslProvider clientProvider, SslProvider serverProvider)
+            throws Exception {
         EventLoopGroup group = new NioEventLoopGroup();
         try {
             Class<? extends ServerChannel> serverClass = NioServerSocketChannel.class;
             Class<? extends Channel> clientClass = NioSocketChannel.class;
             SocketAddress bindAddress = new InetSocketAddress(0);
-            reentryOnHandshakeComplete(group, bindAddress, serverClass, clientClass, false, false);
-            reentryOnHandshakeComplete(group, bindAddress, serverClass, clientClass, false, true);
-            reentryOnHandshakeComplete(group, bindAddress, serverClass, clientClass, true, false);
-            reentryOnHandshakeComplete(group, bindAddress, serverClass, clientClass, true, true);
+            reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
+                    serverClass, clientClass, false, false);
+            reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
+                    serverClass, clientClass, false, true);
+            reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
+                    serverClass, clientClass, true, false);
+            reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
+                    serverClass, clientClass, true, true);
         } finally {
             group.shutdownGracefully();
         }
     }
 
-    @Test(timeout = 30000)
-    public void reentryOnHandshakeCompleteLocalChannel() throws Exception {
+    @ParameterizedTest(name = "{index}: clientProvider={0}, {index}: serverProvider={1}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void reentryOnHandshakeCompleteLocalChannel(SslProvider clientProvider, SslProvider serverProvider)
+            throws Exception {
         EventLoopGroup group = new DefaultEventLoopGroup();
         try {
             Class<? extends ServerChannel> serverClass = LocalServerChannel.class;
             Class<? extends Channel> clientClass = LocalChannel.class;
             SocketAddress bindAddress = new LocalAddress(String.valueOf(current().nextLong()));
-            reentryOnHandshakeComplete(group, bindAddress, serverClass, clientClass, false, false);
-            reentryOnHandshakeComplete(group, bindAddress, serverClass, clientClass, false, true);
-            reentryOnHandshakeComplete(group, bindAddress, serverClass, clientClass, true, false);
-            reentryOnHandshakeComplete(group, bindAddress, serverClass, clientClass, true, true);
+            reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
+                    serverClass, clientClass, false, false);
+            reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
+                    serverClass, clientClass, false, true);
+            reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
+                    serverClass, clientClass, true, false);
+            reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
+                    serverClass, clientClass, true, true);
         } finally {
             group.shutdownGracefully();
         }
     }
 
-    private void reentryOnHandshakeComplete(EventLoopGroup group, SocketAddress bindAddress,
+    private void reentryOnHandshakeComplete(SslProvider clientProvider, SslProvider serverProvider,
+                                            EventLoopGroup group, SocketAddress bindAddress,
                                             Class<? extends ServerChannel> serverClass,
                                             Class<? extends Channel> clientClass, boolean serverAutoRead,
                                             boolean clientAutoRead) throws Exception {

--- a/handler/src/test/java/io/netty/handler/ssl/PemEncodedTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PemEncodedTest.java
@@ -16,21 +16,22 @@
 
 package io.netty.handler.ssl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.security.PrivateKey;
 
 import io.netty.buffer.UnpooledByteBufAllocator;
-import org.junit.Test;
 
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class PemEncodedTest {
 
@@ -71,22 +72,27 @@ public class PemEncodedTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEncodedReturnsNull() throws Exception {
-        PemPrivateKey.toPEM(UnpooledByteBufAllocator.DEFAULT, true, new PrivateKey() {
+        assertThrows(IllegalArgumentException.class, new Executable() {
             @Override
-            public String getAlgorithm() {
-                return null;
-            }
+            public void execute() throws Throwable {
+                PemPrivateKey.toPEM(UnpooledByteBufAllocator.DEFAULT, true, new PrivateKey() {
+                    @Override
+                    public String getAlgorithm() {
+                        return null;
+                    }
 
-            @Override
-            public String getFormat() {
-                return null;
-            }
+                    @Override
+                    public String getFormat() {
+                        return null;
+                    }
 
-            @Override
-            public byte[] getEncoded() {
-                return null;
+                    @Override
+                    public byte[] getEncoded() {
+                        return null;
+                    }
+                });
             }
         });
     }

--- a/handler/src/test/java/io/netty/handler/ssl/PseudoRandomFunctionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PseudoRandomFunctionTest.java
@@ -18,10 +18,9 @@ package io.netty.handler.ssl;
 
 import io.netty.util.CharsetUtil;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 /**
  * The test vectors here were provided via:
  * https://www.ietf.org/mail-archive/web/tls/current/msg03416.html

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -31,14 +31,17 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class RenegotiateTest {
 
-    @Test(timeout = 30000)
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testRenegotiateServer() throws Throwable {
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(2);

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -53,7 +53,6 @@ import org.conscrypt.OpenSSLProvider;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;

--- a/handler/src/test/java/io/netty/handler/ssl/SignatureAlgorithmConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SignatureAlgorithmConverterTest.java
@@ -15,10 +15,10 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SignatureAlgorithmConverterTest {
 

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SniClientTest {
-
+    private static final String PARAMETERIZED_NAME = "{index}: serverSslProvider = {0}, clientSslProvider = {1}";
     static Collection<Object[]> parameters() {
         List<SslProvider> providers = new ArrayList<SslProvider>(Arrays.asList(SslProvider.values()));
         if (!OpenSsl.isAvailable()) {
@@ -69,14 +69,7 @@ public class SniClientTest {
         return params;
     }
 
-    @ParameterizedTest(name = "{index}: serverSslProvider = {0}, clientSslProvider = {1}")
-    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
-    @MethodSource("parameters")
-    public void testSniClient(SslProvider serverProvider, SslProvider clientProvider) throws Exception {
-        testSniClient0(serverProvider, clientProvider);
-    }
-
-    @ParameterizedTest(name = "{index}: serverSslProvider = {0}, clientSslProvider = {1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     @MethodSource("parameters")
     public void testSniSNIMatcherMatchesClient(SslProvider serverProvider, SslProvider clientProvider)
@@ -85,7 +78,7 @@ public class SniClientTest {
         SniClientJava8TestUtil.testSniClient(serverProvider, clientProvider, true);
     }
 
-    @ParameterizedTest(name = "{index}: serverSslProvider = {0}, clientSslProvider = {1}")
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     @MethodSource("parameters")
     public void testSniSNIMatcherDoesNotMatchClient(
@@ -99,7 +92,10 @@ public class SniClientTest {
         });
     }
 
-    private static void testSniClient0(SslProvider sslServerProvider, SslProvider sslClientProvider) throws Exception {
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    @MethodSource("parameters")
+    public void testSniClient(SslProvider sslServerProvider, SslProvider sslClientProvider) throws Exception {
         String sniHostName = "sni.netty.io";
         LocalAddress address = new LocalAddress("test");
         EventLoopGroup group = new DefaultEventLoopGroup(1);

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -31,12 +31,10 @@ import io.netty.util.Mapping;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
@@ -46,12 +44,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 public class SniClientTest {
 
-    @Parameters(name = "{index}: serverSslProvider = {0}, clientSslProvider = {1}")
-    public static Collection<Object[]> parameters() {
+    static Collection<Object[]> parameters() {
         List<SslProvider> providers = new ArrayList<SslProvider>(Arrays.asList(SslProvider.values()));
         if (!OpenSsl.isAvailable()) {
             providers.remove(SslProvider.OPENSSL);
@@ -67,32 +69,37 @@ public class SniClientTest {
         return params;
     }
 
-    private final SslProvider serverProvider;
-    private final SslProvider clientProvider;
-
-    public SniClientTest(SslProvider serverProvider, SslProvider clientProvider) {
-        this.serverProvider = serverProvider;
-        this.clientProvider = clientProvider;
+    @ParameterizedTest(name = "{index}: serverSslProvider = {0}, clientSslProvider = {1}")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    @MethodSource("parameters")
+    public void testSniClient(SslProvider serverProvider, SslProvider clientProvider) throws Exception {
+        testSniClient0(serverProvider, clientProvider);
     }
 
-    @Test(timeout = 30000)
-    public void testSniClient() throws Exception {
-        testSniClient(serverProvider, clientProvider);
-    }
-
-    @Test(timeout = 30000)
-    public void testSniSNIMatcherMatchesClient() throws Exception {
-        Assume.assumeTrue(PlatformDependent.javaVersion() >= 8);
+    @ParameterizedTest(name = "{index}: serverSslProvider = {0}, clientSslProvider = {1}")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    @MethodSource("parameters")
+    public void testSniSNIMatcherMatchesClient(SslProvider serverProvider, SslProvider clientProvider)
+            throws Exception {
+        assumeTrue(PlatformDependent.javaVersion() >= 8);
         SniClientJava8TestUtil.testSniClient(serverProvider, clientProvider, true);
     }
 
-    @Test(timeout = 30000, expected = SSLException.class)
-    public void testSniSNIMatcherDoesNotMatchClient() throws Exception {
-        Assume.assumeTrue(PlatformDependent.javaVersion() >= 8);
-        SniClientJava8TestUtil.testSniClient(serverProvider, clientProvider, false);
+    @ParameterizedTest(name = "{index}: serverSslProvider = {0}, clientSslProvider = {1}")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    @MethodSource("parameters")
+    public void testSniSNIMatcherDoesNotMatchClient(
+            final SslProvider serverProvider, final SslProvider clientProvider) {
+        assumeTrue(PlatformDependent.javaVersion() >= 8);
+        assertThrows(SSLException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                SniClientJava8TestUtil.testSniClient(serverProvider, clientProvider, false);
+            }
+        });
     }
 
-    private static void testSniClient(SslProvider sslServerProvider, SslProvider sslClientProvider) throws Exception {
+    private static void testSniClient0(SslProvider sslServerProvider, SslProvider sslClientProvider) throws Exception {
         String sniHostName = "sni.netty.io";
         LocalAddress address = new LocalAddress("test");
         EventLoopGroup group = new DefaultEventLoopGroup(1);
@@ -148,11 +155,11 @@ public class SniClientTest {
                     sslClientContext.newEngine(ByteBufAllocator.DEFAULT, sniHostName, -1));
             cc = cb.group(group).channel(LocalChannel.class).handler(handler)
                     .connect(address).syncUninterruptibly().channel();
-            Assert.assertEquals(sniHostName, promise.syncUninterruptibly().getNow());
+            assertEquals(sniHostName, promise.syncUninterruptibly().getNow());
 
             // After we are done with handshaking getHandshakeSession() should return null.
             handler.handshakeFuture().syncUninterruptibly();
-            Assert.assertNull(handler.engine().getHandshakeSession());
+            assertNull(handler.engine().getHandshakeSession());
 
             if (PlatformDependent.javaVersion() >= 8) {
                 SniClientJava8TestUtil.assertSSLSession(

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -639,6 +639,7 @@ public class SniHandlerTest {
     public void testNonFragmented(SslProvider provider) throws Exception {
         testWithFragmentSize(provider, Integer.MAX_VALUE);
     }
+
     @ParameterizedTest(name = "{index}: sslProvider={0}")
     @MethodSource("data")
     public void testFragmented(SslProvider provider) throws Exception {

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -16,17 +16,6 @@
 
 package io.netty.handler.ssl;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
-
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -40,9 +29,6 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
 import io.netty.util.concurrent.Future;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
@@ -76,9 +62,25 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.ResourcesUtil;
 import io.netty.util.internal.StringUtil;
-import org.mockito.Mockito;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
 public class SniHandlerTest {
 
     private static ApplicationProtocolConfig newApnConfig() {
@@ -135,8 +137,7 @@ public class SniHandlerTest {
         return sslCtxBuilder.build();
     }
 
-    @Parameterized.Parameters(name = "{index}: sslProvider={0}")
-    public static Iterable<?> data() {
+    static Iterable<?> data() {
         List<SslProvider> params = new ArrayList<SslProvider>(3);
         if (OpenSsl.isAvailable()) {
             params.add(SslProvider.OPENSSL);
@@ -146,20 +147,15 @@ public class SniHandlerTest {
         return params;
     }
 
-    private final SslProvider provider;
-
-    public SniHandlerTest(SslProvider provider) {
-        this.provider = provider;
-    }
-
-    @Test
-    public void testNonSslRecord() throws Exception {
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    public void testNonSslRecord(SslProvider provider) throws Exception {
         SslContext nettyContext = makeSslContext(provider, false);
         try {
             final AtomicReference<SslHandshakeCompletionEvent> evtRef =
                     new AtomicReference<SslHandshakeCompletionEvent>();
             SniHandler handler = new SniHandler(new DomainNameMappingBuilder<SslContext>(nettyContext).build());
-            EmbeddedChannel ch = new EmbeddedChannel(handler, new ChannelInboundHandlerAdapter() {
+            final EmbeddedChannel ch = new EmbeddedChannel(handler, new ChannelInboundHandlerAdapter() {
                 @Override
                 public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                     if (evt instanceof SslHandshakeCompletionEvent) {
@@ -169,27 +165,29 @@ public class SniHandlerTest {
             });
 
             try {
-                byte[] bytes = new byte[1024];
+                final byte[] bytes = new byte[1024];
                 bytes[0] = SslUtils.SSL_CONTENT_TYPE_ALERT;
 
-                try {
-                    ch.writeInbound(Unpooled.wrappedBuffer(bytes));
-                    fail();
-                } catch (DecoderException e) {
-                    assertTrue(e.getCause() instanceof NotSslRecordException);
-                }
+                DecoderException e = assertThrows(DecoderException.class, new Executable() {
+                    @Override
+                    public void execute() throws Throwable {
+                        ch.writeInbound(Unpooled.wrappedBuffer(bytes));
+                    }
+                });
+                assertThat(e.getCause(), CoreMatchers.instanceOf(NotSslRecordException.class));
                 assertFalse(ch.finish());
             } finally {
                 ch.finishAndReleaseAll();
             }
-            assertTrue(evtRef.get().cause() instanceof NotSslRecordException);
+            assertThat(evtRef.get().cause(), CoreMatchers.instanceOf(NotSslRecordException.class));
         } finally {
             releaseAll(nettyContext);
         }
     }
 
-    @Test
-    public void testServerNameParsing() throws Exception {
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    public void testServerNameParsing(SslProvider provider) throws Exception {
         SslContext nettyContext = makeSslContext(provider, false);
         SslContext leanContext = makeSslContext(provider, false);
         SslContext leanContext2 = makeSslContext(provider, false);
@@ -251,8 +249,9 @@ public class SniHandlerTest {
         }
     }
 
-    @Test(expected = DecoderException.class)
-    public void testNonAsciiServerNameParsing() throws Exception {
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    public void testNonAsciiServerNameParsing(SslProvider provider) throws Exception {
         SslContext nettyContext = makeSslContext(provider, false);
         SslContext leanContext = makeSslContext(provider, false);
         SslContext leanContext2 = makeSslContext(provider, false);
@@ -268,13 +267,13 @@ public class SniHandlerTest {
                     .build();
 
             SniHandler handler = new SniHandler(mapping);
-            EmbeddedChannel ch = new EmbeddedChannel(handler);
+            final EmbeddedChannel ch = new EmbeddedChannel(handler);
 
             try {
                 // hex dump of a client hello packet, which contains an invalid hostname "CHAT4。LEANCLOUD。CN"
                 String tlsHandshakeMessageHex1 = "16030100";
                 // part 2
-                String tlsHandshakeMessageHex = "bd010000b90303a74225676d1814ba57faff3b366" +
+                final String tlsHandshakeMessageHex = "bd010000b90303a74225676d1814ba57faff3b366" +
                         "3656ed05ee9dbb2a4dbb1bb1c32d2ea5fc39e0000000100008c0000001700150000164348" +
                         "415434E380824C45414E434C4F5544E38082434E000b000403000102000a00340032000e0" +
                         "00d0019000b000c00180009000a0016001700080006000700140015000400050012001300" +
@@ -285,7 +284,13 @@ public class SniHandlerTest {
                 // Decode should fail because of the badly encoded "HostName" string in the SNI extension
                 // that isn't ASCII as per RFC 6066 - https://tools.ietf.org/html/rfc6066#page-6
                 ch.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex1)));
-                ch.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex)));
+
+                assertThrows(DecoderException.class, new Executable() {
+                    @Override
+                    public void execute() throws Throwable {
+                        ch.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex)));
+                    }
+                });
             } finally {
                 ch.finishAndReleaseAll();
             }
@@ -294,8 +299,9 @@ public class SniHandlerTest {
         }
     }
 
-    @Test
-    public void testFallbackToDefaultContext() throws Exception {
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    public void testFallbackToDefaultContext(SslProvider provider) throws Exception {
         SslContext nettyContext = makeSslContext(provider, false);
         SslContext leanContext = makeSslContext(provider, false);
         SslContext leanContext2 = makeSslContext(provider, false);
@@ -344,8 +350,10 @@ public class SniHandlerTest {
         }
     }
 
-    @Test(timeout = 10000)
-    public void testMajorVersionNot3() throws Exception {
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testMajorVersionNot3(SslProvider provider) throws Exception {
         SslContext nettyContext = makeSslContext(provider, false);
 
         try {
@@ -385,8 +393,9 @@ public class SniHandlerTest {
         }
     }
 
-    @Test
-    public void testSniWithApnHandler() throws Exception {
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    public void testSniWithApnHandler(SslProvider provider) throws Exception {
         SslContext nettyContext = makeSslContext(provider, true);
         SslContext sniContext = makeSslContext(provider, true);
         final SslContext clientContext = makeSslClientContext(provider, true);
@@ -471,8 +480,10 @@ public class SniHandlerTest {
         }
     }
 
-    @Test(timeout = 30000)
-    public void testReplaceHandler() throws Exception {
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testReplaceHandler(SslProvider provider) throws Exception {
         switch (provider) {
             case OPENSSL:
             case OPENSSL_REFCNT:
@@ -623,16 +634,18 @@ public class SniHandlerTest {
         }
     }
 
-    @Test
-    public void testNonFragmented() throws Exception {
-        testWithFragmentSize(Integer.MAX_VALUE);
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    public void testNonFragmented(SslProvider provider) throws Exception {
+        testWithFragmentSize(provider, Integer.MAX_VALUE);
     }
-    @Test
-    public void testFragmented() throws Exception {
-        testWithFragmentSize(50);
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    public void testFragmented(SslProvider provider) throws Exception {
+        testWithFragmentSize(provider, 50);
     }
 
-    private void testWithFragmentSize(final int maxFragmentSize) throws Exception {
+    private void testWithFragmentSize(SslProvider provider, final int maxFragmentSize) throws Exception {
         final String sni = "netty.io";
         SelfSignedCertificate cert = new SelfSignedCertificate();
         final SslContext context = SslContextBuilder.forServer(cert.key(), cert.cert())
@@ -640,7 +653,7 @@ public class SniHandlerTest {
                 .build();
         try {
             @SuppressWarnings("unchecked") final EmbeddedChannel server = new EmbeddedChannel(
-                    new SniHandler(Mockito.mock(DomainNameMapping.class)) {
+                    new SniHandler(mock(DomainNameMapping.class)) {
                 @Override
                 protected Future<SslContext> lookup(final ChannelHandlerContext ctx, final String hostname) {
                     assertEquals(sni, hostname);

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
@@ -18,9 +18,8 @@ package io.netty.handler.ssl;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLEngine;
@@ -36,7 +35,11 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SslContextBuilderTest {
 
@@ -103,23 +106,33 @@ public class SslContextBuilderTest {
     @Test
     public void testContextFromManagersOpenssl() throws Exception {
         OpenSsl.ensureAvailability();
-        Assume.assumeTrue(OpenSsl.useKeyManagerFactory());
+        assumeTrue(OpenSsl.useKeyManagerFactory());
         testContextFromManagers(SslProvider.OPENSSL);
     }
 
-    @Test(expected = SSLException.class)
+    @Test
     public void testUnsupportedPrivateKeyFailsFastForServer() throws Exception {
-        Assume.assumeTrue(OpenSsl.isBoringSSL());
-        testUnsupportedPrivateKeyFailsFast(true);
+        assumeTrue(OpenSsl.isBoringSSL());
+        assertThrows(SSLException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                testUnsupportedPrivateKeyFailsFast(true);
+            }
+        });
     }
 
-    @Test(expected = SSLException.class)
+    @Test
     public void testUnsupportedPrivateKeyFailsFastForClient() throws Exception {
-        Assume.assumeTrue(OpenSsl.isBoringSSL());
-        testUnsupportedPrivateKeyFailsFast(false);
+        assumeTrue(OpenSsl.isBoringSSL());
+        assertThrows(SSLException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                testUnsupportedPrivateKeyFailsFast(false);
+            }
+        });
     }
     private static void testUnsupportedPrivateKeyFailsFast(boolean server) throws Exception {
-        Assume.assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL());
         String cert = "-----BEGIN CERTIFICATE-----\n" +
                 "MIICODCCAY2gAwIBAgIEXKTrajAKBggqhkjOPQQDBDBUMQswCQYDVQQGEwJVUzEM\n" +
                 "MAoGA1UECAwDTi9hMQwwCgYDVQQHDANOL2ExDDAKBgNVBAoMA04vYTEMMAoGA1UE\n" +
@@ -153,10 +166,15 @@ public class SslContextBuilderTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidCipherJdk() throws Exception {
         OpenSsl.ensureAvailability();
-        testInvalidCipher(SslProvider.JDK);
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                testInvalidCipher(SslProvider.JDK);
+            }
+        });
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextTest.java
@@ -16,8 +16,8 @@
 package io.netty.handler.ssl;
 
 import io.netty.util.internal.ResourcesUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,36 +31,47 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class SslContextTest {
 
-    @Test(expected = IOException.class)
+    @Test
     public void testUnencryptedEmptyPassword() throws Exception {
-        PrivateKey key = SslContext.toPrivateKey(
-                ResourcesUtil.getFile(getClass(), "test2_unencrypted.pem"), "");
-        Assert.assertNotNull(key);
+        assertThrows(IOException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                SslContext.toPrivateKey(
+                        ResourcesUtil.getFile(getClass(), "test2_unencrypted.pem"), "");
+            }
+        });
     }
 
     @Test
     public void testUnEncryptedNullPassword() throws Exception {
         PrivateKey key = SslContext.toPrivateKey(
                 ResourcesUtil.getFile(getClass(), "test2_unencrypted.pem"), null);
-        Assert.assertNotNull(key);
+        assertNotNull(key);
     }
 
     @Test
     public void testEncryptedEmptyPassword() throws Exception {
         PrivateKey key = SslContext.toPrivateKey(
                 ResourcesUtil.getFile(getClass(), "test_encrypted_empty_pass.pem"), "");
-        Assert.assertNotNull(key);
+        assertNotNull(key);
     }
 
-    @Test(expected = InvalidKeySpecException.class)
+    @Test
     public void testEncryptedNullPassword() throws Exception {
-        SslContext.toPrivateKey(
-                ResourcesUtil.getFile(getClass(), "test_encrypted_empty_pass.pem"), null);
+        assertThrows(InvalidKeySpecException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                SslContext.toPrivateKey(
+                        ResourcesUtil.getFile(getClass(), "test_encrypted_empty_pass.pem"), null);
+            }
+        });
     }
 
     @Test
@@ -87,12 +98,17 @@ public abstract class SslContextTest {
         newSslContext(crtFile, keyFile, null);
     }
 
-    @Test(expected = SSLException.class)
+    @Test
     public void testSslContextWithUnencryptedPrivateKeyEmptyPass() throws SSLException {
-        File keyFile = ResourcesUtil.getFile(getClass(), "test_unencrypted.pem");
-        File crtFile = ResourcesUtil.getFile(getClass(), "test.crt");
+        final File keyFile = ResourcesUtil.getFile(getClass(), "test_unencrypted.pem");
+        final File crtFile = ResourcesUtil.getFile(getClass(), "test.crt");
 
-        newSslContext(crtFile, keyFile, "");
+        assertThrows(SSLException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                newSslContext(crtFile, keyFile, "");
+            }
+        });
     }
 
     @Test
@@ -116,9 +132,15 @@ public abstract class SslContextTest {
         assertFalse(sslContext.cipherSuites().contains(unsupportedCipher));
     }
 
-    @Test(expected = CertificateException.class)
+    @Test
     public void testUnsupportedParams() throws CertificateException {
-        SslContext.toX509Certificates(new File(getClass().getResource("ec_params_unsupported.pem").getFile()));
+        assertThrows(CertificateException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                SslContext.toX509Certificates(
+                        new File(getClass().getResource("ec_params_unsupported.pem").getFile()));
+            }
+        });
     }
 
     protected abstract SslContext newSslContext(File crtFile, File keyFile, String pass) throws SSLException;

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextTrustManagerTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -25,8 +25,8 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 
 import static io.netty.handler.ssl.Java8SslTestUtils.loadCertCollection;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SslContextTrustManagerTest {
     @Test
@@ -84,7 +84,7 @@ public class SslContextTrustManagerTest {
 
         for (int i = 0; i < eecResources.length; i++) {
             X509Certificate eecCert = eecCerts[i];
-            assertNotNull("Cannot use cert " + eecResources[i], eecCert);
+            assertNotNull(eecCert, "Cannot use cert " + eecResources[i]);
             try {
                 tm.checkServerTrusted(new X509Certificate[] { eecCert }, "RSA");
                 if (!expectations[i]) {

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -33,10 +33,9 @@ import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.Assume;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLException;
@@ -60,14 +59,11 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
-
-@RunWith(Parameterized.class)
 public class SslErrorTest {
 
-    @Parameterized.Parameters(
-            name = "{index}: serverProvider = {0}, clientProvider = {1}, exception = {2}, serverProduceError = {3}")
-    public static Collection<Object[]> data() {
+    static Collection<Object[]> data() {
         List<SslProvider> serverProviders = new ArrayList<SslProvider>(2);
         List<SslProvider> clientProviders = new ArrayList<SslProvider>(3);
 
@@ -110,21 +106,13 @@ public class SslErrorTest {
                 new CertPathValidatorException("x", null, null, -1, reason));
     }
 
-    private final SslProvider serverProvider;
-    private final SslProvider clientProvider;
-    private final CertificateException exception;
-    private final boolean serverProduceError;
-
-    public SslErrorTest(SslProvider serverProvider, SslProvider clientProvider,
-                        CertificateException exception, boolean serverProduceError) {
-        this.serverProvider = serverProvider;
-        this.clientProvider = clientProvider;
-        this.exception = exception;
-        this.serverProduceError = serverProduceError;
-    }
-
-    @Test(timeout = 30000)
-    public void testCorrectAlert() throws Exception {
+    @ParameterizedTest(
+            name = "{index}: serverProvider = {0}, clientProvider = {1}, exception = {2}, serverProduceError = {3}")
+    @MethodSource("data")
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testCorrectAlert(SslProvider serverProvider, final SslProvider clientProvider,
+                                 final CertificateException exception, final boolean serverProduceError)
+            throws Exception {
         // As this only works correctly at the moment when OpenSslEngine is used on the server-side there is
         // no need to run it if there is no openssl is available at all.
         OpenSsl.ensureAvailability();
@@ -140,11 +128,11 @@ public class SslErrorTest {
                 .sslProvider(clientProvider);
 
         if (serverProduceError) {
-            sslServerCtxBuilder.trustManager(new ExceptionTrustManagerFactory());
+            sslServerCtxBuilder.trustManager(new ExceptionTrustManagerFactory(exception));
             sslClientCtxBuilder.trustManager(InsecureTrustManagerFactory.INSTANCE);
         } else {
             sslServerCtxBuilder.trustManager(InsecureTrustManagerFactory.INSTANCE);
-            sslClientCtxBuilder.trustManager(new ExceptionTrustManagerFactory());
+            sslClientCtxBuilder.trustManager(new ExceptionTrustManagerFactory(exception));
         }
 
         final SslContext sslServerCtx = sslServerCtxBuilder.build();
@@ -163,7 +151,8 @@ public class SslErrorTest {
                         protected void initChannel(Channel ch) {
                             ch.pipeline().addLast(sslServerCtx.newHandler(ch.alloc()));
                             if (!serverProduceError) {
-                                ch.pipeline().addLast(new AlertValidationHandler(promise));
+                                ch.pipeline().addLast(new AlertValidationHandler(clientProvider, serverProduceError,
+                                        exception, promise));
                             }
                             ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
 
@@ -182,7 +171,8 @@ public class SslErrorTest {
                         protected void initChannel(Channel ch) {
                             ch.pipeline().addLast(sslClientCtx.newHandler(ch.alloc()));
                             if (serverProduceError) {
-                                ch.pipeline().addLast(new AlertValidationHandler(promise));
+                                ch.pipeline().addLast(new AlertValidationHandler(clientProvider, serverProduceError,
+                                        exception, promise));
                             }
                             ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
 
@@ -209,7 +199,13 @@ public class SslErrorTest {
         }
     }
 
-    private final class ExceptionTrustManagerFactory extends SimpleTrustManagerFactory {
+    private static final class ExceptionTrustManagerFactory extends SimpleTrustManagerFactory {
+        private final CertificateException exception;
+
+        ExceptionTrustManagerFactory(CertificateException exception) {
+            this.exception = exception;
+        }
+
         @Override
         protected void engineInit(KeyStore keyStore) { }
         @Override
@@ -239,10 +235,17 @@ public class SslErrorTest {
         }
     }
 
-    private final class AlertValidationHandler extends ChannelInboundHandlerAdapter {
+    private static final class AlertValidationHandler extends ChannelInboundHandlerAdapter {
+        private final SslProvider clientProvider;
+        private final boolean serverProduceError;
+        private final CertificateException exception;
         private final Promise<Void> promise;
 
-        AlertValidationHandler(Promise<Void> promise) {
+        AlertValidationHandler(SslProvider clientProvider, boolean serverProduceError,
+                               CertificateException exception, Promise<Void> promise) {
+            this.clientProvider = clientProvider;
+            this.serverProduceError = serverProduceError;
+            this.exception = exception;
             this.promise = promise;
         }
 
@@ -255,20 +258,20 @@ public class SslErrorTest {
                     CertPathValidatorException.Reason reason =
                             ((CertPathValidatorException) exception.getCause()).getReason();
                     if (reason == CertPathValidatorException.BasicReason.EXPIRED) {
-                        verifyException(unwrappedCause, promise, "expired");
+                        verifyException(clientProvider, serverProduceError, unwrappedCause, promise, "expired");
                     } else if (reason == CertPathValidatorException.BasicReason.NOT_YET_VALID) {
                         // BoringSSL may use "expired" in this case while others use "bad"
-                        verifyException(unwrappedCause, promise, "expired", "bad");
+                        verifyException(clientProvider, serverProduceError, unwrappedCause, promise, "expired", "bad");
                     } else if (reason == CertPathValidatorException.BasicReason.REVOKED) {
-                        verifyException(unwrappedCause, promise, "revoked");
+                        verifyException(clientProvider, serverProduceError, unwrappedCause, promise, "revoked");
                     }
                 } else if (exception instanceof CertificateExpiredException) {
-                    verifyException(unwrappedCause, promise,  "expired");
+                    verifyException(clientProvider, serverProduceError, unwrappedCause, promise,  "expired");
                 } else if (exception instanceof CertificateNotYetValidException) {
                     // BoringSSL may use "expired" in this case while others use "bad"
-                    verifyException(unwrappedCause, promise, "expired", "bad");
+                    verifyException(clientProvider, serverProduceError, unwrappedCause, promise, "expired", "bad");
                 } else if (exception instanceof CertificateRevokedException) {
-                    verifyException(unwrappedCause, promise, "revoked");
+                    verifyException(clientProvider, serverProduceError, unwrappedCause, promise, "revoked");
                 }
             }
         }
@@ -276,7 +279,8 @@ public class SslErrorTest {
 
     // Its a bit hacky to verify against the message that is part of the exception but there is no other way
     // at the moment as there are no different exceptions for the different alerts.
-    private void verifyException(Throwable cause, Promise<Void> promise, String... messageParts) {
+    private static void verifyException(SslProvider clientProvider, boolean serverProduceError,
+                                 Throwable cause, Promise<Void> promise, String... messageParts) {
         String message = cause.getMessage();
         // When the error is produced on the client side and the client side uses JDK as provider it will always
         // use "certificate unknown".

--- a/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
@@ -17,7 +17,7 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -27,9 +27,9 @@ import java.nio.ByteOrder;
 import java.security.NoSuchAlgorithmException;
 
 import static io.netty.handler.ssl.SslUtils.getEncryptedPacketLength;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SslUtilsTest {
 

--- a/handler/src/test/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactoryTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactoryTest.java
@@ -16,15 +16,18 @@
 
 package io.netty.handler.ssl.util;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import javax.net.ssl.X509TrustManager;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import static io.netty.handler.ssl.Java8SslTestUtils.loadCertCollection;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FingerprintTrustManagerFactoryTest {
 
@@ -48,27 +51,47 @@ public class FingerprintTrustManagerFactoryTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFingerprintWithInvalidLength() {
-        FingerprintTrustManagerFactory.builder("SHA-256").fingerprints("00:00:00").build();
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                FingerprintTrustManagerFactory.builder("SHA-256").fingerprints("00:00:00").build();
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFingerprintWithUnexpectedCharacters() {
-        FingerprintTrustManagerFactory.builder("SHA-256").fingerprints("00:00:00\n").build();
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                FingerprintTrustManagerFactory.builder("SHA-256").fingerprints("00:00:00\n").build();
+            }
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testWithNoFingerprints() {
-        FingerprintTrustManagerFactory.builder("SHA-256").build();
+        assertThrows(IllegalStateException.class, new Executable() {
+            @Override
+            public void execute() {
+                FingerprintTrustManagerFactory.builder("SHA-256").build();
+            }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWithNullFingerprint() {
-        FingerprintTrustManagerFactory
-                .builder("SHA-256")
-                .fingerprints(FIRST_CERT_SHA256_FINGERPRINT, null)
-                .build();
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                FingerprintTrustManagerFactory
+                        .builder("SHA-256")
+                        .fingerprints(FIRST_CERT_SHA256_FINGERPRINT, null)
+                        .build();
+            }
+        });
     }
 
     @Test
@@ -96,7 +119,7 @@ public class FingerprintTrustManagerFactoryTest {
         tm.checkClientTrusted(keyCertChain, "test");
     }
 
-    @Test(expected = CertificateException.class)
+    @Test
     public void testUntrustedCertificateWithSHA256Fingerprint() throws Exception {
         FingerprintTrustManagerFactory factory = FingerprintTrustManagerFactory
                 .builder("SHA-256")
@@ -105,8 +128,14 @@ public class FingerprintTrustManagerFactoryTest {
 
         assertTrue(factory.engineGetTrustManagers().length > 0);
         assertTrue(factory.engineGetTrustManagers()[0] instanceof X509TrustManager);
-        X509TrustManager tm = (X509TrustManager) factory.engineGetTrustManagers()[0];
-        tm.checkClientTrusted(SECOND_CHAIN, "test");
+        final X509TrustManager tm = (X509TrustManager) factory.engineGetTrustManagers()[0];
+
+        assertThrows(CertificateException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                tm.checkClientTrusted(SECOND_CHAIN, "test");
+            }
+        });
     }
 
 }

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateEventTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateEventTest.java
@@ -15,7 +15,8 @@
  */
 package io.netty.handler.timeout;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.timeout.IdleStateEvent.*;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
@@ -29,12 +29,13 @@ import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IdleStateHandlerTest {
 
@@ -67,8 +68,7 @@ public class IdleStateHandlerTest {
     }
 
     private static void anyIdle(TestableIdleStateHandler idleStateHandler, Object... expected) throws Exception {
-
-        assertTrue(expected.length >= 1);
+        assertThat(expected.length,  greaterThanOrEqualTo(1));
 
         final List<Object> events = new ArrayList<Object>();
         ChannelInboundHandlerAdapter handler = new ChannelInboundHandlerAdapter() {

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
@@ -15,13 +15,6 @@
  */
 package io.netty.handler.timeout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -29,13 +22,19 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.ReferenceCountUtil;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IdleStateHandlerTest {
 
@@ -69,7 +68,7 @@ public class IdleStateHandlerTest {
 
     private static void anyIdle(TestableIdleStateHandler idleStateHandler, Object... expected) throws Exception {
 
-        assertTrue("The number of expected events must be >= 1", expected.length >= 1);
+        assertTrue(expected.length >= 1);
 
         final List<Object> events = new ArrayList<Object>();
         ChannelInboundHandlerAdapter handler = new ChannelInboundHandlerAdapter() {
@@ -93,7 +92,7 @@ public class IdleStateHandlerTest {
             // Compare the expected with the actual IdleStateEvents
             for (int i = 0; i < expected.length; i++) {
                 Object evt = events.get(i);
-                assertSame("Element " + i + " is not matching", expected[i], evt);
+                assertSame(expected[i], evt, "Element " + i + " is not matching");
             }
         } finally {
             channel.finishAndReleaseAll();

--- a/handler/src/test/java/io/netty/handler/timeout/WriteTimeoutHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/WriteTimeoutHandlerTest.java
@@ -22,11 +22,11 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WriteTimeoutHandlerTest {
 

--- a/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
@@ -33,11 +33,11 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -48,7 +48,7 @@ import java.nio.charset.Charset;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileRegionThrottleTest {
     private static final byte[] BYTES = new byte[64 * 1024 * 4];
@@ -56,7 +56,7 @@ public class FileRegionThrottleTest {
     private static File tmp;
     private EventLoopGroup group;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws IOException {
         final Random r = new Random();
         for (int i = 0; i < BYTES.length; i++) {
@@ -83,17 +83,17 @@ public class FileRegionThrottleTest {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         group = new NioEventLoopGroup();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         group.shutdownGracefully();
     }
 
-    @Ignore("This test is flaky, need more investigation")
+    @Disabled("This test is flaky, need more investigation")
     @Test
     public void testGlobalWriteThrottle() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
@@ -114,7 +114,7 @@ public class FileRegionThrottleTest {
         cc.writeAndFlush(Unpooled.copiedBuffer("send-file\n", CharsetUtil.US_ASCII)).sync();
         latch.await();
         long timeTaken = TrafficCounter.milliSecondFromNano() - start;
-        assertTrue("Data streamed faster than expected", timeTaken > 3000);
+        assertTrue(timeTaken > 3000, "Data streamed faster than expected");
         sc.close().sync();
         cc.close().sync();
     }

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -16,14 +16,8 @@
 
 package io.netty.handler.traffic;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-
-import org.junit.AfterClass;
-import org.junit.Test;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
@@ -38,6 +32,11 @@ import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.Attribute;
 import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TrafficShapingHandlerTest {
 
@@ -45,7 +44,7 @@ public class TrafficShapingHandlerTest {
     private static final ScheduledExecutorService SES = Executors.newSingleThreadScheduledExecutor();
     private static final DefaultEventLoopGroup GROUP = new DefaultEventLoopGroup(1);
 
-    @AfterClass
+    @AfterAll
     public static void destroy() {
         GROUP.shutdownGracefully();
         SES.shutdown();


### PR DESCRIPTION
Motivation:

We should aim to use junit5 everywhere

Modifications:

Migrate most of the handler module to use junit5

Result:

Part of #10757
