### PR TITLE
Small cleanups

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
@@ -416,7 +417,8 @@ public class ResourceLeakDetector<T> {
                     final int numElements = oldHead.pos + 1;
                     if (numElements >= TARGET_RECORDS) {
                         final int backOffFactor = Math.min(numElements - TARGET_RECORDS, 30);
-                        if (dropped = ThreadLocalRandom.current().nextInt(1 << backOffFactor) != 0) {
+                        dropped = ThreadLocalRandom.current().nextInt(1 << backOffFactor) != 0;
+                        if (dropped) {
                             prevHead = oldHead.next;
                         }
                     } else {
@@ -454,38 +456,8 @@ public class ResourceLeakDetector<T> {
             try {
                 return close();
             } finally {
-                // This method will do `synchronized(trackedObject)` and we should be sure this will not cause deadlock.
-                // It should not, because somewhere up the callstack should be a (successful) `trackedObject.release`,
-                // therefore it is unreasonable that anyone else, anywhere, is holding a lock on the trackedObject.
-                // (Unreasonable but possible, unfortunately.)
-                reachabilityFence0(trackedObject);
-            }
-        }
-
-         /**
-         * Ensures that the object referenced by the given reference remains
-         * <a href="package-summary.html#reachability"><em>strongly reachable</em></a>,
-         * regardless of any prior actions of the program that might otherwise cause
-         * the object to become unreachable; thus, the referenced object is not
-         * reclaimable by garbage collection at least until after the invocation of
-         * this method.
-         *
-         * <p> Recent versions of the JDK have a nasty habit of prematurely deciding objects are unreachable.
-         * see: https://stackoverflow.com/questions/26642153/finalize-called-on-strongly-reachable-object-in-java-8
-         * The Java 9 method Reference.reachabilityFence offers a solution to this problem.
-         *
-         * <p> This method is always implemented as a synchronization on {@code ref}, not as
-         * {@code Reference.reachabilityFence} for consistency across platforms and to allow building on JDK 6-8.
-         * <b>It is the caller's responsibility to ensure that this synchronization will not cause deadlock.</b>
-         *
-         * @param ref the reference. If {@code null}, this method has no effect.
-         * @see java.lang.ref.Reference#reachabilityFence
-         */
-        private static void reachabilityFence0(Object ref) {
-            if (ref != null) {
-                synchronized (ref) {
-                    // Empty synchronized is ok: https://stackoverflow.com/a/31933260/1151521
-                }
+                // Ensure the tracked object remain live and strongly referenced, until close() has finished.
+                Reference.reachabilityFence(trackedObject);
             }
         }
 

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -315,8 +315,6 @@ public class DefaultPromise<V> implements Promise<V> {
     }
 
     /**
-     * {@inheritDoc}
-     *
      * @param mayInterruptIfRunning this value has no effect in this implementation.
      */
     @Override
@@ -467,14 +465,6 @@ public class DefaultPromise<V> implements Promise<V> {
         }
     }
 
-    private void removeListener0(GenericFutureListener<? extends Future<? super V>> listener) {
-        if (listeners instanceof DefaultFutureListeners) {
-            ((DefaultFutureListeners) listeners).remove(listener);
-        } else if (listeners == listener) {
-            listeners = null;
-        }
-    }
-
     private boolean setSuccess0(V result) {
         return setValue0(result == null ? SUCCESS : result);
     }
@@ -614,8 +604,6 @@ public class DefaultPromise<V> implements Promise<V> {
     private static final class StacklessCancellationException extends CancellationException {
 
         private static final long serialVersionUID = -2974906711413716191L;
-
-        private StacklessCancellationException() { }
 
         // Override fillInStackTrace() so we not populate the backtrace via a native call and so leak the
         // Classloader.


### PR DESCRIPTION
Motivation:
Code that isn't used, or has better alternatives in the JDK should be removed or replaced, respectively.

Modification:
Remove dead code in DefaultPromise.
Replace the synchronised-based reachability fence in ResourceLeakDetector, with the JDK Reference.reachabilityFence.

Result:
Cleaner code