### PR TITLE
Disable Flaky `ThreadPerChannelEventLoopGroupTest` test

### DIFF
--- a/transport/src/test/java/io/netty/channel/ThreadPerChannelEventLoopGroupTest.java
+++ b/transport/src/test/java/io/netty/channel/ThreadPerChannelEventLoopGroupTest.java
@@ -25,6 +25,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Disabled("Flaky test; See: https://github.com/netty/netty/issues/11551")
 public class ThreadPerChannelEventLoopGroupTest {
 
     private static final ChannelHandler NOOP_HANDLER = new ChannelHandlerAdapter() {


### PR DESCRIPTION
Motivation:
There are multiple instances when the build stalled at `io.netty.channel.ThreadPerChannelEventLoopGroupTest` test and kept running forever until it was interrupted by GitHub Actions for consuming 6 hours of runtime.

Modification:
Disabled the test until it's fixed.

Result:
No more build failure
