### PR TITLE
Update japicmp plugin to support Java16+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,8 +204,6 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
-        <!-- doesn't work with java16 -->
-        <skipJapicmp>true</skipJapicmp>
       </properties>
     </profile>
 
@@ -987,7 +985,7 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.14.3</version>
+        <version>0.15.3</version>
         <configuration>
           <parameter>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>


### PR DESCRIPTION
Motivation:

japicmp did fix some issues related to Java16+. Let's update so we can also enable it in later java versions

Modifications:

Update to 0.15.3

Result:

Be able to use japicmp with all java versions
