### PR TITLE
Revert "Epoll compiled on GLIBC only supports GLIBC at runtime"

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -326,7 +326,6 @@ static jint netty_epoll_native_epollCtlAdd0(JNIEnv* env, jclass clazz, jint efd,
     }
     return res;
 }
-
 static jint netty_epoll_native_epollCtlMod0(JNIEnv* env, jclass clazz, jint efd, jint fd, jint flags) {
     int res = epollCtl(env, efd, EPOLL_CTL_MOD, fd, flags);
     if (res < 0) {
@@ -541,15 +540,6 @@ static jstring netty_epoll_native_kernelVersion(JNIEnv* env, jclass clazz) {
     return NULL;
 }
 
-static jint netty_epoll_native_gnulibc(JNIEnv* env, jclass clazz) {
-#ifdef __GLIBC__
-    return 1;
-#else
-    // We are using an alternative libc, possibly musl but could be anything.
-    return 0;
-#endif // __GLIBC__
-}
-
 static jboolean netty_epoll_native_isSupportingSendmmsg(JNIEnv* env, jclass clazz) {
     if (SYS_sendmmsg == -1) {
         return JNI_FALSE;
@@ -668,8 +658,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "isSupportingSendmmsg", "()Z", (void *) netty_epoll_native_isSupportingSendmmsg },
   { "isSupportingRecvmmsg", "()Z", (void *) netty_epoll_native_isSupportingRecvmmsg },
   { "tcpFastopenMode", "()I", (void *) netty_epoll_native_tcpFastopenMode },
-  { "kernelVersion", "()Ljava/lang/String;", (void *) netty_epoll_native_kernelVersion },
-  { "gnulibc", "()I", (void *) netty_epoll_native_gnulibc }
+  { "kernelVersion", "()Ljava/lang/String;", (void *) netty_epoll_native_kernelVersion }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 static const JNINativeMethod fixed_method_table[] = {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeStaticallyReferencedJniMethods.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeStaticallyReferencedJniMethods.java
@@ -43,5 +43,4 @@ final class NativeStaticallyReferencedJniMethods {
     static native boolean isSupportingRecvmmsg();
     static native int tcpFastopenMode();
     static native String kernelVersion();
-    static native int gnulibc();
 }


### PR DESCRIPTION
Reverts netty/netty#11722

It appears we can't do this while also ensuring that working glibc use cases are not impacted.
In particular, there's a musl/glibc compatibility layer which solves the binary compatibility even though musl can still be in the library mappings.