### PR TITLE
Update JMH version

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <!-- Skip tests by default; run only if -DskipTests=false is specified -->
     <skipTests>true</skipTests>
-    <jmh.version>1.22</jmh.version>
+    <jmh.version>1.33</jmh.version>
     <!-- This only be set when run on linux as on other platforms we just want to include the jar without native
          code -->
     <epoll.classifier />


### PR DESCRIPTION
Motivation:
There has been a number of fixes to JMH regarding running and profiling on macOS.
Also, it's good to stay up to date regardless.

Modification:
Update the JMH version from 1.22 to 1.33.

Result:
Our JMH version is up to date.
