### PR TITLE
Add Increment and Decrement count positive check in ReferenceCountUtil

### DIFF
--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -49,7 +49,7 @@ public final class ReferenceCountUtil {
      */
     @SuppressWarnings("unchecked")
     public static <T> T retain(T msg, int increment) {
-        ObjectUtil.checkPositive(increment, "Increment");
+        ObjectUtil.checkPositive(increment, "increment");
         if (msg instanceof ReferenceCounted) {
             return (T) ((ReferenceCounted) msg).retain(increment);
         }
@@ -97,7 +97,7 @@ public final class ReferenceCountUtil {
      * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
      */
     public static boolean release(Object msg, int decrement) {
-        ObjectUtil.checkPositive(decrement, "Decrement");
+        ObjectUtil.checkPositive(decrement, "decrement");
         if (msg instanceof ReferenceCounted) {
             return ((ReferenceCounted) msg).release(decrement);
         }
@@ -128,7 +128,7 @@ public final class ReferenceCountUtil {
      */
     public static void safeRelease(Object msg, int decrement) {
         try {
-            ObjectUtil.checkPositive(decrement, "Decrement");
+            ObjectUtil.checkPositive(decrement, "decrement");
             release(msg, decrement);
         } catch (Throwable t) {
             if (logger.isWarnEnabled()) {
@@ -158,7 +158,7 @@ public final class ReferenceCountUtil {
      */
     @Deprecated
     public static <T> T releaseLater(T msg, int decrement) {
-        ObjectUtil.checkPositive(decrement, "Decrement");
+        ObjectUtil.checkPositive(decrement, "decrement");
         if (msg instanceof ReferenceCounted) {
             ThreadDeathWatcher.watch(Thread.currentThread(), new ReleasingTask((ReferenceCounted) msg, decrement));
         }

--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -48,6 +49,7 @@ public final class ReferenceCountUtil {
      */
     @SuppressWarnings("unchecked")
     public static <T> T retain(T msg, int increment) {
+        ObjectUtil.checkPositive(increment, "Increment");
         if (msg instanceof ReferenceCounted) {
             return (T) ((ReferenceCounted) msg).retain(increment);
         }
@@ -95,6 +97,7 @@ public final class ReferenceCountUtil {
      * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
      */
     public static boolean release(Object msg, int decrement) {
+        ObjectUtil.checkPositive(decrement, "Decrement");
         if (msg instanceof ReferenceCounted) {
             return ((ReferenceCounted) msg).release(decrement);
         }
@@ -125,6 +128,7 @@ public final class ReferenceCountUtil {
      */
     public static void safeRelease(Object msg, int decrement) {
         try {
+            ObjectUtil.checkPositive(decrement, "Decrement");
             release(msg, decrement);
         } catch (Throwable t) {
             if (logger.isWarnEnabled()) {
@@ -154,6 +158,7 @@ public final class ReferenceCountUtil {
      */
     @Deprecated
     public static <T> T releaseLater(T msg, int decrement) {
+        ObjectUtil.checkPositive(decrement, "Decrement");
         if (msg instanceof ReferenceCounted) {
             ThreadDeathWatcher.watch(Thread.currentThread(), new ReleasingTask((ReferenceCounted) msg, decrement));
         }


### PR DESCRIPTION
Motivation:
We should have guards in place to check increment or decrement count in `ReferenceCountUtil`. Increment and Decrement counts must be a positive integer.

Modification:
Added `ObjectUtil#checkPositive` checks.

Result:
Prevent release due to invalid count.
