### PR TITLE
Fix DnsQueryTest, we should call release on reference counted objects

### DIFF
--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
@@ -68,7 +68,11 @@ public class DnsQueryTest {
             DatagramPacket packet = writeChannel.readOutbound();
             assertTrue(packet.content().isReadable());
             assertTrue(readChannel.writeInbound(packet));
-            assertEquals(query, readChannel.readInbound());
+
+            DnsQuery decodedDnsQuery = readChannel.readInbound();
+            assertEquals(query, decodedDnsQuery);
+            assertTrue(decodedDnsQuery.release());
+
             assertNull(writeChannel.readOutbound());
             assertNull(readChannel.readInbound());
         }


### PR DESCRIPTION
Motivation:

We should call release on reference counted objects because `touch` can be invoked inside pipeline.

Modification:

Add release().

Result:

Fix flaky test.
