### PR TITLE
Fix CleanerDrop and how it is used

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/ManagedBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/ManagedBufferAllocator.java
@@ -15,6 +15,7 @@
  */
 package io.netty.buffer.api;
 
+import io.netty.buffer.api.internal.CleanerDrop;
 import io.netty.buffer.api.internal.Statics;
 
 import java.util.function.Supplier;
@@ -38,7 +39,11 @@ class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
             throw allocatorClosedException();
         }
         Statics.assertValidBufferSize(size);
-        return manager.allocateShared(this, size, manager.drop(), Statics.CLEANER, allocationType);
+        return manager.allocateShared(this, size, createDrop(), Statics.CLEANER, allocationType);
+    }
+
+    Drop<Buffer> createDrop() {
+        return CleanerDrop.wrap(manager.drop(), manager);
     }
 
     @Override
@@ -70,7 +75,7 @@ class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
 
             @Override
             public <BufferType extends Buffer> Drop<BufferType> drop() {
-                return (Drop<BufferType>) manager.drop();
+                return (Drop<BufferType>) createDrop();
             }
         };
     }

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
@@ -42,7 +42,7 @@ public class ByteBufferMemoryManager implements MemoryManager {
         } else {
             throw new IllegalArgumentException("Unknown allocation type: " + allocationType);
         }
-        return new NioBuffer(buffer, buffer, allocatorControl, convert(drop));
+        return createBuffer(buffer, allocatorControl, drop);
     }
 
     @Override
@@ -65,7 +65,14 @@ public class ByteBufferMemoryManager implements MemoryManager {
     @Override
     public Buffer recoverMemory(AllocatorControl allocatorControl, Object recoverableMemory, Drop<Buffer> drop) {
         ByteBuffer memory = (ByteBuffer) recoverableMemory;
-        return new NioBuffer(memory, memory, allocatorControl, convert(drop));
+        return createBuffer(memory, allocatorControl, drop);
+    }
+
+    private static NioBuffer createBuffer(ByteBuffer memory, AllocatorControl allocatorControl, Drop<Buffer> drop) {
+        Drop<NioBuffer> concreteDrop = convert(drop);
+        NioBuffer nioBuffer = new NioBuffer(memory, memory, allocatorControl, concreteDrop);
+        concreteDrop.attach(nioBuffer);
+        return nioBuffer;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -149,7 +149,9 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
         AllocatorControl.UntetheredMemory memory = control.allocateUntethered(this, allocSize);
         ByteBuffer base = memory.memory();
         ByteBuffer buffer = length == 0? bbslice(base, 0, 0) : base;
-        Buffer copy = new NioBuffer(base, buffer, control, memory.drop());
+        Drop<NioBuffer> drop = memory.drop();
+        NioBuffer copy = new NioBuffer(base, buffer, control, drop);
+        drop.attach(copy);
         copyInto(offset, copy, 0, length);
         copy.writerOffset(length);
         return copy;

--- a/buffer/src/main/java/io/netty/buffer/api/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/CleanerDrop.java
@@ -15,7 +15,10 @@
  */
 package io.netty.buffer.api.internal;
 
+import io.netty.buffer.api.AllocatorControl;
+import io.netty.buffer.api.Buffer;
 import io.netty.buffer.api.Drop;
+import io.netty.buffer.api.MemoryManager;
 
 import java.lang.ref.Cleaner;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * A drop implementation that delegates to another drop instance, either when called directly, or when it becomes
  * cleanable. This ensures that objects are dropped even if they leak.
  */
-public final class CleanerDrop<T> implements Drop<T> {
+public final class CleanerDrop<T extends Buffer> implements Drop<T> {
     private Cleaner.Cleanable cleanable;
     private GatedRunner<T> runner;
 
@@ -32,9 +35,9 @@ public final class CleanerDrop<T> implements Drop<T> {
      * Wrap the given drop instance, and produce a new drop instance that will also call the delegate drop instance if
      * it becomes cleanable.
      */
-    public static <T> Drop<T> wrap(Drop<T> drop) {
+    public static <T extends Buffer> Drop<T> wrap(Drop<T> drop, MemoryManager manager) {
         CleanerDrop<T> cleanerDrop = new CleanerDrop<>();
-        GatedRunner<T> runner = new GatedRunner<>(drop);
+        GatedRunner<T> runner = new GatedRunner<>(drop, manager);
         cleanerDrop.cleanable = Statics.CLEANER.register(cleanerDrop, runner);
         cleanerDrop.runner = runner;
         return cleanerDrop;
@@ -45,13 +48,14 @@ public final class CleanerDrop<T> implements Drop<T> {
 
     @Override
     public void attach(T obj) {
-        runner.set(obj);
+        runner.prepareRecover(obj);
         runner.drop.attach(obj);
     }
 
     @Override
     public void drop(T obj) {
-        attach(obj);
+        runner.dropping = true;
+        runner.set(obj);
         cleanable.clean();
     }
 
@@ -60,20 +64,40 @@ public final class CleanerDrop<T> implements Drop<T> {
         return "CleanerDrop(" + runner.drop + ')';
     }
 
-    private static final class GatedRunner<T> extends AtomicReference<T> implements Runnable {
+    private static final class GatedRunner<T extends Buffer> extends AtomicReference<Object> implements Runnable {
+        private static final NoOpAllocatorControl ALLOC_CONTROL = new NoOpAllocatorControl();
         private static final long serialVersionUID = 2685535951915798850L;
         final Drop<T> drop;
+        final MemoryManager manager;
+        volatile boolean dropping;
 
-        private GatedRunner(Drop<T> drop) {
+        private GatedRunner(Drop<T> drop, MemoryManager manager) {
             this.drop = drop;
+            this.manager = manager;
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public void run() {
-            T obj = getAndSet(null); // Make absolutely sure we only delegate once.
+            Object obj = getAndSet(null); // Make absolutely sure we only delegate once.
             if (obj != null) {
-                drop.drop(obj);
+                if (dropping) {
+                    drop.drop((T) obj);
+                } else {
+                    manager.recoverMemory(ALLOC_CONTROL, obj, (Drop<Buffer>) drop).close();
+                }
             }
+        }
+
+        public void prepareRecover(T obj) {
+            set(manager.unwrapRecoverableMemory(obj));
+        }
+    }
+
+    private static final class NoOpAllocatorControl implements AllocatorControl {
+        @Override
+        public UntetheredMemory allocateUntethered(Buffer originator, int size) {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunk.java
@@ -585,7 +585,7 @@ final class PoolChunk implements PoolChunkMetric {
         @Override
         public <BufferType extends Buffer> Drop<BufferType> drop() {
             PooledDrop pooledDrop = new PooledDrop(chunk.arena, chunk, threadCache, handle, maxLength);
-            return (Drop<BufferType>) CleanerDrop.wrap(pooledDrop);
+            return (Drop<BufferType>) CleanerDrop.wrap(pooledDrop, chunk.arena.manager);
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PooledBufferAllocator.java
@@ -19,6 +19,7 @@ import io.netty.buffer.api.AllocationType;
 import io.netty.buffer.api.AllocatorControl.UntetheredMemory;
 import io.netty.buffer.api.Buffer;
 import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.Drop;
 import io.netty.buffer.api.MemoryManager;
 import io.netty.buffer.api.StandardAllocationTypes;
 import io.netty.buffer.api.internal.Statics;
@@ -302,7 +303,9 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
         PooledAllocatorControl control = new PooledAllocatorControl();
         control.parent = this;
         UntetheredMemory memory = allocate(control, size);
-        Buffer buffer = manager.recoverMemory(control, memory.memory(), memory.drop());
+        Drop<Buffer> drop = memory.drop();
+        Buffer buffer = manager.recoverMemory(control, memory.memory(), drop);
+        drop.attach(buffer);
         return buffer.fill((byte) 0);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -157,7 +157,9 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         int allocSize = Math.max(length, 1); // Allocators don't support allocating zero-sized buffers.
         AllocatorControl.UntetheredMemory memory = control.allocateUntethered(this, allocSize);
         UnsafeMemory unsafeMemory = memory.memory();
-        Buffer copy = new UnsafeBuffer(unsafeMemory, 0, length, control, memory.drop());
+        Drop<UnsafeBuffer> drop = memory.drop();
+        UnsafeBuffer copy = new UnsafeBuffer(unsafeMemory, 0, length, control, drop);
+        drop.attach(copy);
         copyInto(offset, copy, 0, length);
         copy.writerOffset(length);
         return copy;

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -62,7 +62,7 @@ public class UnsafeMemoryManager implements MemoryManager {
         } else {
             throw new IllegalArgumentException("Unknown allocation type: " + allocationType);
         }
-        return new UnsafeBuffer(memory, 0, size32, allocatorControl, convert(drop));
+        return createBuffer(memory, size32, allocatorControl, drop);
     }
 
     @Override
@@ -86,7 +86,16 @@ public class UnsafeMemoryManager implements MemoryManager {
     @Override
     public Buffer recoverMemory(AllocatorControl allocatorControl, Object recoverableMemory, Drop<Buffer> drop) {
         UnsafeMemory memory = (UnsafeMemory) recoverableMemory;
-        return new UnsafeBuffer(memory, 0, memory.size, allocatorControl, convert(drop));
+        int size = memory.size;
+        return createBuffer(memory, size, allocatorControl, drop);
+    }
+
+    private static UnsafeBuffer createBuffer(UnsafeMemory memory, int size, AllocatorControl allocatorControl,
+                                             Drop<Buffer> drop) {
+        Drop<UnsafeBuffer> concreteDrop = convert(drop);
+        UnsafeBuffer unsafeBuffer = new UnsafeBuffer(memory, 0, size, allocatorControl, concreteDrop);
+        concreteDrop.attach(unsafeBuffer);
+        return unsafeBuffer;
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/api/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/CleanerDropTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.tests;
+
+import io.netty.buffer.api.AllocationType;
+import io.netty.buffer.api.AllocatorControl;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.Drop;
+import io.netty.buffer.api.MemoryManager;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.ref.Cleaner;
+import java.util.ServiceLoader.Provider;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CleanerDropTest {
+    static Stream<MemoryManager> managers() {
+        return MemoryManager.availableManagers().map(Provider::get);
+    }
+
+    static Stream<Supplier<BufferAllocator>> allocators() {
+        return Stream.of(
+                supplier("onHeapUnpooled", BufferAllocator::onHeapUnpooled),
+                supplier("offHeapUnpooled", BufferAllocator::offHeapUnpooled),
+                supplier("onHeapPooled", BufferAllocator::onHeapPooled),
+                supplier("offHeapPooled", BufferAllocator::offHeapPooled));
+    }
+
+    static <T> Supplier<T> supplier(String name, Supplier<T> supplier) {
+        return new Supplier<T>() {
+            @Override
+            public T get() {
+                return supplier.get();
+            }
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        };
+    }
+
+    static Stream<Arguments> parameters() {
+        return managers().flatMap(manager -> allocators().map(allocator -> Arguments.of(manager, allocator)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void leakedBufferMustBeDroppedByCleaner(MemoryManager manager,
+                                                   Supplier<BufferAllocator> allocatorSupplier) {
+        Semaphore leakSemaphore = new Semaphore(0);
+        MemoryManager.using(new LeakTrappingMemoryManager(leakSemaphore, manager), () -> {
+            try (BufferAllocator allocator = allocatorSupplier.get()) {
+                leakBuffer(allocator);
+                int counter = 0;
+                do {
+                    produceGarbage();
+                    counter++;
+                    assertThat(counter).isLessThan(5000);
+                } while (!tryAcquireForOneMillisecond(leakSemaphore));
+                return null;
+            }
+        });
+    }
+
+    private static void leakBuffer(BufferAllocator allocator) {
+        allocator.allocate(128);
+    }
+
+    private static boolean tryAcquireForOneMillisecond(Semaphore leakSemaphore) {
+        try {
+            return leakSemaphore.tryAcquire(1, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ignore) {
+            return false;
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private static void produceGarbage() {
+        ThreadLocalRandom.current().ints(256).mapToObj(String::valueOf).collect(Collectors.toList());
+        System.gc();
+    }
+
+    private static class LeakTrappingMemoryManager implements MemoryManager {
+        private final Semaphore leakSemaphore;
+        private final MemoryManager manager;
+
+        LeakTrappingMemoryManager(Semaphore leakSemaphore, MemoryManager manager) {
+            this.leakSemaphore = leakSemaphore;
+            this.manager = manager;
+        }
+
+        @Override
+        public Buffer allocateShared(AllocatorControl allocatorControl, long size,
+                                     Drop<Buffer> drop,
+                                     Cleaner cleaner,
+                                     AllocationType allocationType) {
+            return manager.allocateShared(allocatorControl, size, drop, cleaner, allocationType);
+        }
+
+        @Override
+        public Buffer allocateConstChild(Buffer readOnlyConstParent) {
+            return manager.allocateConstChild(readOnlyConstParent);
+        }
+
+        @Override
+        public Drop<Buffer> drop() {
+            return manager.drop();
+        }
+
+        @Override
+        public Object unwrapRecoverableMemory(Buffer buf) {
+            return manager.unwrapRecoverableMemory(buf);
+        }
+
+        @Override
+        public Buffer recoverMemory(AllocatorControl allocatorControl,
+                                    Object recoverableMemory,
+                                    Drop<Buffer> drop) {
+            leakSemaphore.release(); // Signal that we caught a leak!
+            return manager.recoverMemory(allocatorControl, recoverableMemory, drop);
+        }
+
+        @Override
+        public Object sliceMemory(Object memory, int offset, int length) {
+            return manager.sliceMemory(memory, offset, length);
+        }
+
+        @Override
+        public String implementationName() {
+            return "Leak Tracking " + manager.implementationName();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
When porting the CleanerDrop over to the main Netty repo, it got broken and ended up accidentally holding on to the cleaner-monitored object from the cleaner action.
Such a reference loop means the cleaner will never clean any buffers that leak.

Modification:
Break the reference cycle in the CleanerDrop and ensure that recoverable memory is actually recovered if it leaks.
We test for this by instrumenting the MemoryManager, because these will be indirectly told about leaks.

Result:
Buffers that leak are now properly deallocated or returned to their originating pool.
