### PR TITLE
Fix a bug where SslHandler clients would not process Server Hello messages in a timely manner

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -86,7 +86,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
         run(info, new Runner<Bootstrap>() {
             @Override
             public void run(Bootstrap bootstrap) throws Throwable {
-                NioEventLoopGroup group = new NioEventLoopGroup();
+                NioEventLoopGroup group = new NioEventLoopGroup(1);
                 ServerBootstrap sb = new ServerBootstrap().group(group);
                 Channel serverChannel = sb.childHandler(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -112,7 +112,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
                         }
                     }
                 });
-                bootstrap.connect(serverChannel.localAddress());
+                bootstrap.connect(serverChannel.localAddress()).sync();
 
                 readLatch.await();
                 group.shutdownGracefully().await();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -519,7 +519,8 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) {
             if (!autoRead) {
-                ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(new GenericFutureListener<Future<? super Channel>>() {
+                ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(
+                        new GenericFutureListener<Future<? super Channel>>() {
                     @Override
                     public void operationComplete(Future<? super Channel> future) {
                         ctx.read();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.net.ssl.SSLEngine;
 import java.io.File;
 import java.io.IOException;
 import java.security.cert.CertificateException;
@@ -60,8 +61,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.net.ssl.SSLEngine;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
@@ -521,11 +520,11 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             if (!autoRead) {
                 ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(
                         new GenericFutureListener<Future<? super Channel>>() {
-                    @Override
-                    public void operationComplete(Future<? super Channel> future) {
-                        ctx.read();
-                    }
-                });
+                            @Override
+                            public void operationComplete(Future<? super Channel> future) {
+                                ctx.read();
+                            }
+                        });
             }
         }
 

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -848,10 +848,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         public final void beginRead() {
             assertEventLoop();
 
-            if (!isActive()) {
-                return;
-            }
-
             try {
                 doBeginRead();
             } catch (final Exception e) {

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioChannel.java
@@ -34,6 +34,7 @@ public abstract class AbstractOioChannel extends AbstractChannel {
     protected static final int SO_TIMEOUT = 1000;
 
     boolean readPending;
+    boolean readWhenInactive;
     final Runnable readTask = new Runnable() {
         @Override
         public void run() {
@@ -101,6 +102,10 @@ public abstract class AbstractOioChannel extends AbstractChannel {
     @Override
     protected void doBeginRead() throws Exception {
         if (readPending) {
+            return;
+        }
+        if (!isActive()) {
+            readWhenInactive = true;
             return;
         }
 

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioChannel.java
@@ -34,7 +34,7 @@ public abstract class AbstractOioChannel extends AbstractChannel {
     protected static final int SO_TIMEOUT = 1000;
 
     boolean readPending;
-    private final Runnable readTask = new Runnable() {
+    final Runnable readTask = new Runnable() {
         @Override
         public void run() {
             doRead();

--- a/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
@@ -78,6 +78,9 @@ public abstract class OioByteStreamChannel extends AbstractOioByteChannel {
         }
         this.is = ObjectUtil.checkNotNull(is, "is");
         this.os = ObjectUtil.checkNotNull(os, "os");
+        if (readPending) {
+            eventLoop().execute(readTask);
+        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
@@ -78,8 +78,9 @@ public abstract class OioByteStreamChannel extends AbstractOioByteChannel {
         }
         this.is = ObjectUtil.checkNotNull(is, "is");
         this.os = ObjectUtil.checkNotNull(os, "os");
-        if (readPending) {
+        if (readWhenInactive) {
             eventLoop().execute(readTask);
+            readWhenInactive = false;
         }
     }
 


### PR DESCRIPTION
Motivation:
The TLS handshake must be able to finish on its own, without being driven by outside read calls.
This is currently not the case when TCP FastOpen is enabled.

Modification:

Attach a listener to the SslHandler.handshakeFuture in the EchoClient, that will call `ctx.read`. This makes the SocketSslEchoTest catch the bug.

Allow marking reads as pending, even when a channel is not active.
This is important because, with TCP FastOpen, the handshake processing of a TLS connection will start
before the connection has been established -- before the process of connecting has even been started.

The SslHandler on the client side will add the Client Hello message to the ChannelOutboundBuffer, then
issue a `ctx.read` call for the anticipated Server Hello response, and then flush the Client Hello
message which, in the case of TCP FastOpen, will cause the TCP connection to be established.

In this transaction, it is important that the `ctx.read` call is not ignored since, if auto-read is
turned off, this could delay or even prevent the Server Hello message from being processed, causing
the server-side handshake to time out.

Result:
The SocketSslEchoTest now tests that the SslHandler can finish handshakes on its own, without being driven by 3rd party `ctx.read` calls.
And the epoll and nio implementations pass the new test.