### PR TITLE
All *Bootstrap methods that used to return ChannelFuture now return Future<Channel>

### DIFF
--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -62,13 +62,13 @@ public class HAProxyIntegrationTest {
                   });
               }
           });
-        Channel serverChannel = sb.bind(localAddress).sync().channel();
+        Channel serverChannel = sb.bind(localAddress).get();
 
         Bootstrap b = new Bootstrap();
         Channel clientChannel = b.channel(LocalChannel.class)
                                  .handler(HAProxyMessageEncoder.INSTANCE)
                                  .group(group)
-                                 .connect(localAddress).sync().channel();
+                                 .connect(localAddress).get();
 
         try {
             HAProxyMessage message = new HAProxyMessage(

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -19,7 +19,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -57,8 +56,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyShort;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -405,6 +404,7 @@ public class DataCompressionHttp2Test {
                         .codec(decoder, clientEncoder).build();
                 p.addLast(clientHandler);
                 p.addLast(new ChannelHandler() {
+                    @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();
@@ -415,12 +415,10 @@ public class DataCompressionHttp2Test {
             }
         });
 
-        serverChannel = sb.bind(new InetSocketAddress(0)).sync().channel();
+        serverChannel = sb.bind(new InetSocketAddress(0)).get();
         int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
 
-        ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
-        assertTrue(ccf.awaitUninterruptibly().isSuccess());
-        clientChannel = ccf.channel();
+        clientChannel = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port)).get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));
         assertTrue(serverChannelLatch.await(5, SECONDS));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -321,7 +321,7 @@ public class Http2ConnectionRoundtripTest {
         final CountDownLatch serverSettingsAckLatch2 = new CountDownLatch(2);
         final CountDownLatch serverDataLatch = new CountDownLatch(1);
         final CountDownLatch clientWriteDataLatch = new CountDownLatch(1);
-        final byte[] data = new byte[] {1, 2, 3, 4, 5};
+        final byte[] data = {1, 2, 3, 4, 5};
         final ByteArrayOutputStream out = new ByteArrayOutputStream(data.length);
 
         doAnswer((Answer<Void>) invocationOnMock -> {
@@ -868,7 +868,7 @@ public class Http2ConnectionRoundtripTest {
         final CountDownLatch probeStreamCount = new CountDownLatch(1);
         final AtomicBoolean stream3Exists = new AtomicBoolean();
         final AtomicInteger streamCount = new AtomicInteger();
-        runInChannel(this.clientChannel, () -> {
+        runInChannel(clientChannel, () -> {
             stream3Exists.set(http2Client.connection().stream(3) != null);
             streamCount.set(http2Client.connection().numActiveStreams());
             probeStreamCount.countDown();
@@ -1089,11 +1089,9 @@ public class Http2ConnectionRoundtripTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress("Http2ConnectionRoundtripTest")).sync().channel();
+        serverChannel = sb.bind(new LocalAddress("Http2ConnectionRoundtripTest")).get();
 
-        ChannelFuture ccf = cb.connect(serverChannel.localAddress());
-        assertTrue(ccf.awaitUninterruptibly().isSuccess());
-        clientChannel = ccf.channel();
+        clientChannel = cb.connect(serverChannel.localAddress()).get();
         assertTrue(prefaceWrittenLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));
         http2Client = clientChannel.pipeline().get(Http2ConnectionHandler.class);
         assertTrue(serverInitLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));
@@ -1126,8 +1124,7 @@ public class Http2ConnectionRoundtripTest {
         doAnswer((Answer<Integer>) invocation -> {
             ByteBuf buf = (ByteBuf) invocation.getArguments()[2];
             int padding = (Integer) invocation.getArguments()[3];
-            int processedBytes = buf.readableBytes() + padding;
-            return processedBytes;
+            return buf.readableBytes() + padding;
         }).when(listener).onDataRead(any(ChannelHandlerContext.class), anyInt(),
                 any(ByteBuf.class), anyInt(), anyBoolean());
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilderTest.java
@@ -44,8 +44,8 @@ import java.util.concurrent.CountDownLatch;
 import static io.netty.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -67,7 +67,7 @@ public class Http2MultiplexCodecBuilderTest {
     }
 
     @BeforeEach
-    public void setUp() throws InterruptedException {
+    public void setUp() throws Exception {
         final CountDownLatch serverChannelLatch = new CountDownLatch(1);
         LocalAddress serverAddress = new LocalAddress(getClass().getName());
         serverLastInboundHandler = new SharableLastInboundHandler();
@@ -109,7 +109,7 @@ public class Http2MultiplexCodecBuilderTest {
                         serverChannelLatch.countDown();
                     }
                 });
-        serverChannel = sb.bind(serverAddress).sync().channel();
+        serverChannel = sb.bind(serverAddress).get();
 
         Bootstrap cb = new Bootstrap()
                 .channel(LocalChannel.class)
@@ -120,7 +120,7 @@ public class Http2MultiplexCodecBuilderTest {
                         fail("Should not be called for outbound streams");
                     }
                 }).build());
-        clientChannel = cb.connect(serverAddress).sync().channel();
+        clientChannel = cb.connect(serverAddress).get();
         assertTrue(serverChannelLatch.await(5, SECONDS));
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -44,8 +44,8 @@ import static io.netty.handler.codec.http2.Http2FrameCodecBuilder.forClient;
 import static io.netty.handler.codec.http2.Http2FrameCodecBuilder.forServer;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -78,7 +78,7 @@ public class Http2StreamChannelBootstrapTest {
                             serverChannelLatch.countDown();
                         }
                     });
-            serverChannel = sb.bind(serverAddress).sync().channel();
+            serverChannel = sb.bind(serverAddress).get();
 
             Bootstrap cb = new Bootstrap()
                     .channel(LocalChannel.class)
@@ -89,7 +89,7 @@ public class Http2StreamChannelBootstrapTest {
                             ch.pipeline().addLast(forClient().build(), newMultiplexedHandler());
                         }
                     });
-            clientChannel = cb.connect(serverAddress).sync().channel();
+            clientChannel = cb.connect(serverAddress).get();
             assertTrue(serverChannelLatch.await(3, SECONDS));
 
             Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap(clientChannel);
@@ -145,7 +145,7 @@ public class Http2StreamChannelBootstrapTest {
         when(ctx.executor()).thenReturn(executor);
         when(ctx.handler()).thenReturn(handler);
 
-        Promise<Http2StreamChannel> promise = new DefaultPromise(mock(EventExecutor.class));
+        Promise<Http2StreamChannel> promise = new DefaultPromise<>(mock(EventExecutor.class));
         bootstrap.open0(ctx, promise);
         assertThat(promise.isDone(), is(true));
         assertThat(promise.cause(), is(instanceOf(IllegalStateException.class)));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -43,13 +43,11 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2TestUtil.FrameCountDown;
 import io.netty.util.AsciiString;
 import io.netty.util.concurrent.Future;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
@@ -74,8 +72,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyShort;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -107,7 +105,7 @@ public class HttpToHttp2ConnectionHandlerTest {
     }
 
     @AfterEach
-    public void teardown() throws Exception {
+    public void tearDown() throws Exception {
         if (clientChannel != null) {
             clientChannel.close().syncUninterruptibly();
             clientChannel = null;
@@ -593,11 +591,9 @@ public class HttpToHttp2ConnectionHandlerTest {
             }
         });
 
-        serverChannel = sb.bind(new LocalAddress("HttpToHttp2ConnectionHandlerTest")).sync().channel();
+        serverChannel = sb.bind(new LocalAddress("HttpToHttp2ConnectionHandlerTest")).get();
 
-        ChannelFuture ccf = cb.connect(serverChannel.localAddress());
-        assertTrue(ccf.awaitUninterruptibly().isSuccess());
-        clientChannel = ccf.channel();
+        clientChannel = cb.connect(serverChannel.localAddress()).get();
         assertTrue(prefaceWrittenLatch.await(5, SECONDS));
         assertTrue(serverChannelLatch.await(WAIT_TIME_SECONDS, SECONDS));
     }

--- a/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -22,7 +22,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -33,7 +32,6 @@ import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.EncoderException;
-import java.util.concurrent.TimeUnit;
 import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.xxhash.XXHashFactory;
@@ -46,6 +44,7 @@ import org.mockito.MockitoAnnotations;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.Checksum;
 
@@ -244,7 +243,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void writingAfterClosedChannelDoesNotNPE() throws InterruptedException {
+    public void writingAfterClosedChannelDoesNotNPE() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(2, NioHandler.newFactory());
         Channel serverChannel = null;
         Channel clientChannel = null;
@@ -270,8 +269,8 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
                 }
             });
 
-            serverChannel = sb.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
-            clientChannel = bs.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            serverChannel = sb.bind(new InetSocketAddress(0)).get();
+            clientChannel = bs.connect(serverChannel.localAddress()).get();
 
             final Channel finalClientChannel = clientChannel;
             clientChannel.eventLoop().execute(() -> {

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -64,7 +64,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
     /**
      * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise}
      * will be notified. Cancellation is propagated both ways such that if the {@link Future} is cancelled
-     * the {@link Promise} is cancelled and vise-versa.
+     * the {@link Promise} is cancelled and vice-versa.
      *
      * @param future    the {@link Future} which will be used to listen to for notifying the {@link Promise}.
      * @param promise   the {@link Promise} which will be notified
@@ -79,7 +79,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
     /**
      * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise}
      * will be notified. Cancellation is propagated both ways such that if the {@link Future} is cancelled
-     * the {@link Promise} is cancelled and vise-versa.
+     * the {@link Promise} is cancelled and vice-versa.
      *
      * @param logNotifyFailure  {@code true} if logging should be done in case notification fails.
      * @param future            the {@link Future} which will be used to listen to for notifying the {@link Promise}.
@@ -115,7 +115,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
      * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise} will be
      * notified with the given result.
      * Cancellation is propagated both ways such that if the {@link Future} is cancelled the {@link Promise}
-     * is cancelled and vise-versa.
+     * is cancelled and vice-versa.
      *
      * @param logNotifyFailure {@code true} if logging should be done in case notification fails.
      * @param future           the {@link Future} which will be used to listen to for notifying the {@link Promise}.
@@ -124,7 +124,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
      * @return the passed in {@link Future}
      */
     public static <R, F extends Future<Void>> F cascade(boolean logNotifyFailure, F future,
-                                                               Promise<R> promise, R successResult) {
+                                                        Promise<R> promise, R successResult) {
         promise.addListener(new FutureListener<Object>() {
             @Override
             public void operationComplete(Future<Object> f) {

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -88,12 +88,11 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
      * @param <F>               the type of the {@link Future}
      * @return                  the passed in {@link Future}
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <V, F extends Future<V>> F cascade(boolean logNotifyFailure, final F future,
                                                      final Promise<? super V> promise) {
-        promise.addListener(new FutureListener() {
+        promise.addListener(new FutureListener<Object>() {
             @Override
-            public void operationComplete(Future f) {
+            public void operationComplete(Future<Object> f) {
                 if (f.isCancelled()) {
                     future.cancel(false);
                 }

--- a/example/src/main/java/io/netty/example/discard/DiscardClient.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardClient.java
@@ -16,7 +16,7 @@
 package io.netty.example.discard;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
@@ -65,10 +65,10 @@ public final class DiscardClient {
              });
 
             // Make the connection attempt.
-            ChannelFuture f = b.connect(HOST, PORT).sync();
+            Channel channel = b.connect(HOST, PORT).get();
 
             // Wait until the connection is closed.
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty/example/discard/DiscardServer.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardServer.java
@@ -16,6 +16,7 @@
 package io.netty.example.discard;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
@@ -67,12 +68,12 @@ public final class DiscardServer {
              });
 
             // Bind and start to accept incoming connections.
-            ChannelFuture f = b.bind(PORT).sync();
+            Channel channel = b.bind(PORT).get();
 
             // Wait until the server socket is closed.
             // In this example, this does not happen, but you can do that to gracefully
             // shut down your server.
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             workerGroup.shutdownGracefully();
             bossGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/dns/dot/DoTClient.java
+++ b/example/src/main/java/io/netty/example/dns/dot/DoTClient.java
@@ -17,27 +17,26 @@ package io.netty.example.dns.dot;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufUtil;
-
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.channel.SimpleChannelInboundHandler;
-
+import io.netty.handler.codec.dns.DefaultDnsQuery;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DefaultDnsResponse;
-import io.netty.handler.codec.dns.DnsQuestion;
-import io.netty.handler.codec.dns.DnsQuery;
-import io.netty.handler.codec.dns.DefaultDnsQuery;
 import io.netty.handler.codec.dns.DnsOpCode;
-import io.netty.handler.codec.dns.DnsRecord;
-import io.netty.handler.codec.dns.DnsSection;
-import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRawRecord;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.handler.codec.dns.DnsSection;
 import io.netty.handler.codec.dns.TcpDnsQueryEncoder;
 import io.netty.handler.codec.dns.TcpDnsResponseDecoder;
 import io.netty.handler.ssl.SslContext;
@@ -63,7 +62,7 @@ public final class DoTClient {
         for (int i = 0, count = msg.count(DnsSection.ANSWER); i < count; i++) {
             DnsRecord record = msg.recordAt(DnsSection.ANSWER, i);
             if (record.type() == DnsRecordType.A) {
-                //just print the IP after query
+                // Just print the IP after query
                 DnsRawRecord raw = (DnsRawRecord) record;
                 System.out.println(NetUtil.bytesToIpAddress(ByteBufUtil.getBytes(raw.content())));
             }
@@ -71,7 +70,7 @@ public final class DoTClient {
     }
 
     public static void main(String[] args) throws Exception {
-        EventLoopGroup group = new NioEventLoopGroup();
+        EventLoopGroup group = new MultithreadEventLoopGroup(NioHandler.newFactory());
         try {
             final SslContext sslContext = SslContextBuilder.forClient()
                     .protocols("TLSv1.3", "TLSv1.2")
@@ -100,7 +99,7 @@ public final class DoTClient {
                                     });
                         }
                     });
-            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).sync().channel();
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).get();
 
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)

--- a/example/src/main/java/io/netty/example/dns/tcp/TcpDnsClient.java
+++ b/example/src/main/java/io/netty/example/dns/tcp/TcpDnsClient.java
@@ -17,27 +17,26 @@ package io.netty.example.dns.tcp;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufUtil;
-
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.channel.SimpleChannelInboundHandler;
-
+import io.netty.handler.codec.dns.DefaultDnsQuery;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DefaultDnsResponse;
-import io.netty.handler.codec.dns.DnsQuestion;
-import io.netty.handler.codec.dns.DnsQuery;
-import io.netty.handler.codec.dns.DefaultDnsQuery;
 import io.netty.handler.codec.dns.DnsOpCode;
-import io.netty.handler.codec.dns.DnsRecord;
-import io.netty.handler.codec.dns.DnsSection;
-import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRawRecord;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.handler.codec.dns.DnsSection;
 import io.netty.handler.codec.dns.TcpDnsQueryEncoder;
 import io.netty.handler.codec.dns.TcpDnsResponseDecoder;
 import io.netty.util.NetUtil;
@@ -61,7 +60,7 @@ public final class TcpDnsClient {
         for (int i = 0, count = msg.count(DnsSection.ANSWER); i < count; i++) {
             DnsRecord record = msg.recordAt(DnsSection.ANSWER, i);
             if (record.type() == DnsRecordType.A) {
-                //just print the IP after query
+                // Just print the IP after query
                 DnsRawRecord raw = (DnsRawRecord) record;
                 System.out.println(NetUtil.bytesToIpAddress(ByteBufUtil.getBytes(raw.content())));
             }
@@ -69,7 +68,7 @@ public final class TcpDnsClient {
     }
 
     public static void main(String[] args) throws Exception {
-        EventLoopGroup group = new NioEventLoopGroup();
+        EventLoopGroup group = new MultithreadEventLoopGroup(NioHandler.newFactory());
         try {
             Bootstrap b = new Bootstrap();
             b.group(group)
@@ -94,7 +93,7 @@ public final class TcpDnsClient {
                         }
                     });
 
-            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).sync().channel();
+            final Channel ch = b.connect(DNS_SERVER_HOST, DNS_SERVER_PORT).get();
 
             int randomID = new Random().nextInt(60000 - 1000) + 1000;
             DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)

--- a/example/src/main/java/io/netty/example/dns/udp/DnsClient.java
+++ b/example/src/main/java/io/netty/example/dns/udp/DnsClient.java
@@ -15,9 +15,6 @@
  */
 package io.netty.example.dns.udp;
 
-import java.net.InetSocketAddress;
-import java.util.concurrent.TimeUnit;
-
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
@@ -43,6 +40,9 @@ import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.handler.codec.dns.DnsSection;
 import io.netty.util.NetUtil;
 
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
 public final class DnsClient {
 
     private static final String QUERY_DOMAIN = "www.example.com";
@@ -59,7 +59,7 @@ public final class DnsClient {
         for (int i = 0, count = msg.count(DnsSection.ANSWER); i < count; i++) {
             DnsRecord record = msg.recordAt(DnsSection.ANSWER, i);
             if (record.type() == DnsRecordType.A) {
-                //just print the IP after query
+                // Just print the IP after query
                 DnsRawRecord raw = (DnsRawRecord) record;
                 System.out.println(NetUtil.bytesToIpAddress(ByteBufUtil.getBytes(raw.content())));
             }
@@ -91,13 +91,13 @@ public final class DnsClient {
                     });
                  }
              });
-            final Channel ch = b.bind(0).sync().channel();
+            final Channel ch = b.bind(0).get();
             DnsQuery query = new DatagramDnsQuery(null, addr, 1).setRecord(
                     DnsSection.QUESTION,
                     new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
             ch.writeAndFlush(query).sync();
-            boolean succ = ch.closeFuture().await(10, TimeUnit.SECONDS);
-            if (!succ) {
+            boolean success = ch.closeFuture().await(10, TimeUnit.SECONDS);
+            if (!success) {
                 System.err.println("dns query timeout!");
                 ch.close().sync();
             }

--- a/example/src/main/java/io/netty/example/echo/EchoClient.java
+++ b/example/src/main/java/io/netty/example/echo/EchoClient.java
@@ -16,7 +16,7 @@
 package io.netty.example.echo;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -72,10 +72,10 @@ public final class EchoClient {
              });
 
             // Start the client.
-            ChannelFuture f = b.connect(HOST, PORT).sync();
+            Channel channel = b.connect(HOST, PORT).get();
 
             // Wait until the connection is closed.
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/echo/EchoServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoServer.java
@@ -16,7 +16,7 @@
 package io.netty.example.echo;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -72,10 +72,10 @@ public final class EchoServer {
              });
 
             // Start the server.
-            ChannelFuture f = b.bind(PORT).sync();
+            Channel channel = b.bind(PORT).get();
 
             // Wait until the server socket is closed.
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
             bossGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/factorial/FactorialClient.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialClient.java
@@ -16,7 +16,7 @@
 package io.netty.example.factorial;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.nio.NioHandler;
@@ -54,11 +54,10 @@ public final class FactorialClient {
              .handler(new FactorialClientInitializer(sslCtx));
 
             // Make a new connection.
-            ChannelFuture f = b.connect(HOST, PORT).sync();
+            Channel channel = b.connect(HOST, PORT).get();
 
             // Get the handler instance to retrieve the answer.
-            FactorialClientHandler handler =
-                (FactorialClientHandler) f.channel().pipeline().last();
+            FactorialClientHandler handler = (FactorialClientHandler) channel.pipeline().last();
 
             // Print out the answer.
             System.err.format("Factorial of %,d is: %,d", COUNT, handler.getFactorial());

--- a/example/src/main/java/io/netty/example/factorial/FactorialServer.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialServer.java
@@ -54,7 +54,7 @@ public final class FactorialServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new FactorialServerInitializer(sslCtx));
 
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/file/FileServer.java
+++ b/example/src/main/java/io/netty/example/file/FileServer.java
@@ -16,7 +16,7 @@
 package io.netty.example.file;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -81,10 +81,10 @@ public final class FileServer {
              });
 
             // Start the server.
-            ChannelFuture f = b.bind(PORT).sync();
+            Channel channel = b.bind(PORT).get();
 
             // Wait until the server socket is closed.
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
             bossGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyClient.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyClient.java
@@ -20,7 +20,8 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.haproxy.HAProxyCommand;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
@@ -28,14 +29,14 @@ import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.util.CharsetUtil;
 
-import static io.netty.example.haproxy.HAProxyServer.*;
+import static io.netty.example.haproxy.HAProxyServer.PORT;
 
 public final class HAProxyClient {
 
     private static final String HOST = System.getProperty("host", "127.0.0.1");
 
     public static void main(String[] args) throws Exception {
-        EventLoopGroup group = new NioEventLoopGroup();
+        EventLoopGroup group = new MultithreadEventLoopGroup(NioHandler.newFactory());
         try {
             Bootstrap b = new Bootstrap();
             b.group(group)
@@ -43,7 +44,7 @@ public final class HAProxyClient {
              .handler(new HAProxyHandler());
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).sync().channel();
+            Channel ch = b.connect(HOST, PORT).get();
 
             HAProxyMessage message = new HAProxyMessage(
                     HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
@@ -45,7 +45,7 @@ public final class HAProxyServer {
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HAProxyServerInitializer());
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/http/cors/HttpCorsServer.java
+++ b/example/src/main/java/io/netty/example/http/cors/HttpCorsServer.java
@@ -96,7 +96,7 @@ public final class HttpCorsServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpCorsServerInitializer(sslCtx));
 
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServer.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServer.java
@@ -53,7 +53,7 @@ public final class HttpStaticFileServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpStaticFileServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServer.java
+++ b/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServer.java
@@ -58,7 +58,7 @@ public final class HttpHelloWorldServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpHelloWorldServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopClient.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopClient.java
@@ -81,7 +81,7 @@ public final class HttpSnoopClient {
              .handler(new HttpSnoopClientInitializer(sslCtx));
 
             // Make the connection attempt.
-            Channel ch = b.connect(host, port).sync().channel();
+            Channel ch = b.connect(host, port).get();
 
             // Prepare the HTTP request.
             HttpRequest request = new DefaultFullHttpRequest(

--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServer.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServer.java
@@ -56,7 +56,7 @@ public final class HttpSnoopServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpSnoopServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
@@ -17,7 +17,6 @@ package io.netty.example.http.upload;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.nio.NioHandler;
@@ -41,6 +40,7 @@ import io.netty.handler.codec.http.multipart.InterfaceHttpData;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.concurrent.Future;
 import io.netty.util.internal.SocketUtils;
 
 import java.io.File;
@@ -151,7 +151,7 @@ public final class HttpUploadClient {
             Bootstrap bootstrap, String host, int port, String get, URI uriSimple) throws Exception {
         // XXX /formget
         // No use of HttpPostRequestEncoder since not a POST
-        Channel channel = bootstrap.connect(host, port).sync().channel();
+        Channel channel = bootstrap.connect(host, port).get();
 
         // Prepare the HTTP request.
         QueryStringEncoder encoder = new QueryStringEncoder(get);
@@ -208,9 +208,9 @@ public final class HttpUploadClient {
             List<Entry<String, String>> headers) throws Exception {
         // XXX /formpost
         // Start the connection attempt.
-        ChannelFuture future = bootstrap.connect(SocketUtils.socketAddress(host, port));
+        Future<Channel> future = bootstrap.connect(SocketUtils.socketAddress(host, port));
         // Wait until the connection attempt succeeds or fails.
-        Channel channel = future.sync().channel();
+        Channel channel = future.get();
 
         // Prepare the HTTP request.
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uriSimple.toASCIIString());
@@ -268,9 +268,9 @@ public final class HttpUploadClient {
             Iterable<Entry<String, String>> headers, List<InterfaceHttpData> bodylist) throws Exception {
         // XXX /formpostmultipart
         // Start the connection attempt.
-        ChannelFuture future = bootstrap.connect(SocketUtils.socketAddress(host, port));
+        Future<Channel> future = bootstrap.connect(SocketUtils.socketAddress(host, port));
         // Wait until the connection attempt succeeds or fails.
-        Channel channel = future.sync().channel();
+        Channel channel = future.get();
 
         // Prepare the HTTP request.
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uriFile.toASCIIString());

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadServer.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadServer.java
@@ -54,7 +54,7 @@ public final class HttpUploadServer {
             b.handler(new LoggingHandler(LogLevel.INFO));
             b.childHandler(new HttpUploadServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.err.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServer.java
@@ -56,7 +56,7 @@ public final class WebSocketServer {
              .channel(NioServerSocketChannel.class)
              .childHandler(new WebSocketServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.out.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -119,7 +119,7 @@ public final class WebSocketClient {
                  }
              });
 
-            Channel ch = b.connect(uri.getHost(), port).sync().channel();
+            Channel ch = b.connect(uri.getHost(), port).get();
             handler.handshakeFuture().sync();
 
             BufferedReader console = new BufferedReader(new InputStreamReader(System.in));
@@ -127,11 +127,11 @@ public final class WebSocketClient {
                 String msg = console.readLine();
                 if (msg == null) {
                     break;
-                } else if ("bye".equals(msg.toLowerCase())) {
+                } else if ("bye".equalsIgnoreCase(msg)) {
                     ch.writeAndFlush(new CloseWebSocketFrame());
                     ch.closeFuture().sync();
                     break;
-                } else if ("ping".equals(msg.toLowerCase())) {
+                } else if ("ping".equalsIgnoreCase(msg)) {
                     WebSocketFrame frame = new PingWebSocketFrame(Unpooled.wrappedBuffer(new byte[] { 8, 1, 8, 1 }));
                     ch.writeAndFlush(frame);
                 } else {

--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServer.java
@@ -70,7 +70,7 @@ public final class WebSocketServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new WebSocketServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.out.println("Open your web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http2/helloworld/client/Http2Client.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/Http2Client.java
@@ -34,7 +34,6 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -49,6 +48,9 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.handler.ssl.SslProvider.JDK;
+import static io.netty.handler.ssl.SslProvider.OPENSSL;
+import static io.netty.handler.ssl.SslProvider.isAlpnSupported;
 
 /**
  * An HTTP2 client that allows you to send HTTP2 frames to a server using HTTP1-style approaches
@@ -72,7 +74,7 @@ public final class Http2Client {
         // Configure SSL.
         final SslContext sslCtx;
         if (SSL) {
-            SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
+            SslProvider provider = isAlpnSupported(OPENSSL) ? OPENSSL : JDK;
             sslCtx = SslContextBuilder.forClient()
                 .sslProvider(provider)
                 /* NOTE: the cipher filter may not include all ciphers required by the HTTP/2 specification.
@@ -105,7 +107,7 @@ public final class Http2Client {
             b.handler(initializer);
 
             // Start the client.
-            Channel channel = b.connect().syncUninterruptibly().channel();
+            Channel channel = b.connect().get();
             System.out.println("Connected to [" + HOST + ':' + PORT + ']');
 
             // Wait for the HTTP/2 upgrade to occur.

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/client/Http2FrameClient.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/client/Http2FrameClient.java
@@ -89,7 +89,7 @@ public final class Http2FrameClient {
             b.handler(new Http2ClientFrameInitializer(sslCtx));
 
             // Start the client.
-            final Channel channel = b.connect().syncUninterruptibly().channel();
+            final Channel channel = b.connect().get();
             System.out.println("Connected to [" + HOST + ':' + PORT + ']');
 
             final Http2ClientStreamFrameResponseHandler streamFrameResponseHandler =

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2Server.java
@@ -31,12 +31,13 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+import static io.netty.handler.ssl.SslProvider.isAlpnSupported;
 
 /**
  * An HTTP/2 Server that responds to requests with a Hello World. Once started, you can test the
@@ -55,7 +56,7 @@ public final class Http2Server {
         // Configure SSL.
         final SslContext sslCtx;
         if (SSL) {
-            SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
+            SslProvider provider = isAlpnSupported(SslProvider.OPENSSL) ? SslProvider.OPENSSL : SslProvider.JDK;
             SelfSignedCertificate ssc = new SelfSignedCertificate();
             sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(provider)
@@ -84,7 +85,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2Server.java
@@ -31,12 +31,15 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+import static io.netty.handler.ssl.SslProvider.JDK;
+import static io.netty.handler.ssl.SslProvider.OPENSSL;
+import static io.netty.handler.ssl.SslProvider.isAlpnSupported;
 
 /**
  * An HTTP/2 Server that responds to requests with a Hello World. Once started, you can test the
@@ -55,7 +58,7 @@ public final class Http2Server {
         // Configure SSL.
         final SslContext sslCtx;
         if (SSL) {
-            SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
+            SslProvider provider = isAlpnSupported(OPENSSL) ? OPENSSL : JDK;
             SelfSignedCertificate ssc = new SelfSignedCertificate();
             sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(provider)
@@ -84,7 +87,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2Server.java
@@ -31,12 +31,13 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+import static io.netty.handler.ssl.SslProvider.isAlpnSupported;
 
 /**
  * An HTTP/2 Server that responds to requests with a Hello World. Once started, you can test the
@@ -52,7 +53,7 @@ public final class Http2Server {
         // Configure SSL.
         final SslContext sslCtx;
         if (SSL) {
-            SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
+            SslProvider provider = isAlpnSupported(SslProvider.OPENSSL) ? SslProvider.OPENSSL : SslProvider.JDK;
             SelfSignedCertificate ssc = new SelfSignedCertificate();
             sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(provider)
@@ -81,7 +82,7 @@ public final class Http2Server {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new Http2ServerInitializer(sslCtx));
 
-            Channel ch = b.bind(PORT).sync().channel();
+            Channel ch = b.bind(PORT).get();
 
             System.err.println("Open your HTTP/2-enabled web browser and navigate to " +
                     (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');

--- a/example/src/main/java/io/netty/example/http2/tiles/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http2Server.java
@@ -16,7 +16,6 @@
 
 package io.netty.example.http2.tiles;
 
-import static io.netty.handler.codec.http2.Http2SecurityUtil.CIPHERS;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -35,9 +34,10 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 
+import javax.net.ssl.SSLException;
 import java.security.cert.CertificateException;
 
-import javax.net.ssl.SSLException;
+import static io.netty.handler.codec.http2.Http2SecurityUtil.CIPHERS;
 
 /**
  * Demonstrates an Http2 server using Netty to display a bunch of images and
@@ -65,7 +65,7 @@ public class Http2Server {
             }
         });
 
-        Channel ch = b.bind(PORT).sync().channel();
+        Channel ch = b.bind(PORT).get();
         return ch.closeFuture();
     }
 

--- a/example/src/main/java/io/netty/example/http2/tiles/HttpServer.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/HttpServer.java
@@ -60,7 +60,7 @@ public final class HttpServer {
             }
         });
 
-        Channel ch = b.bind(PORT).sync().channel();
+        Channel ch = b.bind(PORT).get();
         return ch.closeFuture();
     }
 }

--- a/example/src/main/java/io/netty/example/localecho/LocalEcho.java
+++ b/example/src/main/java/io/netty/example/localecho/LocalEcho.java
@@ -20,8 +20,8 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalHandler;
@@ -80,7 +80,7 @@ public final class LocalEcho {
             sb.bind(addr).sync();
 
             // Start the client.
-            Channel ch = cb.connect(addr).sync().channel();
+            Channel ch = cb.connect(addr).get();
 
             // Read commands from the stdin.
             System.out.println("Enter text (quit to end)");

--- a/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
+++ b/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
@@ -72,7 +72,7 @@ public final class MemcacheClient {
                     });
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).sync().channel();
+            Channel ch = b.connect(HOST, PORT).get();
 
             // Read commands from the stdin.
             System.out.println("Enter commands (quit to end)");
@@ -85,7 +85,7 @@ public final class MemcacheClient {
                 if (line == null) {
                     break;
                 }
-                if ("quit".equals(line.toLowerCase())) {
+                if ("quit".equalsIgnoreCase(line)) {
                     ch.close().sync();
                     break;
                 }

--- a/example/src/main/java/io/netty/example/objectecho/ObjectEchoClient.java
+++ b/example/src/main/java/io/netty/example/objectecho/ObjectEchoClient.java
@@ -71,7 +71,7 @@ public final class ObjectEchoClient {
              });
 
             // Start the connection attempt.
-            b.connect(HOST, PORT).sync().channel().closeFuture().sync();
+            b.connect(HOST, PORT).get().closeFuture().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty/example/objectecho/ObjectEchoServer.java
+++ b/example/src/main/java/io/netty/example/objectecho/ObjectEchoServer.java
@@ -73,7 +73,7 @@ public final class ObjectEchoServer {
              });
 
             // Bind and start to accept incoming connections.
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/ocsp/OcspClientExample.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspClientExample.java
@@ -16,29 +16,18 @@
 
 package io.netty.example.ocsp;
 
-import java.math.BigInteger;
-
-import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
-
-import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.nio.NioHandler;
-import org.bouncycastle.asn1.ocsp.OCSPResponseStatus;
-import org.bouncycastle.cert.ocsp.BasicOCSPResp;
-import org.bouncycastle.cert.ocsp.CertificateStatus;
-import org.bouncycastle.cert.ocsp.OCSPResp;
-import org.bouncycastle.cert.ocsp.SingleResp;
-
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -57,6 +46,15 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.ocsp.OcspClientHandler;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
+import org.bouncycastle.asn1.ocsp.OCSPResponseStatus;
+import org.bouncycastle.cert.ocsp.BasicOCSPResp;
+import org.bouncycastle.cert.ocsp.CertificateStatus;
+import org.bouncycastle.cert.ocsp.OCSPResp;
+import org.bouncycastle.cert.ocsp.SingleResp;
+
+import javax.net.ssl.SSLSession;
+import javax.security.cert.X509Certificate;
+import java.math.BigInteger;
 
 /**
  * This is a very simple example for an HTTPS client that uses OCSP stapling.
@@ -99,9 +97,7 @@ public class OcspClientExample {
                         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5 * 1000)
                         .handler(newClientHandler(context, host, promise));
 
-                Channel channel = bootstrap.connect(host, 443)
-                        .syncUninterruptibly()
-                        .channel();
+                Channel channel = bootstrap.connect(host, 443).get();
 
                 try {
                     FullHttpResponse response = promise.get();

--- a/example/src/main/java/io/netty/example/portunification/PortUnificationServer.java
+++ b/example/src/main/java/io/netty/example/portunification/PortUnificationServer.java
@@ -60,7 +60,7 @@ public final class PortUnificationServer {
             });
 
             // Bind and start to accept incoming connections.
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxy.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxy.java
@@ -43,7 +43,7 @@ public final class HexDumpProxy {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HexDumpProxyInitializer(REMOTE_HOST, REMOTE_PORT))
              .childOption(ChannelOption.AUTO_READ, false)
-             .bind(LOCAL_PORT).sync().channel().closeFuture().sync();
+             .bind(LOCAL_PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
@@ -49,10 +49,9 @@ public class HexDumpProxyFrontendHandler implements ChannelHandler {
          .channel(ctx.channel().getClass())
          .handler(new HexDumpProxyBackendHandler(inboundChannel))
          .option(ChannelOption.AUTO_READ, false);
-        Channel channel = b.register().syncUninterruptibly().getNow();
+        outboundChannel = b.register().syncUninterruptibly().getNow();
         InetSocketAddress remote = InetSocketAddress.createUnresolved(remoteHost, remotePort);
-        channel.connect(remote).addListener((ChannelFutureListener) future -> {
-            outboundChannel = future.channel();
+        outboundChannel.connect(remote).addListener((ChannelFutureListener) future -> {
             if (future.isSuccess()) {
                 // connection complete start to read first data
                 inboundChannel.read();

--- a/example/src/main/java/io/netty/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty/example/qotm/QuoteOfTheMomentClient.java
@@ -47,7 +47,7 @@ public final class QuoteOfTheMomentClient {
              .option(ChannelOption.SO_BROADCAST, true)
              .handler(new QuoteOfTheMomentClientHandler());
 
-            Channel ch = b.bind(0).sync().channel();
+            Channel ch = b.bind(0).get();
 
             // Broadcast the QOTM request to port 8080.
             ch.writeAndFlush(new DatagramPacket(

--- a/example/src/main/java/io/netty/example/qotm/QuoteOfTheMomentServer.java
+++ b/example/src/main/java/io/netty/example/qotm/QuoteOfTheMomentServer.java
@@ -41,7 +41,7 @@ public final class QuoteOfTheMomentServer {
              .option(ChannelOption.SO_BROADCAST, true)
              .handler(new QuoteOfTheMomentServerHandler());
 
-            b.bind(PORT).sync().channel().closeFuture().await();
+            b.bind(PORT).get().closeFuture().await();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty/example/redis/RedisClient.java
+++ b/example/src/main/java/io/netty/example/redis/RedisClient.java
@@ -60,7 +60,7 @@ public class RedisClient {
              });
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).sync().channel();
+            Channel ch = b.connect(HOST, PORT).get();
 
             // Read commands from the stdin.
             System.out.println("Enter Redis commands (quit to end)");
@@ -72,7 +72,8 @@ public class RedisClient {
                 if (line == null || "quit".equalsIgnoreCase(line)) { // EOF or "quit"
                     ch.close().sync();
                     break;
-                } else if (line.isEmpty()) { // skip `enter` or `enter` with spaces.
+                }
+                if (line.isEmpty()) { // skip `enter` or `enter` with spaces.
                     continue;
                 }
                 // Sends the received line to the server.

--- a/example/src/main/java/io/netty/example/sctp/SctpEchoClient.java
+++ b/example/src/main/java/io/netty/example/sctp/SctpEchoClient.java
@@ -16,7 +16,7 @@
 package io.netty.example.sctp;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
@@ -57,10 +57,10 @@ public final class SctpEchoClient {
              });
 
             // Start the client.
-            ChannelFuture f = b.connect(HOST, PORT).sync();
+            Channel channel = b.connect(HOST, PORT).get();
 
             // Wait until the connection is closed.
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/sctp/SctpEchoServer.java
+++ b/example/src/main/java/io/netty/example/sctp/SctpEchoServer.java
@@ -16,7 +16,7 @@
 package io.netty.example.sctp;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -55,10 +55,10 @@ public final class SctpEchoServer {
              });
 
             // Start the server.
-            ChannelFuture f = b.bind(PORT).sync();
+            Channel channel = b.bind(PORT).get();
 
             // Wait until the server socket is closed.
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
             bossGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoClient.java
+++ b/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoClient.java
@@ -16,6 +16,7 @@
 package io.netty.example.sctp.multihoming;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
@@ -25,6 +26,7 @@ import io.netty.channel.sctp.SctpChannel;
 import io.netty.channel.sctp.SctpChannelOption;
 import io.netty.channel.sctp.nio.NioSctpChannel;
 import io.netty.example.sctp.SctpEchoClientHandler;
+import io.netty.util.concurrent.Future;
 import io.netty.util.internal.SocketUtils;
 
 import java.net.InetAddress;
@@ -66,10 +68,10 @@ public final class SctpMultiHomingEchoClient {
             InetSocketAddress remoteAddress = SocketUtils.socketAddress(SERVER_REMOTE_HOST, SERVER_REMOTE_PORT);
 
             // Bind the client channel.
-            ChannelFuture bindFuture = b.bind(localAddress).sync();
+            Future<Channel> bindFuture = b.bind(localAddress);
 
             // Get the underlying sctp channel
-            SctpChannel channel = (SctpChannel) bindFuture.channel();
+            SctpChannel channel = (SctpChannel) bindFuture.get();
 
             // Bind the secondary address.
             // Please note that, bindAddress in the client channel should be done before connecting if you have not

--- a/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoServer.java
+++ b/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoServer.java
@@ -16,6 +16,7 @@
 package io.netty.example.sctp.multihoming;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
@@ -28,6 +29,7 @@ import io.netty.channel.sctp.nio.NioSctpServerChannel;
 import io.netty.example.sctp.SctpEchoServerHandler;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.util.concurrent.Future;
 import io.netty.util.internal.SocketUtils;
 
 import java.net.InetAddress;
@@ -66,10 +68,10 @@ public final class SctpMultiHomingEchoServer {
             InetAddress localSecondaryAddress = SocketUtils.addressByName(SERVER_SECONDARY_HOST);
 
             // Bind the server to primary address.
-            ChannelFuture bindFuture = b.bind(localAddress).sync();
+            Future<Channel> bindFuture = b.bind(localAddress);
 
             //Get the underlying sctp channel
-            SctpServerChannel channel = (SctpServerChannel) bindFuture.channel();
+            SctpServerChannel channel = (SctpServerChannel) bindFuture.get();
 
             //Bind the secondary address
             ChannelFuture connectFuture = channel.bindAddress(localSecondaryAddress).sync();

--- a/example/src/main/java/io/netty/example/securechat/SecureChatClient.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatClient.java
@@ -51,7 +51,7 @@ public final class SecureChatClient {
              .handler(new SecureChatClientInitializer(sslCtx));
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).sync().channel();
+            Channel ch = b.connect(HOST, PORT).get();
 
             // Read commands from the stdin.
             ChannelFuture lastWriteFuture = null;
@@ -67,7 +67,7 @@ public final class SecureChatClient {
 
                 // If user typed the 'bye' command, wait until the server closes
                 // the connection.
-                if ("bye".equals(line.toLowerCase())) {
+                if ("bye".equalsIgnoreCase(line)) {
                     ch.closeFuture().sync();
                     break;
                 }

--- a/example/src/main/java/io/netty/example/securechat/SecureChatServer.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatServer.java
@@ -48,7 +48,7 @@ public final class SecureChatServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SecureChatServerInitializer(sslCtx));
 
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/smtp/SmtpClient.java
+++ b/example/src/main/java/io/netty/example/smtp/SmtpClient.java
@@ -36,7 +36,13 @@ import io.netty.util.concurrent.Future;
 
 import java.util.Base64;
 
-import static io.netty.handler.codec.smtp.SmtpCommand.*;
+import static io.netty.handler.codec.smtp.SmtpCommand.AUTH;
+import static io.netty.handler.codec.smtp.SmtpCommand.DATA;
+import static io.netty.handler.codec.smtp.SmtpCommand.EHLO;
+import static io.netty.handler.codec.smtp.SmtpCommand.EMPTY;
+import static io.netty.handler.codec.smtp.SmtpCommand.MAIL;
+import static io.netty.handler.codec.smtp.SmtpCommand.QUIT;
+import static io.netty.handler.codec.smtp.SmtpCommand.RCPT;
 
 /**
  * A simple smtp client
@@ -92,7 +98,7 @@ public class SmtpClient {
                     .future();
 
             // Start connect.
-            Channel ch = b.connect(HOST, PORT).sync().channel();
+            Channel ch = b.connect(HOST, PORT).get();
             f.await();
             ch.close();
         } finally {

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServer.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServer.java
@@ -36,7 +36,7 @@ public final class SocksServer {
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SocksServerInitializer());
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.socksx.v5.Socks5CommandRequest;
 import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 
 @ChannelHandler.Sharable
@@ -53,7 +54,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                                     new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS));
 
                             responseFuture.addListener((ChannelFutureListener) channelFuture -> {
-                                ctx.pipeline().remove(SocksServerConnectHandler.this);
+                                ctx.pipeline().remove(this);
                                 outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
                                 ctx.pipeline().addLast(new RelayHandler(outboundChannel));
                             });
@@ -71,7 +72,8 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                     .option(ChannelOption.SO_KEEPALIVE, true)
                     .handler(new DirectClientHandler(promise));
 
-            b.connect(request.dstAddr(), request.dstPort()).addListener((ChannelFutureListener) future -> {
+            b.connect(request.dstAddr(), request.dstPort()).addListener(
+                    (GenericFutureListener<Future<Channel>>) future -> {
                 if (future.isSuccess()) {
                     // Connection established use handler provided results
                 } else {
@@ -97,7 +99,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                                             request.dstPort()));
 
                             responseFuture.addListener((ChannelFutureListener) channelFuture -> {
-                                ctx.pipeline().remove(SocksServerConnectHandler.this);
+                                ctx.pipeline().remove(this);
                                 outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
                                 ctx.pipeline().addLast(new RelayHandler(outboundChannel));
                             });
@@ -115,7 +117,8 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                     .option(ChannelOption.SO_KEEPALIVE, true)
                     .handler(new DirectClientHandler(promise));
 
-            b.connect(request.dstAddr(), request.dstPort()).addListener((ChannelFutureListener) future -> {
+            b.connect(request.dstAddr(), request.dstPort()).addListener(
+                    (GenericFutureListener<Future<Channel>>) future -> {
                 if (future.isSuccess()) {
                     // Connection established use handler provided results
                 } else {

--- a/example/src/main/java/io/netty/example/stomp/StompClient.java
+++ b/example/src/main/java/io/netty/example/stomp/StompClient.java
@@ -34,7 +34,6 @@ import io.netty.handler.codec.stomp.StompSubframeEncoder;
  */
 public final class StompClient {
 
-    static final boolean SSL = System.getProperty("ssl") != null;
     static final String HOST = System.getProperty("host", "127.0.0.1");
     static final int PORT = Integer.parseInt(System.getProperty("port", "61613"));
     static final String LOGIN = System.getProperty("login", "guest");
@@ -57,7 +56,7 @@ public final class StompClient {
                 }
             });
 
-            b.connect(HOST, PORT).sync().channel().closeFuture().sync();
+            b.connect(HOST, PORT).get().closeFuture().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
@@ -16,33 +16,34 @@
 package io.netty.example.stomp.websocket;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 
 public class StompWebSocketChatServer {
 
     static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
 
     public void start(final int port) throws Exception {
-        NioEventLoopGroup boosGroup = new NioEventLoopGroup(1);
-        NioEventLoopGroup workerGroup = new NioEventLoopGroup();
+        MultithreadEventLoopGroup boosGroup = new MultithreadEventLoopGroup(1, NioHandler.newFactory());
+        MultithreadEventLoopGroup workerGroup = new MultithreadEventLoopGroup(NioHandler.newFactory());
         try {
             ServerBootstrap bootstrap = new ServerBootstrap()
                     .group(boosGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
                     .childHandler(new StompWebSocketChatServerInitializer("/chat"));
-            bootstrap.bind(port).addListener(new ChannelFutureListener() {
+            bootstrap.bind(port).addListener(new GenericFutureListener<Future<Object>>() {
                 @Override
-                public void operationComplete(ChannelFuture future) {
+                public void operationComplete(Future<Object> future) {
                     if (future.isSuccess()) {
                         System.out.println("Open your web browser and navigate to http://127.0.0.1:" + PORT + '/');
                     } else {
                         System.out.println("Cannot start server, follows exception " + future.cause());
                     }
                 }
-            }).channel().closeFuture().sync();
+            }).get().closeFuture().sync();
         } finally {
             boosGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/telnet/TelnetClient.java
+++ b/example/src/main/java/io/netty/example/telnet/TelnetClient.java
@@ -56,7 +56,7 @@ public final class TelnetClient {
              .handler(new TelnetClientInitializer(sslCtx));
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).sync().channel();
+            Channel ch = b.connect(HOST, PORT).get();
 
             // Read commands from the stdin.
             ChannelFuture lastWriteFuture = null;
@@ -72,7 +72,7 @@ public final class TelnetClient {
 
                 // If user typed the 'bye' command, wait until the server closes
                 // the connection.
-                if ("bye".equals(line.toLowerCase())) {
+                if ("bye".equalsIgnoreCase(line)) {
                     ch.closeFuture().sync();
                     break;
                 }

--- a/example/src/main/java/io/netty/example/telnet/TelnetServer.java
+++ b/example/src/main/java/io/netty/example/telnet/TelnetServer.java
@@ -53,7 +53,7 @@ public final class TelnetServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new TelnetServerInitializer(sslCtx));
 
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/uptime/UptimeClient.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClient.java
@@ -16,8 +16,7 @@
 package io.netty.example.uptime;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
@@ -25,6 +24,8 @@ import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 
 
 /**
@@ -59,7 +60,7 @@ public final class UptimeClient {
     }
 
     static void connect() {
-        bs.connect().addListener((ChannelFutureListener) future -> {
+        bs.connect().addListener((GenericFutureListener<Future<Channel>>) future -> {
             if (future.cause() != null) {
                 handler.startTime = -1;
                 handler.println("Failed to connect: " + future.cause());

--- a/example/src/main/java/io/netty/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeServer.java
@@ -16,6 +16,7 @@
 package io.netty.example.uptime;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
@@ -54,12 +55,12 @@ public final class UptimeServer {
                     });
 
             // Bind and start to accept incoming connections.
-            ChannelFuture f = b.bind(PORT).sync();
+            Channel channel = b.bind(PORT).get();
 
             // Wait until the server socket is closed.
             // In this example, this does not happen, but you can do that to gracefully
             // shut down your server.
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             workerGroup.shutdownGracefully();
             bossGroup.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/worldclock/WorldClockClient.java
+++ b/example/src/main/java/io/netty/example/worldclock/WorldClockClient.java
@@ -58,7 +58,7 @@ public final class WorldClockClient {
              .handler(new WorldClockClientInitializer(sslCtx));
 
             // Make a new connection.
-            Channel ch = b.connect(HOST, PORT).sync().channel();
+            Channel ch = b.connect(HOST, PORT).get();
 
             // Get the handler instance to initiate the request.
             WorldClockClientHandler handler = ch.pipeline().get(WorldClockClientHandler.class);

--- a/example/src/main/java/io/netty/example/worldclock/WorldClockServer.java
+++ b/example/src/main/java/io/netty/example/worldclock/WorldClockServer.java
@@ -54,7 +54,7 @@ public final class WorldClockServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new WorldClockServerInitializer(sslCtx));
 
-            b.bind(PORT).sync().channel().closeFuture().sync();
+            b.bind(PORT).get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1476,7 +1476,7 @@ public class SslHandler extends ByteToMessageDecoder {
         }
     }
 
-    private void executeChannelRead(final ChannelHandlerContext ctx, final ByteBuf decodedOut) {
+    private static void executeChannelRead(final ChannelHandlerContext ctx, final ByteBuf decodedOut) {
         try {
             ctx.executor().execute(() -> ctx.fireChannelRead(decodedOut));
         } catch (RejectedExecutionException e) {
@@ -1770,7 +1770,7 @@ public class SslHandler extends ByteToMessageDecoder {
                     task.run();
                     runComplete();
                 }
-            } catch (final Throwable cause) {
+            } catch (Throwable cause) {
                 handleException(cause);
             }
         }
@@ -1805,8 +1805,8 @@ public class SslHandler extends ByteToMessageDecoder {
         // Our control flow may invoke this method multiple times for a single FINISHED event. For example
         // wrapNonAppData may drain pendingUnencryptedWrites in wrap which transitions to handshake from FINISHED to
         // NOT_HANDSHAKING which invokes setHandshakeSuccess, and then wrapNonAppData also directly invokes this method.
-        final boolean notified;
-        if (notified = !handshakePromise.isDone() && handshakePromise.trySuccess(ctx.channel())) {
+        final boolean notified = !handshakePromise.isDone() && handshakePromise.trySuccess(ctx.channel());
+        if (notified) {
             if (logger.isDebugEnabled()) {
                 SSLSession session = engine.getSession();
                 logger.debug(

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -27,8 +27,8 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -47,7 +47,8 @@ import java.util.concurrent.Exchanger;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.concurrent.TimeUnit.*;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -74,7 +75,7 @@ public class FlowControlHandlerTest {
         return Unpooled.wrappedBuffer(new byte[]{ 1 });
     }
 
-    private static Channel newServer(final boolean autoRead, final ChannelHandler... handlers) {
+    private static Channel newServer(final boolean autoRead, final ChannelHandler... handlers) throws Exception {
         assertTrue(handlers.length >= 1);
 
         ServerBootstrap serverBootstrap = new ServerBootstrap();
@@ -90,12 +91,10 @@ public class FlowControlHandlerTest {
                 }
             });
 
-        return serverBootstrap.bind(0)
-                .syncUninterruptibly()
-                .channel();
+        return serverBootstrap.bind(0).get();
     }
 
-    private static Channel newClient(SocketAddress server) {
+    private static Channel newClient(SocketAddress server) throws Exception {
         Bootstrap bootstrap = new Bootstrap();
 
         bootstrap.group(GROUP)
@@ -108,9 +107,7 @@ public class FlowControlHandlerTest {
                 }
             });
 
-        return bootstrap.connect(server)
-                .syncUninterruptibly()
-                .channel();
+        return bootstrap.connect(server).get();
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteCanaryTest.java
@@ -25,8 +25,8 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import java.net.SocketAddress;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -51,9 +53,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -243,7 +242,7 @@ public class CipherSuiteCanaryTest {
                 .group(GROUP)
                 .childHandler(handler);
 
-        return bootstrap.bind(address).sync().channel();
+        return bootstrap.bind(address).get();
     }
 
     private static Channel client(Channel server, ChannelHandler handler) throws Exception {
@@ -254,7 +253,7 @@ public class CipherSuiteCanaryTest {
                 .group(GROUP)
                 .handler(handler);
 
-        return bootstrap.connect(remoteAddress).sync().channel();
+        return bootstrap.connect(remoteAddress).get();
     }
 
     private static List<Object[]> expand(String rfcCipherName) {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -388,7 +388,7 @@ public class OpenSslPrivateKeyMethodTest {
                 .group(GROUP)
                 .childHandler(handler);
 
-        return bootstrap.bind(address).sync().channel();
+        return bootstrap.bind(address).get();
     }
 
     private static Channel client(Channel server, ChannelHandler handler) throws Exception {
@@ -399,7 +399,7 @@ public class OpenSslPrivateKeyMethodTest {
                 .group(GROUP)
                 .handler(handler);
 
-        return bootstrap.connect(remoteAddress).sync().channel();
+        return bootstrap.connect(remoteAddress).get();
     }
 
     private static final class DelegateThread extends Thread {

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -104,7 +104,7 @@ public class ParameterizedSslHandlerTest {
     @Timeout(value = 48000, unit = TimeUnit.MILLISECONDS)
     public void testCompositeBufSizeEstimationGuaranteesSynchronousWrite(
             SslProvider clientProvider, SslProvider serverProvider)
-            throws CertificateException, SSLException, ExecutionException, InterruptedException {
+            throws Exception {
         compositeBufSizeEstimationGuaranteesSynchronousWrite(serverProvider, clientProvider,
                 true, true, true);
         compositeBufSizeEstimationGuaranteesSynchronousWrite(serverProvider, clientProvider,
@@ -206,7 +206,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                    }).bind(new InetSocketAddress(0)).get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -255,7 +255,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).connect(sc.localAddress()).syncUninterruptibly().channel();
+                    }).connect(sc.localAddress()).get();
 
             donePromise.get();
         } finally {
@@ -337,7 +337,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                    }).bind(new InetSocketAddress(0)).get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -356,7 +356,7 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                         }
-                    }).connect(sc.localAddress()).syncUninterruptibly().channel();
+                    }).connect(sc.localAddress()).get();
 
             promise.syncUninterruptibly();
         } finally {
@@ -396,8 +396,8 @@ public class ParameterizedSslHandlerTest {
         testCloseNotify(clientProvider, serverProvider, 0, false);
     }
 
-    private void testCloseNotify(SslProvider clientProvider, SslProvider serverProvider,
-                                 final long closeNotifyReadTimeout, final boolean timeout) throws Exception {
+    private static void testCloseNotify(SslProvider clientProvider, SslProvider serverProvider,
+                                        final long closeNotifyReadTimeout, final boolean timeout) throws Exception {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
 
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
@@ -442,7 +442,7 @@ public class ParameterizedSslHandlerTest {
                             });
                             ch.pipeline().addLast(handler);
                         }
-                    }).bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                    }).bind(new InetSocketAddress(0)).get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -480,7 +480,7 @@ public class ParameterizedSslHandlerTest {
                             });
                             ch.pipeline().addLast(handler);
                         }
-                    }).connect(sc.localAddress()).syncUninterruptibly().channel();
+                    }).connect(sc.localAddress()).get();
 
             serverPromise.awaitUninterruptibly();
             clientPromise.awaitUninterruptibly();
@@ -554,11 +554,11 @@ public class ParameterizedSslHandlerTest {
         }
     }
 
-    private void reentryOnHandshakeComplete(SslProvider clientProvider, SslProvider serverProvider,
-                                            EventLoopGroup group, SocketAddress bindAddress,
-                                            Class<? extends ServerChannel> serverClass,
-                                            Class<? extends Channel> clientClass, boolean serverAutoRead,
-                                            boolean clientAutoRead) throws Exception {
+    private static void reentryOnHandshakeComplete(SslProvider clientProvider, SslProvider serverProvider,
+                                                   EventLoopGroup group, SocketAddress bindAddress,
+                                                   Class<? extends ServerChannel> serverClass,
+                                                   Class<? extends Channel> clientClass, boolean serverAutoRead,
+                                                   boolean clientAutoRead) throws Exception {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         final SslContext sslServerCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(serverProvider)
@@ -589,7 +589,7 @@ public class ParameterizedSslHandlerTest {
                             ch.pipeline().addLast(new ReentryWriteSslHandshakeHandler(expectedContent, serverQueue,
                                     serverLatch));
                         }
-                    }).bind(bindAddress).syncUninterruptibly().channel();
+                    }).bind(bindAddress).get();
 
             cc = new Bootstrap()
                     .group(group)
@@ -602,7 +602,7 @@ public class ParameterizedSslHandlerTest {
                             ch.pipeline().addLast(new ReentryWriteSslHandshakeHandler(expectedContent, clientQueue,
                                     clientLatch));
                         }
-                    }).connect(sc.localAddress()).syncUninterruptibly().channel();
+                    }).connect(sc.localAddress()).get();
 
             serverLatch.await();
             assertEquals(expectedContent, serverQueue.toString());

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -98,7 +98,7 @@ public abstract class RenegotiateTest {
                             });
                         }
                     });
-            Channel channel = sb.bind(new LocalAddress("test")).syncUninterruptibly().channel();
+            Channel channel = sb.bind(new LocalAddress("test")).get();
 
             final SslContext clientContext = SslContextBuilder.forClient()
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
@@ -131,7 +131,7 @@ public abstract class RenegotiateTest {
                         }
                     });
 
-            Channel clientChannel = bootstrap.connect(channel.localAddress()).syncUninterruptibly().channel();
+            Channel clientChannel = bootstrap.connect(channel.localAddress()).get();
             latch.await();
             clientChannel.close().syncUninterruptibly();
             channel.close().syncUninterruptibly();

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -142,7 +142,7 @@ final class SniClientJava8TestUtil {
                         }
                     });
                 }
-            }).bind(address).syncUninterruptibly().channel();
+            }).bind(address).get();
 
             sslClientContext = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)
                     .sslProvider(sslClientProvider).build();
@@ -150,8 +150,7 @@ final class SniClientJava8TestUtil {
             SslHandler sslHandler = new SslHandler(
                     sslClientContext.newEngine(ByteBufAllocator.DEFAULT, sniHost, -1));
             Bootstrap cb = new Bootstrap();
-            cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler)
-                    .connect(address).syncUninterruptibly().channel();
+            cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler).connect(address).get();
 
             promise.syncUninterruptibly();
             sslHandler.handshakeFuture().syncUninterruptibly();

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -20,8 +20,8 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalHandler;
@@ -29,7 +29,6 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
-
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
@@ -39,7 +38,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -131,7 +129,7 @@ public class SniClientTest {
                         return finalContext;
                     }));
                 }
-            }).bind(address).syncUninterruptibly().channel();
+            }).bind(address).get();
 
             TrustManagerFactory tmf = SniClientJava8TestUtil.newSniX509TrustmanagerFactory(sniHostName);
             sslClientContext = SslContextBuilder.forClient().trustManager(tmf)
@@ -140,8 +138,7 @@ public class SniClientTest {
 
             SslHandler handler = new SslHandler(
                     sslClientContext.newEngine(ByteBufAllocator.DEFAULT, sniHostName, -1));
-            cc = cb.group(group).channel(LocalChannel.class).handler(handler)
-                    .connect(address).syncUninterruptibly().channel();
+            cc = cb.group(group).channel(LocalChannel.class).handler(handler).connect(address).get();
             assertEquals(sniHostName, promise.syncUninterruptibly().getNow());
 
             // After we are done with handshaking getHandshakeSession() should return null.

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -162,7 +162,7 @@ public class SslErrorTest {
                                 }
                             });
                         }
-                    }).bind(0).sync().channel();
+                    }).bind(0).get();
 
             clientChannel = new Bootstrap().group(group)
                     .channel(NioSocketChannel.class)
@@ -183,7 +183,7 @@ public class SslErrorTest {
                                 }
                             });
                         }
-                    }).connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+                    }).connect(serverChannel.localAddress()).get();
             // Block until we received the correct exception
             promise.syncUninterruptibly();
         } finally {
@@ -298,8 +298,7 @@ public class SslErrorTest {
             }
         }
         Throwable error = new AssertionError("message not contains any of '"
-                + Arrays.toString(messageParts) + "': " + message);
-        error.initCause(cause);
+                + Arrays.toString(messageParts) + "': " + message, cause);
         promise.setFailure(error);
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
@@ -25,8 +25,8 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalHandler;
@@ -47,13 +47,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
+import javax.net.ssl.SSLHandshakeException;
 import java.net.SocketAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -399,29 +398,25 @@ public class OcspTest {
     }
 
     private static Channel newServer(EventLoopGroup group, SocketAddress address,
-            SslContext context, byte[] response, ChannelHandler handler) {
+            SslContext context, byte[] response, ChannelHandler handler) throws Exception {
 
         ServerBootstrap bootstrap = new ServerBootstrap()
                 .channel(LocalServerChannel.class)
                 .group(group)
                 .childHandler(newServerHandler(context, response, handler));
 
-        return bootstrap.bind(address)
-                .syncUninterruptibly()
-                .channel();
+        return bootstrap.bind(address).get();
     }
 
     private static Channel newClient(EventLoopGroup group, SocketAddress address,
-            SslContext context, OcspClientCallback callback, ChannelHandler handler) {
+            SslContext context, OcspClientCallback callback, ChannelHandler handler) throws Exception {
 
         Bootstrap bootstrap = new Bootstrap()
                 .channel(LocalChannel.class)
                 .group(group)
                 .handler(newClientHandler(context, callback, handler));
 
-        return bootstrap.connect(address)
-                .syncUninterruptibly()
-                .channel();
+        return bootstrap.connect(address).get();
     }
 
     private static ChannelHandler newServerHandler(final SslContext context,

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -16,25 +16,25 @@
 
 package io.netty.handler.traffic;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.local.LocalHandler;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalHandler;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.Attribute;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -72,7 +72,7 @@ public class TrafficShapingHandlerTest {
         }
     }
 
-    private void testHandlerRemove0(final AbstractTrafficShapingHandler trafficHandler)
+    private static void testHandlerRemove0(final AbstractTrafficShapingHandler trafficHandler)
             throws Exception {
         Channel svrChannel = null;
         Channel ch = null;
@@ -91,7 +91,7 @@ public class TrafficShapingHandlerTest {
                         }
                     });
             final LocalAddress svrAddr = new LocalAddress("foo");
-            svrChannel = serverBootstrap.bind(svrAddr).sync().channel();
+            svrChannel = serverBootstrap.bind(svrAddr).get();
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.channel(LocalChannel.class).group(GROUP).handler(new ChannelInitializer<Channel>() {
                 @Override
@@ -99,7 +99,7 @@ public class TrafficShapingHandlerTest {
                     ch.pipeline().addLast("traffic-shaping", trafficHandler);
                 }
             });
-            ch = bootstrap.connect(svrAddr).sync().channel();
+            ch = bootstrap.connect(svrAddr).get();
             Attribute<Runnable> attr = ch.attr(AbstractTrafficShapingHandler.REOPEN_TASK);
             assertNull(attr.get());
             ch.writeAndFlush(Unpooled.wrappedBuffer("foo".getBytes(CharsetUtil.UTF_8)));

--- a/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -72,8 +72,7 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
                 }
             })
             .bind(0)
-            .sync()
-            .channel();
+            .get();
     chan = new Bootstrap()
         .channel(EpollSocketChannel.class)
         .handler(new ChannelInitializer<Channel>() {
@@ -116,8 +115,7 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
         })
         .group(group)
         .connect(serverChan.localAddress())
-        .sync()
-        .channel();
+        .get();
 
         abyte = chan.alloc().directBuffer(1);
         abyte.writeByte('a');

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -479,7 +479,7 @@ public class DnsNameResolver extends InetNameResolver {
             @Override
             protected void initChannel(DatagramChannel ch) {
                 ch.pipeline().addLast(DATAGRAM_ENCODER, DATAGRAM_DECODER, responseHandler);
-                ch.closeFuture().addListener((ChannelFutureListener) future1 -> {
+                ch.closeFuture().addListener(closeFuture -> {
                     resolveCache.clear();
                     cnameCache.clear();
                     authoritativeDnsServerCache.clear();

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServer.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServer.java
@@ -17,7 +17,7 @@ package io.netty.testsuite.autobahn;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
@@ -46,9 +46,9 @@ public class AutobahnServer {
              .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
              .childHandler(new AutobahnServerInitializer());
 
-            ChannelFuture f = b.bind(port).sync();
+            Channel channel = b.bind(port).get();
             System.out.println("Web Socket Server started at port " + port);
-            f.channel().closeFuture().sync();
+            channel.closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();

--- a/testsuite-http2/src/main/java/io/netty/testsuite/http2/Http2Server.java
+++ b/testsuite-http2/src/main/java/io/netty/testsuite/http2/Http2Server.java
@@ -49,7 +49,7 @@ public final class Http2Server {
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new Http2ServerInitializer());
 
-            Channel ch = b.bind(port).sync().channel();
+            Channel ch = b.bind(port).get();
 
             ch.closeFuture().sync();
         } finally {

--- a/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
@@ -50,7 +50,7 @@ public final class HttpNativeServer {
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpNativeServerInitializer());
 
-            Channel channel = b.bind(0).sync().channel();
+            Channel channel = b.bind(0).get();
             System.err.println("Server started, will shutdown now.");
             channel.close().sync();
             serverStartSucess = true;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -16,7 +16,7 @@
 package io.netty.testsuite.transport;
 
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -66,9 +66,9 @@ public abstract class AbstractSingleThreadEventLoopTest {
                 .childHandler(new ChannelHandler() { });
 
         // Not close the Channel to ensure the EventLoop is still shutdown in time.
-        ChannelFuture cf = serverChannelClass() == LocalServerChannel.class
+        Future<Channel> cf = serverChannelClass() == LocalServerChannel.class
                 ? b.bind(new LocalAddress("local")) : b.bind(0);
-        cf.sync().channel();
+        cf.sync();
 
         Future<?> f = loop.shutdownGracefully(0, 1, TimeUnit.MINUTES);
         assertTrue(loop.awaitTermination(600, TimeUnit.MILLISECONDS));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
@@ -29,11 +29,11 @@ import io.netty.handler.codec.sctp.SctpMessageCompletionHandler;
 import io.netty.handler.codec.sctp.SctpOutboundByteStreamHandler;
 import io.netty.testsuite.util.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.TestInfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -92,8 +92,8 @@ public class SctpEchoTest extends AbstractSctpTest {
             }
         });
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 64), data.length - i);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -20,13 +20,14 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.util.CharsetUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
@@ -90,13 +91,13 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
             }
         });
 
-        ChannelFutureListener listener = future -> {
+        GenericFutureListener<Future<? super Channel>> listener = future -> {
             if (!future.isSuccess()) {
                 clientDonePromise.tryFailure(future.cause());
             }
         };
 
-        Channel sc = sb.bind().sync().channel();
+        Channel sc = sb.bind().get();
         for (int i = 0; i < numChannels; i++) {
             cb.connect(sc.localAddress()).addListener(listener);
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
         Socket s = newSocket();
         Channel sc = null;
         try {
-            sc = sb.childHandler(h).childOption(ChannelOption.ALLOW_HALF_CLOSURE, true).bind().sync().channel();
+            sc = sb.childHandler(h).childOption(ChannelOption.ALLOW_HALF_CLOSURE, true).bind().get();
 
             connect(s, sc.localAddress());
             write(s, 1);
@@ -95,7 +95,7 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
         Socket s = newSocket();
         Channel sc = null;
         try {
-            sc = sb.childHandler(h).bind().sync().channel();
+            sc = sb.childHandler(h).bind().get();
 
             connect(s, sc.localAddress());
             write(s, 1);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -115,8 +115,8 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().syncUninterruptibly().channel();
-            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            serverChannel = sb.bind().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
 
             ByteBuf expected = newCompositeBuffer(clientChannel.alloc());
             latch.await();
@@ -258,8 +258,8 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().syncUninterruptibly().channel();
-            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            serverChannel = sb.bind().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
 
             latch.await();
             Object received = clientReceived.get();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramConnectNotExistsTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramConnectNotExistsTest.java
@@ -18,12 +18,12 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
@@ -52,7 +52,7 @@ public class DatagramConnectNotExistsTest extends AbstractClientSocketTest {
     }
 
     public void testConnectNotExists(Bootstrap cb) throws Throwable {
-        // Currently not works on windows
+        // Currently, not works on windows
         // See https://github.com/netty/netty/issues/11285
         assumeFalse(PlatformDependent.isWindows());
         final Promise<Throwable> promise = ImmediateEventExecutor.INSTANCE.newPromise();
@@ -62,15 +62,18 @@ public class DatagramConnectNotExistsTest extends AbstractClientSocketTest {
                 promise.trySuccess(cause);
             }
         });
-        ChannelFuture future = cb.connect(NetUtil.LOCALHOST, SocketTestPermutation.BAD_PORT);
+        Future<Channel> future = cb.connect(NetUtil.LOCALHOST, SocketTestPermutation.BAD_PORT);
+        Channel datagramChannel = null;
         try {
-            Channel datagramChannel = future.syncUninterruptibly().channel();
+            datagramChannel = future.get();
             assertTrue(datagramChannel.isActive());
             datagramChannel.writeAndFlush(
                     Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII)).syncUninterruptibly();
             assertTrue(promise.syncUninterruptibly().getNow() instanceof PortUnreachableException);
         } finally {
-            future.channel().close();
+            if (datagramChannel != null) {
+                datagramChannel.close();
+            }
         }
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
@@ -74,14 +74,14 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         cb.option(ChannelOption.IP_MULTICAST_IF, iface);
         cb.option(ChannelOption.SO_REUSEADDR, true);
 
-        DatagramChannel sc = (DatagramChannel) sb.bind(newSocketAddress(iface)).sync().channel();
+        DatagramChannel sc = (DatagramChannel) sb.bind(newSocketAddress(iface)).get();
         assertEquals(iface, sc.config().getNetworkInterface());
         assertInterfaceAddress(iface, sc.config().getInterface());
 
         InetSocketAddress addr = sc.localAddress();
         cb.localAddress(addr.getPort());
 
-        DatagramChannel cc = (DatagramChannel) cb.bind().sync().channel();
+        DatagramChannel cc = (DatagramChannel) cb.bind().get();
         assertEquals(iface, cc.config().getNetworkInterface());
         assertInterfaceAddress(iface, cc.config().getInterface());
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -47,7 +47,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             cb.handler(new ChannelHandlerAdapter() { });
-            channel = cb.bind(0).sync().channel();
+            channel = cb.bind(0).get();
         } finally {
             closeChannel(channel);
         }
@@ -89,7 +89,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).sync().channel();
+        return cb.bind(newSocketAddress()).get();
     }
 
     @Override
@@ -140,7 +140,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).sync().channel();
+        return sb.bind(newSocketAddress()).get();
     }
 
     @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -168,11 +168,11 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
             final SocketAddress sender;
             if (bindClient) {
-                cc = cb.bind(newSocketAddress()).sync().channel();
+                cc = cb.bind(newSocketAddress()).get();
                 sender = cc.localAddress();
             } else {
                 cb.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
-                cc = cb.register().sync().channel();
+                cc = cb.register().get();
                 sender = null;
             }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/ServerSocketSuspendTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/ServerSocketSuspendTest.java
@@ -50,7 +50,7 @@ public class ServerSocketSuspendTest extends AbstractServerSocketTest {
         sb.option(ChannelOption.AUTO_READ, false);
         sb.childHandler(counter);
 
-        Channel sc = sb.bind().sync().channel();
+        Channel sc = sb.bind().get();
 
         List<Socket> sockets = new ArrayList<>();
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -65,7 +65,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                     .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvByteBufAllocator())
                     .childHandler(serverInitializer);
 
-            serverChannel = sb.bind().syncUninterruptibly().channel();
+            serverChannel = sb.bind().get();
 
             cb.option(ChannelOption.AUTO_READ, true)
                     // We want to ensure that we attempt multiple individual read operations per read loop so we can
@@ -73,7 +73,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                     .option(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvByteBufAllocator())
                     .handler(clientInitializer);
 
-            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
 
             // 3 bytes means 3 independent reads for TestRecvByteBufAllocator
             clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[3]));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -19,7 +19,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -53,8 +52,8 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
         sb.childHandler(serverHandler);
         cb.handler(clientHandler);
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         // Ensure the server socket accepted the client connection *and* initialized pipeline successfully.
         serverHandler.channelFuture.sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -23,12 +23,12 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,8 +54,8 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
         cb.handler(ch);
         sb.childHandler(sh);
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         ChannelFuture f = cc.write(a);
         assertTrue(f.cancel(false));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -50,7 +50,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
 
     public void testShutdownNotYetConnected(Bootstrap cb) throws Throwable {
         SocketChannel ch = (SocketChannel) cb.handler(new ChannelHandler() { })
-                .bind(newSocketAddress()).syncUninterruptibly().channel();
+                .bind(newSocketAddress()).get();
         try {
             try {
                 ch.shutdownInput().syncUninterruptibly();
@@ -91,7 +91,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
                     public void channelActive(ChannelHandlerContext ctx) throws Exception {
                         ctx.writeAndFlush(Unpooled.copyInt(42));
                     }
-                }).channel(NioServerSocketChannel.class).bind(0).sync().channel();
+                }).channel(NioServerSocketChannel.class).bind(0).get();
 
                 final CountDownLatch readLatch = new CountDownLatch(1);
                 bootstrap.handler(new ByteToMessageDecoder() {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
@@ -48,7 +48,9 @@ public class SocketCloseForciblyTest extends AbstractSocketTest {
 
         Channel sc = sb.bind().get();
 
-        cb.connect(sc.localAddress()).get().closeFuture().syncUninterruptibly();
+        Channel channel = cb.register().get();
+        channel.connect(sc.localAddress());
+        channel.closeFuture().syncUninterruptibly();
         sc.close().sync();
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
@@ -46,9 +46,9 @@ public class SocketCloseForciblyTest extends AbstractSocketTest {
 
         cb.handler(new ChannelHandler() { });
 
-        Channel sc = sb.bind().sync().channel();
+        Channel sc = sb.bind().get();
 
-        cb.connect(sc.localAddress()).channel().closeFuture().syncUninterruptibly();
+        cb.connect(sc.localAddress()).get().closeFuture().syncUninterruptibly();
         sc.close().sync();
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -88,7 +88,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().syncUninterruptibly().channel();
+            serverChannel = sb.bind().get();
 
             cb.handler(new ChannelInitializer<Channel>() {
                 @Override
@@ -113,7 +113,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
                     });
                 }
             });
-            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
             latch.await();
         } finally {
             if (serverChannel != null) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ConnectTimeoutException;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -33,14 +34,13 @@ import org.junit.jupiter.api.Timeout;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.Socket;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_HOST;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_PORT;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -58,8 +58,9 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
     public void testConnectTimeout(Bootstrap cb) throws Throwable {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000);
         Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
-        assertThat(future.await(3000), is(true));
-        future.get().close();
+        assertThat(future.await(3000)).isTrue();
+        ExecutionException e = assertThrows(ExecutionException.class, future::get);
+        assertThat(e).hasCauseInstanceOf(ConnectTimeoutException.class);
     }
 
     @Test
@@ -94,8 +95,8 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         cb.handler(handler);
         cb.option(ChannelOption.ALLOW_HALF_CLOSURE, halfClosure);
         Future<Channel> future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).awaitUninterruptibly();
-        assertThat(future.cause(), is(instanceOf(ConnectException.class)));
-        assertThat(errorPromise.cause(), is(nullValue()));
+        assertThat(future.cause()).isInstanceOf(ConnectException.class);
+        assertThat(errorPromise.cause()).isNull();
     }
 
     @Test
@@ -136,7 +137,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         }
 
         if (future.cancel(true)) {
-            assertThat(future.isCancelled(), is(true));
+            assertThat(future.isCancelled()).isTrue();
         } else {
             // Cancellation not supported by the transport.
             future.get().close();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -16,14 +16,15 @@
 package io.netty.testsuite.transport.socket;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
-import io.netty.util.internal.SocketUtils;
 import io.netty.util.NetUtil;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -36,7 +37,9 @@ import java.util.concurrent.TimeUnit;
 
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_HOST;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_PORT;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -54,12 +57,9 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
 
     public void testConnectTimeout(Bootstrap cb) throws Throwable {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000);
-        ChannelFuture future = cb.connect(BAD_HOST, BAD_PORT);
-        try {
-            assertThat(future.await(3000), is(true));
-        } finally {
-            future.channel().close();
-        }
+        Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
+        assertThat(future.await(3000), is(true));
+        future.get().close();
     }
 
     @Test
@@ -93,7 +93,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
 
         cb.handler(handler);
         cb.option(ChannelOption.ALLOW_HALF_CLOSURE, halfClosure);
-        ChannelFuture future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).awaitUninterruptibly();
+        Future<Channel> future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).awaitUninterruptibly();
         assertThat(future.cause(), is(instanceOf(ConnectException.class)));
         assertThat(errorPromise.cause(), is(nullValue()));
     }
@@ -126,24 +126,20 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
 
     public void testConnectCancellation(Bootstrap cb) throws Throwable {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4000);
-        ChannelFuture future = cb.connect(BAD_HOST, BAD_PORT);
-        try {
-            if (future.await(1000)) {
-                if (future.isSuccess()) {
-                    fail("A connection attempt to " + BAD_HOST + " must not succeed.");
-                } else {
-                    throw future.cause();
-                }
-            }
-
-            if (future.cancel(true)) {
-                assertThat(future.channel().closeFuture().await(500), is(true));
-                assertThat(future.isCancelled(), is(true));
+        Future<Channel> future = cb.connect(BAD_HOST, BAD_PORT);
+        if (future.await(1000)) {
+            if (future.isSuccess()) {
+                fail("A connection attempt to " + BAD_HOST + " must not succeed.");
             } else {
-                // Cancellation not supported by the transport.
+                throw future.cause();
             }
-        } finally {
-            future.channel().close();
+        }
+
+        if (future.cancel(true)) {
+            assertThat(future.isCancelled(), is(true));
+        } else {
+            // Cancellation not supported by the transport.
+            future.get().close();
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -96,8 +96,8 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().sync().channel();
-            clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
+            serverChannel = sb.bind().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
             clientChannel.writeAndFlush(clientChannel.alloc().buffer().writeZero(1)).syncUninterruptibly();
 
             // The acceptor shouldn't read any data until we call read() below, but give it some time to see if it will.
@@ -172,8 +172,8 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().sync().channel();
-            clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
+            serverChannel = sb.bind().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
             clientChannel.writeAndFlush(clientChannel.alloc().buffer().writeZero(1)).syncUninterruptibly();
             serverReadLatch.await();
             clientReadLatch.await();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -24,14 +24,14 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -82,8 +82,8 @@ public class SocketEchoTest extends AbstractSocketTest {
         sb.childOption(ChannelOption.AUTO_READ, autoRead);
         cb.option(ChannelOption.AUTO_READ, autoRead);
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 64), data.length - i);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -26,11 +26,11 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.jupiter.api.TestInfo;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,10 +49,10 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
             sb.option(ChannelOption.SO_BACKLOG, 1024);
             sb.childHandler(serverInitializer);
 
-            serverChannel = sb.bind().syncUninterruptibly().channel();
+            serverChannel = sb.bind().get();
 
             cb.handler(new MyInitializer());
-            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
 
             clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[1024]));
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -100,8 +100,8 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         });
         cb.handler(new ChannelHandler() { });
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         // Request file region which is bigger then the underlying file.
         FileRegion region = new DefaultFileRegion(
@@ -163,9 +163,9 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         sb.childHandler(sh);
         cb.handler(ch);
 
-        Channel sc = sb.bind().sync().channel();
+        Channel sc = sb.bind().get();
 
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).get();
         FileRegion region = new DefaultFileRegion(
                 new RandomAccessFile(file, "r").getChannel(), startOffset, data.length - bufferSize);
         FileRegion emptyRegion = new DefaultFileRegion(new RandomAccessFile(file, "r").getChannel(), 0, 0);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -83,8 +83,8 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 3), data.length - i);
             cc.writeAndFlush(Unpooled.wrappedBuffer(data, i, length));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -124,8 +124,8 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         cb.handler(ch);
         sb.childHandler(sh);
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 8), data.length - i);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -104,8 +103,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().sync().channel();
-            Channel clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
+            serverChannel = sb.bind().get();
+            Channel clientChannel = cb.connect(serverChannel.localAddress()).get();
             clientChannel.closeFuture().await();
             assertEquals(1, shutdownEventReceivedCounter.get());
             assertEquals(1, shutdownReadCompleteEventReceivedCounter.get());
@@ -203,8 +202,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().sync().channel();
-            clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
+            serverChannel = sb.bind().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
             clientChannel.read();
 
             serverInitializedLatch.await();
@@ -239,7 +238,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     private static void testAutoCloseFalseDoesShutdownOutput(boolean allowHalfClosed,
                                                              final boolean clientIsLeader,
                                                              ServerBootstrap sb,
-                                                             Bootstrap cb) throws InterruptedException {
+                                                             Bootstrap cb) throws Exception {
         final int expectedBytes = 100;
         final CountDownLatch serverReadExpectedLatch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(1);
@@ -272,8 +271,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().sync().channel();
-            clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
+            serverChannel = sb.bind().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
 
             doneLatch.await();
             assertNull(causeRef.get());
@@ -327,7 +326,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                     // but the close will be done after the Selector did process all events. Because of
                     // this we will need to give it a bit time to ensure the FD is actual closed before we
                     // count down the latch and try to write.
-                    future1.channel().eventLoop().schedule(followerCloseLatch::countDown, 200, TimeUnit.MILLISECONDS);
+                    future1.channel().eventLoop().schedule(followerCloseLatch::countDown, 200, MILLISECONDS);
                 }));
             }
         }
@@ -508,8 +507,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            serverChannel = sb.bind().sync().channel();
-            clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
+            serverChannel = sb.bind().get();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
             clientChannel.read();
 
             serverInitializedLatch.await();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -46,10 +46,10 @@ public class SocketMultipleConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelHandler() { });
-            sc = sb.bind(NetUtil.LOCALHOST, 0).syncUninterruptibly().channel();
+            sc = sb.bind(NetUtil.LOCALHOST, 0).get();
 
             cb.handler(new ChannelHandler() { });
-            cc = cb.register().syncUninterruptibly().channel();
+            cc = cb.register().get();
             cc.connect(sc.localAddress()).syncUninterruptibly();
             ChannelFuture connectFuture2 = cc.connect(sc.localAddress()).await();
             assertTrue(connectFuture2.cause() instanceof AlreadyConnectedException);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
@@ -96,8 +96,8 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
         for (String element : data) {
             cc.writeAndFlush(element);
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
@@ -61,13 +61,13 @@ public class SocketReadPendingTest extends AbstractSocketTest {
               .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvByteBufAllocator(2))
               .childHandler(serverInitializer);
 
-            serverChannel = sb.bind().syncUninterruptibly().channel();
+            serverChannel = sb.bind().get();
 
             cb.option(ChannelOption.AUTO_READ, false)
               // We intend to do 2 reads per read loop wakeup
               .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvByteBufAllocator(2))
               .handler(clientInitializer);
-            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
 
             // 4 bytes means 2 read loops for TestNumReadsRecvByteBufAllocator
             clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[4]));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
@@ -79,8 +79,8 @@ public class SocketRstTest extends AbstractSocketTest {
                 });
             }
         });
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         // Wait for the server to get setup.
         latch.await();
@@ -94,7 +94,7 @@ public class SocketRstTest extends AbstractSocketTest {
         // Verify the client received a RST.
         Throwable cause = throwableRef.get();
         assertTrue(cause instanceof IOException,
-            "actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]");
+                   "actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + ']');
 
         assertRstOnCloseException((IOException) cause, cc);
     }
@@ -133,7 +133,7 @@ public class SocketRstTest extends AbstractSocketTest {
                 });
             }
         });
-        Channel sc = sb.bind().sync().channel();
+        Channel sc = sb.bind().get();
         cb.connect(sc.localAddress()).syncUninterruptibly();
 
         // Wait for the server to get setup.

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -158,7 +158,6 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         try {
             sb.childHandler(new ChannelInitializer<Channel>() {
                 @Override
-                @SuppressWarnings("deprecation")
                 public void initChannel(Channel sch) throws Exception {
                     serverChannel = sch;
                     serverSslHandler = newSslHandler(serverCtx, sch.alloc(), executorService);
@@ -171,7 +170,6 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
 
             cb.handler(new ChannelInitializer<Channel>() {
                 @Override
-                @SuppressWarnings("deprecation")
                 public void initChannel(Channel sch) throws Exception {
                     clientChannel = sch;
                     clientSslHandler = newSslHandler(clientCtx, sch.alloc(), executorService);
@@ -182,7 +180,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                 }
             });
 
-            Channel sc = sb.bind().sync().channel();
+            Channel sc = sb.bind().get();
             cb.connect(sc.localAddress()).sync();
 
             Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();
@@ -228,7 +226,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
     @Sharable
     private static final class TestHandler extends SimpleChannelInboundHandler<ByteBuf> {
 
-        protected final AtomicReference<Throwable> exception;
+        private final AtomicReference<Throwable> exception;
         private int handshakeCounter;
 
         TestHandler(AtomicReference<Throwable> exception) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -307,7 +307,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             }
         });
 
-        final Channel sc = sb.bind().sync().channel();
+        final Channel sc = sb.bind().get();
         cb.connect(sc.localAddress()).sync();
 
         final Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -150,8 +150,8 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
                 }
             });
 
-            Channel sc = sb.bind().sync().channel();
-            Channel cc = cb.connect(sc.localAddress()).sync().channel();
+            Channel sc = sb.bind().get();
+            Channel cc = cb.connect(sc.localAddress()).get();
 
             ch.latch.await();
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -21,8 +21,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.SocketChannel;
@@ -33,7 +33,6 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,7 +40,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -85,7 +83,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
     @MethodSource("data")
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testSslSessionReuse(SslContext serverCtx, SslContext clientCtx, TestInfo testInfo) throws Throwable {
-        run(testInfo, (sb, cb) -> this.testSslSessionReuse(sb, cb, serverCtx, clientCtx));
+        run(testInfo, (sb, cb) -> testSslSessionReuse(sb, cb, serverCtx, clientCtx));
     }
 
     public void testSslSessionReuse(ServerBootstrap sb, Bootstrap cb,
@@ -105,7 +103,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
                 sch.pipeline().addLast(sh);
             }
         });
-        final Channel sc = sb.bind().sync().channel();
+        final Channel sc = sb.bind().get();
 
         cb.handler(new ChannelInitializer<SocketChannel>() {
             @Override
@@ -123,14 +121,14 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         try {
             SSLSessionContext clientSessionCtx = clientCtx.sessionContext();
             ByteBuf msg = Unpooled.wrappedBuffer(new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
-            Channel cc = cb.connect(sc.localAddress()).sync().channel();
+            Channel cc = cb.connect(sc.localAddress()).get();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
             rethrowHandlerExceptions(sh, ch);
             Set<String> sessions = sessionIdSet(clientSessionCtx.getIds());
 
             msg = Unpooled.wrappedBuffer(new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
-            cc = cb.connect(sc.localAddress()).sync().channel();
+            cc = cb.connect(sc.localAddress()).get();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
             assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
@@ -110,8 +110,8 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         run(testInfo, (sb, cb) -> testStartTls(sb, cb, serverCtx, clientCtx));
     }
 
-    public void testStartTls(ServerBootstrap sb, Bootstrap cb,
-                             SslContext serverCtx, SslContext clientCtx) throws Throwable {
+    public static void testStartTls(ServerBootstrap sb, Bootstrap cb,
+                                    SslContext serverCtx, SslContext clientCtx) throws Throwable {
         testStartTls(sb, cb, serverCtx, clientCtx, true);
     }
 
@@ -123,13 +123,13 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         run(testInfo, (sb, cb) -> testStartTlsNotAutoRead(sb, cb, serverCtx, clientCtx));
     }
 
-    public void testStartTlsNotAutoRead(ServerBootstrap sb, Bootstrap cb,
-                                        SslContext serverCtx, SslContext clientCtx) throws Throwable {
+    public static void testStartTlsNotAutoRead(ServerBootstrap sb, Bootstrap cb,
+                                               SslContext serverCtx, SslContext clientCtx) throws Throwable {
         testStartTls(sb, cb, serverCtx, clientCtx, false);
     }
 
-    private void testStartTls(ServerBootstrap sb, Bootstrap cb,
-                              SslContext serverCtx, SslContext clientCtx, boolean autoRead) throws Throwable {
+    private static void testStartTls(ServerBootstrap sb, Bootstrap cb,
+                                     SslContext serverCtx, SslContext clientCtx, boolean autoRead) throws Throwable {
         sb.childOption(ChannelOption.AUTO_READ, autoRead);
         cb.option(ChannelOption.AUTO_READ, autoRead);
 
@@ -159,8 +159,8 @@ public class SocketStartTlsTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         while (cc.isActive()) {
             if (sh.exception.get() != null) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
@@ -104,8 +104,8 @@ public class SocketStringEchoTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
         for (String element : data) {
             String delimiter = random.nextBoolean() ? "\r\n" : "\n";
             cc.writeAndFlush(element + delimiter);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -282,7 +282,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
      * @param multipleMessage
      *            how many message to send at each step (for READ: the first should be 1, as the two last steps to
      *            ensure correct testing)
-     * @throws Throwable
+     * @throws Throwable if something goes wrong, and the test fails.
      */
     private static void testTrafficShapping0(
             ServerBootstrap sb, Bootstrap cb, final boolean additionalExecutor,
@@ -334,8 +334,8 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
             }
         });
 
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         int totalNb = 0;
         for (int i = 1; i < multipleMessage.length; i++) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
@@ -38,8 +38,11 @@ public class WriteBeforeRegisteredTest extends AbstractClientSocketTest {
         TestHandler h = new TestHandler();
         SocketChannel ch = null;
         try {
-            ch = (SocketChannel) cb.handler(h).connect(newSocketAddress()).channel();
+            cb.handler(h);
+            ch = (SocketChannel) cb.createUnregistered().get();
             ch.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 1 }));
+            ch.register().sync();
+            ch.connect(newSocketAddress());
         } finally {
             if (ch != null) {
                 ch.close();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
@@ -39,7 +39,7 @@ public class WriteBeforeRegisteredTest extends AbstractClientSocketTest {
         SocketChannel ch = null;
         try {
             cb.handler(h);
-            ch = (SocketChannel) cb.createUnregistered().get();
+            ch = (SocketChannel) cb.createUnregistered();
             ch.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 1 }));
             ch.register().sync();
             ch.connect(newSocketAddress());

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -16,7 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
@@ -73,7 +73,7 @@ public class EpollDatagramChannelTest {
     }
 
     @Test
-    public void testLocalAddressBeforeAndAfterBind() {
+    public void testLocalAddressBeforeAndAfterBind() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(1, EpollHandler.newFactory());
         try {
             TestHandler handler = new TestHandler();
@@ -85,16 +85,16 @@ public class EpollDatagramChannelTest {
                     .localAddress(localAddressBeforeBind)
                     .handler(handler);
 
-            ChannelFuture future = bootstrap.bind().syncUninterruptibly();
+            Channel channel = bootstrap.bind().get();
 
             assertNull(handler.localAddress);
 
-            SocketAddress localAddressAfterBind = future.channel().localAddress();
+            SocketAddress localAddressAfterBind = channel.localAddress();
             assertNotNull(localAddressAfterBind);
             assertTrue(localAddressAfterBind instanceof InetSocketAddress);
             assertTrue(((InetSocketAddress) localAddressAfterBind).getPort() != 0);
 
-            future.channel().close().syncUninterruptibly();
+            channel.close().syncUninterruptibly();
         } finally {
             group.shutdownGracefully();
         }
@@ -112,7 +112,7 @@ public class EpollDatagramChannelTest {
 
         @Override
         public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
-            this.localAddress = ctx.channel().localAddress();
+            localAddress = ctx.channel().localAddress();
             ctx.fireChannelRegistered();
         }
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -110,7 +110,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                     // Nothing will be sent.
                 }
             });
-            cc = cb.bind(newSocketAddress()).sync().channel();
+            cc = cb.bind(newSocketAddress()).get();
             final SocketAddress ccAddress = cc.localAddress();
 
             final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
@@ -147,7 +147,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
             });
 
             sb.option(ChannelOption.AUTO_READ, false);
-            sc = sb.bind(newSocketAddress()).sync().channel();
+            sc = sb.bind(newSocketAddress()).get();
 
             if (connected) {
                 sc.connect(cc.localAddress()).syncUninterruptibly();
@@ -220,7 +220,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                     // Nothing will be sent.
                 }
             });
-            cc = cb.bind(newSocketAddress()).sync().channel();
+            cc = cb.bind(newSocketAddress()).get();
             final SocketAddress ccAddress = cc.localAddress();
 
             final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
@@ -248,7 +248,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
                 }
             });
 
-            sc = sb.bind(newSocketAddress()).sync().channel();
+            sc = sb.bind(newSocketAddress()).get();
 
             if (connected) {
                 sc.connect(cc.localAddress()).syncUninterruptibly();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
@@ -47,6 +47,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
         return EpollSocketTestPermutation.INSTANCE.datagram(InternetProtocolFamily.IPv4);
     }
 
+    @Override
     public void testSimpleSendWithConnect(Bootstrap sb, Bootstrap cb) throws Throwable {
         // Run this test with IP_RECVORIGDSTADDR option enabled
         sb.option(EpollChannelOption.IP_RECVORIGDSTADDR, true);
@@ -92,11 +93,11 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
 
     private void testSegmentedDatagramPacket(Bootstrap sb, Bootstrap cb, boolean composite, boolean gro)
             throws Throwable {
-        if (!(cb.group() instanceof EpollEventLoopGroup)) {
+        if (!(cb.config().group() instanceof EpollEventLoopGroup)) {
             // Only supported for the native epoll transport.
             return;
         }
-        if (gro && !(sb.group() instanceof EpollEventLoopGroup)) {
+        if (gro && !(sb.config().group() instanceof EpollEventLoopGroup)) {
             // Only supported for the native epoll transport.
             return;
         }
@@ -112,7 +113,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                 }
             });
 
-            cc = cb.bind(newSocketAddress()).sync().channel();
+            cc = cb.bind(newSocketAddress()).get();
 
             final int numBuffers = 16;
             final int segmentSize = 512;
@@ -132,7 +133,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                         latch.countDown();
                     }
                 }
-            }).bind(newSocketAddress()).sync().channel();
+            }).bind(newSocketAddress()).get();
 
             if (sc instanceof EpollDatagramChannel) {
                 assertEquals(gro, sc.config().getOption(EpollChannelOption.UDP_GRO));

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramPathTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramPathTest.java
@@ -39,7 +39,7 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 bootstrap.handler(new ChannelHandlerAdapter() { })
-                         .connect(EpollSocketTestPermutation.newSocketAddress()).sync().channel();
+                         .connect(EpollSocketTestPermutation.newSocketAddress()).get();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {
                 assertTrue(e.getCause() instanceof FileNotFoundException);
@@ -52,7 +52,7 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
-                                      .bind(EpollSocketTestPermutation.newSocketAddress()).sync().channel();
+                                      .bind(EpollSocketTestPermutation.newSocketAddress()).get();
                 ch.writeAndFlush(new DomainDatagramPacket(
                         Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII),
                         EpollSocketTestPermutation.newSocketAddress())).sync();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramUnicastTest.java
@@ -51,7 +51,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             channel = cb.handler(new ChannelHandlerAdapter() { })
-                    .bind(newSocketAddress()).sync().channel();
+                    .bind(newSocketAddress()).get();
             assertThat(channel.localAddress()).isNotNull()
                     .isInstanceOf(DomainSocketAddress.class);
         } finally {
@@ -104,7 +104,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).sync().channel();
+        return cb.bind(newSocketAddress()).get();
     }
 
     @Override
@@ -149,7 +149,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).sync().channel();
+        return sb.bind(newSocketAddress()).get();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.FileDescriptor;
+import io.netty.channel.unix.UnixChannelOption;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractSocketTest;
 import org.junit.jupiter.api.Test;
@@ -85,10 +86,10 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
                 ctx.close();
             }
         });
-        cb.option(EpollChannelOption.DOMAIN_SOCKET_READ_MODE,
-                DomainSocketReadMode.FILE_DESCRIPTORS);
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        cb.option(UnixChannelOption.DOMAIN_SOCKET_READ_MODE,
+                  DomainSocketReadMode.FILE_DESCRIPTORS);
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         Object received = queue.take();
         cc.close().sync();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -37,13 +37,13 @@ public class EpollServerSocketChannelConfigTest {
     private static EpollServerSocketChannel ch;
 
     @BeforeAll
-    public static void before() {
+    public static void before() throws Exception {
         group = new MultithreadEventLoopGroup(1, EpollHandler.newFactory());
         ServerBootstrap bootstrap = new ServerBootstrap();
         ch = (EpollServerSocketChannel) bootstrap.group(group)
                 .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                .bind(new InetSocketAddress(0)).get();
     }
 
     @AfterAll

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -56,12 +56,12 @@ public class EpollSocketChannelConfigTest {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws Exception {
         Bootstrap bootstrap = new Bootstrap();
         ch = (EpollSocketChannel) bootstrap.group(group)
                 .channel(EpollSocketChannel.class)
                 .handler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                .bind(new InetSocketAddress(0)).get();
     }
 
     @AfterEach
@@ -76,9 +76,9 @@ public class EpollSocketChannelConfigTest {
     private static long nextLong(long n) {
         long bits, val;
         do {
-           bits = (rand.nextLong() << 1) >>> 1;
+           bits = rand.nextLong() << 1 >>> 1;
            val = bits % n;
-        } while (bits - val + (n - 1) < 0L);
+        } while (bits - val + n - 1 < 0L);
         return val;
      }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
@@ -38,7 +38,7 @@ public class EpollSocketChannelTest {
             EpollSocketChannel ch = (EpollSocketChannel) bootstrap.group(group)
                     .channel(EpollSocketChannel.class)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                    .bind(new InetSocketAddress(0)).get();
             EpollTcpInfo info = ch.tcpInfo();
             assertTcpInfo0(info);
             ch.close().syncUninterruptibly();
@@ -56,7 +56,7 @@ public class EpollSocketChannelTest {
             EpollSocketChannel ch = (EpollSocketChannel) bootstrap.group(group)
                     .channel(EpollSocketChannel.class)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                    .bind(new InetSocketAddress(0)).get();
             EpollTcpInfo info = new EpollTcpInfo();
             ch.tcpInfo(info);
             assertTcpInfo0(info);
@@ -114,7 +114,7 @@ public class EpollSocketChannelTest {
                     .channel(EpollSocketChannel.class)
                     .option(ChannelOption.SO_LINGER, 10)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                    .bind(new InetSocketAddress(0)).get();
             ch.close().syncUninterruptibly();
         } finally {
             group.shutdownGracefully();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -54,12 +54,12 @@ public class EpollSocketTcpMd5Test {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws Exception {
         ServerBootstrap bootstrap = new ServerBootstrap();
         server = (EpollServerSocketChannel) bootstrap.group(GROUP)
                 .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).syncUninterruptibly().channel();
+                .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).get();
     }
 
     @AfterEach
@@ -80,7 +80,7 @@ public class EpollSocketTcpMd5Test {
         EpollServerSocketChannel ch = (EpollServerSocketChannel) bootstrap.group(GROUP)
                 .channel(EpollServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                .bind(new InetSocketAddress(0)).get();
 
         ch.config().setOption(EpollChannelOption.TCP_MD5SIG,
                 Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
@@ -102,7 +102,7 @@ public class EpollSocketTcpMd5Test {
                     .option(EpollChannelOption.TCP_MD5SIG,
                             Collections.singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
-                    .connect(server.localAddress()).syncUninterruptibly().channel();
+                    .connect(server.localAddress()).get();
             client.close().syncUninterruptibly();
         });
         assertTrue(completion.getCause() instanceof ConnectTimeoutException);
@@ -118,7 +118,7 @@ public class EpollSocketTcpMd5Test {
                 .handler(new ChannelHandler() { })
                 .option(EpollChannelOption.TCP_MD5SIG,
                         Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
-                .connect(server.localAddress()).syncUninterruptibly().channel();
+                .connect(server.localAddress()).get();
         client.close().syncUninterruptibly();
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -33,7 +33,9 @@ import org.junit.jupiter.api.Test;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -94,7 +96,7 @@ public class EpollSocketTcpMd5Test {
         server.config().setOption(EpollChannelOption.TCP_MD5SIG,
                 Collections.singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
 
-        final CompletionException completion = assertThrows(CompletionException.class, () -> {
+        ExecutionException completion = assertThrows(ExecutionException.class, () -> {
             EpollSocketChannel client = (EpollSocketChannel) new Bootstrap().group(GROUP)
                     .channel(EpollSocketChannel.class)
                     .handler(new ChannelHandler() {
@@ -105,7 +107,8 @@ public class EpollSocketTcpMd5Test {
                     .connect(server.localAddress()).get();
             client.close().syncUninterruptibly();
         });
-        assertTrue(completion.getCause() instanceof ConnectTimeoutException);
+        assertThat(completion.getCause())
+                .isInstanceOf(ConnectTimeoutException.class);
     }
 
     @Test

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
@@ -81,7 +81,7 @@ public class KQueueChannelConfigTest {
                     .channel(KQueueSocketChannel.class)
                     .option(ChannelOption.SO_LINGER, 10)
                     .handler(new ChannelHandler() { })
-                    .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                    .bind(new InetSocketAddress(0)).get();
             ch.close().syncUninterruptibly();
         } finally {
             group.shutdownGracefully();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainDatagramPathTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainDatagramPathTest.java
@@ -39,7 +39,7 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 bootstrap.handler(new ChannelHandlerAdapter() { })
-                         .connect(KQueueSocketTestPermutation.newSocketAddress()).sync().channel();
+                         .connect(KQueueSocketTestPermutation.newSocketAddress()).get();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {
                 assertTrue(e.getCause() instanceof FileNotFoundException);
@@ -52,7 +52,7 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, bootstrap -> {
             try {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
-                                      .bind(KQueueSocketTestPermutation.newSocketAddress()).sync().channel();
+                                      .bind(KQueueSocketTestPermutation.newSocketAddress()).get();
                 ch.writeAndFlush(new DomainDatagramPacket(
                         Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII),
                         KQueueSocketTestPermutation.newSocketAddress())).sync();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainDatagramUnicastTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainDatagramUnicastTest.java
@@ -51,7 +51,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
         Channel channel = null;
         try {
             channel = cb.handler(new ChannelHandlerAdapter() { })
-                        .bind(newSocketAddress()).sync().channel();
+                        .bind(newSocketAddress()).get();
             assertThat(channel.localAddress()).isNotNull()
                     .isInstanceOf(DomainSocketAddress.class);
         } finally {
@@ -104,7 +104,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
                 errorRef.compareAndSet(null, cause);
             }
         });
-        return cb.bind(newSocketAddress()).sync().channel();
+        return cb.bind(newSocketAddress()).get();
     }
 
     @Override
@@ -149,7 +149,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
                 });
             }
         });
-        return sb.bind(newSocketAddress()).sync().channel();
+        return sb.bind(newSocketAddress()).get();
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.FileDescriptor;
+import io.netty.channel.unix.UnixChannelOption;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractSocketTest;
 import org.junit.jupiter.api.Test;
@@ -85,10 +86,10 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
                 ctx.close();
             }
         });
-        cb.option(KQueueChannelOption.DOMAIN_SOCKET_READ_MODE,
-                DomainSocketReadMode.FILE_DESCRIPTORS);
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        cb.option(UnixChannelOption.DOMAIN_SOCKET_READ_MODE,
+                  DomainSocketReadMode.FILE_DESCRIPTORS);
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
 
         Object received = queue.take();
         cc.close().sync();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfigTest.java
@@ -36,13 +36,13 @@ public class KQueueServerSocketChannelConfigTest {
     private static KQueueServerSocketChannel ch;
 
     @BeforeAll
-    public static void before() {
+    public static void before() throws Exception {
         group = new MultithreadEventLoopGroup(1, KQueueHandler.newFactory());
         ServerBootstrap bootstrap = new ServerBootstrap();
         ch = (KQueueServerSocketChannel) bootstrap.group(group)
                 .channel(KQueueServerSocketChannel.class)
                 .childHandler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                .bind(new InetSocketAddress(0)).get();
     }
 
     @AfterAll

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -55,16 +55,16 @@ public class KQueueSocketChannelConfigTest {
     }
 
     @BeforeEach
-    public void setup() {
+    public void setUp() throws Exception {
         Bootstrap bootstrap = new Bootstrap();
         ch = (KQueueSocketChannel) bootstrap.group(group)
                 .channel(KQueueSocketChannel.class)
                 .handler(new ChannelHandler() { })
-                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                .bind(new InetSocketAddress(0)).get();
     }
 
     @AfterEach
-    public void teardown() {
+    public void tearDown() {
         ch.close().syncUninterruptibly();
     }
 

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -45,18 +45,17 @@ public abstract class DetectPeerCloseWithoutReadTest {
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void clientCloseWithoutServerReadIsDetectedNoExtraReadRequested() throws InterruptedException {
+    public void clientCloseWithoutServerReadIsDetectedNoExtraReadRequested() throws Exception {
         clientCloseWithoutServerReadIsDetected0(false);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void clientCloseWithoutServerReadIsDetectedExtraReadRequested() throws InterruptedException {
+    public void clientCloseWithoutServerReadIsDetectedExtraReadRequested() throws Exception {
         clientCloseWithoutServerReadIsDetected0(true);
     }
 
-    private void clientCloseWithoutServerReadIsDetected0(final boolean extraReadRequested)
-            throws InterruptedException {
+    private void clientCloseWithoutServerReadIsDetected0(final boolean extraReadRequested) throws Exception {
         EventLoopGroup serverGroup = null;
         EventLoopGroup clientGroup = null;
         Channel serverChannel = null;
@@ -81,13 +80,13 @@ public abstract class DetectPeerCloseWithoutReadTest {
                 }
             });
 
-            serverChannel = sb.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+            serverChannel = sb.bind(new InetSocketAddress(0)).get();
 
             Bootstrap cb = new Bootstrap();
             cb.group(serverGroup);
             cb.channel(clientChannel());
             cb.handler(new ChannelHandler() { });
-            Channel clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            Channel clientChannel = cb.connect(serverChannel.localAddress()).get();
             ByteBuf buf = clientChannel.alloc().buffer(expectedBytes);
             buf.writerIndex(buf.writerIndex() + expectedBytes);
             clientChannel.writeAndFlush(buf).addListener(ChannelFutureListener.CLOSE);
@@ -109,17 +108,17 @@ public abstract class DetectPeerCloseWithoutReadTest {
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void serverCloseWithoutClientReadIsDetectedNoExtraReadRequested() throws InterruptedException {
+    public void serverCloseWithoutClientReadIsDetectedNoExtraReadRequested() throws Exception {
         serverCloseWithoutClientReadIsDetected0(false);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void serverCloseWithoutClientReadIsDetectedExtraReadRequested() throws InterruptedException {
+    public void serverCloseWithoutClientReadIsDetectedExtraReadRequested() throws Exception {
         serverCloseWithoutClientReadIsDetected0(true);
     }
 
-    private void serverCloseWithoutClientReadIsDetected0(final boolean extraReadRequested) throws InterruptedException {
+    private void serverCloseWithoutClientReadIsDetected0(final boolean extraReadRequested) throws Exception {
         EventLoopGroup serverGroup = null;
         EventLoopGroup clientGroup = null;
         Channel serverChannel = null;
@@ -148,7 +147,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
                 }
             });
 
-            serverChannel = sb.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+            serverChannel = sb.bind(new InetSocketAddress(0)).get();
 
             Bootstrap cb = new Bootstrap();
             cb.group(serverGroup);
@@ -164,7 +163,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
                     ch.pipeline().addLast(new TestHandler(bytesRead, extraReadRequested, latch));
                 }
             });
-            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).get();
 
             latch.await();
             assertEquals(expectedBytes, bytesRead.get());

--- a/transport-sctp/src/test/java/io/netty/channel/sctp/SctpLimitStreamsTest.java
+++ b/transport-sctp/src/test/java/io/netty/channel/sctp/SctpLimitStreamsTest.java
@@ -44,7 +44,7 @@ public abstract class SctpLimitStreamsTest {
     @SuppressForbidden(reason = "test-only")
     @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-    public void testSctpInitMaxstreams() {
+    public void testSctpInitMaxstreams() throws Exception {
         EventLoopGroup loop = newEventLoopGroup();
         try {
             ServerBootstrap serverBootstrap = new ServerBootstrap();
@@ -63,10 +63,8 @@ public abstract class SctpLimitStreamsTest {
                             SctpStandardSocketOptions.InitMaxStreams.create(112, 112))
                     .handler(new ChannelHandlerAdapter() { });
 
-            Channel serverChannel = serverBootstrap.bind()
-                    .syncUninterruptibly().channel();
-            SctpChannel clientChannel = (SctpChannel) clientBootstrap.connect(serverChannel.localAddress())
-                    .syncUninterruptibly().channel();
+            Channel serverChannel = serverBootstrap.bind().get();
+            SctpChannel clientChannel = (SctpChannel) clientBootstrap.connect(serverChannel.localAddress()).get();
             assertEquals(1, clientChannel.association().maxOutboundStreams());
             assertEquals(1, clientChannel.association().maxInboundStreams());
             serverChannel.close().syncUninterruptibly();

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -188,16 +188,16 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
     }
 
     /**
-     * Create and register a new channel, but asynchronously.
+     * Create a new unregistered channel.
      * <p>
-     * The returned future completes after the channel has been created and initialised,
-     * but before {@link Channel#register()} has completed.
+     * The returned future completes after the channel has been created and initialised.
+     * The channel must then be {@linkplain Channel#register() registered} separately.
      *
      * @return A future producing the channel object as soon as it has been initialised.
      */
-    public Future<Channel> registerAsynchronously() {
+    public Future<Channel> createUnregistered() {
         validate();
-        return initThenRegister();
+        return initWithoutRegister();
     }
 
     /**
@@ -291,7 +291,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
         return promise;
     }
 
-    final Future<Channel> initThenRegister() {
+    final Future<Channel> initWithoutRegister() {
         EventLoop loop = group.next();
         final Channel channel;
         try {
@@ -304,7 +304,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
         loop.execute(() -> init(channel).addListener((ChannelFutureListener) future -> {
             if (future.isSuccess()) {
                 promise.setSuccess(channel);
-                channel.register();
             } else {
                 channel.unsafe().closeForcibly();
                 promise.setFailure(future.cause());

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -37,7 +37,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -193,7 +192,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
      * <p>
      * The channel must then be {@linkplain Channel#register() registered} separately.
      *
-     * @return A future producing the channel before the channel has been registered.
+     * @return A new unregistered channel.
      * @throws Exception If the channel cannot be created.
      */
     public Channel createUnregistered() throws Exception {
@@ -253,7 +252,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
             // At this point we know that the registration was complete and successful.
             Channel channel = regFuture.getNow();
             ChannelPromise promise = channel.newPromise();
-            cascadeChannel(promise, bindPromise);
+            cascadeChannel(true, promise, bindPromise, channel);
             doBind0(regFuture, channel, localAddress, promise);
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
@@ -266,7 +265,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
                 } else {
                     Channel channel = future.getNow();
                     ChannelPromise promise = channel.newPromise();
-                    cascadeChannel(promise, bindPromise);
+                    cascadeChannel(true, promise, bindPromise, channel);
                     doBind0(regFuture, channel, localAddress, promise);
                 }
             });
@@ -402,7 +401,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
         if (map.isEmpty()) {
             return Collections.emptyMap();
         }
-        return Collections.unmodifiableMap(new HashMap<>(map));
+        return Map.copyOf(map);
     }
 
     static void setAttributes(Channel channel, Map.Entry<AttributeKey<?>, Object>[] attrs) {

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -194,8 +194,9 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
      * The channel must then be {@linkplain Channel#register() registered} separately.
      *
      * @return A future producing the channel before the channel has been registered.
+     * @throws Exception If the channel cannot be created.
      */
-    public Future<Channel> createUnregistered() {
+    public Channel createUnregistered() throws Exception {
         validate();
         return initWithoutRegister();
     }
@@ -298,20 +299,16 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
         return promise;
     }
 
-    final Future<Channel> initWithoutRegister() {
+    final Channel initWithoutRegister() throws Exception {
         EventLoop loop = group.next();
-        final Channel channel;
-        try {
-            channel = newChannel(loop);
-        } catch (Throwable t) {
-            return new FailedFuture<>(loop, t);
-        }
+        Channel channel = newChannel(loop);
 
-        return init(channel).addListener(future -> {
+        init(channel).addListener(future -> {
             if (!future.isSuccess()) {
                 channel.unsafe().closeForcibly();
             }
         });
+        return channel;
     }
 
     abstract C newChannel(EventLoop loop) throws Exception;

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -16,22 +16,20 @@
 
 package io.netty.bootstrap;
 
-import static java.util.Objects.requireNonNull;
-
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.FailedFuture;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.SocketUtils;
-import io.netty.util.AttributeKey;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 
@@ -43,6 +41,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static io.netty.channel.ChannelPromiseNotifier.cascadeChannel;
+import static java.util.Objects.requireNonNull;
 
 /**
  * {@link AbstractBootstrap} is a helper class that makes it easy to bootstrap a {@link Channel}. It support
@@ -182,9 +183,9 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
     /**
      * Create a new {@link Channel} and register it with an {@link EventLoop}.
      */
-    public ChannelFuture register() {
+    public Future<Channel> register() {
         validate();
-        return initAndRegister();
+        return initAndRegister(group.next());
     }
 
     /**
@@ -203,7 +204,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
     /**
      * Create a new {@link Channel} and bind it.
      */
-    public ChannelFuture bind() {
+    public Future<Channel> bind() {
         validate();
         SocketAddress localAddress = this.localAddress;
         requireNonNull(localAddress, "localAddress");
@@ -213,75 +214,82 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
     /**
      * Create a new {@link Channel} and bind it.
      */
-    public ChannelFuture bind(int inetPort) {
+    public Future<Channel> bind(int inetPort) {
         return bind(new InetSocketAddress(inetPort));
     }
 
     /**
      * Create a new {@link Channel} and bind it.
      */
-    public ChannelFuture bind(String inetHost, int inetPort) {
+    public Future<Channel> bind(String inetHost, int inetPort) {
         return bind(SocketUtils.socketAddress(inetHost, inetPort));
     }
 
     /**
      * Create a new {@link Channel} and bind it.
      */
-    public ChannelFuture bind(InetAddress inetHost, int inetPort) {
+    public Future<Channel> bind(InetAddress inetHost, int inetPort) {
         return bind(new InetSocketAddress(inetHost, inetPort));
     }
 
     /**
      * Create a new {@link Channel} and bind it.
      */
-    public ChannelFuture bind(SocketAddress localAddress) {
+    public Future<Channel> bind(SocketAddress localAddress) {
         validate();
         requireNonNull(localAddress, "localAddress");
         return doBind(localAddress);
     }
 
-    private ChannelFuture doBind(final SocketAddress localAddress) {
-        final ChannelFuture regFuture = initAndRegister();
-        final Channel channel = regFuture.channel();
+    private Future<Channel> doBind(final SocketAddress localAddress) {
+        EventLoop loop = group.next();
+        final Future<Channel> regFuture = initAndRegister(loop);
         if (regFuture.cause() != null) {
             return regFuture;
         }
 
+        Promise<Channel> bindPromise = new DefaultPromise<>(loop);
         if (regFuture.isDone()) {
             // At this point we know that the registration was complete and successful.
+            Channel channel = regFuture.getNow();
             ChannelPromise promise = channel.newPromise();
+            cascadeChannel(promise, bindPromise);
             doBind0(regFuture, channel, localAddress, promise);
-            return promise;
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
-            final ChannelPromise promise = channel.newPromise();
-            regFuture.addListener((ChannelFutureListener) future -> {
+            regFuture.addListener((GenericFutureListener<Future<Channel>>) future -> {
                 Throwable cause = future.cause();
                 if (cause != null) {
                     // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
                     // IllegalStateException once we try to access the EventLoop of the Channel.
-                    promise.setFailure(cause);
+                    bindPromise.setFailure(cause);
                 } else {
+                    Channel channel = future.getNow();
+                    ChannelPromise promise = channel.newPromise();
+                    cascadeChannel(promise, bindPromise);
                     doBind0(regFuture, channel, localAddress, promise);
                 }
             });
-            return promise;
         }
+        return bindPromise;
     }
 
-    final ChannelFuture initAndRegister() {
-        EventLoop loop = group.next();
+    final Future<Channel> initAndRegister(EventLoop loop) {
         final Channel channel;
         try {
             channel = newChannel(loop);
         } catch (Throwable t) {
-            return new FailedChannel(loop).newFailedFuture(t);
+            return new FailedFuture<>(loop, t);
         }
 
-        final ChannelPromise promise = channel.newPromise();
-        loop.execute(() -> init(channel).addListener((ChannelFutureListener) future -> {
+        Promise<Channel> promise = new DefaultPromise<>(loop);
+        loop.execute(() -> init(channel).addListener(future -> {
             if (future.isSuccess()) {
-                channel.register(promise);
+                // TODO eventually I think we'd like to be able to either pass the generic promise down,
+                //  or return the future from register().
+                channel.register().addListener(f -> {
+                    promise.setSuccess(channel);
+                });
             } else {
                 channel.unsafe().closeForcibly();
                 promise.setFailure(future.cause());
@@ -301,7 +309,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
         }
 
         Promise<Channel> promise = new DefaultPromise<>(loop);
-        loop.execute(() -> init(channel).addListener((ChannelFutureListener) future -> {
+        loop.execute(() -> init(channel).addListener(future -> {
             if (future.isSuccess()) {
                 promise.setSuccess(channel);
             } else {
@@ -315,12 +323,11 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
 
     abstract C newChannel(EventLoop loop) throws Exception;
 
-    abstract ChannelFuture init(Channel channel);
+    abstract Future<Channel> init(Channel channel);
 
     private static void doBind0(
-            final ChannelFuture regFuture, final Channel channel,
+            final Future<Channel> regFuture, final Channel channel,
             final SocketAddress localAddress, final ChannelPromise promise) {
-
         // This method is invoked before channelRegistered() is triggered.  Give user handlers a chance to set up
         // the pipeline in its channelRegistered() implementation.
         channel.eventLoop().execute(() -> {

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -191,10 +191,9 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
     /**
      * Create a new unregistered channel.
      * <p>
-     * The returned future completes after the channel has been created and initialised.
      * The channel must then be {@linkplain Channel#register() registered} separately.
      *
-     * @return A future producing the channel object as soon as it has been initialised.
+     * @return A future producing the channel before the channel has been registered.
      */
     public Future<Channel> createUnregistered() {
         validate();
@@ -308,17 +307,11 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
             return new FailedFuture<>(loop, t);
         }
 
-        Promise<Channel> promise = new DefaultPromise<>(loop);
-        loop.execute(() -> init(channel).addListener(future -> {
-            if (future.isSuccess()) {
-                promise.setSuccess(channel);
-            } else {
+        return init(channel).addListener(future -> {
+            if (!future.isSuccess()) {
                 channel.unsafe().closeForcibly();
-                promise.setFailure(future.cause());
             }
-        }));
-
-        return promise;
+        });
     }
 
     abstract C newChannel(EventLoop loop) throws Exception;

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -41,7 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static io.netty.channel.ChannelPromiseNotifier.cascadeChannel;
+import static io.netty.util.concurrent.PromiseNotifier.cascade;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -252,7 +252,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
             // At this point we know that the registration was complete and successful.
             Channel channel = regFuture.getNow();
             ChannelPromise promise = channel.newPromise();
-            cascadeChannel(true, promise, bindPromise, channel);
+            cascade(true, promise, bindPromise, channel);
             doBind0(regFuture, channel, localAddress, promise);
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
@@ -265,7 +265,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
                 } else {
                     Channel channel = future.getNow();
                     ChannelPromise promise = channel.newPromise();
-                    cascadeChannel(true, promise, bindPromise, channel);
+                    cascade(true, promise, bindPromise, channel);
                     doBind0(regFuture, channel, localAddress, promise);
                 }
             });

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -199,7 +199,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
             }
             Channel channel = regFuture.getNow();
             ChannelPromise promise = channel.newPromise();
-            cascadeChannel(promise, resolveAndConnectPromise);
+            cascadeChannel(true, promise, resolveAndConnectPromise, channel);
             doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
@@ -214,7 +214,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
                 } else {
                     Channel channel = future.getNow();
                     ChannelPromise promise = channel.newPromise();
-                    cascadeChannel(promise, resolveAndConnectPromise);
+                    cascadeChannel(true, promise, resolveAndConnectPromise, channel);
                     doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
                 }
             });

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -40,7 +40,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import static io.netty.channel.ChannelPromiseNotifier.cascadeChannel;
+import static io.netty.util.concurrent.PromiseNotifier.cascade;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -199,12 +199,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
             }
             Channel channel = regFuture.getNow();
             ChannelPromise promise = channel.newPromise();
-            cascadeChannel(true, promise, resolveAndConnectPromise, channel);
+            cascade(true, promise, resolveAndConnectPromise, channel);
             doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
             regFuture.addListener((GenericFutureListener<Future<Channel>>) future -> {
-                // Directly obtain the cause and do a null check so we only need one volatile read in case of a
+                // Directly obtain the cause and do a null check, so we only need one volatile read in case of a
                 // failure.
                 Throwable cause = future.cause();
                 if (cause != null) {
@@ -214,7 +214,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
                 } else {
                     Channel channel = future.getNow();
                     ChannelPromise promise = channel.newPromise();
-                    cascadeChannel(true, promise, resolveAndConnectPromise, channel);
+                    cascade(true, promise, resolveAndConnectPromise, channel);
                     doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
                 }
             });
@@ -229,7 +229,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
             final AddressResolver<SocketAddress> resolver = this.resolver.getResolver(eventLoop);
 
             if (!resolver.isSupported(remoteAddress) || resolver.isResolved(remoteAddress)) {
-                // Resolver has no idea about what to do with the specified remote address or it's resolved already.
+                // Resolver has no idea about what to do with the specified remote address, or it's resolved already.
                 doConnect(remoteAddress, localAddress, promise);
                 return;
             }

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -231,6 +231,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
             if (!resolver.isSupported(remoteAddress) || resolver.isResolved(remoteAddress)) {
                 // Resolver has no idea about what to do with the specified remote address or it's resolved already.
                 doConnect(remoteAddress, localAddress, promise);
+                return;
             }
 
             final Future<SocketAddress> resolveFuture = resolver.resolve(remoteAddress);
@@ -245,6 +246,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel, ChannelFact
                 } else {
                     // Succeeded to resolve immediately; cached? (or did a blocking lookup)
                     doConnect(resolveFuture.getNow(), localAddress, promise);
+                    return;
                 }
             }
 

--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -31,13 +31,13 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  */
 @Deprecated
 public final class ChannelPromiseNotifier
-    extends PromiseNotifier<Void, ChannelFuture>
-    implements ChannelFutureListener {
+        extends PromiseNotifier<Void, ChannelFuture>
+        implements ChannelFutureListener {
 
     /**
      * Create a new instance
      *
-     * @param promises  the {@link ChannelPromise}s to notify once this {@link ChannelFutureListener} is notified.
+     * @param promises the {@link ChannelPromise}s to notify once this {@link ChannelFutureListener} is notified.
      */
     public ChannelPromiseNotifier(ChannelPromise... promises) {
         super(promises);
@@ -47,38 +47,38 @@ public final class ChannelPromiseNotifier
      * Create a new instance
      *
      * @param logNotifyFailure {@code true} if logging should be done in case notification fails.
-     * @param promises  the {@link ChannelPromise}s to notify once this {@link ChannelFutureListener} is notified.
+     * @param promises         the {@link ChannelPromise}s to notify once this {@link ChannelFutureListener} is
+     *                         notified.
      */
     public ChannelPromiseNotifier(boolean logNotifyFailure, ChannelPromise... promises) {
         super(logNotifyFailure, promises);
     }
 
     /**
-     * Link the {@link ChannelFuture} and {@link Promise} such that if the {@link ChannelFuture} completes the
-     * {@link Promise} will be notified, and completed with the channel in question.
-     * Cancellation is propagated both ways such that if the {@link Future} is cancelled the {@link Promise} is
-     * cancelled and vise-versa.
+     * Link the {@link ChannelFuture} and {@link Promise} such that if the {@link ChannelFuture} completes the {@link
+     * Promise} will be notified, and completed with the channel in question. Cancellation is propagated both ways such
+     * that if the {@link Future} is cancelled the {@link Promise} is cancelled and vise-versa.
      *
-     * @param future    the {@link ChannelFuture} which will be used to listen to for notifying the {@link Promise}.
-     * @param promise   the {@link Promise} which will be notified
-     * @return          the passed in {@link ChannelFuture}
+     * @param future  the {@link ChannelFuture} which will be used to listen to for notifying the {@link Promise}.
+     * @param promise the {@link Promise} which will be notified
+     * @return the passed in {@link ChannelFuture}
      */
     public static ChannelFuture cascadeChannel(ChannelFuture future, final Promise<? super Channel> promise) {
         return cascadeChannel(true, future, promise);
     }
 
     /**
-     * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise}
-     * will be notified. Cancellation is propagated both ways such that if the {@link Future} is cancelled
-     * the {@link Promise} is cancelled and vise-versa.
+     * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise} will be
+     * notified. Cancellation is propagated both ways such that if the {@link Future} is cancelled the {@link Promise}
+     * is cancelled and vise-versa.
      *
-     * @param logNotifyFailure  {@code true} if logging should be done in case notification fails.
-     * @param future            the {@link Future} which will be used to listen to for notifying the {@link Promise}.
-     * @param promise           the {@link Promise} which will be notified
-     * @return                  the passed in {@link Future}
+     * @param logNotifyFailure {@code true} if logging should be done in case notification fails.
+     * @param future           the {@link Future} which will be used to listen to for notifying the {@link Promise}.
+     * @param promise          the {@link Promise} which will be notified
+     * @return the passed in {@link Future}
      */
     public static ChannelFuture cascadeChannel(boolean logNotifyFailure, final ChannelFuture future,
-                                                     final Promise<? super Channel> promise) {
+                                               final Promise<? super Channel> promise) {
         promise.addListener(new FutureListener<Object>() {
             @Override
             public void operationComplete(Future<Object> f) {
@@ -94,11 +94,13 @@ public final class ChannelPromiseNotifier
                     // Just return if we propagate a cancel from the promise to the future and both are notified already
                     return;
                 }
-                InternalLogger internalLogger = logNotifyFailure ?
-                        InternalLoggerFactory.getInstance(PromiseNotifier.class) : null;
                 if (f.isSuccess()) {
                     promise.setSuccess(f.channel());
                 } else if (f.isCancelled()) {
+                    InternalLogger internalLogger = null;
+                    if (logNotifyFailure) {
+                        internalLogger = InternalLoggerFactory.getInstance(PromiseNotifier.class);
+                    }
                     PromiseNotificationUtil.tryCancel(promise, internalLogger);
                 } else {
                     Throwable cause = future.cause();

--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -104,7 +104,7 @@ public final class ChannelPromiseNotifier
                     PromiseNotificationUtil.tryCancel(promise, internalLogger);
                 } else {
                     Throwable cause = future.cause();
-                    promise.setFailure(cause);
+                    promise.tryFailure(cause);
                 }
             }
         });

--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -30,7 +30,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  * @deprecated use {@link PromiseNotifier}.
  */
 @Deprecated
-public class ChannelPromiseNotifier
+public final class ChannelPromiseNotifier
     extends PromiseNotifier<Void, ChannelFuture>
     implements ChannelFutureListener {
 

--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -63,8 +63,8 @@ public final class ChannelPromiseNotifier
      * @param promise the {@link Promise} which will be notified
      * @return the passed in {@link ChannelFuture}
      */
-    public static ChannelFuture cascadeChannel(ChannelFuture future, final Promise<? super Channel> promise) {
-        return cascadeChannel(true, future, promise);
+    public static ChannelFuture cascadeChannel(ChannelFuture future, final Promise<Void> promise) {
+        return cascadeChannel(true, future, promise, null);
     }
 
     /**
@@ -75,10 +75,11 @@ public final class ChannelPromiseNotifier
      * @param logNotifyFailure {@code true} if logging should be done in case notification fails.
      * @param future           the {@link Future} which will be used to listen to for notifying the {@link Promise}.
      * @param promise          the {@link Promise} which will be notified
+     * @param successResult    the result that will be propagated to the promise on success
      * @return the passed in {@link Future}
      */
-    public static ChannelFuture cascadeChannel(boolean logNotifyFailure, final ChannelFuture future,
-                                               final Promise<? super Channel> promise) {
+    public static <R> ChannelFuture cascadeChannel(boolean logNotifyFailure, ChannelFuture future,
+                                                   Promise<R> promise, R successResult) {
         promise.addListener(new FutureListener<Object>() {
             @Override
             public void operationComplete(Future<Object> f) {
@@ -95,7 +96,7 @@ public final class ChannelPromiseNotifier
                     return;
                 }
                 if (f.isSuccess()) {
-                    promise.setSuccess(f.channel());
+                    promise.setSuccess(successResult);
                 } else if (f.isCancelled()) {
                     InternalLogger internalLogger = null;
                     if (logNotifyFailure) {

--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -15,14 +15,7 @@
  */
 package io.netty.channel;
 
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.FutureListener;
-import io.netty.util.concurrent.GenericFutureListener;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
-import io.netty.util.internal.PromiseNotificationUtil;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * ChannelFutureListener implementation which takes other {@link ChannelPromise}(s) and notifies them on completion.
@@ -52,63 +45,5 @@ public final class ChannelPromiseNotifier
      */
     public ChannelPromiseNotifier(boolean logNotifyFailure, ChannelPromise... promises) {
         super(logNotifyFailure, promises);
-    }
-
-    /**
-     * Link the {@link ChannelFuture} and {@link Promise} such that if the {@link ChannelFuture} completes the {@link
-     * Promise} will be notified, and completed with the channel in question. Cancellation is propagated both ways such
-     * that if the {@link Future} is cancelled the {@link Promise} is cancelled and vise-versa.
-     *
-     * @param future  the {@link ChannelFuture} which will be used to listen to for notifying the {@link Promise}.
-     * @param promise the {@link Promise} which will be notified
-     * @return the passed in {@link ChannelFuture}
-     */
-    public static ChannelFuture cascadeChannel(ChannelFuture future, final Promise<Void> promise) {
-        return cascadeChannel(true, future, promise, null);
-    }
-
-    /**
-     * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise} will be
-     * notified. Cancellation is propagated both ways such that if the {@link Future} is cancelled the {@link Promise}
-     * is cancelled and vise-versa.
-     *
-     * @param logNotifyFailure {@code true} if logging should be done in case notification fails.
-     * @param future           the {@link Future} which will be used to listen to for notifying the {@link Promise}.
-     * @param promise          the {@link Promise} which will be notified
-     * @param successResult    the result that will be propagated to the promise on success
-     * @return the passed in {@link Future}
-     */
-    public static <R> ChannelFuture cascadeChannel(boolean logNotifyFailure, ChannelFuture future,
-                                                   Promise<R> promise, R successResult) {
-        promise.addListener(new FutureListener<Object>() {
-            @Override
-            public void operationComplete(Future<Object> f) {
-                if (f.isCancelled()) {
-                    future.cancel(false);
-                }
-            }
-        });
-        future.addListener(new GenericFutureListener<ChannelFuture>() {
-            @Override
-            public void operationComplete(ChannelFuture f) throws Exception {
-                if (promise.isCancelled() && f.isCancelled()) {
-                    // Just return if we propagate a cancel from the promise to the future and both are notified already
-                    return;
-                }
-                if (f.isSuccess()) {
-                    promise.setSuccess(successResult);
-                } else if (f.isCancelled()) {
-                    InternalLogger internalLogger = null;
-                    if (logNotifyFailure) {
-                        internalLogger = InternalLoggerFactory.getInstance(PromiseNotifier.class);
-                    }
-                    PromiseNotificationUtil.tryCancel(promise, internalLogger);
-                } else {
-                    Throwable cause = future.cause();
-                    promise.tryFailure(cause);
-                }
-            }
-        });
-        return future;
     }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -15,7 +15,14 @@
  */
 package io.netty.channel;
 
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
+import io.netty.util.internal.PromiseNotificationUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * ChannelFutureListener implementation which takes other {@link ChannelPromise}(s) and notifies them on completion.
@@ -23,7 +30,7 @@ import io.netty.util.concurrent.PromiseNotifier;
  * @deprecated use {@link PromiseNotifier}.
  */
 @Deprecated
-public final class ChannelPromiseNotifier
+public class ChannelPromiseNotifier
     extends PromiseNotifier<Void, ChannelFuture>
     implements ChannelFutureListener {
 
@@ -44,5 +51,61 @@ public final class ChannelPromiseNotifier
      */
     public ChannelPromiseNotifier(boolean logNotifyFailure, ChannelPromise... promises) {
         super(logNotifyFailure, promises);
+    }
+
+    /**
+     * Link the {@link ChannelFuture} and {@link Promise} such that if the {@link ChannelFuture} completes the
+     * {@link Promise} will be notified, and completed with the channel in question.
+     * Cancellation is propagated both ways such that if the {@link Future} is cancelled the {@link Promise} is
+     * cancelled and vise-versa.
+     *
+     * @param future    the {@link ChannelFuture} which will be used to listen to for notifying the {@link Promise}.
+     * @param promise   the {@link Promise} which will be notified
+     * @return          the passed in {@link ChannelFuture}
+     */
+    public static ChannelFuture cascadeChannel(ChannelFuture future, final Promise<? super Channel> promise) {
+        return cascadeChannel(true, future, promise);
+    }
+
+    /**
+     * Link the {@link Future} and {@link Promise} such that if the {@link Future} completes the {@link Promise}
+     * will be notified. Cancellation is propagated both ways such that if the {@link Future} is cancelled
+     * the {@link Promise} is cancelled and vise-versa.
+     *
+     * @param logNotifyFailure  {@code true} if logging should be done in case notification fails.
+     * @param future            the {@link Future} which will be used to listen to for notifying the {@link Promise}.
+     * @param promise           the {@link Promise} which will be notified
+     * @return                  the passed in {@link Future}
+     */
+    public static ChannelFuture cascadeChannel(boolean logNotifyFailure, final ChannelFuture future,
+                                                     final Promise<? super Channel> promise) {
+        promise.addListener(new FutureListener<Object>() {
+            @Override
+            public void operationComplete(Future<Object> f) {
+                if (f.isCancelled()) {
+                    future.cancel(false);
+                }
+            }
+        });
+        future.addListener(new GenericFutureListener<ChannelFuture>() {
+            @Override
+            public void operationComplete(ChannelFuture f) throws Exception {
+                if (promise.isCancelled() && f.isCancelled()) {
+                    // Just return if we propagate a cancel from the promise to the future and both are notified already
+                    return;
+                }
+                InternalLogger internalLogger = logNotifyFailure ?
+                        InternalLoggerFactory.getInstance(PromiseNotifier.class) : null;
+                if (f.isSuccess()) {
+                    promise.setSuccess(f.channel());
+                } else if (f.isCancelled()) {
+                    PromiseNotificationUtil.tryCancel(promise, internalLogger);
+                } else {
+                    Throwable cause = future.cause();
+                    promise.setFailure(cause);
+                }
+            }
+        });
+        return future;
     }
 }

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -288,8 +288,7 @@ public class BootstrapTest {
             bootstrapA.group(group);
             bootstrapA.channel(LocalChannel.class);
             bootstrapA.handler(registerHandler);
-            Future<Channel> channelFuture = bootstrapA.createUnregistered();
-            Channel channel = channelFuture.get();
+            Channel channel = bootstrapA.createUnregistered();
             ChannelFuture registerFuture = channel.register();
             ChannelFuture connectFuture = channel.connect(LocalAddress.ANY);
             assertFalse(connectFuture.isDone());

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -291,12 +291,14 @@ public class BootstrapTest {
             bootstrapA.group(group);
             bootstrapA.channel(LocalChannel.class);
             bootstrapA.handler(registerHandler);
-            Future<Channel> channelFuture = bootstrapA.registerAsynchronously();
+            Future<Channel> channelFuture = bootstrapA.createUnregistered();
             Channel channel = channelFuture.get();
-            ChannelFuture future = channel.connect(LocalAddress.ANY);
-            assertFalse(future.isDone());
+            ChannelFuture registerFuture = channel.register();
+            ChannelFuture connectFuture = channel.connect(LocalAddress.ANY);
+            assertFalse(connectFuture.isDone());
             registerHandler.registerPromise().setSuccess();
-            assertTrue(assertThrows(CompletionException.class, future::syncUninterruptibly)
+            registerFuture.sync();
+            assertTrue(assertThrows(CompletionException.class, connectFuture::syncUninterruptibly)
                 .getCause() instanceof ConnectException);
         } finally {
             group.shutdownGracefully();

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -246,7 +246,7 @@ public class BootstrapTest {
             registerHandler.registerPromise().setSuccess();
             final BlockingQueue<Boolean> queue = new LinkedBlockingQueue<>();
             future.addListener((GenericFutureListener<Future<Channel>>) future1 -> {
-                queue.add(future1.getNow().eventLoop().inEventLoop(Thread.currentThread()));
+                queue.add(future1.executor().inEventLoop(Thread.currentThread()));
                 queue.add(future1.isSuccess());
             });
             assertTrue(queue.take());

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -17,13 +17,11 @@ package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalHandler;
@@ -130,9 +128,9 @@ public class ServerBootstrapTest {
                     .channel(LocalChannel.class)
                     .handler(new ChannelHandler() { });
 
-            sch = sb.bind(addr).syncUninterruptibly().channel();
+            sch = sb.bind(addr).get();
 
-            cch = cb.connect(addr).syncUninterruptibly().channel();
+            cch = cb.connect(addr).get();
 
             initLatch.await();
             readLatch.await();
@@ -148,7 +146,7 @@ public class ServerBootstrapTest {
     }
 
     @Test
-    public void optionsAndAttributesMustBeAvailableOnChildChannelInit() throws InterruptedException {
+    public void optionsAndAttributesMustBeAvailableOnChildChannelInit() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(1, LocalHandler.newFactory());
         LocalAddress addr = new LocalAddress(UUID.randomUUID().toString());
         final AttributeKey<String> key = AttributeKey.valueOf(UUID.randomUUID().toString());
@@ -167,13 +165,13 @@ public class ServerBootstrapTest {
                         requestServed.set(true);
                     }
                 });
-        Channel serverChannel = sb.bind(addr).syncUninterruptibly().channel();
+        Channel serverChannel = sb.bind(addr).get();
 
         Bootstrap cb = new Bootstrap();
         cb.group(group)
                 .channel(LocalChannel.class)
                 .handler(new ChannelHandler() { });
-        Channel clientChannel = cb.connect(addr).syncUninterruptibly().channel();
+        Channel clientChannel = cb.connect(addr).get();
         serverChannel.close().syncUninterruptibly();
         clientChannel.close().syncUninterruptibly();
         group.shutdownGracefully();

--- a/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
@@ -37,7 +37,7 @@ public abstract class AbstractEventLoopTest {
                 .childHandler(new ChannelHandler() { });
 
         // Not close the Channel to ensure the EventLoop is still shutdown in time.
-        b.bind(0).sync().channel();
+        b.bind(0).sync();
 
         Future<?> f = loop.shutdownGracefully(0, 1, TimeUnit.MINUTES);
         assertTrue(loop.awaitTermination(600, TimeUnit.MILLISECONDS));

--- a/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
@@ -36,9 +36,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ChannelInitializerTest {
     private static final int TIMEOUT_MILLIS = 1000;
@@ -109,7 +109,7 @@ public class ChannelInitializerTest {
     }
 
     @Test
-    public void testChannelInitializerInInitializerCorrectOrdering() {
+    public void testChannelInitializerInInitializerCorrectOrdering() throws Exception {
         final ChannelHandler handler1 = new ChannelHandler() { };
         final ChannelHandler handler2 = new ChannelHandler() { };
         final ChannelHandler handler3 = new ChannelHandler() { };
@@ -130,7 +130,7 @@ public class ChannelInitializerTest {
             }
         }).localAddress(LocalAddress.ANY);
 
-        Channel channel = client.bind().syncUninterruptibly().channel();
+        Channel channel = client.bind().get();
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
@@ -149,7 +149,7 @@ public class ChannelInitializerTest {
     }
 
     @Test
-    public void testChannelInitializerReentrance() {
+    public void testChannelInitializerReentrance() throws Exception {
         final AtomicInteger registeredCalled = new AtomicInteger(0);
         final ChannelHandler handler1 = new ChannelHandler() {
             @Override
@@ -167,7 +167,7 @@ public class ChannelInitializerTest {
             }
         }).localAddress(LocalAddress.ANY);
 
-        Channel channel = client.bind().syncUninterruptibly().channel();
+        Channel channel = client.bind().get();
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
@@ -183,7 +183,7 @@ public class ChannelInitializerTest {
 
     @Test
     @Timeout(value = TIMEOUT_MILLIS, unit = TimeUnit.MILLISECONDS)
-    public void firstHandlerInPipelineShouldReceiveChannelRegisteredEvent() {
+    public void firstHandlerInPipelineShouldReceiveChannelRegisteredEvent() throws Exception {
         testChannelRegisteredEventPropagation(new ChannelInitializer<LocalChannel>() {
             @Override
             public void initChannel(LocalChannel channel) {
@@ -194,7 +194,7 @@ public class ChannelInitializerTest {
 
     @Test
     @Timeout(value = TIMEOUT_MILLIS, unit = TimeUnit.MILLISECONDS)
-    public void lastHandlerInPipelineShouldReceiveChannelRegisteredEvent() {
+    public void lastHandlerInPipelineShouldReceiveChannelRegisteredEvent() throws Exception {
         testChannelRegisteredEventPropagation(new ChannelInitializer<LocalChannel>() {
             @Override
             public void initChannel(LocalChannel channel) {
@@ -235,12 +235,12 @@ public class ChannelInitializerTest {
         assertTrue(called.get());
     }
 
-    private void testChannelRegisteredEventPropagation(ChannelInitializer<LocalChannel> init) {
+    private void testChannelRegisteredEventPropagation(ChannelInitializer<LocalChannel> init) throws Exception {
         Channel clientChannel = null, serverChannel = null;
         try {
             server.childHandler(init);
-            serverChannel = server.bind().syncUninterruptibly().channel();
-            clientChannel = client.connect(SERVER_ADDRESS).syncUninterruptibly().channel();
+            serverChannel = server.bind().get();
+            clientChannel = client.connect(SERVER_ADDRESS).get();
             assertEquals(1, testHandler.channelRegisteredCount.get());
         } finally {
             closeChannel(clientChannel);

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -99,7 +99,7 @@ public class DefaultChannelPipelineTest {
             }
         });
 
-        ChannelFuture bindFuture = sb.bind(LocalAddress.ANY).sync();
+        Channel channel = sb.bind(LocalAddress.ANY).get();
 
         Bootstrap b = new Bootstrap();
         b.group(group).channel(LocalChannel.class);
@@ -110,10 +110,10 @@ public class DefaultChannelPipelineTest {
             }
         });
 
-        self = b.connect(bindFuture.channel().localAddress()).sync().channel();
+        self = b.connect(channel.localAddress()).get();
         peer = peerRef.get();
 
-        bindFuture.channel().close().sync();
+        channel.close().sync();
     }
 
     @AfterEach

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -37,13 +37,13 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress("testWritabilityChanged");
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync().channel();
+        sb.bind(addr).sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).sync().channel();
+        Channel clientChannel = cb.connect(addr).get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -109,13 +109,13 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress("testFlushInWritabilityChanged");
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync().channel();
+        sb.bind(addr).sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
-        Channel clientChannel = cb.connect(addr).sync().channel();
+        Channel clientChannel = cb.connect(addr).get();
         clientChannel.config().setWriteBufferLowWaterMark(512);
         clientChannel.config().setWriteBufferHighWaterMark(1024);
 
@@ -159,13 +159,13 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress("testWriteFlushPingPong");
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync().channel();
+        sb.bind(addr).sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).sync().channel();
+        Channel clientChannel = cb.connect(addr).get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -216,13 +216,13 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress("testCloseInFlush");
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync().channel();
+        sb.bind(addr).sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).sync().channel();
+        Channel clientChannel = cb.connect(addr).get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 
@@ -246,13 +246,13 @@ public class ReentrantChannelTest extends BaseChannelTest {
         LocalAddress addr = new LocalAddress("testFlushFailure");
 
         ServerBootstrap sb = getLocalServerBootstrap();
-        sb.bind(addr).sync().channel();
+        sb.bind(addr).sync();
 
         Bootstrap cb = getLocalClientBootstrap();
 
         setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
 
-        Channel clientChannel = cb.connect(addr).sync().channel();
+        Channel clientChannel = cb.connect(addr).get();
 
         clientChannel.pipeline().addLast(new ChannelHandler() {
 

--- a/transport/src/test/java/io/netty/channel/group/DefaultChannelGroupTest.java
+++ b/transport/src/test/java/io/netty/channel/group/DefaultChannelGroupTest.java
@@ -16,6 +16,7 @@
 package io.netty.channel.group;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -23,6 +24,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.jupiter.api.Test;
 
@@ -46,10 +48,10 @@ public class DefaultChannelGroupTest {
         });
         b.channel(NioServerSocketChannel.class);
 
-        ChannelFuture f = b.bind(0).syncUninterruptibly();
+        Future<Channel> f = b.bind(0).syncUninterruptibly();
 
         if (f.isSuccess()) {
-            allChannels.add(f.channel());
+            allChannels.add(f.getNow());
             allChannels.close().awaitUninterruptibly();
         }
 

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -248,7 +248,7 @@ public class LocalChannelTest {
                                 /* Only slow down the anonymous class in LocalChannel#doRegister() */
                                 if (task.getClass().getEnclosingClass() == LocalChannel.class) {
                                     try {
-                                        closeLatch.await(1, TimeUnit.SECONDS);
+                                        closeLatch.await(1, SECONDS);
                                     } catch (InterruptedException e) {
                                         throw new Error(e);
                                     }
@@ -286,7 +286,7 @@ public class LocalChannelTest {
                     });
             Future<Channel> future = bootstrap.connect(sc.localAddress());
             assertTrue(future.await(2000), "Connection should finish, not time out");
-            cc = future.get();
+            cc = future.await().isSuccess() ? future.get() : null;
         } finally {
             closeChannel(cc);
             closeChannel(sc);

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -114,11 +114,11 @@ public class LocalChannelTest {
             Channel cc = null;
             try {
                 // Start server
-                sc = sb.bind(TEST_ADDRESS).sync().channel();
+                sc = sb.bind(TEST_ADDRESS).get();
 
                 final CountDownLatch latch = new CountDownLatch(1);
                 // Connect to the server
-                cc = cb.connect(sc.localAddress()).sync().channel();
+                cc = cb.connect(sc.localAddress()).get();
                 final Channel ccCpy = cc;
                 cc.eventLoop().execute(() -> {
                     // Send a message event up the pipeline.
@@ -164,10 +164,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).sync().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).sync().channel();
+            cc = cb.connect(sc.localAddress()).get();
 
             // Close the channel and write something.
             cc.close().sync();
@@ -208,7 +208,7 @@ public class LocalChannelTest {
         Channel sc = null;
         Channel cc = null;
         try {
-            sc = sb.bind(TEST_ADDRESS).sync().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
 
             Bootstrap b = new Bootstrap()
                     .group(group2)
@@ -219,7 +219,7 @@ public class LocalChannelTest {
                             // discard
                         }
                     });
-            cc = b.connect(sc.localAddress()).sync().channel();
+            cc = b.connect(sc.localAddress()).get();
             cc.writeAndFlush(new Object());
             assertTrue(latch.await(5, SECONDS));
         } finally {
@@ -274,8 +274,7 @@ public class LocalChannelTest {
                             closeLatch.countDown();
                         }
                     }).
-                    bind(TEST_ADDRESS).
-                    sync().channel();
+                    bind(TEST_ADDRESS).get();
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(clientGroup).
                     channel(LocalChannel.class).
@@ -285,9 +284,9 @@ public class LocalChannelTest {
                             /* Do nothing */
                         }
                     });
-            ChannelFuture future = bootstrap.connect(sc.localAddress());
+            Future<Channel> future = bootstrap.connect(sc.localAddress());
             assertTrue(future.await(2000), "Connection should finish, not time out");
-            cc = future.channel();
+            cc = future.get();
         } finally {
             closeChannel(cc);
             closeChannel(sc);
@@ -296,7 +295,7 @@ public class LocalChannelTest {
     }
 
     @Test
-    public void testReRegister() {
+    public void testReRegister() throws Exception {
         Bootstrap cb = new Bootstrap();
         ServerBootstrap sb = new ServerBootstrap();
 
@@ -317,10 +316,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).syncUninterruptibly().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).syncUninterruptibly().channel();
+            cc = cb.connect(sc.localAddress()).get();
 
             cc.deregister().syncUninterruptibly();
         } finally {
@@ -330,7 +329,7 @@ public class LocalChannelTest {
     }
 
     @Test
-    public void testCloseInWritePromiseCompletePreservesOrder() throws InterruptedException {
+    public void testCloseInWritePromiseCompletePreservesOrder() throws Exception {
         Bootstrap cb = new Bootstrap();
         ServerBootstrap sb = new ServerBootstrap();
         final CountDownLatch messageLatch = new CountDownLatch(2);
@@ -364,10 +363,10 @@ public class LocalChannelTest {
             Channel cc = null;
             try {
                 // Start server
-                sc = sb.bind(TEST_ADDRESS).syncUninterruptibly().channel();
+                sc = sb.bind(TEST_ADDRESS).get();
 
                 // Connect to the server
-                cc = cb.connect(sc.localAddress()).syncUninterruptibly().channel();
+                cc = cb.connect(sc.localAddress()).get();
 
                 final Channel ccCpy = cc;
                 // Make sure a write operation is executed in the eventloop
@@ -389,7 +388,7 @@ public class LocalChannelTest {
     }
 
     @Test
-    public void testCloseAfterWriteInSameEventLoopPreservesOrder() throws InterruptedException {
+    public void testCloseAfterWriteInSameEventLoopPreservesOrder() throws Exception {
         Bootstrap cb = new Bootstrap();
         ServerBootstrap sb = new ServerBootstrap();
         final CountDownLatch messageLatch = new CountDownLatch(3);
@@ -440,10 +439,10 @@ public class LocalChannelTest {
             Channel cc = null;
             try {
                 // Start server
-                sc = sb.bind(TEST_ADDRESS).syncUninterruptibly().channel();
+                sc = sb.bind(TEST_ADDRESS).get();
 
                 // Connect to the server
-                cc = cb.connect(sc.localAddress()).syncUninterruptibly().channel();
+                cc = cb.connect(sc.localAddress()).get();
                 assertTrue(messageLatch.await(5, SECONDS));
                 assertFalse(cc.isOpen());
             } finally {
@@ -456,7 +455,7 @@ public class LocalChannelTest {
     }
 
     @Test
-    public void testWriteInWritePromiseCompletePreservesOrder() throws InterruptedException {
+    public void testWriteInWritePromiseCompletePreservesOrder() throws Exception {
         Bootstrap cb = new Bootstrap();
         ServerBootstrap sb = new ServerBootstrap();
         final CountDownLatch messageLatch = new CountDownLatch(2);
@@ -474,7 +473,7 @@ public class LocalChannelTest {
                 @Override
                 public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                     final long count = messageLatch.getCount();
-                    if ((data.equals(msg) && count == 2) || (data2.equals(msg) && count == 1)) {
+                    if (data.equals(msg) && count == 2 || data2.equals(msg) && count == 1) {
                         ReferenceCountUtil.safeRelease(msg);
                         messageLatch.countDown();
                     } else {
@@ -487,10 +486,10 @@ public class LocalChannelTest {
             Channel cc = null;
             try {
                 // Start server
-                sc = sb.bind(TEST_ADDRESS).syncUninterruptibly().channel();
+                sc = sb.bind(TEST_ADDRESS).get();
 
                 // Connect to the server
-                cc = cb.connect(sc.localAddress()).syncUninterruptibly().channel();
+                cc = cb.connect(sc.localAddress()).get();
 
                 final Channel ccCpy = cc;
                 // Make sure a write operation is executed in the eventloop
@@ -513,7 +512,7 @@ public class LocalChannelTest {
     }
 
     @Test
-    public void testPeerWriteInWritePromiseCompleteDifferentEventLoopPreservesOrder() throws InterruptedException {
+    public void testPeerWriteInWritePromiseCompleteDifferentEventLoopPreservesOrder() throws Exception {
         Bootstrap cb = new Bootstrap();
         ServerBootstrap sb = new ServerBootstrap();
         final CountDownLatch messageLatch = new CountDownLatch(2);
@@ -561,10 +560,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).syncUninterruptibly().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
 
             // Connect to the server
-            cc = cb.connect(sc.localAddress()).syncUninterruptibly().channel();
+            cc = cb.connect(sc.localAddress()).get();
             assertTrue(serverChannelLatch.await(5, SECONDS));
 
             final Channel ccCpy = cc;
@@ -588,7 +587,7 @@ public class LocalChannelTest {
     }
 
     @Test
-    public void testPeerWriteInWritePromiseCompleteSameEventLoopPreservesOrder() throws InterruptedException {
+    public void testPeerWriteInWritePromiseCompleteSameEventLoopPreservesOrder() throws Exception {
         Bootstrap cb = new Bootstrap();
         ServerBootstrap sb = new ServerBootstrap();
         final CountDownLatch messageLatch = new CountDownLatch(2);
@@ -637,10 +636,10 @@ public class LocalChannelTest {
             Channel cc = null;
             try {
                 // Start server
-                sc = sb.bind(TEST_ADDRESS).syncUninterruptibly().channel();
+                sc = sb.bind(TEST_ADDRESS).get();
 
                 // Connect to the server
-                cc = cb.connect(sc.localAddress()).syncUninterruptibly().channel();
+                cc = cb.connect(sc.localAddress()).get();
                 assertTrue(serverChannelLatch.await(5, SECONDS));
 
                 final Channel ccCpy = cc;
@@ -667,7 +666,7 @@ public class LocalChannelTest {
     }
 
     @Test
-    public void testWriteWhilePeerIsClosedReleaseObjectAndFailPromise() throws InterruptedException {
+    public void testWriteWhilePeerIsClosedReleaseObjectAndFailPromise() throws Exception {
         Bootstrap cb = new Bootstrap();
         ServerBootstrap sb = new ServerBootstrap();
         final CountDownLatch serverMessageLatch = new CountDownLatch(1);
@@ -709,10 +708,10 @@ public class LocalChannelTest {
             Channel cc = null;
             try {
                 // Start server
-                sc = sb.bind(TEST_ADDRESS).syncUninterruptibly().channel();
+                sc = sb.bind(TEST_ADDRESS).get();
 
                 // Connect to the server
-                cc = cb.connect(sc.localAddress()).syncUninterruptibly().channel();
+                cc = cb.connect(sc.localAddress()).get();
                 assertTrue(serverChannelLatch.await(5, SECONDS));
 
                 final Channel ccCpy = cc;
@@ -789,9 +788,9 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).sync().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
 
-            cc = cb.register().sync().channel();
+            cc = cb.register().get();
 
             final ChannelPromise promise = cc.newPromise();
             final Promise<Void> assertPromise = cc.eventLoop().newPromise();
@@ -902,10 +901,10 @@ public class LocalChannelTest {
         LocalChannel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).sync().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
 
             // Connect to the server
-            cc = (LocalChannel) cb.connect(sc.localAddress()).sync().channel();
+            cc = (LocalChannel) cb.connect(sc.localAddress()).get();
 
             // Close the channel
             closeChannel(cc);
@@ -980,8 +979,8 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).sync().channel();
-            cc = cb.connect(TEST_ADDRESS).sync().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
+            cc = cb.connect(TEST_ADDRESS).get();
 
             latch.await();
         } finally {
@@ -1041,8 +1040,8 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).sync().channel();
-            cc = cb.connect(TEST_ADDRESS).sync().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
+            cc = cb.connect(TEST_ADDRESS).get();
 
             countDownLatch.await();
         } finally {
@@ -1075,7 +1074,7 @@ public class LocalChannelTest {
         testServerMaxMessagesPerReadRespected(group1, group2, false);
     }
 
-    private void testServerMaxMessagesPerReadRespected(
+    private static void testServerMaxMessagesPerReadRespected(
             EventLoopGroup serverGroup, EventLoopGroup clientGroup, final boolean autoRead) throws Exception {
         final CountDownLatch countDownLatch = new CountDownLatch(5);
         Bootstrap cb = new Bootstrap();
@@ -1106,10 +1105,10 @@ public class LocalChannelTest {
         Channel cc = null;
         try {
             // Start server
-            sc = sb.bind(TEST_ADDRESS).sync().channel();
+            sc = sb.bind(TEST_ADDRESS).get();
             for (int i = 0; i < 5; i++) {
                 try {
-                    cc = cb.connect(TEST_ADDRESS).sync().channel();
+                    cc = cb.connect(TEST_ADDRESS).get();
                 } finally {
                     closeChannel(cc);
                 }

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
@@ -40,7 +40,7 @@ public class LocalTransportThreadModelTest2 {
 
     @Test
     @Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
-    public void testSocketReuse() throws InterruptedException {
+    public void testSocketReuse() throws Exception {
         ServerBootstrap serverBootstrap = new ServerBootstrap();
         LocalHandler serverHandler = new LocalHandler("SERVER");
         serverBootstrap
@@ -60,7 +60,7 @@ public class LocalTransportThreadModelTest2 {
 
         int count = 100;
         for (int i = 1; i < count + 1; i ++) {
-            Channel ch = clientBootstrap.connect().sync().channel();
+            Channel ch = clientBootstrap.connect().get();
 
             // SPIN until we get what we are looking for.
             int target = i * messageCountPerRun;

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioDatagramChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioDatagramChannelTest.java
@@ -57,7 +57,7 @@ public class NioDatagramChannelTest extends AbstractNioChannelTest<NioDatagramCh
                             }
                         });
                 DatagramChannel datagramChannel = (DatagramChannel) udpBootstrap
-                        .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                        .bind(new InetSocketAddress(0)).get();
                 channelGroup.add(datagramChannel);
             }
             assertEquals(100, channelGroup.size());


### PR DESCRIPTION
Motivation:
In #8516 it was proposed to at some point remove the specialised `ChannelFuture` and `ChannelPromise`.
Or at least make them not extend `Future` and `Promise`, respectively.

The first step on that road is to make the various `*Bootstrap` methods that currently return `ChannelFuture`, return `Future<Channel>` instead.

One pain point encountered in this discussion is the need to get access to the channel object after it has been initialised, but without waiting for the channel registration to propagate through the pipeline.

Modification:
Add a `Bootstrap.createUnregistered` method, which will return a `Future<Channel>`.
This future will provide access to the channel as soon as it has been initialised, and it is then up to the caller to call `channel.register()`.

Result:
All `*Bootstrap` methods that previously returned `ChannelFuture` now return `Future<Channel>`.
Furthermore, it's now possible to obtain an initialised but unregistered channel from a bootstrap.