### PR TITLE
Fail build if netty-all pulls in duplicated classes

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -195,7 +195,6 @@
           </execution>
         </executions>
         <configuration>
-          <printEqualFiles>false</printEqualFiles>
           <failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
           <failBuildInCaseOfEqualContentConflict>true</failBuildInCaseOfEqualContentConflict>
           <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>


### PR DESCRIPTION
Motivation:

We should fail the build if netty-all pulls in dependencies that produce duplicated classes on the classpath

Modifications:

Add maven plugin to verify we not have duplicated classes on the classpath / dependencies

Result:

Related to https://github.com/netty/netty/issues/11791
