### PR TITLE
Remove unnecessary toString calls

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
@@ -286,14 +286,14 @@ public class HttpResponseEncoderTest {
 
         ByteBuf buffer = channel.readOutbound();
         StringBuilder responseText = new StringBuilder();
-        responseText.append(HttpVersion.HTTP_1_1.toString()).append(' ').append(status.toString()).append("\r\n");
+        responseText.append(HttpVersion.HTTP_1_1).append(' ').append(status.toString()).append("\r\n");
         if (!headerStripped && headerName != null) {
             responseText.append(headerName).append(": ");
 
             if (HttpHeaderNames.CONTENT_LENGTH.contentEquals(headerName)) {
                 responseText.append('0');
             } else {
-                responseText.append(HttpHeaderValues.CHUNKED.toString());
+                responseText.append(HttpHeaderValues.CHUNKED);
             }
             responseText.append("\r\n");
         }
@@ -383,8 +383,8 @@ public class HttpResponseEncoderTest {
         assertTrue(channel.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT));
 
         StringBuilder responseText = new StringBuilder();
-        responseText.append(HttpVersion.HTTP_1_1.toString()).append(' ')
-                .append(HttpResponseStatus.RESET_CONTENT.toString()).append("\r\n");
+        responseText.append(HttpVersion.HTTP_1_1).append(' ')
+                .append(HttpResponseStatus.RESET_CONTENT).append("\r\n");
         responseText.append(HttpHeaderNames.CONTENT_LENGTH).append(": 0\r\n");
         responseText.append("\r\n");
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -162,7 +162,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
                     return;
                 } else {
                     throw new EncoderException(
-                            HttpResponseStatus.CONTINUE.toString() + " must be a FullHttpResponse");
+                            HttpResponseStatus.CONTINUE + " must be a FullHttpResponse");
                 }
             }
         }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -182,15 +182,15 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
             case SUBSCRIBE:
             case UNSUBSCRIBE:
                 if (dupFlag) {
-                    throw new DecoderException("Illegal BIT 3 in fixed header of " + messageType.toString()
+                    throw new DecoderException("Illegal BIT 3 in fixed header of " + messageType
                             + " message, must be 0, found 1");
                 }
                 if (qosLevel != 1) {
-                    throw new DecoderException("Illegal QOS Level in fixed header of " + messageType.toString()
+                    throw new DecoderException("Illegal QOS Level in fixed header of " + messageType
                             + " message, must be 1, found " + qosLevel);
                 }
                 if (retain) {
-                    throw new DecoderException("Illegal BIT 0 in fixed header of " + messageType.toString()
+                    throw new DecoderException("Illegal BIT 0 in fixed header of " + messageType
                             + " message, must be 0, found 1");
                 }
                 break;
@@ -207,15 +207,15 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
             case SUBACK:
             case UNSUBACK:
                 if (dupFlag) {
-                    throw new DecoderException("Illegal BIT 3 in fixed header of " + messageType.toString()
+                    throw new DecoderException("Illegal BIT 3 in fixed header of " + messageType
                             + " message, must be 0, found 1");
                 }
                 if (qosLevel != 0) {
-                    throw new DecoderException("Illegal BIT 2 or 1 in fixed header of " + messageType.toString()
+                    throw new DecoderException("Illegal BIT 2 or 1 in fixed header of " + messageType
                             + " message, must be 0, found " + qosLevel);
                 }
                 if (retain) {
-                    throw new DecoderException("Illegal BIT 0 in fixed header of " + messageType.toString()
+                    throw new DecoderException("Illegal BIT 0 in fixed header of " + messageType
                             + " message, must be 0, found 1");
                 }
                 break;

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -342,9 +342,9 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
                 headers.add(name, value.toString());
             } else if (validateHeaders) {
                 if (StringUtil.isNullOrEmpty(name)) {
-                    throw new IllegalArgumentException("received an invalid header line '" + value.toString() + '\'');
+                    throw new IllegalArgumentException("received an invalid header line '" + value + '\'');
                 }
-                String line = name + ':' + value.toString();
+                String line = name + ':' + value;
                 throw new IllegalArgumentException("a header value or name contains a prohibited character ':'"
                                                    + ", " + line);
             }

--- a/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
@@ -47,8 +47,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class ResolveAddressHandlerTest {
 
-    private static final LocalAddress UNRESOLVED = new LocalAddress("unresolved-" + UUID.randomUUID().toString());
-    private static final LocalAddress RESOLVED = new LocalAddress("resolved-" + UUID.randomUUID().toString());
+    private static final LocalAddress UNRESOLVED = new LocalAddress("unresolved-" + UUID.randomUUID());
+    private static final LocalAddress RESOLVED = new LocalAddress("resolved-" + UUID.randomUUID());
     private static final Exception ERROR = new UnknownHostException();
 
     private static EventLoopGroup group;


### PR DESCRIPTION
Motivation:
We should get rid of the unnecessary `toString` calls because they're redundant in nature.

Modification:
Removed unnecessary `toString` calls.

Result:
Better code
