### PR TITLE
Change reflection config to match constructor

### DIFF
--- a/testsuite-native-image-client/src/main/resources/reflection-config.json
+++ b/testsuite-native-image-client/src/main/resources/reflection-config.json
@@ -2,7 +2,7 @@
     {
       "name": "io.netty.channel.socket.nio.NioDatagramChannel",
       "methods": [
-        { "name": "<init>", "parameterTypes": [ "io.netty.channel.EventLoop "] }
+        { "name": "<init>", "parameterTypes": [ "io.netty.channel.EventLoop"] }
       ]
     }
 ]

--- a/testsuite-native-image-client/src/main/resources/reflection-config.json
+++ b/testsuite-native-image-client/src/main/resources/reflection-config.json
@@ -2,7 +2,7 @@
     {
       "name": "io.netty.channel.socket.nio.NioDatagramChannel",
       "methods": [
-        { "name": "<init>", "parameterTypes": [] }
+        { "name": "<init>", "parameterTypes": [ "io.netty.channel.EventLoop "] }
       ]
     }
 ]

--- a/transport/src/main/resources/META-INF/native-image/io.netty/transport/reflection-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/transport/reflection-config.json
@@ -2,7 +2,7 @@
     {
       "name": "io.netty.channel.socket.nio.NioServerSocketChannel",
       "methods": [
-        { "name": "<init>", "parameterTypes": [] }
+        { "name": "<init>", "parameterTypes": ["io.netty.channel.EventLoop", "io.netty.channel.EventLoopGroup"] }
       ]
     },
     {

--- a/transport/src/main/resources/META-INF/native-image/io.netty/transport/reflection-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/transport/reflection-config.json
@@ -2,7 +2,7 @@
     {
       "name": "io.netty.channel.socket.nio.NioServerSocketChannel",
       "methods": [
-        { "name": "<init>", "parameterTypes": ["io.netty.channel.EventLoop", "io.netty.channel.EventLoopGroup"] }
+        { "name": "<init>", "parameterTypes": [ "io.netty.channel.EventLoop", "io.netty.channel.EventLoopGroup" ] }
       ]
     },
     {


### PR DESCRIPTION
Motivation:

We need to change the reflection config to match the constructor that is used

Modifications:

Adjust config

Result:

Graal PR jobs pass again