### PR TITLE
Replace wait/notify with explicit waiters

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.LockSupport;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -44,6 +45,24 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     private static final StackTraceElement[] CANCELLATION_STACK = CANCELLATION_CAUSE_HOLDER.cause.getStackTrace();
     static final Object NULL_CONTEXT = new Object();
 
+    /**
+     * There are several possibilities for what 'result' can point to:
+     *
+     * <ul>
+     *     <li>{@code null} — no result computed, no waiters, not cancelled and not un-cancellable.</li>
+     *     <li>{@link #UNCANCELLABLE} — operation has not yet completed, but can now no longer be cancelled.</li>
+     *     <li>{@link Waiter} — operation has not completed, but threads are waiting for completion.
+     *     <ul>
+     *         <li>The {@link Waiter} nodes form a linked list of waiting threads.</li>
+     *         <li>The list is terminated by either a {@code null} reference, or {@link #UNCANCELLABLE}.</li>
+     *         <li>Each waiter node has an uncancellable field, which is true if the next node is either an
+     *         uncancellable waiter, or {@link #UNCANCELLABLE}.</li>
+     *     </ul>
+     *     </li>
+     *     <li>{@link #SUCCESS} — operation completed successfully with a {@code null} result. Terminal.</li>
+     *     <li>{@link CauseHolder} — operation has completed in either failure or from being cancelled. Terminal.</li>
+     * </ul>
+     */
     private volatile Object result;
     private final EventExecutor executor;
 
@@ -61,10 +80,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
      * Threading - synchronized(this). We must support adding listeners when there is no EventExecutor.
      */
     private Object listeners;
-    /**
-     * Threading - synchronized(this). We are required to hold the monitor to use Java's underlying wait()/notifyAll().
-     */
-    private short waiters;
 
     /**
      * Creates a new unfulfilled promise.
@@ -149,15 +164,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     }
 
     @Override
-    public boolean setUncancellable() {
-        if (RESULT_UPDATER.compareAndSet(this, null, UNCANCELLABLE)) {
-            return true;
-        }
-        Object result = this.result;
-        return !isDone0(result) || !isCancelled0(result);
-    }
-
-    @Override
     public Future<V> asFuture() {
         return this;
     }
@@ -176,22 +182,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     @Override
     public boolean isCancellable() {
         return result == null;
-    }
-
-    private static final class LeanCancellationException extends CancellationException {
-        private static final long serialVersionUID = 2794674970981187807L;
-
-        // Suppress a warning since the method doesn't need synchronization
-        @Override
-        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
-            setStackTrace(CANCELLATION_STACK);
-            return this;
-        }
-
-        @Override
-        public String toString() {
-            return CancellationException.class.getName();
-        }
     }
 
     @Override
@@ -242,73 +232,38 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
 
     @Override
     public Future<V> await() throws InterruptedException {
-        if (isDone()) {
-            return this;
-        }
-
-        if (Thread.interrupted()) {
-            throw new InterruptedException(toString());
-        }
-
-        checkDeadLock();
-
-        synchronized (this) {
-            while (!isDone()) {
-                incWaiters();
-                try {
-                    wait();
-                } finally {
-                    decWaiters();
-                }
-            }
+        try {
+            await0(true, true, 0);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
         }
         return this;
     }
 
     @Override
     public Future<V> awaitUninterruptibly() {
-        if (isDone()) {
-            return this;
-        }
-
-        checkDeadLock();
-
-        boolean interrupted = false;
-        synchronized (this) {
-            while (!isDone()) {
-                incWaiters();
-                try {
-                    wait();
-                } catch (InterruptedException e) {
-                    // Interrupted while waiting.
-                    interrupted = true;
-                } finally {
-                    decWaiters();
-                }
-            }
-        }
-
-        if (interrupted) {
+        try {
+            await0(true, false, 0);
+        } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
         }
-
         return this;
     }
 
     @Override
     public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
-        return await0(unit.toNanos(timeout), true);
+        return await0(false, true, unit.toNanos(timeout));
     }
 
     @Override
     public boolean await(long timeoutMillis) throws InterruptedException {
-        return await0(MILLISECONDS.toNanos(timeoutMillis), true);
+        return await0(false, true, MILLISECONDS.toNanos(timeoutMillis));
     }
 
     @Override
     public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
         try {
-            return await0(unit.toNanos(timeout), false);
+            return await0(false, false, unit.toNanos(timeout));
         } catch (InterruptedException e) {
             // Should not be raised at all.
             throw new InternalError();
@@ -318,7 +273,7 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     @Override
     public boolean awaitUninterruptibly(long timeoutMillis) {
         try {
-            return await0(MILLISECONDS.toNanos(timeoutMillis), false);
+            return await0(false, false, MILLISECONDS.toNanos(timeoutMillis));
         } catch (InterruptedException e) {
             // Should not be raised at all.
             throw new InternalError();
@@ -369,7 +324,7 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
             }
             result = this.result;
         }
-        if (result == SUCCESS || result == UNCANCELLABLE) {
+        if (result == SUCCESS) {
             return null;
         }
         Throwable cause = cause0(result);
@@ -380,17 +335,6 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
             throw (CancellationException) cause;
         }
         throw new ExecutionException(cause);
-    }
-
-    @Override
-    public boolean cancel() {
-        if (RESULT_UPDATER.compareAndSet(this, null, CANCELLATION_CAUSE_HOLDER)) {
-            if (checkNotifyWaiters()) {
-                notifyListeners();
-            }
-            return true;
-        }
-        return false;
     }
 
     @Override
@@ -437,7 +381,7 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
             buf.append("(failure: ")
                     .append(((CauseHolder) result).cause)
                     .append(')');
-        } else if (result != null) {
+        } else if (result != null && !Waiter.isWaiter(result)) {
             buf.append("(success: ")
                     .append(result)
                     .append(')');
@@ -539,37 +483,68 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
         return setValue0(new CauseHolder(requireNonNull(cause, "cause")));
     }
 
+    @Override
+    public boolean cancel() {
+        Object existing;
+        do {
+            existing = RESULT_UPDATER.get(this);
+            if (isDone0(existing)) {
+                return false;
+            }
+            if (existing == UNCANCELLABLE || Waiter.isWaiter(existing) && ((Waiter) existing).uncancellable) {
+                return false;
+            }
+        } while (!RESULT_UPDATER.compareAndSet(this, existing, CANCELLATION_CAUSE_HOLDER));
+        unblockWaitersAndNotifyListeners(existing);
+        return true;
+    }
+
+    @Override
+    public boolean setUncancellable() {
+        Waiter uncancellableWaiter = null;
+        Object next;
+        Object result;
+        do {
+            result = this.result;
+            if (Waiter.isWaiter(result)) {
+                if (uncancellableWaiter == null) {
+                    uncancellableWaiter = new Waiter();
+                    uncancellableWaiter.uncancellable = true;
+                }
+                uncancellableWaiter.setNext(result);
+                next = uncancellableWaiter;
+            } else {
+                next = UNCANCELLABLE;
+            }
+        } while (!isDone0(result) && !RESULT_UPDATER.compareAndSet(this, result, next));
+        result = this.result;
+        return !isDone0(result) || !isCancelled0(result);
+    }
+
     private boolean setValue0(Object objResult) {
-        if (RESULT_UPDATER.compareAndSet(this, null, objResult) ||
-            RESULT_UPDATER.compareAndSet(this, UNCANCELLABLE, objResult)) {
-            if (checkNotifyWaiters()) {
+        Object existing;
+        do {
+            existing = RESULT_UPDATER.get(this);
+            if (existing != null && existing != UNCANCELLABLE && existing.getClass() != Waiter.class) {
+                return false;
+            }
+        } while (!RESULT_UPDATER.compareAndSet(this, existing, objResult));
+        unblockWaitersAndNotifyListeners(existing);
+        return true;
+    }
+
+    private void unblockWaitersAndNotifyListeners(Object potentialWaiters) {
+        if (Waiter.isWaiter(potentialWaiters)) {
+            Waiter waiter = (Waiter) potentialWaiters;
+            do {
+                waiter = waiter.unblockAndGetNext();
+            } while (waiter != null);
+        }
+        synchronized (this) {
+            if (listeners != null) {
                 notifyListeners();
             }
-            return true;
         }
-        return false;
-    }
-
-    /**
-     * Check if there are any waiters and if so notify these.
-     * @return {@code true} if there are any listeners attached to the promise, {@code false} otherwise.
-     */
-    private synchronized boolean checkNotifyWaiters() {
-        if (waiters > 0) {
-            notifyAll();
-        }
-        return listeners != null;
-    }
-
-    private void incWaiters() {
-        if (waiters == Short.MAX_VALUE) {
-            throw new IllegalStateException("too many waiters: " + this);
-        }
-        ++waiters;
-    }
-
-    private void decWaiters() {
-        --waiters;
     }
 
     private void rethrowIfFailed() {
@@ -583,13 +558,17 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
         throw new CompletionException(cause);
     }
 
-    private boolean await0(long timeoutNanos, boolean interruptable) throws InterruptedException {
+    private boolean await0(boolean blocking, boolean interruptable, long timeoutNanos) throws InterruptedException {
         if (isDone()) {
             return true;
         }
 
         if (timeoutNanos <= 0) {
-            return isDone();
+            if (blocking) {
+                timeoutNanos = 1;
+            } else {
+                return isDone();
+            }
         }
 
         if (interruptable && Thread.interrupted()) {
@@ -600,39 +579,76 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
 
         // Start counting time from here instead of the first line of this method,
         // to avoid/postpone performance cost of System.nanoTime().
-        final long startTime = System.nanoTime();
-        synchronized (this) {
-            boolean interrupted = false;
-            try {
-                long waitTime = timeoutNanos;
-                while (!isDone() && waitTime > 0) {
-                    incWaiters();
-                    try {
-                        wait(waitTime / 1000000, (int) (waitTime % 1000000));
-                    } catch (InterruptedException e) {
-                        if (interruptable) {
-                            throw e;
-                        } else {
-                            interrupted = true;
-                        }
-                    } finally {
-                        decWaiters();
-                    }
-                    // Check isDone() in advance, try to avoid calculating the elapsed time later.
-                    if (isDone()) {
-                        return true;
-                    }
+        final long startTime = blocking? 0 : System.nanoTime();
+        boolean interrupted = false;
+        try {
+            long waitTime = timeoutNanos;
+            Waiter waiter = getOrInstallWaiter();
+            Object result = this.result;
+            while (!isDone0(result) && waitTime > 0) {
+                assert waiter != null;
+                if (blocking) {
+                    waiter.await(this);
+                } else {
+                    waiter.awaitNanos(this, waitTime);
+                }
+                interrupted |= Thread.interrupted();
+                if (interrupted && interruptable) {
+                    waiter.abandon();
+                    throw new InterruptedException();
+                }
+                // Check isDone() in advance, try to avoid calculating the elapsed time later.
+                result = this.result;
+                if (isDone0(result)) {
+                    return true;
+                }
+                if (!blocking) {
                     // Calculate the elapsed time here instead of in the while condition,
                     // try to avoid performance cost of System.nanoTime() in the first loop of while.
                     waitTime = timeoutNanos - (System.nanoTime() - startTime);
                 }
-                return isDone();
-            } finally {
-                if (interrupted) {
-                    Thread.currentThread().interrupt();
-                }
+            }
+
+            boolean done = isDone0(result);
+            if (!done && waiter != null) {
+                waiter.abandon();
+            }
+            return done;
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
             }
         }
+    }
+
+    private Waiter getOrInstallWaiter() {
+        Object currentResult = result;
+        Thread currentThread = Thread.currentThread();
+        Waiter waiter = null;
+        boolean currentIsWaiter = Waiter.isWaiter(currentResult);
+        if (currentIsWaiter) {
+            // Try to find an abandoned waiter to claim.
+            waiter = (Waiter) currentResult;
+            do {
+                if (waiter.tryClaim(currentThread)) {
+                    return waiter;
+                }
+                waiter = waiter.getNext();
+            } while (waiter != null);
+        }
+        if (currentResult == null || currentResult == UNCANCELLABLE || currentIsWaiter) {
+            // Found no abandoned waiter to claim. Install a new one.
+            waiter = new Waiter();
+            waiter.setOwner(currentThread);
+            do {
+                waiter.setNext(currentResult);
+                if (RESULT_UPDATER.compareAndSet(this, currentResult, waiter)) {
+                    break;
+                }
+                currentResult = result;
+            } while (currentResult == null || currentResult == UNCANCELLABLE || Waiter.isWaiter(currentResult));
+        }
+        return waiter;
     }
 
     private static boolean isCancelled0(Object result) {
@@ -640,14 +656,7 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     }
 
     private static boolean isDone0(Object result) {
-        return result != null && result != UNCANCELLABLE;
-    }
-
-    private static final class CauseHolder {
-        final Throwable cause;
-        CauseHolder(Throwable cause) {
-            this.cause = cause;
-        }
+        return result != null && result != UNCANCELLABLE && result.getClass() != Waiter.class;
     }
 
     static void safeExecute(EventExecutor executor, Runnable task) {
@@ -676,6 +685,29 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
         return stageAdapter;
     }
 
+    private static final class CauseHolder {
+        final Throwable cause;
+        CauseHolder(Throwable cause) {
+            this.cause = cause;
+        }
+    }
+
+    private static final class LeanCancellationException extends CancellationException {
+        private static final long serialVersionUID = 2794674970981187807L;
+
+        // Suppress a warning since the method doesn't need synchronization
+        @Override
+        public Throwable fillInStackTrace() {   // lgtm[java/non-sync-override]
+            setStackTrace(CANCELLATION_STACK);
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return CancellationException.class.getName();
+        }
+    }
+
     private static final class StacklessCancellationException extends CancellationException {
 
         private static final long serialVersionUID = -2974906711413716191L;
@@ -689,6 +721,67 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
 
         static StacklessCancellationException newInstance(Class<?> clazz, String method) {
             return ThrowableUtil.unknownStackTrace(new StacklessCancellationException(), clazz, method);
+        }
+    }
+
+    private static final class Waiter {
+        private static final AtomicReferenceFieldUpdater<Waiter, Thread> OWNER =
+                AtomicReferenceFieldUpdater.newUpdater(Waiter.class, Thread.class, "owner");
+        private volatile Thread owner;
+        private Object next;
+        private boolean uncancellable;
+
+        void setOwner(Thread thread) {
+            owner = thread;
+        }
+
+        boolean tryClaim(Thread candicate) {
+            if (owner == null) {
+                return OWNER.compareAndSet(this, null, candicate);
+            }
+            return false;
+        }
+
+        void abandon() {
+            owner = null;
+        }
+
+        void setNext(Object nextObj) {
+            uncancellable = nextObj == UNCANCELLABLE || isWaiter(nextObj) && ((Waiter) nextObj).uncancellable;
+            next = nextObj;
+        }
+
+        Waiter unblockAndGetNext() {
+            Thread th = owner;
+            if (th != null) {
+                LockSupport.unpark(th);
+            }
+            Object n = next;
+            next = null; // Help GC by limiting old-gen nepotism.
+            if (isWaiter(n)) {
+                return (Waiter) n;
+            }
+            return null;
+        }
+
+        Waiter getNext() {
+            Object n = next;
+            if (isWaiter(n)) {
+                return (Waiter) n;
+            }
+            return null;
+        }
+
+        void await(Object blocker) {
+            LockSupport.park(blocker);
+        }
+
+        void awaitNanos(Object blocker, long timeoutNanoes) {
+            LockSupport.parkNanos(blocker, timeoutNanoes);
+        }
+
+        static boolean isWaiter(Object obj) {
+            return obj != null && obj.getClass() == Waiter.class;
         }
     }
 }


### PR DESCRIPTION
Motivation:
Using monitor locks costs many locks/unlocks in the wait/notify protocol, which limits scalability in high contention scenarios.

Modification:
An explicit wait-set linked list of Waiter objects is used instead.
This avoids the wait/notify lock contention and replaces it with CAS loops on the 'result' field.
This scales better because the locking mechanics of monitor enter/exit do the same thing, but around every wait and notify call.

Result:
Slightly lighter weight locking when making threads wait for a future to produce a result.
