### PR TITLE
Simplify Bitwise operations

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
@@ -38,7 +38,7 @@ public abstract class AbstractDnsOptPseudoRrRecord extends AbstractDnsRecord imp
     // See https://tools.ietf.org/html/rfc6891#section-6.1.3
     private static long packIntoLong(int val, int val2) {
         // We are currently not support DO and Z fields, just use 0.
-        return ((long) (val & 0xff) << 24 | (val2 & 0xff) << 16 | (0) << 8) & 0xFFFFFFFFL;
+        return ((long) (val & 0xff) << 24 | (val2 & 0xff) << 16) & 0xFFFFFFFFL;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
@@ -38,7 +38,7 @@ public abstract class AbstractDnsOptPseudoRrRecord extends AbstractDnsRecord imp
     // See https://tools.ietf.org/html/rfc6891#section-6.1.3
     private static long packIntoLong(int val, int val2) {
         // We are currently not support DO and Z fields, just use 0.
-        return ((val & 0xff) << 24 | (val2 & 0xff) << 16 | (0 & 0xff) <<  8 | 0 & 0xff) & 0xFFFFFFFFL;
+        return ((long) (val & 0xff) << 24 | (val2 & 0xff) << 16 | (0) << 8) & 0xFFFFFFFFL;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
@@ -38,7 +38,7 @@ public abstract class AbstractDnsOptPseudoRrRecord extends AbstractDnsRecord imp
     // See https://tools.ietf.org/html/rfc6891#section-6.1.3
     private static long packIntoLong(int val, int val2) {
         // We are currently not support DO and Z fields, just use 0.
-        return ((long) (val & 0xff) << 24 | (val2 & 0xff) << 16) & 0xFFFFFFFFL;
+        return ((val & 0xffL) << 24 | (val2 & 0xff) << 16) & 0xFFFFFFFFL;
     }
 
     @Override

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
@@ -97,7 +97,7 @@ public class DefaultDnsRecordEncoderTest {
             // Pad the leftover of the last byte with zeros.
             int idx = addressPart.writerIndex() - 1;
             byte lastByte = addressPart.getByte(idx);
-            int paddingMask = -(1 << (8 - lowOrderBitsToPreserve));
+            int paddingMask = -1 << (8 - lowOrderBitsToPreserve);
             addressPart.setByte(idx, lastByte & paddingMask);
         }
 

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
@@ -97,7 +97,7 @@ public class DefaultDnsRecordEncoderTest {
             // Pad the leftover of the last byte with zeros.
             int idx = addressPart.writerIndex() - 1;
             byte lastByte = addressPart.getByte(idx);
-            int paddingMask = -1 << (8 - lowOrderBitsToPreserve);
+            int paddingMask = -1 << 8 - lowOrderBitsToPreserve;
             addressPart.setByte(idx, lastByte & paddingMask);
         }
 

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
@@ -97,7 +97,7 @@ public class DefaultDnsRecordEncoderTest {
             // Pad the leftover of the last byte with zeros.
             int idx = addressPart.writerIndex() - 1;
             byte lastByte = addressPart.getByte(idx);
-            int paddingMask = ~((1 << (8 - lowOrderBitsToPreserve)) - 1);
+            int paddingMask = -(1 << (8 - lowOrderBitsToPreserve));
             addressPart.setByte(idx, lastByte & paddingMask);
         }
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -167,7 +167,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
              *
              * Also see https://github.com/netty/netty/issues/2767
              */
-            return (int) ((-1L << 32 - cidrPrefix));
+            return (int) (-1L << 32 - cidrPrefix);
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -167,7 +167,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
              *
              * Also see https://github.com/netty/netty/issues/2767
              */
-            return (int) ((-1L << 32 - cidrPrefix) & 0xffffffff);
+            return (int) ((-1L << 32 - cidrPrefix));
         }
     }
 


### PR DESCRIPTION
Motivation:
We should keep bitwise operations simple and easy to understand.

Modification:
Simplify few Bitwise operations.

Result:
Less complicated bitwise operation code
