### PR TITLE
Include number of maximum active streams in exception message

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -898,7 +898,7 @@ public class DefaultHttp2Connection implements Http2Connection {
                         Http2Exception.ShutdownHint.GRACEFUL_SHUTDOWN);
             }
             boolean isReserved = state == RESERVED_LOCAL || state == RESERVED_REMOTE;
-            if (isReserved ? numStreams >= maxStreams : !canOpenStream()) {
+            if (!isReserved && !canOpenStream() || isReserved && numStreams >= maxStreams) {
                 throw streamError(streamId, REFUSED_STREAM, "Maximum active streams violated for this endpoint: " +
                         (isReserved ? maxStreams : maxActiveStreams));
             }


### PR DESCRIPTION
Motivation:

When users receive "Maximum active streams violated for this endpoint"
exception, it's useful to know what is the current max streams limit on
HTTP/2 connection.

Modifications:

- Include current number of maximum active streams in exception message;

Result:

Easier debugging of HTTP/2 connections.