### PR TITLE
Refactor HttpContentCompressor using CompressionEncoderFactory

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/CompressionEncoderFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CompressionEncoderFactory.java
@@ -22,8 +22,6 @@ import io.netty.handler.codec.MessageToByteEncoder;
  * Compression Encoder Factory for create {@link MessageToByteEncoder}
  * used to compress http content
  */
-public interface CompressionEncoderFactory {
-    String name();
-
+interface CompressionEncoderFactory {
     MessageToByteEncoder<ByteBuf> createEncoder();
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/CompressionEncoderFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CompressionEncoderFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+/**
+ * Compression Encoder Factory for create {@link MessageToByteEncoder}
+ * used to compress http content
+ */
+public interface CompressionEncoderFactory {
+    String name();
+
+    MessageToByteEncoder<ByteBuf> createEncoder();
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -395,7 +395,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
             ObjectUtil.checkNotNull(gzipOptions, "gzipOptions");
             return ZlibCodecFactory.newZlibEncoder(
                     ZlibWrapper.GZIP, gzipOptions.compressionLevel()
-                    , gzipOptions.windowBits(), gzipOptions.memLevel());
+                    gzipOptions.windowBits(), gzipOptions.memLevel());
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -415,7 +415,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
     }
 
     /**
-     * Compression Encoder Factory for create {@link BrotliEncoder}
+     * Compression Encoder Factory that creates {@link BrotliEncoder}s
      * used to compress http content for br content encoding
      */
     private final class BrEncoderFactory implements CompressionEncoderFactory {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.handler.codec.compression.ZlibEncoder;
 import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.compression.BrotliEncoder;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
@@ -55,15 +56,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
     private final int memLevel;
     private final int contentSizeThreshold;
     private ChannelHandlerContext ctx;
-    private final Map<String, CompressionEncoderFactory> factories =
-            new HashMap<String, CompressionEncoderFactory>() {
-                {
-                    factories.put("gzip", new GzipEncoderFactory());
-                    factories.put("deflate", new DeflateEncoderFactory());
-                    factories.put("br", new BrEncoderFactory());
-                    factories.put("zstd", new ZstdEncoderFactory());
-                }
-            };
+    private final Map<String, CompressionEncoderFactory> factories;
 
     /**
      * Creates a new handler with the default compression level (<tt>6</tt>),
@@ -144,6 +137,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
         this.gzipOptions = null;
         this.deflateOptions = null;
         this.zstdOptions = null;
+        this.factories = null;
         supportsCompressionOptions = false;
     }
 
@@ -213,6 +207,14 @@ public class HttpContentCompressor extends HttpContentEncoder {
         this.gzipOptions = gzipOptions;
         this.deflateOptions = deflateOptions;
         this.zstdOptions = zstdOptions;
+        this.factories = new HashMap<String, CompressionEncoderFactory>() {
+            {
+                put("gzip", new GzipEncoderFactory());
+                put("deflate", new DeflateEncoderFactory());
+                put("br", new BrEncoderFactory());
+                put("zstd", new ZstdEncoderFactory());
+            }
+        };
         this.compressionLevel = -1;
         this.windowBits = -1;
         this.memLevel = -1;
@@ -382,6 +384,10 @@ public class HttpContentCompressor extends HttpContentEncoder {
         return null;
     }
 
+    /**
+     * Compression Encoder Factory for create {@link ZlibEncoder}
+     * used to compress http content for gzip content encoding
+     */
     private final class GzipEncoderFactory implements CompressionEncoderFactory {
 
         @Override
@@ -393,6 +399,10 @@ public class HttpContentCompressor extends HttpContentEncoder {
         }
     }
 
+    /**
+     * Compression Encoder Factory for create {@link ZlibEncoder}
+     * used to compress http content for deflate content encoding
+     */
     private final class DeflateEncoderFactory implements CompressionEncoderFactory {
 
         @Override
@@ -404,6 +414,10 @@ public class HttpContentCompressor extends HttpContentEncoder {
         }
     }
 
+    /**
+     * Compression Encoder Factory for create {@link BrotliEncoder}
+     * used to compress http content for br content encoding
+     */
     private final class BrEncoderFactory implements CompressionEncoderFactory {
 
         @Override
@@ -413,6 +427,10 @@ public class HttpContentCompressor extends HttpContentEncoder {
         }
     }
 
+    /**
+     * Compression Encoder Factory for create {@link ZstdEncoder}
+     * used to compress http content for zstd content encoding
+     */
     private final class ZstdEncoderFactory implements CompressionEncoderFactory {
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -392,7 +392,6 @@ public class HttpContentCompressor extends HttpContentEncoder {
 
         @Override
         public MessageToByteEncoder<ByteBuf> createEncoder() {
-            ObjectUtil.checkNotNull(gzipOptions, "gzipOptions");
             return ZlibCodecFactory.newZlibEncoder(
                     ZlibWrapper.GZIP, gzipOptions.compressionLevel(),
                     gzipOptions.windowBits(), gzipOptions.memLevel());

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -394,7 +394,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
         public MessageToByteEncoder<ByteBuf> createEncoder() {
             ObjectUtil.checkNotNull(gzipOptions, "gzipOptions");
             return ZlibCodecFactory.newZlibEncoder(
-                    ZlibWrapper.GZIP, gzipOptions.compressionLevel()
+                    ZlibWrapper.GZIP, gzipOptions.compressionLevel(),
                     gzipOptions.windowBits(), gzipOptions.memLevel());
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -422,7 +422,6 @@ public class HttpContentCompressor extends HttpContentEncoder {
 
         @Override
         public MessageToByteEncoder<ByteBuf> createEncoder() {
-            ObjectUtil.checkNotNull(brotliOptions, "brotliOptions");
             return new BrotliEncoder(brotliOptions.parameters());
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -385,7 +385,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
     }
 
     /**
-     * Compression Encoder Factory for create {@link ZlibEncoder}
+     * Compression Encoder Factory that creates {@link ZlibEncoder}s
      * used to compress http content for gzip content encoding
      */
     private final class GzipEncoderFactory implements CompressionEncoderFactory {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -400,7 +400,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
     }
 
     /**
-     * Compression Encoder Factory for create {@link ZlibEncoder}
+     * Compression Encoder Factory that creates {@link ZlibEncoder}s
      * used to compress http content for deflate content encoding
      */
     private final class DeflateEncoderFactory implements CompressionEncoderFactory {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -407,7 +407,6 @@ public class HttpContentCompressor extends HttpContentEncoder {
 
         @Override
         public MessageToByteEncoder<ByteBuf> createEncoder() {
-            ObjectUtil.checkNotNull(deflateOptions, "deflateOptions");
             return ZlibCodecFactory.newZlibEncoder(
                     ZlibWrapper.ZLIB, deflateOptions.compressionLevel(),
                     deflateOptions.windowBits(), deflateOptions.memLevel());

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -434,7 +434,6 @@ public class HttpContentCompressor extends HttpContentEncoder {
 
         @Override
         public MessageToByteEncoder<ByteBuf> createEncoder() {
-            ObjectUtil.checkNotNull(zstdOptions, "zstdOptions");
             return new ZstdEncoder(zstdOptions.compressionLevel(),
                     zstdOptions.blockSize(), zstdOptions.maxEncodeSize());
         }


### PR DESCRIPTION
Motivation:

The `HttpContentCompressor.beginEncode()` method has too many if else, so consider refactoring

Modification:

Create the corresponding `CompressionEncoderFactory` according to the compression algorithm, remove the if else

Result:

The code of `HttpContentCompressor` is cleaner than the previous implementation
