### PR TITLE
Refactor using try-with-resources statement

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -139,17 +139,12 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
         checkSize(newsize);
         RandomAccessFile accessFile = new RandomAccessFile(file, "r");
         ByteBuffer byteBuffer;
-        try {
-            FileChannel fileChannel = accessFile.getChannel();
-            try {
-                byte[] array = new byte[(int) newsize];
-                byteBuffer = ByteBuffer.wrap(array);
-                int read = 0;
-                while (read < newsize) {
-                    read += fileChannel.read(byteBuffer);
-                }
-            } finally {
-                fileChannel.close();
+        try (FileChannel fileChannel = accessFile.getChannel()) {
+            byte[] array = new byte[(int) newsize];
+            byteBuffer = ByteBuffer.wrap(array);
+            int read = 0;
+            while (read < newsize) {
+                read += fileChannel.read(byteBuffer);
             }
         } finally {
             accessFile.close();
@@ -245,24 +240,19 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
         int length = byteBuf.readableBytes();
         long written = 0;
         RandomAccessFile accessFile = new RandomAccessFile(dest, "rw");
-        try {
-            FileChannel fileChannel = accessFile.getChannel();
-            try {
-                if (byteBuf.nioBufferCount() == 1) {
-                    ByteBuffer byteBuffer = byteBuf.nioBuffer();
-                    while (written < length) {
-                        written += fileChannel.write(byteBuffer);
-                    }
-                } else {
-                    ByteBuffer[] byteBuffers = byteBuf.nioBuffers();
-                    while (written < length) {
-                        written += fileChannel.write(byteBuffers);
-                    }
+        try (FileChannel fileChannel = accessFile.getChannel()) {
+            if (byteBuf.nioBufferCount() == 1) {
+                ByteBuffer byteBuffer = byteBuf.nioBuffer();
+                while (written < length) {
+                    written += fileChannel.write(byteBuffer);
                 }
-                fileChannel.force(false);
-            } finally {
-                fileChannel.close();
+            } else {
+                ByteBuffer[] byteBuffers = byteBuf.nioBuffers();
+                while (written < length) {
+                    written += fileChannel.write(byteBuffers);
+                }
             }
+            fileChannel.force(false);
         } finally {
             accessFile.close();
         }

--- a/handler/src/test/java/io/netty/handler/ssl/PemEncodedTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PemEncodedTest.java
@@ -103,16 +103,11 @@ public class PemEncodedTest {
 
     private static byte[] toByteArray(File file) throws Exception {
         FileInputStream in = new FileInputStream(file);
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try {
-                byte[] buf = new byte[1024];
-                int len;
-                while ((len = in.read(buf)) != -1) {
-                    baos.write(buf, 0, len);
-                }
-            } finally {
-                baos.close();
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buf = new byte[1024];
+            int len;
+            while ((len = in.read(buf)) != -1) {
+                baos.write(buf, 0, len);
             }
 
             return baos.toByteArray();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
@@ -163,13 +163,11 @@ public class EpollReuseAddrTest {
         int count = 16;
         final CountDownLatch latch = new CountDownLatch(count);
         Runnable r = () -> {
-            try {
-                DatagramSocket socket = new DatagramSocket();
+            try (DatagramSocket socket = new DatagramSocket()) {
                 while (!received1.get() || !received2.get()) {
                     socket.send(new DatagramPacket(
                             bytes, 0, bytes.length, address1.getAddress(), address1.getPort()));
                 }
-                socket.close();
             } catch (IOException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Motivation:
Some autocloseable resources in the `master` branch are closed by manually invoking `.close()`, this is error-prone, can lead to resource leaks and makes the code harder to follow.

Modification:
This pull requests uses try-with-resources statements to simplify the implementation of the resource handling and ensure that resources are always closed properly.

This patch was created automatically with the static analysis tool [Logifix](https://github.com/lyxell/logifix) as part of a research project.