### PR TITLE
Add ByteBufAdaptor.intoByteBuf method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/AllocatorControl.java
+++ b/buffer/src/main/java/io/netty/buffer/api/AllocatorControl.java
@@ -42,6 +42,13 @@ public interface AllocatorControl {
     UntetheredMemory allocateUntethered(Buffer originator, int size);
 
     /**
+     * Get the {@link BufferAllocator} instance that is the source of this allocator control.
+     *
+     * @return The {@link BufferAllocator} controlled by this {@link AllocatorControl}.
+     */
+    BufferAllocator getAllocator();
+
+    /**
      * Memory that isn't attached to any particular buffer.
      */
     interface UntetheredMemory {

--- a/buffer/src/main/java/io/netty/buffer/api/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferAllocator.java
@@ -80,6 +80,21 @@ public interface BufferAllocator extends AutoCloseable {
     }
 
     /**
+     * Determine if this allocator is pooling and reusing its allocated memory.
+     *
+     * @return {@code true} if this allocator is pooling and reusing its memory, {@code false} otherwise.
+     */
+    boolean isPooling();
+
+    /**
+     * Get the {@link AllocationType} from this allocator.
+     * This would typically be one of the {@link StandardAllocationTypes}.
+     *
+     * @return The type of allocations performed by this allocator.
+     */
+    AllocationType getAllocationType();
+
+    /**
      * Allocate a {@link Buffer} of the given size in bytes. This method may throw an {@link OutOfMemoryError} if there
      * is not enough free memory available to allocate a {@link Buffer} of the requested size.
      * <p>

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultGlobalBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultGlobalBufferAllocator.java
@@ -64,6 +64,16 @@ public final class DefaultGlobalBufferAllocator implements BufferAllocator {
     }
 
     @Override
+    public boolean isPooling() {
+        return delegate.isPooling();
+    }
+
+    @Override
+    public AllocationType getAllocationType() {
+        return delegate.getAllocationType();
+    }
+
+    @Override
     public Buffer allocate(int size) {
         return delegate.allocate(size);
     }

--- a/buffer/src/main/java/io/netty/buffer/api/ManagedBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/ManagedBufferAllocator.java
@@ -34,6 +34,16 @@ class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
     }
 
     @Override
+    public boolean isPooling() {
+        return false;
+    }
+
+    @Override
+    public AllocationType getAllocationType() {
+        return allocationType;
+    }
+
+    @Override
     public Buffer allocate(int size) {
         if (closed) {
             throw allocatorClosedException();
@@ -78,5 +88,10 @@ class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
                 return (Drop<BufferType>) createDrop();
             }
         };
+    }
+
+    @Override
+    public BufferAllocator getAllocator() {
+        return this;
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/adaptor/ByteBufAdaptor.java
+++ b/buffer/src/main/java/io/netty/buffer/api/adaptor/ByteBufAdaptor.java
@@ -128,6 +128,22 @@ public final class ByteBufAdaptor extends ByteBuf {
         }
     }
 
+    /**
+     * Convert the given {@link Buffer} into a {@link ByteBuf} using the most optimal method.
+     * The contents of both buffers will be mirrored.
+     *
+     * @param buffer The {@link Buffer} to convert into a {@link ByteBuf}.
+     * @return A {@link ByteBuf} that uses the given {@link Buffer} as a backing store.
+     */
+    public static ByteBuf intoByteBuf(Buffer buffer) {
+        if (buffer instanceof ByteBufConvertible) {
+            ByteBufConvertible convertible = (ByteBufConvertible) buffer;
+            return convertible.asByteBuf();
+        } else {
+            return new ByteBufAdaptor(new ByteBufAllocatorAdaptor(), buffer, buffer.capacity());
+        }
+    }
+
     @Override
     public int capacity() {
         return buffer.capacity();

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -43,7 +43,6 @@ import static io.netty.buffer.api.internal.Statics.bufferIsReadOnly;
 class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent, WritableComponent {
     private static final ByteBuffer CLOSED_BUFFER = ByteBuffer.allocate(0);
 
-    private final AllocatorControl control;
     private ByteBuffer base;
     private ByteBuffer rmem; // For reading.
     private ByteBuffer wmem; // For writing.
@@ -53,19 +52,17 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     private boolean constBuffer;
 
     NioBuffer(ByteBuffer base, ByteBuffer memory, AllocatorControl control, Drop<NioBuffer> drop) {
-        super(ArcDrop.wrap(drop));
+        super(ArcDrop.wrap(drop), control);
         this.base = base;
         rmem = memory;
         wmem = memory;
-        this.control = control;
     }
 
     /**
      * Constructor for {@linkplain BufferAllocator#constBufferSupplier(byte[]) const buffers}.
      */
     NioBuffer(NioBuffer parent) {
-        super(new ArcDrop<>(ArcDrop.acquire(parent.unsafeGetDrop())));
-        control = parent.control;
+        super(new ArcDrop<>(ArcDrop.acquire(parent.unsafeGetDrop())), parent.control);
         base = parent.base;
         rmem = bbslice(parent.rmem, 0, parent.rmem.capacity()); // Need to slice to get independent byte orders.
         assert parent.wmem == CLOSED_BUFFER;

--- a/buffer/src/main/java/io/netty/buffer/api/internal/AdaptableBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/AdaptableBuffer.java
@@ -47,8 +47,8 @@ public abstract class AdaptableBuffer<T extends ResourceSupport<Buffer, T>>
         ByteBufAdaptor bba = adaptor;
         if (bba == null) {
             BufferAllocator allocator = control.getAllocator();
-            BufferAllocator onHeap;
-            BufferAllocator offHeap;
+            final BufferAllocator onHeap;
+            final BufferAllocator offHeap;
             if (allocator.getAllocationType() == StandardAllocationTypes.ON_HEAP) {
                 onHeap = allocator;
                 offHeap = allocator.isPooling() ? BufferAllocator.offHeapPooled() : BufferAllocator.offHeapUnpooled();

--- a/buffer/src/main/java/io/netty/buffer/api/internal/AdaptableBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/AdaptableBuffer.java
@@ -16,9 +16,11 @@
 package io.netty.buffer.api.internal;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.api.AllocatorControl;
 import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.buffer.api.Drop;
+import io.netty.buffer.api.StandardAllocationTypes;
 import io.netty.buffer.api.adaptor.BufferIntegratable;
 import io.netty.buffer.api.adaptor.ByteBufAdaptor;
 import io.netty.buffer.api.adaptor.ByteBufAllocatorAdaptor;
@@ -27,11 +29,14 @@ import io.netty.util.ReferenceCounted;
 
 public abstract class AdaptableBuffer<T extends ResourceSupport<Buffer, T>>
         extends ResourceSupport<Buffer, T> implements BufferIntegratable, Buffer {
-    protected AdaptableBuffer(Drop<T> drop) {
-        super(drop);
-    }
 
     private volatile ByteBufAdaptor adaptor;
+    protected final AllocatorControl control;
+
+    protected AdaptableBuffer(Drop<T> drop, AllocatorControl control) {
+        super(drop);
+        this.control = control;
+    }
 
     public ByteBuf initialise(ByteBufAllocatorAdaptor alloc, int maxCapacity) {
         return new ByteBufAdaptor(alloc, this, maxCapacity);
@@ -41,7 +46,17 @@ public abstract class AdaptableBuffer<T extends ResourceSupport<Buffer, T>>
     public ByteBuf asByteBuf() {
         ByteBufAdaptor bba = adaptor;
         if (bba == null) {
-            ByteBufAllocatorAdaptor alloc = (ByteBufAllocatorAdaptor) ByteBufAllocator.DEFAULT;
+            BufferAllocator allocator = control.getAllocator();
+            BufferAllocator onHeap;
+            BufferAllocator offHeap;
+            if (allocator.getAllocationType() == StandardAllocationTypes.ON_HEAP) {
+                onHeap = allocator;
+                offHeap = allocator.isPooling() ? BufferAllocator.offHeapPooled() : BufferAllocator.offHeapUnpooled();
+            } else {
+                onHeap = allocator.isPooling() ? BufferAllocator.onHeapPooled() : BufferAllocator.onHeapUnpooled();
+                offHeap = allocator;
+            }
+            ByteBufAllocatorAdaptor alloc = new ByteBufAllocatorAdaptor(onHeap, offHeap);
             return adaptor = new ByteBufAdaptor(alloc, this, Integer.MAX_VALUE);
         }
         return bba;

--- a/buffer/src/main/java/io/netty/buffer/api/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/CleanerDrop.java
@@ -17,6 +17,7 @@ package io.netty.buffer.api.internal;
 
 import io.netty.buffer.api.AllocatorControl;
 import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.buffer.api.Drop;
 import io.netty.buffer.api.MemoryManager;
 
@@ -97,6 +98,11 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
     private static final class NoOpAllocatorControl implements AllocatorControl {
         @Override
         public UntetheredMemory allocateUntethered(Buffer originator, int size) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public BufferAllocator getAllocator() {
             throw new UnsupportedOperationException();
         }
     }

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PoolArena.java
@@ -16,8 +16,7 @@
 package io.netty.buffer.api.pool;
 
 import io.netty.buffer.api.AllocationType;
-import io.netty.buffer.api.AllocatorControl;
-import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.AllocatorControl.UntetheredMemory;
 import io.netty.buffer.api.MemoryManager;
 import io.netty.util.internal.StringUtil;
 
@@ -31,7 +30,7 @@ import java.util.concurrent.atomic.LongAdder;
 import static io.netty.buffer.api.pool.PoolChunk.isSubpage;
 import static java.lang.Math.max;
 
-class PoolArena extends SizeClasses implements PoolArenaMetric, AllocatorControl {
+class PoolArena extends SizeClasses implements PoolArenaMetric {
     private static final VarHandle SUBPAGE_ARRAY = MethodHandles.arrayElementVarHandle(PoolSubpage[].class);
     enum SizeClass {
         Small,
@@ -258,11 +257,6 @@ class PoolArena extends SizeClasses implements PoolArenaMetric, AllocatorControl
             }
         }
         return head;
-    }
-
-    @Override
-    public UntetheredMemory allocateUntethered(Buffer originator, int size) {
-        throw new AssertionError("PoolChunk base buffers should never need to reallocate.");
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PooledAllocatorControl.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PooledAllocatorControl.java
@@ -17,6 +17,7 @@ package io.netty.buffer.api.pool;
 
 import io.netty.buffer.api.AllocatorControl;
 import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 
 class PooledAllocatorControl implements AllocatorControl {
     PooledBufferAllocator parent;
@@ -29,5 +30,10 @@ class PooledAllocatorControl implements AllocatorControl {
     @Override
     public UntetheredMemory allocateUntethered(Buffer originator, int size) {
         return parent.allocate(this, size);
+    }
+
+    @Override
+    public BufferAllocator getAllocator() {
+        return parent;
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PooledBufferAllocator.java
@@ -295,6 +295,16 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
     }
 
     @Override
+    public boolean isPooling() {
+        return true;
+    }
+
+    @Override
+    public AllocationType getAllocationType() {
+        return allocationType;
+    }
+
+    @Override
     public Buffer allocate(int size) {
         if (closed) {
             throw allocatorClosedException();

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -49,27 +49,24 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     private long address; // Resolved address (baseOffset + memory.address).
     private int rsize;
     private int wsize;
-    private final AllocatorControl control;
     private boolean readOnly;
     private int roff;
     private int woff;
     private boolean constBuffer;
 
-    UnsafeBuffer(UnsafeMemory memory, long offset, int size, AllocatorControl allocatorControl,
+    UnsafeBuffer(UnsafeMemory memory, long offset, int size, AllocatorControl control,
                         Drop<UnsafeBuffer> drop) {
-        super(ArcDrop.wrap(drop));
+        super(ArcDrop.wrap(drop), control);
         this.memory = memory;
         base = memory.base;
         baseOffset = offset;
         address = memory.address + offset;
         rsize = size;
         wsize = size;
-        control = allocatorControl;
     }
 
     UnsafeBuffer(UnsafeBuffer parent) {
-        super(new ArcDrop<>(ArcDrop.acquire(parent.unsafeGetDrop())));
-        control = parent.control;
+        super(new ArcDrop<>(ArcDrop.acquire(parent.unsafeGetDrop())), parent.control);
         memory = parent.memory;
         base = parent.base;
         baseOffset = parent.baseOffset;


### PR DESCRIPTION
Motivation:
During the transition period, it will be convenient to have a utility method for converting a Buffer into a ByteBuf in the most efficient way.
A ByteBufConvertible interface already exists for this purpose, but not all Buffer instances are guarenteed to implement this, and those that did had been broken.

Modification:
Fix the broken ByteBufConvertible implementations.
Add a ByteBufAdaptor.intoByteBuf method that uses ByteBufConvertible when available, and a direct ByteBufAdaptor wrapping when not.

Result:
Converting a Buffer to a ByteBuf is now just one method call away.
