### PR TITLE
netty-all should not re-package jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ mainframer
 # exclude vscode files
 .vscode/
 *.factorypath
+
+# exclude file created by the flatten plugin
+.flattened-pom.xml

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -47,9 +47,12 @@
   </dependencyManagement>
 
   <profiles>
-    <!-- If the uber profile is used it will automatically fetch the missing native jar from maven and add it to the all jar as well. -->
+    <!--
+      This profile should be used during the release process together with the "native-dependencies" profile.
+      There is no need to do this by hand tho, use the ./scripts/finish_release.sh script.
+     -->
     <profile>
-      <id>uber-staging</id>
+      <id>staging</id>
       <repositories>
         <repository>
           <id>staged-releases</id>
@@ -57,101 +60,48 @@
           <url>https://oss.sonatype.org/service/local/repositories/${stagingRepositoryId}/content/</url>
         </repository>
       </repositories>
-
-      <dependencies>
-        <!-- Depend on all our native jars -->
-        <!-- As this is executed on either macOS or Linux we directly need to specify the classifier -->
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <classifier>linux-x86_64</classifier>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <classifier>linux-aarch_64</classifier>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <classifier>osx-x86_64</classifier>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <classifier>osx-aarch_64</classifier>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <classifier>osx-x86_64</classifier>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <classifier>osx-aarch_64</classifier>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
     </profile>
     <profile>
-      <id>uber-snapshot</id>
-
+      <id>native-dependencies</id>
       <dependencies>
         <!-- Depend on all our native jars -->
         <!-- As this is executed on either macOS or Linux we directly need to specify the classifier -->
+        <!-- These dependencies will also be "merged" into the dependency section by the flatten plugin -->
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
           <classifier>linux-x86_64</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
           <classifier>linux-aarch_64</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
           <classifier>osx-x86_64</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
           <classifier>osx-aarch_64</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
           <classifier>osx-x86_64</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
           <classifier>osx-aarch_64</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
       </dependencies>
     </profile>
@@ -160,12 +110,8 @@
          If you want to also include the native jar for kqueue use -Puber.
     -->
     <profile>
+      <!-- Don't active this profile based on the OS we run on so the flatten plugin will not include it -->
       <id>linux</id>
-      <activation>
-        <os>
-          <family>linux</family>
-        </os>
-      </activation>
       <dependencies>
         <!-- All release modules -->
         <dependency>
@@ -174,20 +120,17 @@
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-resolver-dns-native-macos</artifactId>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
       </dependencies>
     </profile>
@@ -195,12 +138,8 @@
          If you want to also include the native jar for kqueue use -Puber.
     -->
     <profile>
+      <!-- Don't active this profile based on the OS we run on so the flatten plugin will not include it -->
       <id>mac</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
-      </activation>
       <dependencies>
         <!-- All release modules -->
         <dependency>
@@ -209,7 +148,6 @@
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
@@ -217,84 +155,50 @@
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
         <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
           <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>freebsd</id>
-      <activation>
-        <os>
-          <family>unix</family>
-          <name>freebsd</name>
-        </os>
-      </activation>
-      <dependencies>
-        <!-- All release modules -->
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${project.version}</version>
-          <classifier>${jni.classifier}</classifier>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>openbsd</id>
-      <activation>
-        <os>
-          <family>unix</family>
-          <name>openbsd</name>
-        </os>
-      </activation>
-      <dependencies>
-        <!-- All release modules -->
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-          <version>${project.version}</version>
-          <classifier>${jni.classifier}</classifier>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
-          <scope>compile</scope>
-          <optional>true</optional>
-        </dependency>
-        <!-- Just include the classes for the other platform so these are at least present in the netty-all artifact -->
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-          <scope>compile</scope>
-          <optional>true</optional>
         </dependency>
       </dependencies>
     </profile>
   </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.2.2</version>
+        <configuration>
+          <!-- We need to also merge the dependencies defined by our profile. -->
+          <embedBuildProfileDependencies>true</embedBuildProfileDependencies>
+          <!-- Ensure excludes are set correctly -->
+          <flattenDependencyMode>all</flattenDependencyMode>
+        </configuration>
+        <executions>
+          <!-- enable flattening -->
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <!-- ensure proper cleanup -->
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <dependencies>
     <!-- All release modules -->
@@ -302,370 +206,131 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-buffer</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-dns</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-haproxy</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-http</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-http2</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-memcache</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-mqtt</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-redis</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-smtp</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-socks</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-stomp</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-xml</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-common</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-handler</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-handler-proxy</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-resolver</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-resolver-dns</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-rxtx</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-sctp</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-udt</artifactId>
       <scope>compile</scope>
-      <optional>true</optional>
+    </dependency>
+    <!--
+      Use no classifier for the native dependencies. The dependencies with the classifier are added by the
+      native-dependencies profile.
+      -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-resolver-dns-native-macos</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>clean-first</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <!-- Populate the properties whose key is groupId:artifactId:type
-                                   and whose value is the path to the artifact -->
-          <execution>
-            <id>locate-dependencies</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>properties</goal>
-            </goals>
-          </execution>
-
-          <!-- Unpack all source files -->
-          <execution>
-            <id>unpack-sources</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <configuration>
-              <classifier>sources</classifier>
-              <includes>io/netty/**</includes>
-              <includeScope>runtime</includeScope>
-              <includeGroupIds>${project.groupId}</includeGroupIds>
-              <outputDirectory>${generatedSourceDir}</outputDirectory>
-            </configuration>
-          </execution>
-
-          <!-- Unpack all class files -->
-          <execution>
-            <id>unpack-jars</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <configuration>
-              <excludes>io/netty/internal/tcnative/**,io/netty/example/**,META-INF/native/libnetty_tcnative*,META-INF/native/include/**,META-INF/native/**/*.a</excludes>
-              <includes>io/netty/**,META-INF/native/**,META-INF/native-image/**</includes>
-              <includeScope>runtime</includeScope>
-              <includeGroupIds>${project.groupId}</includeGroupIds>
-              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <!-- Instead of generating a new version property file, merge others' version property files into one. -->
-          <execution>
-            <id>write-version-properties</id>
-            <phase>none</phase>
-          </execution>
-          <execution>
-            <id>merge-version-properties</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <taskdef resource="net/sf/antcontrib/antlib.xml" />
-                <propertyselector property="versions" match="^(${project.groupId}:(?!netty-example)[^:]+:jar(?::[^:]+)?)$" select="\1" />
-                <for list="${versions}" param="x">
-                  <sequential>
-                    <unzip src="${@{x}}" dest="${dependencyVersionsDir}">
-                      <patternset>
-                        <include name="META-INF/${project.groupId}.versions.properties" />
-                      </patternset>
-                    </unzip>
-                    <concat destfile="${project.build.outputDirectory}/META-INF/${project.groupId}.versions.properties" append="true">
-                      <path path="${dependencyVersionsDir}/META-INF/${project.groupId}.versions.properties" />
-                    </concat>
-                  </sequential>
-                </for>
-                <delete dir="${dependencyVersionsDir}" quiet="true" />
-              </target>
-            </configuration>
-          </execution>
-
-          <!-- Clean everything once finished so that IDE doesn't find the unpacked files. -->
-          <execution>
-            <id>clean-source-directory</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <delete dir="${generatedSourceDir}" quiet="true" />
-                <delete dir="${dependencyVersionsDir}" quiet="true" />
-                <delete dir="${project.build.outputDirectory}" quiet="true" />
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Include the directory where the source files were unpacked -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${generatedSourceDir}</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Disable OSGi bundle manifest generation -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>generate-manifest</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Override the default JAR configuration -->
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <phase>none</phase>
-          </execution>
-          <execution>
-            <id>all-in-one-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <archive>
-                <manifest>
-                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                </manifest>
-                <manifestEntries>
-                  <Automatic-Module-Name>io.netty.all</Automatic-Module-Name>
-                </manifestEntries>
-                <index>true</index>
-              </archive>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Disable animal sniffer -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Disable checkstyle -->
-      <plugin>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>check-style</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Disable all plugin executions configured by jar packaging -->
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-resources</id>
-            <phase>none</phase>
-          </execution>
-          <execution>
-            <id>default-testResources</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <phase>none</phase>
-          </execution>
-          <execution>
-            <id>default-testCompile</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-test</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>
 

--- a/scripts/finish_release.sh
+++ b/scripts/finish_release.sh
@@ -43,7 +43,7 @@ export JAVA_HOME="$JAVA8_HOME"
 ./mvnw -Psonatype-oss-release -am -pl resolver-dns-native-macos,transport-native-unix-common,transport-native-kqueue clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
 ./mvnw -Psonatype-oss-release,mac-m1-cross-compile -am -pl resolver-dns-native-macos,transport-native-unix-common,transport-native-kqueue clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
 
-./mvnw -Psonatype-oss-release,full,uber-staging -pl all clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
+./mvnw -Psonatype-oss-release,full,native-dependencies,staging -pl all clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true
 
 ./mvnw org.sonatype.plugins:nexus-staging-maven-plugin:rc-close org.sonatype.plugins:nexus-staging-maven-plugin:rc-release -DstagingRepositoryId="$1" -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging -DskipTests=true -DstagingProgressTimeoutMinutes=10
 


### PR DESCRIPTION
Motivation:

As of today our netty-all artifact does just re-package classes / native libs that are included in our other modules. This can result in all kind of different issues especially if some people have netty-all and other netty-* modules on the classpath.

Modifications:

- Change netty-all to not re-package but just depend on the other different modules
- Use the flatten plugin to ensure the correct dependencies are added to the final pom.xml and the optional dependencies are excluded
- Adjust profiles
- Adjust release scripts

Result:

netty-all does not repackage and just pulls in its dependencies.