### PR TITLE
Migrate the rest of the ssl package to junit5

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/AmazonCorrettoSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/AmazonCorrettoSslEngineTest.java
@@ -17,48 +17,28 @@ package io.netty.handler.ssl;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import com.amazon.corretto.crypto.provider.SelfTestStatus;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import javax.crypto.Cipher;
 import java.security.Security;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@RunWith(Parameterized.class)
+
+@DisabledIf("checkIfAccpIsDisabled")
 public class AmazonCorrettoSslEngineTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
-    public static Collection<Object[]> data() {
-        List<Object[]> params = new ArrayList<Object[]>();
-        for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
-
-            if (SslProvider.isTlsv13Supported(SslProvider.JDK)) {
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), true });
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), false });
-            }
-        }
-        return params;
+    static boolean checkIfAccpIsDisabled() {
+        return AmazonCorrettoCryptoProvider.INSTANCE.getLoadingError() != null ||
+                !AmazonCorrettoCryptoProvider.INSTANCE.runSelfTests().equals(SelfTestStatus.PASSED);
     }
 
-    public AmazonCorrettoSslEngineTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
-        super(type, combo, delegate);
-    }
-
-    @BeforeClass
-    public static void checkAccp() {
-        assumeTrue(AmazonCorrettoCryptoProvider.INSTANCE.getLoadingError() == null &&
-                AmazonCorrettoCryptoProvider.INSTANCE.runSelfTests().equals(SelfTestStatus.PASSED));
+    public AmazonCorrettoSslEngineTest() {
+        super(SslProvider.isTlsv13Supported(SslProvider.JDK));
     }
 
     @Override
@@ -71,7 +51,7 @@ public class AmazonCorrettoSslEngineTest extends SSLEngineTest {
         return SslProvider.JDK;
     }
 
-    @Before
+    @BeforeEach
     @Override
     public void setup() {
         // See https://github.com/corretto/amazon-corretto-crypto-provider/blob/develop/README.md#code
@@ -81,7 +61,7 @@ public class AmazonCorrettoSslEngineTest extends SSLEngineTest {
         try {
             AmazonCorrettoCryptoProvider.INSTANCE.assertHealthy();
             String providerName = Cipher.getInstance("AES/GCM/NoPadding").getProvider().getName();
-            Assert.assertEquals(AmazonCorrettoCryptoProvider.PROVIDER_NAME, providerName);
+            assertEquals(AmazonCorrettoCryptoProvider.PROVIDER_NAME, providerName);
         } catch (Throwable e) {
             Security.removeProvider(AmazonCorrettoCryptoProvider.PROVIDER_NAME);
             throw new AssertionError(e);
@@ -89,24 +69,24 @@ public class AmazonCorrettoSslEngineTest extends SSLEngineTest {
         super.setup();
     }
 
-    @After
+    @AfterEach
     @Override
     public void tearDown() throws InterruptedException {
         super.tearDown();
 
         // Remove the provider again and verify that it was removed
         Security.removeProvider(AmazonCorrettoCryptoProvider.PROVIDER_NAME);
-        Assert.assertNull(Security.getProvider(AmazonCorrettoCryptoProvider.PROVIDER_NAME));
+        assertNull(Security.getProvider(AmazonCorrettoCryptoProvider.PROVIDER_NAME));
     }
 
-    @Ignore /* Does the JDK support a "max certificate chain length"? */
+    @Disabled /* Does the JDK support a "max certificate chain length"? */
     @Override
-    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() {
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(SSLEngineTestParam param) {
     }
 
-    @Ignore /* Does the JDK support a "max certificate chain length"? */
+    @Disabled /* Does the JDK support a "max certificate chain length"? */
     @Override
-    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() {
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(SSLEngineTestParam param) {
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -16,39 +16,22 @@
 package io.netty.handler.ssl;
 
 import java.security.Provider;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import javax.net.ssl.SSLSessionContext;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
-import static org.junit.Assume.assumeTrue;
 
-@RunWith(Parameterized.class)
+@DisabledIf("checkConscryptDisabled")
 public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
-    public static Collection<Object[]> data() {
-        List<Object[]> params = new ArrayList<Object[]>();
-        for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
-        }
-        return params;
+    public ConscryptJdkSslEngineInteropTest() {
+        super(false);
     }
 
-    public ConscryptJdkSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
-        super(type, combo, delegate);
-    }
-
-    @BeforeClass
-    public static void checkConscrypt() {
-        assumeTrue(Conscrypt.isAvailable());
+    static boolean checkConscryptDisabled() {
+        return !Conscrypt.isAvailable();
     }
 
     @Override
@@ -66,14 +49,16 @@ public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
         return Java8SslTestUtils.conscryptProvider();
     }
 
-    @Ignore /* Does the JDK support a "max certificate chain length"? */
+    @Disabled /* Does the JDK support a "max certificate chain length"? */
     @Override
-    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() throws Exception {
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
     }
 
-    @Ignore /* Does the JDK support a "max certificate chain length"? */
+    @Disabled /* Does the JDK support a "max certificate chain length"? */
     @Override
-    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(SSLEngineTestParam param)
+            throws Exception {
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptOpenSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptOpenSslEngineInteropTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.ssl;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
@@ -28,6 +29,7 @@ import java.util.List;
 import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@DisabledIf("checkConscryptDisabled")
 public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptOpenSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptOpenSslEngineInteropTest.java
@@ -15,48 +15,33 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
 
 import java.security.Provider;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@RunWith(Parameterized.class)
 public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}, useTasks = {3}")
-    public static Collection<Object[]> data() {
-        List<Object[]> params = new ArrayList<Object[]>();
-        for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false, false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false, true });
-
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true, false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true, true });
+    @Override
+    protected List<SSLEngineTestParam> newTestParams() {
+        List<SSLEngineTestParam> params = super.newTestParams();
+        List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
+        for (SSLEngineTestParam param: params) {
+            testParams.add(new OpenSslEngineTestParam(true, param));
+            testParams.add(new OpenSslEngineTestParam(false, param));
         }
-        return params;
+        return testParams;
     }
 
-    private final boolean useTasks;
-
-    public ConscryptOpenSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo,
-                                             boolean delegate, boolean useTasks) {
-        super(type, combo, delegate);
-        this.useTasks = useTasks;
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void checkOpenssl() {
         OpenSsl.ensureAvailability();
     }
@@ -77,17 +62,15 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
     }
 
     @Override
-    @Test
-    @Ignore("TODO: Make this work with Conscrypt")
-    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() {
-        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth();
+    @Disabled("TODO: Make this work with Conscrypt")
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(SSLEngineTestParam param) {
+        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    @Ignore("TODO: Make this work with Conscrypt")
-    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() {
-        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth();
+    @Disabled("TODO: Make this work with Conscrypt")
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(SSLEngineTestParam param) {
+        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(param);
     }
 
     @Override
@@ -97,45 +80,42 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
+        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
+        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
+        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testSessionAfterHandshakeKeyManagerFactory() throws Exception {
+    public void testSessionAfterHandshakeKeyManagerFactory(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionAfterHandshakeKeyManagerFactory();
+        super.testSessionAfterHandshakeKeyManagerFactory(param);
     }
 
     @Override
-    @Test
-    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth() throws Exception {
+    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth();
+        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth(param);
     }
 
     @Override
-    @Test
-    public void testSupportedSignatureAlgorithms() throws Exception {
+    public void testSupportedSignatureAlgorithms(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSupportedSignatureAlgorithms();
+        super.testSupportedSignatureAlgorithms(param);
     }
 
     @Override
@@ -145,18 +125,17 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
     }
 
     @Override
-    @Test
-    public void testSessionLocalWhenNonMutualWithKeyManager() throws Exception {
+    public void testSessionLocalWhenNonMutualWithKeyManager(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionLocalWhenNonMutualWithKeyManager();
+        super.testSessionLocalWhenNonMutualWithKeyManager(param);
     }
 
     @Override
-    public void testSessionLocalWhenNonMutualWithoutKeyManager() throws Exception {
+    public void testSessionLocalWhenNonMutualWithoutKeyManager(SSLEngineTestParam param) throws Exception {
         // This only really works when the KeyManagerFactory is supported as otherwise we not really know when
         // we need to provide a cert.
         assumeTrue(OpenSsl.supportsKeyManagerFactory());
-        super.testSessionLocalWhenNonMutualWithoutKeyManager();
+        super.testSessionLocalWhenNonMutualWithoutKeyManager(param);
     }
 
     @Override
@@ -165,24 +144,21 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
     }
 
     @Override
-    @Test
-    public void testSessionCache() throws Exception {
+    public void testSessionCache(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCache();
+        super.testSessionCache(param);
     }
 
     @Override
-    @Test
-    public void testSessionCacheTimeout() throws Exception {
+    public void testSessionCacheTimeout(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCacheTimeout();
+        super.testSessionCacheTimeout(param);
     }
 
     @Override
-    @Test
-    public void testSessionCacheSize() throws Exception {
+    public void testSessionCacheSize(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCacheSize();
+        super.testSessionCacheSize(param);
     }
 
     @Override
@@ -192,9 +168,11 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
 
     @SuppressWarnings("deprecation")
     @Override
-    protected SslContext wrapContext(SslContext context) {
+    protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
         if (context instanceof OpenSslContext) {
-            ((OpenSslContext) context).setUseTasks(useTasks);
+            if (param instanceof OpenSslEngineTestParam) {
+                ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
+            }
             // Explicit enable the session cache as its disabled by default on the client side.
             ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
         }

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
@@ -15,39 +15,22 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import javax.net.ssl.SSLSessionContext;
 import java.security.Provider;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
-import static org.junit.Assume.assumeTrue;
-
-@RunWith(Parameterized.class)
+@DisabledIf("checkConscryptDisabled")
 public class ConscryptSslEngineTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
-    public static Collection<Object[]> data() {
-        List<Object[]> params = new ArrayList<Object[]>();
-        for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
-        }
-        return params;
+    static boolean checkConscryptDisabled() {
+        return !Conscrypt.isAvailable();
     }
 
-    public ConscryptSslEngineTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
-        super(type, combo, delegate);
-    }
-
-    @BeforeClass
-    public static void checkConscrypt() {
-        assumeTrue(Conscrypt.isAvailable());
+    public ConscryptSslEngineTest() {
+        super(false);
     }
 
     @Override
@@ -70,14 +53,14 @@ public class ConscryptSslEngineTest extends SSLEngineTest {
         return Java8SslTestUtils.conscryptProvider();
     }
 
-    @Ignore /* Does the JDK support a "max certificate chain length"? */
+    @Disabled /* Does the JDK support a "max certificate chain length"? */
     @Override
-    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() {
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(SSLEngineTestParam param) {
     }
 
-    @Ignore /* Does the JDK support a "max certificate chain length"? */
+    @Disabled /* Does the JDK support a "max certificate chain length"? */
     @Override
-    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() {
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(SSLEngineTestParam param) {
     }
 
     @Override
@@ -85,8 +68,8 @@ public class ConscryptSslEngineTest extends SSLEngineTest {
         // Not supported by conscrypt
     }
 
-    @Ignore("Possible Conscrypt bug")
-    public void testSessionCacheTimeout() throws Exception {
+    @Disabled("Possible Conscrypt bug")
+    public void testSessionCacheTimeout(SSLEngineTestParam param) throws Exception {
         // Skip
         // https://github.com/google/conscrypt/issues/851
     }

--- a/handler/src/test/java/io/netty/handler/ssl/Java8SslTestUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/Java8SslTestUtils.java
@@ -29,7 +29,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public final class Java8SslTestUtils {
 
@@ -70,7 +70,7 @@ public final class Java8SslTestUtils {
             InputStream is = null;
             try {
                 is = SslContextTest.class.getResourceAsStream(resourceName);
-                assertNotNull("Cannot find " + resourceName, is);
+                assertNotNull(is, "Cannot find " + resourceName);
                 certCollection[i] = (X509Certificate) certFactory
                         .generateCertificate(is);
             } finally {

--- a/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
@@ -17,39 +17,20 @@ package io.netty.handler.ssl;
 
 import java.security.Provider;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import javax.net.ssl.SSLSessionContext;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
-import static org.junit.Assume.assumeTrue;
-
-@RunWith(Parameterized.class)
+@DisabledIf("checkConscryptDisabled")
 public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}")
-    public static Collection<Object[]> data() {
-        List<Object[]> params = new ArrayList<Object[]>();
-        for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true });
-        }
-        return params;
+    static boolean checkConscryptDisabled() {
+        return !Conscrypt.isAvailable();
     }
 
-    public JdkConscryptSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo, boolean delegate) {
-        super(type, combo, delegate);
-    }
-
-    @BeforeClass
-    public static void checkConscrypt() {
-        assumeTrue(Conscrypt.isAvailable());
+    public JdkConscryptSslEngineInteropTest() {
+        super(false);
     }
 
     @Override
@@ -68,17 +49,17 @@ public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
     }
 
     @Override
-    @Test
-    @Ignore("TODO: Make this work with Conscrypt")
-    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() throws Exception {
-        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth();
+    @Disabled("TODO: Make this work with Conscrypt")
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
+        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    @Ignore("TODO: Make this work with Conscrypt")
-    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
-        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth();
+    @Disabled("TODO: Make this work with Conscrypt")
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(SSLEngineTestParam param)
+            throws Exception {
+        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(param);
     }
 
     @Override
@@ -87,9 +68,9 @@ public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
         return super.mySetupMutualAuthServerIsValidClientException(cause) || causedBySSLException(cause);
     }
 
-    @Ignore("Ignore due bug in Conscrypt")
+    @Disabled("Ignore due bug in Conscrypt")
     @Override
-    public void testHandshakeSession() throws Exception {
+    public void testHandshakeSession(SSLEngineTestParam param) throws Exception {
         // Ignore as Conscrypt does not correctly return the local certificates while the TrustManager is invoked.
         // See https://github.com/google/conscrypt/issues/634
     }
@@ -99,8 +80,8 @@ public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
         // Not supported by conscrypt
     }
 
-    @Ignore("Possible Conscrypt bug")
-    public void testSessionCacheTimeout() {
+    @Disabled("Possible Conscrypt bug")
+    public void testSessionCacheTimeout(SSLEngineTestParam param) {
         // Skip
         // https://github.com/google/conscrypt/issues/851
     }

--- a/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -15,54 +15,36 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
 import javax.net.ssl.SSLEngine;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
 import static io.netty.internal.tcnative.SSL.SSL_CVERIFY_IGNORED;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@RunWith(Parameterized.class)
 public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}, useTasks = {3}")
-    public static Collection<Object[]> data() {
-        List<Object[]> params = new ArrayList<Object[]>();
-        for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false, false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false, true });
+    public JdkOpenSslEngineInteroptTest() {
+        super(SslProvider.isTlsv13Supported(SslProvider.JDK) &&
+                SslProvider.isTlsv13Supported(SslProvider.OPENSSL));
+    }
 
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true, false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true, true });
-
-            if (SslProvider.isTlsv13Supported(SslProvider.JDK) && SslProvider.isTlsv13Supported(SslProvider.OPENSSL)) {
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), false, false });
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), false, true });
-
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), true, false });
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), true, true });
-            }
+    @Override
+    protected List<SSLEngineTestParam> newTestParams() {
+        List<SSLEngineTestParam> params = super.newTestParams();
+        List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
+        for (SSLEngineTestParam param: params) {
+            testParams.add(new OpenSslEngineTestParam(true, param));
+            testParams.add(new OpenSslEngineTestParam(false, param));
         }
-        return params;
+        return testParams;
     }
 
-    private final boolean useTasks;
-
-    public JdkOpenSslEngineInteroptTest(BufferType type, ProtocolCipherCombo protocolCipherCombo,
-                                        boolean delegate, boolean useTasks) {
-        super(type, protocolCipherCombo, delegate);
-        this.useTasks = useTasks;
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void checkOpenSsl() {
         OpenSsl.ensureAvailability();
     }
@@ -78,59 +60,55 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
     }
 
     @Override
-    @Test
-    @Ignore("Disable until figured out why this sometimes fail on the CI")
-    public void testMutualAuthSameCerts() throws Throwable {
-        super.testMutualAuthSameCerts();
+    @Disabled("Disable until figured out why this sometimes fail on the CI")
+    public void testMutualAuthSameCerts(SSLEngineTestParam param) throws Throwable {
+        super.testMutualAuthSameCerts(param);
+    }
+
+    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
+        checkShouldUseKeyManagerFactory();
+        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
+        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
+        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
+        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() throws Exception {
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth();
+        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
+    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth();
+        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth(param);
     }
 
     @Override
-    @Test
-    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth() throws Exception {
+    public void testSessionAfterHandshakeKeyManagerFactory(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth();
-    }
-
-    @Override
-    @Test
-    public void testSessionAfterHandshakeKeyManagerFactory() throws Exception {
-        checkShouldUseKeyManagerFactory();
-        super.testSessionAfterHandshakeKeyManagerFactory();
+        super.testSessionAfterHandshakeKeyManagerFactory(param);
     }
 
     @Override
@@ -146,52 +124,47 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
     }
 
     @Override
-    public void testHandshakeSession() throws Exception {
+    public void testHandshakeSession(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testHandshakeSession();
+        super.testHandshakeSession(param);
     }
 
     @Override
-    @Test
-    public void testSupportedSignatureAlgorithms() throws Exception {
+    public void testSupportedSignatureAlgorithms(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSupportedSignatureAlgorithms();
+        super.testSupportedSignatureAlgorithms(param);
     }
 
     @Override
-    @Test
-    public void testSessionLocalWhenNonMutualWithKeyManager() throws Exception {
+    public void testSessionLocalWhenNonMutualWithKeyManager(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionLocalWhenNonMutualWithKeyManager();
+        super.testSessionLocalWhenNonMutualWithKeyManager(param);
     }
 
     @Override
-    public void testSessionLocalWhenNonMutualWithoutKeyManager() throws Exception {
+    public void testSessionLocalWhenNonMutualWithoutKeyManager(SSLEngineTestParam param) throws Exception {
         // This only really works when the KeyManagerFactory is supported as otherwise we not really know when
         // we need to provide a cert.
         assumeTrue(OpenSsl.supportsKeyManagerFactory());
-        super.testSessionLocalWhenNonMutualWithoutKeyManager();
+        super.testSessionLocalWhenNonMutualWithoutKeyManager(param);
     }
 
     @Override
-    @Test
-    public void testSessionCache() throws Exception {
+    public void testSessionCache(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCache();
+        super.testSessionCache(param);
     }
 
     @Override
-    @Test
-    public void testSessionCacheTimeout() throws Exception {
+    public void testSessionCacheTimeout(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCacheTimeout();
+        super.testSessionCacheTimeout(param);
     }
 
     @Override
-    @Test
-    public void testSessionCacheSize() throws Exception {
+    public void testSessionCacheSize(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCacheSize();
+        super.testSessionCacheSize(param);
     }
 
     @Override
@@ -201,9 +174,9 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
 
     @SuppressWarnings("deprecation")
     @Override
-    protected SslContext wrapContext(SslContext context) {
-        if (context instanceof OpenSslContext) {
-            ((OpenSslContext) context).setUseTasks(useTasks);
+    protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
+        if (context instanceof OpenSslContext && param instanceof OpenSslEngineTestParam) {
+            ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
             // Explicit enable the session cache as its disabled by default on the client side.
             ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
         }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslClientContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslClientContextTest.java
@@ -16,14 +16,14 @@
 package io.netty.handler.ssl;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
 
 public class OpenSslClientContextTest extends SslContextTest  {
 
-    @BeforeClass
+    @BeforeAll
     public static void checkOpenSsl() {
         OpenSsl.ensureAvailability();
     }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslConscryptSslEngineInteropTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.ssl;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
@@ -27,6 +28,7 @@ import java.util.List;
 import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@DisabledIf("checkConscryptDisabled")
 public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest {
     @Override
     protected List<SSLEngineTestParam> newTestParams() {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslConscryptSslEngineInteropTest.java
@@ -15,47 +15,31 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
 import java.security.Provider;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@RunWith(Parameterized.class)
 public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest {
-
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}, useTasks = {3}")
-    public static Collection<Object[]> data() {
-        List<Object[]> params = new ArrayList<Object[]>();
-        for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false, false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false, true });
-
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true, false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true, true });
+    @Override
+    protected List<SSLEngineTestParam> newTestParams() {
+        List<SSLEngineTestParam> params = super.newTestParams();
+        List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
+        for (SSLEngineTestParam param: params) {
+            testParams.add(new OpenSslEngineTestParam(true, param));
+            testParams.add(new OpenSslEngineTestParam(false, param));
         }
-        return params;
+        return testParams;
     }
 
-    private final boolean useTasks;
-
-    public OpenSslConscryptSslEngineInteropTest(BufferType type, ProtocolCipherCombo combo,
-                                                boolean delegate, boolean useTasks) {
-        super(type, combo, delegate);
-        this.useTasks = useTasks;
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void checkOpenssl() {
         OpenSsl.ensureAvailability();
     }
@@ -76,17 +60,15 @@ public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest
     }
 
     @Override
-    @Test
-    @Ignore("TODO: Make this work with Conscrypt")
-    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() {
-        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth();
+    @Disabled("TODO: Make this work with Conscrypt")
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(SSLEngineTestParam param) {
+        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    @Ignore("TODO: Make this work with Conscrypt")
-    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() {
-        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth();
+    @Disabled("TODO: Make this work with Conscrypt")
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(SSLEngineTestParam param) {
+        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(param);
     }
 
     @Override
@@ -96,38 +78,36 @@ public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
+        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
+        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
+        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth() throws Exception {
+    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth();
+        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth(param);
     }
 
     @Override
-    @Test
-    public void testSupportedSignatureAlgorithms() throws Exception {
+    public void testSupportedSignatureAlgorithms(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSupportedSignatureAlgorithms();
+        super.testSupportedSignatureAlgorithms(param);
     }
 
     @Override
@@ -137,31 +117,27 @@ public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest
     }
 
     @Override
-    @Test
-    public void testSessionLocalWhenNonMutualWithKeyManager() throws Exception {
+    public void testSessionLocalWhenNonMutualWithKeyManager(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionLocalWhenNonMutualWithKeyManager();
+        super.testSessionLocalWhenNonMutualWithKeyManager(param);
     }
 
     @Override
-    @Test
-    public void testSessionCache() throws Exception {
+    public void testSessionCache(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCache();
+        super.testSessionCache(param);
     }
 
     @Override
-    @Test
-    public void testSessionCacheTimeout() throws Exception {
+    public void testSessionCacheTimeout(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCacheTimeout();
+        super.testSessionCacheTimeout(param);
     }
 
     @Override
-    @Test
-    public void testSessionCacheSize() throws Exception {
+    public void testSessionCacheSize(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCacheSize();
+        super.testSessionCacheSize(param);
     }
 
     @Override
@@ -176,9 +152,11 @@ public class OpenSslConscryptSslEngineInteropTest extends ConscryptSslEngineTest
 
     @SuppressWarnings("deprecation")
     @Override
-    protected SslContext wrapContext(SslContext context) {
+    protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
         if (context instanceof OpenSslContext) {
-            ((OpenSslContext) context).setUseTasks(useTasks);
+            if (param instanceof OpenSslEngineTestParam) {
+                ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
+            }
             // Explicit enable the session cache as its disabled by default on the client side.
             ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
         }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTestParam.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTestParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,20 +15,20 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.jupiter.api.BeforeAll;
-
-import javax.net.ssl.SSLException;
-import java.io.File;
-
-public class OpenSslServerContextTest extends SslContextTest {
-
-    @BeforeAll
-    public static void checkOpenSsl() {
-        OpenSsl.ensureAvailability();
+final class OpenSslEngineTestParam extends SSLEngineTest.SSLEngineTestParam {
+    final boolean useTasks;
+    OpenSslEngineTestParam(boolean useTasks, SSLEngineTest.SSLEngineTestParam param) {
+        super(param.type(), param.combo(), param.delegate());
+        this.useTasks = useTasks;
     }
 
     @Override
-    protected SslContext newSslContext(File crtFile, File keyFile, String pass) throws SSLException {
-        return new OpenSslServerContext(crtFile, keyFile, pass);
+    public String toString() {
+        return "OpenSslEngineTestParam{" +
+                "type=" + type() +
+                ", protocolCipherCombo=" + combo() +
+                ", delegate=" + delegate() +
+                ", useTasks=" + useTasks +
+                '}';
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslErrorStackAssertSSLEngine.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslErrorStackAssertSSLEngine.java
@@ -18,7 +18,6 @@ package io.netty.handler.ssl;
 import io.netty.internal.tcnative.SSL;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assert;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
@@ -28,6 +27,8 @@ import javax.net.ssl.SSLSession;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.function.BiFunction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Special {@link SSLEngine} which allows to wrap a {@link ReferenceCountedOpenSslEngine} and verify that that
@@ -436,6 +437,6 @@ final class OpenSslErrorStackAssertSSLEngine extends JdkSslEngine implements Ref
 
     private static void assertErrorStackEmpty() {
         long error = SSL.getLastErrorNumber();
-        Assert.assertEquals("SSL error stack non-empty: " + SSL.getErrorString(error), 0, error);
+        assertEquals(0, error, "SSL error stack non-empty: " + SSL.getErrorString(error));
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
@@ -15,57 +15,38 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
 import javax.net.ssl.SSLEngine;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@RunWith(Parameterized.class)
 public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
 
-    @Parameterized.Parameters(name = "{index}: bufferType = {0}, combo = {1}, delegate = {2}, useTasks = {3}")
-    public static Collection<Object[]> data() {
-        List<Object[]> params = new ArrayList<Object[]>();
-        for (BufferType type: BufferType.values()) {
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false, false });
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), false, true });
+    public OpenSslJdkSslEngineInteroptTest() {
+        super(SslProvider.isTlsv13Supported(SslProvider.JDK) &&
+                SslProvider.isTlsv13Supported(SslProvider.OPENSSL));
+    }
 
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true, false});
-            params.add(new Object[] { type, ProtocolCipherCombo.tlsv12(), true, true });
-
-            if (SslProvider.isTlsv13Supported(SslProvider.JDK) && SslProvider.isTlsv13Supported(SslProvider.OPENSSL)) {
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), false, false });
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), false, true });
-
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), true, false });
-                params.add(new Object[] { type, ProtocolCipherCombo.tlsv13(), true, true });
-            }
+    @Override
+    protected List<SSLEngineTestParam> newTestParams() {
+        List<SSLEngineTestParam> params = super.newTestParams();
+        List<SSLEngineTestParam> testParams = new ArrayList<SSLEngineTestParam>();
+        for (SSLEngineTestParam param: params) {
+            testParams.add(new OpenSslEngineTestParam(true, param));
+            testParams.add(new OpenSslEngineTestParam(false, param));
         }
-        return params;
+        return testParams;
     }
 
-    private final boolean useTasks;
-
-    public OpenSslJdkSslEngineInteroptTest(BufferType type, ProtocolCipherCombo combo,
-                                           boolean delegate, boolean useTasks) {
-        super(type, combo, delegate);
-        this.useTasks = useTasks;
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void checkOpenSsl() {
-        assumeTrue(OpenSsl.isAvailable());
+        OpenSsl.ensureAvailability();
     }
 
     @Override
@@ -78,42 +59,43 @@ public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
         return SslProvider.JDK;
     }
 
-    @Ignore /* Does the JDK support a "max certificate chain length"? */
+    @Disabled /* Does the JDK support a "max certificate chain length"? */
     @Override
-    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() throws Exception {
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
     }
 
-    @Ignore /* Does the JDK support a "max certificate chain length"? */
+    @Disabled /* Does the JDK support a "max certificate chain length"? */
     @Override
-    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth(SSLEngineTestParam param)
+            throws Exception {
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
+        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
+        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
+    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth(SSLEngineTestParam param)
+            throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
+        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth(param);
     }
 
     @Override
-    @Test
-    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth() throws Exception {
+    public void testSessionAfterHandshakeKeyManagerFactoryMutualAuth(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth();
+        super.testSessionAfterHandshakeKeyManagerFactoryMutualAuth(param);
     }
 
     @Override
@@ -123,52 +105,47 @@ public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
     }
 
     @Override
-    public void testHandshakeSession() throws Exception {
+    public void testHandshakeSession(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testHandshakeSession();
+        super.testHandshakeSession(param);
     }
 
     @Override
-    @Test
-    public void testSupportedSignatureAlgorithms() throws Exception {
+    public void testSupportedSignatureAlgorithms(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSupportedSignatureAlgorithms();
+        super.testSupportedSignatureAlgorithms(param);
     }
 
     @Override
-    @Test
-    public void testSessionLocalWhenNonMutualWithKeyManager() throws Exception {
+    public void testSessionLocalWhenNonMutualWithKeyManager(SSLEngineTestParam param) throws Exception {
         checkShouldUseKeyManagerFactory();
-        super.testSessionLocalWhenNonMutualWithKeyManager();
+        super.testSessionLocalWhenNonMutualWithKeyManager(param);
     }
 
     @Override
-    public void testSessionLocalWhenNonMutualWithoutKeyManager() throws Exception {
+    public void testSessionLocalWhenNonMutualWithoutKeyManager(SSLEngineTestParam param) throws Exception {
         // This only really works when the KeyManagerFactory is supported as otherwise we not really know when
         // we need to provide a cert.
         assumeTrue(OpenSsl.supportsKeyManagerFactory());
-        super.testSessionLocalWhenNonMutualWithoutKeyManager();
+        super.testSessionLocalWhenNonMutualWithoutKeyManager(param);
     }
 
     @Override
-    @Test
-    public void testSessionCache() throws Exception {
+    public void testSessionCache(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCache();
+        super.testSessionCache(param);
     }
 
     @Override
-    @Test
-    public void testSessionCacheTimeout() throws Exception {
+    public void testSessionCacheTimeout(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCacheTimeout();
+        super.testSessionCacheTimeout(param);
     }
 
     @Override
-    @Test
-    public void testSessionCacheSize() throws Exception {
+    public void testSessionCacheSize(SSLEngineTestParam param) throws Exception {
         assumeTrue(OpenSsl.isSessionCacheSupported());
-        super.testSessionCacheSize();
+        super.testSessionCacheSize(param);
     }
 
     @Override
@@ -178,9 +155,9 @@ public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
 
     @SuppressWarnings("deprecation")
     @Override
-    protected SslContext wrapContext(SslContext context) {
-        if (context instanceof OpenSslContext) {
-            ((OpenSslContext) context).setUseTasks(useTasks);
+    protected SslContext wrapContext(SSLEngineTestParam param, SslContext context) {
+        if (context instanceof OpenSslContext && param instanceof OpenSslEngineTestParam) {
+            ((OpenSslContext) context).setUseTasks(((OpenSslEngineTestParam) param).useTasks);
             // Explicit enable the session cache as its disabled by default on the client side.
             ((OpenSslContext) context).sessionContext().setSessionCacheEnabled(true);
         }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslRenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslRenegotiateTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -24,11 +24,10 @@ import javax.net.ssl.SSLException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assume.assumeTrue;
 
 public class OpenSslRenegotiateTest extends RenegotiateTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void checkOpenSsl() {
         OpenSsl.ensureAvailability();
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -34,7 +34,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ThrowableUtil;
-import org.junit.Assert;
 
 import javax.net.ssl.ExtendedSSLSession;
 import javax.net.ssl.KeyManager;
@@ -66,6 +65,11 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * In extra class to be able to run tests with java7 without trying to load classes that not exists in java7.
@@ -171,17 +175,17 @@ final class SniClientJava8TestUtil {
     }
 
     private static void assertSSLSession(boolean clientSide, SSLSession session, SNIServerName name) {
-        Assert.assertNotNull(session);
+        assertNotNull(session);
         if (session instanceof ExtendedSSLSession) {
             ExtendedSSLSession extendedSSLSession = (ExtendedSSLSession) session;
             List<SNIServerName> names = extendedSSLSession.getRequestedServerNames();
-            Assert.assertEquals(1, names.size());
-            Assert.assertEquals(name, names.get(0));
-            Assert.assertTrue(extendedSSLSession.getLocalSupportedSignatureAlgorithms().length > 0);
+            assertEquals(1, names.size());
+            assertEquals(name, names.get(0));
+            assertTrue(extendedSSLSession.getLocalSupportedSignatureAlgorithms().length > 0);
             if (clientSide) {
-                Assert.assertEquals(0, extendedSSLSession.getPeerSupportedSignatureAlgorithms().length);
+                assertEquals(0, extendedSSLSession.getPeerSupportedSignatureAlgorithms().length);
             } else {
-                Assert.assertTrue(extendedSSLSession.getPeerSupportedSignatureAlgorithms().length >= 0);
+                assertTrue(extendedSSLSession.getPeerSupportedSignatureAlgorithms().length >= 0);
             }
         }
     }
@@ -214,19 +218,19 @@ final class SniClientJava8TestUtil {
                 @Override
                 public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket)
                         throws CertificateException {
-                    Assert.fail();
+                    fail();
                 }
 
                 @Override
                 public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket)
                         throws CertificateException {
-                    Assert.fail();
+                    fail();
                 }
 
                 @Override
                 public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine)
                         throws CertificateException {
-                    Assert.fail();
+                    fail();
                 }
 
                 @Override
@@ -238,13 +242,13 @@ final class SniClientJava8TestUtil {
                 @Override
                 public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
                         throws CertificateException {
-                    Assert.fail();
+                    fail();
                 }
 
                 @Override
                 public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
                         throws CertificateException {
-                    Assert.fail();
+                    fail();
                 }
 
                 @Override

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -72,7 +72,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextTest.java
@@ -31,7 +31,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
-import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -124,7 +124,7 @@ public abstract class SslContextTest {
         } catch (IllegalArgumentException e) {
             exception = e;
         }
-        assumeNotNull(exception);
+        assumeTrue(exception != null);
         File keyFile = ResourcesUtil.getFile(getClass(), "test_unencrypted.pem");
         File crtFile = ResourcesUtil.getFile(getClass(), "test.crt");
 

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -103,7 +103,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 


### PR DESCRIPTION
Motivation:

We should use junit5 everywhere.

Modifications:

- Refactor rest of tests to use junit5

Result:

Part of https://github.com/netty/netty/issues/10757