### PR TITLE
Fix JavaDoc of SelfSignedCertiticate regarding Private Key type

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -285,7 +285,7 @@ public final class SelfSignedCertificate {
     }
 
     /**
-     * Returns the generated RSA private key file in PEM format.
+     * Returns the generated EC/RSA private key file in PEM format.
      */
     public File privateKey() {
         return privateKey;
@@ -299,14 +299,14 @@ public final class SelfSignedCertificate {
     }
 
     /**
-     * Returns the generated RSA private key.
+     * Returns the generated EC/RSA private key.
      */
     public PrivateKey key() {
         return key;
     }
 
     /**
-     * Deletes the generated X.509 certificate file and RSA private key file.
+     * Deletes the generated X.509 certificate file and EC/RSA private key file.
      */
     public void delete() {
         safeDelete(certificate);


### PR DESCRIPTION
Motivation:
SelfSignedCertificate generates EC/RSA key pair and this should be explicitly mentioned in JavaDoc. Currently, only "RSA" was mentioned not "EC".

Modification:
Changed RSA to EC/RSA

Result:
Correct JavaDoc
