### PR TITLE
Support RESP3 for codec-redis

### DIFF
--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/AbstractNumberRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/AbstractNumberRedisMessage.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.redis;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+import java.math.BigInteger;
+
+/**
+ * Abstract class for Number type message.
+ */
+@UnstableApi
+public abstract class AbstractNumberRedisMessage implements RedisMessage {
+
+    protected final Number value;
+
+    /**
+     * For create a {@link IntegerRedisMessage} the given int {@code value}.
+     *
+     * @param value the message content.
+     */
+    AbstractNumberRedisMessage(long value) {
+        this.value = value;
+    }
+
+    /**
+     * For create a {@link DoubleRedisMessage} the given double {@code value}.
+     *
+     * @param value the message content.
+     */
+    AbstractNumberRedisMessage(double value) {
+        this.value = value;
+    }
+
+    /**
+     * For create a {@link BigNumberRedisMessage} the given BigInteger {@code value}.
+     *
+     * @param value the message content.
+     */
+    AbstractNumberRedisMessage(BigInteger value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(StringUtil.simpleClassName(this))
+            .append('[')
+            .append("value=")
+            .append(value)
+            .append(']').toString();
+    }
+
+}

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/BigNumberRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/BigNumberRedisMessage.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.redis;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.math.BigInteger;
+
+/**
+ * Big number of <a href="https://github.com/antirez/RESP3/blob/master/spec.md">RESP3</a>.
+ */
+@UnstableApi
+public class BigNumberRedisMessage extends AbstractNumberRedisMessage {
+
+    /**
+     * Creates a {@link BigNumberRedisMessage} for the given byte {@code content}.
+     *
+     * @param value the message content.
+     */
+    public BigNumberRedisMessage(byte[] value) {
+        super(new BigInteger(value));
+    }
+
+    /**
+     * Creates a {@link BigNumberRedisMessage} for the given string {@code content}.
+     *
+     * @param value the message content.
+     */
+    public BigNumberRedisMessage(String value) {
+        super(new BigInteger(value));
+    }
+
+    /**
+     * Creates a {@link BigNumberRedisMessage} for the given BigInteger {@code content}.
+     *
+     * @param value the message content.
+     */
+    public BigNumberRedisMessage(BigInteger value) {
+        super(value);
+    }
+
+    /**
+     * Get string represent the value of this {@link DoubleRedisMessage}.
+     *
+     * @return string value
+     */
+    public String value() {
+        return value.toString();
+    }
+
+}

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/BigNumberRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/BigNumberRedisMessage.java
@@ -31,7 +31,7 @@ public class BigNumberRedisMessage extends AbstractNumberRedisMessage {
      * @param value the message content.
      */
     public BigNumberRedisMessage(byte[] value) {
-        super(new BigInteger(value));
+        this(new String(value));
     }
 
     /**
@@ -40,7 +40,7 @@ public class BigNumberRedisMessage extends AbstractNumberRedisMessage {
      * @param value the message content.
      */
     public BigNumberRedisMessage(String value) {
-        super(new BigInteger(value));
+        this(new BigInteger(value));
     }
 
     /**

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/BooleanRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/BooleanRedisMessage.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.redis;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * Boolean of <a href="https://github.com/antirez/RESP3/blob/master/spec.md">RESP3</a>.
+ */
+@UnstableApi
+public class BooleanRedisMessage implements RedisMessage {
+
+    private boolean value;
+
+    public static final BooleanRedisMessage TRUE_BOOLEAN_INSTANCE = new BooleanRedisMessage(true);
+
+    public static final BooleanRedisMessage FALSE_BOOLEAN_INSTANCE = new BooleanRedisMessage(false);
+
+    /**
+     * Creates a {@link BooleanRedisMessage} for the given {@code value}.
+     *
+     * @param value true or false.
+     */
+    private BooleanRedisMessage(boolean value) {
+        this.value = value;
+    }
+
+    /**
+     * Get boolean value of this {@link BooleanRedisMessage}.
+     *
+     * @return boolean value
+     */
+    public boolean value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(StringUtil.simpleClassName(this))
+            .append('[')
+            .append("value=")
+            .append(value)
+            .append(']').toString();
+    }
+}

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/BulkErrorStringHeaderRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/BulkErrorStringHeaderRedisMessage.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.redis;
+
+public class BulkErrorStringHeaderRedisMessage extends BulkStringHeaderRedisMessage {
+
+    /**
+     * Creates a {@link BulkErrorStringHeaderRedisMessage}.
+     *
+     * @param bulkStringLength follow content length.
+     */
+    public BulkErrorStringHeaderRedisMessage(int bulkStringLength) {
+        super(bulkStringLength);
+    }
+}

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/DoubleRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/DoubleRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -18,27 +18,31 @@ package io.netty.handler.codec.redis;
 import io.netty.util.internal.UnstableApi;
 
 /**
- * Integers of <a href="https://redis.io/topics/protocol">RESP</a>.
+ * Double of <a href="https://github.com/antirez/RESP3/blob/master/spec.md">RESP3</a>.
  */
 @UnstableApi
-public final class IntegerRedisMessage extends AbstractNumberRedisMessage {
+public class DoubleRedisMessage extends AbstractNumberRedisMessage {
+
+    public static final DoubleRedisMessage POSITIVE_INFINITY_DOUBLE_INSTANCE = new DoubleRedisMessage(Double.MAX_VALUE);
+
+    public static final DoubleRedisMessage NEGATIVE_INFINITY_DOUBLE_INSTANCE = new DoubleRedisMessage(Double.MIN_VALUE);
 
     /**
-     * Creates a {@link IntegerRedisMessage} for the given {@code content}.
+     * Creates a {@link DoubleRedisMessage} for the given {@code content}.
      *
      * @param value the message content.
      */
-    public IntegerRedisMessage(long value) {
+    public DoubleRedisMessage(double value) {
         super(value);
     }
 
     /**
-     * Get long value of this {@link IntegerRedisMessage}.
+     * Get long value of this {@link DoubleRedisMessage}.
      *
-     * @return long value
+     * @return double value
      */
-    public long value() {
-        return value.intValue();
+    public double value() {
+        return value.doubleValue();
     }
 
 }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/FullBulkErrorStringRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/FullBulkErrorStringRedisMessage.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.redis;
+
+import io.netty.buffer.ByteBuf;
+
+public class FullBulkErrorStringRedisMessage extends FullBulkStringRedisMessage {
+
+    /**
+     * Creates a {@link FullBulkErrorStringRedisMessage} for the given {@code content}.
+     *
+     * @param content the content, must not be {@code null}. If content is null or empty,
+     *                use {@link NullRedisMessage#INSTANCE instead of constructor.
+     */
+    public FullBulkErrorStringRedisMessage(ByteBuf content) {
+        super(content);
+    }
+}

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/NullRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/NullRedisMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -18,27 +18,14 @@ package io.netty.handler.codec.redis;
 import io.netty.util.internal.UnstableApi;
 
 /**
- * Integers of <a href="https://redis.io/topics/protocol">RESP</a>.
+ * NULL of <a href="https://github.com/antirez/RESP3/blob/master/spec.md">RESP3</a>.
  */
 @UnstableApi
-public final class IntegerRedisMessage extends AbstractNumberRedisMessage {
+public class NullRedisMessage implements RedisMessage {
 
-    /**
-     * Creates a {@link IntegerRedisMessage} for the given {@code content}.
-     *
-     * @param value the message content.
-     */
-    public IntegerRedisMessage(long value) {
-        super(value);
-    }
+    public static final NullRedisMessage INSTANCE = new NullRedisMessage();
 
-    /**
-     * Get long value of this {@link IntegerRedisMessage}.
-     *
-     * @return long value
-     */
-    public long value() {
-        return value.intValue();
+    private NullRedisMessage() {
     }
 
 }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisBulkStringAggregator.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisBulkStringAggregator.java
@@ -22,8 +22,10 @@ import io.netty.handler.codec.MessageAggregator;
 import io.netty.util.internal.UnstableApi;
 
 /**
- * A {@link ChannelHandler} that aggregates an {@link BulkStringHeaderRedisMessage}
- * and its following {@link BulkStringRedisContent}s into a single {@link FullBulkStringRedisMessage}
+ * A {@link ChannelHandler} that aggregates
+ * an {@link BulkStringHeaderRedisMessage} or {@link BulkErrorStringHeaderRedisMessage}
+ * and its following {@link BulkStringRedisContent}s into correspondingly
+ * a single {@link FullBulkStringRedisMessage} or {@link FullBulkErrorStringRedisMessage}
  * with no following {@link BulkStringRedisContent}s.  It is useful when you don't want to take
  * care of {@link RedisMessage}s whose transfer encoding is 'chunked'.  Insert this
  * handler after {@link RedisDecoder} in the {@link ChannelPipeline}:
@@ -95,6 +97,10 @@ public final class RedisBulkStringAggregator extends MessageAggregator<RedisMess
     @Override
     protected FullBulkStringRedisMessage beginAggregation(BulkStringHeaderRedisMessage start, ByteBuf content)
             throws Exception {
-        return new FullBulkStringRedisMessage(content);
+        if (start instanceof BulkErrorStringHeaderRedisMessage) {
+            return new FullBulkErrorStringRedisMessage(content);
+        } else {
+            return new FullBulkStringRedisMessage(content);
+        }
     }
 }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisCodecUtil.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisCodecUtil.java
@@ -30,6 +30,10 @@ final class RedisCodecUtil {
         return Long.toString(value).getBytes(CharsetUtil.US_ASCII);
     }
 
+    static byte[] doubleToAsciiBytes(double value) {
+        return Double.toString(value).getBytes(CharsetUtil.US_ASCII);
+    }
+
     /**
      * Returns a {@code short} value using endian order.
      */

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisConstants.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisConstants.java
@@ -31,6 +31,16 @@ final class RedisConstants {
 
     static final int NULL_VALUE = -1;
 
+    static final int BOOLEAN_LENGTH = 1;
+
+    static final byte BOOLEAN_TRUE_CONTENT = 't';
+
+    static final byte BOOLEAN_FALSE_CONTENT = 'f';
+
+    static final String DOUBLE_POSITIVE_INF_CONTENT = "inf";
+
+    static final String DOUBLE_NEGATIVE_INF_CONTENT = "-inf";
+
     static final int REDIS_MESSAGE_MAX_LENGTH = 512 * 1024 * 1024; // 512MB
 
     // 64KB is max inline length of current Redis server implementation.
@@ -38,7 +48,11 @@ final class RedisConstants {
 
     static final int POSITIVE_LONG_MAX_LENGTH = 19; // length of Long.MAX_VALUE
 
+    static final int POSITIVE_DOUBLE_MAX_LENGTH = 16; // length of DOUBLE.MAX_VALUE
+
     static final int LONG_MAX_LENGTH = POSITIVE_LONG_MAX_LENGTH + 1; // +1 is sign
+
+    static final int DOUBLE_MAX_LENGTH = POSITIVE_DOUBLE_MAX_LENGTH + 1; // +1 is sign
 
     static final short NULL_SHORT = RedisCodecUtil.makeShort('-', '1');
 

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisMessageType.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisMessageType.java
@@ -29,7 +29,17 @@ public enum RedisMessageType {
     ERROR((byte) '-', true),
     INTEGER((byte) ':', true),
     BULK_STRING((byte) '$', false),
-    ARRAY_HEADER((byte) '*', false);
+    ARRAY_HEADER((byte) '*', false),
+    NULL((byte) '_', true),
+    DOUBLE((byte) ',', true),
+    BOOLEAN((byte) '#', true),
+    BLOB_ERROR((byte) '!', false),
+    VERBATIM_STRING((byte) '=', false),
+    BIG_NUMBER((byte) '(', true),
+    MAP((byte) '%', false),
+    SET((byte) '~', false),
+    ATTRIBUTE((byte) '|', false),
+    PUSH((byte) '>', false);
 
     private final Byte value;
     private final boolean inline;
@@ -92,6 +102,26 @@ public enum RedisMessageType {
             return BULK_STRING;
         case '*':
             return ARRAY_HEADER;
+        case '_':
+            return NULL;
+        case ',':
+            return DOUBLE;
+        case '#':
+            return BOOLEAN;
+        case '!':
+            return BLOB_ERROR;
+        case '=':
+            return VERBATIM_STRING;
+        case '(':
+            return BIG_NUMBER;
+        case '%':
+            return MAP;
+        case '~':
+            return SET;
+        case '|':
+            return ATTRIBUTE;
+        case '>':
+            return PUSH;
         default:
             return INLINE_COMMAND;
         }

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
@@ -437,4 +437,22 @@ public class RedisDecoderTest {
         });
     }
 
+    @Test
+    public void shouldDecodeBulkErrorString() {
+        String buf1 = "bulk\nst";
+        String buf2 = "ring\ntest\n1234";
+        byte[] content = bytesOf(buf1 + buf2);
+        assertFalse(channel.writeInbound(byteBufOf("!")));
+        assertFalse(channel.writeInbound(byteBufOf(Integer.toString(content.length))));
+        assertFalse(channel.writeInbound(byteBufOf("\r\n")));
+        assertFalse(channel.writeInbound(byteBufOf(buf1)));
+        assertFalse(channel.writeInbound(byteBufOf(buf2)));
+        assertTrue(channel.writeInbound(byteBufOf("\r\n")));
+
+        FullBulkErrorStringRedisMessage msg = channel.readInbound();
+
+        assertThat(bytesOf(msg.content()), is(content));
+
+        ReferenceCountUtil.release(msg);
+    }
 }


### PR DESCRIPTION
Motivation:  
- Support encode/decode new types introduced by RESP3
- [RESP3](Redis Serialization Protocol 3) specification (https://github.com/antirez/RESP3/blob/master/spec.md)

Modifications: 
- Add new types of NullRedisMessage, BooleanRedisMessage
- Add new number types of DoubleRedisMessage, BigNumberRedisMessage
- Add BulkErrorStringHeaderRedisMessage & FullBulkErrorStringRedisMessage for support [blob error](https://github.com/antirez/RESP3/blame/master/spec.md#L289). (Just extend BulkStringHeaderRedisMessage & FullBulkStringRedisMessage) 
- Extract AbstractNumberRedisMessage to unify IntegerRedisMessage & DoubleRedisMessage & BigNumberRedisMessage
- Modify RedisEncoder & RedisDecoder to support new types
- Modify RedisBulkStringAggregator to support blob error message
- Add unit tests
- Fix some [typo](https://github.com/netty/netty/blob/7cc31b865366f31790895f573b2e6c97f171d382/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisEncoder.java#L30)

- support Verbatim string, Map, Set, Push types message


Result:  
- codec-redis can encode/decode RESP3