### PR TITLE
Use the correct readerIndex() when handle BLOCK_TYPE_NON_COMPRESSED

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -280,7 +280,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
         if (compressedLength >= flushableBytes) {
             blockType = BLOCK_TYPE_NON_COMPRESSED;
             compressedLength = flushableBytes;
-            out.setBytes(idx + HEADER_LENGTH, buffer, 0, flushableBytes);
+            out.setBytes(idx + HEADER_LENGTH, buffer, buffer.readerIndex(), flushableBytes);
         } else {
             blockType = BLOCK_TYPE_COMPRESSED;
         }


### PR DESCRIPTION
Motivation:

We need to use the readerIndex() as offset when handle BLOCK_TYPE_NON_COMPRESSED as it might not be 0.

Modifications:

Correctly use readerIndex()

Result:

Correctly handle BLOCK_TYPE_NON_COMPRESSED when the readerIndex() != 0