### PR TITLE
Remove overrides of Throwable.fillInStackTrace

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -573,17 +573,7 @@ public class ResourceLeakDetector<T> {
     private static class TraceRecord extends Throwable {
         private static final long serialVersionUID = 6065153674892850720L;
 
-        private static final TraceRecord BOTTOM = new TraceRecord() {
-            private static final long serialVersionUID = 7396077602074694571L;
-
-            // Override fillInStackTrace() so we not populate the backtrace via a native call and so leak the
-            // Classloader.
-            // See https://github.com/netty/netty/pull/10691
-            @Override
-            public Throwable fillInStackTrace() {
-                return this;
-            }
-        };
+        private static final TraceRecord BOTTOM = new TraceRecord();
 
         private final String hintString;
         private final TraceRecord next;
@@ -593,17 +583,18 @@ public class ResourceLeakDetector<T> {
             // This needs to be generated even if toString() is never called as it may change later on.
             hintString = hint instanceof ResourceLeakHint ? ((ResourceLeakHint) hint).toHintString() : hint.toString();
             this.next = next;
-            this.pos = next.pos + 1;
+            pos = next.pos + 1;
         }
 
         TraceRecord(TraceRecord next) {
            hintString = null;
            this.next = next;
-           this.pos = next.pos + 1;
+           pos = next.pos + 1;
         }
 
         // Used to terminate the stack
         private TraceRecord() {
+            super(null, null, false, false);
             hintString = null;
             next = null;
             pos = -1;

--- a/common/src/main/java/io/netty/util/Signal.java
+++ b/common/src/main/java/io/netty/util/Signal.java
@@ -51,6 +51,7 @@ public final class Signal extends Error implements Constant<Signal> {
      * Creates a new {@link Signal} with the specified {@code name}.
      */
     private Signal(int id, String name) {
+        super(null, null, false, false);
         constant = new SignalConstant(id, name);
     }
 
@@ -62,18 +63,6 @@ public final class Signal extends Error implements Constant<Signal> {
         if (this != signal) {
             throw new IllegalStateException("unexpected signal: " + signal);
         }
-    }
-
-    // Suppress a warning since the method doesn't need synchronization
-    @Override
-    public Throwable initCause(Throwable cause) {   // lgtm[java/non-sync-override]
-        return this;
-    }
-
-    // Suppress a warning since the method doesn't need synchronization
-    @Override
-    public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
-        return this;
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/timeout/TimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/TimeoutException.java
@@ -31,10 +31,4 @@ public class TimeoutException extends ChannelException {
     TimeoutException(boolean shared) {
         super(null, null, shared);
     }
-
-    // Suppress a warning since the method doesn't need synchronization
-    @Override
-    public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
-        return this;
-    }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverException.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverException.java
@@ -33,14 +33,14 @@ public class DnsNameResolverException extends RuntimeException {
     private final DnsQuestion question;
 
     public DnsNameResolverException(InetSocketAddress remoteAddress, DnsQuestion question, String message) {
-        super(message);
+        super(message, null, true, false);
         this.remoteAddress = validateRemoteAddress(remoteAddress);
         this.question = validateQuestion(question);
     }
 
     public DnsNameResolverException(
             InetSocketAddress remoteAddress, DnsQuestion question, String message, Throwable cause) {
-        super(message, cause);
+        super(message, cause, true, false);
         this.remoteAddress = validateRemoteAddress(remoteAddress);
         this.question = validateQuestion(question);
     }
@@ -65,12 +65,5 @@ public class DnsNameResolverException extends RuntimeException {
      */
     public DnsQuestion question() {
         return question;
-    }
-
-    // Suppress a warning since the method doesn't need synchronization
-    @Override
-    public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
-        setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        return this;
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -118,7 +118,7 @@ abstract class DnsResolveContext<T> {
         private static final long serialVersionUID = 1209303419266433003L;
 
         private DnsResolveContextException(String message) {
-            super(message, null, false, true);
+            super(message, null, false, true); // Need to keep the stack trace mutable.
         }
 
         // Override fillInStackTrace() so we not populate the backtrace via a native call and so leak the

--- a/transport/src/main/java/io/netty/channel/ChannelException.java
+++ b/transport/src/main/java/io/netty/channel/ChannelException.java
@@ -53,7 +53,7 @@ public class ChannelException extends RuntimeException {
 
     @UnstableApi
     protected ChannelException(String message, Throwable cause, boolean shared) {
-        super(message, cause, false, true);
+        super(message, cause, false, false);
         assert shared;
     }
 }


### PR DESCRIPTION
Motivation:
Since Java 7, there are new constructors available that allow us to avoid initialising the stack traces of certain exceptions.

Modification:
Use these constructors instead of overriding Throwable.fillInStackTrace.

Result:
Cleaner code