### PR TITLE
Inline variables to make code more readable

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -1278,8 +1278,7 @@ public class Http2ConnectionRoundtripTest {
             public Integer answer(InvocationOnMock invocation) throws Throwable {
                 ByteBuf buf = (ByteBuf) invocation.getArguments()[2];
                 int padding = (Integer) invocation.getArguments()[3];
-                int processedBytes = buf.readableBytes() + padding;
-                return processedBytes;
+                return buf.readableBytes() + padding;
             }
 
         }).when(listener).onDataRead(any(ChannelHandlerContext.class), anyInt(),

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorDependencyTreeTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorDependencyTreeTest.java
@@ -301,17 +301,16 @@ public class WeightedFairQueueByteDistributorDependencyTreeTest extends
         // Stream 3 (hasn't been opened) should result in stream 5 being dropped.
         // dropping stream 5 will distribute its weight to children (only 9)
         setPriority(3, 9, weight3, false);
-        short newWeight9 = weight5;
-        verifyLowestPrecedenceStateShouldBeDropped3(weight3, weight7, newWeight9);
+        verifyLowestPrecedenceStateShouldBeDropped3(weight3, weight7, weight5);
 
         // Stream 5's state has been discarded so we should be able to re-insert this state.
         setPriority(5, 0, weight5, false);
-        verifyLowestPrecedenceStateShouldBeDropped4(weight5, weight7, newWeight9);
+        verifyLowestPrecedenceStateShouldBeDropped4(weight5, weight7, weight5);
 
         // All streams are at the same level, so stream ID should be used to drop the numeric lowest valued stream.
         short weight11 = (short) (weight9 - 1);
         setPriority(11, 0, weight11, false);
-        verifyLowestPrecedenceStateShouldBeDropped5(weight7, newWeight9, weight11);
+        verifyLowestPrecedenceStateShouldBeDropped5(weight7, weight5, weight11);
     }
 
     private void verifyLowestPrecedenceStateShouldBeDropped1(short weight3, short weight5, short weight7) {

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanStageEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanStageEncoder.java
@@ -341,7 +341,6 @@ final class Bzip2HuffmanStageEncoder {
         final Bzip2BitWriter writer = this.writer;
         final int[][] huffmanMergedCodeSymbols = this.huffmanMergedCodeSymbols;
         final byte[] selectors = this.selectors;
-        final char[] mtf = mtfBlock;
         final int mtfLength = this.mtfLength;
 
         int selectorIndex = 0;
@@ -350,7 +349,7 @@ final class Bzip2HuffmanStageEncoder {
             final int[] tableMergedCodeSymbols = huffmanMergedCodeSymbols[selectors[selectorIndex++]];
 
             while (mtfIndex <= groupEnd) {
-                final int mergedCodeSymbol = tableMergedCodeSymbols[mtf[mtfIndex++]];
+                final int mergedCodeSymbol = tableMergedCodeSymbols[mtfBlock[mtfIndex++]];
                 writer.writeBits(out, mergedCodeSymbol >>> 24, mergedCodeSymbol);
             }
         }

--- a/common/src/main/java/io/netty/util/ResourceLeakException.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakException.java
@@ -49,9 +49,8 @@ public class ResourceLeakException extends RuntimeException {
 
     @Override
     public int hashCode() {
-        StackTraceElement[] trace  = cachedStackTrace;
         int hashCode = 0;
-        for (StackTraceElement e: trace) {
+        for (StackTraceElement e: cachedStackTrace) {
             hashCode = hashCode * 31 + e.hashCode();
         }
         return hashCode;

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -243,8 +243,7 @@ public final class StringUtil {
         assert HEX2B.length == (Character.MAX_VALUE + 1);
         // Character.digit() is not used here, as it addresses a larger
         // set of characters (both ASCII and full-width latin letters).
-        final int index = c;
-        return HEX2B[index];
+        return HEX2B[c];
     }
 
     /**

--- a/common/src/test/java/io/netty/util/internal/StringUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/StringUtilTest.java
@@ -175,15 +175,13 @@ public class StringUtilTest {
     @Test
     public void escapeCsvEmpty() {
         CharSequence value = "";
-        CharSequence expected = value;
-        escapeCsv(value, expected);
+        escapeCsv(value, value);
     }
 
     @Test
     public void escapeCsvUnquoted() {
         CharSequence value = "something";
-        CharSequence expected = value;
-        escapeCsv(value, expected);
+        escapeCsv(value, value);
     }
 
     @Test
@@ -259,8 +257,7 @@ public class StringUtilTest {
     @Test
     public void escapeCsvQuoted() {
         CharSequence value = "\"foo,goo\"";
-        CharSequence expected = value;
-        escapeCsv(value, expected);
+        escapeCsv(value, value);
     }
 
     @Test

--- a/microbench/src/main/java/io/netty/handler/codec/http/DecodeHexBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/DecodeHexBenchmark.java
@@ -165,14 +165,13 @@ public class DecodeHexBenchmark extends AbstractMicrobenchmark {
     }
 
     private static int decodeHexNibbleWithCheck(final char c) {
-        final int index = c;
-        if (index >= HEX2B.length) {
+        if ((int) c >= HEX2B.length) {
             return -1;
         }
         if (PlatformDependent.hasUnsafe()) {
-            return PlatformDependent.getByte(HEX2B, index);
+            return PlatformDependent.getByte(HEX2B, c);
         }
-        return HEX2B[index];
+        return HEX2B[c];
     }
 
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -207,10 +207,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     }
 
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> domainSocket() {
-
-        List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> list =
-                combo(serverDomainSocket(), clientDomainSocket());
-        return list;
+        return combo(serverDomainSocket(), clientDomainSocket());
     }
 
     public List<BootstrapFactory<ServerBootstrap>> serverDomainSocket() {

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -135,7 +135,6 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     }
 
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> domainSocket() {
-
         return combo(serverDomainSocket(), clientDomainSocket());
     }
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -136,9 +136,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
 
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> domainSocket() {
 
-        List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> list =
-                combo(serverDomainSocket(), clientDomainSocket());
-        return list;
+        return combo(serverDomainSocket(), clientDomainSocket());
     }
 
     public List<BootstrapFactory<ServerBootstrap>> serverDomainSocket() {


### PR DESCRIPTION
Motivation:
There are lots of redundant variable declarations which should be inlined to make good look better.

Modification:
Made variables inlined.

Result:
Less redundant variable and more readable code.