### PR TITLE
run timeout task at new thread to avoid the worker thread blocking

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -96,7 +96,9 @@ public class HashedWheelTimer implements Timer {
     private static final AtomicIntegerFieldUpdater<HashedWheelTimer> WORKER_STATE_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(HashedWheelTimer.class, "workerState");
 
-    private final ExecutorService timeoutTaskThreadPool = Executors.newFixedThreadPool(NettyRuntime.availableProcessors());
+    private final ExecutorService timeoutTaskThreadPool =
+            Executors.newFixedThreadPool(NettyRuntime.availableProcessors());
+
     private final ResourceLeakTracker<HashedWheelTimer> leak;
     private final Worker worker = new Worker();
     private final Thread workerThread;
@@ -583,7 +585,7 @@ public class HashedWheelTimer implements Timer {
     private static final class TimeoutTaskRunnable implements Runnable {
         private final HashedWheelTimeout timeout;
 
-        public TimeoutTaskRunnable(HashedWheelTimeout timeout) {
+        TimeoutTaskRunnable(HashedWheelTimeout timeout) {
             this.timeout = timeout;
         }
 

--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -157,7 +157,7 @@ public class HashedWheelTimerTest {
         for (int i = 0; i < scheduledTasks; i++) {
             long delay = queue.take();
             assertTrue(delay >= timeout && delay < maxTimeout,
-                "Timeout + " + scheduledTasks + " delay " + delay + " must be " + timeout + " < " + maxTimeout);
+                "Timeout + " + i + "/" + scheduledTasks + " delay " + delay + " must be " + timeout + " < " + maxTimeout);
         }
 
         timer.stop();

--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -157,7 +157,8 @@ public class HashedWheelTimerTest {
         for (int i = 0; i < scheduledTasks; i++) {
             long delay = queue.take();
             assertTrue(delay >= timeout && delay < maxTimeout,
-                "Timeout + " + i + "/" + scheduledTasks + " delay " + delay + " must be " + timeout + " < " + maxTimeout);
+                "Timeout + " + i + "/" + scheduledTasks + " delay " + delay + " must be " +
+                timeout + " < " + maxTimeout);
         }
 
         timer.stop();


### PR DESCRIPTION
Motivation:
fixes #11724 
* currentTime in waitForNextTick() will be negative only if the application must keep running last more than 262 years, so there are no need to check currentTime is negative or not.
* the worker thread will be blocked if timeout task hangs, so it should be runned at a new thread.

Modification:
1.  remove currentTime  negative checking in waitForNextTick().
2.  run timeout task at new thread.