### PR TITLE
Refactor StompSubframeDecoder to use only ByteToMessageDecoder

### DIFF
--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.stomp;
 
+import java.util.List;
+
 public final class StompTestConstants {
     public static final String CONNECT_FRAME =
         "CONNECT\n" +
@@ -76,6 +78,23 @@ public final class StompTestConstants {
             "content-type:text/plain\n" +
             '\n' +
             "body\0";
+
+    public static final String[] SEND_FRAME_FRAGMENTS = {
+            "SEN", "D\n",
+            "destination:/queue/a\n",
+            "content-type", ":", "text/plain", "\n",
+            "\n",
+            "Client Send Hello !!!\n",
+            "\0",
+            "\n"
+    };
+
+    public static final String FRAME_WITH_CONTENT_LENGTH_WITHOUT_NULL = "SEND\n" +
+            "destination:/queue/a\n" +
+            "content-type:text/plain\n" +
+            "content-length:4\n" +
+            '\n' +
+            "body\n";
 
     private StompTestConstants() { }
 }


### PR DESCRIPTION
Motivation:

Refactor `StompSubframeDecoder` to use only `ByteToMessageDecoder`, fix possible memory leak when
frame with content-length no ended with `NULL` octet. Related with #11659 but for 4.1

Modification:
Replace usages of `ReplayingDecoder` with ByteToMessageDecoder.
Release `lastContentFrame` when `NULL` octet not find.
Add more tests.

Result:
Improved performance for StompSubframeDecoder and fix bugus behavior.
