### PR TITLE
Use the standard `japicmp.skip` instead of the custom `skipJapicmp`

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <generatedSourceDir>${project.build.directory}/src</generatedSourceDir>
     <dependencyVersionsDir>${project.build.directory}/versions</dependencyVersionsDir>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
   </properties>
 
   <dependencyManagement>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -30,7 +30,7 @@
   <name>Netty/Example</name>
 
   <properties>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -38,7 +38,7 @@
     <!-- This only be set when run on mac as on other platforms we just want to include the jar without native
          code -->
     <kqueue.classifier />
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
   </properties>
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -525,7 +525,6 @@
     <skipOsgiTestsuite>false</skipOsgiTestsuite>
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
-    <skipJapicmp>false</skipJapicmp>
     <graalvm.version>19.3.6</graalvm.version>
     <brotli4j.version>1.5.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
@@ -1035,7 +1034,6 @@
               <exclude>io.netty.handler.codec.dns.TcpDnsResponseEncoder</exclude>
             </excludes>
           </parameter>
-          <skip>${skipJapicmp}</skip>
         </configuration>
         <executions>
           <execution>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -29,7 +29,7 @@
   <name>Netty/Testsuite/Autobahn</name>
 
   <properties>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
   </properties>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -29,7 +29,7 @@
   <name>Netty/Testsuite/Http2</name>
 
   <properties>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
   </properties>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -29,7 +29,7 @@
   <name>Netty/Testsuite/NativeImage/ClientRuntimeInit</name>
 
   <properties>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
   </properties>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -29,7 +29,7 @@
   <name>Netty/Testsuite/NativeImage/Client</name>
 
   <properties>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
   </properties>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -29,7 +29,7 @@
   <name>Netty/Testsuite/NativeImage</name>
 
   <properties>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
   </properties>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -29,7 +29,7 @@
   <name>Netty/Testsuite/Native</name>
 
   <properties>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <skipNativeTestsuite>false</skipNativeTestsuite>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <exam.version>4.13.0</exam.version>
     <argLine.java9.extras>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED</argLine.java9.extras>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
   </properties>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -38,7 +38,7 @@
 
     <jarName>${project.artifactId}-${project.version}.jar</jarName>
     <shadedPackagePrefix>io.netty.</shadedPackagePrefix>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
   </properties>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -129,7 +129,7 @@
   <properties>
     <!-- Needed for SSL tests as these use the SelfSignedCertificate --> 
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
   </properties>
 
   <build>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -75,7 +75,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <!-- Needed for SelfSignedCertificate -->
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
-    <skipJapicmp>true</skipJapicmp>
+    <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
   </properties>


### PR DESCRIPTION
Motivation:
Fewer surprises when plugins respond to the settings they document.

Modification:
Change the `skipJapicmp` maven property to `japicmp.skip` to match the property that the `japicmp` plugin is already looking for by default.

Result:
More predictable use of the `japicmp` plugin from the command line, for instance.