### PR TITLE
Fix possible leak in StompSubframeDecoder when a frame not ending with the NULL octet

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -231,13 +231,14 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
     }
 
     private static void skipControlCharacters(ByteBuf buffer) {
-        int offset = buffer.forEachByte(ByteProcessor.FIND_NON_CRLF);
-
-        if (offset == 0) {
-            return;
+        byte b;
+        for (;;) {
+            b = buffer.readByte();
+            if (b != StompConstants.CR && b != StompConstants.LF) {
+                buffer.readerIndex(buffer.readerIndex() - 1);
+                break;
+            }
         }
-
-        buffer.readerIndex(offset);
     }
 
     private void resetDecoder() {

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -243,6 +243,5 @@ public class StompSubframeDecoderTest {
         assertTrue(lastContentFrame.decoderResult().isFailure());
         assertEquals("unexpected byte in buffer 1 while expecting NULL byte",
                      lastContentFrame.decoderResult().cause().getMessage());
-
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -226,4 +226,23 @@ public class StompSubframeDecoderTest {
         assertEquals("body", contentSubFrame.content().toString(UTF_8));
         assertTrue(contentSubFrame.release());
     }
+
+    @Test
+    void testFrameWithContentLengthAndWithoutNullEnding() {
+        channel = new EmbeddedChannel(new StompSubframeDecoder(true));
+
+        ByteBuf incoming = Unpooled.wrappedBuffer(FRAME_WITHOUT_NULL_ENDING.getBytes(UTF_8));
+        assertTrue(channel.writeInbound(incoming));
+
+        StompHeadersSubframe headersFrame = channel.readInbound();
+        assertNotNull(headersFrame);
+        assertFalse(headersFrame.decoderResult().isFailure());
+
+        StompContentSubframe lastContentFrame = channel.readInbound();
+        assertNotNull(lastContentFrame);
+        assertTrue(lastContentFrame.decoderResult().isFailure());
+        assertEquals("unexpected byte in buffer 1 while expecting NULL byte",
+                     lastContentFrame.decoderResult().cause().getMessage());
+
+    }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
@@ -77,5 +77,12 @@ public final class StompTestConstants {
             '\n' +
             "body\0";
 
+    public static final String FRAME_WITHOUT_NULL_ENDING = "SEND\n" +
+             "destination:/queue/a\n" +
+             "content-type:text/plain\n" +
+             "content-length:4\n" +
+             '\n' +
+             "body\1";
+
     private StompTestConstants() { }
 }


### PR DESCRIPTION
Motivation:

Currently if a frame not ending with the NULL octet we throws an exception and not release `lastContent` frame if it present.

Modification:

Release `lastContent` if it present in exceptional case.

Result:

Fixed possible leak.