### PR TITLE
Remove const-tracking fields from buffers

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -49,7 +49,6 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
 
     private int roff;
     private int woff;
-    private boolean constBuffer;
 
     NioBuffer(ByteBuffer base, ByteBuffer memory, AllocatorControl control, Drop<NioBuffer> drop) {
         super(drop, control);
@@ -68,7 +67,6 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
         wmem = CLOSED_BUFFER;
         roff = parent.roff;
         woff = parent.woff;
-        constBuffer = true;
     }
 
     @Override
@@ -294,7 +292,6 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
         base = buffer;
         rmem = buffer;
         wmem = buffer;
-        constBuffer = false;
         drop.attach(this);
     }
 
@@ -324,7 +321,6 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
             splitBuffer.makeReadOnly();
         }
         // Split preserves const-state.
-        splitBuffer.constBuffer = constBuffer;
         rmem = bbslice(rmem, splitOffset, rmem.capacity() - splitOffset);
         if (!readOnly) {
             wmem = rmem;
@@ -901,7 +897,6 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
         var roff = this.roff;
         var woff = this.woff;
         var readOnly = readOnly();
-        var isConst = constBuffer;
         ByteBuffer base = this.base;
         ByteBuffer rmem = this.rmem;
         return new Owned<NioBuffer>() {
@@ -913,7 +908,6 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
                 if (readOnly) {
                     copy.makeReadOnly();
                 }
-                copy.constBuffer = isConst;
                 return copy;
             }
         };

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -53,7 +53,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     private boolean readOnly;
     private int roff;
     private int woff;
-    private boolean constBuffer;
 
     UnsafeBuffer(UnsafeMemory memory, long offset, int size, AllocatorControl control,
                         Drop<UnsafeBuffer> drop) {
@@ -80,7 +79,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         readOnly = parent.readOnly;
         roff = parent.roff;
         woff = parent.woff;
-        constBuffer = true;
     }
 
     @Override
@@ -364,7 +362,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         address = memory.address;
         rsize = memory.size;
         wsize = memory.size;
-        constBuffer = false;
         drop.attach(this);
     }
 
@@ -393,7 +390,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
             splitBuffer.makeReadOnly();
         }
         // Split preserves const-state.
-        splitBuffer.constBuffer = constBuffer;
         rsize -= splitOffset;
         baseOffset += splitOffset;
         address += splitOffset;
@@ -1067,7 +1063,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         var roff = this.roff;
         var woff = this.woff;
         var readOnly = readOnly();
-        var isConst = constBuffer;
         UnsafeMemory memory = this.memory;
         AllocatorControl control = this.control;
         long baseOffset = this.baseOffset;
@@ -1081,7 +1076,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
                 if (readOnly) {
                     copy.makeReadOnly();
                 }
-                copy.constBuffer = isConst;
                 return copy;
             }
         };


### PR DESCRIPTION
Motivation:
These are no longer necessary, since the read-only state is now irreversible.
The const-ness of a buffer was only used to moderate what happened when a const-buffer was made writeable.

Modification:
Remove the unused fields from NioBuffer and UnsafeBuffer.

Result:
Cleaner code.
