### PR TITLE
Use install_tool_name and codesign to patch id of shaded library

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -181,22 +181,24 @@ public final class NativeLibraryLoader {
             in = url.openStream();
             out = new FileOutputStream(tmpFile);
 
-            if (shouldShadedLibraryIdBePatched(packagePrefix)) {
-                patchShadedLibraryId(in, out, originalName, name);
-            } else {
-                byte[] buffer = new byte[8192];
-                int length;
-                while ((length = in.read(buffer)) > 0) {
-                    out.write(buffer, 0, length);
-                }
+            byte[] buffer = new byte[8192];
+            int length;
+            while ((length = in.read(buffer)) > 0) {
+                out.write(buffer, 0, length);
             }
-
             out.flush();
+
+            if (shouldShadedLibraryIdBePatched(packagePrefix)) {
+                // Let's try to patch the id and re-sign it. This is a best-effort and might fail if a
+                // SecurityManager is setup or the right executables are not installed :/
+                tryPatchShadedLibraryIdAndSign(tmpFile, originalName);
+            }
 
             // Close the output stream before loading the unpacked library,
             // because otherwise Windows will refuse to load it when it's in use by other process.
             closeQuietly(out);
             out = null;
+
             loadLibrary(loader, tmpFile.getPath(), true);
         } catch (UnsatisfiedLinkError e) {
             try {
@@ -234,91 +236,54 @@ public final class NativeLibraryLoader {
         }
     }
 
-    // Package-private for testing.
-    static boolean patchShadedLibraryId(InputStream in, OutputStream out, String originalName, String name)
-            throws IOException {
-        byte[] buffer = new byte[8192];
-        int length;
-        // We read the whole native lib into memory to make it easier to monkey-patch the id.
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(in.available());
-
-        while ((length = in.read(buffer)) > 0) {
-            byteArrayOutputStream.write(buffer, 0, length);
+    static void tryPatchShadedLibraryIdAndSign(File libraryFile, String originalName) {
+        String newId = new String(generateUniqueId(originalName.length()), CharsetUtil.UTF_8);
+        if (!tryExec("install_name_tool -id " + newId + " " + libraryFile.getAbsolutePath())) {
+            return;
         }
-        byteArrayOutputStream.flush();
-        byte[] bytes = byteArrayOutputStream.toByteArray();
-        byteArrayOutputStream.close();
 
-        final boolean patched;
-        // Try to patch the library id.
-        if (!patchShadedLibraryId(bytes, originalName, name)) {
-            // We did not find the Id, check if we used a originalName that has the os and arch as suffix.
-            // If this is the case we should also try to patch with the os and arch suffix removed.
-            String os = PlatformDependent.normalizedOs();
-            String arch = PlatformDependent.normalizedArch();
-            String osArch = "_" + os + "_" + arch;
-            if (originalName.endsWith(osArch)) {
-                patched = patchShadedLibraryId(bytes,
-                        originalName.substring(0, originalName.length() - osArch.length()), name);
-            } else {
-                patched = false;
+        tryExec("codesign -s - " + libraryFile.getAbsolutePath());
+    }
+
+    private static boolean tryExec(String cmd) {
+        try {
+            int exitValue = Runtime.getRuntime().exec(cmd).waitFor();
+            if (exitValue != 0) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Execution of '{}' failed: {}", cmd, exitValue);
+                }
+                return false;
             }
-        } else {
-            patched = true;
+            if (logger.isDebugEnabled()) {
+                logger.debug("Execution of '{}' succeed: {}", cmd, exitValue);
+            }
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (IOException e) {
+            if (logger.isInfoEnabled()) {
+                logger.info("Execution of '{}' failed.", cmd, e);
+            }
+        } catch (SecurityException e) {
+            if (logger.isInfoEnabled()) {
+                logger.info("Execution of '{}' failed.", cmd, e);
+            }
         }
-        out.write(bytes, 0, bytes.length);
-        return patched;
+        return false;
     }
 
     private static boolean shouldShadedLibraryIdBePatched(String packagePrefix) {
         return TRY_TO_PATCH_SHADED_ID && PlatformDependent.isOsx() && !packagePrefix.isEmpty();
     }
 
-    /**
-     * Try to patch shaded library to ensure it uses a unique ID.
-     */
-    private static boolean patchShadedLibraryId(byte[] bytes, String originalName, String name) {
-        // Our native libs always have the name as part of their id so we can search for it and replace it
-        // to make the ID unique if shading is used.
-        byte[] nameBytes = originalName.getBytes(CharsetUtil.UTF_8);
-        int idIdx = -1;
-
-        // Be aware this is a really raw way of patching a dylib but it does all we need without implementing
-        // a full mach-o parser and writer. Basically we just replace the the original bytes with some
-        // random bytes as part of the ID regeneration. The important thing here is that we need to use the same
-        // length to not corrupt the mach-o header.
-        outerLoop: for (int i = 0; i < bytes.length && bytes.length - i >= nameBytes.length; i++) {
-            int idx = i;
-            for (int j = 0; j < nameBytes.length;) {
-                if (bytes[idx++] != nameBytes[j++]) {
-                    // Did not match the name, increase the index and try again.
-                    break;
-                } else if (j == nameBytes.length) {
-                    // We found the index within the id.
-                    idIdx = i;
-                    break outerLoop;
-                }
-            }
+    private static byte[] generateUniqueId(int length) {
+        byte[] idBytes = new byte[length];
+        for (int i = 0; i < idBytes.length; i++) {
+            // We should only use bytes as replacement that are in our UNIQUE_ID_BYTES array.
+            idBytes[i] = UNIQUE_ID_BYTES[PlatformDependent.threadLocalRandom()
+                    .nextInt(UNIQUE_ID_BYTES.length)];
         }
-
-        if (idIdx == -1) {
-            logger.debug("Was not able to find the ID of the shaded native library {}, can't adjust it.", name);
-            return false;
-        } else {
-            // We found our ID... now monkey-patch it!
-            for (int i = 0; i < nameBytes.length; i++) {
-                // We should only use bytes as replacement that are in our UNIQUE_ID_BYTES array.
-                bytes[idIdx + i] = UNIQUE_ID_BYTES[PlatformDependent.threadLocalRandom()
-                                                                    .nextInt(UNIQUE_ID_BYTES.length)];
-            }
-
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Found the ID of the shaded native library {}. Replacing ID part {} with {}",
-                        name, originalName, new String(bytes, idIdx, nameBytes.length, CharsetUtil.UTF_8));
-            }
-            return true;
-        }
+        return idBytes;
     }
 
     /**

--- a/common/src/test/java/io/netty/util/internal/NativeLibraryLoaderTest.java
+++ b/common/src/test/java/io/netty/util/internal/NativeLibraryLoaderTest.java
@@ -15,19 +15,11 @@
  */
 package io.netty.util.internal;
 
-import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -71,72 +63,6 @@ public class NativeLibraryLoaderTest {
             assertTrue(expectedSuppressedExceptionClass.isInstance(suppressed[0]));
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    public void testPatchingId() throws IOException {
-        testPatchingId0(true, false);
-    }
-
-    @Test
-    public void testPatchingIdWithOsArch() throws IOException {
-        testPatchingId0(true, true);
-    }
-
-    @Test
-    public void testPatchingIdNotMatch() throws IOException {
-        testPatchingId0(false, false);
-    }
-
-    @Test
-    public void testPatchingIdWithOsArchNotMatch() throws IOException {
-        testPatchingId0(false, true);
-    }
-
-    private static void testPatchingId0(boolean match, boolean withOsArch) throws IOException {
-        byte[] bytes = new byte[1024];
-        PlatformDependent.threadLocalRandom().nextBytes(bytes);
-        byte[] idBytes = ("/workspace/netty-tcnative/boringssl-static/target/" +
-                "native-build/target/lib/libnetty_tcnative-2.0.20.Final.jnilib").getBytes(CharsetUtil.UTF_8);
-
-        String originalName;
-        if (match) {
-            originalName = "netty-tcnative";
-        } else {
-            originalName = "nonexist_tcnative";
-        }
-        String name = "shaded_" + originalName;
-        if (withOsArch) {
-            name += "_osx_x86_64";
-        }
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        out.write(bytes, 0, bytes.length);
-        out.write(idBytes, 0, idBytes.length);
-        out.write(bytes, 0 , bytes.length);
-
-        out.flush();
-        byte[] inBytes = out.toByteArray();
-        out.close();
-
-        InputStream inputStream = new ByteArrayInputStream(inBytes);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try {
-            assertEquals(match,
-                    NativeLibraryLoader.patchShadedLibraryId(inputStream, outputStream, originalName, name));
-
-            outputStream.flush();
-            byte[] outputBytes = outputStream.toByteArray();
-            assertArrayEquals(bytes, Arrays.copyOfRange(outputBytes, 0, bytes.length));
-            byte[] patchedId = Arrays.copyOfRange(outputBytes, bytes.length, bytes.length + idBytes.length);
-            assertEquals(!match, Arrays.equals(idBytes, patchedId));
-            assertArrayEquals(bytes,
-                    Arrays.copyOfRange(outputBytes, bytes.length + idBytes.length, outputBytes.length));
-            assertEquals(inBytes.length, outputBytes.length);
-        } finally {
-            inputStream.close();
-            outputStream.close();
         }
     }
 }


### PR DESCRIPTION
Motivation:

How we did patch the id of the shaded library could lead to JVM crashes if signature validation was used on macOS. This is the case on m1 for example.

Modifications:

- Replace our "hand-rolled" way of patching the id with using install_tool_name
- Re-sign the library after patching the id

Result:

No more crashes due adjusted id on m1 when shading is used
