### PR TITLE
Call OpenSsl.ensureAvailability() before trying to construct OpenSsl*…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -827,12 +827,14 @@ public abstract class SslContext {
                         sessionTimeout, keyStoreType);
             case OPENSSL:
                 verifyNullSslContextProvider(provider, sslContextProvider);
+                OpenSsl.ensureAvailability();
                 return new OpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
                         enableOcsp, keyStoreType, options);
             case OPENSSL_REFCNT:
                 verifyNullSslContextProvider(provider, sslContextProvider);
+                OpenSsl.ensureAvailability();
                 return new ReferenceCountedOpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,


### PR DESCRIPTION
…Context

Motivation:

At the moment why you try to build a SslContext via SslProvider.OPENSSL* and netty-tcnative* is not on the classpath it will fail with:

```
Exception in thread "main" java.lang.NoClassDefFoundError: io/netty/internal/tcnative/SSLPrivateKeyMethod
	at io.netty.handler.ssl.SslContext.newClientContextInternal(SslContext.java:830)
	at io.netty.handler.ssl.SslContextBuilder.build(SslContextBuilder.java:611)
	at io.netty.handler.codec.http.Main.main(Main.java:34)
Caused by: java.lang.ClassNotFoundException: io.netty.internal.tcnative.SSLPrivateKeyMethod
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 3 more
```

We should do better here.

Modifications:

Call `OpenSsl.ensureAvailability()` before trying to construct OpenSsl*Context instances

Result:

More clear error message like:

```
java.lang.UnsatisfiedLinkError: failed to load the required native library

	at io.netty.handler.ssl.OpenSsl.ensureAvailability(OpenSsl.java:540)
	at io.netty.handler.ssl.SslContext.newClientContextInternal(SslContext.java:830)
	at io.netty.handler.ssl.SslContextBuilder.build(SslContextBuilder.java:611)
        ...
Caused by: java.lang.ClassNotFoundException: io.netty.internal.tcnative.SSLContext
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:398)
	at io.netty.handler.ssl.OpenSsl.<clinit>(OpenSsl.java:126)
	... 68 more
```