### PR TITLE
Make implementing Resource.touch optional

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/Resource.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Resource.java
@@ -57,10 +57,13 @@ public interface Resource<T extends Resource<T>> extends AutoCloseable {
     /**
      * Record the current access location for debugging purposes.
      * This information may be included if the resource throws a life-cycle related exception, or if it leaks.
-     * If this resource has already been closed, then this method has not effect.
+     * If this resource has already been closed, then this method has no effect.
      *
      * @param hint An optional hint about this access and its context. May be {@code null}.
      * @return This resource instance.
      */
-    T touch(Object hint);
+    @SuppressWarnings("unchecked")
+    default T touch(Object hint) {
+        return (T) this;
+    }
 }


### PR DESCRIPTION
Motivation:
The Resource.touch method is only used for debugging life-cycle issues, and is then only useful for objects that track their life-cycles.
Buffers do this, but there will be many other implementations of the Resource interface where it makes less sense.

Modification:
Add a default implementation of the Resource.touch method that just returns the resource instance.
This is enough to conform to the specification of the method as declared.

Result:
The touch method declaration no longer pollutes implementations where it serves no purpose.
This eases the burden of implementing the Resource interface.