### PR TITLE
Fix typo in AbstractSearchProcessorFactory.java

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/search/AbstractSearchProcessorFactory.java
+++ b/buffer/src/main/java/io/netty/buffer/search/AbstractSearchProcessorFactory.java
@@ -39,7 +39,7 @@ package io.netty.buffer.search;
  * {@link io.netty.buffer.ByteBuf}s). A new instance should be created with {@link AbstractSearchProcessorFactory} for
  * every search session. However, a {@link SearchProcessor} can (and should) be reused within the search session,
  * eg. when searching for all occurrences of the {@code needle} within the same {@code haystack}. That way, it can
- * also detect overlapping occurrences of the {@code needle} (eg. a string "ABABAB" contains two occurences of "BAB"
+ * also detect overlapping occurrences of the {@code needle} (eg. a string "ABABAB" contains two occurrences of "BAB"
  * that overlap by one character "B"). For this to work correctly, after an occurrence of the {@code needle} is
  * found ending at index {@code idx}, the search should continue starting from the index {@code idx + 1}.
  * <br>


### PR DESCRIPTION


Motivation:

Fixed typo.
```
occurences -> occurrences
```