### PR TITLE
ApplicationProtocolNegotiationHandler should enforce the present of S…

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -77,14 +77,16 @@ public class ApplicationProtocolNegotiationHandlerTest {
             }
         };
 
+        SSLEngine engine = SSLContext.getDefault().createSSLEngine();
+        engine.setUseClientMode(true);
         EmbeddedChannel channel = new EmbeddedChannel(
-                new SslHandler(SSLContext.getDefault().createSSLEngine()), alpnHandler);
+                new SslHandler(engine), alpnHandler);
         SSLHandshakeException exception = new SSLHandshakeException("error");
         SslHandshakeCompletionEvent completionEvent = new SslHandshakeCompletionEvent(exception);
         channel.pipeline().fireUserEventTriggered(completionEvent);
         channel.pipeline().fireExceptionCaught(new DecoderException(exception));
         assertNull(channel.pipeline().context(alpnHandler));
-        assertFalse(channel.finishAndReleaseAll());
+        channel.finishAndReleaseAll();
     }
 
     @Test
@@ -124,6 +126,8 @@ public class ApplicationProtocolNegotiationHandlerTest {
         };
         SslHandler sslHandler = new SslHandler(SSLContext.getDefault().createSSLEngine());
         final EmbeddedChannel channel = new EmbeddedChannel(sslHandler, alpnHandler);
+        channel.runPendingTasks();
+
         channel.pipeline().remove(sslHandler);
         channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -117,29 +117,6 @@ public class ApplicationProtocolNegotiationHandlerTest {
     }
 
     @Test
-    public void testHandshakeSuccessButNoSslHandler() throws NoSuchAlgorithmException {
-        ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
-            @Override
-            protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
-                fail();
-            }
-        };
-        SslHandler sslHandler = new SslHandler(SSLContext.getDefault().createSSLEngine());
-        final EmbeddedChannel channel = new EmbeddedChannel(sslHandler, alpnHandler);
-        channel.runPendingTasks();
-
-        channel.pipeline().remove(sslHandler);
-        channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
-        assertNull(channel.pipeline().context(alpnHandler));
-        assertThrows(IllegalStateException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.finishAndReleaseAll();
-            }
-        });
-    }
-
-    @Test
     public void testBufferMessagesUntilHandshakeComplete() throws Exception {
         testBufferMessagesUntilHandshakeComplete(null);
     }


### PR DESCRIPTION
…slHandler in the ChannelPipeline

Motivation:

750d23583c187b4e8dafdfea3f4fbeaf1d9be7cd did introduce a change in ApplicationProtocolNegotiationHandler that let the handler buffer all inbound data until the SSL handshake was completed. Due of this change a user might get buffer data forever if the SslHandler is not in the pipeline but the ApplicationProtocolNegotiationHandler was added. We should better guard the user against this "missconfiguration" of the ChannelPipeline.

Modifications:

- Enforce the presents of SslHandler in the ChannelPipeline when ApplicationProtocolNegotiationHandler is added
- Add unit tests
- Clarify in the javadocs the relationship between SslHandler and ApplicationProtocolNegotiationHandler

Result:

Less likely the user missconfigure the ChannelPipeline when using the ApplicationProtocolNegotiationHandler.
