### PR TITLE
Generate xref for examples as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,6 @@
               <windowTitle>Netty Source Xref (${project.version})</windowTitle>
               <excludes>
                 <exclude>**/com/sun/**/*.java</exclude>
-                <exclude>**/example/**/*.java</exclude>
                 <exclude>**/microbench/**/*.java</exclude>
                 <exclude>**/microbenchmark/**/*.java</exclude>
               </excludes>


### PR DESCRIPTION
Motivation:

We should generate the xref files for examples as well as we link to these on our website

Modifications:

Remove exclude

Result:

Correctly generate xref for examples