### PR TITLE
Add PromiseNotifier static method which takes care of cancel propagation

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -21,9 +21,9 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.concurrent.ScheduledFuture;
 
 import java.net.SocketAddress;
@@ -113,7 +113,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             promise.setFailure(new ClosedChannelException());
         } else if (msg instanceof CloseWebSocketFrame) {
             closeSent(promise.unvoid());
-            ctx.write(msg).addListener(new ChannelPromiseNotifier(false, closeSent));
+            ctx.write(msg).addListener(new PromiseNotifier<Void, ChannelFuture>(false, closeSent));
         } else {
             ctx.write(msg, promise);
         }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
@@ -188,7 +188,7 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), promise);
-                    PromiseNotifier.fuse(f, promise);
+                    PromiseNotifier.link(f, promise);
                 }
             });
             return promise;

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
@@ -188,7 +188,7 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), promise);
-                    PromiseNotifier.link(f, promise);
+                    PromiseNotifier.cascade(f, promise);
                 }
             });
             return promise;

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
@@ -21,9 +21,9 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.PromiseNotifier;
 
 import java.util.concurrent.TimeUnit;
 
@@ -188,7 +188,7 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), promise);
-                    f.addListener(new ChannelPromiseNotifier(promise));
+                    PromiseNotifier.fuse(f, promise);
                 }
             });
             return promise;

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -254,7 +254,7 @@ public class JZlibEncoder extends ZlibEncoder {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), p);
-                    PromiseNotifier.fuse(f, promise);
+                    PromiseNotifier.link(f, promise);
                 }
             });
             return p;

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -254,7 +254,7 @@ public class JZlibEncoder extends ZlibEncoder {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), p);
-                    PromiseNotifier.link(f, promise);
+                    PromiseNotifier.cascade(f, promise);
                 }
             });
             return p;

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -23,8 +23,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ObjectUtil;
 
@@ -254,7 +254,7 @@ public class JZlibEncoder extends ZlibEncoder {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), p);
-                    f.addListener(new ChannelPromiseNotifier(promise));
+                    PromiseNotifier.fuse(f, promise);
                 }
             });
             return p;

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -20,8 +20,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SuppressJava6Requirement;
@@ -166,7 +166,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), p);
-                    f.addListener(new ChannelPromiseNotifier(promise));
+                    PromiseNotifier.fuse(f, promise);
                 }
             });
             return p;

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -166,7 +166,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), p);
-                    PromiseNotifier.link(f, promise);
+                    PromiseNotifier.cascade(f, promise);
                 }
             });
             return p;

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -166,7 +166,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), p);
-                    PromiseNotifier.fuse(f, promise);
+                    PromiseNotifier.link(f, promise);
                 }
             });
             return p;

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -359,7 +359,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), promise);
-                    PromiseNotifier.fuse(f, promise);
+                    PromiseNotifier.link(f, promise);
                 }
             });
             return promise;

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -359,7 +359,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), promise);
-                    PromiseNotifier.link(f, promise);
+                    PromiseNotifier.cascade(f, promise);
                 }
             });
             return promise;

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -23,10 +23,10 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.ObjectUtil;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Exception;
@@ -359,7 +359,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
                 @Override
                 public void run() {
                     ChannelFuture f = finishEncode(ctx(), promise);
-                    f.addListener(new ChannelPromiseNotifier(promise));
+                    PromiseNotifier.fuse(f, promise);
                 }
             });
             return promise;

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -62,9 +62,9 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
     }
 
     /**
-     * Link the {@link Future} and {@link Promise}. This means that if the {@link Future} completes the {@link Promise}
-     * will be notified. That said cancellation is propagated both ways. This means if the {@link Future} is cancelled
-     * the {@link Promise} is cancelled as well and vise-versa.
+     * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise}
+     * will be notified. Cancellation is propagated both ways such that if the {@link Future} is cancelled
+     * the {@link Promise} is cancelled and vise-versa.
      *
      * @param future    the {@link Future} which will be used to listen to for notifying the {@link Promise}.
      * @param promise   the {@link Promise} which will be notified

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -62,7 +62,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
     }
 
     /**
-     * Fuse the {@link Future} and {@link Promise}. This means that if the {@link Future} completes the {@link Promise}
+     * Link the {@link Future} and {@link Promise}. This means that if the {@link Future} completes the {@link Promise}
      * will be notified. That said cancellation is propagated both ways. This means if the {@link Future} is cancelled
      * the {@link Promise} is cancelled as well and vise-versa.
      *
@@ -72,12 +72,12 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
      * @param <F>       the type of the {@link Future}
      * @return          the passed in {@link Future}
      */
-    public static <V, F extends Future<V>> F fuse(final F future, final Promise<? super V> promise) {
-        return fuse(true, future, promise);
+    public static <V, F extends Future<V>> F link(final F future, final Promise<? super V> promise) {
+        return link(true, future, promise);
     }
 
     /**
-     * Fuse the {@link Future} and {@link Promise}. This means that if the {@link Future} completes the {@link Promise}
+     * Link the {@link Future} and {@link Promise}. This means that if the {@link Future} completes the {@link Promise}
      * will be notified. That said cancellation is propagated both ways. This means if the {@link Future} is cancelled
      * the {@link Promise} is cancelled as well and vise-versa.
      *
@@ -89,7 +89,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
      * @return                  the passed in {@link Future}
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <V, F extends Future<V>> F fuse(boolean logNotifyFailure, final F future,
+    public static <V, F extends Future<V>> F link(boolean logNotifyFailure, final F future,
                                                   final Promise<? super V> promise) {
         promise.addListener(new FutureListener() {
             @Override

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -72,14 +72,14 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
      * @param <F>       the type of the {@link Future}
      * @return          the passed in {@link Future}
      */
-    public static <V, F extends Future<V>> F link(final F future, final Promise<? super V> promise) {
-        return link(true, future, promise);
+    public static <V, F extends Future<V>> F cascade(final F future, final Promise<? super V> promise) {
+        return cascade(true, future, promise);
     }
 
     /**
-     * Link the {@link Future} and {@link Promise}. This means that if the {@link Future} completes the {@link Promise}
-     * will be notified. That said cancellation is propagated both ways. This means if the {@link Future} is cancelled
-     * the {@link Promise} is cancelled as well and vise-versa.
+     * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise}
+     * will be notified. Cancellation is propagated both ways such that if the {@link Future} is cancelled
+     * the {@link Promise} is cancelled and vise-versa.
      *
      * @param logNotifyFailure  {@code true} if logging should be done in case notification fails.
      * @param future            the {@link Future} which will be used to listen to for notifying the {@link Promise}.
@@ -89,8 +89,8 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
      * @return                  the passed in {@link Future}
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <V, F extends Future<V>> F link(boolean logNotifyFailure, final F future,
-                                                  final Promise<? super V> promise) {
+    public static <V, F extends Future<V>> F cascade(boolean logNotifyFailure, final F future,
+                                                     final Promise<? super V> promise) {
         promise.addListener(new FutureListener() {
             @Override
             public void operationComplete(Future f) {

--- a/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
@@ -97,17 +97,14 @@ public class PromiseNotifierTest {
 
     @Test
     public void testCancelPropagationWhenFusedFromFuture() {
-        @SuppressWarnings("unchecked")
-        Promise<Void> p1 = mock(Promise.class);
-        when(p1.cancel(false)).thenReturn(true);
+        Promise<Void> p1 = ImmediateEventExecutor.INSTANCE.newPromise();
+        Promise<Void> p2 = ImmediateEventExecutor.INSTANCE.newPromise();
 
-        Promise<Void> promise = ImmediateEventExecutor.INSTANCE.newPromise();
-
-        Promise<Void> returned = PromiseNotifier.link(promise, p1);
-        assertSame(promise, returned);
+        Promise<Void> returned = PromiseNotifier.link(p1, p2);
+        assertSame(p1, returned);
 
         assertTrue(returned.cancel(false));
         assertTrue(returned.isCancelled());
-        verify(p1).cancel(false);
+        assertTrue(p2.isCancelled());
     }
 }

--- a/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
@@ -100,7 +100,7 @@ public class PromiseNotifierTest {
         Promise<Void> p1 = ImmediateEventExecutor.INSTANCE.newPromise();
         Promise<Void> p2 = ImmediateEventExecutor.INSTANCE.newPromise();
 
-        Promise<Void> returned = PromiseNotifier.link(p1, p2);
+        Promise<Void> returned = PromiseNotifier.cascade(p1, p2);
         assertSame(p1, returned);
 
         assertTrue(returned.cancel(false));

--- a/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
@@ -103,7 +103,7 @@ public class PromiseNotifierTest {
 
         Promise<Void> promise = ImmediateEventExecutor.INSTANCE.newPromise();
 
-        Promise<Void> returned = PromiseNotifier.fuse(promise, p1);
+        Promise<Void> returned = PromiseNotifier.link(promise, p1);
         assertSame(promise, returned);
 
         assertTrue(returned.cancel(false));

--- a/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
@@ -19,7 +19,9 @@ package io.netty.util.concurrent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class PromiseNotifierTest {
@@ -93,4 +95,19 @@ public class PromiseNotifierTest {
         verify(p2).tryFailure(t);
     }
 
+    @Test
+    public void testCancelPropagationWhenFusedFromFuture() {
+        @SuppressWarnings("unchecked")
+        Promise<Void> p1 = mock(Promise.class);
+        when(p1.cancel(false)).thenReturn(true);
+
+        Promise<Void> promise = ImmediateEventExecutor.INSTANCE.newPromise();
+
+        Promise<Void> returned = PromiseNotifier.fuse(promise, p1);
+        assertSame(promise, returned);
+
+        assertTrue(returned.cancel(false));
+        assertTrue(returned.isCancelled());
+        verify(p1).cancel(false);
+    }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -33,7 +33,6 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
@@ -1949,8 +1948,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 // because of a propagated Exception.
                 //
                 // See https://github.com/netty/netty/issues/5931
-                safeClose(ctx, closeNotifyPromise, ctx.newPromise().addListener(
-                        new ChannelPromiseNotifier(false, promise)));
+                safeClose(ctx, closeNotifyPromise, PromiseNotifier.fuse(false, ctx.newPromise(), promise));
             } else {
                 /// We already handling the close_notify so just attach the promise to the sslClosePromise.
                 sslClosePromise.addListener(new FutureListener<Channel>() {
@@ -2053,7 +2051,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         if (!oldHandshakePromise.isDone()) {
             // There's no need to handshake because handshake is in progress already.
             // Merge the new promise into the old one.
-            oldHandshakePromise.addListener(new PromiseNotifier<Channel, Future<Channel>>(newHandshakePromise));
+            PromiseNotifier.fuse(oldHandshakePromise, newHandshakePromise);
         } else {
             handshakePromise = newHandshakePromise;
             handshake(true);
@@ -2234,7 +2232,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         // IllegalStateException.
         // Also we not want to log if the notification happens as this is expected in some cases.
         // See https://github.com/netty/netty/issues/5598
-        future.addListener(new ChannelPromiseNotifier(false, promise));
+        PromiseNotifier.fuse(false, future, promise);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1948,7 +1948,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 // because of a propagated Exception.
                 //
                 // See https://github.com/netty/netty/issues/5931
-                safeClose(ctx, closeNotifyPromise, PromiseNotifier.fuse(false, ctx.newPromise(), promise));
+                safeClose(ctx, closeNotifyPromise, PromiseNotifier.link(false, ctx.newPromise(), promise));
             } else {
                 /// We already handling the close_notify so just attach the promise to the sslClosePromise.
                 sslClosePromise.addListener(new FutureListener<Channel>() {
@@ -2051,7 +2051,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         if (!oldHandshakePromise.isDone()) {
             // There's no need to handshake because handshake is in progress already.
             // Merge the new promise into the old one.
-            PromiseNotifier.fuse(oldHandshakePromise, newHandshakePromise);
+            PromiseNotifier.link(oldHandshakePromise, newHandshakePromise);
         } else {
             handshakePromise = newHandshakePromise;
             handshake(true);
@@ -2232,7 +2232,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         // IllegalStateException.
         // Also we not want to log if the notification happens as this is expected in some cases.
         // See https://github.com/netty/netty/issues/5598
-        PromiseNotifier.fuse(false, future, promise);
+        PromiseNotifier.link(false, future, promise);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1948,7 +1948,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 // because of a propagated Exception.
                 //
                 // See https://github.com/netty/netty/issues/5931
-                safeClose(ctx, closeNotifyPromise, PromiseNotifier.link(false, ctx.newPromise(), promise));
+                safeClose(ctx, closeNotifyPromise, PromiseNotifier.cascade(false, ctx.newPromise(), promise));
             } else {
                 /// We already handling the close_notify so just attach the promise to the sslClosePromise.
                 sslClosePromise.addListener(new FutureListener<Channel>() {
@@ -2051,7 +2051,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         if (!oldHandshakePromise.isDone()) {
             // There's no need to handshake because handshake is in progress already.
             // Merge the new promise into the old one.
-            PromiseNotifier.link(oldHandshakePromise, newHandshakePromise);
+            PromiseNotifier.cascade(oldHandshakePromise, newHandshakePromise);
         } else {
             handshakePromise = newHandshakePromise;
             handshake(true);
@@ -2232,7 +2232,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         // IllegalStateException.
         // Also we not want to log if the notification happens as this is expected in some cases.
         // See https://github.com/netty/netty/issues/5598
-        PromiseNotifier.link(false, future, promise);
+        PromiseNotifier.cascade(false, future, promise);
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -436,7 +436,7 @@ public class ParameterizedSslHandlerTest {
                         protected void initChannel(Channel ch) throws Exception {
                             SslHandler handler = sslServerCtx.newHandler(ch.alloc());
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
-                            PromiseNotifier.link(handler.sslCloseFuture(), serverPromise);
+                            PromiseNotifier.cascade(handler.sslCloseFuture(), serverPromise);
                             handler.handshakeFuture().addListener(new FutureListener<Channel>() {
                                 @Override
                                 public void operationComplete(Future<Channel> future) {
@@ -474,7 +474,7 @@ public class ParameterizedSslHandlerTest {
 
                             SslHandler handler = sslClientCtx.newHandler(ch.alloc());
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
-                            PromiseNotifier.link(handler.sslCloseFuture(), clientPromise);
+                            PromiseNotifier.cascade(handler.sslCloseFuture(), clientPromise);
                             handler.handshakeFuture().addListener(new FutureListener<Channel>() {
                                 @Override
                                 public void operationComplete(Future<Channel> future) {

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -436,7 +436,7 @@ public class ParameterizedSslHandlerTest {
                         protected void initChannel(Channel ch) throws Exception {
                             SslHandler handler = sslServerCtx.newHandler(ch.alloc());
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
-                            PromiseNotifier.fuse(handler.sslCloseFuture(), serverPromise);
+                            PromiseNotifier.link(handler.sslCloseFuture(), serverPromise);
                             handler.handshakeFuture().addListener(new FutureListener<Channel>() {
                                 @Override
                                 public void operationComplete(Future<Channel> future) {
@@ -474,7 +474,7 @@ public class ParameterizedSslHandlerTest {
 
                             SslHandler handler = sslClientCtx.newHandler(ch.alloc());
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
-                            PromiseNotifier.fuse(handler.sslCloseFuture(), clientPromise);
+                            PromiseNotifier.link(handler.sslCloseFuture(), clientPromise);
                             handler.handshakeFuture().addListener(new FutureListener<Channel>() {
                                 @Override
                                 public void operationComplete(Future<Channel> future) {

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -436,8 +436,7 @@ public class ParameterizedSslHandlerTest {
                         protected void initChannel(Channel ch) throws Exception {
                             SslHandler handler = sslServerCtx.newHandler(ch.alloc());
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
-                            handler.sslCloseFuture().addListener(
-                                    new PromiseNotifier<Channel, Future<Channel>>(serverPromise));
+                            PromiseNotifier.fuse(handler.sslCloseFuture(), serverPromise);
                             handler.handshakeFuture().addListener(new FutureListener<Channel>() {
                                 @Override
                                 public void operationComplete(Future<Channel> future) {
@@ -475,8 +474,7 @@ public class ParameterizedSslHandlerTest {
 
                             SslHandler handler = sslClientCtx.newHandler(ch.alloc());
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
-                            handler.sslCloseFuture().addListener(
-                                    new PromiseNotifier<Channel, Future<Channel>>(clientPromise));
+                            PromiseNotifier.fuse(handler.sslCloseFuture(), clientPromise);
                             handler.handshakeFuture().addListener(new FutureListener<Channel>() {
                                 @Override
                                 public void operationComplete(Future<Channel> future) {

--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -19,7 +19,10 @@ import io.netty.util.concurrent.PromiseNotifier;
 
 /**
  * ChannelFutureListener implementation which takes other {@link ChannelPromise}(s) and notifies them on completion.
+ *
+ * @deprecated use {@link PromiseNotifier}.
  */
+@Deprecated
 public final class ChannelPromiseNotifier
     extends PromiseNotifier<Void, ChannelFuture>
     implements ChannelFutureListener {


### PR DESCRIPTION
Motivation:

At the moment we not correctly propagate cancellation in some case when we use the PromiseNotifier.

Modifications:

- Add PromiseNotifier static method which takes care of cancellation
- Add unit test

Result:

Correctly propagate cancellation of operation
