### PR TITLE
Support large or variable chunk sizes

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -29,6 +29,7 @@ import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS;
+import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_ALLOW_PARTIAL_CHUNKS;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
@@ -136,8 +137,20 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
             boolean validateHeaders, int initialBufferSize, boolean parseHttpAfterConnectRequest,
             boolean allowDuplicateContentLengths) {
+        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, validateHeaders,
+            initialBufferSize, parseHttpAfterConnectRequest, allowDuplicateContentLengths,
+            DEFAULT_ALLOW_PARTIAL_CHUNKS);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public HttpClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            boolean validateHeaders, int initialBufferSize, boolean parseHttpAfterConnectRequest,
+            boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
         init(new Decoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
-                         allowDuplicateContentLengths),
+                         allowDuplicateContentLengths, allowPartialChunks),
              new Encoder());
         this.parseHttpAfterConnectRequest = parseHttpAfterConnectRequest;
         this.failOnMissingResponse = failOnMissingResponse;
@@ -204,9 +217,9 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
         }
 
         Decoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
-                int initialBufferSize, boolean allowDuplicateContentLengths) {
+                int initialBufferSize, boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
             super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
-                  allowDuplicateContentLengths);
+                  allowDuplicateContentLengths, allowPartialChunks);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -76,6 +76,15 @@ import java.util.List;
  *     The duplicated field-values will be replaced with a single valid Content-Length field.
  *     See <a href="https://tools.ietf.org/html/rfc7230#section-3.3.2">RFC 7230, Section 3.3.2</a>.</td>
  * </tr>
+ * <tr>
+ * <td>{@code allowPartialChunks}</td>
+ * <td>{@value #DEFAULT_ALLOW_PARTIAL_CHUNKS}</td>
+ * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
+ *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
+ *     Otherwise if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into a {@link HttpContent} util
+ *     the readable bytes is grater or equal to the chunk size.</td>
+ * </tr>
  * </table>
  *
  * <h3>Chunked Content</h3>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -81,9 +81,9 @@ import java.util.List;
  * <td>{@value #DEFAULT_ALLOW_PARTIAL_CHUNKS}</td>
  * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
  *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
- *     Otherwise if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
- *     is set to {@code false}, the {@link ByteBuf} is not decoded into a {@link HttpContent} util
- *     the readable bytes is grater or equal to the chunk size.</td>
+ *     Otherwise, if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} util
+ *     the readable bytes are grater or equal to the chunk size.</td>
  * </tr>
  * </table>
  *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -393,7 +393,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             assert chunkSize <= Integer.MAX_VALUE;
             int toRead = Math.min((int) chunkSize, maxChunkSize);
             if (!allowPartialChunks && buffer.readableBytes() < toRead) {
-              return;
+                return;
             }
             toRead = Math.min(toRead, buffer.readableBytes());
             if (toRead == 0) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -139,7 +139,6 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
     private HttpMessage message;
     private long chunkSize;
-    private ByteBuf chunkedContent;
     private long contentLength = Long.MIN_VALUE;
     private volatile boolean resetRequested;
 
@@ -358,7 +357,6 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 currentState = State.READ_CHUNK_FOOTER;
                 return;
             }
-            chunkedContent = buffer.alloc().buffer(chunkSize);
             currentState = State.READ_CHUNKED_CONTENT;
             // fall-through
         } catch (Exception e) {
@@ -368,23 +366,17 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         case READ_CHUNKED_CONTENT: {
             assert chunkSize <= Integer.MAX_VALUE;
             int toRead = Math.min((int) chunkSize, maxChunkSize);
-            toRead = Math.min(toRead, buffer.readableBytes());
-            if (toRead == 0) {
+            if (toRead == 0 || buffer.readableBytes() < toRead) {
                 return;
             }
-            chunkedContent.writeBytes(buffer.readRetainedSlice(toRead));
+            HttpContent chunk = new DefaultHttpContent(buffer.readRetainedSlice(toRead));
             chunkSize -= toRead;
+
+            out.add(chunk);
+
             if (chunkSize != 0) {
-                if (toRead == maxChunkSize) {
-                    HttpContent chunk = new DefaultHttpContent(chunkedContent);
-                    out.add(chunk);
-                    chunkedContent = buffer.alloc().buffer(Long.valueOf(chunkSize).intValue());
-                }
                 return;
             }
-            HttpContent chunk = new DefaultHttpContent(chunkedContent);
-            out.add(chunk);
-            chunkedContent = null;
             currentState = State.READ_CHUNK_DELIMITER;
             // fall-through
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -82,8 +82,8 @@ import java.util.List;
  * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
  *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
  *     Otherwise, if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
- *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} util
- *     the readable bytes are grater or equal to the chunk size.</td>
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} until
+ *     the readable bytes are greater or equal to the chunk size.</td>
  * </tr>
  * </table>
  *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -89,6 +89,13 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
               initialBufferSize, allowDuplicateContentLengths);
     }
 
+    public HttpRequestDecoder(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
+            int initialBufferSize, boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
+        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders,
+              initialBufferSize, allowDuplicateContentLengths, allowPartialChunks);
+    }
+
     @Override
     protected HttpMessage createMessage(String[] initialLine) throws Exception {
         return new DefaultHttpRequest(

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -51,6 +51,30 @@ import io.netty.handler.codec.TooLongFrameException;
  *     after this decoder in the {@link ChannelPipeline}.</td>
  * </tr>
  * </table>
+ *
+ * <h3>Parameters that control parsing behavior</h3>
+ * <table border="1">
+ * <tr>
+ * <th>Name</th><th>Default value</th><th>Meaning</th>
+ * </tr>
+ * <tr>
+ * <td>{@code allowDuplicateContentLengths}</td>
+ * <td>{@value #DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS}</td>
+ * <td>When set to {@code false}, will reject any messages that contain multiple Content-Length header fields.
+ *     When set to {@code true}, will allow multiple Content-Length headers only if they are all the same decimal value.
+ *     The duplicated field-values will be replaced with a single valid Content-Length field.
+ *     See <a href="https://tools.ietf.org/html/rfc7230#section-3.3.2">RFC 7230, Section 3.3.2</a>.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code allowPartialChunks}</td>
+ * <td>{@value #DEFAULT_ALLOW_PARTIAL_CHUNKS}</td>
+ * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
+ *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
+ *     Otherwise if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into a {@link HttpContent} util
+ *     the readable bytes is grater or equal to the chunk size.</td>
+ * </tr>
+ * </table>
  */
 public class HttpRequestDecoder extends HttpObjectDecoder {
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -70,9 +70,9 @@ import io.netty.handler.codec.TooLongFrameException;
  * <td>{@value #DEFAULT_ALLOW_PARTIAL_CHUNKS}</td>
  * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
  *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
- *     Otherwise if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
- *     is set to {@code false}, the {@link ByteBuf} is not decoded into a {@link HttpContent} util
- *     the readable bytes is grater or equal to the chunk size.</td>
+ *     Otherwise, if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} util
+ *     the readable bytes are grater or equal to the chunk size.</td>
  * </tr>
  * </table>
  */

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -71,8 +71,8 @@ import io.netty.handler.codec.TooLongFrameException;
  * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
  *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
  *     Otherwise, if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
- *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} util
- *     the readable bytes are grater or equal to the chunk size.</td>
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} until
+ *     the readable bytes are greater or equal to the chunk size.</td>
  * </tr>
  * </table>
  */

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -148,7 +148,7 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
             int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
             int initialBufferSize, boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
         super(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders,
-          initialBufferSize, allowDuplicateContentLengths, allowPartialChunks);
+              initialBufferSize, allowDuplicateContentLengths, allowPartialChunks);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -72,8 +72,8 @@ import io.netty.handler.codec.TooLongFrameException;
  * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
  *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
  *     Otherwise, if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
- *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} util
- *     the readable bytes are grater or equal to the chunk size.</td>
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} until
+ *     the readable bytes are greater or equal to the chunk size.</td>
  * </tr>
  * </table>
  *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -53,6 +53,30 @@ import io.netty.handler.codec.TooLongFrameException;
  * </tr>
  * </table>
  *
+ * <h3>Parameters that control parsing behavior</h3>
+ * <table border="1">
+ * <tr>
+ * <th>Name</th><th>Default value</th><th>Meaning</th>
+ * </tr>
+ * <tr>
+ * <td>{@code allowDuplicateContentLengths}</td>
+ * <td>{@value #DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS}</td>
+ * <td>When set to {@code false}, will reject any messages that contain multiple Content-Length header fields.
+ *     When set to {@code true}, will allow multiple Content-Length headers only if they are all the same decimal value.
+ *     The duplicated field-values will be replaced with a single valid Content-Length field.
+ *     See <a href="https://tools.ietf.org/html/rfc7230#section-3.3.2">RFC 7230, Section 3.3.2</a>.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code allowPartialChunks}</td>
+ * <td>{@value #DEFAULT_ALLOW_PARTIAL_CHUNKS}</td>
+ * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
+ *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
+ *     Otherwise if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into a {@link HttpContent} util
+ *     the readable bytes is grater or equal to the chunk size.</td>
+ * </tr>
+ * </table>
+ *
  * <h3>Decoding a response for a <tt>HEAD</tt> request</h3>
  * <p>
  * Unlike other HTTP requests, the successful response of a <tt>HEAD</tt>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -71,9 +71,9 @@ import io.netty.handler.codec.TooLongFrameException;
  * <td>{@value #DEFAULT_ALLOW_PARTIAL_CHUNKS}</td>
  * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
  *     is set to {@code true}, the chunk will be split into multiple {@link HttpContent}s.
- *     Otherwise if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
- *     is set to {@code false}, the {@link ByteBuf} is not decoded into a {@link HttpContent} util
- *     the readable bytes is grater or equal to the chunk size.</td>
+ *     Otherwise, if the chunk size does not exceed {@code maxChunkSize} and {@code allowPartialChunks}
+ *     is set to {@code false}, the {@link ByteBuf} is not decoded into an {@link HttpContent} util
+ *     the readable bytes are grater or equal to the chunk size.</td>
  * </tr>
  * </table>
  *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -120,6 +120,13 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
               initialBufferSize, allowDuplicateContentLengths);
     }
 
+    public HttpResponseDecoder(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
+            int initialBufferSize, boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
+        super(maxInitialLineLength, maxHeaderSize, maxChunkSize, DEFAULT_CHUNKED_SUPPORTED, validateHeaders,
+          initialBufferSize, allowDuplicateContentLengths, allowPartialChunks);
+    }
+
     @Override
     protected HttpMessage createMessage(String[] initialLine) {
         return new DefaultHttpResponse(

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -86,6 +86,16 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
     }
 
     /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
+                           int initialBufferSize, boolean allowDuplicateContentLengths, boolean allowPartialChunks) {
+        init(new HttpServerRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders,
+                                          initialBufferSize, allowDuplicateContentLengths, allowPartialChunks),
+             new HttpServerResponseEncoder());
+    }
+
+    /**
      * Upgrades to another protocol from HTTP. Removes the {@link HttpRequestDecoder} and
      * {@link HttpResponseEncoder} from the pipeline.
      */
@@ -115,6 +125,13 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
                                  boolean validateHeaders, int initialBufferSize, boolean allowDuplicateContentLengths) {
             super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
                   allowDuplicateContentLengths);
+        }
+
+        HttpServerRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize,
+                                 boolean validateHeaders, int initialBufferSize, boolean allowDuplicateContentLengths,
+                                 boolean allowPartialChunks) {
+            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize,
+                  allowDuplicateContentLengths, allowPartialChunks);
         }
 
         @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -181,27 +181,21 @@ public class HttpResponseDecoderTest {
         assertTrue(ch.writeInbound(partialChunk2));
 
         HttpContent content = ch.readInbound();
-
-        assertEquals(chunkSize, content.content().readableBytes());
-
-        byte[] decodedChunkBytes = new byte[chunkSize];
-        content.content().readBytes(decodedChunkBytes, 0, chunkSize);
-
-        assertArrayEquals(chunkBytes, decodedChunkBytes);
+        assertEquals(chunk, content.content());
         content.release();
+        chunk.release();
 
         assertFalse(ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII)));
 
         // Write the last chunk.
-        ch.writeInbound(Unpooled.copiedBuffer("0\r\n\r\n", CharsetUtil.US_ASCII));
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer("0\r\n\r\n", CharsetUtil.US_ASCII)));
 
         // Ensure the last chunk was decoded.
         HttpContent lastContent = ch.readInbound();
         assertFalse(lastContent.content().isReadable());
         lastContent.release();
 
-        ch.finish();
-        assertNull(ch.readInbound());
+        assertFalse(ch.finish());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -161,7 +161,7 @@ public class HttpResponseDecoderTest {
         String headers = "HTTP/1.1 200 OK\r\n"
             + "Transfer-Encoding: chunked\r\n"
             + "\r\n";
-        ch.writeInbound(Unpooled.copiedBuffer(headers, CharsetUtil.US_ASCII));
+       assertTrue(ch.writeInbound(Unpooled.copiedBuffer(headers, CharsetUtil.US_ASCII)));
 
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -147,56 +147,64 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResponseChunkedExceedBufferSize() {
-      EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
+    public void testResponseDisallowPartialChunks() {
+        HttpResponseDecoder decoder = new HttpResponseDecoder(
+            HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH,
+            HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE,
+            HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE,
+            HttpObjectDecoder.DEFAULT_VALIDATE_HEADERS,
+            HttpObjectDecoder.DEFAULT_INITIAL_BUFFER_SIZE,
+            HttpObjectDecoder.DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS,
+            false);
+        EmbeddedChannel ch = new EmbeddedChannel(decoder);
 
-      String headers = "HTTP/1.1 200 OK\r\n"
-          + "Transfer-Encoding: chunked\r\n"
-          + "\r\n";
-      ch.writeInbound(Unpooled.copiedBuffer(headers, CharsetUtil.US_ASCII));
+        String headers = "HTTP/1.1 200 OK\r\n"
+            + "Transfer-Encoding: chunked\r\n"
+            + "\r\n";
+        ch.writeInbound(Unpooled.copiedBuffer(headers, CharsetUtil.US_ASCII));
 
-      HttpResponse res = ch.readInbound();
-      assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
-      assertThat(res.status(), is(HttpResponseStatus.OK));
+        HttpResponse res = ch.readInbound();
+        assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
+        assertThat(res.status(), is(HttpResponseStatus.OK));
 
-      byte[] chunk = new byte[10];
-      for (int i = 0; i < chunk.length; i++) {
-          chunk[i] = (byte) i;
-      }
+        byte[] chunk = new byte[10];
+        for (int i = 0; i < chunk.length; i++) {
+            chunk[i] = (byte) i;
+        }
 
-      byte[] partialChunk1 = new byte[5];
-      System.arraycopy(chunk, 0, partialChunk1, 0, 5);
-      byte[] partialChunk2 = new byte[5];
-      System.arraycopy(chunk, 5, partialChunk2, 0, 5);
+        byte[] partialChunk1 = new byte[5];
+        System.arraycopy(chunk, 0, partialChunk1, 0, 5);
+        byte[] partialChunk2 = new byte[5];
+        System.arraycopy(chunk, 5, partialChunk2, 0, 5);
 
-      for (int i = 0; i < 10; i++) {
-          assertFalse(ch.writeInbound(Unpooled.copiedBuffer(Integer.toHexString(chunk.length)
-              + "\r\n", CharsetUtil.US_ASCII)));
-          assertTrue(ch.writeInbound(Unpooled.copiedBuffer(partialChunk1), Unpooled.copiedBuffer(partialChunk2)));
+        for (int i = 0; i < 10; i++) {
+            assertFalse(ch.writeInbound(Unpooled.copiedBuffer(Integer.toHexString(chunk.length)
+                + "\r\n", CharsetUtil.US_ASCII)));
+            assertTrue(ch.writeInbound(Unpooled.copiedBuffer(partialChunk1), Unpooled.copiedBuffer(partialChunk2)));
 
-          HttpContent content = ch.readInbound();
-          assertEquals(chunk.length, content.content().readableBytes());
+            HttpContent content = ch.readInbound();
+            assertEquals(chunk.length, content.content().readableBytes());
 
-          byte[] decodedChunk = new byte[chunk.length];
-          int toRead = Math.min(content.content().readableBytes(), chunk.length);
-          content.content().readBytes(decodedChunk, 0, toRead);
+            byte[] decodedChunk = new byte[chunk.length];
+            int toRead = Math.min(content.content().readableBytes(), chunk.length);
+            content.content().readBytes(decodedChunk, 0, toRead);
 
-          assertArrayEquals(chunk, decodedChunk);
-          content.release();
+            assertArrayEquals(chunk, decodedChunk);
+            content.release();
 
-          assertFalse(ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII)));
-      }
+            assertFalse(ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII)));
+        }
 
-      // Write the last chunk.
-      ch.writeInbound(Unpooled.copiedBuffer("0\r\n\r\n", CharsetUtil.US_ASCII));
+        // Write the last chunk.
+        ch.writeInbound(Unpooled.copiedBuffer("0\r\n\r\n", CharsetUtil.US_ASCII));
 
-      // Ensure the last chunk was decoded.
-      LastHttpContent content = ch.readInbound();
-      assertFalse(content.content().isReadable());
-      content.release();
+        // Ensure the last chunk was decoded.
+        LastHttpContent content = ch.readInbound();
+        assertFalse(content.content().isReadable());
+        content.release();
 
-      ch.finish();
-      assertNull(ch.readInbound());
+        ch.finish();
+        assertNull(ch.readInbound());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -184,13 +184,10 @@ public class HttpResponseDecoderTest {
 
         assertEquals(chunkSize, content.content().readableBytes());
 
-        byte[] expectedChunk = new byte[chunkSize];
-        chunk.readBytes(expectedChunk, 0, chunkSize);
+        byte[] decodedChunkBytes = new byte[chunkSize];
+        content.content().readBytes(decodedChunkBytes, 0, chunkSize);
 
-        byte[] actualChunk = new byte[chunkSize];
-        content.content().readBytes(actualChunk, 0, chunkSize);
-
-        assertArrayEquals(expectedChunk, actualChunk);
+        assertArrayEquals(chunkBytes, decodedChunkBytes);
         content.release();
 
         assertFalse(ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII)));


### PR DESCRIPTION
Motivation:

Chunks are split up into even smaller chunks when the underlying
buffer's readable bytes are less than the chunk size.

The underlying buffer can be smaller than a chunk size if:

- The chunk size is larger than the maximum plaintext chunk allowed by the TLS RFC,
  see: io.netty.handler.ssl.SslHandler.MAX_PLAINTEXT_LENGTH.

- The chunk sizes are variable in size,
  which may cause Netty to guess a buffer size that is smaller than a chunk size.

Modification:

Create a variable in HttpObjectDecoder: ByteBuf chunkedContent

- Initialize chunkedContent in READ_CHUNK_SIZE with chunkSize as buffer size.

- In READ_CHUNKED_CONTENT write bytes into chunkedContent

  - If the remaining chunk size is not 0 and toRead ==maxChunkSize,
    create a chunk using the chunkedContent and add it to the output messages
    before re-initializing chunkedContent with the remaining chunkSize as buffer size.

  - If the remaining chunk size is not 0 and toRead != maxChunkSize,
    return without adding any output messages.

  - If the remaining chunk size is 0,
    create a chunk using the chunkedContent and add it to the output messages;
    set chunkedContent = null and fall-through.

Result:

Support large or variable chunk sizes
