### PR TITLE
Add some docs for io.netty.leakDetection.acquireAndReleaseOnly.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -35,6 +35,7 @@ import java.nio.charset.Charset;
 
 final class AdvancedLeakAwareByteBuf extends SimpleLeakAwareByteBuf {
 
+    // If set to true we will only record stacktraces for touch(...), release(...) and retain(...) calls.
     private static final String PROP_ACQUIRE_AND_RELEASE_ONLY = "io.netty.leakDetection.acquireAndReleaseOnly";
     private static final boolean ACQUIRE_AND_RELEASE_ONLY;
 


### PR DESCRIPTION
Motivation:

We should add some docs / comment to explain what io.netty.leakDetection.acquireAndReleaseOnly is all about.

Modifications:

Add some comments

Result:

Fixes https://github.com/netty/netty/issues/11576.