### PR TITLE
Make variables final

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -42,8 +42,8 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
     };
 
     // Value might not equal "real" reference count, all access should be via the updater
-    @SuppressWarnings("unused")
-    private final int refCnt = updater.initialValue();
+    @SuppressWarnings({"unused", "FieldMayBeFinal"})
+    private volatile int refCnt = updater.initialValue();
 
     protected AbstractReferenceCountedByteBuf(int maxCapacity) {
         super(maxCapacity);

--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -43,7 +43,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
 
     // Value might not equal "real" reference count, all access should be via the updater
     @SuppressWarnings("unused")
-    private volatile int refCnt = updater.initialValue();
+    private final int refCnt = updater.initialValue();
 
     protected AbstractReferenceCountedByteBuf(int maxCapacity) {
         super(maxCapacity);

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -667,7 +667,7 @@ public class ByteBufUtilTest {
                 ByteBufUtil.utf8Bytes(usAscii, 5, 18));
     }
 
-    private static int[][] INVALID_RANGES = new int[][] {
+    private static final int[][] INVALID_RANGES = new int[][] {
         { -1, 5 }, { 5, 30 }, { 10, 5 }
     };
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -55,7 +55,7 @@ public class CorsHandler extends ChannelDuplexHandler {
 
     private HttpRequest request;
     private final List<CorsConfig> configList;
-    private boolean isShortCircuit;
+    private final boolean isShortCircuit;
 
     /**
      * Creates a new instance with a single {@link CorsConfig}.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -97,7 +97,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
     /**
      * If multipart, this is the boundary for the global multipart
      */
-    private String multipartDataBoundary;
+    private final String multipartDataBoundary;
 
     /**
      * If multipart, there could be internal multiparts (mixed) to the global

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedAttribute.java
@@ -27,8 +27,8 @@ import java.nio.charset.Charset;
  * Mixed implementation using both in Memory and in File with a limit of size
  */
 public class MixedAttribute implements Attribute {
-    private String baseDir;
-    private boolean deleteOnExit;
+    private final String baseDir;
+    private final boolean deleteOnExit;
     private Attribute attribute;
 
     private final long limitSize;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/AbstractWeightedFairQueueByteDistributorDependencyTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/AbstractWeightedFairQueueByteDistributorDependencyTest.java
@@ -24,7 +24,7 @@ import org.mockito.stubbing.Answer;
 abstract class AbstractWeightedFairQueueByteDistributorDependencyTest {
     Http2Connection connection;
     WeightedFairQueueByteDistributor distributor;
-    private IntObjectMap<TestStreamByteDistributorStreamState> stateMap =
+    private final IntObjectMap<TestStreamByteDistributorStreamState> stateMap =
             new IntObjectHashMap<TestStreamByteDistributorStreamState>();
 
     @Mock

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
@@ -242,6 +242,7 @@ final class HpackTestCase {
     }
 
     static class HeaderBlock {
+        @SuppressWarnings("FieldMayBeFinal")
         private int maxHeaderTableSize = -1;
         private byte[] encodedBytes;
         private List<String> encoded;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
@@ -242,7 +242,7 @@ final class HpackTestCase {
     }
 
     static class HeaderBlock {
-        private int maxHeaderTableSize = -1;
+        private final int maxHeaderTableSize = -1;
         private byte[] encodedBytes;
         private List<String> encoded;
         private List<HpackHeaderField> headers;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
@@ -242,7 +242,7 @@ final class HpackTestCase {
     }
 
     static class HeaderBlock {
-        private final int maxHeaderTableSize = -1;
+        private int maxHeaderTableSize = -1;
         private byte[] encodedBytes;
         private List<String> encoded;
         private List<HpackHeaderField> headers;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
@@ -75,7 +75,7 @@ public class Http2ControlFrameLimitEncoderTest {
 
     private int numWrites;
 
-    private Queue<ChannelPromise> goAwayPromises = new ArrayDeque<ChannelPromise>();
+    private final Queue<ChannelPromise> goAwayPromises = new ArrayDeque<ChannelPromise>();
 
     /**
      * Init fields and do mocking.

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -356,7 +356,7 @@ public final class MqttMessageBuilders {
         private Long maximumPacketSize;
         private int topicAliasMaximum;
         private String reasonString;
-        private MqttProperties.UserProperties userProperties = new MqttProperties.UserProperties();
+        private final MqttProperties.UserProperties userProperties = new MqttProperties.UserProperties();
         private Boolean wildcardSubscriptionAvailable;
         private Boolean subscriptionIdentifiersAvailable;
         private Boolean sharedSubscriptionAvailable;

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/FixedRedisMessagePool.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/FixedRedisMessagePool.java
@@ -56,7 +56,7 @@ public final class FixedRedisMessagePool implements RedisMessagePool {
         WRONGTYPE("WRONGTYPE Operation against a key holding the wrong kind of value"),
         NOT_AUTH("NOAUTH Authentication required.");
 
-        private String msg;
+        private final String msg;
 
         RedisErrorKey(String msg) {
             this.msg = msg;

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -404,7 +404,7 @@ public abstract class ZlibTest {
     }
 
     private static final class TestByteBufAllocator extends AbstractByteBufAllocator {
-        private ByteBufAllocator wrapped;
+        private final ByteBufAllocator wrapped;
         private int maxAllocation;
 
         TestByteBufAllocator(ByteBufAllocator wrapped) {

--- a/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
+++ b/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
@@ -42,7 +42,7 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
 
     // Value might not equal "real" reference count, all access should be via the updater
     @SuppressWarnings("unused")
-    private volatile int refCnt = updater.initialValue();
+    private final int refCnt = updater.initialValue();
 
     @Override
     public int refCnt() {

--- a/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
+++ b/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
@@ -41,8 +41,8 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
     };
 
     // Value might not equal "real" reference count, all access should be via the updater
-    @SuppressWarnings("unused")
-    private final int refCnt = updater.initialValue();
+    @SuppressWarnings({"unused", "FieldMayBeFinal"})
+    private volatile int refCnt = updater.initialValue();
 
     @Override
     public int refCnt() {

--- a/common/src/test/java/io/netty/util/AsciiStringMemoryTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringMemoryTest.java
@@ -36,7 +36,7 @@ public class AsciiStringMemoryTest {
     private int length = 100;
     private AsciiString aAsciiString;
     private AsciiString bAsciiString;
-    private Random r = new Random();
+    private final Random r = new Random();
 
     @BeforeEach
     public void setup() {

--- a/common/src/test/java/io/netty/util/ResourceLeakDetectorTest.java
+++ b/common/src/test/java/io/netty/util/ResourceLeakDetectorTest.java
@@ -37,7 +37,7 @@ public class ResourceLeakDetectorTest {
         final CyclicBarrier barrier = new CyclicBarrier(threads.length);
         for (int i = 0; i < threads.length; i++) {
             Thread t = new Thread(new Runnable() {
-                Queue<LeakAwareResource> resources = new ArrayDeque<LeakAwareResource>(100);
+                final Queue<LeakAwareResource> resources = new ArrayDeque<LeakAwareResource>(100);
 
                 @Override
                 public void run() {

--- a/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
@@ -147,7 +147,7 @@ public class FileRegionThrottleTest {
 
     private static final class ReadHandler extends ChannelInboundHandlerAdapter {
         private long bytesTransferred;
-        private CountDownLatch latch;
+        private final CountDownLatch latch;
 
         ReadHandler(CountDownLatch latch) {
             this.latch = latch;

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpRequestEncoderInsertBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpRequestEncoderInsertBenchmark.java
@@ -34,9 +34,9 @@ import static io.netty.handler.codec.http.HttpConstants.*;
 @Measurement(iterations = 20)
 public class HttpRequestEncoderInsertBenchmark extends AbstractMicrobenchmark {
 
-    private String uri = "http://localhost?eventType=CRITICAL&from=0&to=1497437160327&limit=10&offset=0";
-    private OldHttpRequestEncoder encoderOld = new OldHttpRequestEncoder();
-    private HttpRequestEncoder encoderNew = new HttpRequestEncoder();
+    private final String uri = "http://localhost?eventType=CRITICAL&from=0&to=1497437160327&limit=10&offset=0";
+    private final OldHttpRequestEncoder encoderOld = new OldHttpRequestEncoder();
+    private final HttpRequestEncoder encoderNew = new HttpRequestEncoder();
 
     @Benchmark
     public ByteBuf oldEncoder() throws Exception {

--- a/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
@@ -115,7 +115,7 @@ public class Http2FrameWriterDataBenchmark extends AbstractMicrobenchmark {
     private static final class OldDefaultHttp2FrameWriter implements Http2DataWriter {
         private static final ByteBuf ZERO_BUFFER =
                 unreleasableBuffer(directBuffer(MAX_UNSIGNED_BYTE).writeZero(MAX_UNSIGNED_BYTE)).asReadOnly();
-        private int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
+        private final int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
         @Override
         public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
                                        int padding, boolean endStream, ChannelPromise promise) {

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteAccumulatingHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteAccumulatingHandlerContext.java
@@ -25,7 +25,7 @@ import io.netty.util.internal.ObjectUtil;
 
 public abstract class EmbeddedChannelWriteAccumulatingHandlerContext extends EmbeddedChannelHandlerContext {
     private ByteBuf cumulation;
-    private ByteToMessageDecoder.Cumulator cumulator;
+    private final ByteToMessageDecoder.Cumulator cumulator;
 
     protected EmbeddedChannelWriteAccumulatingHandlerContext(ByteBufAllocator alloc, ChannelHandler handler,
                                                           ByteToMessageDecoder.Cumulator writeCumulator) {

--- a/microbench/src/main/java/io/netty/microbench/http2/NoPriorityByteDistributionBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoPriorityByteDistributionBenchmark.java
@@ -98,7 +98,7 @@ public class NoPriorityByteDistributionBenchmark extends AbstractMicrobenchmark 
         }
     }
 
-    private Http2StreamVisitor invocationVisitor = new Http2StreamVisitor() {
+    private final Http2StreamVisitor invocationVisitor = new Http2StreamVisitor() {
         @Override
         public boolean visit(Http2Stream stream) throws Http2Exception {
             // Restore the connection window.

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
@@ -64,7 +64,7 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
      */
     public static final class DelegateHarnessExecutor extends AbstractEventExecutor {
         private static EventLoop executor;
-        private InternalLogger logger = InternalLoggerFactory.getInstance(DelegateHarnessExecutor.class);
+        private final InternalLogger logger = InternalLoggerFactory.getInstance(DelegateHarnessExecutor.class);
 
         public DelegateHarnessExecutor(int maxThreads, String prefix) {
             logger.debug("Using DelegateHarnessExecutor executor {}", this);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -191,7 +191,7 @@ class TestDnsServer extends DnsServer {
         @Override
         public ProtocolDecoder getDecoder(IoSession session) {
             return new ProtocolDecoderAdapter() {
-                private DnsMessageDecoder decoder = new DnsMessageDecoder();
+                private final DnsMessageDecoder decoder = new DnsMessageDecoder();
 
                 @Override
                 public void decode(IoSession session, IoBuffer in, ProtocolDecoderOutput out) throws IOException {

--- a/transport/src/test/java/io/netty/channel/AdaptiveRecvByteBufAllocatorTest.java
+++ b/transport/src/test/java/io/netty/channel/AdaptiveRecvByteBufAllocatorTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 public class AdaptiveRecvByteBufAllocatorTest {
     @Mock
     private ChannelConfig config;
-    private ByteBufAllocator alloc = UnpooledByteBufAllocator.DEFAULT;
+    private final ByteBufAllocator alloc = UnpooledByteBufAllocator.DEFAULT;
     private RecvByteBufAllocator.ExtendedHandle handle;
 
     @BeforeEach

--- a/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
+++ b/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
@@ -22,7 +22,7 @@ public class CustomChannelId implements ChannelId {
 
     private static final long serialVersionUID = 1L;
 
-    private int id;
+    private final int id;
 
     CustomChannelId(int id) {
         this.id = id;


### PR DESCRIPTION
Motivation:
We should make variables `final` which are not reinstated again in code to match the code style and makes the code look better.

Modification:
Made couples of variables as `final`.

Result:
Variables marked as `final`.
