### PR TITLE
Deprecate UnaryPromiseNotifier

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -24,7 +24,7 @@ import io.netty.util.collection.IntObjectMap;
 import io.netty.util.collection.IntObjectMap.PrimitiveEntry;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.UnaryPromiseNotifier;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
@@ -128,7 +128,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             } else if (promise instanceof ChannelPromise && ((ChannelFuture) closePromise).isVoid()) {
                 closePromise = promise;
             } else {
-                closePromise.addListener(new UnaryPromiseNotifier<Void>(promise));
+                PromiseNotifier.cascade(closePromise, promise);
             }
         } else {
             closePromise = promise;

--- a/common/src/main/java/io/netty/util/concurrent/UnaryPromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/UnaryPromiseNotifier.java
@@ -19,6 +19,11 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+/**
+ *
+ * @deprecated use {@link PromiseNotifier#cascade(boolean, Future, Promise)}.
+ */
+@Deprecated
 public final class UnaryPromiseNotifier<T> implements FutureListener<T> {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(UnaryPromiseNotifier.class);
     private final Promise<? super T> promise;

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -41,7 +41,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
-import io.netty.util.concurrent.UnaryPromiseNotifier;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.ResourcesUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
@@ -1053,8 +1053,8 @@ public abstract class SSLEngineTest {
                         // through we just want to verify the local failure condition. This way we don't have to worry
                         // about verifying the payload and releasing the content on the server side.
                         if (failureExpected) {
-                            ctx.write(ctx.alloc().buffer(1).writeByte(1))
-                                    .addListener(new UnaryPromiseNotifier<Void>(clientWritePromise));
+                            ChannelFuture f = ctx.write(ctx.alloc().buffer(1).writeByte(1));
+                            PromiseNotifier.cascade(f, clientWritePromise);
                         }
                     }
 


### PR DESCRIPTION
Motivation:

Users should use PromiseNotifier.cascade(...) methods and so the UnaryPromiseNotifier becomes useless.

Modifications:

- Mark UnaryPromiseNotifier as deprecated
- Replaces usages with PromiseNotifier.cascade(...)

Result:

Cleanup
