### PR TITLE
Make EpollSocketChannelConfigTest tollerant of fd reuse race

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -868,6 +868,12 @@
         <version>1.2.3</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>io.github.artsok</groupId>
+        <artifactId>rerunner-jupiter</artifactId>
+        <version>2.1.6</version>
+        <scope>test</scope>
+      </dependency>
 
       <!-- Test dependencies for jboss marshalling encoder/decoder -->
       <dependency>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -401,6 +401,11 @@
       <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.github.artsok</groupId>
+      <artifactId>rerunner-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.epoll;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -136,7 +137,10 @@ public class EpollSocketChannelConfigTest {
         assertTrue(ch.config().isTcpQuickAck());
     }
 
-    @Test
+    // For this test to pass, we are relying on the sockets file descriptor not being reused after the socket is closed.
+    // This is inherently racy, so we allow getSoLinger to throw ChannelException a few of times, but eventually we do
+    // want to see a ClosedChannelException for the test to pass.
+    @RepeatedIfExceptionsTest(repeats = 4, exceptions = ChannelException.class)
     public void testSetOptionWhenClosed() {
         ch.close().syncUninterruptibly();
         try {
@@ -147,7 +151,10 @@ public class EpollSocketChannelConfigTest {
         }
     }
 
-    @Test
+    // For this test to pass, we are relying on the sockets file descriptor not being reused after the socket is closed.
+    // This is inherently racy, so we allow getSoLinger to throw ChannelException a few of times, but eventually we do
+    // want to see a ClosedChannelException for the test to pass.
+    @RepeatedIfExceptionsTest(repeats = 4, exceptions = ChannelException.class)
     public void testGetOptionWhenClosed() {
         ch.close().syncUninterruptibly();
         try {


### PR DESCRIPTION
Motivation:
We cannot control when "the system" reuses file descriptors.
This makes any test that assert on the behaviour of closed file descriptors inherently racy.

Modification:
Allow the EpollSocketChannelConfigTest socketoption tests a few tries to get the correct assertion on the behaviour of closed socket file descriptors.

Result:
The EpollSocketChannelConfigTest should now be much less flaky.
