### PR TITLE
SimpleChannelPool::notifyConnect should tryFailure when an exception occurs

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -242,39 +242,44 @@ public class FixedChannelPool extends SimpleChannelPool {
     }
 
     private void acquire0(final Promise<Channel> promise) {
-        assert executor.inEventLoop();
+        try {
+            assert executor.inEventLoop();
 
-        if (closed) {
-            promise.setFailure(new IllegalStateException("FixedChannelPool was closed"));
-            return;
-        }
-        if (acquiredChannelCount.get() < maxConnections) {
-            assert acquiredChannelCount.get() >= 0;
-
-            // We need to create a new promise as we need to ensure the AcquireListener runs in the correct
-            // EventLoop
-            Promise<Channel> p = executor.newPromise();
-            AcquireListener l = new AcquireListener(promise);
-            l.acquired();
-            p.addListener(l);
-            super.acquire(p);
-        } else {
-            if (pendingAcquireCount >= maxPendingAcquires) {
-                tooManyOutstanding(promise);
-            } else {
-                AcquireTask task = new AcquireTask(promise);
-                if (pendingAcquireQueue.offer(task)) {
-                    ++pendingAcquireCount;
-
-                    if (timeoutTask != null) {
-                        task.timeoutFuture = executor.schedule(timeoutTask, acquireTimeoutNanos, TimeUnit.NANOSECONDS);
-                    }
-                } else {
-                    tooManyOutstanding(promise);
-                }
+            if (closed) {
+                promise.setFailure(new IllegalStateException("FixedChannelPool was closed"));
+                return;
             }
+            if (acquiredChannelCount.get() < maxConnections) {
+                assert acquiredChannelCount.get() >= 0;
 
-            assert pendingAcquireCount > 0;
+                // We need to create a new promise as we need to ensure the AcquireListener runs in the correct
+                // EventLoop
+                Promise<Channel> p = executor.newPromise();
+                AcquireListener l = new AcquireListener(promise);
+                l.acquired();
+                p.addListener(l);
+                super.acquire(p);
+            } else {
+                if (pendingAcquireCount >= maxPendingAcquires) {
+                    tooManyOutstanding(promise);
+                } else {
+                    AcquireTask task = new AcquireTask(promise);
+                    if (pendingAcquireQueue.offer(task)) {
+                        ++pendingAcquireCount;
+
+                        if (timeoutTask != null) {
+                            task.timeoutFuture = executor.schedule(timeoutTask, acquireTimeoutNanos,
+                                  TimeUnit.NANOSECONDS);
+                        }
+                    } else {
+                        tooManyOutstanding(promise);
+                    }
+                }
+
+                assert pendingAcquireCount > 0;
+            }
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
         }
     }
 
@@ -289,26 +294,30 @@ public class FixedChannelPool extends SimpleChannelPool {
         super.release(channel, p.addListener(new FutureListener<Void>() {
 
             @Override
-            public void operationComplete(Future<Void> future) throws Exception {
-                assert executor.inEventLoop();
+            public void operationComplete(Future<Void> future) {
+                try {
+                    assert executor.inEventLoop();
 
-                if (closed) {
-                    // Since the pool is closed, we have no choice but to close the channel
-                    channel.close();
-                    promise.setFailure(new IllegalStateException("FixedChannelPool was closed"));
-                    return;
-                }
-
-                if (future.isSuccess()) {
-                    decrementAndRunTaskQueue();
-                    promise.setSuccess(null);
-                } else {
-                    Throwable cause = future.cause();
-                    // Check if the exception was not because of we passed the Channel to the wrong pool.
-                    if (!(cause instanceof IllegalArgumentException)) {
-                        decrementAndRunTaskQueue();
+                    if (closed) {
+                        // Since the pool is closed, we have no choice but to close the channel
+                        channel.close();
+                        promise.setFailure(new IllegalStateException("FixedChannelPool was closed"));
+                        return;
                     }
-                    promise.setFailure(future.cause());
+
+                    if (future.isSuccess()) {
+                        decrementAndRunTaskQueue();
+                        promise.setSuccess(null);
+                    } else {
+                        Throwable cause = future.cause();
+                        // Check if the exception was not because of we passed the Channel to the wrong pool.
+                        if (!(cause instanceof IllegalArgumentException)) {
+                            decrementAndRunTaskQueue();
+                        }
+                        promise.setFailure(future.cause());
+                    }
+                } catch (Throwable cause) {
+                    promise.tryFailure(cause);
                 }
             }
         }));
@@ -399,27 +408,31 @@ public class FixedChannelPool extends SimpleChannelPool {
 
         @Override
         public void operationComplete(Future<Channel> future) throws Exception {
-            assert executor.inEventLoop();
+            try {
+                assert executor.inEventLoop();
 
-            if (closed) {
+                if (closed) {
+                    if (future.isSuccess()) {
+                        // Since the pool is closed, we have no choice but to close the channel
+                        future.getNow().close();
+                    }
+                    originalPromise.setFailure(new IllegalStateException("FixedChannelPool was closed"));
+                    return;
+                }
+
                 if (future.isSuccess()) {
-                    // Since the pool is closed, we have no choice but to close the channel
-                    future.getNow().close();
-                }
-                originalPromise.setFailure(new IllegalStateException("FixedChannelPool was closed"));
-                return;
-            }
-
-            if (future.isSuccess()) {
-                originalPromise.setSuccess(future.getNow());
-            } else {
-                if (acquired) {
-                    decrementAndRunTaskQueue();
+                    originalPromise.setSuccess(future.getNow());
                 } else {
-                    runTaskQueue();
-                }
+                    if (acquired) {
+                        decrementAndRunTaskQueue();
+                    } else {
+                        runTaskQueue();
+                    }
 
-                originalPromise.setFailure(future.cause());
+                    originalPromise.setFailure(future.cause());
+                }
+            } catch (Throwable cause) {
+                originalPromise.tryFailure(cause);
             }
         }
 

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -255,7 +255,7 @@ public class FixedChannelPool extends SimpleChannelPool {
                 // We need to create a new promise as we need to ensure the AcquireListener runs in the correct
                 // EventLoop
                 Promise<Channel> p = executor.newPromise();
-                AcquireListener l = createAcquireListener(promise);
+                AcquireListener l = new AcquireListener(promise);
                 l.acquired();
                 p.addListener(l);
                 super.acquire(p);
@@ -281,10 +281,6 @@ public class FixedChannelPool extends SimpleChannelPool {
         } catch (Throwable cause) {
             promise.tryFailure(cause);
         }
-    }
-
-    protected AcquireListener createAcquireListener(Promise<Channel> promise) {
-        return new AcquireListener(promise);
     }
 
     private void tooManyOutstanding(Promise<?> promise) {
@@ -402,7 +398,7 @@ public class FixedChannelPool extends SimpleChannelPool {
         public abstract void onTimeout(AcquireTask task);
     }
 
-    protected class AcquireListener implements FutureListener<Channel> {
+    private class AcquireListener implements FutureListener<Channel> {
         private final Promise<Channel> originalPromise;
         protected boolean acquired;
 

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -255,7 +255,7 @@ public class FixedChannelPool extends SimpleChannelPool {
                 // We need to create a new promise as we need to ensure the AcquireListener runs in the correct
                 // EventLoop
                 Promise<Channel> p = executor.newPromise();
-                AcquireListener l = new AcquireListener(promise);
+                AcquireListener l = createAcquireListener(promise);
                 l.acquired();
                 p.addListener(l);
                 super.acquire(p);
@@ -281,6 +281,10 @@ public class FixedChannelPool extends SimpleChannelPool {
         } catch (Throwable cause) {
             promise.tryFailure(cause);
         }
+    }
+
+    protected AcquireListener createAcquireListener(Promise<Channel> promise) {
+        return new AcquireListener(promise);
     }
 
     private void tooManyOutstanding(Promise<?> promise) {
@@ -398,7 +402,7 @@ public class FixedChannelPool extends SimpleChannelPool {
         public abstract void onTimeout(AcquireTask task);
     }
 
-    private class AcquireListener implements FutureListener<Channel> {
+    protected class AcquireListener implements FutureListener<Channel> {
         private final Promise<Channel> originalPromise;
         protected boolean acquired;
 

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -236,7 +236,7 @@ public class FixedChannelPool extends SimpleChannelPool {
                 });
             }
         } catch (Throwable cause) {
-            promise.setFailure(cause);
+            promise.tryFailure(cause);
         }
         return promise;
     }
@@ -279,7 +279,7 @@ public class FixedChannelPool extends SimpleChannelPool {
                 assert pendingAcquireCount > 0;
             }
         } catch (Throwable cause) {
-            promise.setFailure(cause);
+            promise.tryFailure(cause);
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -26,19 +26,13 @@ import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
-import io.netty.util.concurrent.Promise;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.Queue;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
SimpleChannelPool::notifyConnect should tryFailure when an exception occurs

Motivation:

During the channelAcquired handler invocation if an exception occurred the application will hang

Modifications:

Call tryFailure of the promise if an exception occurred

Result:

After your change, the promise will fail and the system won't hang.