### PR TITLE
Fix scope of Mockito dependency

### DIFF
--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -98,4 +99,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -77,6 +77,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -102,4 +103,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -112,6 +112,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- Test dependencies for jboss marshalling encoder/decoder -->
@@ -134,4 +135,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -86,6 +86,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <!-- Add dependency on dev-tools as otherwise the build will fail if not installed first manually -->
     <!-- See https://github.com/netty/netty/issues/7842 -->

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>
-

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -90,6 +90,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -101,4 +102,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>
-

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>
-


### PR DESCRIPTION
_Motivation:_

Mockito treated as a compile-time dependency and transitively added to dependents projects

_Modification:_

Change scope of the Mockito dependency from default one to explicit `test`

_Result:_

Fixes generated POM files