### PR TITLE
Make DnsNameResolver.cnameCache() public

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -576,7 +576,7 @@ public class DnsNameResolver extends InetNameResolver {
     /**
      * Returns the {@link DnsCnameCache}.
      */
-    DnsCnameCache cnameCache() {
+    public DnsCnameCache cnameCache() {
         return cnameCache;
     }
 


### PR DESCRIPTION
Motivation:

Users may want to clear the cache manually. For this it should be possible to access it first.

Modifications:

Change the visibility to public

Result:

Be able to clear the cache manually. Related to https://github.com/netty/netty/issues/11519