### PR TITLE
Be able to build on JDK17

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -1103,7 +1103,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
             SSLParameters parameters = new SSLParameters();
             Java8SslTestUtils.setSNIMatcher(parameters, name);
             engine.setSSLParameters(parameters);
-            assertTrue(unwrapEngine(engine).checkSniHostnameMatch(name));
             assertFalse(unwrapEngine(engine).checkSniHostnameMatch("other".getBytes(CharsetUtil.UTF_8)));
         } finally {
             cleanupServerSslEngine(engine);

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,32 @@
         <testJvm />
       </properties>
     </profile>
+    <profile>
+      <id>java17</id>
+      <activation>
+        <jdk>17</jdk>
+      </activation>
+      <properties>
+        <!-- Not use alpn agent as Java11+ supports alpn out of the box -->
+        <argLine.alpnAgent />
+        <argLine.java9.extras />
+        <!-- Export some stuff which is used during our tests -->
+        <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
+        <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
+        <!-- 1.4.x does not work in Java10+ -->
+        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <!-- This is the minimum supported by Java12+ -->
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <!-- pax-exam does not work on latest Java12 EA 22 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <!-- doesn't work with java16 -->
+        <skipJapicmp>true</skipJapicmp>
+      </properties>
+    </profile>
+
     <!-- JDK16 -->
     <profile>
       <id>java16</id>

--- a/pom.xml
+++ b/pom.xml
@@ -203,8 +203,6 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
-        <!-- doesn't work with java16 -->
-        <skipJapicmp>true</skipJapicmp>
       </properties>
     </profile>
 


### PR DESCRIPTION
Motivation:

As the release of JDK17 is getting closer and there are ea builds already we should ensure we can actually build netty with it.

Modifications:

- Add profile for JDK17
- Remove test-code that would fail with JDK17 due the changes in https://github.com/openjdk/jdk17/commit/4f4d0f5366a8926f373ea25774a536399281c841.

Result:

Be able to build and run testsuite with JDK17
