### PR TITLE
The ByteBufAdaptor should cache and reuse its ByteBufAllocatorAdaptor instance

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/adaptor/ByteBufAdaptor.java
+++ b/buffer/src/main/java/io/netty/buffer/api/adaptor/ByteBufAdaptor.java
@@ -140,7 +140,7 @@ public final class ByteBufAdaptor extends ByteBuf {
             ByteBufConvertible convertible = (ByteBufConvertible) buffer;
             return convertible.asByteBuf();
         } else {
-            return new ByteBufAdaptor(new ByteBufAllocatorAdaptor(), buffer, buffer.capacity());
+            return new ByteBufAdaptor(ByteBufAllocatorAdaptor.DEFAULT_INSTANCE, buffer, buffer.capacity());
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/internal/UncloseableBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/UncloseableBufferAllocator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.buffer.api.internal;
+
+import io.netty.buffer.api.AllocationType;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.util.internal.UnstableApi;
+
+import java.util.function.Supplier;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
+import static java.lang.Runtime.getRuntime;
+
+/**
+ * Internal wrapper for making allocators uncloseable.
+ *
+ * @implNote Beware that each uncloseable allocator adds a shut-down hook for closing themselves when the JVM shuts
+ * down. These shut-down hooks cannot be removed, so uncloseable allocators should only be created in a very small
+ * number, and reused throughout the lifetime of the JVM.
+ */
+@UnstableApi
+public class UncloseableBufferAllocator implements BufferAllocator {
+    private final BufferAllocator delegate;
+    private final String uncloseableMessage;
+
+    protected UncloseableBufferAllocator(BufferAllocator delegate, String uncloseableMessage) {
+        this.delegate = checkNotNullWithIAE(delegate, "delegate");
+        this.uncloseableMessage = uncloseableMessage;
+        getRuntime().addShutdownHook(new Thread(delegate::close));
+    }
+
+    @Override
+    public final boolean isPooling() {
+        return delegate.isPooling();
+    }
+
+    @Override
+    public final AllocationType getAllocationType() {
+        return delegate.getAllocationType();
+    }
+
+    @Override
+    public final Buffer allocate(int size) {
+        return delegate.allocate(size);
+    }
+
+    @Override
+    public final Supplier<Buffer> constBufferSupplier(byte[] bytes) {
+        return delegate.constBufferSupplier(bytes);
+    }
+
+    /**
+     * @throws UnsupportedOperationException Close is not supported on this allocator.
+     */
+    @Override
+    public final void close() {
+        throw new UnsupportedOperationException(uncloseableMessage);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -60,7 +60,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     protected final Channel channel;
 
     private volatile ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
-    private volatile BufferAllocator bufferAllocator = DefaultGlobalBufferAllocator.DEFAUL_GLOBAL_BUFFER_ALLOCATOR;
+    private volatile BufferAllocator bufferAllocator = DefaultGlobalBufferAllocator.DEFAULT_GLOBAL_BUFFER_ALLOCATOR;
     private volatile RecvByteBufAllocator rcvBufAllocator;
     private volatile MessageSizeEstimator msgSizeEstimator = DEFAULT_MSG_SIZE_ESTIMATOR;
 


### PR DESCRIPTION
Motivation:
It can be costly to create BufferAllocators all the time, so we should avoid doing that in ByteBufAdaptor.intoByteBuf.

Modification:
Create a globally shared and cached ByteBufAllocatorAdaptor instance, which is based on the DefaultGlobalBufferAllocator.
We also create a counter-part allocator, because the allocator adaptor needs both an on-heap and an off-heap allocator.
Both of these allocators are kept as constants and initialised once.
A new UncloseableBufferAllocator class is added to be the base class for both the global allocator and its counter-part.

Result:
No more allocators created when a Buffer is converted into a ByteBuf.
