### PR TITLE
Remove public API's that take Promise

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
@@ -100,7 +100,7 @@ public abstract class WebSocketServerHandshakerTest {
                                                              "ws://example.com/chat");
         request.headers().set("x-client-header", "value");
         try {
-            serverHandshaker.handshake(null, request, null, null);
+            serverHandshaker.handshake(null, request, null);
         } catch (WebSocketServerHandshakeException exception) {
             assertNotNull(exception.getMessage());
             assertEquals(request.headers(), exception.request().headers());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.UnstableApi;
 
 import static java.util.Objects.requireNonNull;
@@ -35,73 +34,70 @@ public class DecoratingHttp2FrameWriter implements Http2FrameWriter {
 
     @Override
     public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-                                  boolean endStream, Promise<Void> promise) {
-        return delegate.writeData(ctx, streamId, data, padding, endStream, promise);
+                                  boolean endStream) {
+        return delegate.writeData(ctx, streamId, data, padding, endStream);
     }
 
     @Override
     public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
-                                     boolean endStream, Promise<Void> promise) {
-        return delegate.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
+                                     boolean endStream) {
+        return delegate.writeHeaders(ctx, streamId, headers, padding, endStream);
     }
 
     @Override
     public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
                                      int streamDependency, short weight, boolean exclusive, int padding,
-                                     boolean endStream, Promise<Void> promise) {
+                                     boolean endStream) {
         return delegate
-                .writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive, padding, endStream, promise);
+                .writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive, padding, endStream);
     }
 
     @Override
     public Future<Void> writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
-                                      boolean exclusive, Promise<Void> promise) {
-        return delegate.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
+                                      boolean exclusive) {
+        return delegate.writePriority(ctx, streamId, streamDependency, weight, exclusive);
     }
 
     @Override
-    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-                                       Promise<Void> promise) {
-        return delegate.writeRstStream(ctx, streamId, errorCode, promise);
+    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode) {
+        return delegate.writeRstStream(ctx, streamId, errorCode);
     }
 
     @Override
-    public Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings, Promise<Void> promise) {
-        return delegate.writeSettings(ctx, settings, promise);
+    public Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings) {
+        return delegate.writeSettings(ctx, settings);
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
-        return delegate.writeSettingsAck(ctx, promise);
+    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx) {
+        return delegate.writeSettingsAck(ctx);
     }
 
     @Override
-    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
-        return delegate.writePing(ctx, ack, data, promise);
+    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data) {
+        return delegate.writePing(ctx, ack, data);
     }
 
     @Override
     public Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-                                         Http2Headers headers, int padding, Promise<Void> promise) {
-        return delegate.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
+                                         Http2Headers headers, int padding) {
+        return delegate.writePushPromise(ctx, streamId, promisedStreamId, headers, padding);
     }
 
     @Override
-    public Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData,
-                                     Promise<Void> promise) {
-        return delegate.writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
+    public Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData) {
+        return delegate.writeGoAway(ctx, lastStreamId, errorCode, debugData);
     }
 
     @Override
-    public Future<Void> writeWindowUpdate(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement,
-                                          Promise<Void> promise) {
-        return delegate.writeWindowUpdate(ctx, streamId, windowSizeIncrement, promise);
+    public Future<Void> writeWindowUpdate(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) {
+        return delegate.writeWindowUpdate(ctx, streamId, windowSizeIncrement);
     }
 
     @Override
     public Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
-                                   ByteBuf payload, Promise<Void> promise) {
-        return delegate.writeFrame(ctx, frameType, streamId, flags, payload, promise);
+                                   ByteBuf payload) {
+        return delegate.writeFrame(ctx, frameType, streamId, flags, payload);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -20,7 +20,6 @@ import io.netty.handler.codec.http2.Http2Stream.State;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 import io.netty.util.collection.IntObjectMap.PrimitiveEntry;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.UnaryPromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
@@ -116,7 +115,7 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     @Override
-    public Future<Void> close(final Promise<Void> promise) {
+    public void close(final Promise<Void> promise) {
         requireNonNull(promise, "promise");
         // Since we allow this method to be called multiple times, we must make sure that all the promises are notified
         // when all streams are removed and the close operation completes.
@@ -131,7 +130,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
         if (isStreamMapEmpty()) {
             promise.trySuccess(null);
-            return promise;
+            return;
         }
 
         Iterator<PrimitiveEntry<Http2Stream>> itr = streamMap.entries().iterator();
@@ -162,7 +161,6 @@ public class DefaultHttp2Connection implements Http2Connection {
                 }
             }
         }
-        return closePromise;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -498,7 +498,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 // Acknowledge receipt of the settings. We should do this before we process the settings to ensure our
                 // remote peer applies these settings before any subsequent frames that we may send which depend upon
                 // these new settings. See https://github.com/netty/netty/issues/6520.
-                encoder.writeSettingsAck(ctx, ctx.newPromise());
+                encoder.writeSettingsAck(ctx);
 
                 encoder.remoteSettings(settings);
             } else {
@@ -512,7 +512,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         public void onPingRead(ChannelHandlerContext ctx, long data) throws Http2Exception {
             if (autoAckPing) {
                 // Send an ack back to the remote client.
-                encoder.writePing(ctx, true, data, ctx.newPromise());
+                encoder.writePing(ctx, true, data);
             }
             listener.onPingRead(ctx, data);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -241,7 +241,9 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             // Use a try/finally here in case the data has been released before calling this method. This is not
             // necessary above because we internally allocate frameHeader.
             try {
-                if (data != null) {
+                if (data != null &&
+                        // Check if the data was released already.
+                        data.refCnt() > 0) {
                     data.release();
                 }
             } finally {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -21,7 +21,6 @@ import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregato
 import io.netty.handler.codec.http2.Http2FrameWriter.Configuration;
 import io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.UnstableApi;
 
 import static io.netty.buffer.Unpooled.directBuffer;
@@ -133,9 +132,9 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
     @Override
     public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-                                  int padding, boolean endStream, Promise<Void> promise) {
+                                  int padding, boolean endStream) {
         final SimpleChannelPromiseAggregator promiseAggregator =
-                new SimpleChannelPromiseAggregator(promise, ctx.executor());
+                new SimpleChannelPromiseAggregator(ctx.newPromise(), ctx.executor());
         ByteBuf frameHeader = null;
         try {
             verifyStreamId(streamId, STREAM_ID);
@@ -256,22 +255,22 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
     @Override
     public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId,
-                                     Http2Headers headers, int padding, boolean endStream, Promise<Void> promise) {
+                                     Http2Headers headers, int padding, boolean endStream) {
         return writeHeadersInternal(ctx, streamId, headers, padding, endStream,
-                false, 0, (short) 0, false, promise);
+                false, 0, (short) 0, false);
     }
 
     @Override
     public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId,
                                      Http2Headers headers, int streamDependency, short weight, boolean exclusive,
-                                     int padding, boolean endStream, Promise<Void> promise) {
+                                     int padding, boolean endStream) {
         return writeHeadersInternal(ctx, streamId, headers, padding, endStream,
-                true, streamDependency, weight, exclusive, promise);
+                true, streamDependency, weight, exclusive);
     }
 
     @Override
     public Future<Void> writePriority(ChannelHandlerContext ctx, int streamId,
-                                      int streamDependency, short weight, boolean exclusive, Promise<Void> promise) {
+                                      int streamDependency, short weight, boolean exclusive) {
         try {
             verifyStreamId(streamId, STREAM_ID);
             verifyStreamOrConnectionId(streamDependency, STREAM_DEPENDENCY);
@@ -282,15 +281,14 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             buf.writeInt(exclusive ? (int) (0x80000000L | streamDependency) : streamDependency);
             // Adjust the weight so that it fits into a single byte on the wire.
             buf.writeByte(weight - 1);
-            return ctx.write(buf).cascadeTo(promise);
+            return ctx.write(buf);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            return ctx.newFailedFuture(t);
         }
     }
 
     @Override
-    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-                                       Promise<Void> promise) {
+    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode) {
         try {
             verifyStreamId(streamId, STREAM_ID);
             verifyErrorCode(errorCode);
@@ -298,15 +296,14 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             ByteBuf buf = ctx.alloc().buffer(RST_STREAM_FRAME_LENGTH);
             writeFrameHeaderInternal(buf, INT_FIELD_LENGTH, RST_STREAM, new Http2Flags(), streamId);
             buf.writeInt((int) errorCode);
-            return ctx.write(buf).cascadeTo(promise);
+            return ctx.write(buf);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            return ctx.newFailedFuture(t);
         }
     }
 
     @Override
-    public Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
-                                      Promise<Void> promise) {
+    public Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings) {
         try {
             requireNonNull(settings, "settings");
             int payloadLength = SETTING_ENTRY_LENGTH * settings.size();
@@ -316,39 +313,40 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 buf.writeChar(entry.key());
                 buf.writeInt(entry.value().intValue());
             }
-            return ctx.write(buf).cascadeTo(promise);
+            return ctx.write(buf);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            return ctx.newFailedFuture(t);
         }
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
+    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx) {
         try {
             ByteBuf buf = ctx.alloc().buffer(FRAME_HEADER_LENGTH);
             writeFrameHeaderInternal(buf, 0, SETTINGS, new Http2Flags().ack(true), 0);
-            return ctx.write(buf).cascadeTo(promise);
+            return ctx.write(buf);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            return ctx.newFailedFuture(t);
         }
     }
 
     @Override
-    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
+    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data) {
         Http2Flags flags = ack ? new Http2Flags().ack(true) : new Http2Flags();
         ByteBuf buf = ctx.alloc().buffer(FRAME_HEADER_LENGTH + PING_FRAME_PAYLOAD_LENGTH);
         // Assume nothing below will throw until buf is written. That way we don't have to take care of ownership
         // in the catch block.
         writeFrameHeaderInternal(buf, PING_FRAME_PAYLOAD_LENGTH, PING, flags, 0);
         buf.writeLong(data);
-        return ctx.write(buf).cascadeTo(promise);
+        return ctx.write(buf);
     }
 
     @Override
     public Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-                                         Http2Headers headers, int padding, Promise<Void> promise) {
+                                         Http2Headers headers, int padding) {
         ByteBuf headerBlock = null;
-        SimpleChannelPromiseAggregator promiseAggregator = new SimpleChannelPromiseAggregator(promise, ctx.executor());
+        SimpleChannelPromiseAggregator promiseAggregator =
+                new SimpleChannelPromiseAggregator(ctx.newPromise(), ctx.executor());
         try {
             verifyStreamId(streamId, STREAM_ID);
             verifyStreamId(promisedStreamId, "Promised Stream ID");
@@ -403,8 +401,9 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
     @Override
     public Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, Promise<Void> promise) {
-        SimpleChannelPromiseAggregator promiseAggregator = new SimpleChannelPromiseAggregator(promise, ctx.executor());
+            ByteBuf debugData) {
+        SimpleChannelPromiseAggregator promiseAggregator =
+                new SimpleChannelPromiseAggregator(ctx.newPromise(), ctx.executor());
         try {
             verifyStreamOrConnectionId(lastStreamId, "Last Stream ID");
             verifyErrorCode(errorCode);
@@ -437,7 +436,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
     @Override
     public Future<Void> writeWindowUpdate(ChannelHandlerContext ctx, int streamId,
-                                          int windowSizeIncrement, Promise<Void> promise) {
+                                          int windowSizeIncrement) {
         try {
             verifyStreamOrConnectionId(streamId, STREAM_ID);
             verifyWindowSizeIncrement(windowSizeIncrement);
@@ -445,16 +444,17 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             ByteBuf buf = ctx.alloc().buffer(WINDOW_UPDATE_FRAME_LENGTH);
             writeFrameHeaderInternal(buf, INT_FIELD_LENGTH, WINDOW_UPDATE, new Http2Flags(), streamId);
             buf.writeInt(windowSizeIncrement);
-            return ctx.write(buf).cascadeTo(promise);
+            return ctx.write(buf);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            return ctx.newFailedFuture(t);
         }
     }
 
     @Override
     public Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-                                   Http2Flags flags, ByteBuf payload, Promise<Void> promise) {
-        SimpleChannelPromiseAggregator promiseAggregator = new SimpleChannelPromiseAggregator(promise, ctx.executor());
+                                   Http2Flags flags, ByteBuf payload) {
+        SimpleChannelPromiseAggregator promiseAggregator =
+                new SimpleChannelPromiseAggregator(ctx.newPromise(), ctx.executor());
         try {
             verifyStreamOrConnectionId(streamId, STREAM_ID);
             ByteBuf buf = ctx.alloc().buffer(FRAME_HEADER_LENGTH);
@@ -481,9 +481,10 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
     private Future<Void> writeHeadersInternal(ChannelHandlerContext ctx,
             int streamId, Http2Headers headers, int padding, boolean endStream,
-            boolean hasPriority, int streamDependency, short weight, boolean exclusive, Promise<Void> promise) {
+            boolean hasPriority, int streamDependency, short weight, boolean exclusive) {
         ByteBuf headerBlock = null;
-        SimpleChannelPromiseAggregator promiseAggregator = new SimpleChannelPromiseAggregator(promise, ctx.executor());
+        SimpleChannelPromiseAggregator promiseAggregator =
+                new SimpleChannelPromiseAggregator(ctx.newPromise(), ctx.executor());
         try {
             verifyStreamId(streamId, STREAM_ID);
             if (hasPriority) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -483,7 +483,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
             }
 
             // Send a window update for the stream/connection.
-            frameWriter.writeWindowUpdate(ctx, stream.id(), deltaWindowSize, ctx.newPromise());
+            frameWriter.writeWindowUpdate(ctx, stream.id(), deltaWindowSize);
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -253,6 +253,8 @@ public interface Http2Connection {
      * all streams that exists (active or otherwise) will be closed and removed.
      * <p>Note if iterating active streams via {@link #forEachActiveStream(Http2StreamVisitor)} and an exception is
      * thrown it is necessary to call this method again to ensure the close completes.
+     *
+     * @param promise Will be completed when all streams have been removed, and listeners have been notified.
      */
     void close(Promise<Void> promise);
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -253,10 +253,8 @@ public interface Http2Connection {
      * all streams that exists (active or otherwise) will be closed and removed.
      * <p>Note if iterating active streams via {@link #forEachActiveStream(Http2StreamVisitor)} and an exception is
      * thrown it is necessary to call this method again to ensure the close completes.
-     * @param promise Will be completed when all streams have been removed, and listeners have been notified.
-     * @return A future that will be completed when all streams have been removed, and listeners have been notified.
      */
-    Future<Void> close(Promise<Void> promise);
+    void close(Promise<Void> promise);
 
     /**
      * Creates a new key that is unique within this {@link Http2Connection}.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
@@ -61,9 +61,8 @@ public interface Http2ConnectionEncoder extends Http2FrameWriter {
     /**
      * Writes the given data to the internal {@link Http2FrameWriter} without performing any
      * state checks on the connection/stream.
-     * @return
      */
     @Override
     Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-                            Http2Flags flags, ByteBuf payload, Promise<Void> promise);
+                            Http2Flags flags, ByteBuf payload);
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -49,38 +48,53 @@ final class Http2ControlFrameLimitEncoder extends DecoratingHttp2ConnectionEncod
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
-        Promise<Void> newPromise = handleOutstandingControlFrames(ctx, promise);
-        if (newPromise == null) {
-            return promise;
+    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx) {
+        try {
+            FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
+            Future<Void> f = super.writeSettingsAck(ctx);
+            if (listener != null) {
+                f.addListener(listener);
+            }
+            return f;
+        } catch (Http2Exception e) {
+            return ctx.newFailedFuture(e);
         }
-        return super.writeSettingsAck(ctx, newPromise);
     }
 
     @Override
-    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
+    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data) {
         // Only apply the limit to ping acks.
         if (ack) {
-            Promise<Void> newPromise = handleOutstandingControlFrames(ctx, promise);
-            if (newPromise == null) {
-                return promise;
+            try {
+                FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
+                Future<Void> f = super.writePing(ctx, ack, data);
+                if (listener != null) {
+                    f.addListener(listener);
+                }
+                return f;
+            } catch (Http2Exception e) {
+                return ctx.newFailedFuture(e);
             }
-            return super.writePing(ctx, ack, data, newPromise);
         }
-        return super.writePing(ctx, ack, data, promise);
+        return super.writePing(ctx, ack, data);
     }
 
     @Override
     public Future<Void> writeRstStream(
-            ChannelHandlerContext ctx, int streamId, long errorCode, Promise<Void> promise) {
-        Promise<Void> newPromise = handleOutstandingControlFrames(ctx, promise);
-        if (newPromise == null) {
-            return promise;
+            ChannelHandlerContext ctx, int streamId, long errorCode) {
+        try {
+            FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
+            Future<Void> f = super.writeRstStream(ctx, streamId, errorCode);
+            if (listener != null) {
+                f.addListener(listener);
+            }
+            return f;
+        } catch (Http2Exception e) {
+            return ctx.newFailedFuture(e);
         }
-        return super.writeRstStream(ctx, streamId, errorCode, newPromise);
     }
 
-    private Promise<Void> handleOutstandingControlFrames(ChannelHandlerContext ctx, Promise<Void> promise) {
+    private FutureListener<Void> handleOutstandingControlFrames(ChannelHandlerContext ctx) throws Http2Exception {
         if (!limitReached) {
             if (outstandingControlFrames == maxOutstandingControlFrames) {
                 // Let's try to flush once as we may be able to flush some of the control frames.
@@ -96,13 +110,14 @@ final class Http2ControlFrameLimitEncoder extends DecoratingHttp2ConnectionEncod
                 // First notify the Http2LifecycleManager and then close the connection.
                 lifecycleManager.onError(ctx, true, exception);
                 ctx.close();
+                return null;
             }
             outstandingControlFrames++;
 
             // We did not reach the limit yet, add the listener to decrement the number of outstanding control frames
             // once the promise was completed
-            promise.addListener(outstandingControlFramesListener);
+            return outstandingControlFramesListener;
         }
-        return promise;
+        return null;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
@@ -49,32 +49,24 @@ final class Http2ControlFrameLimitEncoder extends DecoratingHttp2ConnectionEncod
 
     @Override
     public Future<Void> writeSettingsAck(ChannelHandlerContext ctx) {
-        try {
-            FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
-            Future<Void> f = super.writeSettingsAck(ctx);
-            if (listener != null) {
-                f.addListener(listener);
-            }
-            return f;
-        } catch (Http2Exception e) {
-            return ctx.newFailedFuture(e);
+        FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
+        Future<Void> f = super.writeSettingsAck(ctx);
+        if (listener != null) {
+            f.addListener(listener);
         }
+        return f;
     }
 
     @Override
     public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data) {
         // Only apply the limit to ping acks.
         if (ack) {
-            try {
-                FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
-                Future<Void> f = super.writePing(ctx, ack, data);
-                if (listener != null) {
-                    f.addListener(listener);
-                }
-                return f;
-            } catch (Http2Exception e) {
-                return ctx.newFailedFuture(e);
+            FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
+            Future<Void> f = super.writePing(ctx, ack, data);
+            if (listener != null) {
+                f.addListener(listener);
             }
+            return f;
         }
         return super.writePing(ctx, ack, data);
     }
@@ -82,19 +74,15 @@ final class Http2ControlFrameLimitEncoder extends DecoratingHttp2ConnectionEncod
     @Override
     public Future<Void> writeRstStream(
             ChannelHandlerContext ctx, int streamId, long errorCode) {
-        try {
-            FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
-            Future<Void> f = super.writeRstStream(ctx, streamId, errorCode);
-            if (listener != null) {
-                f.addListener(listener);
-            }
-            return f;
-        } catch (Http2Exception e) {
-            return ctx.newFailedFuture(e);
+        FutureListener<Void> listener = handleOutstandingControlFrames(ctx);
+        Future<Void> f = super.writeRstStream(ctx, streamId, errorCode);
+        if (listener != null) {
+            f.addListener(listener);
         }
+        return f;
     }
 
-    private FutureListener<Void> handleOutstandingControlFrames(ChannelHandlerContext ctx) throws Http2Exception {
+    private FutureListener<Void> handleOutstandingControlFrames(ChannelHandlerContext ctx) {
         if (!limitReached) {
             if (outstandingControlFrames == maxOutstandingControlFrames) {
                 // Let's try to flush once as we may be able to flush some of the control frames.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
@@ -37,9 +37,8 @@ public interface Http2DataWriter {
      *                A 256 byte padding is encoded as the pad length field with value 255 and 255 padding bytes
      *                appended to the end of the frame.
      * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
     Future<Void> writeData(ChannelHandlerContext ctx, int streamId,
-                     ByteBuf data, int padding, boolean endStream, Promise<Void> promise);
+                     ByteBuf data, int padding, boolean endStream);
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.Closeable;
@@ -54,7 +53,6 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
      *                256 (inclusive).
      * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param promise the promise for the write.
      * @return the future for the write.
      * <a href="https://tools.ietf.org/html/rfc7540#section-10.5.1">Section 10.5.1</a> states the following:
      * <pre>
@@ -65,7 +63,7 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * If this call has <strong>NOT</strong> modified the HPACK header state you are free to throw a stream error.
      */
     Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-                        int padding, boolean endStream, Promise<Void> promise);
+                        int padding, boolean endStream);
 
     /**
      * Writes a HEADERS frame with priority specified to the remote endpoint.
@@ -80,7 +78,6 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
      *                256 (inclusive).
      * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param promise the promise for the write.
      * @return the future for the write.
      * <a href="https://tools.ietf.org/html/rfc7540#section-10.5.1">Section 10.5.1</a> states the following:
      * <pre>
@@ -91,8 +88,7 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * If this call has <strong>NOT</strong> modified the HPACK header state you are free to throw a stream error.
      */
     Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-                               int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
-                               Promise<Void> promise);
+                               int streamDependency, short weight, boolean exclusive, int padding, boolean endStream);
 
     /**
      * Writes a PRIORITY frame to the remote endpoint.
@@ -103,11 +99,10 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      *            depend on the connection.
      * @param weight the weight for this stream.
      * @param exclusive whether this stream should be the exclusive dependant of its parent.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
     Future<Void> writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency,
-            short weight, boolean exclusive, Promise<Void> promise);
+            short weight, boolean exclusive);
 
     /**
      * Writes a RST_STREAM frame to the remote endpoint.
@@ -115,31 +110,26 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param ctx the context to use for writing.
      * @param streamId the stream for which to send the frame.
      * @param errorCode the error code indicating the nature of the failure.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
-    Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-            Promise<Void> promise);
+    Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode);
 
     /**
      * Writes a SETTINGS frame to the remote endpoint.
      *
      * @param ctx the context to use for writing.
      * @param settings the settings to be sent.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
-    Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
-            Promise<Void> promise);
+    Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings);
 
     /**
      * Writes a SETTINGS acknowledgment to the remote endpoint.
      *
      * @param ctx the context to use for writing.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
-    Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise);
+    Future<Void> writeSettingsAck(ChannelHandlerContext ctx);
 
     /**
      * Writes a PING frame to the remote endpoint.
@@ -148,11 +138,9 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param ack indicates whether this is an ack of a PING frame previously received from the
      *            remote endpoint.
      * @param data the payload of the frame.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
-    Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data,
-            Promise<Void> promise);
+    Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data);
 
     /**
      * Writes a PUSH_PROMISE frame to the remote endpoint.
@@ -163,7 +151,6 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param headers the headers to be sent.
      * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
      *                256 (inclusive).
-     * @param promise the promise for the write.
      * @return the future for the write.
      * <a href="https://tools.ietf.org/html/rfc7540#section-10.5.1">Section 10.5.1</a> states the following:
      * <pre>
@@ -174,7 +161,7 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * If this call has <strong>NOT</strong> modified the HPACK header state you are free to throw a stream error.
      */
     Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-                                   Http2Headers headers, int padding, Promise<Void> promise);
+                                   Http2Headers headers, int padding);
 
     /**
      * Writes a GO_AWAY frame to the remote endpoint.
@@ -183,11 +170,10 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param lastStreamId the last known stream of this endpoint.
      * @param errorCode the error code, if the connection was abnormally terminated.
      * @param debugData application-defined debug data. This will be released by this method.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
     Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, Promise<Void> promise);
+            ByteBuf debugData);
 
     /**
      * Writes a WINDOW_UPDATE frame to the remote endpoint.
@@ -196,11 +182,10 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param streamId the stream for which to send the frame.
      * @param windowSizeIncrement the number of bytes by which the local inbound flow control window
      *            is increasing.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
     Future<Void> writeWindowUpdate(ChannelHandlerContext ctx, int streamId,
-            int windowSizeIncrement, Promise<Void> promise);
+            int windowSizeIncrement);
 
     /**
      * Generic write method for any HTTP/2 frame. This allows writing of non-standard frames.
@@ -210,11 +195,10 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param streamId the stream for which to send the frame.
      * @param flags the flags to write for this frame.
      * @param payload the payload to write for this frame. This will be released by this method.
-     * @param promise the promise for the write.
      * @return the future for the write.
      */
     Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-            Http2Flags flags, ByteBuf payload, Promise<Void> promise);
+            Http2Flags flags, ByteBuf payload);
 
     /**
      * Get the configuration related elements for this {@link Http2FrameWriter}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
@@ -59,13 +59,11 @@ public interface Http2LifecycleManager {
      * @param ctx The context used for communication and buffer allocation if necessary.
      * @param streamId The identifier of the stream to reset.
      * @param errorCode Justification as to why this stream is being reset. See {@link Http2Error}.
-     * @param promise Used to indicate the return status of this operation.
      * @return Will be considered successful when the connection and stream state has been updated, and a
      * {@code RST_STREAM} frame has been sent to the peer. If the stream state has already been updated and a
      * {@code RST_STREAM} frame has been sent then the return status may indicate success immediately.
      */
-    Future<Void> resetStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-            Promise<Void> promise);
+    Future<Void> resetStream(ChannelHandlerContext ctx, int streamId, long errorCode);
 
     /**
      * Prevents the peer from creating streams and close the connection if {@code errorCode} is not
@@ -78,13 +76,12 @@ public interface Http2LifecycleManager {
      * @param lastStreamId The last stream that the local endpoint is claiming it will accept.
      * @param errorCode The rational as to why the connection is being closed. See {@link Http2Error}.
      * @param debugData For diagnostic purposes (carries no semantic value).
-     * @param promise Used to indicate the return status of this operation.
      * @return Will be considered successful when the connection and stream state has been updated, and a
      * {@code GO_AWAY} frame has been sent to the peer. If the stream state has already been updated and a
      * {@code GO_AWAY} frame has been sent then the return status may indicate success immediately.
      */
     Future<Void> goAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, Promise<Void> promise);
+            ByteBuf debugData);
 
     /**
      * Processes the given error.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.UnstableApi;
 
 import static io.netty.handler.codec.http2.Http2FrameLogger.Direction.OUTBOUND;
@@ -40,93 +39,92 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
 
     @Override
     public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-                                  int padding, boolean endStream, Promise<Void> promise) {
+                                  int padding, boolean endStream) {
         logger.logData(OUTBOUND, ctx, streamId, data, padding, endStream);
-        return writer.writeData(ctx, streamId, data, padding, endStream, promise);
+        return writer.writeData(ctx, streamId, data, padding, endStream);
     }
 
     @Override
     public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId,
-                                     Http2Headers headers, int padding, boolean endStream, Promise<Void> promise) {
+                                     Http2Headers headers, int padding, boolean endStream) {
         logger.logHeaders(OUTBOUND, ctx, streamId, headers, padding, endStream);
-        return writer.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
+        return writer.writeHeaders(ctx, streamId, headers, padding, endStream);
     }
 
     @Override
     public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId,
                                      Http2Headers headers, int streamDependency, short weight, boolean exclusive,
-                                     int padding, boolean endStream, Promise<Void> promise) {
+                                     int padding, boolean endStream) {
         logger.logHeaders(OUTBOUND, ctx, streamId, headers, streamDependency, weight, exclusive,
                 padding, endStream);
         return writer.writeHeaders(ctx, streamId, headers, streamDependency, weight,
-                exclusive, padding, endStream, promise);
+                exclusive, padding, endStream);
     }
 
     @Override
     public Future<Void> writePriority(ChannelHandlerContext ctx, int streamId,
-                                      int streamDependency, short weight, boolean exclusive, Promise<Void> promise) {
+                                      int streamDependency, short weight, boolean exclusive) {
         logger.logPriority(OUTBOUND, ctx, streamId, streamDependency, weight, exclusive);
-        return writer.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
+        return writer.writePriority(ctx, streamId, streamDependency, weight, exclusive);
     }
 
     @Override
     public Future<Void> writeRstStream(ChannelHandlerContext ctx,
-                                       int streamId, long errorCode, Promise<Void> promise) {
+                                       int streamId, long errorCode) {
         logger.logRstStream(OUTBOUND, ctx, streamId, errorCode);
-        return writer.writeRstStream(ctx, streamId, errorCode, promise);
+        return writer.writeRstStream(ctx, streamId, errorCode);
     }
 
     @Override
     public Future<Void> writeSettings(ChannelHandlerContext ctx,
-                                      Http2Settings settings, Promise<Void> promise) {
+                                      Http2Settings settings) {
         logger.logSettings(OUTBOUND, ctx, settings);
-        return writer.writeSettings(ctx, settings, promise);
+        return writer.writeSettings(ctx, settings);
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
+    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx) {
         logger.logSettingsAck(OUTBOUND, ctx);
-        return writer.writeSettingsAck(ctx, promise);
+        return writer.writeSettingsAck(ctx);
     }
 
     @Override
     public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack,
-                                  long data, Promise<Void> promise) {
+                                  long data) {
         if (ack) {
             logger.logPingAck(OUTBOUND, ctx, data);
         } else {
             logger.logPing(OUTBOUND, ctx, data);
         }
-        return writer.writePing(ctx, ack, data, promise);
+        return writer.writePing(ctx, ack, data);
     }
 
     @Override
     public Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId,
-                                         int promisedStreamId, Http2Headers headers, int padding,
-                                         Promise<Void> promise) {
+                                         int promisedStreamId, Http2Headers headers, int padding) {
         logger.logPushPromise(OUTBOUND, ctx, streamId, promisedStreamId, headers, padding);
-        return writer.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
+        return writer.writePushPromise(ctx, streamId, promisedStreamId, headers, padding);
     }
 
     @Override
     public Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, Promise<Void> promise) {
+            ByteBuf debugData) {
         logger.logGoAway(OUTBOUND, ctx, lastStreamId, errorCode, debugData);
-        return writer.writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
+        return writer.writeGoAway(ctx, lastStreamId, errorCode, debugData);
     }
 
     @Override
     public Future<Void> writeWindowUpdate(ChannelHandlerContext ctx,
-                                          int streamId, int windowSizeIncrement, Promise<Void> promise) {
+                                          int streamId, int windowSizeIncrement) {
         logger.logWindowsUpdate(OUTBOUND, ctx, streamId, windowSizeIncrement);
-        return writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement, promise);
+        return writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement);
     }
 
     @Override
     public Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-                                   Http2Flags flags, ByteBuf payload, Promise<Void> promise) {
+                                   Http2Flags flags, ByteBuf payload) {
         logger.logUnknownFrame(OUTBOUND, ctx, frameType, streamId, flags, payload);
-        return writer.writeFrame(ctx, frameType, streamId, flags, payload, promise);
+        return writer.writeFrame(ctx, frameType, streamId, flags, payload);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -133,7 +133,6 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
                     // Write trailing headers.
                     writeHeaders(ctx, encoder, currentStreamId, trailers, http2Trailers, true)
                             .cascadeTo(promiseAggregator.newPromise());
-
                 }
             }
         } catch (Throwable t) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -106,7 +106,7 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
                 Http2Headers http2Headers = HttpConversionUtil.toHttp2Headers(httpMsg, validateHeaders);
                 endStream = msg instanceof FullHttpMessage && !((FullHttpMessage) msg).content().isReadable();
                 writeHeaders(ctx, encoder, currentStreamId, httpMsg.headers(), http2Headers,
-                        endStream, promiseAggregator);
+                        endStream).cascadeTo(promiseAggregator.newPromise());
             }
 
             if (!endStream && msg instanceof HttpContent) {
@@ -125,12 +125,15 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
                 // Write the data
                 final ByteBuf content = ((HttpContent) msg).content();
                 endStream = isLastContent && trailers.isEmpty();
-                encoder.writeData(ctx, currentStreamId, content, 0, endStream, promiseAggregator.newPromise());
+                encoder.writeData(ctx, currentStreamId, content, 0, endStream)
+                        .cascadeTo(promiseAggregator.newPromise());
                 release = false;
 
                 if (!trailers.isEmpty()) {
                     // Write trailing headers.
-                    writeHeaders(ctx, encoder, currentStreamId, trailers, http2Trailers, true, promiseAggregator);
+                    writeHeaders(ctx, encoder, currentStreamId, trailers, http2Trailers, true)
+                            .cascadeTo(promiseAggregator.newPromise());
+
                 }
             }
         } catch (Throwable t) {
@@ -145,14 +148,13 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
         return promise;
     }
 
-    private static void writeHeaders(ChannelHandlerContext ctx, Http2ConnectionEncoder encoder, int streamId,
-                                     HttpHeaders headers, Http2Headers http2Headers, boolean endStream,
-                                     SimpleChannelPromiseAggregator promiseAggregator) {
+    private static Future<Void> writeHeaders(ChannelHandlerContext ctx, Http2ConnectionEncoder encoder, int streamId,
+                                     HttpHeaders headers, Http2Headers http2Headers, boolean endStream) {
         int dependencyId = headers.getInt(
                 HttpConversionUtil.ExtensionHeaderNames.STREAM_DEPENDENCY_ID.text(), 0);
         short weight = headers.getShort(
                 HttpConversionUtil.ExtensionHeaderNames.STREAM_WEIGHT.text(), Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT);
-        encoder.writeHeaders(ctx, streamId, http2Headers, dependencyId, weight, false,
-                0, endStream, promiseAggregator.newPromise());
+        return encoder.writeHeaders(ctx, streamId, http2Headers, dependencyId, weight, false,
+                0, endStream);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -139,7 +139,7 @@ public class DataCompressionHttp2Test {
                 .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.GZIP);
 
         runInChannel(clientChannel, () -> {
-            clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, true, newPromiseClient());
+            clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, true);
             clientHandler.flush(ctxClient());
         });
         awaitServer();
@@ -157,8 +157,8 @@ public class DataCompressionHttp2Test {
                     .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.GZIP);
 
             runInChannel(clientChannel, () -> {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true);
                 clientHandler.flush(ctxClient());
             });
             awaitServer();
@@ -178,8 +178,8 @@ public class DataCompressionHttp2Test {
                     .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.GZIP);
 
             runInChannel(clientChannel, () -> {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true);
                 clientHandler.flush(ctxClient());
             });
             awaitServer();
@@ -201,9 +201,9 @@ public class DataCompressionHttp2Test {
                     .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.GZIP);
 
             runInChannel(clientChannel, () -> {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data1.retain(), 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data2.retain(), 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data1.retain(), 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data2.retain(), 0, true);
                 clientHandler.flush(ctxClient());
             });
             awaitServer();
@@ -224,8 +224,8 @@ public class DataCompressionHttp2Test {
                     .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.BR);
 
             runInChannel(clientChannel, () -> {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true);
                 clientHandler.flush(ctxClient());
             });
             awaitServer();
@@ -245,8 +245,8 @@ public class DataCompressionHttp2Test {
                     .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.BR);
 
             runInChannel(clientChannel, () -> {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true);
                 clientHandler.flush(ctxClient());
             });
             awaitServer();
@@ -266,8 +266,8 @@ public class DataCompressionHttp2Test {
                     .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.ZSTD);
 
             runInChannel(clientChannel, () -> {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true);
                 clientHandler.flush(ctxClient());
             });
             awaitServer();
@@ -287,8 +287,8 @@ public class DataCompressionHttp2Test {
                     .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.ZSTD);
 
             runInChannel(clientChannel, () -> {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true);
                 clientHandler.flush(ctxClient());
             });
             awaitServer();
@@ -310,8 +310,8 @@ public class DataCompressionHttp2Test {
                     .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.DEFLATE);
 
             runInChannel(clientChannel, () -> {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false);
+                clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true);
                 clientHandler.flush(ctxClient());
             });
             awaitServer();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -79,7 +79,6 @@ public class DefaultHttp2ConnectionDecoderTest {
     private static final int STATE_RECV_TRAILERS = 1 << 1;
 
     private Http2ConnectionDecoder decoder;
-    private Promise<Void> promise;
 
     @Mock
     private Http2Connection connection;
@@ -130,7 +129,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        promise = new DefaultPromise<>(ImmediateEventExecutor.INSTANCE);
+        Promise<Void> promise = new DefaultPromise<>(ImmediateEventExecutor.INSTANCE);
 
         final AtomicInteger headersReceivedState = new AtomicInteger();
         when(channel.isActive()).thenReturn(true);
@@ -209,7 +208,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         decode().onSettingsRead(ctx, new Http2Settings());
         verify(listener).onSettingsRead(eq(ctx), eq(new Http2Settings()));
         assertTrue(decoder.prefaceReceived());
-        verify(encoder).writeSettingsAck(eq(ctx), eq(promise));
+        verify(encoder).writeSettingsAck(eq(ctx));
 
         // Simulate receiving the SETTINGS ACK for the initial settings.
         decode().onSettingsAckRead(ctx);
@@ -793,7 +792,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     @Test
     public void pingReadShouldReplyWithAck() throws Exception {
         decode().onPingRead(ctx, 0L);
-        verify(encoder).writePing(eq(ctx), eq(true), eq(0L), eq(promise));
+        verify(encoder).writePing(eq(ctx), eq(true), eq(0L));
         verify(listener, never()).onPingAckRead(eq(ctx), any(long.class));
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -22,7 +22,6 @@ import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.local.LocalHandler;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
 import io.netty.handler.codec.http2.Http2Stream.State;
-import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -634,7 +633,6 @@ public class DefaultHttp2ConnectionTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final Promise<Void> promise = group.next().newPromise();
         client.close(promise.addListener(future -> {
-            assertTrue(promise.isDone());
             latch.countDown();
         }));
         assertTrue(latch.await(5, TimeUnit.SECONDS));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -22,7 +22,6 @@ import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.local.LocalHandler;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
 import io.netty.handler.codec.http2.Http2Stream.State;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterAll;
@@ -157,10 +156,9 @@ public class DefaultHttp2ConnectionTest {
         final Promise<Void> promise = group.next().newPromise();
         final CountDownLatch latch = new CountDownLatch(client.numActiveStreams());
         client.forEachActiveStream(stream -> {
-            client.close(promise).addListener((FutureListener<Void>) future -> {
-                assertTrue(promise.isDone());
+            client.close(promise.addListener(future -> {
                 latch.countDown();
-            });
+            }));
             return true;
         });
         assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -186,10 +184,9 @@ public class DefaultHttp2ConnectionTest {
                 return true;
             });
         } catch (Http2Exception ignored) {
-            client.close(promise).addListener((FutureListener<Void>) future -> {
-                assertTrue(promise.isDone());
+            client.close(promise.addListener(future -> {
                 latch.countDown();
-            });
+            }));
         }
         assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
@@ -636,10 +633,10 @@ public class DefaultHttp2ConnectionTest {
     private void testRemoveAllStreams() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final Promise<Void> promise = group.next().newPromise();
-        client.close(promise).addListener((FutureListener<Void>) future -> {
+        client.close(promise.addListener(future -> {
             assertTrue(promise.isDone());
             latch.countDown();
-        });
+        }));
         assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -417,17 +417,16 @@ public class DefaultHttp2LocalFlowControllerTest {
     }
 
     private void verifyWindowUpdateSent(int streamId, int windowSizeIncrement) {
-        verify(frameWriter).writeWindowUpdate(eq(ctx), eq(streamId), eq(windowSizeIncrement), eq(promise));
+        verify(frameWriter).writeWindowUpdate(eq(ctx), eq(streamId), eq(windowSizeIncrement));
     }
 
     private void verifyWindowUpdateNotSent(int streamId) {
-        verify(frameWriter, never()).writeWindowUpdate(eq(ctx), eq(streamId), anyInt(), eq(promise));
+        verify(frameWriter, never()).writeWindowUpdate(eq(ctx), eq(streamId), anyInt());
     }
 
     @SuppressWarnings("unchecked")
     private void verifyWindowUpdateNotSent() {
-        verify(frameWriter, never()).writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(), anyInt(),
-                any(Promise.class));
+        verify(frameWriter, never()).writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(), anyInt());
     }
 
     private int window(int streamId) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -32,7 +32,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.PromiseNotifier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -170,7 +169,6 @@ public class Http2ConnectionHandlerTest {
         }).when(future).addListener(any(FutureListener.class));
         when(future.cause()).thenReturn(fakeException);
         when(channel.isActive()).thenReturn(true);
-        //when(future.isDone()).thenReturn(true);
         when(future.isFailed()).thenReturn(true);
         when(channel.pipeline()).thenReturn(pipeline);
         when(connection.remote()).thenReturn(remote);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -32,6 +32,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.PromiseNotifier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,8 +56,10 @@ import static io.netty.handler.codec.http2.Http2Stream.State.IDLE;
 import static io.netty.util.CharsetUtil.US_ASCII;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
@@ -157,7 +160,7 @@ public class Http2ConnectionHandlerTest {
             buf.release();
             return future;
         }).when(frameWriter).writeGoAway(
-                any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class), any(Promise.class));
+                any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class));
         doAnswer((Answer<Future<Void>>) invocation -> {
             Object o = invocation.getArguments()[0];
             if (o instanceof FutureListener) {
@@ -167,6 +170,8 @@ public class Http2ConnectionHandlerTest {
         }).when(future).addListener(any(FutureListener.class));
         when(future.cause()).thenReturn(fakeException);
         when(channel.isActive()).thenReturn(true);
+        //when(future.isDone()).thenReturn(true);
+        when(future.isFailed()).thenReturn(true);
         when(channel.pipeline()).thenReturn(pipeline);
         when(connection.remote()).thenReturn(remote);
         when(remote.flowController()).thenReturn(remoteFlowController);
@@ -185,10 +190,13 @@ public class Http2ConnectionHandlerTest {
         when(connection.goAwaySent(anyInt(), anyLong(), any(ByteBuf.class))).thenReturn(true);
         when(stream.open(anyBoolean())).thenReturn(stream);
         when(encoder.writeSettings(any(ChannelHandlerContext.class),
-                any(Http2Settings.class), eq(promise))).thenReturn(future);
+                any(Http2Settings.class))).thenReturn(future);
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(ctx.channel()).thenReturn(channel);
-        when(ctx.newSucceededFuture()).thenReturn(future);
+        when(ctx.newFailedFuture(any(Throwable.class)))
+                .thenAnswer(invocationOnMock ->
+                        DefaultPromise.newFailedPromise(executor, invocationOnMock.getArgument(0)));
+        when(ctx.newSucceededFuture()).thenReturn(DefaultPromise.newSuccessfulPromise(executor, null));
         when(ctx.newPromise()).thenReturn(promise);
         when(ctx.write(any())).thenReturn(future);
         when(ctx.executor()).thenReturn(executor);
@@ -254,7 +262,7 @@ public class Http2ConnectionHandlerTest {
         final Answer<Object> verifier = in -> {
             assertEquals(in.getArgument(0), evt);  // sanity check...
             verify(ctx).write(eq(connectionPrefaceBuf()));
-            verify(encoder).writeSettings(eq(ctx), any(Http2Settings.class), any(Promise.class));
+            verify(encoder).writeSettings(eq(ctx), any(Http2Settings.class));
             verified.set(true);
             return null;
         };
@@ -292,7 +300,7 @@ public class Http2ConnectionHandlerTest {
         handler.channelRead(ctx, copiedBuffer("BAD_PREFACE", UTF_8));
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeGoAway(any(ChannelHandlerContext.class),
-                eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()), captor.capture(), eq(promise));
+                eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()), captor.capture());
         assertEquals(0, captor.getValue().refCnt());
     }
 
@@ -303,7 +311,7 @@ public class Http2ConnectionHandlerTest {
         handler.channelRead(ctx, copiedBuffer("GET /path HTTP/1.1", US_ASCII));
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeGoAway(any(ChannelHandlerContext.class), eq(Integer.MAX_VALUE),
-                eq(PROTOCOL_ERROR.code()), captor.capture(), eq(promise));
+                eq(PROTOCOL_ERROR.code()), captor.capture());
         assertEquals(0, captor.getValue().refCnt());
         assertTrue(goAwayDebugCap.contains("/path"));
     }
@@ -319,7 +327,7 @@ public class Http2ConnectionHandlerTest {
         handler.channelRead(ctx, buf);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter, atLeastOnce()).writeGoAway(any(ChannelHandlerContext.class),
-                eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()), captor.capture(), eq(promise));
+                eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()), captor.capture());
         assertEquals(0, captor.getValue().refCnt());
     }
 
@@ -373,7 +381,7 @@ public class Http2ConnectionHandlerTest {
         handler.exceptionCaught(ctx, e);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()),
-                captor.capture(), eq(promise));
+                captor.capture());
         captor.getValue().release();
     }
 
@@ -389,16 +397,16 @@ public class Http2ConnectionHandlerTest {
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
-                eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+                eq(PROTOCOL_ERROR.code()))).thenReturn(future);
 
         handler.exceptionCaught(ctx, e);
 
         ArgumentCaptor<Http2Headers> captor = ArgumentCaptor.forClass(Http2Headers.class);
         verify(encoder).writeHeaders(eq(ctx), eq(STREAM_ID),
-                captor.capture(), eq(padding), eq(true), eq(promise));
+                captor.capture(), eq(padding), eq(true));
         Http2Headers headers = captor.getValue();
         assertEquals(HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE.codeAsText(), headers.status());
-        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code());
     }
 
     @Test
@@ -413,13 +421,13 @@ public class Http2ConnectionHandlerTest {
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
-            eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+            eq(PROTOCOL_ERROR.code()))).thenReturn(future);
 
         handler.exceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
-            any(Http2Headers.class), eq(padding), eq(true), eq(promise));
-        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+            any(Http2Headers.class), eq(padding), eq(true));
+        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code());
     }
 
     @Test
@@ -434,13 +442,13 @@ public class Http2ConnectionHandlerTest {
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
-                eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+                eq(PROTOCOL_ERROR.code()))).thenReturn(future);
 
         handler.exceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
-                any(Http2Headers.class), eq(padding), eq(true), eq(promise));
-        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+                any(Http2Headers.class), eq(padding), eq(true));
+        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code());
     }
 
     @Test
@@ -448,7 +456,7 @@ public class Http2ConnectionHandlerTest {
         final CountDownLatch latch = new CountDownLatch(1);
         handler = new Http2ConnectionHandler(decoder, encoder, new Http2Settings()) {
             @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
                     latch.countDown();
                 }
@@ -470,13 +478,13 @@ public class Http2ConnectionHandlerTest {
         when(stream.isHeadersSent()).thenReturn(true);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
-            eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+            eq(PROTOCOL_ERROR.code()))).thenReturn(future);
         handler.exceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
-            any(Http2Headers.class), eq(padding), eq(true), eq(promise));
+            any(Http2Headers.class), eq(padding), eq(true));
 
-        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code());
     }
 
     @Test
@@ -494,14 +502,14 @@ public class Http2ConnectionHandlerTest {
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
-            eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+            eq(PROTOCOL_ERROR.code()))).thenReturn(future);
         handler.exceptionCaught(ctx, e);
 
         verify(remote).createStream(STREAM_ID, true);
         verify(encoder).writeHeaders(eq(ctx), eq(STREAM_ID),
-            any(Http2Headers.class), eq(padding), eq(true), eq(promise));
+            any(Http2Headers.class), eq(padding), eq(true));
 
-        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+        verify(frameWriter).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code());
     }
 
     @Test
@@ -518,9 +526,9 @@ public class Http2ConnectionHandlerTest {
     public void writeRstOnNonExistantStreamShouldSucceed() throws Exception {
         handler = newHandler();
         when(frameWriter.writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID),
-                                        eq(STREAM_CLOSED.code()), eq(promise))).thenReturn(future);
-        handler.resetStream(ctx, NON_EXISTANT_STREAM_ID, STREAM_CLOSED.code(), promise);
-        verify(frameWriter).writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID), eq(STREAM_CLOSED.code()), eq(promise));
+                                        eq(STREAM_CLOSED.code()))).thenReturn(future);
+        handler.resetStream(ctx, NON_EXISTANT_STREAM_ID, STREAM_CLOSED.code());
+        verify(frameWriter).writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID), eq(STREAM_CLOSED.code()));
     }
 
     @Test
@@ -528,21 +536,21 @@ public class Http2ConnectionHandlerTest {
         handler = newHandler();
         when(stream.id()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
-                anyLong(), any(Promise.class))).thenReturn(future);
+                anyLong())).thenReturn(future);
         when(stream.state()).thenReturn(CLOSED);
         when(stream.isHeadersSent()).thenReturn(true);
         // The stream is "closed" but is still known about by the connection (connection().stream(..)
         // will return the stream). We should still write a RST_STREAM frame in this scenario.
-        handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise);
-        verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(Promise.class));
+        handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code());
+        verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong());
     }
 
     @Test
     public void writeRstOnIdleStreamShouldNotWriteButStillSucceed() throws Exception {
         handler = newHandler();
         when(stream.state()).thenReturn(IDLE);
-        handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise);
-        verify(frameWriter, never()).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(Promise.class));
+        handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code());
+        verify(frameWriter, never()).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong());
         verify(stream).close();
     }
 
@@ -585,11 +593,10 @@ public class Http2ConnectionHandlerTest {
             return null;
         }).when(future).addListener(any(FutureListener.class));
         handler = newHandler();
-        handler.goAway(ctx, STREAM_ID, errorCode, data, promise);
+        handler.goAway(ctx, STREAM_ID, errorCode, data);
 
         verify(connection).goAwaySent(eq(STREAM_ID), eq(errorCode), eq(data));
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data),
-                eq(promise));
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data));
         verify(ctx).close();
         assertEquals(0, data.refCnt());
     }
@@ -600,13 +607,12 @@ public class Http2ConnectionHandlerTest {
         ByteBuf data = dummyData();
         long errorCode = Http2Error.INTERNAL_ERROR.code();
 
-        handler.goAway(ctx, STREAM_ID + 2, errorCode, data.retain(), promise);
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID + 2), eq(errorCode), eq(data),
-                eq(promise));
+        handler.goAway(ctx, STREAM_ID + 2, errorCode, data.retain());
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID + 2), eq(errorCode), eq(data));
         verify(connection).goAwaySent(eq(STREAM_ID + 2), eq(errorCode), eq(data));
         promise = new DefaultPromise<>(ImmediateEventExecutor.INSTANCE);
-        handler.goAway(ctx, STREAM_ID, errorCode, data, promise);
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data), eq(promise));
+        handler.goAway(ctx, STREAM_ID, errorCode, data);
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data));
         verify(connection).goAwaySent(eq(STREAM_ID), eq(errorCode), eq(data));
         assertEquals(0, data.refCnt());
     }
@@ -617,20 +623,24 @@ public class Http2ConnectionHandlerTest {
         ByteBuf data = dummyData();
         long errorCode = Http2Error.INTERNAL_ERROR.code();
 
-        handler.goAway(ctx, STREAM_ID, errorCode, data.retain(), promise);
+        Future<Void> future = handler.goAway(ctx, STREAM_ID, errorCode, data.retain());
         verify(connection).goAwaySent(eq(STREAM_ID), eq(errorCode), eq(data));
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data), eq(promise));
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data));
         // The frameWriter is only mocked, so it should not have interacted with the promise.
-        assertFalse(promise.isDone());
+        assertFalse(future.isDone());
 
         when(connection.goAwaySent()).thenReturn(true);
         when(remote.lastStreamKnownByPeer()).thenReturn(STREAM_ID);
+
+        Exception ex = new IllegalStateException();
         doAnswer((Answer<Boolean>) invocationOnMock -> {
-            throw new IllegalStateException();
+            throw ex;
         }).when(connection).goAwaySent(anyInt(), anyLong(), any(ByteBuf.class));
-        handler.goAway(ctx, STREAM_ID + 2, errorCode, data, promise);
-        assertTrue(promise.isDone());
-        assertFalse(promise.isSuccess());
+        Future<Void> future2 = handler.goAway(ctx, STREAM_ID + 2, errorCode, data);
+        assertTrue(future2.isDone());
+        assertFalse(future2.isSuccess());
+        assertSame(ex, future2.cause());
+
         assertEquals(0, data.refCnt());
         verifyNoMoreInteractions(frameWriter);
     }
@@ -657,9 +667,8 @@ public class Http2ConnectionHandlerTest {
         when(channel.isActive()).thenReturn(false);
         handler.channelInactive(ctx);
         verify(frameWriter, never()).writeGoAway(any(ChannelHandlerContext.class), anyInt(), anyLong(),
-                                                 any(ByteBuf.class), any(Promise.class));
-        verify(frameWriter, never()).writeRstStream(any(ChannelHandlerContext.class), anyInt(), anyLong(),
-                                                    any(Promise.class));
+                                                 any(ByteBuf.class));
+        verify(frameWriter, never()).writeRstStream(any(ChannelHandlerContext.class), anyInt(), anyLong());
     }
 
     @Test
@@ -729,22 +738,14 @@ public class Http2ConnectionHandlerTest {
             return stream;
         });
         when(stream.isResetSent()).then((Answer<Boolean>) invocationOnMock -> resetSent.get());
-        when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(Promise.class)))
-                .then((Answer<Future<Void>>) invocationOnMock -> {
-                    Promise<Void> promise = invocationOnMock.getArgument(3);
-                    return promise.setSuccess(null);
-                });
+        when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID), anyLong()))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
 
-        Promise<Void> promise =
-                new DefaultPromise<>(ImmediateEventExecutor.INSTANCE);
-        final Promise<Void> promise2 =
-                new DefaultPromise<>(ImmediateEventExecutor.INSTANCE);
-        promise.addListener(future -> handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise2));
-
-        handler.resetStream(ctx, STREAM_ID, CANCEL.code(), promise);
-        verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(Promise.class));
-        assertTrue(promise.isSuccess());
-        assertTrue(promise2.isSuccess());
+        Future<Void> f1 = handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code());
+        Future<Void> f2 = handler.resetStream(ctx, STREAM_ID, CANCEL.code());
+        verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong());
+        assertTrue(f1.isSuccess());
+        assertTrue(f2.isSuccess());
     }
 
     private static ByteBuf dummyData() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
@@ -158,7 +158,7 @@ public class Http2ControlFrameLimitEncoderTest {
     private Promise<Void> handlePromise() {
         Promise<Void> p =  ImmediateEventExecutor.INSTANCE.newPromise();
         if (++numWrites == 2) {
-            return p.setSuccess(null);
+            p.setSuccess(null);
         }
         return p;
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -58,7 +58,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
 import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
-import static io.netty.handler.codec.http2.Http2TestUtil.anyChannelPromise;
 import static io.netty.handler.codec.http2.Http2TestUtil.anyHttp2Settings;
 import static io.netty.handler.codec.http2.Http2TestUtil.assertEqualsAndRelease;
 import static io.netty.handler.codec.http2.Http2TestUtil.bb;
@@ -82,7 +81,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 /**
  * Unit tests for {@link Http2FrameCodec}.
  */
-@SuppressWarnings("unchecked")
 public class Http2FrameCodecTest {
 
     // For verifying outbound frames
@@ -141,13 +139,13 @@ public class Http2FrameCodecTest {
         channel.pipeline().fireChannelActive();
 
         // Handshake
-        verify(frameWriter).writeSettings(any(ChannelHandlerContext.class), anyHttp2Settings(), anyChannelPromise());
+        verify(frameWriter).writeSettings(any(ChannelHandlerContext.class), anyHttp2Settings());
         verifyNoMoreInteractions(frameWriter);
         channel.writeInbound(Http2CodecUtil.connectionPrefaceBuf());
 
         frameInboundWriter.writeInboundSettings(initialRemoteSettings);
 
-        verify(frameWriter).writeSettingsAck(any(ChannelHandlerContext.class), anyChannelPromise());
+        verify(frameWriter).writeSettingsAck(any(ChannelHandlerContext.class));
 
         frameInboundWriter.writeInboundSettingsAck();
 
@@ -178,9 +176,9 @@ public class Http2FrameCodecTest {
         channel.writeOutbound(new DefaultHttp2HeadersFrame(response, true, 27).stream(stream2));
         verify(frameWriter).writeHeaders(
                 any(ChannelHandlerContext.class), eq(1), eq(response),
-                eq(27), eq(true), anyChannelPromise());
+                eq(27), eq(true));
         verify(frameWriter, never()).writeRstStream(
-                any(ChannelHandlerContext.class), anyInt(), anyLong(), anyChannelPromise());
+                any(ChannelHandlerContext.class), anyInt(), anyLong());
 
         assertEquals(State.CLOSED, stream.state());
         event = inboundHandler.readInboundMessageOrUserEvent();
@@ -207,9 +205,9 @@ public class Http2FrameCodecTest {
         channel.writeOutbound(new DefaultHttp2HeadersFrame(response, true, 27).stream(stream2));
         verify(frameWriter).writeHeaders(
                 any(ChannelHandlerContext.class), eq(1), eq(response),
-                eq(27), eq(true), anyChannelPromise());
+                eq(27), eq(true));
         verify(frameWriter, never()).writeRstStream(
-                any(ChannelHandlerContext.class), anyInt(), anyLong(), anyChannelPromise());
+                any(ChannelHandlerContext.class), anyInt(), anyLong());
 
         assertEquals(State.CLOSED, stream.state());
         assertTrue(channel.isActive());
@@ -266,12 +264,12 @@ public class Http2FrameCodecTest {
 
         inboundHandler.writeOutbound(new DefaultHttp2HeadersFrame(response, false).stream(stream2));
         verify(frameWriter).writeHeaders(any(ChannelHandlerContext.class), eq(1), eq(response), eq(0),
-                eq(false), anyChannelPromise());
+                eq(false));
 
         channel.writeOutbound(new DefaultHttp2DataFrame(bb("world"), true, 27).stream(stream2));
         ArgumentCaptor<ByteBuf> outboundData = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeData(any(ChannelHandlerContext.class), eq(1), outboundData.capture(), eq(27),
-                                      eq(true), anyChannelPromise());
+                                      eq(true));
 
         ByteBuf bb = bb("world");
         assertEquals(bb, outboundData.getValue());
@@ -280,7 +278,7 @@ public class Http2FrameCodecTest {
         outboundData.getValue().release();
 
         verify(frameWriter, never()).writeRstStream(any(ChannelHandlerContext.class),
-                anyInt(), anyLong(), anyChannelPromise());
+                anyInt(), anyLong());
         assertTrue(channel.isActive());
     }
 
@@ -301,7 +299,7 @@ public class Http2FrameCodecTest {
         assertEquals(3, stream2.id());
 
         channel.writeOutbound(new DefaultHttp2ResetFrame(314 /* non-standard error */).stream(stream2));
-        verify(frameWriter).writeRstStream(any(ChannelHandlerContext.class), eq(3), eq(314L), anyChannelPromise());
+        verify(frameWriter).writeRstStream(any(ChannelHandlerContext.class), eq(3), eq(314L));
         assertEquals(State.CLOSED, stream.state());
         assertTrue(channel.isActive());
     }
@@ -343,7 +341,7 @@ public class Http2FrameCodecTest {
 
         channel.writeOutbound(goAwayFrame);
         verify(frameWriter).writeGoAway(any(ChannelHandlerContext.class), eq(7),
-                eq(NO_ERROR.code()), eq(expected), anyChannelPromise());
+                eq(NO_ERROR.code()), eq(expected));
         assertEquals(State.OPEN, stream.state());
         assertTrue(channel.isActive());
         expected.release();
@@ -419,7 +417,7 @@ public class Http2FrameCodecTest {
         channel.writeOutbound(goAwayFrame);
         // When the last stream id computation overflows, the last stream id should just be set to 2^31 - 1.
         verify(frameWriter).writeGoAway(any(ChannelHandlerContext.class), eq(Integer.MAX_VALUE),
-                eq(NO_ERROR.code()), eq(debugData), anyChannelPromise());
+                eq(NO_ERROR.code()), eq(debugData));
         debugData.release();
         assertEquals(State.OPEN, stream.state());
         assertTrue(channel.isActive());
@@ -596,7 +594,7 @@ public class Http2FrameCodecTest {
         channel.write(unknownFrame);
 
         verify(frameWriter).writeFrame(any(ChannelHandlerContext.class), eq(unknownFrame.frameType()),
-                eq(unknownFrame.stream().id()), eq(unknownFrame.flags()), eq(buffer), any(Promise.class));
+                eq(unknownFrame.stream().id()), eq(unknownFrame.flags()), eq(buffer));
     }
 
     @Test
@@ -604,7 +602,7 @@ public class Http2FrameCodecTest {
         Http2Settings settings = new Http2Settings();
         channel.write(new DefaultHttp2SettingsFrame(settings));
 
-        verify(frameWriter).writeSettings(any(ChannelHandlerContext.class), same(settings), any(Promise.class));
+        verify(frameWriter).writeSettings(any(ChannelHandlerContext.class), same(settings));
     }
 
     @Test
@@ -763,7 +761,7 @@ public class Http2FrameCodecTest {
         channel.writeAndFlush(new DefaultHttp2PingFrame(12345));
 
         verify(frameWriter).writePing(any(ChannelHandlerContext.class), eq(false),
-                eq(12345L), anyChannelPromise());
+                eq(12345L));
     }
 
     @Test
@@ -781,7 +779,7 @@ public class Http2FrameCodecTest {
         Http2Settings settings = new Http2Settings().maxConcurrentStreams(1);
         channel.writeAndFlush(new DefaultHttp2SettingsFrame(settings));
 
-        verify(frameWriter).writeSettings(any(ChannelHandlerContext.class), eq(settings), anyChannelPromise());
+        verify(frameWriter).writeSettings(any(ChannelHandlerContext.class), eq(settings));
     }
 
     @Test
@@ -837,21 +835,21 @@ public class Http2FrameCodecTest {
         Http2PingFrame frame = inboundHandler.readInbound();
         assertFalse(frame.ack());
         assertEquals(8, frame.content());
-        verify(frameWriter).writePing(any(ChannelHandlerContext.class), eq(true), eq(8L), anyChannelPromise());
+        verify(frameWriter).writePing(any(ChannelHandlerContext.class), eq(true), eq(8L));
     }
 
     @Test
     public void autoAckPingFalse() throws Exception {
         setUp(Http2FrameCodecBuilder.forServer().autoAckPingFrame(false), new Http2Settings());
         frameInboundWriter.writeInboundPing(false, 8);
-        verify(frameWriter, never()).writePing(any(ChannelHandlerContext.class), eq(true), eq(8L), anyChannelPromise());
+        verify(frameWriter, never()).writePing(any(ChannelHandlerContext.class), eq(true), eq(8L));
         Http2PingFrame frame = inboundHandler.readInbound();
         assertFalse(frame.ack());
         assertEquals(8, frame.content());
 
         // Now ack the frame manually.
         channel.writeAndFlush(new DefaultHttp2PingFrame(8, true));
-        verify(frameWriter).writePing(any(ChannelHandlerContext.class), eq(true), eq(8L), anyChannelPromise());
+        verify(frameWriter).writePing(any(ChannelHandlerContext.class), eq(true), eq(8L));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -49,59 +49,59 @@ final class Http2FrameInboundWriter {
     }
 
     void writeInboundData(int streamId, ByteBuf data, int padding, boolean endStream) {
-        writer.writeData(ctx, streamId, data, padding, endStream, ctx.newPromise()).syncUninterruptibly();
+        writer.writeData(ctx, streamId, data, padding, endStream).syncUninterruptibly();
     }
 
     void writeInboundHeaders(int streamId, Http2Headers headers,
                          int padding, boolean endStream) {
-        writer.writeHeaders(ctx, streamId, headers, padding, endStream, ctx.newPromise()).syncUninterruptibly();
+        writer.writeHeaders(ctx, streamId, headers, padding, endStream).syncUninterruptibly();
     }
 
     void writeInboundHeaders(int streamId, Http2Headers headers,
                                int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
         writer.writeHeaders(ctx, streamId, headers, streamDependency,
-                weight, exclusive, padding, endStream, ctx.newPromise()).syncUninterruptibly();
+                weight, exclusive, padding, endStream).syncUninterruptibly();
     }
 
     void writeInboundPriority(int streamId, int streamDependency,
                                 short weight, boolean exclusive) {
         writer.writePriority(ctx, streamId, streamDependency, weight,
-                exclusive, ctx.newPromise()).syncUninterruptibly();
+                exclusive).syncUninterruptibly();
     }
 
     void writeInboundRstStream(int streamId, long errorCode) {
-        writer.writeRstStream(ctx, streamId, errorCode, ctx.newPromise()).syncUninterruptibly();
+        writer.writeRstStream(ctx, streamId, errorCode).syncUninterruptibly();
     }
 
     void writeInboundSettings(Http2Settings settings) {
-        writer.writeSettings(ctx, settings, ctx.newPromise()).syncUninterruptibly();
+        writer.writeSettings(ctx, settings).syncUninterruptibly();
     }
 
     void writeInboundSettingsAck() {
-        writer.writeSettingsAck(ctx, ctx.newPromise()).syncUninterruptibly();
+        writer.writeSettingsAck(ctx).syncUninterruptibly();
     }
 
     void writeInboundPing(boolean ack, long data) {
-        writer.writePing(ctx, ack, data, ctx.newPromise()).syncUninterruptibly();
+        writer.writePing(ctx, ack, data).syncUninterruptibly();
     }
 
     void writePushPromise(int streamId, int promisedStreamId,
                                    Http2Headers headers, int padding) {
            writer.writePushPromise(ctx, streamId, promisedStreamId,
-                   headers, padding, ctx.newPromise()).syncUninterruptibly();
+                   headers, padding).syncUninterruptibly();
     }
 
     void writeInboundGoAway(int lastStreamId, long errorCode, ByteBuf debugData) {
-        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData, ctx.newPromise()).syncUninterruptibly();
+        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData).syncUninterruptibly();
     }
 
     void writeInboundWindowUpdate(int streamId, int windowSizeIncrement) {
-        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement, ctx.newPromise()).syncUninterruptibly();
+        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement).syncUninterruptibly();
     }
 
     void writeInboundFrame(byte frameType, int streamId,
                              Http2Flags flags, ByteBuf payload) {
-        writer.writeFrame(ctx, frameType, streamId, flags, payload, ctx.newPromise()).syncUninterruptibly();
+        writer.writeFrame(ctx, frameType, streamId, flags, payload).syncUninterruptibly();
     }
 
     private static final class WriteInboundChannelHandlerContext

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -59,7 +59,6 @@ import static org.mockito.Mockito.anyShort;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -134,7 +133,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void emptyDataShouldMatch() throws Exception {
         final ByteBuf data = EMPTY_BUFFER;
-        writer.writeData(ctx, STREAM_ID, data.slice(), 0, false, ctx.newPromise());
+        writer.writeData(ctx, STREAM_ID, data.slice(), 0, false);
         readFrames();
         verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(0), eq(false));
     }
@@ -142,7 +141,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void dataShouldMatch() throws Exception {
         final ByteBuf data = data(10);
-        writer.writeData(ctx, STREAM_ID, data.slice(), 1, false, ctx.newPromise());
+        writer.writeData(ctx, STREAM_ID, data.slice(), 1, false);
         readFrames();
         verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(1), eq(false));
     }
@@ -150,7 +149,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void dataWithPaddingShouldMatch() throws Exception {
         final ByteBuf data = data(10);
-        writer.writeData(ctx, STREAM_ID, data.slice(), MAX_PADDING, true, ctx.newPromise());
+        writer.writeData(ctx, STREAM_ID, data.slice(), MAX_PADDING, true);
         readFrames();
         verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(MAX_PADDING), eq(true));
     }
@@ -163,7 +162,7 @@ public class Http2FrameRoundtripTest {
         final boolean endOfStream = true;
 
         writer.writeData(ctx, STREAM_ID, originalData.slice(), originalPadding,
-                endOfStream, ctx.newPromise());
+                endOfStream);
         readFrames();
 
         // Verify that at least one frame was sent with eos=false and exactly one with eos=true.
@@ -196,7 +195,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void emptyHeadersShouldMatch() throws Exception {
         final Http2Headers headers = EmptyHttp2Headers.INSTANCE;
-        writer.writeHeaders(ctx, STREAM_ID, headers, 0, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 0, true);
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0), eq(true));
     }
@@ -204,7 +203,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void emptyHeadersWithPaddingShouldMatch() throws Exception {
         final Http2Headers headers = EmptyHttp2Headers.INSTANCE;
-        writer.writeHeaders(ctx, STREAM_ID, headers, MAX_PADDING, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, MAX_PADDING, true);
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(MAX_PADDING), eq(true));
     }
@@ -212,7 +211,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void binaryHeadersWithoutPriorityShouldMatch() throws Exception {
         final Http2Headers headers = binaryHeaders();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 0, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 0, true);
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0), eq(true));
     }
@@ -220,7 +219,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void headersFrameWithoutPriorityShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 0, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 0, true);
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0), eq(true));
     }
@@ -228,7 +227,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void headersFrameWithPriorityShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 4, (short) 255, true, 0, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 4, (short) 255, true, 0, true);
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(4), eq((short) 255),
                 eq(true), eq(0), eq(true));
@@ -237,7 +236,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void headersWithPaddingWithoutPriorityShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writeHeaders(ctx, STREAM_ID, headers, MAX_PADDING, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, MAX_PADDING, true);
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(MAX_PADDING), eq(true));
     }
@@ -245,7 +244,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void headersWithPaddingWithPriorityShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, 1, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, 1, true);
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(2), eq((short) 3), eq(true),
                 eq(1), eq(true));
@@ -254,7 +253,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void continuedHeadersShouldMatch() throws Exception {
         final Http2Headers headers = largeHeaders();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, 0, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, 0, true);
         readFrames();
         verify(listener)
                 .onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(2), eq((short) 3), eq(true), eq(0), eq(true));
@@ -263,7 +262,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void continuedHeadersWithPaddingShouldMatch() throws Exception {
         final Http2Headers headers = largeHeaders();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, MAX_PADDING, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, MAX_PADDING, true);
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(2), eq((short) 3), eq(true),
                 eq(MAX_PADDING), eq(true));
@@ -275,7 +274,7 @@ public class Http2FrameRoundtripTest {
         final int maxListSize = 100;
         reader.configuration().headersConfiguration().maxHeaderListSize(maxListSize, maxListSize);
         final Http2Headers headers = headersOfSize(maxListSize + 1);
-        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, MAX_PADDING, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, MAX_PADDING, true);
         assertThrows(Http2Exception.class, new Executable() {
             @Override
             public void execute() throws Throwable {
@@ -290,7 +289,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void emptyPushPromiseShouldMatch() throws Exception {
         final Http2Headers headers = EmptyHttp2Headers.INSTANCE;
-        writer.writePushPromise(ctx, STREAM_ID, 2, headers, 0, ctx.newPromise());
+        writer.writePushPromise(ctx, STREAM_ID, 2, headers, 0);
         readFrames();
         verify(listener).onPushPromiseRead(eq(ctx), eq(STREAM_ID), eq(2), eq(headers), eq(0));
     }
@@ -298,7 +297,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void pushPromiseFrameShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writePushPromise(ctx, STREAM_ID, 1, headers, 5, ctx.newPromise());
+        writer.writePushPromise(ctx, STREAM_ID, 1, headers, 5);
         readFrames();
         verify(listener).onPushPromiseRead(eq(ctx), eq(STREAM_ID), eq(1), eq(headers), eq(5));
     }
@@ -306,7 +305,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void pushPromiseWithPaddingShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writePushPromise(ctx, STREAM_ID, 2, headers, MAX_PADDING, ctx.newPromise());
+        writer.writePushPromise(ctx, STREAM_ID, 2, headers, MAX_PADDING);
         readFrames();
         verify(listener).onPushPromiseRead(eq(ctx), eq(STREAM_ID), eq(2), eq(headers), eq(MAX_PADDING));
     }
@@ -314,7 +313,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void continuedPushPromiseShouldMatch() throws Exception {
         final Http2Headers headers = largeHeaders();
-        writer.writePushPromise(ctx, STREAM_ID, 2, headers, 0, ctx.newPromise());
+        writer.writePushPromise(ctx, STREAM_ID, 2, headers, 0);
         readFrames();
         verify(listener).onPushPromiseRead(eq(ctx), eq(STREAM_ID), eq(2), eq(headers), eq(0));
     }
@@ -322,7 +321,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void continuedPushPromiseWithPaddingShouldMatch() throws Exception {
         final Http2Headers headers = largeHeaders();
-        writer.writePushPromise(ctx, STREAM_ID, 2, headers, 0xFF, ctx.newPromise());
+        writer.writePushPromise(ctx, STREAM_ID, 2, headers, 0xFF);
         readFrames();
         verify(listener).onPushPromiseRead(eq(ctx), eq(STREAM_ID), eq(2), eq(headers), eq(0xFF));
     }
@@ -332,7 +331,7 @@ public class Http2FrameRoundtripTest {
         final String text = "test";
         final ByteBuf data = buf(text.getBytes());
 
-        writer.writeGoAway(ctx, STREAM_ID, ERROR_CODE, data.slice(), ctx.newPromise());
+        writer.writeGoAway(ctx, STREAM_ID, ERROR_CODE, data.slice());
         readFrames();
 
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
@@ -342,7 +341,7 @@ public class Http2FrameRoundtripTest {
 
     @Test
     public void pingFrameShouldMatch() throws Exception {
-        writer.writePing(ctx, false, 1234567, ctx.newPromise());
+        writer.writePing(ctx, false, 1234567);
         readFrames();
 
         ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(long.class);
@@ -352,7 +351,7 @@ public class Http2FrameRoundtripTest {
 
     @Test
     public void pingAckFrameShouldMatch() throws Exception {
-        writer.writePing(ctx, true, 1234567, ctx.newPromise());
+        writer.writePing(ctx, true, 1234567);
         readFrames();
 
         ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(long.class);
@@ -362,14 +361,14 @@ public class Http2FrameRoundtripTest {
 
     @Test
     public void priorityFrameShouldMatch() throws Exception {
-        writer.writePriority(ctx, STREAM_ID, 1, (short) 1, true, ctx.newPromise());
+        writer.writePriority(ctx, STREAM_ID, 1, (short) 1, true);
         readFrames();
         verify(listener).onPriorityRead(eq(ctx), eq(STREAM_ID), eq(1), eq((short) 1), eq(true));
     }
 
     @Test
     public void rstStreamFrameShouldMatch() throws Exception {
-        writer.writeRstStream(ctx, STREAM_ID, ERROR_CODE, ctx.newPromise());
+        writer.writeRstStream(ctx, STREAM_ID, ERROR_CODE);
         readFrames();
         verify(listener).onRstStreamRead(eq(ctx), eq(STREAM_ID), eq(ERROR_CODE));
     }
@@ -377,7 +376,7 @@ public class Http2FrameRoundtripTest {
     @Test
     public void emptySettingsFrameShouldMatch() throws Exception {
         final Http2Settings settings = new Http2Settings();
-        writer.writeSettings(ctx, settings, ctx.newPromise());
+        writer.writeSettings(ctx, settings);
         readFrames();
         verify(listener).onSettingsRead(eq(ctx), eq(settings));
     }
@@ -390,21 +389,21 @@ public class Http2FrameRoundtripTest {
         settings.initialWindowSize(123);
         settings.maxConcurrentStreams(456);
 
-        writer.writeSettings(ctx, settings, ctx.newPromise());
+        writer.writeSettings(ctx, settings);
         readFrames();
         verify(listener).onSettingsRead(eq(ctx), eq(settings));
     }
 
     @Test
     public void settingsAckShouldMatch() throws Exception {
-        writer.writeSettingsAck(ctx, ctx.newPromise());
+        writer.writeSettingsAck(ctx);
         readFrames();
         verify(listener).onSettingsAckRead(eq(ctx));
     }
 
     @Test
     public void windowUpdateFrameShouldMatch() throws Exception {
-        writer.writeWindowUpdate(ctx, STREAM_ID, WINDOW_UPDATE, ctx.newPromise());
+        writer.writeWindowUpdate(ctx, STREAM_ID, WINDOW_UPDATE);
         readFrames();
         verify(listener).onWindowUpdateRead(eq(ctx), eq(STREAM_ID), eq(WINDOW_UPDATE));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -22,10 +22,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -360,50 +359,45 @@ public final class Http2TestUtil {
         }).when(frameWriter).close();
 
         when(frameWriter.configuration()).thenReturn(configuration);
-        when(frameWriter.writeSettings(any(ChannelHandlerContext.class), any(Http2Settings.class),
-                any(Promise.class))).thenAnswer((Answer<Future<Void>>) invocationOnMock ->
-                ((Promise<Void>) invocationOnMock.getArgument(2)).setSuccess(null));
+        when(frameWriter.writeSettings(any(ChannelHandlerContext.class), any(Http2Settings.class)))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
 
-        when(frameWriter.writeSettingsAck(any(ChannelHandlerContext.class), any(Promise.class)))
-                .thenAnswer((Answer<Future<Void>>) invocationOnMock ->
-                        ((Promise<Void>) invocationOnMock.getArgument(1)).setSuccess(null));
+        when(frameWriter.writeSettingsAck(any(ChannelHandlerContext.class)))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
 
+        when(frameWriter.writePing(any(ChannelHandlerContext.class), anyBoolean(), anyLong()))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
         when(frameWriter.writeGoAway(any(ChannelHandlerContext.class), anyInt(),
-                anyLong(), any(ByteBuf.class), any(Promise.class))).thenAnswer(invocationOnMock -> {
+                anyLong(), any(ByteBuf.class))).thenAnswer(invocationOnMock -> {
                     buffers.offer((ByteBuf) invocationOnMock.getArgument(3));
-                    return ((Promise<Void>) invocationOnMock.getArgument(4)).setSuccess(null);
+                    return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
                 });
         when(frameWriter.writeHeaders(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class), anyInt(),
-                anyBoolean(), any(Promise.class))).thenAnswer((Answer<Future<Void>>) invocationOnMock ->
-                ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null));
+                anyBoolean())).thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
 
         when(frameWriter.writeHeaders(any(ChannelHandlerContext.class), anyInt(),
-                any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(), anyInt(), anyBoolean(),
-                any(Promise.class))).thenAnswer((Answer<Future<Void>>) invocationOnMock ->
-                ((Promise<Void>) invocationOnMock.getArgument(8)).setSuccess(null));
+                any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(), anyInt(), anyBoolean()))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
 
         when(frameWriter.writeData(any(ChannelHandlerContext.class), anyInt(), any(ByteBuf.class), anyInt(),
-                anyBoolean(), any(Promise.class))).thenAnswer(invocationOnMock -> {
+                anyBoolean())).thenAnswer(invocationOnMock -> {
                     buffers.offer((ByteBuf) invocationOnMock.getArgument(2));
-                    return ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
+                    return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
                 });
 
         when(frameWriter.writeRstStream(any(ChannelHandlerContext.class), anyInt(),
-                anyLong(), any(Promise.class))).thenAnswer((Answer<Future<Void>>) invocationOnMock ->
-                ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null));
+                anyLong())).thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
 
-        when(frameWriter.writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(), anyInt(),
-                any(Promise.class))).then((Answer<Future<Void>>) invocationOnMock ->
-                ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null));
+        when(frameWriter.writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(), anyInt()))
+                .thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
 
         when(frameWriter.writePushPromise(any(ChannelHandlerContext.class), anyInt(), anyInt(), any(Http2Headers.class),
-                anyInt(), anyChannelPromise())).thenAnswer((Answer<Future<Void>>) invocationOnMock ->
-                ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null));
+                anyInt())).thenReturn(ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
 
         when(frameWriter.writeFrame(any(ChannelHandlerContext.class), anyByte(), anyInt(), any(Http2Flags.class),
-                any(ByteBuf.class), anyChannelPromise())).thenAnswer(invocationOnMock -> {
+                any(ByteBuf.class))).thenAnswer(invocationOnMock -> {
                     buffers.offer((ByteBuf) invocationOnMock.getArgument(4));
-                    return ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
+                    return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);
                 });
         return frameWriter;
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -146,7 +146,7 @@ public class InboundHttp2ToHttpAdapterTest {
                     scheme(new AsciiString("https")).authority(new AsciiString("example.org"))
                     .path(new AsciiString("/some/path/resource2"));
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -179,7 +179,7 @@ public class InboundHttp2ToHttpAdapterTest {
                     .add(HttpHeaderNames.COOKIE, "c=d")
                     .add(HttpHeaderNames.COOKIE, "e=f");
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -211,7 +211,7 @@ public class InboundHttp2ToHttpAdapterTest {
                     .add(HttpHeaderNames.COOKIE, "a=b; c=d")
                     .add(HttpHeaderNames.COOKIE, "e=f");
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -235,7 +235,7 @@ public class InboundHttp2ToHttpAdapterTest {
                 .add(new AsciiString("çã".getBytes(CharsetUtil.UTF_8)),
                         new AsciiString("Ãã".getBytes(CharsetUtil.UTF_8)));
         runInChannel(clientChannel, () -> {
-            clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+            clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true);
             clientChannel.flush();
         });
         awaitResponses();
@@ -257,9 +257,8 @@ public class InboundHttp2ToHttpAdapterTest {
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).path(
                     new AsciiString("/some/path/resource2"));
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
-                                                  newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false);
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -288,12 +287,12 @@ public class InboundHttp2ToHttpAdapterTest {
                     new AsciiString("/some/path/resource2"));
             final int midPoint = text.length() / 2;
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false);
                 clientHandler.encoder().writeData(
-                        ctxClient(), 3, content.retainedSlice(0, midPoint), 0, false, newPromiseClient());
+                        ctxClient(), 3, content.retainedSlice(0, midPoint), 0, false);
                 clientHandler.encoder().writeData(
                         ctxClient(), 3, content.retainedSlice(midPoint, text.length() - midPoint),
-                        0, true, newPromiseClient());
+                        0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -321,10 +320,10 @@ public class InboundHttp2ToHttpAdapterTest {
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).path(
                     new AsciiString("/some/path/resource2"));
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
-                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
-                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, true, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false);
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, false);
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, false);
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retain(), 0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -360,10 +359,9 @@ public class InboundHttp2ToHttpAdapterTest {
                     .set(new AsciiString("foo2"), new AsciiString("goo2"))
                     .add(new AsciiString("foo2"), new AsciiString("goo3"));
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, false,
-                                                  newPromiseClient());
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers2, 0, true, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false);
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, false);
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers2, 0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -402,14 +400,12 @@ public class InboundHttp2ToHttpAdapterTest {
             final Http2Headers http2Headers2 = new DefaultHttp2Headers().method(new AsciiString("PUT")).path(
                     new AsciiString("/some/path/resource2"));
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false);
                 clientHandler.encoder().writeHeaders(ctxClient(), 5, http2Headers2, 3, (short) 123, true, 0,
-                        false, newPromiseClient());
+                        false);
                 clientChannel.flush(); // Headers are queued in the flow controller and so flush them.
-                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
-                                                  newPromiseClient());
-                clientHandler.encoder().writeData(ctxClient(), 5, content2.retainedDuplicate(), 0, true,
-                                                  newPromiseClient());
+                clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true);
+                clientHandler.encoder().writeData(ctxClient(), 5, content2.retainedDuplicate(), 0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -456,7 +452,7 @@ public class InboundHttp2ToHttpAdapterTest {
             final Http2Headers http2Headers3 = new DefaultHttp2Headers().method(new AsciiString("GET"))
                     .path(new AsciiString("/push/test"));
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers3, 0, true, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers3, 0, true);
                 clientChannel.flush();
             });
             awaitRequests();
@@ -475,12 +471,10 @@ public class InboundHttp2ToHttpAdapterTest {
                     .scheme(new AsciiString("https"))
                     .authority(new AsciiString("example.org"));
             runInChannel(serverConnectedChannel, () -> {
-                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2Headers, 0, false, newPromiseServer());
-                serverHandler.encoder().writePushPromise(ctxServer(), 3, 2, http2Headers2, 0, newPromiseServer());
-                serverHandler.encoder().writeData(ctxServer(), 3, content.retainedDuplicate(), 0, true,
-                                                  newPromiseServer());
-                serverHandler.encoder().writeData(ctxServer(), 5, content2.retainedDuplicate(), 0, true,
-                                                  newPromiseServer());
+                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2Headers, 0, false);
+                serverHandler.encoder().writePushPromise(ctxServer(), 3, 2, http2Headers2, 0);
+                serverHandler.encoder().writeData(ctxServer(), 3, content.retainedDuplicate(), 0, true);
+                serverHandler.encoder().writeData(ctxServer(), 5, content2.retainedDuplicate(), 0, true);
                 serverConnectedChannel.flush();
             });
             awaitResponses();
@@ -518,7 +512,7 @@ public class InboundHttp2ToHttpAdapterTest {
 
         try {
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false);
                 clientChannel.flush();
             });
 
@@ -528,8 +522,7 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
             final Http2Headers http2HeadersResponse = new DefaultHttp2Headers().status(new AsciiString("100"));
             runInChannel(serverConnectedChannel, () -> {
-                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2HeadersResponse, 0, false,
-                                                     newPromiseServer());
+                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2HeadersResponse, 0, false);
                 serverConnectedChannel.flush();
             });
 
@@ -538,8 +531,7 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, text.length());
             httpHeaders.remove(HttpHeaderNames.EXPECT);
             runInChannel(clientChannel, () -> {
-                clientHandler.encoder().writeData(ctxClient(), 3, payload.retainedDuplicate(), 0, true,
-                                                  newPromiseClient());
+                clientHandler.encoder().writeData(ctxClient(), 3, payload.retainedDuplicate(), 0, true);
                 clientChannel.flush();
             });
 
@@ -551,8 +543,7 @@ public class InboundHttp2ToHttpAdapterTest {
 
             final Http2Headers http2HeadersResponse2 = new DefaultHttp2Headers().status(new AsciiString("200"));
             runInChannel(serverConnectedChannel, () -> {
-                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2HeadersResponse2, 0, true,
-                                                     newPromiseServer());
+                serverHandler.encoder().writeHeaders(ctxServer(), 3, http2HeadersResponse2, 0, true);
                 serverConnectedChannel.flush();
             });
 
@@ -586,7 +577,7 @@ public class InboundHttp2ToHttpAdapterTest {
         boostrapEnv(1, 1, 2);
         final Http2Settings settings = new Http2Settings().pushEnabled(true);
         runInChannel(clientChannel, () -> {
-            clientHandler.encoder().writeSettings(ctxClient(), settings, newPromiseClient());
+            clientHandler.encoder().writeSettings(ctxClient(), settings);
             clientChannel.flush();
         });
         assertTrue(settingsLatch.await(5, SECONDS));

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -88,8 +88,8 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
     private void sendResponse(ChannelHandlerContext ctx, int streamId, ByteBuf payload) {
         // Send a frame for the response status
         Http2Headers headers = new DefaultHttp2Headers().status(OK.codeAsText());
-        encoder().writeHeaders(ctx, streamId, headers, 0, false, ctx.newPromise());
-        encoder().writeData(ctx, streamId, payload, 0, true, ctx.newPromise());
+        encoder().writeHeaders(ctx, streamId, headers, 0, false);
+        encoder().writeData(ctx, streamId, payload, 0, true);
 
         // no need to call flush as channelReadComplete(...) will take care of it.
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -602,17 +602,8 @@ public class SslHandler extends ByteToMessageDecoder {
      * {@link ChannelHandlerContext#close()}
      */
     public Future<Void> closeOutbound() {
-        return closeOutbound(ctx.newPromise());
-    }
-
-    /**
-     * Sends an SSL {@code close_notify} message to the specified channel and
-     * destroys the underlying {@link SSLEngine}. This will <strong>not</strong> close the underlying
-     * {@link Channel}. If you want to also close the {@link Channel} use {@link Channel#close()} or
-     * {@link ChannelHandlerContext#close()}
-     */
-    public Future<Void> closeOutbound(final Promise<Void> promise) {
         final ChannelHandlerContext ctx = this.ctx;
+        Promise<Void> promise = ctx.newPromise();
         if (ctx.executor().inEventLoop()) {
             closeOutbound0(promise);
         } else {

--- a/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
@@ -101,14 +101,14 @@ public class Http2FrameWriterDataBenchmark extends AbstractMicrobenchmark {
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     public void newWriter() {
-        writer.writeData(ctx, 3, payload.retain(), padding, true, ctx.newPromise());
+        writer.writeData(ctx, 3, payload.retain(), padding, true);
         ctx.flush();
     }
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     public void oldWriter() {
-        oldWriter.writeData(ctx, 3, payload.retain(), padding, true, ctx.newPromise());
+        oldWriter.writeData(ctx, 3, payload.retain(), padding, true);
         ctx.flush();
     }
 
@@ -118,9 +118,9 @@ public class Http2FrameWriterDataBenchmark extends AbstractMicrobenchmark {
         private final int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
         @Override
         public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-                                      int padding, boolean endStream, Promise<Void> promise) {
+                                      int padding, boolean endStream) {
             final Http2CodecUtil.SimpleChannelPromiseAggregator promiseAggregator =
-                    new Http2CodecUtil.SimpleChannelPromiseAggregator(promise, ctx.executor());
+                    new Http2CodecUtil.SimpleChannelPromiseAggregator(ctx.newPromise(), ctx.executor());
             final DataFrameHeader header = new DataFrameHeader(ctx, streamId);
             boolean needToReleaseHeaders = true;
             boolean needToReleaseData = true;

--- a/testsuite-http2/src/main/java/io/netty/testsuite/http2/HelloWorldHttp2Handler.java
+++ b/testsuite-http2/src/main/java/io/netty/testsuite/http2/HelloWorldHttp2Handler.java
@@ -88,8 +88,8 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
     private void sendResponse(ChannelHandlerContext ctx, int streamId, ByteBuf payload) {
         // Send a frame for the response status
         Http2Headers headers = new DefaultHttp2Headers().status(OK.codeAsText());
-        encoder().writeHeaders(ctx, streamId, headers, 0, false, ctx.newPromise());
-        encoder().writeData(ctx, streamId, payload, 0, true, ctx.newPromise());
+        encoder().writeHeaders(ctx, streamId, headers, 0, false);
+        encoder().writeData(ctx, streamId, payload, 0, true);
 
         // no need to call flush as channelReadComplete(...) will take care of it.
     }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
@@ -839,7 +839,6 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
             executor.execute(runnable);
             return true;
         } catch (Throwable cause) {
-            cause.printStackTrace();
             try {
                 if (msg != null) {
                     ReferenceCountUtil.release(msg);
@@ -937,7 +936,6 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
             ctx = null;
             msg = null;
             promise = null;
-            //new Throwable().printStackTrace();
             handle.recycle(this);
         }
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
@@ -839,6 +839,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
             executor.execute(runnable);
             return true;
         } catch (Throwable cause) {
+            cause.printStackTrace();
             try {
                 if (msg != null) {
                     ReferenceCountUtil.release(msg);
@@ -936,6 +937,7 @@ final class DefaultChannelHandlerContext implements ChannelHandlerContext, Resou
             ctx = null;
             msg = null;
             promise = null;
+            //new Throwable().printStackTrace();
             handle.recycle(this);
         }
 


### PR DESCRIPTION
Motivation:

We did recently change the Channel / ChannelHandler API to always act on the Future only. We should do the same for our handlers.

Modifications:

- Adjust http2 API
- Adjust other handlers API

Result:

Easier to use API and more consistent