### PR TITLE
Ensure CompositeByteBuf.decompose(...) returns the non unwrapped buffer

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -731,7 +731,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         Component firstC = components[componentId];
 
         // It's important to use srcBuf and NOT buf as we need to return the "original" source buffer and not the
-        // unwrapped one as otherwise me could loose the ability to correctly update the reference count on the
+        // unwrapped one as otherwise we could loose the ability to correctly update the reference count on the
         // returned buffer.
         ByteBuf slice = firstC.srcBuf.slice(firstC.srcIdx(offset), Math.min(firstC.endOffset - offset, bytesToSlice));
         bytesToSlice -= slice.readableBytes();

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -747,7 +747,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         do {
             Component component = components[++componentId];
             // It's important to use srcBuf and NOT buf as we need to return the "original" source buffer and not the
-            // unwrapped one as otherwise me could loose the ability to correctly update the reference count on the
+            // unwrapped one as otherwise we could loose the ability to correctly update the reference count on the
             // returned buffer.
             slice = component.srcBuf.slice(component.srcIdx(component.offset),
                     Math.min(component.length(), bytesToSlice));

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -730,7 +730,10 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         // The first component
         Component firstC = components[componentId];
 
-        ByteBuf slice = firstC.buf.slice(firstC.idx(offset), Math.min(firstC.endOffset - offset, bytesToSlice));
+        // It's important to use srcBuf and NOT buf as we need to return the "original" source buffer and not the
+        // unwrapped one as otherwise me could loose the ability to correctly update the reference count on the
+        // returned buffer.
+        ByteBuf slice = firstC.srcBuf.slice(firstC.srcIdx(offset), Math.min(firstC.endOffset - offset, bytesToSlice));
         bytesToSlice -= slice.readableBytes();
 
         if (bytesToSlice == 0) {
@@ -743,7 +746,11 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         // Add all the slices until there is nothing more left and then return the List.
         do {
             Component component = components[++componentId];
-            slice = component.buf.slice(component.idx(component.offset), Math.min(component.length(), bytesToSlice));
+            // It's important to use srcBuf and NOT buf as we need to return the "original" source buffer and not the
+            // unwrapped one as otherwise me could loose the ability to correctly update the reference count on the
+            // returned buffer.
+            slice = component.srcBuf.slice(component.srcIdx(component.offset),
+                    Math.min(component.length(), bytesToSlice));
             bytesToSlice -= slice.readableBytes();
             sliceList.add(slice);
         } while (bytesToSlice > 0);

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -1505,6 +1505,38 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     }
 
     @Test
+    public void testDecomposeReturnNonUnwrappedBuffers() {
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(1024);
+        buf.writeZero(1024);
+        ByteBuf sliced = buf.retainedSlice(100, 200);
+        ByteBuf sliced2 = buf.retainedSlice(400, 100);
+        sliced.retain();
+        sliced2.retain();
+        assertEquals(2, sliced.refCnt());
+        CompositeByteBuf composite = compositeBuffer();
+        composite.addComponents(true, sliced);
+        composite.addComponents(true, sliced2);
+
+        List<ByteBuf> bufferList = composite.decompose(100, 150);
+        assertEquals(2, bufferList.size());
+        ByteBuf decomposed = bufferList.get(0);
+        ByteBuf decomposed2 = bufferList.get(1);
+        assertSame(sliced.refCnt(), decomposed.refCnt());
+        decomposed.release();
+        decomposed2.release();
+
+        assertSame(sliced.refCnt(), decomposed.refCnt());
+        assertSame(sliced2.refCnt(), decomposed2.refCnt());
+
+        composite.release();
+        buf.release();
+
+        for (ByteBuf buffer: bufferList) {
+            assertEquals(0, buffer.refCnt());
+        }
+    }
+
+    @Test
     public void testComponentsLessThanLowerBound() {
         try {
             new CompositeByteBuf(ALLOC, true, 0);

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -1479,6 +1479,32 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     }
 
     @Test
+    public void testDecomposeReturnNonUnwrappedBuffer() {
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(1024);
+        buf.writeZero(1024);
+        ByteBuf sliced = buf.retainedSlice(100, 200);
+        sliced.retain();
+        assertEquals(2, sliced.refCnt());
+        CompositeByteBuf composite = newCompositeBuffer();
+        composite.addComponents(true, sliced);
+
+        List<ByteBuf> bufferList = composite.decompose(0, 100);
+        assertEquals(1, bufferList.size());
+        ByteBuf decomposed = bufferList.get(0);
+        assertSame(sliced.refCnt(), decomposed.refCnt());
+        decomposed.release();
+
+        assertSame(sliced.refCnt(), decomposed.refCnt());
+
+        composite.release();
+        buf.release();
+
+        for (ByteBuf buffer: bufferList) {
+            assertEquals(0, buffer.refCnt());
+        }
+    }
+
+    @Test
     public void testComponentsLessThanLowerBound() {
         try {
             new CompositeByteBuf(ALLOC, true, 0);


### PR DESCRIPTION
Motivation:

We did return the previous unwrapped buffer when calling decompose(...). This could result in inconsistency in terms of reference counting and so to leaks.

Modifications:

- Correctly return the non unwrapped buffer (the original) when calling decompose(...)
- Add unit test

Result:

No more reference count issues when using decompose(...)