### PR TITLE
Buffer should not expose nativeAddress() directly

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -173,12 +173,6 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     Buffer fill(byte value);
 
     /**
-     * Gives the native memory address backing this buffer, or return 0 if this buffer has no native memory address.
-     * @return The native memory address, if any, otherwise 0.
-     */
-    long nativeAddress();
-
-    /**
      * Makes this buffer read-only. This is irreversible.
      * This operation is also idempotent, so calling this method multiple times on the same buffer makes no difference.
      *

--- a/buffer/src/main/java/io/netty/buffer/api/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferAllocator.java
@@ -25,8 +25,9 @@ import java.util.function.Supplier;
 public interface BufferAllocator extends AutoCloseable {
     /**
      * Produces a {@link BufferAllocator} that allocates unpooled, on-heap buffers.
-     * On-heap buffers have a {@code byte[]} internally, and their {@linkplain Buffer#nativeAddress() native address}
-     * is zero.
+     * On-heap buffers have a {@code byte[]} internally, and their
+     * {@linkplain ReadableComponent#readableNativeAddress() readable} and
+     * {@linkplain WritableComponent#writableNativeAddress() writable} native addresses are zero.
      * <p>
      * The concrete {@link Buffer} implementation is chosen by {@link MemoryManager#instance()}.
      *
@@ -39,7 +40,8 @@ public interface BufferAllocator extends AutoCloseable {
     /**
      * Produces a {@link BufferAllocator} that allocates unpooled, off-heap buffers.
      * Off-heap buffers a native memory pointer internally, which can be obtained from their
-     * {@linkplain Buffer#nativeAddress() native address method.
+     * {@linkplain ReadableComponent#readableNativeAddress() readable} and
+     * {@linkplain WritableComponent#writableNativeAddress() writable} native address methods.
      * <p>
      * The concrete {@link Buffer} implementation is chosen by {@link MemoryManager#instance()}.
      *
@@ -51,8 +53,9 @@ public interface BufferAllocator extends AutoCloseable {
 
     /**
      * Produces a pooling {@link BufferAllocator} that allocates and recycles on-heap buffers.
-     * On-heap buffers have a {@code byte[]} internally, and their {@linkplain Buffer#nativeAddress() native address}
-     * is zero.
+     * On-heap buffers have a {@code byte[]} internally, and their
+     * {@linkplain ReadableComponent#readableNativeAddress() readable} and
+     * {@linkplain WritableComponent#writableNativeAddress() writable} native addresses are zero.
      * <p>
      * The concrete {@link Buffer} implementation is chosen by {@link MemoryManager#instance()}.
      *
@@ -65,7 +68,8 @@ public interface BufferAllocator extends AutoCloseable {
     /**
      * Produces a pooling {@link BufferAllocator} that allocates and recycles off-heap buffers.
      * Off-heap buffers a native memory pointer internally, which can be obtained from their
-     * {@linkplain Buffer#nativeAddress() native address method.
+     * {@linkplain ReadableComponent#readableNativeAddress() readable} and
+     * {@linkplain WritableComponent#writableNativeAddress() writable} native address methods.
      * <p>
      * The concrete {@link Buffer} implementation is chosen by {@link MemoryManager#instance()}.
      *

--- a/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
@@ -77,11 +77,6 @@ public class BufferStub implements Buffer {
     }
 
     @Override
-    public long nativeAddress() {
-        return delegate.nativeAddress();
-    }
-
-    @Override
     public Buffer makeReadOnly() {
         return delegate.makeReadOnly();
     }

--- a/buffer/src/main/java/io/netty/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/CompositeBuffer.java
@@ -385,11 +385,6 @@ public final class CompositeBuffer extends ResourceSupport<Buffer, CompositeBuff
     }
 
     @Override
-    public long nativeAddress() {
-        return 0;
-    }
-
-    @Override
     public CompositeBuffer makeReadOnly() {
         for (Buffer buf : bufs) {
             buf.makeReadOnly();

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -165,8 +165,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
         return this;
     }
 
-    @Override
-    public long nativeAddress() {
+    private long nativeAddress() {
         return rmem.isDirect() && PlatformDependent.hasUnsafe()? PlatformDependent.directBufferAddress(rmem) : 0;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -135,8 +135,7 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         return this;
     }
 
-    @Override
-    public long nativeAddress() {
+    private long nativeAddress() {
         return base == null? address : 0;
     }
 
@@ -232,14 +231,16 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         if (dest.readOnly()) {
             throw bufferIsReadOnly(this);
         }
-        long nativeAddress = dest.nativeAddress();
         try {
-            if (nativeAddress != 0) {
-                PlatformDependent.copyMemory(base, address + srcPos, null, nativeAddress + destPos, length);
-            } else if (dest instanceof UnsafeBuffer) {
+            if (dest instanceof UnsafeBuffer) {
                 UnsafeBuffer destUnsafe = (UnsafeBuffer) dest;
-                PlatformDependent.copyMemory(
-                        base, address + srcPos, destUnsafe.base, destUnsafe.address + destPos, length);
+                long nativeAddress = destUnsafe.nativeAddress();
+                if (nativeAddress != 0) {
+                    PlatformDependent.copyMemory(base, address + srcPos, null, nativeAddress + destPos, length);
+                } else {
+                    PlatformDependent.copyMemory(
+                            base, address + srcPos, destUnsafe.base, destUnsafe.address + destPos, length);
+                }
             } else {
                 Statics.copyToViaReverseLoop(this, srcPos, dest, destPos, length);
             }

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferBulkAccessTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferBulkAccessTest.java
@@ -233,7 +233,30 @@ public class BufferBulkAccessTest extends BufferTestSupport {
     public void heapBufferMustHaveZeroAddress(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
-            assertThat(buf.nativeAddress()).isZero();
+            assertThat(buf.countReadableComponents()).isZero();
+            assertThat(buf.countWritableComponents()).isOne();
+            buf.forEachWritable(0, (index, component) -> {
+                assertThat(component.writableNativeAddress()).isZero();
+                return true;
+            });
+            buf.writeInt(42);
+            assertThat(buf.countReadableComponents()).isOne();
+            assertThat(buf.countWritableComponents()).isOne();
+            buf.forEachReadable(0, (index, component) -> {
+                assertThat(component.readableNativeAddress()).isZero();
+                return true;
+            });
+            buf.forEachWritable(0, (index, component) -> {
+                assertThat(component.writableNativeAddress()).isZero();
+                return true;
+            });
+            buf.writeInt(42);
+            assertThat(buf.countReadableComponents()).isOne();
+            assertThat(buf.countWritableComponents()).isZero();
+            buf.forEachReadable(0, (index, component) -> {
+                assertThat(component.readableNativeAddress()).isZero();
+                return true;
+            });
         }
     }
 
@@ -242,7 +265,30 @@ public class BufferBulkAccessTest extends BufferTestSupport {
     public void directBufferMustHaveNonZeroAddress(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
-            assertThat(buf.nativeAddress()).isNotZero();
+            assertThat(buf.countReadableComponents()).isZero();
+            assertThat(buf.countWritableComponents()).isOne();
+            buf.forEachWritable(0, (index, component) -> {
+                assertThat(component.writableNativeAddress()).isNotZero();
+                return true;
+            });
+            buf.writeInt(42);
+            assertThat(buf.countReadableComponents()).isOne();
+            assertThat(buf.countWritableComponents()).isOne();
+            buf.forEachReadable(0, (index, component) -> {
+                assertThat(component.readableNativeAddress()).isNotZero();
+                return true;
+            });
+            buf.forEachWritable(0, (index, component) -> {
+                assertThat(component.writableNativeAddress()).isNotZero();
+                return true;
+            });
+            buf.writeInt(42);
+            assertThat(buf.countReadableComponents()).isOne();
+            assertThat(buf.countWritableComponents()).isZero();
+            buf.forEachReadable(0, (index, component) -> {
+                assertThat(component.readableNativeAddress()).isNotZero();
+                return true;
+            });
         }
     }
 


### PR DESCRIPTION
Motivation:
Accessing the native address, if a buffer has any, violates the no-aliasing rule for Buffers.
Also, it inherently assumes that a buffer has a single, native memory allocation.
The native address, or addresses, are already available via the Readable- and WritableComponents.
Accessing these via forEachReadable and forEachWritable will also ensure that composite buffers will be handled correctly.

Modification:
Remove the nativeAddress() method from the Buffer API.
Update the ByteBufAdaptor and a few tests to cope with this change.

Result:
Less error prone code, and make unsafe APIs a bit more hidden.
