### PR TITLE
Epoll compiled on GLIBC only supports GLIBC at runtime

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -326,6 +326,7 @@ static jint netty_epoll_native_epollCtlAdd0(JNIEnv* env, jclass clazz, jint efd,
     }
     return res;
 }
+
 static jint netty_epoll_native_epollCtlMod0(JNIEnv* env, jclass clazz, jint efd, jint fd, jint flags) {
     int res = epollCtl(env, efd, EPOLL_CTL_MOD, fd, flags);
     if (res < 0) {
@@ -540,6 +541,15 @@ static jstring netty_epoll_native_kernelVersion(JNIEnv* env, jclass clazz) {
     return NULL;
 }
 
+static jint netty_epoll_native_gnulibc(JNIEnv* env, jclass clazz) {
+#ifdef __GLIBC__
+    return 1;
+#else
+    // We are using an alternative libc, possibly musl but could be anything.
+    return 0;
+#endif // __GLIBC__
+}
+
 static jboolean netty_epoll_native_isSupportingSendmmsg(JNIEnv* env, jclass clazz) {
     if (SYS_sendmmsg == -1) {
         return JNI_FALSE;
@@ -658,7 +668,8 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "isSupportingSendmmsg", "()Z", (void *) netty_epoll_native_isSupportingSendmmsg },
   { "isSupportingRecvmmsg", "()Z", (void *) netty_epoll_native_isSupportingRecvmmsg },
   { "tcpFastopenMode", "()I", (void *) netty_epoll_native_tcpFastopenMode },
-  { "kernelVersion", "()Ljava/lang/String;", (void *) netty_epoll_native_kernelVersion }
+  { "kernelVersion", "()Ljava/lang/String;", (void *) netty_epoll_native_kernelVersion },
+  { "gnulibc", "()I", (void *) netty_epoll_native_gnulibc }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 static const JNINativeMethod fixed_method_table[] = {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -55,7 +55,7 @@ import static io.netty.channel.unix.Errors.newIOException;
  * <p>Static members which call JNI methods must be defined in {@link NativeStaticallyReferencedJniMethods}.
  */
 public final class Native {
-    private static final boolean skipMuslCheck = SystemPropertyUtil.getBoolean("io.netty.native.musl.check", false);
+    private static final boolean checkMusl = SystemPropertyUtil.getBoolean("io.netty.native.musl.check", true);
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
 
     static {
@@ -98,7 +98,7 @@ public final class Native {
                 // Just ignore
             }
         }
-        if (!skipMuslCheck && gnulibc() == 1) {
+        if (checkMusl && gnulibc() == 1) {
             // Our binary is compiled for linking with GLIBC.
             // Let's check that we don't have anything that looks like Musl libc in our runtime.
             try {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -109,6 +109,7 @@ public final class Native {
                     boolean gnulibcFound = false;
                     String line;
                     while ((line = reader.readLine()) != null) {
+                        logger.debug(line);
                         if (gnulibcPattern.matcher(line).find()) {
                             gnulibcFound = true;
                             break;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -105,20 +105,14 @@ public final class Native {
                 FileInputStream fis = new FileInputStream("/proc/self/maps");
                 try {
                     BufferedReader reader = new BufferedReader(new InputStreamReader(fis));
-                    boolean muslFound = false;
                     String line;
                     while ((line = reader.readLine()) != null) {
                         if (line.contains("-musl-")) {
-                            muslFound = true;
-                            break;
+                            throw new LinkageError("Native library was compiled for linking with GLIBC, but GLIBC " +
+                                    "was not found among library mappings. This likely means the OS/JVM uses an " +
+                                    "alternative libc, such as musl. To fix, either use NIO transport, or build a " +
+                                    "native transport for your platform.");
                         }
-                    }
-                    if (muslFound) {
-                        throw new LinkageError(
-                                "Native library was compiled for linking with GLIBC, but GLIBC was not found among " +
-                                        "library mappings. This likely means the OS/JVM uses an alternative libc, " +
-                                        "such as musl. To fix, either use NIO transport, or build a native transport " +
-                                        "for your platform.");
                     }
                 } finally {
                     try {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeStaticallyReferencedJniMethods.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeStaticallyReferencedJniMethods.java
@@ -43,4 +43,5 @@ final class NativeStaticallyReferencedJniMethods {
     static native boolean isSupportingRecvmmsg();
     static native int tcpFastopenMode();
     static native String kernelVersion();
+    static native int gnulibc();
 }


### PR DESCRIPTION
Motivation:
It is possible to run into JVM crashes when our native binaries are compiled for one libc but then linked with another at runtime.
There is no guarantee that their ABIs will be compatible, and this can cause all sorts of trouble.
All our Linux binaries are compiled for GLIBC, so it makes sense to check that any binary compiled for GLIBC also ends up with GLIBC at runtime.
Especially since alternative libc implementations, such as musl, are getting increasingly popular in a containerised/serverless world.

Modification:
Add a check when loading the epoll native library that verifies: if the library was compiled for GLIBC, then we must also have a GLIBC loaded at runtime.
The key is to make this check without making any libc calls in our native code.
We make this check by reading `/proc/self/maps`, which contain paths for all loaded libraries in our process.
GLIBC tends to have paths with a particular pattern to their name, so we look for that.
At compile time, we rely on `__GLIBC__` to determine if the binary is compiled for GLIBC or not.
We cannot check for Musl because they intentionally expose no equivalent define to check for.
By checking for GLIBC specifically, we also end up handling all other alternative libc implementations, and not just Musl.

Result:
Epoll is now reported as not available when running a GLIBC binary on a Musl - or any other alternative libc - based system.
Previously, epoll would be reported as available, but could cause JVM crashes.

This fixes #11701
