### PR TITLE
Support getting used memory from a user perspective at `PooledByteBufAllocator` level

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -98,6 +98,11 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             return this;
         }
         checkNewCapacity(newCapacity);
+        if (isDirect()) {
+            chunk.arena.parent.incrementUsedDirectBytes(newCapacity - length);
+        } else {
+            chunk.arena.parent.incrementUsedHeapBytes(newCapacity - length);
+        }
         if (!chunk.unpooled) {
             // If the request capacity does not require reallocation, just update the length of the memory.
             if (newCapacity > length) {
@@ -168,7 +173,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             final long handle = this.handle;
             this.handle = -1;
             memory = null;
-            chunk.arena.free(chunk, tmpNioBuf, handle, maxLength, cache);
+            chunk.arena.free(chunk, tmpNioBuf, handle, maxLength, cache, true);
             tmpNioBuf = null;
             chunk = null;
             recycle();

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocatorMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocatorMetric.java
@@ -107,12 +107,22 @@ public final class PooledByteBufAllocatorMetric implements ByteBufAllocatorMetri
         return allocator.usedDirectMemory();
     }
 
+    public long usedHeapBytes() {
+        return allocator.usedHeapBytes();
+    }
+
+    public long usedDirectBytes() {
+        return allocator.usedDirectBytes();
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(256);
         sb.append(StringUtil.simpleClassName(this))
                 .append("(usedHeapMemory: ").append(usedHeapMemory())
                 .append("; usedDirectMemory: ").append(usedDirectMemory())
+                .append("; usedHeapBytes: ").append(usedHeapBytes())
+                .append("; usedDirectBytes: ").append(usedDirectBytes())
                 .append("; numHeapArenas: ").append(numHeapArenas())
                 .append("; numDirectArenas: ").append(numDirectArenas())
                 .append("; smallCacheSize: ").append(smallCacheSize())

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -689,4 +689,67 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
         assertTrue(beforeFreeBytes < afterFreeBytes);
     }
+
+    @Test
+    void testCountUsedDirectBytes() {
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 256, 64, false);
+        assertEquals(0, allocator.usedDirectBytes());
+
+        // Allocate
+        ByteBuf buffer = allocator.directBuffer(16, 128);
+        assertEquals(16, allocator.usedDirectBytes());
+
+        // Shrink
+        buffer.capacity(8);
+        assertEquals(8, allocator.usedDirectBytes());
+
+        buffer.capacity(2);
+        assertEquals(2, allocator.usedDirectBytes());
+
+        // Grow
+        buffer.writeLong(1);
+        assertEquals(16, allocator.usedDirectBytes());
+
+        buffer.writeLong(1);
+        assertEquals(16, allocator.usedDirectBytes());
+
+        buffer.writeLong(1);
+        assertEquals(64, allocator.usedDirectBytes());
+
+        // Release
+        buffer.release();
+        assertEquals(0, allocator.usedDirectBytes());
+    }
+
+    @Test
+    void testCountUsedHeapBytes() {
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 256, 64, false);
+        assertEquals(0, allocator.usedHeapBytes());
+
+        // Allocate
+        ByteBuf buffer = allocator.heapBuffer(16, 128);
+        assertEquals(16, allocator.usedHeapBytes());
+
+        // Shrink
+        buffer.capacity(8);
+        assertEquals(8, allocator.usedHeapBytes());
+
+        buffer.capacity(2);
+        assertEquals(2, allocator.usedHeapBytes());
+
+        // Grow
+        buffer.writeLong(1);
+        assertEquals(16, allocator.usedHeapBytes());
+
+        buffer.writeLong(1);
+        assertEquals(16, allocator.usedHeapBytes());
+
+        buffer.writeLong(1);
+        assertEquals(64, allocator.usedHeapBytes());
+
+        // Release
+        buffer.release();
+        assertEquals(0, allocator.usedHeapBytes());
+    }
+
 }


### PR DESCRIPTION
## Motivation
Our server has its own implementation to decide whether to provide service for users according to the real-time estimated total free memory of the heap memory and the direct memory (mainly the memory used by `io.netty.buffer.PooledByteBufAllocator` for our server). If our server detects it's running out of physical memory, it will just respond with the client requests with something like `Service Unavailable`.

But the problem is: We cannot know the used memory of PooledByteBufAllocator efficiently. For example, we have allocated and cached 8GB chunks in a `PooledByteBufAllocator`, but there is no property to know: From the user perspective, what exactly the used memory is, 1GB or 8GB?

The PR will provide `usedDirectBytes` and `usedHeapBytes` for these purposes.

## Modification
(Honestly, I didn't come up with better names to distinguish the existing `usedDirectMemory` and the new `usedDirectBytes`. If Netty were a new project, we can distinguish these memories by calling the existing `usedDirectMemory` `committedDirectMemory` and the new memory metric `usedDirectMemory`, but Netty has been widely used in the Java world so I don't call them in this way)

When a pooled buffer is allocated/deallocated, grows, and shrinks, count the increase/decrease size to count `usedDirectBytes` and `usedHeapBytes`

## Result

Fixes #11637