### PR TITLE
Fix leak in TcpDnsTest

### DIFF
--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -44,6 +44,7 @@ public class TcpDnsTest {
         DnsQuery readQuery = channel.readInbound();
         assertThat(readQuery, is(query));
         assertThat(readQuery.recordAt(DnsSection.QUESTION).name(), is(query.recordAt(DnsSection.QUESTION).name()));
+        readQuery.release();
         assertFalse(channel.finish());
     }
 


### PR DESCRIPTION
Motivation:

We did get a report for a leak on the CI.

Modifications:

Fix leak in test by correctly releasing the query

Result:

No more leaks