### PR TITLE
Remove ApplicationProtocolNegotiationHandler when no SslHandler is pr…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -102,13 +102,9 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
         if (!sslHandlerChecked) {
             sslHandlerChecked = true;
             if (ctx.pipeline().get(SslHandler.class) == null) {
-                if (bufferedMessages.isEmpty()) {
-                    ctx.fireChannelRead(msg);
-                } else {
-                    // Add to the buffered messages and just remove ourself. This will take care of keep the correct
-                    // ordering.
-                    bufferedMessages.add(msg);
-                }
+                // Add to the buffered messages and just remove ourself. This will take care of keep the correct
+                // ordering.
+                bufferedMessages.add(msg);
                 removeSelfIfPresent(ctx);
                 return;
             }

--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -99,18 +99,16 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        // Let's buffer all data until this handler will be removed from the pipeline.
+        bufferedMessages.add(msg);
         if (!sslHandlerChecked) {
             sslHandlerChecked = true;
             if (ctx.pipeline().get(SslHandler.class) == null) {
-                // Add to the buffered messages and just remove ourself. This will take care of keep the correct
-                // ordering.
-                bufferedMessages.add(msg);
+                // Just remove ourself if there is no SslHandler in the pipeline and so we would otherwise
+                // buffer forever.
                 removeSelfIfPresent(ctx);
-                return;
             }
         }
-        // Let's buffer all data until this handler will be removed from the pipeline.
-        bufferedMessages.add(msg);
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -59,11 +59,15 @@ public class ApplicationProtocolNegotiationHandlerTest {
 
         EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
         String msg = "msg";
+        String msg2 = "msg2";
+
         assertTrue(channel.writeInbound(msg));
+        assertTrue(channel.writeInbound(msg2));
         assertNull(channel.pipeline().context(alpnHandler));
         assertEquals(msg, channel.readInbound());
+        assertEquals(msg2, channel.readInbound());
 
-        channel.finishAndReleaseAll();
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test


### PR DESCRIPTION
…esent

Motivation:

Motivation:

750d235 did introduce a change in ApplicationProtocolNegotiationHandler that let the handler buffer all inbound data until the SSL handshake was completed. Due of this change a user might get buffer data forever if the SslHandler is not in the pipeline but the ApplicationProtocolNegotiationHandler was added. We should better guard the user against this "missconfiguration" of the ChannelPipeline.

Modifications:

- Remove the ApplicationProtocolNegotiationHandler when no SslHandler is present when the first message was received
- Add unit test

Result:

No possible that we buffer forever

