### PR TITLE
`ApplicationProtocolNegotiationHandler` should drain buffer messages on channel close

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -20,8 +20,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.handler.codec.DecoderException;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.RecyclableArrayList;
 import io.netty.util.internal.logging.InternalLogger;
@@ -145,7 +145,17 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
             }
         }
 
+        if (evt instanceof ChannelInputShutdownEvent) {
+            fireBufferedMessages();
+        }
+
         ctx.fireUserEventTriggered(evt);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        fireBufferedMessages();
+        super.channelInactive(ctx);
     }
 
     private void removeSelfIfPresent(ChannelHandlerContext ctx) {
@@ -168,7 +178,7 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
     /**
      * Invoked on failed initial SSL/TLS handshake.
      */
-    protected void handshakeFailure(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    protected void handshakeFailure(ChannelHandlerContext ctx, Throwable cause) {
         logger.warn("{} TLS handshake failed:", ctx.channel(), cause);
         ctx.close();
     }

--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -178,7 +178,7 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
     /**
      * Invoked on failed initial SSL/TLS handshake.
      */
-    protected void handshakeFailure(ChannelHandlerContext ctx, Throwable cause) {
+    protected void handshakeFailure(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         logger.warn("{} TLS handshake failed:", ctx.channel(), cause);
         ctx.close();
     }


### PR DESCRIPTION
__Motivation__

`ApplicationProtocolNegotiationHandler` buffers messages which are read before SSL handshake complete event is received and drains them when the handler is removed. However, the channel may be closed (or input shutdown) before SSL handshake  event is received in which case we may fire channel read after channel closure (from `handlerRemoved()`).

__Modification__

Intercept `channelInactive()` and input closed event and drain the buffer.

__Result__

If channel is closed before SSL handshake complete event is received, we still maintain the order of message read and channel closure.