### PR TITLE
Avoid allocating new arenas per thread when caching is disabled

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PooledBufferAllocator.java
@@ -334,7 +334,7 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
 
     UntetheredMemory allocate(PooledAllocatorControl control, int size) {
         PoolThreadCache cache = threadCache.get();
-        PoolArena arena = cache.arena;
+        PoolArena arena = cache.getArena();
 
         if (arena != null) {
             return arena.allocate(control, cache, size);
@@ -459,7 +459,7 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
                 return cache;
             }
             // No caching so just use 0 as sizes.
-            return new PoolThreadCache(null, 0, 0, 0, 0);
+            return new PoolThreadCache(arena, 0, 0, 0, 0);
         }
 
         @Override

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferLifeCycleTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferLifeCycleTest.java
@@ -560,8 +560,8 @@ public class BufferLifeCycleTest extends BufferTestSupport {
                     copy.resetOffsets().ensureWritable(Long.BYTES);
                     assertThat(split.capacity()).isEqualTo(Long.BYTES);
                     assertThat(copy.capacity()).isEqualTo(Long.BYTES);
-                    assertThat(split.getLong(0)).isEqualTo(0x01020304_00000000L);
-                    assertThat(copy.getLong(0)).isEqualTo(0x05060708_00000000L);
+                    assertEquals(0x01020304, split.getInt(0));
+                    assertEquals(0x05060708, copy.getInt(0));
                 }
             }
         }


### PR DESCRIPTION
Motivation:
Even when thread-local caching is disabled, the PooledBufferAllocator still needs to return a PoolThreadCache instance that contain an arena from the pool.
This is how allocation calls generally access arenas in the pool, regardless of thread-local caching.
This means if the PoolThreadCache has no arena, then the allocation will fall back to the unpooled path.
In other words, if thread-local caching failed, then _all_ pooling and caching would be disabled for the allocator.
This is clearly suboptimal behaviour.

Modification:
The PoolThreadCache now acquires a reference to the least-used arena at the time of initialisation.
Since buffers and leak detection rely on cleaners and phantom references to the memory, the PoolThreadCache will have to only hold a weak reference to the arena and its memory regions.
Otherwise, the thread-local caches would hold strong references to the memory, and prevent it from being reclaimed.
The arenas should only be held live by the central pool for caching, or by buffers for use.

Result:
The new Buffers are pooled and cached more effectively, when the allocating thread does not support FastThreadLocals, or when caching is turned off.
