### PR TITLE
Fix leak in TcpDnsTest

### DIFF
--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -66,6 +66,7 @@ public class TcpDnsTest {
         assertThat(readResponse.<DnsRawRecord>recordAt(DnsSection.ANSWER).content(), is(record.content()));
         ReferenceCountUtil.release(readResponse);
         ReferenceCountUtil.release(record);
+        query.release();
         assertFalse(channel.finish());
     }
 


### PR DESCRIPTION
Motivation:

In another PR we did observe a leak report for TcpDnsTest

Modifications:

Correctly release the query.

Result:

No more leaks
