### PR TITLE
Add a fork method to Drop

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -59,6 +59,15 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         }
 
         @Override
+        public Drop<DefaultCompositeBuffer> fork() {
+            return this;
+        }
+
+        @Override
+        public void attach(DefaultCompositeBuffer obj) {
+        }
+
+        @Override
         public String toString() {
             return "COMPOSITE_DROP";
         }

--- a/buffer/src/main/java/io/netty/buffer/api/Drop.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Drop.java
@@ -21,7 +21,6 @@ package io.netty.buffer.api;
  *
  * @param <T> The type of resource that can be dropped.
  */
-@FunctionalInterface
 public interface Drop<T> {
     /**
      * Dispose of the resources in the given {@link Resource} instance.
@@ -31,10 +30,19 @@ public interface Drop<T> {
     void drop(T obj);
 
     /**
+     * Branch the responsibility of dropping a resource.
+     * This drop instance will remain associated with its current resource, while the returned drop instance
+     * must be {@linkplain #attach(Object) attached} to its new resource.
+     *
+     * @return A drop instance, similar to this one, but for the purpose of being associated with a different but
+     * related resource.
+     */
+    Drop<T> fork();
+
+    /**
      * Called when the resource changes owner.
      *
      * @param obj The new {@link Resource} instance with the new owner.
      */
-    default void attach(T obj) {
-    }
+    void attach(T obj);
 }

--- a/buffer/src/main/java/io/netty/buffer/api/MemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/MemoryManager.java
@@ -21,7 +21,6 @@ import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.lang.ref.Cleaner;
 import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader.Provider;
@@ -104,13 +103,12 @@ public interface MemoryManager {
      *                        requested the allocation of this buffer.
      * @param size The size of the buffer to allocate. This size is assumed to be valid for the implementation.
      * @param drop The {@link Drop} instance to use when the buffer is {@linkplain Resource#close() closed}.
-     * @param cleaner The {@link Cleaner} that the underlying memory should be attached to. Can be {@code null}.
      * @param allocationType The type of allocation to perform.
      *                      Typically, one of the {@linkplain StandardAllocationTypes}.
      * @return A {@link Buffer} instance with the given configuration.
      * @throws IllegalArgumentException For unknown {@link AllocationType}s.
      */
-    Buffer allocateShared(AllocatorControl allocatorControl, long size, Drop<Buffer> drop, Cleaner cleaner,
+    Buffer allocateShared(AllocatorControl allocatorControl, long size, Drop<Buffer> drop,
                           AllocationType allocationType);
 
     /**
@@ -123,7 +121,7 @@ public interface MemoryManager {
      *
      * @param readOnlyConstParent The read-only parent buffer for which a const buffer should be created. The parent
      *                            buffer is allocated in the usual way, with
-     *                            {@link #allocateShared(AllocatorControl, long, Drop, Cleaner, AllocationType)},
+     *                            {@link #allocateShared(AllocatorControl, long, Drop, AllocationType)},
      *                            initialised with contents, and then made {@linkplain Buffer#makeReadOnly() read-only}.
      * @return A const buffer with the same size, contents, and read-only state of the given parent buffer.
      */

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
@@ -23,7 +23,6 @@ import io.netty.buffer.api.MemoryManager;
 import io.netty.buffer.api.StandardAllocationTypes;
 import io.netty.buffer.api.internal.Statics;
 
-import java.lang.ref.Cleaner;
 import java.nio.ByteBuffer;
 
 import static io.netty.buffer.api.internal.Statics.bbslice;
@@ -31,7 +30,7 @@ import static io.netty.buffer.api.internal.Statics.convert;
 
 public class ByteBufferMemoryManager implements MemoryManager {
     @Override
-    public Buffer allocateShared(AllocatorControl allocatorControl, long size, Drop<Buffer> drop, Cleaner cleaner,
+    public Buffer allocateShared(AllocatorControl allocatorControl, long size, Drop<Buffer> drop,
                                  AllocationType allocationType) {
         int capacity = Math.toIntExact(size);
         final ByteBuffer buffer;

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
@@ -46,9 +46,8 @@ public class ByteBufferMemoryManager implements MemoryManager {
 
     @Override
     public Buffer allocateConstChild(Buffer readOnlyConstParent) {
-        assert readOnlyConstParent.readOnly();
         NioBuffer buf = (NioBuffer) readOnlyConstParent;
-        return new NioBuffer(buf);
+        return buf.newConstChild();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/internal/ArcDrop.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/ArcDrop.java
@@ -78,16 +78,13 @@ public final class ArcDrop<T> implements Drop<T> {
     }
 
     @Override
+    public Drop<T> fork() {
+        return increment();
+    }
+
+    @Override
     public void attach(T obj) {
         delegate.attach(obj);
-    }
-
-    public boolean isOwned() {
-        return count <= 1;
-    }
-
-    public int countBorrows() {
-        return count - 1;
     }
 
     public Drop<T> unwrap() {

--- a/buffer/src/main/java/io/netty/buffer/api/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/CleanerDrop.java
@@ -61,6 +61,11 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
     }
 
     @Override
+    public Drop<T> fork() {
+        return wrap(runner.drop.fork(), runner.manager);
+    }
+
+    @Override
     public String toString() {
         return "CleanerDrop(" + runner.drop + ')';
     }

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PooledBufferAllocator.java
@@ -327,7 +327,7 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
         PooledAllocatorControl control = new PooledAllocatorControl();
         control.parent = this;
         Buffer constantBuffer = manager.allocateShared(
-                control, bytes.length, manager.drop(), Statics.CLEANER, allocationType);
+                control, bytes.length, manager.drop(), allocationType);
         constantBuffer.writeBytes(bytes).makeReadOnly();
         return () -> manager.allocateConstChild(constantBuffer);
     }

--- a/buffer/src/main/java/io/netty/buffer/api/pool/UnpooledUnthetheredMemory.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/UnpooledUnthetheredMemory.java
@@ -20,7 +20,6 @@ import io.netty.buffer.api.AllocatorControl;
 import io.netty.buffer.api.Buffer;
 import io.netty.buffer.api.Drop;
 import io.netty.buffer.api.MemoryManager;
-import io.netty.buffer.api.internal.Statics;
 
 @SuppressWarnings("unchecked")
 class UnpooledUnthetheredMemory implements AllocatorControl.UntetheredMemory {
@@ -32,7 +31,7 @@ class UnpooledUnthetheredMemory implements AllocatorControl.UntetheredMemory {
         this.manager = manager;
         PooledAllocatorControl allocatorControl = new PooledAllocatorControl();
         allocatorControl.parent = allocator;
-        buffer = manager.allocateShared(allocatorControl, size, manager.drop(), Statics.CLEANER, allocationType);
+        buffer = manager.allocateShared(allocatorControl, size, manager.drop(), allocationType);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -69,8 +69,8 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     /**
      * Constructor for {@linkplain BufferAllocator#constBufferSupplier(byte[]) const buffers}.
      */
-    UnsafeBuffer(UnsafeBuffer parent) {
-        super(parent.unsafeGetDrop().fork(), parent.control);
+    private UnsafeBuffer(UnsafeBuffer parent, Drop<UnsafeBuffer> drop) {
+        super(drop, parent.control);
         memory = parent.memory;
         base = parent.base;
         baseOffset = parent.baseOffset;
@@ -81,7 +81,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         roff = parent.roff;
         woff = parent.woff;
         constBuffer = true;
-        unsafeGetDrop().attach(this);
     }
 
     @Override
@@ -1394,6 +1393,14 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
 
     Object recover() {
         return memory;
+    }
+
+    Buffer newConstChild() {
+        assert readOnly();
+        Drop<UnsafeBuffer> drop = unsafeGetDrop().fork();
+        UnsafeBuffer child = new UnsafeBuffer(this, drop);
+        drop.attach(child);
+        return child;
     }
 
     private static final class ForwardUnsafeByteCursor implements ByteCursor {

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeCleanerDrop.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeCleanerDrop.java
@@ -32,9 +32,18 @@ public class UnsafeCleanerDrop implements Drop<Buffer> {
         cleaner.register(memory, new FreeAddress(address, size));
     }
 
+    private UnsafeCleanerDrop(Drop<Buffer> drop) {
+        this.drop = drop;
+    }
+
     @Override
     public void drop(Buffer obj) {
         drop.drop(obj);
+    }
+
+    @Override
+    public Drop<Buffer> fork() {
+        return new UnsafeCleanerDrop(drop.fork());
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -39,15 +39,13 @@ public class UnsafeMemoryManager implements MemoryManager {
     }
 
     @Override
-    public Buffer allocateShared(AllocatorControl allocatorControl, long size, Drop<Buffer> drop, Cleaner cleaner,
+    public Buffer allocateShared(AllocatorControl allocatorControl, long size, Drop<Buffer> drop,
                                  AllocationType allocationType) {
         final Object base;
         final long address;
         final UnsafeMemory memory;
         final int size32 = Math.toIntExact(size);
-        if (cleaner == null) {
-            cleaner = Statics.CLEANER;
-        }
+        Cleaner cleaner = Statics.CLEANER;
         if (allocationType == StandardAllocationTypes.OFF_HEAP) {
             base = null;
             address = PlatformDependent.allocateMemory(size);

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -65,9 +65,8 @@ public class UnsafeMemoryManager implements MemoryManager {
 
     @Override
     public Buffer allocateConstChild(Buffer readOnlyConstParent) {
-        assert readOnlyConstParent.readOnly();
         UnsafeBuffer buf = (UnsafeBuffer) readOnlyConstParent;
-        return new UnsafeBuffer(buf);
+        return buf.newConstChild();
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferCompositionTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferCompositionTest.java
@@ -608,8 +608,20 @@ public class BufferCompositionTest extends BufferTestSupport {
                     allocator.allocate(3).send(),
                     allocator.allocate(3).send(),
                     allocator.allocate(2).send());
-            Drop<Object> throwingDrop = obj -> {
-                throw new RuntimeException("Expected.");
+            Drop<Object> throwingDrop = new Drop<>() {
+                @Override
+                public void drop(Object obj) {
+                    throw new RuntimeException("Expected.");
+                }
+
+                @Override
+                public Drop<Object> fork() {
+                    return this;
+                }
+
+                @Override
+                public void attach(Object obj) {
+                }
             };
             try {
                 Statics.unsafeSetDrop((ResourceSupport<?, ?>) composite, throwingDrop);

--- a/buffer/src/test/java/io/netty/buffer/api/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/CleanerDropTest.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.lang.ref.Cleaner;
 import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader.Provider;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -124,9 +122,8 @@ public class CleanerDropTest {
         @Override
         public Buffer allocateShared(AllocatorControl allocatorControl, long size,
                                      Drop<Buffer> drop,
-                                     Cleaner cleaner,
                                      AllocationType allocationType) {
-            return manager.allocateShared(allocatorControl, size, drop, cleaner, allocationType);
+            return manager.allocateShared(allocatorControl, size, drop, allocationType);
         }
 
         @Override


### PR DESCRIPTION
Motivation:
We have multiple places where ownership of some memory, and its associated drop instance, branches.
These were previously handled by carefully threading drops through ArcDrop instances.
We can avoid these careful gymnastics and make the code clearer by adding an explicit fork() method to the Drop interface.
This in turn allows the CleanerDrop to wrap the ArcDrop, which logically makes more sense.

Modification:
Add a fork method to the Drop interface.
The Drop interface is no longer a functional interface.
Create some static methods to standardise the way drops are created and wrapped, so these are always done in the same way.
The CleanerDrop is now the outer-most drop instance, which and each fork of the CleanerDrop creates a new CleanerDrop instance.
This allows us to theoretically track leaks more closely associated with the specific buffer or object that leaked, rather than marking the original allocation as leaked when any split-off or child-buffer is leaked.

Result:
Cleaner code, and more precise leak tracked (once we have leak tracking).

This PR is based on #11710