### PR TITLE
Throw exceptions when rule violating UDS paths been passed in.

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
@@ -15,6 +15,13 @@
  */
 package io.netty.channel.epoll;
 
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.channel.unix.Errors.NativeIoException;
+import io.netty.channel.unix.Socket;
+import java.nio.charset.Charset;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
@@ -61,6 +68,30 @@ public class LinuxSocketTest {
                                     1234));
                         }
                     });
+        } finally {
+            socket.close();
+        }
+    }
+
+    @Test
+    public void testUnixDomainSocketTooLongPathFails() throws IOException {
+        // Most systems has a limit for UDS path of 108, 255 is generally too long.
+        StringBuilder socketPath = new StringBuilder("/tmp/");
+        while (socketPath.length() < 255) {
+            socketPath.append(UUID.randomUUID());
+        }
+
+        final DomainSocketAddress domainSocketAddress = new DomainSocketAddress(
+            socketPath.toString());
+        final Socket socket = Socket.newSocketDomain();
+        try {
+            Exception exception = Assertions.assertThrows(NativeIoException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    socket.bind(domainSocketAddress);
+                }
+            });
+            Assertions.assertTrue(exception.getMessage().contains("too long"));
         } finally {
             socket.close();
         }

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -764,12 +764,13 @@ static jint netty_unix_socket_bindDomainSocket(JNIEnv* env, jclass clazz, jint f
 
     jbyte* socket_path = (*env)->GetByteArrayElements(env, socketPath, 0);
     jint socket_path_len = (*env)->GetArrayLength(env, socketPath);
-    if (socket_path_len > sizeof(addr.sun_path)) {
-        socket_path_len = sizeof(addr.sun_path);
+
+    if (socket_path_len > sizeof(addr.sun_path) || (socket_path_len == sizeof(addr.sun_path) && socket_path[socket_path_len] != '\0')) {
+        return -ENAMETOOLONG;
     }
     memcpy(addr.sun_path, socket_path, socket_path_len);
 
-    if (unlink((const char*) socket_path) == -1 && errno != ENOENT) {
+    if (unlink((const char*) addr.sun_path) == -1 && errno != ENOENT) {
         return -errno;
     }
 
@@ -791,8 +792,9 @@ static jint netty_unix_socket_connectDomainSocket(JNIEnv* env, jclass clazz, jin
 
     jbyte* socket_path = (*env)->GetByteArrayElements(env, socketPath, 0);
     socket_path_len = (*env)->GetArrayLength(env, socketPath);
-    if (socket_path_len > sizeof(addr.sun_path)) {
-        socket_path_len = sizeof(addr.sun_path);
+
+    if (socket_path_len > sizeof(addr.sun_path) || (socket_path_len == sizeof(addr.sun_path) && socket_path[socket_path_len] != '\0')) {
+        return -ENAMETOOLONG;
     }
     memcpy(addr.sun_path, socket_path, socket_path_len);
 


### PR DESCRIPTION
Motivation:

Currently, Netty is silently truncating all over the limit UDS paths and ignoring the `sun_path`'s null-termination role, which hurts compatibility with other UDS clients and servers.

Modifications:

Adding a validation in the JNI code, if the UDS path is not satisfying the system limit or Linux spec throw a NativeIoException.

Result:

All UDS paths Netty can successfully bind are connectable by other programs.

Fixes #11652

There is also an alternative fix which is let the JNI layer expose the system's `sun_path` limit to Java. After that, the checks can be put into Java layer.