### PR TITLE
Use default methods in Channel

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandler;
@@ -370,128 +369,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     @Override
     public ChannelPipeline pipeline() {
         return pipeline;
-    }
-
-    @Override
-    public ByteBufAllocator alloc() {
-        return config().getAllocator();
-    }
-
-    @Override
-    public Channel read() {
-        pipeline().read();
-        return this;
-    }
-
-    @Override
-    public Channel flush() {
-        pipeline().flush();
-        return this;
-    }
-
-    @Override
-    public Future<Void> bind(SocketAddress localAddress) {
-        return pipeline().bind(localAddress);
-    }
-
-    @Override
-    public Future<Void> connect(SocketAddress remoteAddress) {
-        return pipeline().connect(remoteAddress);
-    }
-
-    @Override
-    public Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return pipeline().connect(remoteAddress, localAddress);
-    }
-
-    @Override
-    public Future<Void> disconnect() {
-        return pipeline().disconnect();
-    }
-
-    @Override
-    public Future<Void> close() {
-        return pipeline().close();
-    }
-
-    @Override
-    public Future<Void> register() {
-        return pipeline().register();
-    }
-
-    @Override
-    public Future<Void> deregister() {
-        return pipeline().deregister();
-    }
-
-    @Override
-    public Future<Void> bind(SocketAddress localAddress, Promise<Void> promise) {
-        return pipeline().bind(localAddress, promise);
-    }
-
-    @Override
-    public Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
-        return pipeline().connect(remoteAddress, promise);
-    }
-
-    @Override
-    public Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-        return pipeline().connect(remoteAddress, localAddress, promise);
-    }
-
-    @Override
-    public Future<Void> disconnect(Promise<Void> promise) {
-        return pipeline().disconnect(promise);
-    }
-
-    @Override
-    public Future<Void> close(Promise<Void> promise) {
-        return pipeline().close(promise);
-    }
-
-    @Override
-    public Future<Void> register(Promise<Void> promise) {
-        return pipeline().register(promise);
-    }
-
-    @Override
-    public Future<Void> deregister(Promise<Void> promise) {
-        return pipeline().deregister(promise);
-    }
-
-    @Override
-    public Future<Void> write(Object msg) {
-        return pipeline().write(msg);
-    }
-
-    @Override
-    public Future<Void> write(Object msg, Promise<Void> promise) {
-        return pipeline().write(msg, promise);
-    }
-
-    @Override
-    public Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
-        return pipeline().writeAndFlush(msg, promise);
-    }
-
-    @Override
-    public Future<Void> writeAndFlush(Object msg) {
-        return pipeline().writeAndFlush(msg);
-    }
-
-    @Override
-    public Promise<Void> newPromise() {
-        return pipeline().newPromise();
-    }
-
-    @Override
-    public Future<Void> newSucceededFuture() {
-        return pipeline().newSucceededFuture();
-    }
-
-    @Override
-    public Future<Void> newFailedFuture(Throwable cause) {
-        return pipeline().newFailedFuture(cause);
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -32,11 +32,11 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class AbstractEventExecutor extends AbstractExecutorService implements EventExecutor {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractEventExecutor.class);
-
     static final long DEFAULT_SHUTDOWN_QUIET_PERIOD = 2;
     static final long DEFAULT_SHUTDOWN_TIMEOUT = 15;
 
     private final Collection<EventExecutor> selfCollection = Collections.singleton(this);
+    private final Future<?> successFullVoidFuture = DefaultPromise.newSuccessfulPromise(this, null);
 
     @Override
     public EventExecutor next() {
@@ -82,6 +82,11 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
 
     @Override
     public <V> Future<V> newSucceededFuture(V result) {
+        if (result == null) {
+            @SuppressWarnings("unchecked")
+            Future<V> f = (Future<V>) successFullVoidFuture;
+            return f;
+        }
         return DefaultPromise.newSuccessfulPromise(this, result);
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -36,7 +36,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     static final long DEFAULT_SHUTDOWN_TIMEOUT = 15;
 
     private final Collection<EventExecutor> selfCollection = Collections.singleton(this);
-    private final Future<?> successFullVoidFuture = DefaultPromise.newSuccessfulPromise(this, null);
+    private final Future<?> successfulVoidFuture = DefaultPromise.newSuccessfulPromise(this, null);
 
     @Override
     public EventExecutor next() {
@@ -84,7 +84,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     public <V> Future<V> newSucceededFuture(V result) {
         if (result == null) {
             @SuppressWarnings("unchecked")
-            Future<V> f = (Future<V>) successFullVoidFuture;
+            Future<V> f = (Future<V>) successfulVoidFuture;
             return f;
         }
         return DefaultPromise.newSuccessfulPromise(this, result);

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -222,7 +222,7 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
 
     @Override
     default Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return pipeline().connect(remoteAddress);
+        return pipeline().connect(remoteAddress, localAddress);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We can make things easier for implementations by providing some default methods

Modifications:

- Add default methods to Channel
- Remove code from AbstractChannel

Result:

Easier to implement custom Channel
