### PR TITLE
Make use of Character.BYTES instead of integer literals

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -873,23 +873,23 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
 
     @Override
     public char readChar() {
-        return prepRead(2).readChar();
+        return prepRead(Character.BYTES).readChar();
     }
 
     @Override
     public char getChar(int roff) {
-        return prepGet(roff, 2).getChar(subOffset);
+        return prepGet(roff, Character.BYTES).getChar(subOffset);
     }
 
     @Override
     public CompositeBuffer writeChar(char value) {
-        prepWrite(2).writeChar(value);
+        prepWrite(Character.BYTES).writeChar(value);
         return this;
     }
 
     @Override
     public CompositeBuffer setChar(int woff, char value) {
-        prepWrite(woff, 2).setChar(subOffset, value);
+        prepWrite(woff, Character.BYTES).setChar(subOffset, value);
         return this;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -547,15 +547,15 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
 
     @Override
     public char readChar() {
-        checkRead(roff, 2);
+        checkRead(roff, Character.BYTES);
         var value = rmem.getChar(roff);
-        roff += 2;
+        roff += Character.BYTES;
         return value;
     }
 
     @Override
     public char getChar(int roff) {
-        checkGet(roff, 2);
+        checkGet(roff, Character.BYTES);
         return rmem.getChar(roff);
     }
 
@@ -563,10 +563,10 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     public Buffer writeChar(char value) {
         try {
             wmem.putChar(woff, value);
-            woff += 2;
+            woff += Character.BYTES;
             return this;
         } catch (IndexOutOfBoundsException e) {
-            throw checkWriteState(e, woff, 2);
+            throw checkWriteState(e, woff, Character.BYTES);
         } catch (ReadOnlyBufferException e) {
             throw bufferIsReadOnly(this);
         }
@@ -578,7 +578,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
             wmem.putChar(woff, value);
             return this;
         } catch (IndexOutOfBoundsException e) {
-            throw checkWriteState(e, woff, 2);
+            throw checkWriteState(e, woff, Character.BYTES);
         } catch (ReadOnlyBufferException e) {
             throw bufferIsReadOnly(this);
         }
@@ -588,7 +588,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     public short readShort() {
         checkRead(roff, Short.BYTES);
         var value = rmem.getShort(roff);
-        roff += 2;
+        roff += Short.BYTES;
         return value;
     }
 
@@ -602,7 +602,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     public int readUnsignedShort() {
         checkRead(roff, Short.BYTES);
         var value = rmem.getShort(roff) & 0xFFFF;
-        roff += 2;
+        roff += Short.BYTES;
         return value;
     }
 


### PR DESCRIPTION
Motivation:
We should use constants instead of integer literals where possible, when these explain the code better.

Modification:
We had a number of places where we used the integer literal `2` instead of `Character.BYTES` or `Short.BYTES`.
These have been changed to reference their relevant constants.

Result:
Cleaner code.

This PR is currently based upon #11751 to avoid merge conflicts.