### PR TITLE
We should define netty-tcnative (with classifier) as runtime dependency

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -294,7 +294,7 @@
       <!-- Add netty-tcnative* as well as users need to ensure they use the correct version -->
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative</artifactId>
+        <artifactId>netty-tcnative-classes</artifactId>
         <version>${tcnative.version}</version>
       </dependency>
       <dependency>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -62,7 +62,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>${tcnative.artifactId}</artifactId>
+      <artifactId>netty-tcnative-classes</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.45.Final</tcnative.version>
+    <tcnative.version>2.0.46.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
@@ -642,7 +642,7 @@
       <!-- Our own Tomcat Native fork - completely optional for the native lib, used for accelerating SSL with OpenSSL. -->
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>${tcnative.artifactId}</artifactId>
+        <artifactId>netty-tcnative-classes</artifactId>
         <version>${tcnative.version}</version>
         <scope>compile</scope>
       </dependency>


### PR DESCRIPTION
Motivation:

The netty-tcnative lib that contains the native lib should be a runtime dependency while the one without the native lib should be compile time

Modifications:

- Add netty-tcnative dependency as compile time and netty-tcnative with classifier as runtime time dependency

Result:

More correct dependency declaration
