### PR TITLE
Fix a number of javadoc issues

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -258,11 +258,11 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 ctx.fireChannelRead(message);
                 return;
             default:
-                /**
-                 * <a href="https://tools.ietf.org/html/rfc7230#section-3.3.3">RFC 7230, 3.3.3</a> states that if a
-                 * request does not have either a transfer-encoding or a content-length header then the message body
-                 * length is 0. However for a response the body length is the number of octets received prior to the
-                 * server closing the connection. So we treat this as variable length chunked encoding.
+                /*
+                  RFC 7230, 3.3.3 (https://tools.ietf.org/html/rfc7230#section-3.3.3) states that if a
+                  request does not have either a transfer-encoding or a content-length header then the message body
+                  length is 0. However for a response the body length is the number of octets received prior to the
+                  server closing the connection. So we treat this as variable length chunked encoding.
                  */
                 long contentLength = contentLength();
                 if (contentLength == 0 || contentLength == -1 && isDecodingRequest()) {
@@ -327,9 +327,9 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             }
             return;
         }
-        /**
-         * everything else after this point takes care of reading chunked content. basically, read chunk size,
-         * read chunk, read and ignore the CRLF and repeat until 0
+        /*
+          everything else after this point takes care of reading chunked content. basically, read chunk size,
+          read chunk, read and ignore the CRLF and repeat until 0
          */
         case READ_CHUNK_SIZE: try {
             AppendableCharSequence line = lineParser.parse(buffer);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
@@ -190,7 +190,7 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
      * original InterfaceHttpData object.
      *
      * @param dest Destination file - must be not null.
-     * @return True if the write is successful.
+     * @return {@code true} if the write is successful.
      * @throws IOException If an IO error occurs while renaming the underlying file of this HttpData.
      */
     boolean renameTo(File dest) throws IOException;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
@@ -50,9 +50,8 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
     /**
      * Set the content from the ChannelBuffer (erase any previous data)
      *
-     * @param buffer
-     *            must be not null
-     * @throws IOException
+     * @param buffer Must be not null.
+     * @throws IOException If an IO error occurs when setting the content of this HttpData.
      */
     void setContent(ByteBuf buffer) throws IOException;
 
@@ -63,25 +62,23 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
      *            must be not null except if last is set to False
      * @param last
      *            True of the buffer is the last one
-     * @throws IOException
+     * @throws IOException If an IO error occurs while adding content to this HttpData.
      */
     void addContent(ByteBuf buffer, boolean last) throws IOException;
 
     /**
      * Set the content from the file (erase any previous data)
      *
-     * @param file
-     *            must be not null
-     * @throws IOException
+     * @param file Must be not null.
+     * @throws IOException If an IO error occurs when setting the content of this HttpData.
      */
     void setContent(File file) throws IOException;
 
     /**
      * Set the content from the inputStream (erase any previous data)
      *
-     * @param inputStream
-     *            must be not null
-     * @throws IOException
+     * @param inputStream Must be not null.
+     * @throws IOException If an IO error occurs when setting the content of this HttpData.
      */
     void setContent(InputStream inputStream) throws IOException;
 
@@ -125,7 +122,7 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
      * Note: this method will allocate a lot of memory, if the data is currently stored on the file system.
      *
      * @return the contents of the file item as an array of bytes.
-     * @throws IOException
+     * @throws IOException If an IO error occurs while reading the data contents of this HttpData.
      */
     byte[] get() throws IOException;
 
@@ -134,7 +131,7 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
      * Note: this method will allocate a lot of memory, if the data is currently stored on the file system.
      *
      * @return the content of the file item as a ByteBuf
-     * @throws IOException
+     * @throws IOException If an IO error occurs while reading the data contents of this HttpData.
      */
     ByteBuf getByteBuf() throws IOException;
 
@@ -155,7 +152,7 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
      *
      * @return the contents of the file item as a String, using the default
      *         character encoding.
-     * @throws IOException
+     * @throws IOException If an IO error occurs while reading the data contents of this HttpData.
      */
     String getString() throws IOException;
 
@@ -167,7 +164,7 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
      *            the charset to use
      * @return the contents of the file item as a String, using the specified
      *         charset.
-     * @throws IOException
+     * @throws IOException If an IO error occurs while reading the data contents of this HttpData.
      */
     String getString(Charset encoding) throws IOException;
 
@@ -192,10 +189,9 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
      * the new file will be out of the cleaner of the factory that creates the
      * original InterfaceHttpData object.
      *
-     * @param dest
-     *            destination file - must be not null
-     * @return True if the write is successful
-     * @throws IOException
+     * @param dest Destination file - must be not null.
+     * @return True if the write is successful.
+     * @throws IOException If an IO error occurs while renaming the underlying file of this HttpData.
      */
     boolean renameTo(File dest) throws IOException;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -594,8 +594,6 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
 
     /**
      * Skip control Characters
-     *
-     * @throws NotEnoughDataDecoderException
      */
     private static void skipControlCharacters(ByteBuf undecodedChunk) {
         if (!undecodedChunk.hasArray()) {
@@ -637,7 +635,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
      * @param closeDelimiterStatus
      *            the next getStatus if the delimiter is a close delimiter
      * @return the next InterfaceHttpData if any
-     * @throws ErrorDataDecoderException
+     * @throws ErrorDataDecoderException If no multipart delimiter is found, or an error occurs during decoding.
      */
     private InterfaceHttpData findMultipartDelimiter(String delimiter, MultiPartStatus dispositionStatus,
             MultiPartStatus closeDelimiterStatus) {
@@ -680,7 +678,6 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
      * Find the next Disposition
      *
      * @return the next InterfaceHttpData if any
-     * @throws ErrorDataDecoderException
      */
     private InterfaceHttpData findMultipartDisposition() {
         int readerIndex = undecodedChunk.readerIndex();
@@ -839,7 +836,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
      * @param delimiter
      *            the delimiter to use
      * @return the InterfaceHttpData if any
-     * @throws ErrorDataDecoderException
+     * @throws ErrorDataDecoderException If an error occurs when decoding the multipart data.
      */
     protected InterfaceHttpData getFileUpload(String delimiter) {
         // eventually restart from existing FileUpload
@@ -1146,7 +1143,6 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
      * Load the field value or file data from a Multipart request
      *
      * @return {@code true} if the last chunk is loaded (boundary delimiter found), {@code false} if need more chunks
-     * @throws ErrorDataDecoderException
      */
     private static boolean loadDataMultipartOptimized(ByteBuf undecodedChunk, String delimiter, HttpData httpData) {
         if (!undecodedChunk.isReadable()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
@@ -223,7 +223,7 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
      *
      * @param response
      *            HTTP response returned from the server for the request sent by beginOpeningHandshake00().
-     * @throws WebSocketHandshakeException
+     * @throws WebSocketHandshakeException If the handshake or challenge is invalid.
      */
     @Override
     protected void verify(FullHttpResponse response) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
@@ -260,7 +260,7 @@ public class WebSocketClientHandshaker07 extends WebSocketClientHandshaker {
      *
      * @param response
      *            HTTP response returned from the server for the request sent by beginOpeningHandshake00().
-     * @throws WebSocketHandshakeException
+     * @throws WebSocketHandshakeException If the handshake or challenge is invalid.
      */
     @Override
     protected void verify(FullHttpResponse response) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
@@ -262,7 +262,7 @@ public class WebSocketClientHandshaker08 extends WebSocketClientHandshaker {
      *
      * @param response
      *            HTTP response returned from the server for the request sent by beginOpeningHandshake00().
-     * @throws WebSocketHandshakeException
+     * @throws WebSocketHandshakeException If the handshake or challenge is invalid.
      */
     @Override
     protected void verify(FullHttpResponse response) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -148,10 +148,10 @@ public class HttpClientCodecTest {
                             // This is just a simple demo...don't block in IO
                             assertTrue(ctx.channel() instanceof SocketChannel);
                             final SocketChannel sChannel = (SocketChannel) ctx.channel();
-                            /**
-                             * The point of this test is to not add any content-length or content-encoding headers
-                             * and the client should still handle this.
-                             * See <a href="https://tools.ietf.org/html/rfc7230#section-3.3.3">RFC 7230, 3.3.3</a>.
+                            /*
+                              The point of this test is to not add any content-length or content-encoding headers
+                              and the client should still handle this.
+                              See RFC 7230, 3.3.3: https://tools.ietf.org/html/rfc7230#section-3.3.3.
                              */
                             sChannel.writeAndFlush(Unpooled.wrappedBuffer(("HTTP/1.0 200 OK\r\n" +
                             "Date: Fri, 31 Dec 1999 23:59:59 GMT\r\n" +

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -586,7 +586,8 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
          *
          * @param numBytes the number of bytes to be returned to the flow control window.
          * @return true if {@code WINDOW_UPDATE} was written, false otherwise.
-         * @throws Http2Exception
+         * @throws Http2Exception If the number of bytes is too great for the current window,
+         * or an internal error occurs.
          */
         boolean consumeBytes(int numBytes) throws Http2Exception;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -89,7 +89,7 @@ import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
  * {@link Http2ChannelDuplexHandler#newStream()}, and then writing a {@link Http2HeadersFrame} object with the stream
  * attached.
  *
- * <pre>
+ * <pre>{@code
  *     final Http2Stream2 stream = handler.newStream();
  *     ctx.write(headersFrame.stream(stream)).addListener(new ChannelFutureListener() {
  *
@@ -110,7 +110,7 @@ import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
  *             }
  *         }
  *     }
- * </pre>
+ * }</pre>
  *
  * <p>If a new stream cannot be created due to stream id exhaustion of the endpoint, the {@link ChannelPromise} of the
  * HEADERS frame will fail with a {@link Http2NoMoreStreamIdsException}.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackEncoderTest.java
@@ -67,7 +67,6 @@ public class HpackEncoderTest {
     /**
      * The encoder should not impose an arbitrary limit on the header size if
      * the server has not specified any limit.
-     * @throws Http2Exception
      */
     @Test
     public void testWillEncode16MBHeaderByDefault() throws Http2Exception {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -121,10 +121,10 @@ public class Http2FrameCodecTest {
     }
 
     private void setUp(Http2FrameCodecBuilder frameCodecBuilder, Http2Settings initialRemoteSettings) throws Exception {
-        /**
-         * Some tests call this method twice. Once with JUnit's @Before and once directly to pass special settings.
-         * This call ensures that in case of two consecutive calls to setUp(), the previous channel is shutdown and
-         * ByteBufs are released correctly.
+        /*
+          Some tests call this method twice. Once with JUnit's @Before and once directly to pass special settings.
+          This call ensures that in case of two consecutive calls to setUp(), the previous channel is shutdown and
+          ByteBufs are released correctly.
          */
         tearDown();
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
@@ -194,7 +194,6 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
      * When the channel goes inactive, release all frames to prevent data leaks.
      *
      * @param ctx handler context
-     * @throws Exception
      */
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -156,8 +156,9 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
      * Decodes the fixed header. It's one byte for the flags and then variable
      * bytes for the remaining length.
      *
-     * @see
+     * See
      * https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180841
+     * for more information.
      *
      * @param buffer the buffer to decode from
      * @return the fixed header

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -64,16 +64,16 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         final int num = 266;
         assertThat(ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num), is(size));
         final byte[] buf = new byte[size + num];
-        /**
-         * 8    A    0    2
-         * 1000 1010 0000 0010
-         * 0000 1010 0000 0010
-         * 0000 0010 0000 1010
-         *  000 0010  000 1010
-         *
-         *  0000 0001 0000 1010
-         *  0    1    0    A
-         * 266
+        /*
+          8    A    0    2
+          1000 1010 0000 0010
+          0000 1010 0000 0010
+          0000 0010 0000 1010
+           000 0010  000 1010
+
+           0000 0001 0000 1010
+           0    1    0    A
+          266
          */
 
         buf[0] = (byte) (0x8A & 0xFF);
@@ -99,16 +99,16 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         final int num = 0x4000;
         assertThat(ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num), is(size));
         final byte[] buf = new byte[size + num];
-        /**
-         * 8    0    8    0    0    1
-         * 1000 0000 1000 0000 0000 0001
-         * 0000 0000 0000 0000 0000 0001
-         * 0000 0001 0000 0000 0000 0000
-         *  000 0001  000 0000  000 0000
-         *
-         *    0 0000 0100 0000 0000 0000
-         *    0    0    4    0    0    0
-         *
+        /*
+          8    0    8    0    0    1
+          1000 0000 1000 0000 0000 0001
+          0000 0000 0000 0000 0000 0001
+          0000 0001 0000 0000 0000 0000
+           000 0001  000 0000  000 0000
+
+             0 0000 0100 0000 0000 0000
+             0    0    4    0    0    0
+
          */
 
         buf[0] = (byte) (0x80 & 0xFF);
@@ -135,16 +135,16 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         final int num = 0x200000;
         assertThat(ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num), is(size));
         final byte[] buf = new byte[size + num];
-        /**
-         * 8    0    8    0    8    0    0    1
-         * 1000 0000 1000 0000 1000 0000 0000 0001
-         * 0000 0000 0000 0000 0000 0000 0000 0001
-         * 0000 0001 0000 0000 0000 0000 0000 0000
-         *  000 0001  000 0000  000 0000  000 0000
-         *
-         *    0000 0010 0000 0000 0000 0000 0000
-         *    0    2    0    0    0    0    0
-         *
+        /*
+          8    0    8    0    8    0    0    1
+          1000 0000 1000 0000 1000 0000 0000 0001
+          0000 0000 0000 0000 0000 0000 0000 0001
+          0000 0001 0000 0000 0000 0000 0000 0000
+           000 0001  000 0000  000 0000  000 0000
+
+             0000 0010 0000 0000 0000 0000 0000
+             0    2    0    0    0    0    0
+
          */
 
         buf[0] = (byte) (0x80 & 0xFF);

--- a/common/src/main/java/io/netty/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty/util/concurrent/Future.java
@@ -60,7 +60,7 @@ public interface Future<V> extends java.util.concurrent.Future<V> {
      * failed.
      *
      * @throws CancellationException if the computation was cancelled
-     * @throws {@link java.util.concurrent.CompletionException} if the computation threw an exception.
+     * @throws java.util.concurrent.CompletionException if the computation threw an exception.
      * @throws InterruptedException if the current thread was interrupted while waiting
      *
      */
@@ -71,7 +71,7 @@ public interface Future<V> extends java.util.concurrent.Future<V> {
      * failed.
      *
      * @throws CancellationException if the computation was cancelled
-     * @throws {@link java.util.concurrent.CompletionException} if the computation threw an exception.
+     * @throws java.util.concurrent.CompletionException if the computation threw an exception.
      */
     Future<V> syncUninterruptibly();
 

--- a/common/src/main/java/io/netty/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty/util/concurrent/Future.java
@@ -16,6 +16,7 @@
 package io.netty.util.concurrent;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -60,7 +61,7 @@ public interface Future<V> extends java.util.concurrent.Future<V> {
      * failed.
      *
      * @throws CancellationException if the computation was cancelled
-     * @throws java.util.concurrent.CompletionException if the computation threw an exception.
+     * @throws CompletionException if the computation threw an exception.
      * @throws InterruptedException if the current thread was interrupted while waiting
      *
      */
@@ -71,7 +72,7 @@ public interface Future<V> extends java.util.concurrent.Future<V> {
      * failed.
      *
      * @throws CancellationException if the computation was cancelled
-     * @throws java.util.concurrent.CompletionException if the computation threw an exception.
+     * @throws CompletionException if the computation threw an exception.
      */
     Future<V> syncUninterruptibly();
 

--- a/common/src/main/java/io/netty/util/internal/logging/CommonsLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/CommonsLogger.java
@@ -13,29 +13,29 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/**
- * Copyright (c) 2004-2011 QOS.ch
- * All rights reserved.
- *
- * Permission is hereby granted, free  of charge, to any person obtaining
- * a  copy  of this  software  and  associated  documentation files  (the
- * "Software"), to  deal in  the Software without  restriction, including
- * without limitation  the rights to  use, copy, modify,  merge, publish,
- * distribute,  sublicense, and/or sell  copies of  the Software,  and to
- * permit persons to whom the Software  is furnished to do so, subject to
- * the following conditions:
- *
- * The  above  copyright  notice  and  this permission  notice  shall  be
- * included in all copies or substantial portions of the Software.
- *
- * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
- * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
- * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
+/*
+  Copyright (c) 2004-2011 QOS.ch
+  All rights reserved.
+
+  Permission is hereby granted, free  of charge, to any person obtaining
+  a  copy  of this  software  and  associated  documentation files  (the
+  "Software"), to  deal in  the Software without  restriction, including
+  without limitation  the rights to  use, copy, modify,  merge, publish,
+  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+  permit persons to whom the Software  is furnished to do so, subject to
+  the following conditions:
+
+  The  above  copyright  notice  and  this permission  notice  shall  be
+  included in all copies or substantial portions of the Software.
+
+  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
  */
 package io.netty.util.internal.logging;
 

--- a/common/src/main/java/io/netty/util/internal/logging/FormattingTuple.java
+++ b/common/src/main/java/io/netty/util/internal/logging/FormattingTuple.java
@@ -13,29 +13,29 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/**
- * Copyright (c) 2004-2011 QOS.ch
- * All rights reserved.
- *
- * Permission is hereby granted, free  of charge, to any person obtaining
- * a  copy  of this  software  and  associated  documentation files  (the
- * "Software"), to  deal in  the Software without  restriction, including
- * without limitation  the rights to  use, copy, modify,  merge, publish,
- * distribute,  sublicense, and/or sell  copies of  the Software,  and to
- * permit persons to whom the Software  is furnished to do so, subject to
- * the following conditions:
- *
- * The  above  copyright  notice  and  this permission  notice  shall  be
- * included in all copies or substantial portions of the Software.
- *
- * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
- * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
- * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
+/*
+  Copyright (c) 2004-2011 QOS.ch
+  All rights reserved.
+
+  Permission is hereby granted, free  of charge, to any person obtaining
+  a  copy  of this  software  and  associated  documentation files  (the
+  "Software"), to  deal in  the Software without  restriction, including
+  without limitation  the rights to  use, copy, modify,  merge, publish,
+  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+  permit persons to whom the Software  is furnished to do so, subject to
+  the following conditions:
+
+  The  above  copyright  notice  and  this permission  notice  shall  be
+  included in all copies or substantial portions of the Software.
+
+  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
  */
 package io.netty.util.internal.logging;
 

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLogger.java
@@ -13,29 +13,29 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/**
- * Copyright (c) 2004-2011 QOS.ch
- * All rights reserved.
- *
- * Permission is hereby granted, free  of charge, to any person obtaining
- * a  copy  of this  software  and  associated  documentation files  (the
- * "Software"), to  deal in  the Software without  restriction, including
- * without limitation  the rights to  use, copy, modify,  merge, publish,
- * distribute,  sublicense, and/or sell  copies of  the Software,  and to
- * permit persons to whom the Software  is furnished to do so, subject to
- * the following conditions:
- *
- * The  above  copyright  notice  and  this permission  notice  shall  be
- * included in all copies or substantial portions of the Software.
- *
- * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
- * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
- * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
+/*
+  Copyright (c) 2004-2011 QOS.ch
+  All rights reserved.
+
+  Permission is hereby granted, free  of charge, to any person obtaining
+  a  copy  of this  software  and  associated  documentation files  (the
+  "Software"), to  deal in  the Software without  restriction, including
+  without limitation  the rights to  use, copy, modify,  merge, publish,
+  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+  permit persons to whom the Software  is furnished to do so, subject to
+  the following conditions:
+
+  The  above  copyright  notice  and  this permission  notice  shall  be
+  included in all copies or substantial portions of the Software.
+
+  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
  */
 package io.netty.util.internal.logging;
 

--- a/common/src/main/java/io/netty/util/internal/logging/JdkLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/JdkLogger.java
@@ -13,29 +13,29 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/**
- * Copyright (c) 2004-2011 QOS.ch
- * All rights reserved.
- *
- * Permission is hereby granted, free  of charge, to any person obtaining
- * a  copy  of this  software  and  associated  documentation files  (the
- * "Software"), to  deal in  the Software without  restriction, including
- * without limitation  the rights to  use, copy, modify,  merge, publish,
- * distribute,  sublicense, and/or sell  copies of  the Software,  and to
- * permit persons to whom the Software  is furnished to do so, subject to
- * the following conditions:
- *
- * The  above  copyright  notice  and  this permission  notice  shall  be
- * included in all copies or substantial portions of the Software.
- *
- * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
- * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
- * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
+/*
+  Copyright (c) 2004-2011 QOS.ch
+  All rights reserved.
+
+  Permission is hereby granted, free  of charge, to any person obtaining
+  a  copy  of this  software  and  associated  documentation files  (the
+  "Software"), to  deal in  the Software without  restriction, including
+  without limitation  the rights to  use, copy, modify,  merge, publish,
+  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+  permit persons to whom the Software  is furnished to do so, subject to
+  the following conditions:
+
+  The  above  copyright  notice  and  this permission  notice  shall  be
+  included in all copies or substantial portions of the Software.
+
+  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
  */
 package io.netty.util.internal.logging;
 

--- a/common/src/main/java/io/netty/util/internal/logging/Log4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4JLogger.java
@@ -13,29 +13,29 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/**
- * Copyright (c) 2004-2011 QOS.ch
- * All rights reserved.
- *
- * Permission is hereby granted, free  of charge, to any person obtaining
- * a  copy  of this  software  and  associated  documentation files  (the
- * "Software"), to  deal in  the Software without  restriction, including
- * without limitation  the rights to  use, copy, modify,  merge, publish,
- * distribute,  sublicense, and/or sell  copies of  the Software,  and to
- * permit persons to whom the Software  is furnished to do so, subject to
- * the following conditions:
- *
- * The  above  copyright  notice  and  this permission  notice  shall  be
- * included in all copies or substantial portions of the Software.
- *
- * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
- * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
- * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
+/*
+  Copyright (c) 2004-2011 QOS.ch
+  All rights reserved.
+
+  Permission is hereby granted, free  of charge, to any person obtaining
+  a  copy  of this  software  and  associated  documentation files  (the
+  "Software"), to  deal in  the Software without  restriction, including
+  without limitation  the rights to  use, copy, modify,  merge, publish,
+  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+  permit persons to whom the Software  is furnished to do so, subject to
+  the following conditions:
+
+  The  above  copyright  notice  and  this permission  notice  shall  be
+  included in all copies or substantial portions of the Software.
+
+  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
  */
 package io.netty.util.internal.logging;
 

--- a/common/src/main/java/io/netty/util/internal/logging/MessageFormatter.java
+++ b/common/src/main/java/io/netty/util/internal/logging/MessageFormatter.java
@@ -13,29 +13,29 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/**
- * Copyright (c) 2004-2011 QOS.ch
- * All rights reserved.
- *
- * Permission is hereby granted, free  of charge, to any person obtaining
- * a  copy  of this  software  and  associated  documentation files  (the
- * "Software"), to  deal in  the Software without  restriction, including
- * without limitation  the rights to  use, copy, modify,  merge, publish,
- * distribute,  sublicense, and/or sell  copies of  the Software,  and to
- * permit persons to whom the Software  is furnished to do so, subject to
- * the following conditions:
- *
- * The  above  copyright  notice  and  this permission  notice  shall  be
- * included in all copies or substantial portions of the Software.
- *
- * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
- * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
- * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
+/*
+  Copyright (c) 2004-2011 QOS.ch
+  All rights reserved.
+
+  Permission is hereby granted, free  of charge, to any person obtaining
+  a  copy  of this  software  and  associated  documentation files  (the
+  "Software"), to  deal in  the Software without  restriction, including
+  without limitation  the rights to  use, copy, modify,  merge, publish,
+  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+  permit persons to whom the Software  is furnished to do so, subject to
+  the following conditions:
+
+  The  above  copyright  notice  and  this permission  notice  shall  be
+  included in all copies or substantial portions of the Software.
+
+  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
  */
 package io.netty.util.internal.logging;
 

--- a/common/src/test/java/io/netty/util/internal/logging/MessageFormatterTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/MessageFormatterTest.java
@@ -13,28 +13,28 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/**
- * Copyright (c) 2004-2011 QOS.ch
- * All rights reserved.
- * <p>
- * Permission is hereby granted, free  of charge, to any person obtaining
- * a  copy  of this  software  and  associated  documentation files  (the
- * "Software"), to  deal in  the Software without  restriction, including
- * without limitation  the rights to  use, copy, modify,  merge, publish,
- * distribute,  sublicense, and/or sell  copies of  the Software,  and to
- * permit persons to whom the Software  is furnished to do so, subject to
- * the following conditions:
- * <p>
- * The  above  copyright  notice  and  this permission  notice  shall  be
- * included in all copies or substantial portions of the Software.
- * <p>
- * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
- * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
- * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*
+  Copyright (c) 2004-2011 QOS.ch
+  All rights reserved.
+  <p>
+  Permission is hereby granted, free  of charge, to any person obtaining
+  a  copy  of this  software  and  associated  documentation files  (the
+  "Software"), to  deal in  the Software without  restriction, including
+  without limitation  the rights to  use, copy, modify,  merge, publish,
+  distribute,  sublicense, and/or sell  copies of  the Software,  and to
+  permit persons to whom the Software  is furnished to do so, subject to
+  the following conditions:
+  <p>
+  The  above  copyright  notice  and  this permission  notice  shall  be
+  included in all copies or substantial portions of the Software.
+  <p>
+  THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+  EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+  MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package io.netty.util.internal.logging;
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslMasterKeyHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslMasterKeyHandler.java
@@ -52,7 +52,7 @@ public abstract class SslMasterKeyHandler implements ChannelHandler {
     /**
      * A system property that can be used to turn on/off the {@link SslMasterKeyHandler} dynamically without having
      * to edit your pipeline.
-     * <code>-Dio.netty.ssl.masterKeyHandler=true</code>
+     * {@code -Dio.netty.ssl.masterKeyHandler=true}
      */
     public static final String SYSTEM_PROP_KEY = "io.netty.ssl.masterKeyHandler";
 
@@ -171,8 +171,8 @@ public abstract class SslMasterKeyHandler implements ChannelHandler {
     }
 
     /**
-     * Record the session identifier and master key to the {@link InternalLogger} named <code>io.netty.wireshark</code>.
-     * ex. <code>RSA Session-ID:XXX Master-Key:YYY</code>
+     * Record the session identifier and master key to the {@link InternalLogger} named {@code io.netty.wireshark}.
+     * ex. {@code RSA Session-ID:XXX Master-Key:YYY}
      * This format is understood by Wireshark 1.6.0.
      * https://code.wireshark.org/review/gitweb?p=wireshark.git;a=commit;h=686d4cabb41185591c361f9ec6b709034317144b
      * The key and session identifier are forwarded to the log named 'io.netty.wireshark'.

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueRecvByteAllocatorHandle.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueRecvByteAllocatorHandle.java
@@ -88,15 +88,15 @@ final class KQueueRecvByteAllocatorHandle extends DelegatingHandle implements Ex
     }
 
     boolean maybeMoreDataToRead() {
-        /**
-         * kqueue with EV_CLEAR flag set requires that we read until we consume "data" bytes
-         * (see <a href="https://www.freebsd.org/cgi/man.cgi?kqueue">kqueue man</a>). However in order to
-         * respect auto read we supporting reading to stop if auto read is off. If auto read is on we force reading to
-         * continue to avoid a {@link StackOverflowError} between channelReadComplete and reading from the
-         * channel. It is expected that the {@link #KQueueSocketChannel} implementations will track if all data was not
-         * read, and will force a EVFILT_READ ready event.
-         *
-         * It is assumed EOF is handled externally by checking {@link #isReadEOF()}.
+        /*
+          kqueue with EV_CLEAR flag set requires that we read until we consume "data" bytes
+          (see kqueue man: https://www.freebsd.org/cgi/man.cgi?kqueue). However, in order to
+          respect auto read we support reading to stop if auto read is off. If auto read is on we force reading to
+          continue to avoid a {@link StackOverflowError} between channelReadComplete and reading from the
+          channel. It is expected that the {@link #KQueueSocketChannel} implementations will track if all data was not
+          read, and will force a EVFILT_READ ready event.
+
+          It is assumed EOF is handled externally by checking {@link #isReadEOF()}.
          */
         return numberBytesPending != 0;
     }

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
@@ -49,8 +49,6 @@ public final class Unix {
 
     /**
      * Internal method... Should never be called from the user.
-     *
-     * @param registerTask
      */
     @UnstableApi
     public static void registerInternal(Runnable registerTask) {

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
@@ -49,6 +49,8 @@ public final class Unix {
 
     /**
      * Internal method... Should never be called from the user.
+     *
+     * @param registerTask The task to run if this thread caused registration.
      */
     @UnstableApi
     public static void registerInternal(Runnable registerTask) {


### PR DESCRIPTION
Motivation:
Let's have fewer warnings about broken, missing, or abuse of javadoc comments.

Modification:
Added descriptions to throws clauses that were missing them.
Remove link clauses from throws clauses - these are implied.
Turned some javadoc comments into block comments because they were not applied to APIs.
Use code clauses instead of code tags.

Result:
Fewer javadoc crimes.
