### PR TITLE
Fix little-endian get/set methods in SwappedByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -474,7 +474,7 @@ public final class ByteBufUtil {
     private static long compareUintLittleEndian(
             ByteBuf bufferA, ByteBuf bufferB, int aIndex, int bIndex, int uintCountIncrement) {
         for (int aEnd = aIndex + uintCountIncrement; aIndex < aEnd; aIndex += 4, bIndex += 4) {
-            long comp = bufferA.getUnsignedIntLE(aIndex) - bufferB.getUnsignedIntLE(bIndex);
+            long comp = uintFromLE(bufferA.getUnsignedIntLE(aIndex)) - uintFromLE(bufferB.getUnsignedIntLE(bIndex));
             if (comp != 0) {
                 return comp;
             }
@@ -485,7 +485,9 @@ public final class ByteBufUtil {
     private static long compareUintBigEndianA(
             ByteBuf bufferA, ByteBuf bufferB, int aIndex, int bIndex, int uintCountIncrement) {
         for (int aEnd = aIndex + uintCountIncrement; aIndex < aEnd; aIndex += 4, bIndex += 4) {
-            long comp =  bufferA.getUnsignedInt(aIndex) - bufferB.getUnsignedIntLE(bIndex);
+            long a = bufferA.getUnsignedInt(aIndex);
+            long b = uintFromLE(bufferB.getUnsignedIntLE(bIndex));
+            long comp =  a - b;
             if (comp != 0) {
                 return comp;
             }
@@ -496,12 +498,18 @@ public final class ByteBufUtil {
     private static long compareUintBigEndianB(
             ByteBuf bufferA, ByteBuf bufferB, int aIndex, int bIndex, int uintCountIncrement) {
         for (int aEnd = aIndex + uintCountIncrement; aIndex < aEnd; aIndex += 4, bIndex += 4) {
-            long comp =  bufferA.getUnsignedIntLE(aIndex) - bufferB.getUnsignedInt(bIndex);
+            long a = uintFromLE(bufferA.getUnsignedIntLE(aIndex));
+            long b = bufferB.getUnsignedInt(bIndex);
+            long comp =  a - b;
             if (comp != 0) {
                 return comp;
             }
         }
         return 0;
+    }
+
+    private static long uintFromLE(long value) {
+        return Long.reverseBytes(value) >>> Integer.SIZE;
     }
 
     private static final class SWARByteSearch {

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -246,7 +246,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public short getShortLE(int index) {
-        return buf.getShort(index);
+        return buf.getShortLE(index);
     }
 
     @Override
@@ -266,7 +266,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public int getMediumLE(int index) {
-        return buf.getMedium(index);
+        return buf.getMediumLE(index);
     }
 
     @Override
@@ -286,7 +286,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public int getIntLE(int index) {
-        return buf.getInt(index);
+        return buf.getIntLE(index);
     }
 
     @Override
@@ -306,7 +306,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public long getLongLE(int index) {
-        return buf.getLong(index);
+        return buf.getLongLE(index);
     }
 
     @Override
@@ -401,7 +401,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf setShortLE(int index, int value) {
-        buf.setShort(index, (short) value);
+        buf.setShortLE(index, (short) value);
         return this;
     }
 
@@ -413,7 +413,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf setMediumLE(int index, int value) {
-        buf.setMedium(index, value);
+        buf.setMediumLE(index, value);
         return this;
     }
 
@@ -425,7 +425,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf setIntLE(int index, int value) {
-        buf.setInt(index, value);
+        buf.setIntLE(index, value);
         return this;
     }
 
@@ -437,7 +437,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf setLongLE(int index, long value) {
-        buf.setLong(index, value);
+        buf.setLongLE(index, value);
         return this;
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -5943,6 +5943,16 @@ public abstract class AbstractByteBufTest {
         buffer.readerIndex(0);
         assertEquals(0x0807060504030201L, Double.doubleToRawLongBits(buffer.readDoubleLE()));
         buffer.readerIndex(0);
+
+        assertEquals(0x0201, buffer.getShortLE(0));
+        assertEquals(0x0201, buffer.getUnsignedShortLE(0));
+        assertEquals(0x030201, buffer.getMediumLE(0));
+        assertEquals(0x030201, buffer.getUnsignedMediumLE(0));
+        assertEquals(0x04030201, buffer.getIntLE(0));
+        assertEquals(0x04030201, buffer.getUnsignedIntLE(0));
+        assertEquals(0x04030201, Float.floatToRawIntBits(buffer.getFloatLE(0)));
+        assertEquals(0x0807060504030201L, buffer.getLongLE(0));
+        assertEquals(0x0807060504030201L, Double.doubleToRawLongBits(buffer.getDoubleLE(0)));
     }
 
     @Test
@@ -5965,5 +5975,18 @@ public abstract class AbstractByteBufTest {
         buffer.clear();
         buffer.writeDoubleLE(Double.longBitsToDouble(0x0102030405060708L));
         assertEquals(0x0102030405060708L, Double.doubleToRawLongBits(buffer.readDoubleLE()));
+
+        buffer.setShortLE(0, 0x0102);
+        assertEquals(0x0102, buffer.getShortLE(0));
+        buffer.setMediumLE(0, 0x010203);
+        assertEquals(0x010203, buffer.getMediumLE(0));
+        buffer.setIntLE(0, 0x01020304);
+        assertEquals(0x01020304, buffer.getIntLE(0));
+        buffer.setFloatLE(0, Float.intBitsToFloat(0x01020304));
+        assertEquals(0x01020304, Float.floatToRawIntBits(buffer.getFloatLE(0)));
+        buffer.setLongLE(0, 0x0102030405060708L);
+        assertEquals(0x0102030405060708L, buffer.getLongLE(0));
+        buffer.setDoubleLE(0, Double.longBitsToDouble(0x0102030405060708L));
+        assertEquals(0x0102030405060708L, Double.doubleToRawLongBits(buffer.getDoubleLE(0)));
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -767,5 +768,54 @@ public class UnpooledTest {
         } finally {
             wrappedBuffer.release();
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void littleEndianWriteOnLittleEndianBufferMustStoreLittleEndianValue() {
+        ByteBuf b = buffer(1024).order(ByteOrder.LITTLE_ENDIAN);
+
+        b.writeShortLE(0x0102);
+        assertEquals((short) 0x0102, b.getShortLE(0));
+        assertEquals((short) 0x0102, b.getShort(0));
+        b.clear();
+
+        b.writeMediumLE(0x010203);
+        assertEquals(0x010203, b.getMediumLE(0));
+        assertEquals(0x010203, b.getMedium(0));
+        b.clear();
+
+        b.writeIntLE(0x01020304);
+        assertEquals(0x01020304, b.getIntLE(0));
+        assertEquals(0x01020304, b.getInt(0));
+        b.clear();
+
+        b.writeLongLE(0x0102030405060708L);
+        assertEquals(0x0102030405060708L, b.getLongLE(0));
+        assertEquals(0x0102030405060708L, b.getLong(0));
+    }
+
+    @Test
+    public void littleEndianWriteOnDefaultBufferMustStoreLittleEndianValue() {
+        ByteBuf b = buffer(1024);
+
+        b.writeShortLE(0x0102);
+        assertEquals((short) 0x0102, b.getShortLE(0));
+        assertEquals((short) 0x0201, b.getShort(0));
+        b.clear();
+
+        b.writeMediumLE(0x010203);
+        assertEquals(0x010203, b.getMediumLE(0));
+        assertEquals(0x030201, b.getMedium(0));
+        b.clear();
+
+        b.writeIntLE(0x01020304);
+        assertEquals(0x01020304, b.getIntLE(0));
+        assertEquals(0x04030201, b.getInt(0));
+        b.clear();
+
+        b.writeLongLE(0x0102030405060708L);
+        assertEquals(0x0102030405060708L, b.getLongLE(0));
+        assertEquals(0x0807060504030201L, b.getLong(0));
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -327,15 +327,21 @@ final class SslUtils {
     // Reads a big-endian unsigned short integer from the buffer
     @SuppressWarnings("deprecation")
     private static int unsignedShortBE(ByteBuf buffer, int offset) {
-        return buffer.order() == ByteOrder.BIG_ENDIAN ?
-                buffer.getUnsignedShort(offset) : buffer.getUnsignedShortLE(offset);
+        int value = buffer.getUnsignedShort(offset);
+        if (buffer.order() == ByteOrder.LITTLE_ENDIAN) {
+            value = Integer.reverseBytes(value) >>> Short.SIZE;
+        }
+        return value;
     }
 
     // Reads a big-endian short integer from the buffer
     @SuppressWarnings("deprecation")
     private static short shortBE(ByteBuf buffer, int offset) {
-        return buffer.order() == ByteOrder.BIG_ENDIAN ?
-                buffer.getShort(offset) : buffer.getShortLE(offset);
+        short value = buffer.getShort(offset);
+        if (buffer.order() == ByteOrder.LITTLE_ENDIAN) {
+            value = Short.reverseBytes(value);
+        }
+        return value;
     }
 
     private static short unsignedByte(byte b) {


### PR DESCRIPTION
Motivation:
The `*LE` family of accessor methods are documented to always perform accesses in little-endian byte order, regardless of what `ByteBuf.order()` has been set on a buffer.
This was not always honoured by the `SwappedByteBuf`, and many methods were fixed in #10747, except the get and set methods were missed by that PR.

Modification:
Fix the methods that were missed in #10747 and make the testing more thorough by also covering get and set methods.

Result:
Any `ByteBuf` accessor method that is suffixed with `LE` now always perform a little-endian access, regardless of the buffers configured byte order.

This fixes #11700
