### PR TITLE
Fix a problem with IP protocol version confusion on MacOS when TCP FastOpen is enabled

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketTest.java
@@ -34,11 +34,11 @@ public abstract class AbstractSocketTest extends AbstractComboTestsuiteTest<Serv
     }
 
     @Override
-    protected void configure(ServerBootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
-        bootstrap.localAddress(newSocketAddress());
-        bootstrap.option(ChannelOption.ALLOCATOR, allocator);
-        bootstrap.childOption(ChannelOption.ALLOCATOR, allocator);
-        bootstrap2.option(ChannelOption.ALLOCATOR, allocator);
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        sb.localAddress(newSocketAddress());
+        sb.option(ChannelOption.ALLOCATOR, allocator);
+        sb.childOption(ChannelOption.ALLOCATOR, allocator);
+        cb.option(ChannelOption.ALLOCATOR, allocator);
     }
 
     protected SocketAddress newSocketAddress() {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramPathTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramPathTest.java
@@ -41,7 +41,7 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
             public void run(Bootstrap bootstrap) {
                 try {
                     bootstrap.handler(new ChannelInboundHandlerAdapter())
-                             .connect(EpollSocketTestPermutation.newSocketAddress()).sync().channel();
+                             .connect(EpollSocketTestPermutation.newDomainSocketAddress()).sync().channel();
                     fail("Expected FileNotFoundException");
                 } catch (Exception e) {
                     assertTrue(e instanceof FileNotFoundException);
@@ -57,10 +57,10 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
             public void run(Bootstrap bootstrap) {
                 try {
                     Channel ch = bootstrap.handler(new ChannelInboundHandlerAdapter())
-                                          .bind(EpollSocketTestPermutation.newSocketAddress()).sync().channel();
+                                          .bind(EpollSocketTestPermutation.newDomainSocketAddress()).sync().channel();
                     ch.writeAndFlush(new DomainDatagramPacket(
                             Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII),
-                            EpollSocketTestPermutation.newSocketAddress())).sync();
+                            EpollSocketTestPermutation.newDomainSocketAddress())).sync();
                     fail("Expected FileNotFoundException");
                 } catch (Exception e) {
                     assertTrue(e instanceof FileNotFoundException);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramUnicastTest.java
@@ -80,7 +80,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
 
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketDataReadInitialStateTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketDataReadInitialStateTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class EpollDomainSocketDataReadInitialStateTest extends SocketDataReadInitialStateTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketEchoTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketEchoTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class EpollDomainSocketEchoTest extends EpollSocketEchoTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class EpollDomainSocketFdTest extends AbstractSocketTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFileRegionTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFileRegionTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class EpollDomainSocketFileRegionTest extends EpollSocketFileRegionTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketGatheringWriteTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketGatheringWriteTest.java
@@ -27,7 +27,7 @@ public class EpollDomainSocketGatheringWriteTest extends SocketGatheringWriteTes
 
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketObjectEchoTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketObjectEchoTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class EpollDomainSocketObjectEchoTest extends SocketObjectEchoTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketReuseFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketReuseFdTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class EpollDomainSocketReuseFdTest extends AbstractSocketReuseFdTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketShutdownOutputByPeerTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketShutdownOutputByPeerTest.java
@@ -35,7 +35,7 @@ public class EpollDomainSocketShutdownOutputByPeerTest extends AbstractSocketShu
 
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslClientRenegotiateTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslClientRenegotiateTest.java
@@ -31,6 +31,6 @@ public class EpollDomainSocketSslClientRenegotiateTest extends SocketSslClientRe
 
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslEchoTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslEchoTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class EpollDomainSocketSslEchoTest extends SocketSslEchoTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslGreetingTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketSslGreetingTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class EpollDomainSocketSslGreetingTest extends SocketSslGreetingTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketStartTlsTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketStartTlsTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class EpollDomainSocketStartTlsTest extends SocketStartTlsTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketStringEchoTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketStringEchoTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class EpollDomainSocketStringEchoTest extends SocketStringEchoTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newSocketAddress();
+        return EpollSocketTestPermutation.newDomainSocketAddress();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollJdkLoopbackSocketSslEchoTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollJdkLoopbackSocketSslEchoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,23 +15,13 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.SocketFixedLengthEchoTest;
+import io.netty.channel.unix.tests.UnixTestUtils;
 
 import java.net.SocketAddress;
-import java.util.List;
 
-public class EpollDomainSocketFixedLengthEchoTest extends SocketFixedLengthEchoTest {
-
+public class EpollJdkLoopbackSocketSslEchoTest extends EpollSocketSslEchoTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newDomainSocketAddress();
-    }
-
-    @Override
-    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
-        return EpollSocketTestPermutation.INSTANCE.domainSocket();
+        return UnixTestUtils.newInetLoopbackSocketAddress();
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTest.java
@@ -47,7 +47,7 @@ public class EpollSocketTest extends SocketTest<LinuxSocket> {
         LinuxSocket s2 = LinuxSocket.newSocketDomain();
 
         try {
-            DomainSocketAddress dsa = UnixTestUtils.newSocketAddress();
+            DomainSocketAddress dsa = UnixTestUtils.newDomainSocketAddress();
             s1.bind(dsa);
             s1.listen(1);
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -259,7 +259,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         );
     }
 
-    public static DomainSocketAddress newSocketAddress() {
-        return UnixTestUtils.newSocketAddress();
+    public static DomainSocketAddress newDomainSocketAddress() {
+        return UnixTestUtils.newDomainSocketAddress();
     }
 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -125,7 +125,7 @@ final class BsdSocket extends Socket {
             sourcePort = 0;
         } else {
             InetAddress sourceInetAddress = source.getAddress();
-            sourceIPv6 = useIpv6(sourceInetAddress);
+            sourceIPv6 = useIpv6(this, sourceInetAddress);
             if (sourceInetAddress instanceof Inet6Address) {
                 sourceAddress = sourceInetAddress.getAddress();
                 sourceScopeId = ((Inet6Address) sourceInetAddress).getScopeId();
@@ -138,7 +138,7 @@ final class BsdSocket extends Socket {
         }
 
         InetAddress destinationInetAddress = destination.getAddress();
-        boolean destinationIPv6 = useIpv6(destinationInetAddress);
+        boolean destinationIPv6 = useIpv6(this, destinationInetAddress);
         byte[] destinationAddress;
         int destinationScopeId;
         if (destinationInetAddress instanceof Inet6Address) {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -125,8 +125,8 @@ final class BsdSocket extends Socket {
             sourcePort = 0;
         } else {
             InetAddress sourceInetAddress = source.getAddress();
-            sourceIPv6 = sourceInetAddress instanceof Inet6Address;
-            if (sourceIPv6) {
+            sourceIPv6 = useIpv6(sourceInetAddress);
+            if (sourceInetAddress instanceof Inet6Address) {
                 sourceAddress = sourceInetAddress.getAddress();
                 sourceScopeId = ((Inet6Address) sourceInetAddress).getScopeId();
             } else {
@@ -138,10 +138,10 @@ final class BsdSocket extends Socket {
         }
 
         InetAddress destinationInetAddress = destination.getAddress();
-        boolean destinationIPv6 = destinationInetAddress instanceof Inet6Address;
+        boolean destinationIPv6 = useIpv6(destinationInetAddress);
         byte[] destinationAddress;
         int destinationScopeId;
-        if (destinationIPv6) {
+        if (destinationInetAddress instanceof Inet6Address) {
             destinationAddress = destinationInetAddress.getAddress();
             destinationScopeId = ((Inet6Address) destinationInetAddress).getScopeId();
         } else {

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueJdkLoopbackSocketSslEchoTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueJdkLoopbackSocketSslEchoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2021 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,25 +13,15 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel.epoll;
+package io.netty.channel.kqueue;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.transport.socket.SocketFixedLengthEchoTest;
+import io.netty.channel.unix.tests.UnixTestUtils;
 
 import java.net.SocketAddress;
-import java.util.List;
 
-public class EpollDomainSocketFixedLengthEchoTest extends SocketFixedLengthEchoTest {
-
+public class KQueueJdkLoopbackSocketSslEchoTest extends KQueueSocketSslEchoTest {
     @Override
     protected SocketAddress newSocketAddress() {
-        return EpollSocketTestPermutation.newDomainSocketAddress();
-    }
-
-    @Override
-    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
-        return EpollSocketTestPermutation.INSTANCE.domainSocket();
+        return UnixTestUtils.newInetLoopbackSocketAddress();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTest.java
@@ -40,7 +40,7 @@ public class KQueueSocketTest extends SocketTest<BsdSocket> {
         BsdSocket s2 = BsdSocket.newSocketDomain();
 
         try {
-            DomainSocketAddress dsa = UnixTestUtils.newSocketAddress();
+            DomainSocketAddress dsa = UnixTestUtils.newDomainSocketAddress();
             s1.bind(dsa);
             s1.listen(1);
 
@@ -61,7 +61,7 @@ public class KQueueSocketTest extends SocketTest<BsdSocket> {
         BsdSocket s2 = BsdSocket.newSocketDomain();
 
         try {
-            DomainSocketAddress dsa = UnixTestUtils.newSocketAddress();
+            DomainSocketAddress dsa = UnixTestUtils.newDomainSocketAddress();
             s1.bind(dsa);
             s1.listen(1);
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -50,7 +50,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
 
         List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> list =
-                combo(serverSocket(), clientSocket());
+                combo(serverSocket(), clientSocketWithFastOpen());
 
         list.remove(list.size() - 1); // Exclude NIO x NIO test
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -202,6 +202,6 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     }
 
     public static DomainSocketAddress newSocketAddress() {
-        return UnixTestUtils.newSocketAddress();
+        return UnixTestUtils.newDomainSocketAddress();
     }
 }

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/UnixTestUtils.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/UnixTestUtils.java
@@ -20,9 +20,18 @@ import io.netty.util.internal.PlatformDependent;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public final class UnixTestUtils {
-    public static DomainSocketAddress newSocketAddress() {
+    private static final Object INET_LOOPBACK_UNAVAILABLE = new Object();
+    private static volatile Object inetLoopbackCache;
+
+    public static DomainSocketAddress newDomainSocketAddress() {
         try {
             File file;
             do {
@@ -34,6 +43,31 @@ public final class UnixTestUtils {
             return new DomainSocketAddress(file);
         } catch (IOException e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * The JDK method may produce IPv4 loopback addresses where {@link io.netty.util.NetUtil#LOCALHOST} might be an
+     * IPv6 addresses.
+     * This difference can stress the system in different ways that are important to test.
+     */
+    public static SocketAddress newInetLoopbackSocketAddress() {
+        Object loopback = inetLoopbackCache;
+
+        if (loopback == null) {
+            inetLoopbackCache = loopback = getLoopbackAddress();
+        }
+
+        assumeTrue(loopback != INET_LOOPBACK_UNAVAILABLE, "InetAddress.getLoopbackAddress() is not available");
+        return new InetSocketAddress((InetAddress) loopback, 0);
+    }
+
+    private static Object getLoopbackAddress() {
+        try {
+            Method method = InetAddress.class.getMethod("getLoopbackAddress");
+            return method.invoke(null);
+        } catch (Exception e) {
+            return INET_LOOPBACK_UNAVAILABLE;
         }
     }
 

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/UnixTestUtils.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/UnixTestUtils.java
@@ -74,7 +74,7 @@ public final class UnixTestUtils {
         try {
             Method method = InetAddress.class.getMethod("getLoopbackAddress");
             return method.invoke(null);
-        } catch (Exception e) {
+        } catch (Exception ignore) {
             return INET_LOOPBACK_UNAVAILABLE;
         }
     }

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/UnixTestUtils.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/UnixTestUtils.java
@@ -31,6 +31,14 @@ public final class UnixTestUtils {
     private static final Object INET_LOOPBACK_UNAVAILABLE = new Object();
     private static volatile Object inetLoopbackCache;
 
+    /**
+     * @deprecated Use {@link #newDomainSocketAddress()} instead.
+     */
+    @Deprecated
+    public static DomainSocketAddress newSocketAddress() {
+        return newDomainSocketAddress();
+    }
+
     public static DomainSocketAddress newDomainSocketAddress() {
         try {
             File file;

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -58,7 +58,7 @@ public class Socket extends FileDescriptor {
     /**
      * Returns {@code true} if we should use IPv6 internally, {@code false} otherwise.
      */
-    private boolean useIpv6(InetAddress address) {
+    protected boolean useIpv6(InetAddress address) {
         return ipv6 || address instanceof Inet6Address;
     }
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -58,7 +58,7 @@ public class Socket extends FileDescriptor {
     /**
      * Returns {@code true} if we should use IPv6 internally, {@code false} otherwise.
      */
-    protected boolean useIpv6(InetAddress address) {
+    protected final boolean useIpv6(InetAddress address) {
         return ipv6 || address instanceof Inet6Address;
     }
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -58,8 +58,16 @@ public class Socket extends FileDescriptor {
     /**
      * Returns {@code true} if we should use IPv6 internally, {@code false} otherwise.
      */
-    protected final boolean useIpv6(InetAddress address) {
-        return ipv6 || address instanceof Inet6Address;
+    private boolean useIpv6(InetAddress address) {
+        return useIpv6(this, address);
+    }
+
+    /**
+     * Returns {@code true} if the given socket and address combination should use IPv6 internally,
+     * {@code false} otherwise.
+     */
+    protected static boolean useIpv6(Socket socket, InetAddress address) {
+        return socket.ipv6 || address instanceof Inet6Address;
     }
 
     public final void shutdown() throws IOException {


### PR DESCRIPTION
Motivation:
This fixes a bug that would result in an `io.netty.channel.unix.Errors$NativeIoException: connectx(..) failed: Address family not supported by protocol family` error.
This happens when the connecting socket is configured to use IPv6 but the address being connected to is IPv4.
This can occur because, for instance, Netty and `InetAddress.getLoopbackAddress()` have different preferences for IPv6 vs. IPv4.

Modification:
Pass the correct ipv6 or ipv4 flags to connectx, depending on whether the socket was created for AF_INET or AF_INET6, rather than relying on the IP version of the destination address.

Result:
No more issue with TCP FastOpen on MacOS when using addresses of the "wrong" IP version.
