### PR TITLE
Exclude transitive dependencies of rarely used modules from netty-all

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -250,6 +250,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-xml</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml</groupId>
+          <artifactId>aalto-xml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -285,6 +291,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-rxtx</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.rxtx</groupId>
+          <artifactId>rxtx</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -295,6 +307,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-udt</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.barchart.udt</groupId>
+          <artifactId>barchart-udt-bundle</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!--
       Use no classifier for the native dependencies. The dependencies with the classifier are added by the


### PR DESCRIPTION
Motivation:
Netty-all is used to unconditionally pull in all netty modules with the same version.
Some of these modules have dependencies themselves that are pulled in transitively, yet they are rarely used.

Modification:
Exclude the transitive dependencies of netty-codec-xml, netty-transport-rxtx, and netty-transport-udt.

Those who wish to restore these modules to working order can additionally depend on org.fasterxml:aalto-xml, org.rxtx:rxtx, or com.barchart.udt:barchart-udt-bundle, respectively.

Result:
Depending on netty-all no longer transitively depends on any non-netty maven modules.
