### PR TITLE
Make the needTask flag lowering consistent in ReferenceCountedOpenSslEngine

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1451,12 +1451,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 // The engine was destroyed in the meantime, just return.
                 return;
             }
-            try {
-                task.run();
-            } finally {
-                // The task was run, reset needTask to false so getHandshakeStatus() returns the correct value.
-                needTask = false;
-            }
+            // The task was run, reset needTask to false so getHandshakeStatus() returns the correct value.
+            needTask = false;
+            task.run();
         }
     }
 


### PR DESCRIPTION
Motivation:
The needTask flag needs to be lowered before an off-loaded task is executed.
This is because the executed task might want to inspect the needTask state, and it should not see itself in that case.

Modification:
Lower the needTask state before the task execution, not only for asynchronous tasks but also for synchronous tasks.

Result:
More consistent behaviour.

Draft to see what the build says.