### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
@@ -60,7 +60,7 @@ public class HttpContentDecoderTest {
             -41, 81, 40, -49, 47, -54, 73, 1, 0, 58, 114, -85, -1, 12, 0, 0, 0
     };
     private static final String SAMPLE_STRING = "Hello, I am Meow!. A small kitten. :)" +
-            "I sleep all day, and meow all night.";;
+            "I sleep all day, and meow all night.";
     private static final byte[] SAMPLE_BZ_BYTES = new byte[]{27, 72, 0, 0, -60, -102, 91, -86, 103, 20,
             -28, -23, 54, -101, 11, -106, -16, -32, -95, -61, -37, 94, -16, 97, -40, -93, -56, 18, 21, 86,
             -110, 82, -41, 102, -89, 20, 11, 10, -68, -31, 96, -116, -55, -80, -31, -91, 96, -64, 83, 51,

--- a/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
@@ -138,5 +138,5 @@ public class ResolveAddressHandlerTest {
                 }
             };
         }
-    };
+    }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1675,5 +1675,5 @@ public class SslHandlerTest {
         public boolean isSharable() {
             return true;
         }
-    };
+    }
 }

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolMapDeadlockTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolMapDeadlockTest.java
@@ -260,5 +260,5 @@ public class FixedChannelPoolMapDeadlockTest {
         public void channelCreated(Channel ch) throws Exception {
             // noop
         }
-    };
+    }
 }


### PR DESCRIPTION
Motivation:
We should get rid of unnecessary semicolons because they don't do anything in code.

Modification:
Removed unnecessary semicolons.

Result:
Better code
