### PR TITLE
Use junit5 methods

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 final class OpenSslTestUtils {
     private OpenSslTestUtils() {


### PR DESCRIPTION
Motivation:

We missed to update one junit4 method usage to junit5

Modifications:

Use junit5 methods

Result:

No more usage of junit4
