### PR TITLE
Fix QueryStringEncoder encodes tilde

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -245,6 +245,6 @@ public class QueryStringEncoder {
      */
     private static boolean dontNeedEncoding(char ch) {
         return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9'
-                || ch == '-' || ch == '_' || ch == '.' || ch == '*';
+                || ch == '-' || ch == '_' || ch == '.' || ch == '*' || ch == '~';
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringEncoderTest.java
@@ -56,6 +56,11 @@ public class QueryStringEncoderTest {
         e.addParam("d", null);
         assertEquals("/foo?a=1&b=&c&d", e.toString());
         assertEquals(new URI("/foo?a=1&b=&c&d"), e.toUri());
+
+        e = new QueryStringEncoder("/foo");
+        e.addParam("test", "a~b");
+        assertEquals("/foo?test=a~b", e.toString());
+        assertEquals(new URI("/foo?test=a~b"), e.toUri());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

In this issue(https://github.com/netty/netty/issues/11578 ) discussed that tilde should not be encoded in `QueryStringEncoder`, this pr is to fix this problem

Modification:

Modified `QueryStringEncoder` so that it does not encode tilde, and added a test case

Result:

Fixes https://github.com/netty/netty/issues/11581

