### PR TITLE
Re-enable ByteBuf test for ByteBufAdaptor

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/api/tests/adaptor/ByteBufAdaptorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/adaptor/ByteBufAdaptorTest.java
@@ -91,9 +91,4 @@ public abstract class ByteBufAdaptorTest extends AbstractByteBufTest {
     @Override
     public void testToByteBuffer2() {
     }
-
-    @Disabled("No longer allowed to allocate 0 sized buffers, except for composite buffers with no components.")
-    @Override
-    public void testLittleEndianWithExpand() {
-    }
 }


### PR DESCRIPTION
Motivation:
We should run as many ByteBuf tests on the ByteBufAdaptor as possible.
This test had previously been disabled because at the time it was not possible to allocate zero-sized buffers using the new API.

Modification:
Re-enable ByteBufAdaptorTest that was relying on zero-sized buffer allocations.

Result:
Our ByteBufAdaptor is more thoroughly tested.
