### PR TITLE
Disable flaky `Http2MultiplexTransportTest` test on Windows

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -457,6 +457,7 @@ public class Http2MultiplexTransportTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "See: https://github.com/netty/netty/issues/11542")
     @Timeout(value = 5000L, unit = MILLISECONDS)
     public void testFireChannelReadAfterHandshakeSuccess_JDK() throws Exception {
         assumeTrue(SslProvider.isAlpnSupported(SslProvider.JDK));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -51,6 +51,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.X509TrustManager;
@@ -462,6 +464,7 @@ public class Http2MultiplexTransportTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "See: https://github.com/netty/netty/issues/11542")
     @Timeout(value = 5000L, unit = MILLISECONDS)
     public void testFireChannelReadAfterHandshakeSuccess_OPENSSL() throws Exception {
         assumeTrue(OpenSsl.isAvailable());


### PR DESCRIPTION
Motivation:
Lately, `Http2MultiplexTransportTest.testFireChannelReadAfterHandshakeSuccess_OPENSSL` is failing a lot on Windows CI. We should disable until it's fixed.

Modification:
DIsabled `Http2MultiplexTransportTest.testFireChannelReadAfterHandshakeSuccess_OPENSSL` test on Windows

Result:
CI will pass tests on Windows

See #11542  
