### PR TITLE
Add Zstd.isAvailable() check in ZstdOptions

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -186,8 +186,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
                 } else if (compressionOption instanceof DeflateOptions) {
                     deflateOptions = (DeflateOptions) compressionOption;
                 } else if (compressionOption instanceof ZstdOptions) {
-                    // zstd might not be available
-                    zstdOptions = Zstd.isAvailable() ? (ZstdOptions) compressionOption : null;
+                    zstdOptions = (ZstdOptions) compressionOption;
                 } else {
                     throw new IllegalArgumentException("Unsupported " + CompressionOptions.class.getSimpleName() +
                             ": " + compressionOption);

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -95,6 +95,11 @@
       <artifactId>brotli4j</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliOptions.java
@@ -34,11 +34,11 @@ public final class BrotliOptions implements CompressionOptions {
     );
 
     BrotliOptions(Encoder.Parameters parameters) {
-        this.parameters = ObjectUtil.checkNotNull(parameters, "Parameters");
-
         if (!Brotli.isAvailable()) {
             throw new IllegalStateException("Brotli is not available", Brotli.cause());
         }
+
+        this.parameters = ObjectUtil.checkNotNull(parameters, "Parameters");
     }
 
     public Encoder.Parameters parameters() {

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdOptions.java
@@ -50,6 +50,10 @@ public class ZstdOptions implements CompressionOptions {
      *           specifies the level of the compression
      */
     ZstdOptions(int compressionLevel, int blockSize, int maxEncodeSize) {
+        if (!Zstd.isAvailable()) {
+            throw new IllegalStateException("zstd-jni is not available", Zstd.cause());
+        }
+
         this.compressionLevel = ObjectUtil.checkInRange(compressionLevel, 0, MAX_COMPRESSION_LEVEL, "compressionLevel");
         this.blockSize = ObjectUtil.checkPositive(blockSize, "blockSize");
         this.maxEncodeSize = ObjectUtil.checkPositive(maxEncodeSize, "maxEncodeSize");


### PR DESCRIPTION
Motivation:

At present, the verification methods of `ZstdOptions` and `BrotliOptions` are not consistent, and the processing methods of `ZstdOptions` and `BrotliOptions` in `HttpContentCompressor` are also inconsistent.
The http2 module does not add zstd-jni dependency, so `ClassNotFoundException` may be thrown

Modification:

Added `Zstd.isAvailable()` check in `ZstdOptions` to be consistent, and added zstd-jni dependency in http2 module

Result:

The verification methods of `ZstdOptions` and `BrotliOptions` are consistent, and `ClassNotFoundException` will not be thrown
