### PR TITLE
Make SniCompletionEvent constructor public

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
@@ -25,16 +25,16 @@ import io.netty.util.internal.UnstableApi;
 public final class SniCompletionEvent extends SslCompletionEvent {
     private final String hostname;
 
-    SniCompletionEvent(String hostname) {
+    public SniCompletionEvent(String hostname) {
         this.hostname = hostname;
     }
 
-    SniCompletionEvent(String hostname, Throwable cause) {
+    public SniCompletionEvent(String hostname, Throwable cause) {
         super(cause);
         this.hostname = hostname;
     }
 
-    SniCompletionEvent(Throwable cause) {
+    public SniCompletionEvent(Throwable cause) {
         this(null, cause);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -26,7 +27,7 @@ public final class SniCompletionEvent extends SslCompletionEvent {
     private final String hostname;
 
     public SniCompletionEvent(String hostname) {
-        this.hostname = hostname;
+        this.hostname = ObjectUtil.checkNotNull(hostname, "hostname");
     }
 
     public SniCompletionEvent(String hostname, Throwable cause) {

--- a/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -27,7 +26,7 @@ public final class SniCompletionEvent extends SslCompletionEvent {
     private final String hostname;
 
     public SniCompletionEvent(String hostname) {
-        this.hostname = ObjectUtil.checkNotNull(hostname, "hostname");
+        this.hostname = hostname;
     }
 
     public SniCompletionEvent(String hostname, Throwable cause) {


### PR DESCRIPTION
Motivation:

It is useful to re-use these events (as for example in QUIC) so let us allow to do so by changing the visibility to public

Modifications:

Change constructors to public

Result:

Be able to re-use the events