### PR TITLE
Add a `makeInaccessible` callback to `ResourceSupport`

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -44,7 +44,6 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     private static final Drop<DefaultCompositeBuffer> COMPOSITE_DROP = new Drop<>() {
         @Override
         public void drop(DefaultCompositeBuffer buf) {
-            buf.makeInaccessible();
             RuntimeException re = null;
             for (Buffer b : buf.bufs) {
                 try {
@@ -1096,7 +1095,6 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             throw throwable;
         }
         boolean readOnly = this.readOnly;
-        makeInaccessible();
         return drop -> {
             Buffer[] received = new Buffer[sends.length];
             for (int i = 0; i < sends.length; i++) {
@@ -1109,7 +1107,8 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         };
     }
 
-    private void makeInaccessible() {
+    @Override
+    protected void makeInaccessible() {
         capacity = 0;
         roff = 0;
         woff = 0;

--- a/buffer/src/main/java/io/netty/buffer/api/internal/ResourceSupport.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/ResourceSupport.java
@@ -19,6 +19,7 @@ import io.netty.buffer.api.Drop;
 import io.netty.buffer.api.Owned;
 import io.netty.buffer.api.Resource;
 import io.netty.buffer.api.Send;
+import io.netty.util.internal.UnstableApi;
 
 import java.util.Objects;
 
@@ -28,6 +29,7 @@ import java.util.Objects;
  * @param <I> The public interface for the resource.
  * @param <T> The concrete implementation of the resource.
  */
+@UnstableApi
 public abstract class ResourceSupport<I extends Resource<I>, T extends ResourceSupport<I, T>> implements Resource<I> {
     private int acquires; // Closed if negative.
     private Drop<T> drop;
@@ -87,13 +89,18 @@ public abstract class ResourceSupport<I extends Resource<I>, T extends ResourceS
         if (acquires == -1) {
             throw attachTrace(new IllegalStateException("Double-free: Resource already closed and dropped."));
         }
-        if (acquires == 0) {
-            tracer.drop(acquires);
-            drop.drop(impl());
-            makeInaccessible();
-        }
+        int acq = acquires;
         acquires--;
-        tracer.close(acquires);
+        tracer.close(acq);
+        if (acq == 0) {
+            // The 'acquires' was 0, now decremented to -1, which means we need to drop.
+            tracer.drop(0);
+            try {
+                drop.drop(impl());
+            } finally {
+                makeInaccessible();
+            }
+        }
     }
 
     /**
@@ -115,10 +122,13 @@ public abstract class ResourceSupport<I extends Resource<I>, T extends ResourceS
         if (!isOwned()) {
             throw notSendableException();
         }
-        var owned = tracer.send(prepareSend(), acquires);
-        makeInaccessible();
-        acquires = -2; // Close without dropping. This also ignore future double-free attempts.
-        return new SendFromOwned<I, T>(owned, drop, getClass());
+        try {
+            var owned = tracer.send(prepareSend(), acquires);
+            return new SendFromOwned<I, T>(owned, drop, getClass());
+        } finally {
+            acquires = -2; // Close without dropping. This also ignore future double-free attempts.
+            makeInaccessible();
+        }
     }
 
     /**
@@ -203,8 +213,10 @@ public abstract class ResourceSupport<I extends Resource<I>, T extends ResourceS
 
     /**
      * Called when this resource needs to be considered inaccessible.
-     * This is called at the correct points when the resource is being closed or sent,
+     * This is called at the correct points, by the {@link ResourceSupport} class,
+     * when the resource is being closed or sent,
      * and can be used to set further traps for accesses that makes accessibility checks cheap.
+     * There would normally not be any reason to call this directly from a sub-class.
      */
     protected void makeInaccessible() {
     }


### PR DESCRIPTION
Motivation:
All buffer implementation require the same "make inaccessible" callback at the same points, and currently wraps their drop instance in order to get it right.
There is no reason to repeat this ceremony 3 or 4 times, when `ResourceSupport` can just define a protected method and call that in the right places.

Modification:
Add a protected `makeInaccessible` method to `ResourceSupport`, which will called after drop, and in-between send/receive pairs.
Remove redundant MakeInaccessible drop wrappers.

Result:
Cleaner code.