### PR TITLE
Bump Brotli4j to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <skipJapicmp>false</skipJapicmp>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.4.2</brotli4j.version>
+    <brotli4j.version>1.5.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:
Brotli4j had some changes for performance improvements. So we should upgrade to the latest version of Brotli4j.

See https://github.com/hyperxpro/Brotli4j/pull/27

Modification:
Upgraded Broti4j from 1.4.2 to 1.5.0.

Result:
Up-to-date Broti4j library.
