### PR TITLE
Ensure we include hs_err* files when build failed

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -74,4 +74,6 @@ jobs:
         if: ${{ failure() }}
         with:
           name: target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -81,7 +81,9 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-pr-windows-target
-          path: "**/target/"
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log
 
   build-pr-aarch64:
     name: linux-aarch64-verify-native
@@ -196,5 +198,6 @@ jobs:
         if: ${{ failure() }}
         with:
           name: build-${{ matrix.setup }}-target
-          path: "**/target/"
-
+          path: |
+            **/target/surefire-reports/
+            **/hs_err*.log


### PR DESCRIPTION
Motivation:

We the build failed we should ensure we also include hs_err* files as it may have failed due a native crash

Modifications:

Adjust path matching to include hs_err as well

Result:

Easier to debug native crashes
