### PR TITLE
Ensure bom don't define extra dependencies

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -17,13 +17,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty</groupId>
-    <artifactId>netty-parent</artifactId>
-    <version>4.1.69.Final-SNAPSHOT</version>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+    <relativePath />
   </parent>
 
+  <groupId>io.netty</groupId>
   <artifactId>netty-bom</artifactId>
+  <version>4.1.69.Final-SNAPSHOT</version>
   <packaging>pom</packaging>
+
   <name>Netty/BOM</name>
   <description>Netty (Bill of Materials)</description>
   <url>https://netty.io/</url>
@@ -59,212 +63,216 @@
     </developer>
   </developers>
 
+  <properties>
+    <!-- Keep in sync with ../pom.xml -->
+    <tcnative.version>2.0.43.Final</tcnative.version>
+  </properties>
   <dependencyManagement>
     <dependencies>
       <!-- All release modules -->
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-dns</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-haproxy</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http2</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-memcache</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-mqtt</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-smtp</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-socks</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-stomp</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-xml</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-dev-tools</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-rxtx</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-sctp</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-udt</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-example</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>${project.version}</version>
+        <version>4.1.69.Final-SNAPSHOT</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <!-- Add netty-tcnative* as well as users need to ensure they use the correct version -->

--- a/pom.xml
+++ b/pom.xml
@@ -508,6 +508,7 @@
     <!-- keep in sync with PlatformDependent#ALLOWED_LINUX_OS_CLASSIFIERS -->
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
+    <!-- Keep in sync with bom/pom.xml -->
     <tcnative.version>2.0.43.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>


### PR DESCRIPTION
Motivation:

The bom shouldnt depend on the parent as it may define extra dependencies that would be "pulled" in.

See https://github.com/netty/netty/pull/11672#discussion_r707619462

Modifications:

- Revert commit d6383bf2478267eb62b1f71807c2a3c34794d1b0.
- Add tcnative version and add comments to ensure we keep the version in-sync

Result:

Correct bom for netty