### PR TITLE
Exclude target folder when doing xml validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1212,6 +1212,9 @@
               <includes>
                 <include>**/pom.xml</include>
               </includes>
+              <excludes>
+                <exclude>**/target/**</exclude>
+              </excludes>
             </formatFileSet>
           </formatFileSets>
           <useDefaultFormatFileSet>false</useDefaultFormatFileSet>


### PR DESCRIPTION
Motivation:

The validation can fail when a previous build was done because of left-overs in the target directory. We should not do any validation of files in this directory.

Modifications:

Exclude the target directory

Result:

No more xml validation failures