### PR TITLE
Respect jdk.tls.namedGroups when using native SSL implementation

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/GroupsConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/GroupsConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Convert java naming to OpenSSL naming if possible and if not return the original name.
+ */
+final class GroupsConverter {
+
+    private static final Map<String, String> mappings;
+
+    static {
+        // See https://tools.ietf.org/search/rfc4492#appendix-A and https://www.java.com/en/configure_crypto.html
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("P-224", "P-224");
+        map.put("secp224r1", "P-224");
+        map.put("P-256", "P-256");
+        map.put("prime256v1", "P-256");
+        map.put("secp256r1", "P-256");
+
+        map.put("P-384", "P-384");
+        map.put("secp384r1", "P-384");
+
+        map.put("P-521", "P-521");
+        map.put("secp521r1", "P-521");
+
+        map.put("X25519", "X25519");
+        map.put("x25519", "X25519");
+
+        map.put("CECPQ2", "CECPQ2");
+        mappings = Collections.unmodifiableMap(map);
+    }
+
+    static String toOpenSsl(String key) {
+        String mapping = mappings.get(key);
+        if (mapping == null) {
+            return key;
+        }
+        return mapping;
+    }
+
+    private GroupsConverter() { }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/GroupsConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/GroupsConverter.java
@@ -29,22 +29,12 @@ final class GroupsConverter {
     static {
         // See https://tools.ietf.org/search/rfc4492#appendix-A and https://www.java.com/en/configure_crypto.html
         Map<String, String> map = new HashMap<String, String>();
-        map.put("P-224", "P-224");
         map.put("secp224r1", "P-224");
-        map.put("P-256", "P-256");
         map.put("prime256v1", "P-256");
         map.put("secp256r1", "P-256");
-
-        map.put("P-384", "P-384");
         map.put("secp384r1", "P-384");
-
-        map.put("P-521", "P-521");
         map.put("secp521r1", "P-521");
-
-        map.put("X25519", "X25519");
         map.put("x25519", "X25519");
-
-        map.put("CECPQ2", "CECPQ2");
         mappings = Collections.unmodifiableMap(map);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -336,16 +336,16 @@ public final class OpenSsl {
 
                         if (supportedNamedGroups.isEmpty()) {
                             namedGroups = DEFAULT_NAMED_GROUPS;
-                            logger.info("All configured namedGroups are not supported: {}. Use default: .",
+                            logger.info("All configured namedGroups are not supported: {}. Use default: {}.",
                                     Arrays.toString(unsupportedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS)),
                                     Arrays.toString(DEFAULT_NAMED_GROUPS));
                         } else {
                             namedGroups = supportedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS);
                             if (unsupportedNamedGroups.isEmpty()) {
-                                logger.info("Use configured namedGroups -D 'jdk.tls.namedGroup': {} ",
+                                logger.info("Using configured namedGroups -D 'jdk.tls.namedGroup': {} ",
                                         Arrays.toString(namedGroups));
                             } else {
-                                logger.info("Use supported configured namedGroups: {}. Unsupported namedGroups: {}. ",
+                                logger.info("Using supported configured namedGroups: {}. Unsupported namedGroups: {}. ",
                                         Arrays.toString(namedGroups),
                                         Arrays.toString(unsupportedNamedGroups.toArray(EmptyArrays.EMPTY_STRINGS)));
                             }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -117,6 +117,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     // https://mail.openjdk.java.net/pipermail/security-dev/2021-March/024758.html
     static final boolean CLIENT_ENABLE_SESSION_CACHE =
             SystemPropertyUtil.getBoolean("io.netty.handler.ssl.openssl.sessionCacheClient", false);
+
     /**
      * The OpenSSL SSL_CTX object.
      *
@@ -384,6 +385,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             if (asyncPrivateKeyMethod != null) {
                 SSLContext.setPrivateKeyMethod(ctx, new AsyncPrivateKeyMethod(engineMap, asyncPrivateKeyMethod));
             }
+            // Set the curves.
+            SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);
             success = true;
         } finally {
             if (!success) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -386,7 +386,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                 SSLContext.setPrivateKeyMethod(ctx, new AsyncPrivateKeyMethod(engineMap, asyncPrivateKeyMethod));
             }
             // Set the curves.
-            boolean done = SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);
+            SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);
             success = true;
         } finally {
             if (!success) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -386,7 +386,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                 SSLContext.setPrivateKeyMethod(ctx, new AsyncPrivateKeyMethod(engineMap, asyncPrivateKeyMethod));
             }
             // Set the curves.
-            SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);
+            boolean done = SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);
             success = true;
         } finally {
             if (!success) {

--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
     <!-- keep in sync with PlatformDependent#ALLOWED_LINUX_OS_CLASSIFIERS -->
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.42.Final-SNAPSHOT</tcnative.version>
+    <tcnative.version>2.0.42.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
     <!-- keep in sync with PlatformDependent#ALLOWED_LINUX_OS_CLASSIFIERS -->
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.41.Final</tcnative.version>
+    <tcnative.version>2.0.42.Final-SNAPSHOT</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

When using the JDK implementation for SSL its possible to adjust the used named groups. We should allow to do this as well and also select some default groups that will reduce the number of roundtrips.

Modifications:

- Upgrade netty-tcnative so we can set the curves
- Respect jdk.tls.namedGroups
- Use default groups of "P-256", "P-384", "X25519" so its compatible with what the JDK versions < 13 support as well.

Result:

Be able to set the used groups