### PR TITLE
Small code style fixes

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferCharSequenceTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferCharSequenceTest.java
@@ -32,7 +32,8 @@ public class BufferCharSequenceTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     void readCharSequence(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator(); Buffer buf = allocator.allocate(32)) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(32)) {
             String data = "Hello World";
             buf.writeBytes(data.getBytes(US_ASCII));
             assertEquals(data.length(), buf.writerOffset());
@@ -48,7 +49,8 @@ public class BufferCharSequenceTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     void writeCharSequence(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator(); Buffer buf = allocator.allocate(32)) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(32)) {
             AsciiString data = new AsciiString("Hello world".getBytes(US_ASCII));
             buf.writeCharSequence(data, US_ASCII);
             assertEquals(data.length(), buf.writerOffset());
@@ -64,7 +66,8 @@ public class BufferCharSequenceTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
     void readAndWriteCharSequence(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator(); Buffer buf = allocator.allocate(32)) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(32)) {
             AsciiString data = new AsciiString("Hello world".getBytes(US_ASCII));
             buf.writeCharSequence(data, US_ASCII);
             assertEquals(data.length(), buf.writerOffset());

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferOffsetsTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferOffsetsTest.java
@@ -192,7 +192,8 @@ public class BufferOffsetsTest extends BufferTestSupport {
     }
 
     private void skipReadable(Fixture fixture, int capacity, int writeBytes, int readBytes, int offset) {
-        try (BufferAllocator allocator = fixture.createAllocator(); Buffer buf = allocator.allocate(capacity)) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(capacity)) {
             writeRandomBytes(buf, writeBytes);
 
             for (int i = 0; i < readBytes; i++) {
@@ -217,7 +218,8 @@ public class BufferOffsetsTest extends BufferTestSupport {
     }
 
     private void skipWritable(Fixture fixture, int capacity, int writeBytes, int offset) {
-        try (BufferAllocator allocator = fixture.createAllocator(); Buffer buf = allocator.allocate(capacity)) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(capacity)) {
             writeRandomBytes(buf, writeBytes);
 
             buf.skipWritable(offset);

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferSplitTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferSplitTest.java
@@ -46,7 +46,8 @@ public class BufferSplitTest extends BufferTestSupport {
     }
 
     private void readSplit(Fixture fixture, int capacity, int writeBytes, int readBytes, int offset) {
-        try (BufferAllocator allocator = fixture.createAllocator(); Buffer buf = allocator.allocate(capacity)) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(capacity)) {
             writeRandomBytes(buf, writeBytes);
             assertEquals(writeBytes, buf.writerOffset());
 
@@ -92,7 +93,8 @@ public class BufferSplitTest extends BufferTestSupport {
     }
 
     private void writeSplit(Fixture fixture, int capacity, int writeBytes, int readBytes, int offset) {
-        try (BufferAllocator allocator = fixture.createAllocator(); Buffer buf = allocator.allocate(capacity)) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(capacity)) {
             writeRandomBytes(buf, writeBytes);
             assertEquals(writeBytes, buf.writerOffset());
             for (int i = 0; i < readBytes; i++) {
@@ -126,7 +128,8 @@ public class BufferSplitTest extends BufferTestSupport {
 
     private static void splitPostFullOrRead(Fixture fixture, boolean read) {
         final int capacity = 3;
-        try (BufferAllocator allocator = fixture.createAllocator(); Buffer buf = allocator.allocate(capacity)) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(capacity)) {
             writeRandomBytes(buf, capacity);
             assertEquals(buf.capacity(), buf.writerOffset());
             if (read) {


### PR DESCRIPTION
Motivation:
Not sure if its possible to make checkstyle check for this, but we should only have one statement per line.

Modification:
Fix a few places where try-with-resources clauses had two statements per line.

Result:
Cleaner code.
