### PR TITLE
Replace master with main branch

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ name: Build project
 
 on:
   push:
-    branches: [ "master"]
+    branches: [ "main"]
 
   schedule:
     - cron: '30 1 * * 1'  # At 01:30 on Monday, every Monday.

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -17,7 +17,7 @@ name: Deploy project
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
   schedule:
     - cron: '30 1 * * 1'  # At 01:30 on Monday, every Monday.

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,7 +17,7 @@ name: Build PR
 
 on:
   pull_request:
-    branches: [ "master"]
+    branches: [ "main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -166,7 +166,7 @@ jobs:
         working-directory: ./prepare-release-workspace/
         if: ${{ failure() }}
         # Rollback the release in case of an failure
-        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty master
+        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty main
 
   deploy-staged-release:
     runs-on: ubuntu-18.04
@@ -246,4 +246,4 @@ jobs:
         working-directory: ./prepare-release-workspace/
         if: ${{ failure() }}
         # Rollback the release in case of an failure
-        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty master
+        run: bash ./.github/scripts/release_rollback.sh release.properties netty/netty main

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,10 +22,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["4.1", master]
+    branches: ["4.1", main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["4.1", master]
+    branches: ["4.1", main]
   schedule:
     - cron: '0 13 * * 3'
 


### PR DESCRIPTION
Motivation:

We should not use master as branch name, better to switch to main

Modifications:

Replace master branch name with main

Result:

Use main as replacement for master