### PR TITLE
Add Buffer.bytesBefore

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -369,23 +369,6 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     }
 
     /**
-     * Locate the first occurrence of the given {@code needle} byte in this buffer, within the given bounds.
-     * If the needle is not found, {@code -1} is returned.
-     * The from-bound is inclusive, and the to-bound is exclusive.
-     * <p>
-     * This method does not modify the {@linkplain #readerOffset() reader-offset} or the
-     * {@linkplain #writerOffset() write-offset}.
-     *
-     * @param fromOffsetInclusive The offset of the first byte to search.
-     * @param length The number of bytes from the {@code fromOffsetInclusive} to search.
-     * @param needle The byte value to search for.
-     * @return The absolute offset into this buffer of the found value, or {@code -1} if none was found.
-     * @throws IllegalArgumentException If the {@code fromOffsetInclusive} argument is less than zero,
-     * or the {@code length} argument is less than zero.
-     */
-    int firstOffsetOf(int fromOffsetInclusive, int length, byte needle);
-
-    /**
      * Get the number of {@linkplain #readableBytes() readable bytes}, until the given {@code needle} is found in this
      * buffer.
      * If the needle is not found, {@code -1} is returned.
@@ -397,13 +380,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @return The offset, relative to the current {@link #readerOffset()}, of the found value, or {@code -1} if none
      * was found.
      */
-    default int bytesBefore(byte needle) {
-        int offset = firstOffsetOf(readerOffset(), readableBytes(), needle);
-        if (offset == -1) {
-            return -1;
-        }
-        return offset - readerOffset();
-    }
+    int bytesBefore(byte needle);
 
     /**
      * Opens a cursor to iterate the readable bytes of this buffer. The {@linkplain #readerOffset() reader offset} and

--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -386,7 +386,8 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     int firstOffsetOf(int fromOffsetInclusive, int length, byte needle);
 
     /**
-     * Get the number of {@linkplain #readableBytes() readable bytes}, until the given {@code needle} is found in this buffer.
+     * Get the number of {@linkplain #readableBytes() readable bytes}, until the given {@code needle} is found in this
+     * buffer.
      * If the needle is not found, {@code -1} is returned.
      * <p>
      * This method does not modify the {@linkplain #readerOffset() reader-offset} or the

--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -371,7 +371,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     /**
      * Locate the first occurrence of the given {@code needle} byte in this buffer, within the given bounds.
      * If the needle is not found, {@code -1} is returned.
-     * The from-bound is always inclusive, and the to-bound is always exclusive.
+     * The from-bound is inclusive, and the to-bound is exclusive.
      * <p>
      * This method does not modify the {@linkplain #readerOffset() reader-offset} or the
      * {@linkplain #writerOffset() write-offset}.

--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -369,6 +369,42 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     }
 
     /**
+     * Locate the first occurrence of the given {@code needle} byte in this buffer, within the given bounds.
+     * If the needle is not found, {@code -1} is returned.
+     * The from-bound is always inclusive, and the to-bound is always exclusive.
+     * <p>
+     * This method does not modify the {@linkplain #readerOffset() reader-offset} or the
+     * {@linkplain #writerOffset() write-offset}.
+     *
+     * @param fromOffsetInclusive The offset of the first byte to search.
+     * @param length The number of bytes from the {@code fromOffsetInclusive} to search.
+     * @param needle The byte value to search for.
+     * @return The absolute offset into this buffer of the found value, or {@code -1} if none was found.
+     * @throws IllegalArgumentException If the {@code fromOffsetInclusive} argument is less than zero,
+     * or the {@code length} argument is less than zero.
+     */
+    int firstOffsetOf(int fromOffsetInclusive, int length, byte needle);
+
+    /**
+     * Get the number of {@linkplain #readableBytes() readable bytes}, until the given {@code needle} is found in this buffer.
+     * If the needle is not found, {@code -1} is returned.
+     * <p>
+     * This method does not modify the {@linkplain #readerOffset() reader-offset} or the
+     * {@linkplain #writerOffset() write-offset}.
+     *
+     * @param needle The byte value to search for.
+     * @return The offset, relative to the current {@link #readerOffset()}, of the found value, or {@code -1} if none
+     * was found.
+     */
+    default int bytesBefore(byte needle) {
+        int offset = firstOffsetOf(readerOffset(), readableBytes(), needle);
+        if (offset == -1) {
+            return -1;
+        }
+        return offset - readerOffset();
+    }
+
+    /**
      * Opens a cursor to iterate the readable bytes of this buffer. The {@linkplain #readerOffset() reader offset} and
      * {@linkplain #writerOffset() writer offset} are not modified by the cursor.
      * <p>

--- a/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
@@ -118,8 +118,8 @@ public class BufferStub implements Buffer {
     }
 
     @Override
-    public int firstOffsetOf(int fromOffsetInclusive, int toOffsetExclusive, byte needle) {
-        return delegate.firstOffsetOf(fromOffsetInclusive, toOffsetExclusive, needle);
+    public int bytesBefore(byte needle) {
+        return delegate.bytesBefore(needle);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
@@ -118,6 +118,11 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public int firstOffsetOf(int fromOffsetInclusive, int toOffsetExclusive, byte needle) {
+        return delegate.firstOffsetOf(fromOffsetInclusive, toOffsetExclusive, needle);
+    }
+
+    @Override
     public ByteCursor openCursor() {
         return delegate.openCursor();
     }

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -432,9 +432,6 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }
-        if (bufs.length == 0) {
-            return -1;
-        }
         final int length = readableBytes();
         final int start = searchOffsets(readerOffset());
         int skip = 0;

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -438,10 +438,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         int off = fromOffsetInclusive - offsets[startBufferIndex];
         Buffer buf = bufs[startBufferIndex];
         int len = Math.min(buf.capacity() - off, length);
-        for (;;) {
-            if (len < 1) {
-                return -1;
-            }
+        while (len > 0) {
             int found = buf.firstOffsetOf(off, len, needle);
             if (found != -1) {
                 return offsets[startBufferIndex] + found;
@@ -455,6 +452,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             off = 0;
             len = Math.min(buf.capacity(), length);
         }
+        return -1;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -433,9 +433,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             throw bufferIsClosed(this);
         }
         final int length = readableBytes();
-        final int start = searchOffsets(readerOffset());
-        int skip = 0;
-        for (int i = start; skip < length; i++) {
+        for (int i = searchOffsets(readerOffset()), skip = 0; skip < length; i++) {
             Buffer buf = bufs[i];
             int found = buf.bytesBefore(needle);
             if (found != -1) {

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -431,6 +431,9 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     public int firstOffsetOf(int fromOffsetInclusive, int length, byte needle) {
         checkLength(length);
         checkGetBounds(fromOffsetInclusive, length);
+        if (!isAccessible()) {
+            throw bufferIsClosed(this);
+        }
         int startBufferIndex = searchOffsets(fromOffsetInclusive);
         int off = fromOffsetInclusive - offsets[startBufferIndex];
         Buffer buf = bufs[startBufferIndex];

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -200,10 +200,11 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
         }
         final int end = Math.addExact(fromOffsetInclusive, length);
 
-        if (length > 16) {
-            final int longEnd = fromOffsetInclusive + (length >>> 3) * Long.BYTES;
+        if (length > 7) {
             final long pattern = (needle & 0xFFL) * 0x101010101010101L;
-            for (; fromOffsetInclusive < longEnd; fromOffsetInclusive += Long.BYTES) {
+            for (final int longEnd = fromOffsetInclusive + (length >>> 3) * Long.BYTES;
+                 fromOffsetInclusive < longEnd;
+                 fromOffsetInclusive += Long.BYTES) {
                 final long word = rmem.getLong(fromOffsetInclusive);
 
                 long input = word ^ pattern;

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -195,6 +195,9 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     public int firstOffsetOf(int fromOffsetInclusive, int length, byte needle) {
         checkLength(length);
         checkGet(fromOffsetInclusive, length);
+        if (!isAccessible()) {
+            throw bufferIsClosed(this);
+        }
         final int end = Math.addExact(fromOffsetInclusive, length);
 
         if (length > 16) {

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -193,6 +193,8 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
 
     @Override
     public int bytesBefore(byte needle) {
+        // For the details of this algorithm, see Hacker's Delight, Chapter 6, Searching Words.
+        // Richard Startin also describes this on his blog: https://richardstartin.github.io/posts/finding-bytes
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }

--- a/buffer/src/main/java/io/netty/buffer/api/internal/MemoryManagerOverride.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/MemoryManagerOverride.java
@@ -17,6 +17,8 @@ package io.netty.buffer.api.internal;
 
 import io.netty.buffer.api.MemoryManager;
 import io.netty.buffer.api.bytebuffer.ByteBufferMemoryManager;
+import io.netty.buffer.api.unsafe.UnsafeMemoryManager;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -49,6 +51,13 @@ public final class MemoryManagerOverride {
                 logger.debug("{} requested implementation is unavailable: {} (using default {} implementation instead)",
                              systemProperty, configured, fallback.implementationName());
                 return fallback;
+            }
+        }
+        if (PlatformDependent.hasUnsafe() && PlatformDependent.hasDirectBufferNoCleanerConstructor()) {
+            try {
+                return new UnsafeMemoryManager();
+            } catch (Exception ignore) {
+                // We will just fall back to ByteBuffer based memory management if Unsafe fails.
             }
         }
         return new ByteBufferMemoryManager();

--- a/buffer/src/main/java/io/netty/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/Statics.java
@@ -123,6 +123,12 @@ public interface Statics {
         }
     }
 
+    static void checkLength(int length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("The length cannot be negative: " + length + '.');
+        }
+    }
+
     static void copyToViaReverseLoop(Buffer src, int srcPos, Buffer dest, int destPos, int length) {
         if (length == 0) {
             return;

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -261,6 +261,8 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
 
     @Override
     public int bytesBefore(byte needle) {
+        // For the details of this algorithm, see Hacker's Delight, Chapter 6, Searching Words.
+        // Richard Startin also describes this on his blog: https://richardstartin.github.io/posts/finding-bytes
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -270,10 +270,11 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
             final int end = Math.addExact(fromOffsetInclusive, length);
             final long addr = address;
 
-            if (length > 16) {
-                final int longEnd = fromOffsetInclusive + (length >>> 3) * Long.BYTES;
+            if (length > 7) {
                 final long pattern = (needle & 0xFFL) * 0x101010101010101L;
-                for (; fromOffsetInclusive < longEnd; fromOffsetInclusive += Long.BYTES) {
+                for (final int longEnd = fromOffsetInclusive + (length >>> 3) * Long.BYTES;
+                     fromOffsetInclusive < longEnd;
+                     fromOffsetInclusive += Long.BYTES) {
                     final long word = FIRST_OFFSET_OF_USE_LITTLE_ENDIAN?
                             PlatformDependent.getLong(base, addr + fromOffsetInclusive) :
                             loadLong(addr + fromOffsetInclusive);

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -263,6 +263,9 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     public int firstOffsetOf(int fromOffsetInclusive, int length, byte needle) {
         checkLength(length);
         checkGet(fromOffsetInclusive, length);
+        if (!isAccessible()) {
+            throw bufferIsClosed(this);
+        }
         try {
             final int end = Math.addExact(fromOffsetInclusive, length);
             final long addr = address;

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -256,7 +256,7 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
      * Most deployment platforms support unaligned access, and are little-endian.
      * This allows us to micro-optimise for this common case.
      */
-    private static final boolean FIRST_OFFSET_OF_USE_LITTLE_ENDIAN =
+    private static final boolean BYTES_BEFORE_USE_LITTLE_ENDIAN =
             PlatformDependent.isUnaligned() && ByteOrder.nativeOrder() != ByteOrder.BIG_ENDIAN;
 
     @Override
@@ -275,14 +275,14 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
                 for (final int longEnd = offset + (length >>> 3) * Long.BYTES;
                      offset < longEnd;
                      offset += Long.BYTES) {
-                    final long word = FIRST_OFFSET_OF_USE_LITTLE_ENDIAN?
+                    final long word = BYTES_BEFORE_USE_LITTLE_ENDIAN?
                             PlatformDependent.getLong(base, addr + offset) :
                             loadLong(addr + offset);
 
                     final long input = word ^ pattern;
                     final long tmp =
                             ~((input & 0x7F7F7F7F7F7F7F7FL) + 0x7F7F7F7F7F7F7F7FL | input | 0x7F7F7F7F7F7F7F7FL);
-                    final int binaryPosition = FIRST_OFFSET_OF_USE_LITTLE_ENDIAN?
+                    final int binaryPosition = BYTES_BEFORE_USE_LITTLE_ENDIAN?
                             Long.numberOfTrailingZeros(tmp) :
                             Long.numberOfLeadingZeros(tmp);
 

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -31,7 +31,9 @@ import static io.netty.buffer.api.internal.Statics.convert;
 public class UnsafeMemoryManager implements MemoryManager {
     public UnsafeMemoryManager() {
         if (!PlatformDependent.hasUnsafe()) {
-            throw new UnsupportedOperationException("Unsafe is not available.");
+            UnsupportedOperationException notSupported = new UnsupportedOperationException("Unsafe is not available.");
+            notSupported.addSuppressed(PlatformDependent.getUnsafeUnavailabilityCause());
+            throw notSupported;
         }
         if (!PlatformDependent.hasDirectBufferNoCleanerConstructor()) {
             throw new UnsupportedOperationException("DirectByteBuffer internal constructor is not available.");

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferSearchTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferSearchTest.java
@@ -28,42 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class BufferSearchTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")
-    public void fromOffsetCannotBeLessThanZero(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.firstOffsetOf(-1, 1, (byte) 0));
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
-    public void lengthCannotBeLessThanZero(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(8)) {
-            assertThrows(IllegalArgumentException.class, () -> buf.firstOffsetOf(1, -1, (byte) 0));
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
-    public void firstOffsetOfMustThrowOnInaccessibleBuffer(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator()) {
-            Buffer buffer = allocator.allocate(8);
-            buffer.writeLong(0x0102030405060708L);
-            assertThat(buffer.firstOffsetOf(0, 8, (byte) 0x03)).isEqualTo(2);
-            var send = buffer.send();
-            assertThrows(IllegalStateException.class, () -> buffer.firstOffsetOf(0, 0, (byte) 0));
-            assertThrows(IllegalStateException.class, () -> buffer.firstOffsetOf(0, 1, (byte) 0));
-            Buffer received = send.receive();
-            assertThat(received.firstOffsetOf(0, 8, (byte) 0x03)).isEqualTo(2);
-            received.close();
-            assertThrows(IllegalStateException.class, () -> received.firstOffsetOf(0, 0, (byte) 0));
-            assertThrows(IllegalStateException.class, () -> received.firstOffsetOf(0, 1, (byte) 0));
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
     public void bytesBeforeMustThrowOnInaccessibleBuffer(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator()) {
             Buffer buffer = allocator.allocate(8);
@@ -75,33 +39,6 @@ public class BufferSearchTest extends BufferTestSupport {
             assertThat(received.bytesBefore((byte) 0x03)).isEqualTo(2);
             received.close();
             assertThrows(IllegalStateException.class, () -> received.bytesBefore((byte) 0));
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
-    public void firstOffsetOfMustThrowWhenRangeIsOutOfBounds(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buffer = allocator.allocate(8)) {
-            buffer.writeLong(0x0102030405060708L);
-            assertThrows(IndexOutOfBoundsException.class, () -> buffer.firstOffsetOf(1, 8, (byte) 9));
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
-    public void firstOffsetOfMustFindNeedleAtStartOffset(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(128)) {
-            fillBuffer(buf);
-            byte needle = (byte) 0xA5;
-            buf.setByte(3, needle);
-            int maxLen = buf.readableBytes() - 3;
-            for (int len = 1; len < maxLen; len++) {
-                assertThat(buf.firstOffsetOf(3, len, needle))
-                        .as("firstOffsetOf(3, %s, %X) should be 3", len, needle)
-                        .isEqualTo(3);
-            }
         }
     }
 
@@ -122,23 +59,6 @@ public class BufferSearchTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void firstOffsetOfMustFindNeedleAfterStartOffset(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(128)) {
-            fillBuffer(buf);
-            byte needle = (byte) 0xA5;
-            buf.setByte(3, needle);
-            int maxLen = buf.readableBytes() - 3;
-            for (int len = 4; len < maxLen; len++) {
-                assertThat(buf.firstOffsetOf(2, len, needle))
-                        .as("firstOffsetOf(2, %s, %X) should be 3", len, needle)
-                        .isEqualTo(3);
-            }
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
     public void bytesBeforeMustFindNeedleAfterStart(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(128)) {
@@ -149,24 +69,6 @@ public class BufferSearchTest extends BufferTestSupport {
             assertThat(buf.bytesBefore(needle))
                     .as("bytesBefore(%X) should be 0", needle)
                     .isEqualTo(1);
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
-    public void firstOffsetOfMustFindNeedleCloseToEndOffset(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(128)) {
-            fillBuffer(buf);
-            byte needle = (byte) 0xA5;
-            int offset = buf.capacity() - 2;
-            buf.setByte(offset, needle);
-            while (buf.readableBytes() > 1) {
-                assertThat(buf.firstOffsetOf(buf.readerOffset(), buf.readableBytes(), needle))
-                        .as("firstOffsetOf(%s, %s, %X)", buf.readerOffset(), buf.readableBytes(), needle)
-                        .isEqualTo(offset);
-                buf.skipReadable(1);
-            }
         }
     }
 
@@ -184,27 +86,6 @@ public class BufferSearchTest extends BufferTestSupport {
                         .as("bytesBefore(%X)", needle)
                         .isEqualTo(offset);
                 offset--;
-                buf.skipReadable(1);
-            }
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
-    public void firstOffsetOfMustFindNeedlePriorToEndOffset(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(128)) {
-            fillBuffer(buf);
-            byte needle = (byte) 0xA5;
-            int offset = buf.capacity() - 1;
-            buf.setByte(offset, needle);
-            while (buf.readableBytes() > 0) {
-                int fromOffsetInclusive = buf.readerOffset();
-                int length = buf.readableBytes();
-                int actual = buf.firstOffsetOf(fromOffsetInclusive, length, needle);
-                assertThat(actual)
-                        .as("firstOffsetOf(%s, %s, %X)", fromOffsetInclusive, length, needle)
-                        .isEqualTo(offset);
                 buf.skipReadable(1);
             }
         }
@@ -231,24 +112,6 @@ public class BufferSearchTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void firstOffsetOfMustNotFindNeedleAtEndOffset(Fixture fixture) {
-        try (BufferAllocator allocator = fixture.createAllocator();
-             Buffer buf = allocator.allocate(128)) {
-            fillBuffer(buf);
-            byte needle = (byte) 0xA5;
-            int offset = buf.capacity() - 1;
-            buf.setByte(offset, needle);
-            while (buf.readableBytes() - 1 > 0) {
-                assertThat(buf.firstOffsetOf(buf.readerOffset(), buf.readableBytes() - 1, needle))
-                        .as("firstOffsetOf(%s, %s, %X)", buf.readerOffset(), buf.readableBytes() - 1, needle)
-                        .isEqualTo(-1);
-                buf.skipReadable(1);
-            }
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("allocators")
     public void bytesBeforeMustNotFindNeedleOutsideReadableRange(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(128)) {
@@ -265,6 +128,7 @@ public class BufferSearchTest extends BufferTestSupport {
             }
         }
     }
+    // todo bytes before on zero sized buffer
 
     private static void fillBuffer(Buffer buf) {
         ThreadLocalRandom rng = ThreadLocalRandom.current();

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferSearchTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferSearchTest.java
@@ -128,7 +128,15 @@ public class BufferSearchTest extends BufferTestSupport {
             }
         }
     }
-    // todo bytes before on zero sized buffer
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void bytesBeforeOnEmptyBufferMustNotFindAnything(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(0)) {
+            assertThat(buf.bytesBefore((byte) 0)).isEqualTo(-1);
+        }
+    }
 
     private static void fillBuffer(Buffer buf) {
         ThreadLocalRandom rng = ThreadLocalRandom.current();

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferSearchTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferSearchTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.tests;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BufferSearchTest extends BufferTestSupport {
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void fromOffsetCannotBeLessThanZero(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            assertThrows(IndexOutOfBoundsException.class, () -> buf.firstOffsetOf(-1, 1, (byte) 0));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void lengthCannotBeLessThanZero(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            assertThrows(IllegalArgumentException.class, () -> buf.firstOffsetOf(1, -1, (byte) 0));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void firstOffsetOfMustThrowOnInaccessibleBuffer(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator()) {
+            Buffer buffer = allocator.allocate(8);
+            buffer.writeLong(0x0102030405060708L);
+            assertThat(buffer.firstOffsetOf(0, 8, (byte) 0x03)).isEqualTo(2);
+            var send = buffer.send();
+            assertThrows(IllegalStateException.class, () -> buffer.firstOffsetOf(0, 1, (byte) 0));
+            Buffer received = send.receive();
+            assertThat(received.firstOffsetOf(0, 8, (byte) 0x03)).isEqualTo(2);
+            received.close();
+            assertThrows(IllegalStateException.class, () -> received.firstOffsetOf(0, 1, (byte) 0));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void firstOffsetOfMustThrowWhenRangeIsOutOfBounds(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(8)) {
+            buffer.writeLong(0x0102030405060708L);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.firstOffsetOf(1, 8, (byte) 9));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void firstOffsetOfMustFindNeedleAtStartOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(128)) {
+            fillBuffer(buf);
+            byte needle = (byte) 0xA5;
+            buf.setByte(3, needle);
+            int maxLen = buf.readableBytes() - 3;
+            for (int len = 1; len < maxLen; len++) {
+                assertThat(buf.firstOffsetOf(3, len, needle))
+                        .as("firstOffsetOf(3, %s, %X) should be 3", len, needle)
+                        .isEqualTo(3);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void firstOffsetOfMustFindNeedleAfterStartOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(128)) {
+            fillBuffer(buf);
+            byte needle = (byte) 0xA5;
+            buf.setByte(3, needle);
+            int maxLen = buf.readableBytes() - 3;
+            for (int len = 4; len < maxLen; len++) {
+                assertThat(buf.firstOffsetOf(2, len, needle))
+                        .as("firstOffsetOf(2, %s, %X) should be 3", len, needle)
+                        .isEqualTo(3);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void firstOffsetOfMustFindNeedleCloseToEndOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(128)) {
+            fillBuffer(buf);
+            byte needle = (byte) 0xA5;
+            int offset = buf.capacity() - 2;
+            buf.setByte(offset, needle);
+            while (buf.readableBytes() > 1) {
+                assertThat(buf.firstOffsetOf(buf.readerOffset(), buf.readableBytes(), needle))
+                        .as("firstOffsetOf(%s, %s, %X)", buf.readerOffset(), buf.readableBytes(), needle)
+                        .isEqualTo(offset);
+                buf.skipReadable(1);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void firstOffsetOfMustFindNeedlePriorToEndOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(128)) {
+            fillBuffer(buf);
+            byte needle = (byte) 0xA5;
+            int offset = buf.capacity() - 1;
+            buf.setByte(offset, needle);
+            while (buf.readableBytes() > 0) {
+                int fromOffsetInclusive = buf.readerOffset();
+                int length = buf.readableBytes();
+                int actual = buf.firstOffsetOf(fromOffsetInclusive, length, needle);
+                assertThat(actual)
+                        .as("firstOffsetOf(%s, %s, %X)", fromOffsetInclusive, length, needle)
+                        .isEqualTo(offset);
+                buf.skipReadable(1);
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void firstOffsetOfMustNotFindNeedleAtEndOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(128)) {
+            fillBuffer(buf);
+            byte needle = (byte) 0xA5;
+            int offset = buf.capacity() - 1;
+            buf.setByte(offset, needle);
+            while (buf.readableBytes() - 1 > 0) {
+                assertThat(buf.firstOffsetOf(buf.readerOffset(), buf.readableBytes() - 1, needle))
+                        .as("firstOffsetOf(%s, %s, %X)", buf.readerOffset(), buf.readableBytes() - 1, needle)
+                        .isEqualTo(-1);
+                buf.skipReadable(1);
+            }
+        }
+    }
+
+    private static void fillBuffer(Buffer buf) {
+        ThreadLocalRandom rng = ThreadLocalRandom.current();
+        int len = buf.capacity() / Long.BYTES;
+        for (int i = 0; i < len; i++) {
+            // Random bytes, but lower nibble is zeroed to avoid accidentally matching our needle.
+            buf.writeLong(rng.nextLong() & 0xF0F0F0F0_F0F0F0F0L);
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/handler/codec/http/DecodeHexBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/DecodeHexBenchmark.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
-import org.jctools.util.Pow2;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.CompilerControl.Mode;
@@ -59,7 +58,7 @@ public class DecodeHexBenchmark extends AbstractMicrobenchmark {
     public void init() {
         final char[] hexCh = hex.toCharArray();
         next = 0;
-        inputs = Pow2.roundToPowerOfTwo(inputs);
+        inputs = PlatformDependent.roundToPowerOfTwo(inputs);
         hexDigits = new char[inputs][];
         hexDigits[0] = hexCh;
         if (inputs > 1) {

--- a/microbench/src/main/java/io/netty/microbench/buffer/BufferBytesBeforeBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/BufferBytesBeforeBenchmark.java
@@ -54,20 +54,20 @@ public class BufferBytesBeforeBenchmark extends AbstractMicrobenchmark {
             "23",
             "32",
     })
-    int size;
+    private int size;
 
     @Param({
             "4",
             "11",
     })
-    int logPermutations;
+    private int logPermutations;
 
     @Param({ "1" })
-    int seed;
+    private int seed;
 
-    int permutations;
+    private int permutations;
 
-    Buffer[] data;
+    private Buffer[] data;
     private int i;
 
     @Param({ "0" })
@@ -102,6 +102,7 @@ public class BufferBytesBeforeBenchmark extends AbstractMicrobenchmark {
                 pooled? BufferAllocator.onHeapPooled() : BufferAllocator.onHeapUnpooled());
         for (int i = 0; i < permutations; ++i) {
             data[i] = allocator.allocate(size);
+            data[i].skipWritable(size);
             for (int j = 0; j < size; j++) {
                 int value = random.nextInt(Byte.MIN_VALUE, Byte.MAX_VALUE + 1);
                 // turn any found value into something different

--- a/microbench/src/main/java/io/netty/microbench/buffer/BufferBytesBeforeBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/BufferBytesBeforeBenchmark.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
         "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 8, time = 1)
-public class BufferOffsetOfBenchmark extends AbstractMicrobenchmark {
+public class BufferBytesBeforeBenchmark extends AbstractMicrobenchmark {
 
     @Param({
             "7",
@@ -126,7 +126,7 @@ public class BufferOffsetOfBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public int indexOf() {
-        return getData().firstOffsetOf(0, size, needleByte);
+        return getData().bytesBefore(needleByte);
     }
 
     @TearDown

--- a/microbench/src/main/java/io/netty/microbench/buffer/BufferOffsetOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/BufferOffsetOfBenchmark.java
@@ -42,15 +42,25 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 2, jvmArgsAppend = {
         "-Dio.netty.tryReflectionSetAccessible=true",
         "--add-opens", "java.base/java.nio=ALL-UNNAMED",
-        "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED" })
+        "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED",
+        "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 8, time = 1)
 public class BufferOffsetOfBenchmark extends AbstractMicrobenchmark {
 
-    @Param({ /*"7", "16", "23",*/ "32", "500" })
+    @Param({
+            "7",
+            "16",
+            "23",
+            "32" ,
+//            "500",
+    })
     int size;
 
-    @Param({ "4", "11" })
+    @Param({
+            "4",
+            "11",
+    })
     int logPermutations;
 
     @Param({ "1" })
@@ -64,12 +74,21 @@ public class BufferOffsetOfBenchmark extends AbstractMicrobenchmark {
     @Param({ "0" })
     private byte needleByte;
 
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean direct;
-    @Param({ "false", "true" })
+    @Param({
+            "false",
+            "true",
+    })
     private boolean noUnsafe;
 
-    @Param({ "false", "true" })
+    @Param({
+            "false",
+            "true",
+    })
     private boolean pooled;
 
     @Setup(Level.Trial)

--- a/microbench/src/main/java/io/netty/microbench/buffer/BufferOffsetOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/BufferOffsetOfBenchmark.java
@@ -52,8 +52,7 @@ public class BufferOffsetOfBenchmark extends AbstractMicrobenchmark {
             "7",
             "16",
             "23",
-            "32" ,
-//            "500",
+            "32",
     })
     int size;
 

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufIndexOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufIndexOfBenchmark.java
@@ -51,20 +51,20 @@ public class ByteBufIndexOfBenchmark extends AbstractMicrobenchmark {
             "23",
             "32",
     })
-    int size;
+    private int size;
 
     @Param({
             "4",
             "11",
     })
-    int logPermutations;
+    private int logPermutations;
 
     @Param({ "1" })
-    int seed;
+    private int seed;
 
-    int permutations;
+    private int permutations;
 
-    ByteBuf[] data;
+    private ByteBuf[] data;
     private int i;
 
     @Param({ "0" })

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufIndexOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufIndexOfBenchmark.java
@@ -38,15 +38,26 @@ import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(2)
+@Fork(value = 2, jvmArgsAppend = {
+        "-Dio.netty.tryReflectionSetAccessible=true",
+        "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 8, time = 1)
 public class ByteBufIndexOfBenchmark extends AbstractMicrobenchmark {
 
-    @Param({ /*"7", "16", "23",*/ "32", "500" })
+    @Param({
+            "7",
+            "16",
+            "23",
+            "32",
+//            "500",
+    })
     int size;
 
-    @Param({ "4", "11" })
+    @Param({
+            "4",
+            "11",
+    })
     int logPermutations;
 
     @Param({ "1" })
@@ -60,12 +71,21 @@ public class ByteBufIndexOfBenchmark extends AbstractMicrobenchmark {
     @Param({ "0" })
     private byte needleByte;
 
-    @Param({ "true", "false" })
+    @Param({
+            "true",
+            "false",
+    })
     private boolean direct;
-    @Param({ "false", "true" })
+    @Param({
+            "false",
+            "true",
+    })
     private boolean noUnsafe;
 
-    @Param({ "false", "true" })
+    @Param({
+            "false",
+            "true",
+    })
     private boolean pooled;
 
     @Setup(Level.Trial)

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufIndexOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufIndexOfBenchmark.java
@@ -50,7 +50,6 @@ public class ByteBufIndexOfBenchmark extends AbstractMicrobenchmark {
             "16",
             "23",
             "32",
-//            "500",
     })
     int size;
 


### PR DESCRIPTION
Motivation:
Being able to find a particular byte within a buffer is important and performance critical in a number of use cases.

Modification:
Add a Buffer.bytesBefore method to Buffer, which quickly finds the offset of a byte into the readable area of a buffer.
The implementation is based on the existing ByteBufUtil.firstIndexOf.
Tests and benchmarks are also added

Result:
We now have a fast way to find the first occurrence of a particular byte in the readable area of a buffer.
The performance of this method is in the ballpark of the existing ByteBufUtil.firstIndexOf; some cases are better, others are worse.