### PR TITLE
Fix ByteBufUtil indexOf ClassCastException

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -247,7 +247,7 @@ public final class ByteBufUtil {
 
         // When the needle has only one byte that can be read,
         // the firstIndexOf method needs to be called
-        if (m == 1) {
+        if (m == 1 && haystack instanceof  AbstractByteBuf) {
             return firstIndexOf((AbstractByteBuf) haystack, haystack.readerIndex(),
                     haystack.writerIndex(), needle.getByte(needle.readerIndex()));
         }

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -245,11 +245,14 @@ public final class ByteBufUtil {
             return 0;
         }
 
-        // When the needle has only one byte that can be read and haystack is AbstractByteBuf,
+        // When the needle has only one byte that can be read,
         // the firstIndexOf method can be used
-        if (m == 1 && haystack instanceof AbstractByteBuf) {
-            return firstIndexOf((AbstractByteBuf) haystack, haystack.readerIndex(),
-                    haystack.writerIndex(), needle.getByte(needle.readerIndex()));
+        if (m == 1) {
+            return haystack instanceof AbstractByteBuf ? firstIndexOf((AbstractByteBuf) haystack,
+                    haystack.readerIndex(), haystack.writerIndex(),
+                    needle.getByte(needle.readerIndex()))
+                    : haystack.indexOf(haystack.readerIndex(), haystack.writerIndex(),
+                          needle.getByte(needle.readerIndex()));
         }
 
         int i;

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -246,12 +246,9 @@ public final class ByteBufUtil {
         }
 
         // When the needle has only one byte that can be read,
-        // the firstIndexOf method can be used
+        // the ByteBuf.indexOf() can be used
         if (m == 1) {
-            return haystack instanceof AbstractByteBuf ? firstIndexOf((AbstractByteBuf) haystack,
-                    haystack.readerIndex(), haystack.writerIndex(),
-                    needle.getByte(needle.readerIndex()))
-                    : haystack.indexOf(haystack.readerIndex(), haystack.writerIndex(),
+            return haystack.indexOf(haystack.readerIndex(), haystack.writerIndex(),
                           needle.getByte(needle.readerIndex()));
         }
 

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -245,8 +245,8 @@ public final class ByteBufUtil {
             return 0;
         }
 
-        // When the needle has only one byte that can be read,
-        // the firstIndexOf method needs to be called
+        // When the needle has only one byte that can be read and haystack is AbstractByteBuf,
+        // the firstIndexOf method can be used
         if (m == 1 && haystack instanceof  AbstractByteBuf) {
             return firstIndexOf((AbstractByteBuf) haystack, haystack.readerIndex(),
                     haystack.writerIndex(), needle.getByte(needle.readerIndex()));

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -141,6 +141,12 @@ public class ByteBufUtilTest {
         assertEquals(1, ByteBufUtil.indexOf(needle, haystack));
         haystack.release();
 
+        haystack = new WrappedByteBuf(Unpooled.copiedBuffer("abc123", CharsetUtil.UTF_8));
+        assertEquals(0, ByteBufUtil.indexOf(Unpooled.copiedBuffer("a", CharsetUtil.UTF_8), haystack));
+        assertEquals(1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("bc".getBytes(CharsetUtil.UTF_8)), haystack));
+        assertEquals(-1, ByteBufUtil.indexOf(Unpooled.copiedBuffer("abcdef".getBytes(CharsetUtil.UTF_8)), haystack));
+        haystack.release();
+
         haystack = Unpooled.copiedBuffer("123aab123", CharsetUtil.UTF_8);
         assertEquals(3, ByteBufUtil.indexOf(Unpooled.copiedBuffer("aab", CharsetUtil.UTF_8), haystack));
         haystack.release();


### PR DESCRIPTION
Motivation:

In this issue(https://github.com/netty/netty/issues/11678) , it is proposed that `ByteBufUtil.indexOf()` may throw `ClassCastException`, so type checking on `haystack` is required

Modification:

Use `ByteBuf.indexOf()` instead of `firstIndexOf()`, and add test case

Result:

Fixes https://github.com/netty/netty/issues/11678

