### PR TITLE
Add a Resource.touch method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/BufferHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferHolder.java
@@ -146,4 +146,11 @@ public abstract class BufferHolder<T extends BufferHolder<T>> implements Resourc
     public boolean isAccessible() {
         return buf.isAccessible();
     }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T touch(Object hint) {
+        buf.touch(hint);
+        return (T) this;
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
@@ -452,4 +452,10 @@ public class BufferStub implements Buffer {
     public boolean isAccessible() {
         return delegate.isAccessible();
     }
+
+    @Override
+    public Buffer touch(Object hint) {
+        delegate.touch(hint);
+        return this;
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -1122,6 +1122,15 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         return super.isOwned() && allConstituentsAreOwned();
     }
 
+    @Override
+    public CompositeBuffer touch(Object hint) {
+        super.touch(hint);
+        for (Buffer buf : bufs) {
+            buf.touch(hint);
+        }
+        return this;
+    }
+
     private boolean allConstituentsAreOwned() {
         boolean result = true;
         for (Buffer buf : bufs) {

--- a/buffer/src/main/java/io/netty/buffer/api/Resource.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Resource.java
@@ -53,4 +53,14 @@ public interface Resource<T extends Resource<T>> extends AutoCloseable {
      * or been {@linkplain #send() sent} elsewhere.
      */
     boolean isAccessible();
+
+    /**
+     * Record the current access location for debugging purposes.
+     * This information may be included if the resource throws a life-cycle related exception, or if it leaks.
+     * If this resource has already been closed, then this method has not effect.
+     *
+     * @param hint An optional hint about this access and its context. May be {@code null}.
+     * @return This resource instance.
+     */
+    T touch(Object hint);
 }

--- a/buffer/src/main/java/io/netty/buffer/api/internal/AdaptableBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/AdaptableBuffer.java
@@ -71,7 +71,8 @@ public abstract class AdaptableBuffer<T extends ResourceSupport<Buffer, T>>
     }
 
     @Override
-    public ReferenceCounted touch(Object hint) {
+    public AdaptableBuffer<T> touch(Object hint) {
+        super.touch(hint);
         return this;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/internal/ResourceSupport.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/ResourceSupport.java
@@ -188,6 +188,14 @@ public abstract class ResourceSupport<I extends Resource<I>, T extends ResourceS
         return acquires >= 0;
     }
 
+    @Override
+    public I touch(Object hint) {
+        if (isAccessible()) {
+            tracer.touch(acquires, hint);
+        }
+        return self();
+    }
+
     /**
      * Prepare this instance for ownership transfer. This method is called from {@link #send()} in the sending thread.
      * This method should put this resource in a deactivated state where it is no longer accessible from the currently


### PR DESCRIPTION
Motivation:
It is useful for debugging to be able to add important "touch points" to the life cycle trace of an object, so that life cycle issues can be debugged with higher fidelity information than what the usual acquire/close/send/receive trace points provide.

Modification:
A `touch` method is added to the `Resource` interface, and `ResourceSupport` provides an implementation.
Implementations have also been added to `BufferHolder`, `BufferStub`, `AdaptableBuffer` (for compatibility with `ByteBuf` API), and `DefaultCompositeBuffer`.
The LifecycleTracer has also been extended to support this new trace point, and the internals have been streamlined a bit.
No test has been added at this point, because the lifecycle tracer API needs more work before it is testable.
This will come in a later PR.

Result:
It is now possible to "touch" buffers to add more information to their life cycle traces.
