### PR TITLE
Update japicmp-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1015,7 +1015,7 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.15.3</version>
+        <version>0.15.4</version>
         <configuration>
           <parameter>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>
@@ -1030,10 +1030,6 @@
             <excludes>
               <exclude>@io.netty.util.internal.UnstableApi</exclude>
               <exclude>io.netty.util.internal.shaded</exclude>
-              <!-- Added to fix false-positive -->
-              <exclude>io.netty.handler.codec.dns.TcpDnsQueryDecoder</exclude>
-              <exclude>io.netty.handler.codec.dns.TcpDnsResponseEncoder</exclude>
-              <exclude>io.netty.channel.ServerChannelRecvByteBufAllocator</exclude>
             </excludes>
           </parameter>
         </configuration>


### PR DESCRIPTION
Motivation:

A new japicmp-maven-plugin version was released which fixes a few issues that affected us.

Modifications:

- Upgrade the japicmp-maven-plugin
- Remove excludes that we added as a workaround

Result:

No more workarounds needed for japicmp-maven-plugin
