### PR TITLE
Add application/zstd content-type and zstd content-encoding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -44,6 +44,10 @@ public final class HttpHeaderValues {
      */
     public static final AsciiString APPLICATION_XML = AsciiString.cached("application/xml");
     /**
+     * {@code "application/zstd"}
+     */
+    public static final AsciiString APPLICATION_ZSTD = AsciiString.cached("application/zstd");
+    /**
      * {@code "attachment"}
      * See {@link HttpHeaderNames#CONTENT_DISPOSITION}
      */
@@ -115,6 +119,10 @@ public final class HttpHeaderValues {
      * {@code "br"}
      */
     public static final AsciiString BR = AsciiString.cached("br");
+    /**
+     * {@code "zstd"}
+     */
+    public static final AsciiString ZSTD = AsciiString.cached("zstd");
     /**
      * {@code "gzip,deflate"}
      */


### PR DESCRIPTION
Motivation:

ZSTD has a wide range of uses on the Internet, so should consider adding `application/zstd` HTTP media-type and `zstd` content-encoding, see  https://tools.ietf.org/html/rfc8478

Modification:

Add `application/zstd` HTTP media-type and `zstd` content-encoding

Result:

netty provides `application/zstd` HTTP media-type and `zstd content-encoding` as http headers
