### PR TITLE
Disable flaky test for now

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -74,6 +75,13 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
     @Override
     protected SslProvider sslServerProvider() {
         return SslProvider.OPENSSL;
+    }
+
+    @Override
+    @Test
+    @Ignore("Disable until figured out why this sometimes fail on the CI")
+    public void testMutualAuthSameCerts() throws Throwable {
+        super.testMutualAuthSameCerts();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

JdkOpenSslEngineInteroptTest.testMutualAuthSameCerts() is flaky on the CI and so fails the PR build quite often.
Let's disable it for now until we were able to reproduce it locally and fix it.

Modifications:

Disable flaky test

Result:

More stable CI builds