### PR TITLE
Only do a partial build for a few jobs when verify PRs

### DIFF
--- a/.github/scripts/mvn_build_affected_only.sh
+++ b/.github/scripts/mvn_build_affected_only.sh
@@ -21,12 +21,38 @@ if [ "$#" -lt 2 ]; then
     exit 1
 fi
 
+git fetch
+
+ALL_MODULES=$(find . -name pom.xml | cut -d '/' -f 2 )
 MODULES=$(git diff --name-only "$1" | cut -d '/' -f 1 | sort -u | sed -n -e 'H;${x;s/\n/,/g;s/^,//;p;}')
 MAVEN_ARGUMENTS=${*:2}
 if [ -z "$MODULES" ]; then
   echo "No changes detected, skipping build"
   exit 0
 fi
+
+ALL_MODULES_ARRAY=($ALL_MODULES)
+MODULES_ARRAY=($MODULES)
+
+for module in "${MODULES_ARRAY[@]}"
+do
+  found=0;
+  for m in "${ALL_MODULES_ARRAY[@]}"
+  do
+    if [ "$module" == "$m" ]; then
+      found=1;
+      break
+    fi
+  done
+
+  if [ "$found" != 1 ]; then
+    echo "Can't detect module that changed, run a full build"
+    echo "./mvnw $MAVEN_ARGUMENTS"
+    ./mvnw "${@:2}"
+    exit 0
+  fi
+done
+
 echo "Changes detected, start the build"
 echo "./mvnw -pl $MODULES -amd $MAVEN_ARGUMENTS"
 ./mvnw -pl "$MODULES" -amd "${@:2}"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -135,16 +135,16 @@ jobs:
         include:
           - setup: linux-x86_64-java8
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run build-leak"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.18.yaml run partly-build-leak"
           - setup: linux-x86_64-java11
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run partly-build-leak"
           - setup: linux-x86_64-java11-graal
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.graalvm111.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.graalvm111.yaml run build-leak"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.graalvm111.yaml run partly-build-leak"
           - setup: linux-x86_64-java16
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.116.yaml build"
-            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.116.yaml run build-leak"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.116.yaml run partly-build-leak"
           - setup: linux-x86_64-java11-boringssl
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-boringssl-static"
@@ -177,6 +177,8 @@ jobs:
         run: docker-compose ${{ matrix.docker-compose-build }}
 
       - name: Build project with leak detection
+        env:
+          BRANCH: origin/${{ github.base_ref }}
         run: docker-compose ${{ matrix.docker-compose-run }} | tee build-leak.output
 
       - name: Checking for test failures

--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -22,3 +22,9 @@ services:
 
   shell:
     image: netty:centos-6-1.11
+
+  partly-build-leak:
+    image: netty:centos-6-1.11
+
+  partly-build-leak-boringssl-static:
+    image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.116.yaml
+++ b/docker/docker-compose.centos-6.116.yaml
@@ -22,3 +22,9 @@ services:
 
   shell:
     image: netty:centos-6-1.16
+
+  partly-build-leak:
+    image: netty:centos-6-1.16
+
+  partly-build-leak-boringssl-static:
+    image: netty:centos-6-1.16

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -31,3 +31,9 @@ services:
 
   shell:
     image: netty:centos-6-1.8
+
+  partly-build-leak:
+    image: netty:centos-6-1.8
+
+  partly-build-leak-boringssl-static:
+    image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.graalvm111.yaml
+++ b/docker/docker-compose.centos-6.graalvm111.yaml
@@ -22,3 +22,9 @@ services:
 
   shell:
     image: netty:centos-6-1.11
+
+  partly-build-leak:
+    image: netty:centos-6-1.11
+
+  partly-build-leak-boringssl-static:
+    image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.graalvm18.yaml
+++ b/docker/docker-compose.centos-6.graalvm18.yaml
@@ -22,3 +22,9 @@ services:
 
   shell:
     image: netty:centos-6-1.8
+
+  partly-build-leak:
+    image: netty:centos-6-1.8
+
+  partly-build-leak-boringssl-static:
+    image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.openj9111.yaml
+++ b/docker/docker-compose.centos-6.openj9111.yaml
@@ -22,3 +22,9 @@ services:
 
   shell:
     image: netty:centos-6-openj9-1.11
+
+  partly-build-leak:
+    image: netty:centos-6-openj9-1.11
+
+  partly-build-leak-boringssl-static:
+    image: netty:centos-6-openj9-1.11

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
+      - BRANCH
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg
@@ -26,6 +27,10 @@ services:
   build-leak:
     <<: *common
     command: /bin/bash -cl "./mvnw -B -ntp -Pleak clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora"
+
+  partly-build-leak:
+    <<: *common
+    command: /bin/bash -cl "./.github/scripts/mvn_build_affected_only.sh ${BRANCH} -B -ntp -Pleak clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora"
 
   build:
     <<: *common
@@ -61,6 +66,11 @@ services:
   build-leak-boringssl-static:
     <<: *common
     command: /bin/bash -cl "./mvnw -B -ntp -Pboringssl,leak clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
+
+
+  partly-build-leak-boringssl-static:
+    <<: *common
+    command: /bin/bash -cl "./.github/scripts/mvn_build_affected_only.sh ${BRANCH} -B -ntp -Pboringssl,leak clean install -Dio.netty.testsuite.badHost=netty.io -Dxml.skip=true"
 
   shell:
     <<: *common


### PR DESCRIPTION
Motivation:

Currently the PR verification takes a lot of time. We should try to only run builds for the affected modules in most cases to speed up the build.

Modifications:

Adjust docker files and workflow to only run build for affected modules for a lot of jobs while still run full builds for windows + java11 with BoringSSL

Result:

Hopefully quicker feedback loop when verify PRs
