### PR TITLE
Add server-side TCP FastOpen support for macOS

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
@@ -143,13 +143,13 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
     }
 
     /**
-     * Enables tcpFastOpen on the server channel. If the underlying os doesnt support TCP_FASTOPEN setting this has no
+     * Enables tcpFastOpen on the server channel. If the underlying os doesn't support TCP_FASTOPEN setting this has no
      * effect. This has to be set before doing listen on the socket otherwise this takes no effect.
      *
      * @param pendingFastOpenRequestsThreshold number of requests to be pending for fastopen at a given point in time
-     * for security. @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
+     * for security.
      *
-     * @see <a href="https://tools.ietf.org/html/rfc7413">RFC 7413 TCP FastOpen</a>
+     * @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
      */
     public EpollServerChannelConfig setTcpFastopen(int pendingFastOpenRequestsThreshold) {
         checkPositiveOrZero(this.pendingFastOpenRequestsThreshold, "pendingFastOpenRequestsThreshold");

--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -194,6 +194,10 @@ static void netty_kqueue_bsdsocket_setSndLowAt(JNIEnv* env, jclass clazz, jint f
     netty_unix_socket_setOption(env, fd, SOL_SOCKET, SO_SNDLOWAT, &optval, sizeof(optval));
 }
 
+static void netty_kqueue_bsdsocket_setTcpFastOpen(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    netty_unix_socket_setOption(env, fd, IPPROTO_TCP, TCP_FASTOPEN, &optval, sizeof(optval));
+}
+
 static jint netty_kqueue_bsdsocket_getTcpNoPush(JNIEnv* env, jclass clazz, jint fd) {
   int optval;
   if (netty_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_NOPUSH, &optval, sizeof(optval)) == -1) {
@@ -208,6 +212,15 @@ static jint netty_kqueue_bsdsocket_getSndLowAt(JNIEnv* env, jclass clazz, jint f
     return -1;
   }
   return optval;
+}
+
+static jint netty_kqueue_bsdsocket_isTcpFastOpen(JNIEnv* env, jclass clazz, jint fd) {
+    int optval = 0;
+    if (netty_unix_socket_getOption(env, fd, IPPROTO_TCP, TCP_FASTOPEN, &optval, sizeof(optval)) == -1) {
+        netty_unix_socket_getOptionHandleError(env, errno);
+        return 0;
+    }
+    return optval;
 }
 
 static jobject netty_kqueue_bsdsocket_getPeerCredentials(JNIEnv *env, jclass clazz, jint fd) {
@@ -249,9 +262,11 @@ static const JNINativeMethod fixed_method_table[] = {
   { "setAcceptFilter", "(ILjava/lang/String;Ljava/lang/String;)V", (void *) netty_kqueue_bsdsocket_setAcceptFilter },
   { "setTcpNoPush", "(II)V", (void *) netty_kqueue_bsdsocket_setTcpNoPush },
   { "setSndLowAt", "(II)V", (void *) netty_kqueue_bsdsocket_setSndLowAt },
+  { "setTcpFastOpen", "(II)V", (void *) netty_kqueue_bsdsocket_setTcpFastOpen },
   { "getAcceptFilter", "(I)[Ljava/lang/String;", (void *) netty_kqueue_bsdsocket_getAcceptFilter },
   { "getTcpNoPush", "(I)I", (void *) netty_kqueue_bsdsocket_getTcpNoPush },
   { "getSndLowAt", "(I)I", (void *) netty_kqueue_bsdsocket_getSndLowAt },
+  { "isTcpFastOpen", "(I)I", (void *) netty_kqueue_bsdsocket_isTcpFastOpen },
   { "connectx", "(IIZ[BIIZ[BIIIJII)I", (void *) netty_kqueue_bsdsocket_connectx }
 };
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -65,6 +65,10 @@ final class BsdSocket extends Socket {
         setSndLowAt(intValue(), lowAt);
     }
 
+    public void setTcpFastOpen(boolean enableTcpFastOpen) throws IOException {
+        setTcpFastOpen(intValue(), enableTcpFastOpen ? 1 : 0);
+    }
+
     boolean isTcpNoPush() throws IOException {
         return getTcpNoPush(intValue()) != 0;
     }
@@ -76,6 +80,10 @@ final class BsdSocket extends Socket {
     AcceptFilter getAcceptFilter() throws IOException {
         String[] result = getAcceptFilter(intValue());
         return result == null ? PLATFORM_UNSUPPORTED : new AcceptFilter(result[0], result[1]);
+    }
+
+    public boolean isTcpFastOpen() throws IOException {
+        return isTcpFastOpen(intValue()) != 0;
     }
 
     PeerCredentials getPeerCredentials() throws IOException {
@@ -224,6 +232,8 @@ final class BsdSocket extends Socket {
 
     private static native int getSndLowAt(int fd) throws IOException;
 
+    private static native int isTcpFastOpen(int fd) throws IOException;
+
     private static native PeerCredentials getPeerCredentials(int fd) throws IOException;
 
     private static native void setAcceptFilter(int fd, String filterName, String filterArgs) throws IOException;
@@ -231,4 +241,6 @@ final class BsdSocket extends Socket {
     private static native void setTcpNoPush(int fd, int tcpNoPush) throws IOException;
 
     private static native void setSndLowAt(int fd, int lowAt) throws IOException;
+
+    private static native void setTcpFastOpen(int fd, int enableFastOpen) throws IOException;
 }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerChannelConfig.java
@@ -31,11 +31,13 @@ import java.util.Map;
 import static io.netty.channel.ChannelOption.SO_BACKLOG;
 import static io.netty.channel.ChannelOption.SO_RCVBUF;
 import static io.netty.channel.ChannelOption.SO_REUSEADDR;
+import static io.netty.channel.ChannelOption.TCP_FASTOPEN;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 @UnstableApi
 public class KQueueServerChannelConfig extends KQueueChannelConfig implements ServerSocketChannelConfig {
     private volatile int backlog = NetUtil.SOMAXCONN;
+    private volatile boolean enableTcpFastOpen;
 
     KQueueServerChannelConfig(AbstractKQueueChannel channel) {
         super(channel);
@@ -43,7 +45,7 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), SO_RCVBUF, SO_REUSEADDR, SO_BACKLOG);
+        return getOptions(super.getOptions(), SO_RCVBUF, SO_REUSEADDR, SO_BACKLOG, TCP_FASTOPEN);
     }
 
     @SuppressWarnings("unchecked")
@@ -58,6 +60,9 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
         if (option == SO_BACKLOG) {
             return (T) Integer.valueOf(getBacklog());
         }
+        if (option == TCP_FASTOPEN) {
+            return (T) (isTcpFastOpen() ? Integer.valueOf(1) : Integer.valueOf(0));
+        }
         return super.getOption(option);
     }
 
@@ -71,6 +76,8 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
             setReuseAddress((Boolean) value);
         } else if (option == SO_BACKLOG) {
             setBacklog((Integer) value);
+        } else if (option == TCP_FASTOPEN) {
+            setTcpFastOpen((Integer) value > 0);
         } else {
             return super.setOption(option, value);
         }
@@ -125,6 +132,28 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
     public KQueueServerChannelConfig setBacklog(int backlog) {
         checkPositiveOrZero(backlog, "backlog");
         this.backlog = backlog;
+        return this;
+    }
+
+    /**
+     * Returns {@code true} if TCP FastOpen is enabled.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
+     */
+    public boolean isTcpFastOpen() {
+        return enableTcpFastOpen;
+    }
+
+    /**
+     * Enables TCP FastOpen on the server channel. If the underlying os doesn't support TCP_FASTOPEN setting this has no
+     * effect. This has to be set before doing listen on the socket otherwise this takes no effect.
+     *
+     * @param enableTcpFastOpen {@code true} if TCP FastOpen should be enabled for incomming connections.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
+     */
+    public KQueueServerChannelConfig setTcpFastOpen(boolean enableTcpFastOpen) {
+        this.enableTcpFastOpen = enableTcpFastOpen;
         return this;
     }
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
@@ -59,9 +59,10 @@ public final class KQueueServerSocketChannel extends AbstractKQueueServerChannel
     @Override
     protected void doBind(SocketAddress localAddress) throws Exception {
         super.doBind(localAddress);
-
-        // TODO(scott): tcp fast open here!
         socket.listen(config.getBacklog());
+        if (config.isTcpFastOpen()) {
+            socket.setTcpFastOpen(true);
+        }
         active = true;
     }
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
@@ -31,7 +31,7 @@ import static io.netty.channel.kqueue.KQueueChannelOption.SO_ACCEPTFILTER;
 import static io.netty.channel.unix.UnixChannelOption.SO_REUSEPORT;
 
 @UnstableApi
-public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig implements ServerSocketChannelConfig {
+public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig {
     KQueueServerSocketChannelConfig(KQueueServerSocketChannel channel) {
         super(channel);
 
@@ -133,6 +133,12 @@ public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig i
     @Override
     public KQueueServerSocketChannelConfig setBacklog(int backlog) {
         super.setBacklog(backlog);
+        return this;
+    }
+
+    @Override
+    public KQueueServerSocketChannelConfig setTcpFastOpen(boolean enableTcpFastOpen) {
+        super.setTcpFastOpen(enableTcpFastOpen);
         return this;
     }
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -67,6 +67,15 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                                             .channel(KQueueServerSocketChannel.class);
             }
         });
+        toReturn.add(new BootstrapFactory<ServerBootstrap>() {
+            @Override
+            public ServerBootstrap newInstance() {
+                ServerBootstrap serverBootstrap = new ServerBootstrap().group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
+                                                                       .channel(KQueueServerSocketChannel.class);
+                serverBootstrap.option(ChannelOption.TCP_FASTOPEN, 1);
+                return serverBootstrap;
+            }
+        });
 
         toReturn.add(new BootstrapFactory<ServerBootstrap>() {
             @Override


### PR DESCRIPTION
Motivation:
This completes the story of TCP FastOpen support for macOS.

Modification:
On macOS, to enable TCP FastOpen for a listening socket, we need to set it as a socket option after the bind(2) and listen(2) calls (as opposed to before the listen call, like on Linux, or at config time).
Native methods are added to BsdSocket for getting and setting the TCP_FASTOPEN socket option.
Since activation happens at bind-time, a field is also added to KQueueServerChannelConfig, to track if TCP FastOpen should be enabled or not.
By default, it is off, which leaves this socket option unset to the operating system.

Result:
We now have both client and server support for TCP FastOpen on macOS.

Draft until I've done manual testing and inspected the data streams with Wireshark.
