### PR TITLE
Update Groovy versions

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -162,12 +162,12 @@
       <plugin>
         <groupId>org.codehaus.gmaven</groupId>
         <artifactId>groovy-maven-plugin</artifactId>
-        <version>2.0</version>
+        <version>2.1.1</version>
         <dependencies>
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.8</version>
+            <artifactId>groovy</artifactId>
+            <version>3.0.9</version>
           </dependency>
           <dependency>
             <groupId>ant</groupId>


### PR DESCRIPTION
Motivation:
The old Groovy versions are running into compatibility issues with the latest JDK snapshots.

Modification:
Update the groovy maven plugin and its groovy dependency to the latest versions.
It looks like groovy-all is now a pom-dependency, so we switch to just groovy since we don't need what's in -all beyond that.

Result:
We now build on the latest JDK snapshots.
