### PR TITLE
[Feature] Add FallbackByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/FallbackByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/FallbackByteBufAllocator.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+/**
+ * The {@link ByteBufAllocator} implementation that use fallback policy.
+ */
+public final class FallbackByteBufAllocator extends AbstractByteBufAllocator {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(FallbackByteBufAllocator.class);
+
+    private final ByteBufAllocator allocator;
+    private final boolean preferDirect;
+    private final boolean canFallback;
+
+    /**
+     * Create a new instance which uses {@link ByteBufAllocator}.
+     *
+     * @param allocator the {@link ByteBufAllocator}
+     */
+    public FallbackByteBufAllocator(ByteBufAllocator allocator) {
+        this(allocator, false, true);
+    }
+
+    /**
+     * Create a new instance which uses {@link ByteBufAllocator} and preferDirect.
+     *
+     * @param allocator    the {@link ByteBufAllocator}
+     * @param preferDirect {@code true} if {@link ByteBufAllocator} should try to allocate a direct buffer rather than
+     *                     a heap buffer
+     */
+    public FallbackByteBufAllocator(ByteBufAllocator allocator, boolean preferDirect) {
+        this(allocator, preferDirect, true);
+    }
+
+    /**
+     * Create a new instance which uses {@link ByteBufAllocator}, preferDirect and canFallback.
+     *
+     * @param allocator    the {@link ByteBufAllocator}
+     * @param preferDirect {@code true} if {@link ByteBufAllocator} should try to allocate a direct buffer rather than
+     *                     a heap buffer
+     * @param canFallback  {@code true} if {@link ByteBufAllocator} should try to allocate a heap buffer when fail to
+     *                     allocate a direct buffer
+     */
+    public FallbackByteBufAllocator(ByteBufAllocator allocator, boolean preferDirect, boolean canFallback) {
+        super(preferDirect);
+        this.allocator = ObjectUtil.checkNotNull(allocator, "allocator");
+        this.preferDirect = preferDirect;
+        this.canFallback = canFallback;
+    }
+
+    @Override
+    public ByteBuf buffer(int initialCapacity, int maxCapacity) {
+        if (preferDirect) {
+            return newDirectBuffer(initialCapacity, maxCapacity, canFallback);
+        } else {
+            return newHeapBuffer(initialCapacity, maxCapacity);
+        }
+    }
+
+    @Override
+    public ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+        return allocator.heapBuffer(initialCapacity, maxCapacity);
+    }
+
+    @Override
+    public ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+        return newDirectBuffer(initialCapacity, maxCapacity, false);
+    }
+
+    private ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity, boolean canFallback) {
+
+        try {
+            return allocator.directBuffer(initialCapacity, maxCapacity);
+        } catch (OutOfMemoryError e) {
+            if (canFallback) {
+                logger.error("allocate direct buffer error,fall back to heap", e);
+                return allocator.heapBuffer(initialCapacity, maxCapacity);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public boolean isDirectBufferPooled() {
+        return allocator.isDirectBufferPooled();
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -179,6 +179,9 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     public static final PooledByteBufAllocator DEFAULT =
             new PooledByteBufAllocator(PlatformDependent.directBufferPreferred());
 
+    public static final FallbackByteBufAllocator FALL_BACK =
+            new FallbackByteBufAllocator(DEFAULT);
+
     private final PoolArena<byte[]>[] heapArenas;
     private final PoolArena<ByteBuffer>[] directArenas;
     private final int smallCacheSize;
@@ -210,7 +213,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     @Deprecated
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-             0, DEFAULT_SMALL_CACHE_SIZE, DEFAULT_NORMAL_CACHE_SIZE);
+                0, DEFAULT_SMALL_CACHE_SIZE, DEFAULT_NORMAL_CACHE_SIZE);
     }
 
     /**
@@ -221,7 +224,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder,
                                   int tinyCacheSize, int smallCacheSize, int normalCacheSize) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder, smallCacheSize,
-             normalCacheSize, DEFAULT_USE_CACHE_FOR_ALL_THREADS, DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
+                normalCacheSize, DEFAULT_USE_CACHE_FOR_ALL_THREADS, DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
     }
 
     /**
@@ -234,8 +237,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                                   int smallCacheSize, int normalCacheSize,
                                   boolean useCacheForAllThreads) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-             smallCacheSize, normalCacheSize,
-             useCacheForAllThreads);
+                smallCacheSize, normalCacheSize,
+                useCacheForAllThreads);
     }
 
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena,
@@ -243,8 +246,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                                   int smallCacheSize, int normalCacheSize,
                                   boolean useCacheForAllThreads) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-             smallCacheSize, normalCacheSize,
-             useCacheForAllThreads, DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
+                smallCacheSize, normalCacheSize,
+                useCacheForAllThreads, DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
     }
 
     /**
@@ -256,8 +259,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                                   int tinyCacheSize, int smallCacheSize, int normalCacheSize,
                                   boolean useCacheForAllThreads, int directMemoryCacheAlignment) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-             smallCacheSize, normalCacheSize,
-             useCacheForAllThreads, directMemoryCacheAlignment);
+                smallCacheSize, normalCacheSize,
+                useCacheForAllThreads, directMemoryCacheAlignment);
     }
 
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder,
@@ -717,8 +720,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         int directArenasLen = directArenas == null ? 0 : directArenas.length;
 
         buf.append(directArenasLen)
-           .append(" direct arena(s):")
-           .append(StringUtil.NEWLINE);
+                .append(" direct arena(s):")
+                .append(StringUtil.NEWLINE);
         if (directArenasLen > 0) {
             for (PoolArena<ByteBuffer> a: directArenas) {
                 buf.append(a);

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -213,7 +213,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     @Deprecated
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-                0, DEFAULT_SMALL_CACHE_SIZE, DEFAULT_NORMAL_CACHE_SIZE);
+             0, DEFAULT_SMALL_CACHE_SIZE, DEFAULT_NORMAL_CACHE_SIZE);
     }
 
     /**
@@ -224,7 +224,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder,
                                   int tinyCacheSize, int smallCacheSize, int normalCacheSize) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder, smallCacheSize,
-                normalCacheSize, DEFAULT_USE_CACHE_FOR_ALL_THREADS, DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
+             normalCacheSize, DEFAULT_USE_CACHE_FOR_ALL_THREADS, DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
     }
 
     /**
@@ -237,8 +237,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                                   int smallCacheSize, int normalCacheSize,
                                   boolean useCacheForAllThreads) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-                smallCacheSize, normalCacheSize,
-                useCacheForAllThreads);
+             smallCacheSize, normalCacheSize,
+             useCacheForAllThreads);
     }
 
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena,
@@ -246,8 +246,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                                   int smallCacheSize, int normalCacheSize,
                                   boolean useCacheForAllThreads) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-                smallCacheSize, normalCacheSize,
-                useCacheForAllThreads, DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
+             smallCacheSize, normalCacheSize,
+             useCacheForAllThreads, DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT);
     }
 
     /**
@@ -259,8 +259,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
                                   int tinyCacheSize, int smallCacheSize, int normalCacheSize,
                                   boolean useCacheForAllThreads, int directMemoryCacheAlignment) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-                smallCacheSize, normalCacheSize,
-                useCacheForAllThreads, directMemoryCacheAlignment);
+             smallCacheSize, normalCacheSize,
+             useCacheForAllThreads, directMemoryCacheAlignment);
     }
 
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder,
@@ -720,8 +720,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         int directArenasLen = directArenas == null ? 0 : directArenas.length;
 
         buf.append(directArenasLen)
-                .append(" direct arena(s):")
-                .append(StringUtil.NEWLINE);
+           .append(" direct arena(s):")
+           .append(StringUtil.NEWLINE);
         if (directArenasLen > 0) {
             for (PoolArena<ByteBuffer> a: directArenas) {
                 buf.append(a);

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -37,6 +37,12 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
             new UnpooledByteBufAllocator(PlatformDependent.directBufferPreferred());
 
     /**
+     * Default instance which uses leak-detection for direct buffers and fallback policy.
+     */
+    public static final FallbackByteBufAllocator FALL_BACK =
+            new FallbackByteBufAllocator(DEFAULT);
+
+    /**
      * Create a new instance which uses leak-detection for direct buffers.
      *
      * @param preferDirect {@code true} if {@link #buffer(int)} should try to allocate a direct buffer rather than

--- a/buffer/src/test/java/io/netty/buffer/FallbackByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/FallbackByteBufAllocatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+public class FallbackByteBufAllocatorTest {
+
+    @Test
+    public void testHeapBuffer() {
+        ByteBufAllocator allocator = new FallbackByteBufAllocator(new PooledByteBufAllocator(), false);
+        ByteBuf buffer = allocator.heapBuffer(1, 8);
+        try {
+            assertBuffer(buffer, false, 1, 8);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testBuffer() {
+        testBuffer(true, 8);
+        testBuffer(false, 8);
+    }
+
+    private static void testBuffer(boolean preferDirect, int maxCapacity) {
+        ByteBufAllocator allocator = new FallbackByteBufAllocator(new PooledByteBufAllocator(), preferDirect);
+        ByteBuf buffer = allocator.buffer(1, maxCapacity);
+        try {
+            assertBuffer(buffer, preferDirect, 1, maxCapacity);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDirectBuffer() {
+        ByteBufAllocator allocator = new FallbackByteBufAllocator(new PooledByteBufAllocator(true), true);
+        ByteBuf buffer = allocator.directBuffer(1, 8);
+        try {
+            assertBuffer(buffer, true, 1, 8);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDirectFallbackBuffer() {
+        ByteBufAllocator allocator = new FallbackByteBufAllocator(new PooledByteBufAllocator(true) {
+            @Override
+            protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+                throw new OutOfMemoryError();
+            }
+        }, true);
+        ByteBuf buffer = allocator.buffer(1, 8);
+        try {
+            assertBuffer(buffer, false, 1, 8);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static void assertBuffer(ByteBuf buffer, boolean expectedDirect,
+                                     int expectedCapacity, int expectedMaxCapacity) {
+        assertEquals(expectedDirect, buffer.isDirect());
+        assertEquals(expectedCapacity, buffer.capacity());
+        assertEquals(expectedMaxCapacity, buffer.maxCapacity());
+    }
+}


### PR DESCRIPTION
Motivation:

Many users use direct memory allocation in large quantities. However, direct memory is limited. When the direct memory allocation is abnormal, such as insufficient direct memory, an error will be thrown by default. However, the jvm heap memory is often sufficient at this time, and some users may would like to continue to use the heap memory (or just print logs), and fallback to the heap memory. Considering that dealing direct memory problems is often very complicated, in some cases, users need a fallback strategy to solve or temporarily downgrade this problem

Modification:

Add `FallbackByteBufAllocator` and test case to block pooled and unpooled methods through combination

Result:

In extreme cases, users can continue to allocate memory. Can make the user's application to maintain flexibility and appropriate memory allocation strategy
