### PR TITLE
Remove io.netty.http2.validateContentLength SystemProperty

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -20,7 +20,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
-import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -52,8 +51,6 @@ import static java.lang.Math.min;
  */
 @UnstableApi
 public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
-    private static final boolean VALIDATE_CONTENT_LENGTH =
-            SystemPropertyUtil.getBoolean("io.netty.http2.validateContentLength", true);
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultHttp2ConnectionDecoder.class);
     private Http2FrameListener internalFrameListener = new PrefaceFrameListener();
     private final Http2Connection connection;
@@ -232,9 +229,6 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
     // See https://tools.ietf.org/html/rfc7540#section-8.1.2.6
     private void verifyContentLength(Http2Stream stream, int data, boolean isEnd) throws Http2Exception {
-        if (!VALIDATE_CONTENT_LENGTH) {
-            return;
-        }
         ContentLength contentLength = stream.getProperty(contentLengthKey);
         if (contentLength != null) {
             try {


### PR DESCRIPTION
Motivation:
io.netty.http2.validateContentLength SystemProperty was added as a way
to opt-out for compabitility for libraries/applications that violated
the RFC's content-length matching requirements [1] but have not yet been
fixed. This SystemProperty has been around for a few months now and it
is assumed these issues have now been addressed in 3rd party code.

[1] https://tools.ietf.org/html/rfc7540#section-8.1.2.6

Modifications:
- Remove the io.netty.http2.validateContentLength SystemProperty,
  preventing folks from opting out of RFC's required content-length
  matching.

Result:
No more escape hatch in H2 for content-length matching enforcement.