### PR TITLE
Add support for client-side TCP FastOpen to KQueue MacOS

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
@@ -28,11 +28,9 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
-import org.opentest4j.TestAbortedException;
 
 import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
@@ -189,8 +187,9 @@ public class SocketConnectTest extends AbstractSocketTest {
     }
 
     protected void enableTcpFastOpen(ServerBootstrap sb, Bootstrap cb) {
-        throw new TestAbortedException(
-                "Support for testing TCP_FASTOPEN not enabled for " + StringUtil.simpleClassName(this));
+        // TFO is an almost-pure optimisation and should not change any observable behaviour in our tests.
+        sb.option(ChannelOption.TCP_FASTOPEN, 5);
+        cb.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
     }
 
     private static void assertLocalAddress(InetSocketAddress address) {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketConnectTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketConnectTest.java
@@ -29,10 +29,4 @@ public class EpollSocketConnectTest extends SocketConnectTest {
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return EpollSocketTestPermutation.INSTANCE.socketWithoutFastOpen();
     }
-
-    @Override
-    protected void enableTcpFastOpen(ServerBootstrap sb, Bootstrap cb) {
-        sb.option(ChannelOption.TCP_FASTOPEN, 5);
-        cb.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
-    }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -68,7 +68,6 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         return list;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
         List<BootstrapFactory<ServerBootstrap>> toReturn = new ArrayList<BootstrapFactory<ServerBootstrap>>();
@@ -207,10 +206,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     }
 
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> domainSocket() {
-
-        List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> list =
-                combo(serverDomainSocket(), clientDomainSocket());
-        return list;
+        return combo(serverDomainSocket(), clientDomainSocket());
     }
 
     public List<BootstrapFactory<ServerBootstrap>> serverDomainSocket() {

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -111,14 +111,14 @@ static jint netty_kqueue_bsdsocket_connectx(JNIEnv* env,
         endpoints.sae_srcaddr = (const struct sockaddr*) &srcaddr;
         endpoints.sae_srcaddrlen = srcaddrlen;
     }
-    if (NULL != destinationAddress) {
-        if (-1 == netty_unix_socket_initSockaddr(env,
-                destinationIPv6, destinationAddress, destinationScopeId, destinationPort, &dstaddr, &dstaddrlen)) {
-            return -1;
-        }
-        endpoints.sae_dstaddr = (const struct sockaddr*) &dstaddr;
-        endpoints.sae_dstaddrlen = dstaddrlen;
+
+    assert destinationAddress != NULL; // Java side will ensure destination is never null.
+    if (-1 == netty_unix_socket_initSockaddr(env,
+            destinationIPv6, destinationAddress, destinationScopeId, destinationPort, &dstaddr, &dstaddrlen)) {
+        return -1;
     }
+    endpoints.sae_dstaddr = (const struct sockaddr*) &dstaddr;
+    endpoints.sae_dstaddrlen = dstaddrlen;
 
     int socket = (int) socketFd;
     const struct iovec* iov = (const struct iovec*) iovAddress;

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -238,22 +238,6 @@ static jobject netty_kqueue_bsdsocket_getPeerCredentials(JNIEnv *env, jclass cla
 
     return (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, pid, credentials.cr_uid, gids);
 }
-
-static jint netty_kqueue_bsdsocket_connectResumeOnReadWrite(JNIEnv *env) {
-#ifdef CONNECT_RESUME_ON_READ_WRITE
-    return CONNECT_RESUME_ON_READ_WRITE;
-#else
-    return 0;
-#endif
-}
-
-static jint netty_kqueue_bsdsocket_connectDataIdempotent(JNIEnv *env) {
-#ifdef CONNECT_DATA_IDEMPOTENT
-    return CONNECT_DATA_IDEMPOTENT;
-#else
-    return 0;
-#endif
-}
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
@@ -264,9 +248,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "getAcceptFilter", "(I)[Ljava/lang/String;", (void *) netty_kqueue_bsdsocket_getAcceptFilter },
   { "getTcpNoPush", "(I)I", (void *) netty_kqueue_bsdsocket_getTcpNoPush },
   { "getSndLowAt", "(I)I", (void *) netty_kqueue_bsdsocket_getSndLowAt },
-  { "connectx", "(IIZ[BIIZ[BIIIJII)I", (void *) netty_kqueue_bsdsocket_connectx },
-  { "connectResumeOnReadWrite", "()I", (void *) netty_kqueue_bsdsocket_connectResumeOnReadWrite },
-  { "connectDataIdempotent", "()I", (void *) netty_kqueue_bsdsocket_connectDataIdempotent }
+  { "connectx", "(IIZ[BIIZ[BIIIJII)I", (void *) netty_kqueue_bsdsocket_connectx }
 };
 
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -106,7 +106,9 @@ static jint netty_kqueue_bsdsocket_connectx(JNIEnv* env,
     if (NULL != sourceAddress) {
         if (-1 == netty_unix_socket_initSockaddr(env,
                 sourceIPv6, sourceAddress, sourceScopeId, sourcePort, &srcaddr, &srcaddrlen)) {
-            return -1;
+            netty_unix_errors_throwIOException(env,
+                "Source address specified, but could not be converted to sockaddr.");
+            return -EINVAL;
         }
         endpoints.sae_srcaddr = (const struct sockaddr*) &srcaddr;
         endpoints.sae_srcaddrlen = srcaddrlen;
@@ -115,7 +117,8 @@ static jint netty_kqueue_bsdsocket_connectx(JNIEnv* env,
     assert destinationAddress != NULL; // Java side will ensure destination is never null.
     if (-1 == netty_unix_socket_initSockaddr(env,
             destinationIPv6, destinationAddress, destinationScopeId, destinationPort, &dstaddr, &dstaddrlen)) {
-        return -1;
+        netty_unix_errors_throwIOException(env, "Destination address could not be converted to sockaddr.");
+        return -EINVAL;
     }
     endpoints.sae_dstaddr = (const struct sockaddr*) &dstaddr;
     endpoints.sae_dstaddrlen = dstaddrlen;

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+#include <assert.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
@@ -83,7 +84,7 @@ static jlong netty_kqueue_bsdsocket_sendFile(JNIEnv* env, jclass clazz, jint soc
     return res < 0 ? -err : 0;
 }
 
-static jint netty_kqueue_bsdsocket_connectx(JNIEnv* env,
+static jint netty_kqueue_bsdsocket_connectx(JNIEnv* env, jclass clazz,
         jint socketFd,
         jint socketInterface,
         jboolean sourceIPv6, jbyteArray sourceAddress, jint sourceScopeId, jint sourcePort,
@@ -114,7 +115,7 @@ static jint netty_kqueue_bsdsocket_connectx(JNIEnv* env,
         endpoints.sae_srcaddrlen = srcaddrlen;
     }
 
-    assert destinationAddress != NULL; // Java side will ensure destination is never null.
+    assert(destinationAddress != NULL); // Java side will ensure destination is never null.
     if (-1 == netty_unix_socket_initSockaddr(env,
             destinationIPv6, destinationAddress, destinationScopeId, destinationPort, &dstaddr, &dstaddrlen)) {
         netty_unix_errors_throwIOException(env, "Destination address could not be converted to sockaddr.");

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -60,6 +60,12 @@
 #ifndef NOTE_DISCONNECTED
 #define NOTE_DISCONNECTED 0x00001000
 #endif /* NOTE_DISCONNECTED */
+#ifndef CONNECT_RESUME_ON_READ_WRITE
+#define CONNECT_RESUME_ON_READ_WRITE 0x1
+#endif /* CONNECT_RESUME_ON_READ_WRITE */
+#ifndef CONNECT_DATA_IDEMPOTENT
+#define CONNECT_DATA_IDEMPOTENT 0x2
+#endif /* CONNECT_DATA_IDEMPOTENT */
 #else
 #ifndef EVFILT_SOCK
 #define EVFILT_SOCK 0 // Disabled
@@ -73,6 +79,12 @@
 #ifndef NOTE_DISCONNECTED
 #define NOTE_DISCONNECTED 0
 #endif /* NOTE_DISCONNECTED */
+#ifndef CONNECT_RESUME_ON_READ_WRITE
+#define CONNECT_RESUME_ON_READ_WRITE 0
+#endif /* CONNECT_RESUME_ON_READ_WRITE */
+#ifndef CONNECT_DATA_IDEMPOTENT
+#define CONNECT_DATA_IDEMPOTENT 0
+#endif /* CONNECT_DATA_IDEMPOTENT */
 #endif /* __APPLE__ */
 
 static clockid_t waitClockId = 0; // initialized by netty_unix_util_initialize_wait_clock
@@ -247,6 +259,14 @@ static jshort netty_kqueue_native_noteDisconnected(JNIEnv* env, jclass clazz) {
    return NOTE_DISCONNECTED;
 }
 
+static jint netty_kqueue_bsdsocket_connectResumeOnReadWrite(JNIEnv *env) {
+    return CONNECT_RESUME_ON_READ_WRITE;
+}
+
+static jint netty_kqueue_bsdsocket_connectDataIdempotent(JNIEnv *env) {
+    return CONNECT_DATA_IDEMPOTENT;
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "evfiltRead", "()S", (void *) netty_kqueue_native_evfiltRead },
@@ -262,7 +282,9 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "evError", "()S", (void *) netty_kqueue_native_evError },
   { "noteReadClosed", "()S", (void *) netty_kqueue_native_noteReadClosed },
   { "noteConnReset", "()S", (void *) netty_kqueue_native_noteConnReset },
-  { "noteDisconnected", "()S", (void *) netty_kqueue_native_noteDisconnected }
+  { "noteDisconnected", "()S", (void *) netty_kqueue_native_noteDisconnected },
+  { "connectResumeOnReadWrite", "()I", (void *) netty_kqueue_bsdsocket_connectResumeOnReadWrite },
+  { "connectDataIdempotent", "()I", (void *) netty_kqueue_bsdsocket_connectDataIdempotent }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 static const JNINativeMethod fixed_method_table[] = {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -390,7 +390,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         final void readReadyFinally(ChannelConfig config) {
             maybeMoreDataToRead = allocHandle.maybeMoreDataToRead();
 
-            if (allocHandle.isReadEOF() || (readPending && maybeMoreDataToRead)) {
+            if (allocHandle.isReadEOF() || readPending && maybeMoreDataToRead) {
                 // trigger a read again as there may be something left to read and because of ET we
                 // will not get notified again until we read everything from the socket
                 //
@@ -699,7 +699,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             socket.bind(localAddress);
         }
 
-        boolean connected = doConnect0(remoteAddress);
+        boolean connected = doConnect0(remoteAddress, localAddress);
         if (connected) {
             remote = remoteSocketAddr == null?
                     remoteAddress : computeRemoteAddr(remoteSocketAddr, socket.remoteAddress());
@@ -711,10 +711,10 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         return connected;
     }
 
-    private boolean doConnect0(SocketAddress remote) throws Exception {
+    protected boolean doConnect0(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
         boolean success = false;
         try {
-            boolean connected = socket.connect(remote);
+            boolean connected = socket.connect(remoteAddress);
             if (!connected) {
                 writeFilter(true);
             }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -138,7 +138,7 @@ final class BsdSocket extends Socket {
             destinationScopeId = 0;
             destinationAddress = ipv4MappedIpv6Address(destinationInetAddress.getAddress());
         }
-        int destinationPort = source.getPort();
+        int destinationPort = destination.getPort();
 
         long iovAddress;
         int iovCount;
@@ -162,7 +162,7 @@ final class BsdSocket extends Socket {
                 destinationIPv6, destinationAddress, destinationScopeId, destinationPort,
                 flags, iovAddress, iovCount, iovDataLength);
         if (result < 0) {
-            return ioResult("connectx", -result);
+            return ioResult("connectx", result);
         }
         return result;
     }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -26,6 +26,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import static io.netty.channel.kqueue.AcceptFilter.PLATFORM_UNSUPPORTED;
+import static io.netty.channel.kqueue.Native.CONNECT_TCP_FASTOPEN;
 import static io.netty.channel.unix.Errors.ioResult;
 import static io.netty.channel.unix.NativeInetAddress.ipv4MappedIpv6Address;
 
@@ -87,7 +88,7 @@ final class BsdSocket extends Socket {
 
     int connectx(InetSocketAddress source, InetSocketAddress destination, IovArray data, boolean tcpFastOpen)
             throws IOException {
-        int flags = tcpFastOpen ? connectResumeOnReadWrite() | connectDataIdempotent() : 0;
+        int flags = tcpFastOpen ? CONNECT_TCP_FASTOPEN : 0;
         return connectx(source, destination, data, flags);
     }
 
@@ -192,6 +193,4 @@ final class BsdSocket extends Socket {
     private static native void setAcceptFilter(int fd, String filterName, String filterArgs) throws IOException;
     private static native void setTcpNoPush(int fd, int tcpNoPush) throws IOException;
     private static native void setSndLowAt(int fd, int lowAt) throws IOException;
-    private static native int connectResumeOnReadWrite();
-    private static native int connectDataIdempotent();
 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -29,7 +29,7 @@ import static io.netty.channel.kqueue.AcceptFilter.PLATFORM_UNSUPPORTED;
 import static io.netty.channel.kqueue.Native.CONNECT_TCP_FASTOPEN;
 import static io.netty.channel.unix.Errors.ioResult;
 import static io.netty.channel.unix.NativeInetAddress.ipv4MappedIpv6Address;
-import static java.util.Objects.requireNonNull;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * A socket which provides access BSD native methods.
@@ -101,7 +101,7 @@ final class BsdSocket extends Socket {
 
     private int connectx(InetSocketAddress source, InetSocketAddress destination, IovArray data, int flags)
             throws IOException {
-        requireNonNull(destination, "Destination InetSocketAddress cannot be null.");
+        checkNotNull(destination, "Destination InetSocketAddress cannot be null.");
 
         boolean sourceIPv6;
         byte[] sourceAddress;

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -40,6 +40,12 @@ final class BsdSocket extends Socket {
     private static final int APPLE_SND_LOW_AT_MAX = 1 << 17;
     private static final int FREEBSD_SND_LOW_AT_MAX = 1 << 15;
     static final int BSD_SND_LOW_AT_MAX = Math.min(APPLE_SND_LOW_AT_MAX, FREEBSD_SND_LOW_AT_MAX);
+    /**
+     * The `endpoints` structure passed to `connectx(2)` has an optional "source interface" field,
+     * which is the index of the network interface to use.
+     * According to `if_nametoindex(3)`, the value 0 is used when no interface is specified.
+     */
+    private static final int UNSPECIFIED_SOURCE_INTERFACE = 0;
 
     BsdSocket(int fd) {
         super(fd);
@@ -94,8 +100,6 @@ final class BsdSocket extends Socket {
 
     private int connectx(InetSocketAddress source, InetSocketAddress destination, IovArray data, int flags)
             throws IOException {
-        int sourceInterface = 0;
-
         InetAddress sourceInetAddress = source.getAddress();
         boolean sourceIPv6 = sourceInetAddress instanceof Inet6Address;
         byte[] sourceAddress;
@@ -142,7 +146,7 @@ final class BsdSocket extends Socket {
         }
 
         int result = connectx(intValue(),
-                sourceInterface, sourceIPv6, sourceAddress, sourceScopeId, sourcePort,
+                UNSPECIFIED_SOURCE_INTERFACE, sourceIPv6, sourceAddress, sourceScopeId, sourcePort,
                 destinationIPv6, destinationAddress, destinationScopeId, destinationPort,
                 flags, iovAddress, iovCount, iovDataLength);
         if (result < 0) {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -91,7 +91,8 @@ final class BsdSocket extends Socket {
         return connectx(source, destination, data, flags);
     }
 
-    int connectx(InetSocketAddress source, InetSocketAddress destination, IovArray data, int flags) throws IOException {
+    private int connectx(InetSocketAddress source, InetSocketAddress destination, IovArray data, int flags)
+            throws IOException {
         int sourceInterface = 0;
 
         InetAddress sourceInetAddress = source.getAddress();

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
@@ -42,6 +42,7 @@ import static io.netty.channel.kqueue.KQueueChannelOption.TCP_NOPUSH;
 @UnstableApi
 public final class KQueueSocketChannelConfig extends KQueueChannelConfig implements SocketChannelConfig {
     private volatile boolean allowHalfClosure;
+    private volatile boolean tcpFastopen;
 
     KQueueSocketChannelConfig(KQueueSocketChannel channel) {
         super(channel);
@@ -92,6 +93,9 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
         if (option == TCP_NOPUSH) {
             return (T) Boolean.valueOf(isTcpNoPush());
         }
+        if (option == ChannelOption.TCP_FASTOPEN_CONNECT) {
+            return (T) Boolean.valueOf(isTcpFastOpenConnect());
+        }
         return super.getOption(option);
     }
 
@@ -119,6 +123,8 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
             setSndLowAt((Integer) value);
         } else if (option == TCP_NOPUSH) {
             setTcpNoPush((Boolean) value);
+        } else if (option == ChannelOption.TCP_FASTOPEN_CONNECT) {
+            setTcpFastOpenConnect((Boolean) value);
         } else {
             return super.setOption(option, value);
         }
@@ -295,6 +301,21 @@ public final class KQueueSocketChannelConfig extends KQueueChannelConfig impleme
     @Override
     public boolean isAllowHalfClosure() {
         return allowHalfClosure;
+    }
+
+    /**
+     * Enables client TCP fast open, if available.
+     */
+    public KQueueSocketChannelConfig setTcpFastOpenConnect(boolean fastOpenConnect) {
+        tcpFastopen = fastOpenConnect;
+        return this;
+    }
+
+    /**
+     * Returns {@code true} if TCP fast open is enabled, {@code false} otherwise.
+     */
+    public boolean isTcpFastOpenConnect() {
+        return tcpFastopen;
     }
 
     @Override

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueStaticallyReferencedJniMethods.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueStaticallyReferencedJniMethods.java
@@ -46,4 +46,8 @@ final class KQueueStaticallyReferencedJniMethods {
     static native short evfiltWrite();
     static native short evfiltUser();
     static native short evfiltSock();
+
+    // Flags for connectx(2)
+    static native int connectResumeOnReadWrite();
+    static native int connectDataIdempotent();
 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -29,6 +29,8 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 
+import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.connectDataIdempotent;
+import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.connectResumeOnReadWrite;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evAdd;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evClear;
 import static io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods.evDelete;
@@ -103,6 +105,11 @@ final class Native {
     static final short EVFILT_WRITE = evfiltWrite();
     static final short EVFILT_USER = evfiltUser();
     static final short EVFILT_SOCK = evfiltSock();
+
+    // Flags for connectx(2)
+    static final int CONNECT_RESUME_ON_READ_WRITE = connectResumeOnReadWrite();
+    static final int CONNECT_DATA_IDEMPOTENT = connectDataIdempotent();
+    static final int CONNECT_TCP_FASTOPEN = CONNECT_RESUME_ON_READ_WRITE | CONNECT_DATA_IDEMPOTENT;
 
     static FileDescriptor newKQueue() {
         return new FileDescriptor(kqueueCreate());

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -107,8 +107,8 @@ final class Native {
     static final short EVFILT_SOCK = evfiltSock();
 
     // Flags for connectx(2)
-    static final int CONNECT_RESUME_ON_READ_WRITE = connectResumeOnReadWrite();
-    static final int CONNECT_DATA_IDEMPOTENT = connectDataIdempotent();
+    private static final int CONNECT_RESUME_ON_READ_WRITE = connectResumeOnReadWrite();
+    private static final int CONNECT_DATA_IDEMPOTENT = connectDataIdempotent();
     static final int CONNECT_TCP_FASTOPEN = CONNECT_RESUME_ON_READ_WRITE | CONNECT_DATA_IDEMPOTENT;
 
     static FileDescriptor newKQueue() {

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelNotYetConnectedTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelNotYetConnectedTest.java
@@ -24,6 +24,6 @@ import java.util.List;
 public class KQueueSocketChannelNotYetConnectedTest extends SocketChannelNotYetConnectedTest {
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return KQueueSocketTestPermutation.INSTANCE.clientSocket();
+        return KQueueSocketTestPermutation.INSTANCE.clientSocketWithFastOpen();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -19,6 +19,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
@@ -30,8 +31,6 @@ import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.TestsuitePermutation.BootstrapFactory;
 import io.netty.testsuite.transport.socket.SocketTestPermutation;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,8 +46,6 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     static final EventLoopGroup KQUEUE_WORKER_GROUP =
             new KQueueEventLoopGroup(WORKERS, new DefaultThreadFactory("testsuite-KQueue-worker", true));
 
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(KQueueSocketTestPermutation.class);
-
     @Override
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
 
@@ -60,7 +57,6 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
         return list;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
         List<BootstrapFactory<ServerBootstrap>> toReturn = new ArrayList<BootstrapFactory<ServerBootstrap>>();
@@ -83,30 +79,47 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
         return toReturn;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public List<BootstrapFactory<Bootstrap>> clientSocket() {
-        return Arrays.asList(
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class);
-                    }
-                },
-                new BootstrapFactory<Bootstrap>() {
-                    @Override
-                    public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
-                    }
-                }
-        );
+        List<BootstrapFactory<Bootstrap>> toReturn = new ArrayList<BootstrapFactory<Bootstrap>>();
+
+        toReturn.add(new BootstrapFactory<Bootstrap>() {
+            @Override
+            public Bootstrap newInstance() {
+                return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class);
+            }
+        });
+
+        toReturn.add(new BootstrapFactory<Bootstrap>() {
+            @Override
+            public Bootstrap newInstance() {
+                return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
+            }
+        });
+
+        return toReturn;
+    }
+
+    @Override
+    public List<BootstrapFactory<Bootstrap>> clientSocketWithFastOpen() {
+        List<BootstrapFactory<Bootstrap>> factories = clientSocket();
+
+        int insertIndex = factories.size() - 1; // Keep NIO fixture last.
+        factories.add(insertIndex, new BootstrapFactory<Bootstrap>() {
+            @Override
+            public Bootstrap newInstance() {
+                return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class)
+                        .option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
+            }
+        });
+
+        return factories;
     }
 
     @Override
     public List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> datagram(
             final InternetProtocolFamily family) {
         // Make the list of Bootstrap factories.
-        @SuppressWarnings("unchecked")
         List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override
@@ -135,10 +148,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     }
 
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> domainSocket() {
-
-        List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> list =
-                combo(serverDomainSocket(), clientDomainSocket());
-        return list;
+        return combo(serverDomainSocket(), clientDomainSocket());
     }
 
     public List<BootstrapFactory<ServerBootstrap>> serverDomainSocket() {

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueWriteBeforeRegisteredTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueWriteBeforeRegisteredTest.java
@@ -25,6 +25,6 @@ public class KqueueWriteBeforeRegisteredTest extends WriteBeforeRegisteredTest {
 
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
-        return KQueueSocketTestPermutation.INSTANCE.clientSocket();
+        return KQueueSocketTestPermutation.INSTANCE.clientSocketWithFastOpen();
     }
 }

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -52,7 +52,7 @@ public class Socket extends FileDescriptor {
 
     public Socket(int fd) {
         super(fd);
-        this.ipv6 = isIPv6(fd);
+        ipv6 = isIPv6(fd);
     }
 
     /**
@@ -72,7 +72,7 @@ public class Socket extends FileDescriptor {
             // shutdown anything. This is because if the underlying FD is reused and we still have an object which
             // represents the previous incarnation of the FD we need to be sure we don't inadvertently shutdown the
             // "new" FD without explicitly having a change.
-            final int oldState = this.state;
+            final int oldState = state;
             if (isClosed(oldState)) {
                 throw new ClosedChannelException();
             }


### PR DESCRIPTION
Motivation:
The MacOS-specific `connectx(2)` system call make it possible to establish client-side connections with TCP FastOpen.

Modification:
Add support for TCP FastOpen to the KQueue transport, and add the `connectx(2)` system call to `BsdSocket`.

Result:
It's now possible to use TCP FastOpen when initiating connections on MacOS.