### PR TITLE
Our SNI hostname validation was really basic and could lead to except…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -54,6 +54,15 @@ final class Java8SslUtils {
         sslParameters.setServerNames(getSniHostNames(names));
     }
 
+    static boolean isValidHostNameForSNI(String hostname) {
+        try {
+            new SNIHostName(hostname);
+            return true;
+        } catch (IllegalArgumentException illegal) {
+            return false;
+        }
+    }
+
     static List getSniHostNames(List<String> names) {
         if (names == null || names.isEmpty()) {
             return Collections.emptyList();

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -342,8 +342,17 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 // Use SNI if peerHost was specified and a valid hostname
                 // See https://github.com/netty/netty/issues/4746
                 if (clientMode && SslUtils.isValidHostNameForSNI(peerHost)) {
-                    SSL.setTlsExtHostName(ssl, peerHost);
-                    sniHostNames = Collections.singletonList(peerHost);
+                    // If on java8 and later we should do some extra validation to ensure we can construct the
+                    // SNIHostName later again.
+                    if (PlatformDependent.javaVersion() >= 8) {
+                        if (Java8SslUtils.isValidHostNameForSNI(peerHost)) {
+                            SSL.setTlsExtHostName(ssl, peerHost);
+                            sniHostNames = Collections.singletonList(peerHost);
+                        }
+                    } else {
+                        SSL.setTlsExtHostName(ssl, peerHost);
+                        sniHostNames = Collections.singletonList(peerHost);
+                    }
                 }
 
                 if (enableOcsp) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -480,7 +480,7 @@ final class SslUtils {
     static boolean isValidHostNameForSNI(String hostname) {
         return hostname != null &&
                hostname.indexOf('.') > 0 &&
-               !hostname.endsWith(".") &&
+               !hostname.endsWith(".") && !hostname.startsWith("/") &&
                !NetUtil.isValidIpV4Address(hostname) &&
                !NetUtil.isValidIpV6Address(hostname);
     }
@@ -491,10 +491,6 @@ final class SslUtils {
     static boolean isTLSv13Cipher(String cipher) {
         // See https://tools.ietf.org/html/rfc8446#appendix-B.4
         return TLSV13_CIPHERS.contains(cipher);
-    }
-
-    static boolean isEmpty(Object[] arr) {
-        return arr == null || arr.length == 0;
     }
 
     private SslUtils() {

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -79,4 +79,12 @@ public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
     protected void invalidateSessionsAndAssert(SSLSessionContext context) {
         // Not supported by conscrypt
     }
+
+    @MethodSource("newTestParams")
+    @ParameterizedTest
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void testInvalidSNIIsIgnoredAndNotThrow(SSLEngineTestParam param) throws Exception {
+        super.testInvalidSNIIsIgnoredAndNotThrow(param);
+    }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptOpenSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptOpenSslEngineInteropTest.java
@@ -191,6 +191,14 @@ public class ConscryptOpenSslEngineInteropTest extends ConscryptSslEngineTest {
         super.testSessionCacheSize(param);
     }
 
+    @MethodSource("newTestParams")
+    @ParameterizedTest
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void testInvalidSNIIsIgnoredAndNotThrow(SSLEngineTestParam param) throws Exception {
+        super.testInvalidSNIIsIgnoredAndNotThrow(param);
+    }
+
     @Override
     protected SSLEngine wrapEngine(SSLEngine engine) {
         return Java8SslTestUtils.wrapSSLEngineForTesting(engine);

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptSslEngineTest.java
@@ -88,4 +88,12 @@ public class ConscryptSslEngineTest extends SSLEngineTest {
     public void testRSASSAPSS(SSLEngineTestParam param) {
         // skip
     }
+
+    @MethodSource("newTestParams")
+    @ParameterizedTest
+    @Disabled("Disabled due a conscrypt bug")
+    @Override
+    public void testInvalidSNIIsIgnoredAndNotThrow(SSLEngineTestParam param) throws Exception {
+        super.testInvalidSNIIsIgnoredAndNotThrow(param);
+    }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -4198,14 +4198,15 @@ public abstract class SSLEngineTest {
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .sslProvider(sslClientProvider())
-                // This test only works for non TLSv1.3 for now
-                .protocols(param.protocols())
                 .sslContextProvider(clientSslContextProvider())
+                .protocols(param.protocols())
+                .ciphers(param.ciphers())
                 .build());
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
                 .sslContextProvider(serverSslContextProvider())
+                .protocols(param.protocols())
                 .ciphers(param.ciphers())
                 .build());
         SSLEngine clientEngine = null;

--- a/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
@@ -100,4 +100,9 @@ public class SslUtilsTest {
         assertEquals(bodyLength + SslUtils.SSL_RECORD_HEADER_LENGTH, packetLength);
         buf.release();
     }
+
+    @Test
+    public void testValidHostNameForSni() {
+        assertFalse(SslUtils.isValidHostNameForSNI("/test.de"));
+    }
 }


### PR DESCRIPTION
…ions later on

Motivation:

Our validation of the SNI hostname was incomplete and so we could end up with an exception once the user calls getSSLParameters() later on

Modifications:

- Just use SNIHostName to validate the name when on Java8 and later
- Add unit test

Result:

Don't throw exceptions once we try to retrieve the SSLParamaters when an invalid SNI hostname was used while creating the engine

