### PR TITLE
Add CI job for JDK17

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -147,6 +147,9 @@ jobs:
           - setup: linux-x86_64-java16
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.116.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.116.yaml run build-leak"
+          - setup: linux-x86_64-java17
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.117.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.117.yaml run build-leak"
           - setup: linux-x86_64-java11-boringssl
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-6.111.yaml run build-leak-boringssl-static"

--- a/docker/docker-compose.centos-6.117.yaml
+++ b/docker/docker-compose.centos-6.117.yaml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-7-1.17
+    build:
+      args:
+        java_version : "zulu@1.17.0-0"
+
+  build:
+    image: netty:centos-7-1.17
+
+  build-leak:
+    image: netty:centos-7-1.17
+
+  build-boringssl-static:
+    image: netty:centos-7-1.17
+
+  build-leak-boringssl-static:
+    image: netty:centos-7-1.17
+
+  shell:
+    image: netty:centos-7-1.17

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -68,6 +68,15 @@
         <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
       </properties>
     </profile>
+    <profile>
+      <id>java17</id>
+      <activation>
+        <jdk>17</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>


### PR DESCRIPTION
Motivation:

As JDK17 is really close to be released we should add a CI job for it to ensure netty works correctly when using it.

Modifications:

Add docker config and workflow config to run CI job for JDK17

Result:

Ensure netty works on JDK17 as well