### PR TITLE
Make ByteCursor implementations static final inner classes

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -95,7 +95,6 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
         assertTrue(clazz.isInstance(buffer instanceof SimpleLeakAwareByteBuf ? buffer.unwrap() : buffer));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testUsedDirectMemory() {
         T allocator =  newAllocator(true);
@@ -114,7 +113,6 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
         assertEquals(expectedUsedMemoryAfterRelease(allocator, capacity), metric.usedDirectMemory());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testUsedHeapMemory() {
         T allocator =  newAllocator(true);


### PR DESCRIPTION
Motivation:
People might be tempted to use mocking tools like Mockito.spy() on the ByteCursors.
By returning instances where the concrete classes are final, we will be forcing integrators to use stub-like wrappers instead.
Such stubs are more well-behaved since they are implemented in terms of the real instance.
This prevents the mocked objects from (easily) producing behaviour that violates the API specification.

Modification:
All ByteCursor implementations have changed from using anonymous inner classes, to using static-final named inner classes.

Result:
The concrete ByteCursor classes can no longer be extended via byte code generation, such as from mocking tools.

This is the PR promised in response to this comment: https://github.com/netty/netty/pull/11347#discussion_r656916053