### PR TITLE
Release resources in PortUnificationServerHandler

### DIFF
--- a/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
+++ b/example/src/main/java/io/netty/example/portunification/PortUnificationServerHandler.java
@@ -73,7 +73,7 @@ public class PortUnificationServerHandler extends ByteToMessageDecoder {
                 switchToFactorial(ctx);
             } else {
                 // Unknown protocol; discard everything and close the connection.
-                in.clear();
+                in.release();
                 ctx.close();
             }
         }


### PR DESCRIPTION
Buffer has to be released before closing a connection. See also [Norman's answer](https://stackoverflow.com/a/51289193/2104560)

