### PR TITLE
Try to get the PR Reports workflow running again

### DIFF
--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -32,7 +32,7 @@ jobs:
           - setup: linux-x86_64-java11
           - setup: linux-x86_64-java16
           - setup: linux-x86_64-java11-boringssl
-          - setuo: windows-x86_64-java11-boringssl
+          - setup: windows-x86_64-java11-boringssl
     steps:
       - name: Download Artifacts
         uses: dawidd6/action-download-artifact@v2.11.0

--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -35,7 +35,7 @@ jobs:
           - setup: windows-x86_64-java11-boringssl
     steps:
       - name: Download Artifacts
-        uses: dawidd6/action-download-artifact@v2.11.0
+        uses: dawidd6/action-download-artifact@v2.14.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -44,7 +44,7 @@ jobs:
           # File location set in ci-pr.yml and must be coordinated.
           name: test-results-${{ matrix.setup }}
       - name: Publish Test Report
-        uses: scacap/action-surefire-report@v1.0.7
+        uses: scacap/action-surefire-report@v1.0.13
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/target/surefire-reports/TEST-*.xml'


### PR DESCRIPTION
Motivation:
This workflow has been broken for a couple of months now.
It would be nice if we could get junit test reports back in out PR checks.

Modificatoin:
Fix a test matrix typo.

Result:
Hopefully the PR Reports workflow starts working again.

Draft until it actually does work. There are probably several things wrong that will take time to work through.
