### PR TITLE
HAProxyMessage.sourceAddress() can be null

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -501,8 +501,8 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
     }
 
     /**
-     * Returns the human-readable source address of this {@link HAProxyMessage}.
-     * Returns null if HAProxy performs health check with send-proxy-v2
+     * Returns the human-readable source address of this {@link HAProxyMessage} or {@code null}
+     * if HAProxy performs health check with {@code send-proxy-v2}.
      */
     public String sourceAddress() {
         return sourceAddress;

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -502,6 +502,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
 
     /**
      * Returns the human-readable source address of this {@link HAProxyMessage}.
+     * Returns null if HAProxy performs health check with send-proxy-v2
      */
     public String sourceAddress() {
         return sourceAddress;


### PR DESCRIPTION
It happens if and only if we've `check` && `send-proxy-v2`. Changing `send-proxy-v2` to `send-proxy` makes no error in the console, removing `check` too.

Motivation:

I configured HAProxy with `check` and `send-proxy-v2`. I downloaded BungeeCord and I've encountered the situation described here: https://github.com/SpigotMC/BungeeCord/pull/3147

Modification:

Added to the documentation information that sourceAddress can be null. I didn't check other methods, but if you want I can check it later. I think it only happens to sourceAddress, destinationAddress and ports. My English isn't the best, so feel free to edit this.
