### PR TITLE
Make the TCP_FASTOPEN channel option transport agnostic

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
@@ -32,7 +32,11 @@ public final class EpollChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> IP_FREEBIND = valueOf("IP_FREEBIND");
     public static final ChannelOption<Boolean> IP_TRANSPARENT = valueOf("IP_TRANSPARENT");
     public static final ChannelOption<Boolean> IP_RECVORIGDSTADDR = valueOf("IP_RECVORIGDSTADDR");
-    public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(EpollChannelOption.class, "TCP_FASTOPEN");
+    /**
+     * @deprecated Use {@link ChannelOption#TCP_FASTOPEN} instead.
+     */
+    @Deprecated
+    public static final ChannelOption<Integer> TCP_FASTOPEN = ChannelOption.TCP_FASTOPEN;
 
     /**
      * @deprecated Use {@link ChannelOption#TCP_FASTOPEN_CONNECT} instead.

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import static io.netty.channel.ChannelOption.SO_BACKLOG;
 import static io.netty.channel.ChannelOption.SO_RCVBUF;
 import static io.netty.channel.ChannelOption.SO_REUSEADDR;
+import static io.netty.channel.ChannelOption.TCP_FASTOPEN;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 public class EpollServerChannelConfig extends EpollChannelConfig implements ServerSocketChannelConfig {
@@ -42,7 +43,7 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), SO_RCVBUF, SO_REUSEADDR, SO_BACKLOG, EpollChannelOption.TCP_FASTOPEN);
+        return getOptions(super.getOptions(), SO_RCVBUF, SO_REUSEADDR, SO_BACKLOG, TCP_FASTOPEN);
     }
 
     @SuppressWarnings("unchecked")
@@ -57,7 +58,7 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
         if (option == SO_BACKLOG) {
             return (T) Integer.valueOf(getBacklog());
         }
-        if (option == EpollChannelOption.TCP_FASTOPEN) {
+        if (option == TCP_FASTOPEN) {
             return (T) Integer.valueOf(getTcpFastopen());
         }
         return super.getOption(option);
@@ -73,7 +74,7 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
             setReuseAddress((Boolean) value);
         } else if (option == SO_BACKLOG) {
             setBacklog((Integer) value);
-        } else if (option == EpollChannelOption.TCP_FASTOPEN) {
+        } else if (option == TCP_FASTOPEN) {
             setTcpFastopen((Integer) value);
         } else {
             return super.setOption(option, value);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketConnectTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketConnectTest.java
@@ -32,7 +32,7 @@ public class EpollSocketConnectTest extends SocketConnectTest {
 
     @Override
     protected void enableTcpFastOpen(ServerBootstrap sb, Bootstrap cb) {
-        sb.option(EpollChannelOption.TCP_FASTOPEN, 5);
+        sb.option(ChannelOption.TCP_FASTOPEN, 5);
         cb.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -85,7 +85,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                 public ServerBootstrap newInstance() {
                     ServerBootstrap serverBootstrap = new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
                                                                            .channel(EpollServerSocketChannel.class);
-                    serverBootstrap.option(EpollChannelOption.TCP_FASTOPEN, 5);
+                    serverBootstrap.option(ChannelOption.TCP_FASTOPEN, 5);
                     return serverBootstrap;
                 }
             });

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -131,6 +131,7 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
      * Client-side TCP FastOpen. Sending data with the initial TCP handshake.
      */
     public static final ChannelOption<Boolean> TCP_FASTOPEN_CONNECT = valueOf("TCP_FASTOPEN_CONNECT");
+
     /**
      * Server-side TCP FastOpen. Configures the maximum number of outstanding (waiting to be accepted) TFO connections.
      */

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -127,7 +127,14 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     public static final ChannelOption<Boolean> IP_MULTICAST_LOOP_DISABLED = valueOf("IP_MULTICAST_LOOP_DISABLED");
 
     public static final ChannelOption<Boolean> TCP_NODELAY = valueOf("TCP_NODELAY");
+    /**
+     * Client-side TCP FastOpen. Sending data with the initial TCP handshake.
+     */
     public static final ChannelOption<Boolean> TCP_FASTOPEN_CONNECT = valueOf("TCP_FASTOPEN_CONNECT");
+    /**
+     * Server-side TCP FastOpen. Configures the maximum number of outstanding (waiting to be accepted) TFO connections.
+     */
+    public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(ChannelOption.class, "TCP_FASTOPEN");
 
     @Deprecated
     public static final ChannelOption<Boolean> DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION =


### PR DESCRIPTION
Motivation:
TCP FastOpen is a pure optimisation, that is opportunistically applied.
There is no reason to make it specific to the epoll transport, and in the future we could add support to other transports.
Besides, the client-side equivalent, TCP_FASTOPEN_CONNECT, is already transport agnostic.

Modification:
Move the TCP_FASTOPEN channel option from EpollChannelOption to ChannelOption.
Mark the field in EpollChannelOption as deprecated.

Result:
All channel options related to TCP FastOpen are now transport agnostic.
However, we still only actually support TFO on the epoll transport.
