### PR TITLE
Add CompositeBuffer.decomposeBuffer method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/CompositeBuffer.java
@@ -814,7 +814,18 @@ public final class CompositeBuffer extends ResourceSupport<Buffer, CompositeBuff
     public Buffer[] decomposeBuffer() {
         Buffer[] result = bufs;
         bufs = EMPTY_BUFFER_ARRAY;
-        close();
+        try {
+            close();
+        } catch (Exception e) {
+            for (Buffer buffer : result) {
+                try {
+                    buffer.close();
+                } catch (Exception ex) {
+                    e.addSuppressed(ex);
+                }
+            }
+            throw e;
+        }
         return result;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/CompositeBuffer.java
@@ -816,11 +816,11 @@ public final class CompositeBuffer extends ResourceSupport<Buffer, CompositeBuff
         bufs = EMPTY_BUFFER_ARRAY;
         try {
             close();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             for (Buffer buffer : result) {
                 try {
                     buffer.close();
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     e.addSuppressed(ex);
                 }
             }

--- a/buffer/src/main/java/io/netty/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/Statics.java
@@ -206,4 +206,9 @@ public interface Statics {
     static int countBorrows(ResourceSupport<?, ?> obj) {
         return ResourceSupport.countBorrows(obj);
     }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    static void unsafeSetDrop(ResourceSupport<?, ?> obj, Drop<?> replacement) {
+        obj.unsafeSetDrop((Drop) replacement);
+    }
 }

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferCompositionTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferCompositionTest.java
@@ -20,8 +20,10 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.buffer.api.BufferClosedException;
 import io.netty.buffer.api.BufferReadOnlyException;
 import io.netty.buffer.api.CompositeBuffer;
+import io.netty.buffer.api.Drop;
 import io.netty.buffer.api.Send;
 import io.netty.buffer.api.internal.ResourceSupport;
+import io.netty.buffer.api.internal.Statics;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static io.netty.buffer.api.internal.Statics.acquire;
 import static io.netty.buffer.api.internal.Statics.isOwned;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -594,6 +597,39 @@ public class BufferCompositionTest extends BufferTestSupport {
             assertThat(components[2].writableBytes()).isZero();
             assertThat(components[1].readShort()).isEqualTo((short) 0x0506);
             assertThat(components[2].readShort()).isEqualTo((short) 0x0708);
+        }
+    }
+
+    @Test
+    public void failureInDecomposeMustCloseConstituentBuffers() {
+        try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
+            CompositeBuffer composite = CompositeBuffer.compose(
+                    allocator,
+                    allocator.allocate(3).send(),
+                    allocator.allocate(3).send(),
+                    allocator.allocate(2).send());
+            Drop<Object> throwingDrop = obj -> {
+                throw new RuntimeException("Expected.");
+            };
+            try {
+                Statics.unsafeSetDrop(composite, throwingDrop);
+            } catch (Exception e) {
+                composite.close();
+                throw e;
+            }
+            Buffer[] inners  = new Buffer[3];
+            assertThat(composite.countWritableComponents()).isEqualTo(3);
+            int count = composite.forEachWritable(0, (i, component) -> {
+                inners[i] = (Buffer) component;
+                return true;
+            });
+            assertThat(count).isEqualTo(3);
+            var re = assertThrows(RuntimeException.class, () -> composite.decomposeBuffer());
+            assertThat(re.getMessage()).isEqualTo("Expected.");
+            // The failure to decompose the buffer should have closed the inner buffers we extracted earlier.
+            for (Buffer inner : inners) {
+                assertFalse(inner.isAccessible());
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:
It may in some cases be useful to unwrap a composite buffer and work on the array of buffers directly.
The decomposeBuffer method makes this possible safely, by killing the composite buffer in the process.

Modification:
Add a CompositeBuffer.decomposeBuffer method, which returns the array of the constituent component buffers of the composite buffer, and at the same time closes the composite buffer without closing its components.
The caller effectively takes ownership of the component buffers away from the composite buffer.

Result:
This API makes buffer composition fully reversible.
