### PR TITLE
Remove dead code and fix warnings in the http2 module

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
-import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_LIST_SIZE;
@@ -347,7 +346,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
      */
     protected B encoderEnforceMaxQueuedControlFrames(int maxQueuedControlFrames) {
         enforceNonCodecConstraints("encoderEnforceMaxQueuedControlFrames");
-        this.maxQueuedControlFrames = ObjectUtil.checkPositiveOrZero(maxQueuedControlFrames, "maxQueuedControlFrames");
+        this.maxQueuedControlFrames = checkPositiveOrZero(maxQueuedControlFrames, "maxQueuedControlFrames");
         return self();
     }
 
@@ -376,7 +375,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
      */
     protected B encoderIgnoreMaxHeaderListSize(boolean ignoreMaxHeaderListSize) {
         enforceNonCodecConstraints("encoderIgnoreMaxHeaderListSize");
-        this.encoderIgnoreMaxHeaderListSize = ignoreMaxHeaderListSize;
+        encoderIgnoreMaxHeaderListSize = ignoreMaxHeaderListSize;
         return self();
     }
 
@@ -428,7 +427,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
      */
     protected B decoderEnforceMaxConsecutiveEmptyDataFrames(int maxConsecutiveEmptyFrames) {
         enforceNonCodecConstraints("maxConsecutiveEmptyFrames");
-        this.maxConsecutiveEmptyFrames = ObjectUtil.checkPositiveOrZero(
+        this.maxConsecutiveEmptyFrames = checkPositiveOrZero(
                 maxConsecutiveEmptyFrames, "maxConsecutiveEmptyFrames");
         return self();
     }
@@ -439,7 +438,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
      */
     protected B autoAckSettingsFrame(boolean autoAckSettings) {
         enforceNonCodecConstraints("autoAckSettingsFrame");
-        this.autoAckSettingsFrame = autoAckSettings;
+        autoAckSettingsFrame = autoAckSettings;
         return self();
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -110,7 +110,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         if (cause != null) {
             Throwable unwrappedCause;
             // Unwrap if needed
-            if (cause instanceof Http2FrameStreamException && ((unwrappedCause = cause.getCause()) != null)) {
+            if (cause instanceof Http2FrameStreamException && (unwrappedCause = cause.getCause()) != null) {
                 cause = unwrappedCause;
             }
 
@@ -677,7 +677,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
 
             // Only ever send a reset frame if the connection is still alive and if the stream was created before
             // as otherwise we may send a RST on a stream in an invalid state and cause a connection error.
-            if (parent().isActive() && !readEOS && Http2CodecUtil.isStreamIdValid(stream.id())) {
+            if (parent().isActive() && !readEOS && isStreamIdValid(stream.id())) {
                 Http2StreamFrame resetFrame = new DefaultHttp2ResetFrame(Http2Error.CANCEL).stream(stream());
                 write(resetFrame, unsafe().voidPromise());
                 flush();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamFrame.java
@@ -45,7 +45,7 @@ public abstract class AbstractHttp2StreamFrame implements Http2StreamFrame {
             return false;
         }
         Http2StreamFrame other = (Http2StreamFrame) o;
-        return stream == other.stream() || (stream != null && stream.equals(other.stream()));
+        return stream == other.stream() || stream != null && stream.equals(other.stream());
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2Stream.State;
 import io.netty.util.collection.IntObjectHashMap;
@@ -124,7 +125,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         if (closePromise != null) {
             if (closePromise == promise) {
                 // Do nothing
-            } else if ((promise instanceof ChannelPromise) && ((ChannelPromise) closePromise).isVoid()) {
+            } else if (promise instanceof ChannelPromise && ((ChannelFuture) closePromise).isVoid()) {
                 closePromise = promise;
             } else {
                 closePromise.addListener(new UnaryPromiseNotifier<Void>(promise));
@@ -681,7 +682,7 @@ public class DefaultHttp2Connection implements Http2Connection {
          */
         private int nextReservationStreamId;
         private int lastStreamKnownByPeer = -1;
-        private boolean pushToAllowed = true;
+        private boolean pushToAllowed;
         private F flowController;
         private int maxStreams;
         private int maxActiveStreams;
@@ -846,7 +847,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         private void lastStreamKnownByPeer(int lastKnownStream) {
-            this.lastStreamKnownByPeer = lastKnownStream;
+            lastStreamKnownByPeer = lastKnownStream;
         }
 
         @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -163,11 +163,6 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         return listener;
     }
 
-    // Visible for testing
-    Http2FrameListener internalFrameListener() {
-        return internalFrameListener;
-    }
-
     @Override
     public boolean prefaceReceived() {
         return FrameReadListener.class == internalFrameListener.getClass();
@@ -632,7 +627,8 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 // sent). We don't have enough information to know for sure, so we choose the lesser of the two errors.
                 throw streamError(streamId, STREAM_CLOSED, "Received %s frame for an unknown stream %d",
                                   frameName, streamId);
-            } else if (stream.isResetSent() || streamCreatedAfterGoAwaySent(streamId)) {
+            }
+            if (stream.isResetSent() || streamCreatedAfterGoAwaySent(streamId)) {
                 // If we have sent a reset stream it is assumed the stream will be closed after the write completes.
                 // If we have not sent a reset, but the stream was created after a GoAway this is not supported by
                 // DefaultHttp2Connection and if a custom Http2Connection is used it is assumed the lifetime is managed
@@ -641,8 +637,8 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 if (logger.isInfoEnabled()) {
                     logger.info("{} ignoring {} frame for stream {}", ctx.channel(), frameName,
                             stream.isResetSent() ? "RST_STREAM sent." :
-                                ("Stream created after GOAWAY sent. Last known stream by peer " +
-                                 connection.remote().lastStreamKnownByPeer()));
+                                    "Stream created after GOAWAY sent. Last known stream by peer " +
+                                     connection.remote().lastStreamKnownByPeer());
                 }
 
                 return true;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -555,7 +555,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
                               int padding, boolean endOfStream, ChannelPromise promise) {
             super(stream, padding, endOfStream, promise.unvoid());
             this.headers = headers;
-            this.hasPriorty = hasPriority;
+            hasPriorty = hasPriority;
             this.streamDependency = streamDependency;
             this.weight = weight;
             this.exclusive = exclusive;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -545,7 +545,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
      */
     private final class FlowControlledHeaders extends FlowControlledBase {
         private final Http2Headers headers;
-        private final boolean hasPriorty;
+        private final boolean hasPriority;
         private final int streamDependency;
         private final short weight;
         private final boolean exclusive;
@@ -555,7 +555,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
                               int padding, boolean endOfStream, ChannelPromise promise) {
             super(stream, padding, endOfStream, promise.unvoid());
             this.headers = headers;
-            hasPriorty = hasPriority;
+            this.hasPriority = hasPriority;
             this.streamDependency = streamDependency;
             this.weight = weight;
             this.exclusive = exclusive;
@@ -581,7 +581,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
             // closeStreamLocal().
             promise.addListener(this);
 
-            ChannelFuture f = sendHeaders(frameWriter, ctx, stream.id(), headers, hasPriorty, streamDependency,
+            ChannelFuture f = sendHeaders(frameWriter, ctx, stream.id(), headers, hasPriority, streamDependency,
                     weight, exclusive, padding, endOfStream, promise);
             // Writing headers may fail during the encode state if they violate HPACK limits.
             Throwable failureCause = f.cause();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -27,7 +27,6 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.INT_FIELD_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.PING_FRAME_PAYLOAD_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.PRIORITY_ENTRY_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_INITIAL_WINDOW_SIZE;
-import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_MAX_FRAME_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTING_ENTRY_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.headerListSizeExceeded;
 import static io.netty.handler.codec.http2.Http2CodecUtil.isMaxFrameSizeValid;
@@ -523,14 +522,10 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
                 try {
                     settings.put(id, Long.valueOf(value));
                 } catch (IllegalArgumentException e) {
-                    switch(id) {
-                    case SETTINGS_MAX_FRAME_SIZE:
-                        throw connectionError(PROTOCOL_ERROR, e, e.getMessage());
-                    case SETTINGS_INITIAL_WINDOW_SIZE:
+                    if (id == SETTINGS_INITIAL_WINDOW_SIZE) {
                         throw connectionError(FLOW_CONTROL_ERROR, e, e.getMessage());
-                    default:
-                        throw connectionError(PROTOCOL_ERROR, e, e.getMessage());
                     }
+                    throw connectionError(PROTOCOL_ERROR, e, e.getMessage());
                 }
             }
             listener.onSettingsRead(ctx, settings);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -204,7 +204,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
                 do {
                     int frameDataBytes = min(remainingData, maxFrameSize);
-                    int framePaddingBytes = min(padding, max(0, (maxFrameSize - 1) - frameDataBytes));
+                    int framePaddingBytes = min(padding, max(0, maxFrameSize - 1 - frameDataBytes));
 
                     // Decrement the remaining counters.
                     padding -= framePaddingBytes;
@@ -623,11 +623,5 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
     private static void verifyWindowSizeIncrement(int windowSizeIncrement) {
         checkPositiveOrZero(windowSizeIncrement, "windowSizeIncrement");
-    }
-
-    private static void verifyPingPayload(ByteBuf data) {
-        if (data == null || data.readableBytes() != PING_FRAME_PAYLOAD_LENGTH) {
-            throw new IllegalArgumentException("Opaque data must be " + PING_FRAME_PAYLOAD_LENGTH + " bytes");
-        }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -166,7 +166,7 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
     @Override
     public int hashCode() {
         int hash = super.hashCode();
-        hash = hash * 31 + (int) (errorCode ^ (errorCode >>> 32));
+        hash = hash * 31 + (int) (errorCode ^ errorCode >>> 32);
         hash = hash * 31 + extraStreamIds;
         return hash;
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -117,7 +117,7 @@ public class DefaultHttp2Headers
 
     @Override
     public Http2Headers clear() {
-        this.firstNonPseudo = head;
+        firstNonPseudo = head;
         return super.clear();
     }
 
@@ -203,7 +203,7 @@ public class DefaultHttp2Headers
     }
 
     private final class Http2HeaderEntry extends HeaderEntry<CharSequence, CharSequence> {
-        protected Http2HeaderEntry(int hash, CharSequence key, CharSequence value,
+        Http2HeaderEntry(int hash, CharSequence key, CharSequence value,
                 HeaderEntry<CharSequence, CharSequence> next) {
             super(hash, key);
             this.value = value;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -80,7 +80,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     DefaultHttp2HeadersDecoder(boolean validateHeaders, HpackDecoder hpackDecoder) {
         this.hpackDecoder = ObjectUtil.checkNotNull(hpackDecoder, "hpackDecoder");
         this.validateHeaders = validateHeaders;
-        this.maxHeaderListSizeGoAway =
+        maxHeaderListSizeGoAway =
                 Http2CodecUtil.calculateMaxHeaderListSizeGoAway(hpackDecoder.getMaxHeaderListSize());
     }
 
@@ -101,7 +101,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
                     goAwayMax, max);
         }
         hpackDecoder.setMaxHeaderListSize(max);
-        this.maxHeaderListSizeGoAway = goAwayMax;
+        maxHeaderListSizeGoAway = goAwayMax;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -410,7 +410,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
 
             window += delta;
             processedWindow += delta;
-            lowerBound = Math.min(delta, 0);
+            lowerBound = min(delta, 0);
         }
 
         @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -108,7 +108,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             @Override
             public void onStreamHalfClosed(Http2Stream stream) {
                 if (HALF_CLOSED_LOCAL == stream.state()) {
-                    /**
+                    /*
                      * When this method is called there should not be any
                      * pending frames left if the API is used correctly. However,
                      * it is possible that a erroneous application can sneak

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
@@ -79,7 +79,7 @@ public final class DefaultHttp2ResetFrame extends AbstractHttp2StreamFrame imple
     @Override
     public int hashCode() {
         int hash = super.hashCode();
-        hash = hash * 31 + (int) (errorCode ^ (errorCode >>> 32));
+        hash = hash * 31 + (int) (errorCode ^ errorCode >>> 32);
         return hash;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -189,7 +189,7 @@ final class HpackDecoder {
                         }
                     } else {
                         // Literal Header Field without Indexing / never Indexed
-                        indexType = ((b & 0x10) == 0x10) ? IndexType.NEVER : IndexType.NONE;
+                        indexType = (b & 0x10) == 0x10 ? IndexType.NEVER : IndexType.NONE;
                         index = b & 0x0F;
                         switch (index) {
                             case 0:
@@ -560,7 +560,7 @@ final class HpackDecoder {
 
             if (validate) {
                 try {
-                    previousType = HpackDecoder.validate(streamId, name, previousType);
+                    previousType = validate(streamId, name, previousType);
                 } catch (Http2Exception ex) {
                     validationException = ex;
                     return;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
@@ -245,14 +245,14 @@ final class HpackEncoder {
      */
     private static void encodeInteger(ByteBuf out, int mask, int n, long i) {
         assert n >= 0 && n <= 8 : "N: " + n;
-        int nbits = 0xFF >>> (8 - n);
+        int nbits = 0xFF >>> 8 - n;
         if (i < nbits) {
             out.writeByte((int) (mask | i));
         } else {
             out.writeByte(mask | nbits);
             long length = i - nbits;
             for (; (length & ~0x7F) != 0; length >>>= 7) {
-                out.writeByte((int) ((length & 0x7F) | 0x80));
+                out.writeByte((int) (length & 0x7F | 0x80));
             }
             out.writeByte((int) length);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanEncoder.java
@@ -135,7 +135,7 @@ final class HpackHuffmanEncoder {
         for (int i = 0; i < data.length(); i++) {
             len += lengths[data.charAt(i) & 0xFF];
         }
-        return (int) ((len + 7) >> 3);
+        return (int) (len + 7 >> 3);
     }
 
     private final class EncodeProcessor implements ByteProcessor {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -199,7 +199,7 @@ final class HpackStaticTable {
     /**
      * Returns the last position in the array that contains multiple
      * fields with the same name. Starting from this position, all
-     * names are unique. Similary to {@link getIndexInsensitive} method
+     * names are unique. Similary to {@link #getIndexInsensitive(CharSequence, CharSequence)} method
      * assumes all entries for a given header field are sequential
      */
     private static int maxSameNameFieldIndex() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -89,7 +89,7 @@ public interface Http2Connection {
 
         /**
          * Called when a {@code GOAWAY} was received from the remote endpoint. This event handler duplicates {@link
-         * Http2FrameListener#onGoAwayRead(io.netty.channel.ChannelHandlerContext, int, long, io.netty.buffer.ByteBuf)}
+         * Http2FrameListener#onGoAwayRead(io.netty.channel.ChannelHandlerContext, int, long, ByteBuf)}
          * but is added here in order to simplify application logic for handling {@code GOAWAY} in a uniform way. An
          * application should generally not handle both events, but if it does this method is called second, after
          * notifying the {@link Http2FrameListener}.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
@@ -40,7 +40,7 @@ public enum Http2Error {
     private final long code;
     private static final Http2Error[] INT_TO_ENUM_MAP;
     static {
-        Http2Error[] errors = Http2Error.values();
+        Http2Error[] errors = values();
         Http2Error[] map = new Http2Error[errors.length];
         for (Http2Error error : errors) {
             map[(int) error.code()] = error;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
@@ -136,25 +136,25 @@ public class Http2Exception extends Exception {
 
     /**
      * Use if an error which can be isolated to a single stream has occurred.  If the {@code id} is not
-     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link Http2Exception.StreamException} will be returned.
+     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link StreamException} will be returned.
      * Otherwise the error is considered a connection error and a {@link Http2Exception} is returned.
      * @param id The stream id for which the error is isolated to.
      * @param error The type of error as defined by the HTTP/2 specification.
      * @param fmt String with the content and format for the additional debug data.
      * @param args Objects which fit into the format defined by {@code fmt}.
      * @return If the {@code id} is not
-     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link Http2Exception.StreamException} will be returned.
+     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link StreamException} will be returned.
      * Otherwise the error is considered a connection error and a {@link Http2Exception} is returned.
      */
     public static Http2Exception streamError(int id, Http2Error error, String fmt, Object... args) {
         return CONNECTION_STREAM_ID == id ?
-                Http2Exception.connectionError(error, fmt, args) :
+                connectionError(error, fmt, args) :
                     new StreamException(id, error, String.format(fmt, args));
     }
 
     /**
      * Use if an error which can be isolated to a single stream has occurred.  If the {@code id} is not
-     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link Http2Exception.StreamException} will be returned.
+     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link StreamException} will be returned.
      * Otherwise the error is considered a connection error and a {@link Http2Exception} is returned.
      * @param id The stream id for which the error is isolated to.
      * @param error The type of error as defined by the HTTP/2 specification.
@@ -162,20 +162,20 @@ public class Http2Exception extends Exception {
      * @param fmt String with the content and format for the additional debug data.
      * @param args Objects which fit into the format defined by {@code fmt}.
      * @return If the {@code id} is not
-     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link Http2Exception.StreamException} will be returned.
+     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link StreamException} will be returned.
      * Otherwise the error is considered a connection error and a {@link Http2Exception} is returned.
      */
     public static Http2Exception streamError(int id, Http2Error error, Throwable cause,
             String fmt, Object... args) {
         return CONNECTION_STREAM_ID == id ?
-                Http2Exception.connectionError(error, cause, fmt, args) :
+                connectionError(error, cause, fmt, args) :
                     new StreamException(id, error, String.format(fmt, args), cause);
     }
 
     /**
      * A specific stream error resulting from failing to decode headers that exceeds the max header size list.
      * If the {@code id} is not {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a
-     * {@link Http2Exception.StreamException} will be returned. Otherwise the error is considered a
+     * {@link StreamException} will be returned. Otherwise the error is considered a
      * connection error and a {@link Http2Exception} is returned.
      * @param id The stream id for which the error is isolated to.
      * @param error The type of error as defined by the HTTP/2 specification.
@@ -190,14 +190,14 @@ public class Http2Exception extends Exception {
     public static Http2Exception headerListSizeError(int id, Http2Error error, boolean onDecode,
             String fmt, Object... args) {
         return CONNECTION_STREAM_ID == id ?
-                Http2Exception.connectionError(error, fmt, args) :
+                connectionError(error, fmt, args) :
                     new HeaderListSizeException(id, error, String.format(fmt, args), onDecode);
     }
 
     /**
      * Check if an exception is isolated to a single stream or the entire connection.
      * @param e The exception to check.
-     * @return {@code true} if {@code e} is an instance of {@link Http2Exception.StreamException}.
+     * @return {@code true} if {@code e} is an instance of {@link StreamException}.
      * {@code false} otherwise.
      */
     public static boolean isStreamError(Http2Exception e) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -71,7 +71,7 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
         private static final CharSequenceMap<PseudoHeaderName> PSEUDO_HEADERS = new CharSequenceMap<PseudoHeaderName>();
 
         static {
-            for (PseudoHeaderName pseudoHeader : PseudoHeaderName.values()) {
+            for (PseudoHeaderName pseudoHeader : values()) {
                 PSEUDO_HEADERS.add(pseudoHeader.value(), pseudoHeader);
             }
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -43,7 +43,7 @@ public class Http2MultiplexCodecBuilder
     }
 
     private static ChannelHandler checkSharable(ChannelHandler handler) {
-        if ((handler instanceof ChannelHandlerAdapter && !((ChannelHandlerAdapter) handler).isSharable()) &&
+        if (handler instanceof ChannelHandlerAdapter && !((ChannelHandlerAdapter) handler).isSharable() &&
                 !handler.getClass().isAnnotationPresent(ChannelHandler.Sharable.class)) {
             throw new IllegalArgumentException("The handler must be Sharable");
         }
@@ -77,7 +77,7 @@ public class Http2MultiplexCodecBuilder
     }
 
     public Http2MultiplexCodecBuilder withUpgradeStreamHandler(ChannelHandler upgradeStreamHandler) {
-        if (this.isServer()) {
+        if (isServer()) {
             throw new IllegalArgumentException("Server codecs don't use an extra handler for the upgrade stream");
         }
         this.upgradeStreamHandler = upgradeStreamHandler;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -63,7 +63,6 @@ public final class Http2StreamChannelBootstrap {
      * Allow to specify a {@link ChannelOption} which is used for the {@link Http2StreamChannel} instances once they got
      * created. Use a value of {@code null} to remove a previous set {@link ChannelOption}.
      */
-    @SuppressWarnings("unchecked")
     public <T> Http2StreamChannelBootstrap option(ChannelOption<T> option, T value) {
         ObjectUtil.checkNotNull(option, "option");
 
@@ -81,7 +80,6 @@ public final class Http2StreamChannelBootstrap {
      * Allow to specify an initial attribute of the newly created {@link Http2StreamChannel}.  If the {@code value} is
      * {@code null}, the attribute of the specified {@code key} is removed.
      */
-    @SuppressWarnings("unchecked")
     public <T> Http2StreamChannelBootstrap attr(AttributeKey<T> key, T value) {
         ObjectUtil.checkNotNull(key, "key");
         if (value == null) {
@@ -112,7 +110,6 @@ public final class Http2StreamChannelBootstrap {
      * Open a new {@link Http2StreamChannel} to use and notifies the given {@link Promise}.
      * @return the {@link Future} that will be notified once the channel was opened successfully or it failed.
      */
-    @SuppressWarnings("deprecation")
     public Future<Http2StreamChannel> open(final Promise<Http2StreamChannel> promise) {
         try {
             ChannelHandlerContext ctx = findCtx();
@@ -138,9 +135,10 @@ public final class Http2StreamChannelBootstrap {
         return promise;
     }
 
+    @SuppressWarnings("deprecation")
     private ChannelHandlerContext findCtx() throws ClosedChannelException {
         // First try to use cached context and if this not work lets try to lookup the context.
-        ChannelHandlerContext ctx = this.multiplexCtx;
+        ChannelHandlerContext ctx = multiplexCtx;
         if (ctx != null && !ctx.isRemoved()) {
             return ctx;
         }
@@ -158,7 +156,7 @@ public final class Http2StreamChannelBootstrap {
                 throw new ClosedChannelException();
             }
         }
-        this.multiplexCtx = ctx;
+        multiplexCtx = ctx;
         return ctx;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -78,7 +78,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
 
     @Override
     public boolean acceptInboundMessage(Object msg) throws Exception {
-        return (msg instanceof Http2HeadersFrame) || (msg instanceof Http2DataFrame);
+        return msg instanceof Http2HeadersFrame || msg instanceof Http2DataFrame;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -443,7 +443,7 @@ public final class HttpConversionUtil {
             if (!isOriginForm(requestTargetUri) && !isAsteriskForm(requestTargetUri)) {
                 // Attempt to take from HOST header before taking from the request-line
                 String host = inHeaders.getAsString(HttpHeaderNames.HOST);
-                setHttp2Authority((host == null || host.isEmpty()) ? requestTargetUri.getAuthority() : host, out);
+                setHttp2Authority(host == null || host.isEmpty() ? requestTargetUri.getAuthority() : host, out);
             }
         } else if (in instanceof HttpResponse) {
             HttpResponse response = (HttpResponse) in;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -485,7 +485,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
 
     @Override
     public int size() {
-        return (pseudoHeaders.length + otherHeaders.length) >>> 1;
+        return pseudoHeaders.length + otherHeaders.length >>> 1;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
@@ -126,7 +126,7 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
 
     public StreamBufferingEncoder(Http2ConnectionEncoder delegate, int initialMaxConcurrentStreams) {
         super(delegate);
-        this.maxConcurrentStreams = initialMaxConcurrentStreams;
+        maxConcurrentStreams = initialMaxConcurrentStreams;
         connection().addListener(new Http2ConnectionAdapter() {
 
             @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
@@ -159,7 +159,7 @@ public final class UniformStreamByteDistributor implements StreamByteDistributor
             //    we gave the state a chance to write zero length frames. We wait until updateStreamableBytes is
             //    called again before this state is allowed to write.
             windowNegative = windowSize < 0;
-            if (hasFrame && (windowSize > 0 || (windowSize == 0 && !writing))) {
+            if (hasFrame && (windowSize > 0 || windowSize == 0 && !writing)) {
                 addToQueue();
             }
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -442,6 +442,7 @@ public class DataCompressionHttp2Test {
                         .codec(decoder, clientEncoder).build();
                 p.addLast(clientHandler);
                 p.addLast(new ChannelInboundHandlerAdapter() {
+                    @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -492,6 +492,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         }
     }
 
+    @Test
     public void headersReadForUnknownStreamShouldThrow() throws Exception {
         when(connection.stream(STREAM_ID)).thenReturn(null);
         assertThrows(Http2Exception.class, new Executable() {
@@ -636,7 +637,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         }
     }
 
-    @Test()
+    @Test
     public void headersReadForPromisedStreamShouldCloseStream() throws Exception {
         when(stream.state()).thenReturn(RESERVED_REMOTE);
         decode().onHeadersRead(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, true);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -111,19 +111,19 @@ public class DefaultHttp2ConnectionTest {
     }
 
     @Test
-    public void removeAllStreamsWithJustOneLocalStream() throws InterruptedException, Http2Exception {
+    public void removeAllStreamsWithJustOneLocalStream() throws Exception {
         client.local().createStream(3, false);
         testRemoveAllStreams();
     }
 
     @Test
-    public void removeAllStreamsWithJustOneRemoveStream() throws InterruptedException, Http2Exception {
+    public void removeAllStreamsWithJustOneRemoveStream() throws Exception {
         client.remote().createStream(2, false);
         testRemoveAllStreams();
     }
 
     @Test
-    public void removeAllStreamsWithManyActiveStreams() throws InterruptedException, Http2Exception {
+    public void removeAllStreamsWithManyActiveStreams() throws Exception {
         Endpoint<Http2RemoteFlowController> remote = client.remote();
         Endpoint<Http2LocalFlowController> local = client.local();
         for (int c = 3, s = 2; c < 5000; c += 2, s += 2) {
@@ -134,7 +134,7 @@ public class DefaultHttp2ConnectionTest {
     }
 
     @Test
-    public void removeIndividualStreamsWhileCloseDoesNotNPE() throws InterruptedException, Http2Exception {
+    public void removeIndividualStreamsWhileCloseDoesNotNPE() throws Exception {
         final Http2Stream streamA = client.local().createStream(3, false);
         final Http2Stream streamB = client.remote().createStream(2, false);
         doAnswer(new Answer<Void>() {
@@ -154,7 +154,7 @@ public class DefaultHttp2ConnectionTest {
     }
 
     @Test
-    public void removeAllStreamsWhileIteratingActiveStreams() throws InterruptedException, Http2Exception {
+    public void removeAllStreamsWhileIteratingActiveStreams() throws Exception {
         final Endpoint<Http2RemoteFlowController> remote = client.remote();
         final Endpoint<Http2LocalFlowController> local = client.local();
         for (int c = 3, s = 2; c < 5000; c += 2, s += 2) {
@@ -181,7 +181,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void removeAllStreamsWhileIteratingActiveStreamsAndExceptionOccurs()
-            throws InterruptedException, Http2Exception {
+            throws Exception {
         final Endpoint<Http2RemoteFlowController> remote = client.remote();
         final Endpoint<Http2LocalFlowController> local = client.local();
         for (int c = 3, s = 2; c < 5000; c += 2, s += 2) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -161,7 +161,7 @@ public class DefaultHttp2FrameWriterTest {
     }
 
     /**
-     * Test large headers that exceed {@link DefaultHttp2FrameWriter#maxFrameSize}
+     * Test large headers that exceed {@link DefaultHttp2FrameWriter#maxFrameSize()}
      * the remaining headers will be sent in a CONTINUATION frame
      */
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -185,7 +185,7 @@ public class DefaultHttp2HeadersTest {
             if (entry.getKey().length() == 0 || entry.getKey().charAt(0) != ':') {
                 lastNonPseudoName = entry.getKey();
             } else if (lastNonPseudoName != null) {
-                fail("All pseudo headers must be fist in iteration. Pseudo header " + entry.getKey() +
+                fail("All pseudo headers must be first in iteration. Pseudo header " + entry.getKey() +
                         " is after a non pseudo header " + lastNonPseudoName);
             }
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDynamicTableTest.java
@@ -98,7 +98,7 @@ public class HpackDynamicTableTest {
         table.add(entry2);
         assertEquals(2, table.length());
         assertEquals(size1 + size2, table.size());
-        table.setCapacity((size1 + size2) * 2); //larger capacity
+        table.setCapacity(((long) size1 + size2) * 2); //larger capacity
         assertEquals(2, table.length());
         assertEquals(size1 + size2, table.size());
         table.setCapacity(size2); //smaller capacity

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -210,7 +210,7 @@ public class Http2ConnectionHandlerTest {
         when(ctx.voidPromise()).thenReturn(voidPromise);
         when(ctx.write(any())).thenReturn(future);
         when(ctx.executor()).thenReturn(executor);
-        doAnswer(new Answer() {
+        doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock in) throws Throwable {
                 Object msg = in.getArgument(0);
@@ -268,10 +268,10 @@ public class Http2ConnectionHandlerTest {
                 Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE;
 
         final AtomicBoolean verified = new AtomicBoolean(false);
-        final Answer verifier = new Answer() {
+        final Answer<Object> verifier = new Answer<Object>() {
             @Override
             public Object answer(final InvocationOnMock in) throws Throwable {
-                assertTrue(in.getArgument(0).equals(evt));  // sanity check...
+                assertEquals(in.getArgument(0), evt);  // sanity check...
                 verify(ctx).write(eq(connectionPrefaceBuf()));
                 verify(encoder).writeSettings(eq(ctx), any(Http2Settings.class), any(ChannelPromise.class));
                 verified.set(true);
@@ -514,7 +514,7 @@ public class Http2ConnectionHandlerTest {
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
-            eq(Http2Error.PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+            eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
         handler.exceptionCaught(ctx, e);
 
         verify(remote).createStream(STREAM_ID, true);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -120,7 +120,7 @@ public class Http2FrameCodecTest {
     }
 
     private void setUp(Http2FrameCodecBuilder frameCodecBuilder, Http2Settings initialRemoteSettings) throws Exception {
-        /**
+        /*
          * Some tests call this method twice. Once with JUnit's @Before and once directly to pass special settings.
          * This call ensures that in case of two consecutive calls to setUp(), the previous channel is shutdown and
          * ByteBufs are released correctly.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -46,7 +46,7 @@ final class Http2FrameInboundWriter {
     }
 
     Http2FrameInboundWriter(EmbeddedChannel channel, Http2FrameWriter writer) {
-        this.ctx = new WriteInboundChannelHandlerContext(channel);
+        ctx = new WriteInboundChannelHandlerContext(channel);
         this.writer = writer;
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -616,7 +616,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         assertFalse(inboundHandler.isChannelActive());
 
         // A RST_STREAM frame should NOT be emitted, as we received a RST_STREAM.
-        verify(frameWriter, Mockito.never()).writeRstStream(eqCodecCtx(), eqStreamId(channel),
+        verify(frameWriter, never()).writeRstStream(eqCodecCtx(), eqStreamId(channel),
                 anyLong(), anyChannelPromise());
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -63,7 +63,6 @@ import java.security.cert.X509Certificate;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -241,7 +240,7 @@ public class Http2MultiplexTransportTest {
                                             }
                                         });
                                     }
-                                }, 500, TimeUnit.MILLISECONDS);
+                                }, 500, MILLISECONDS);
                             }
                             ReferenceCountUtil.release(msg);
                         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -158,7 +158,7 @@ public class Http2StreamChannelBootstrapTest {
         when(ctx.executor()).thenReturn(executor);
         when(ctx.handler()).thenReturn(handler);
 
-        Promise<Http2StreamChannel> promise = new DefaultPromise(mock(EventExecutor.class));
+        Promise<Http2StreamChannel> promise = new DefaultPromise<Http2StreamChannel>(mock(EventExecutor.class));
         bootstrap.open0(ctx, promise);
         assertThat(promise.isDone(), is(true));
         assertThat(promise.cause(), is(instanceOf(IllegalStateException.class)));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -145,7 +145,7 @@ public class HttpConversionUtilTest {
     @Test
     public void stripTEHeadersAccountsForOWS() {
         HttpHeaders inHeaders = new DefaultHttpHeaders();
-        inHeaders.add(TE, " " + TRAILERS + " ");
+        inHeaders.add(TE, " " + TRAILERS + ' ');
         Http2Headers out = new DefaultHttp2Headers();
         HttpConversionUtil.toHttp2Headers(inHeaders, out);
         assertSame(TRAILERS, out.get(TE));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -727,6 +727,7 @@ public class InboundHttp2ToHttpAdapterTest {
                     }
                 });
                 p.addLast(new ChannelInboundHandlerAdapter() {
+                    @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                         if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                             prefaceWrittenLatch.countDown();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
@@ -244,11 +244,10 @@ public class ReadOnlyHttp2HeadersTest {
 
     @Test
     public void testIteratorMultipleValues() {
-        Http2Headers headers = ReadOnlyHttp2Headers.serverHeaders(false, new AsciiString("200"), new AsciiString[] {
+        Http2Headers headers = ReadOnlyHttp2Headers.serverHeaders(false, new AsciiString("200"),
                 new AsciiString("name2"), new AsciiString("value1"),
                 new AsciiString("name1"), new AsciiString("value2"),
-                new AsciiString("name2"), new AsciiString("value3")
-        });
+                new AsciiString("name2"), new AsciiString("value3"));
         Iterator<CharSequence> itr = headers.valueIterator("name2");
         assertTrue(itr.hasNext());
         assertTrue(AsciiString.contentEqualsIgnoreCase("value1", itr.next()));


### PR DESCRIPTION
Motivation:
Opportunities for clean up found while working on a different PR.

Modification:
* Dead code has been removed.
* Unnecessary parenthesis, qualifiers, etc. removed.
* Unused imports removed.
* Override annotations added where missing.

Result:
Cleaner code
