### PR TITLE
Try to make the PR Reports workflow more robust

### DIFF
--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -26,13 +26,17 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        ignore-if-missing: [false]
         include:
           - setup: linux-x86_64-java8
+            ignore-if-missing: true
           - setup: linux-x86_64-java11
           - setup: linux-x86_64-java16
           - setup: linux-x86_64-java11-boringssl
           - setup: windows-x86_64-java11-boringssl
+    continue-on-error: ${{ matrix.ignore-if-missing }}
     steps:
       - name: Download Artifacts
         uses: dawidd6/action-download-artifact@v2.14.1


### PR DESCRIPTION
Motiviation:
The workflow from the default branch is the one that gets to run for all PRs, regardless of what branch they are targeting.
This means the 4.1 PR Reports workflow needs to tollerate master branch PRs, where there is no Java 8 builds.

Modification:
Make the PR Reports tolerate that the Java 8 matrix fails if they are missing.

Result:
Hopefully we'll get working PR Reports for master branch PRs now.
If there is no issue then describe the changes introduced by this PR.
