### PR TITLE
Clarify exception message for SearchDomainUnknownHostException

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -262,7 +262,8 @@ abstract class DnsResolveContext<T> {
         private static final long serialVersionUID = -8573510133644997085L;
 
         SearchDomainUnknownHostException(Throwable cause, String originalHostname) {
-            super("Search domain query failed. Original hostname: '" + originalHostname + "' " + cause.getMessage());
+            super("Failed to resolve '" + originalHostname + "' and search domain query for configured domain" +
+                    " failed as well. " + cause.getMessage());
             setStackTrace(cause.getStackTrace());
 
             // Preserve the cause
@@ -1031,7 +1032,7 @@ abstract class DnsResolveContext<T> {
         final int tries = maxAllowedQueries - allowedQueries;
         final StringBuilder buf = new StringBuilder(64);
 
-        buf.append("failed to resolve '").append(hostname).append('\'');
+        buf.append("Failed to resolve '").append(hostname).append('\'');
         if (tries > 1) {
             if (tries < maxAllowedQueries) {
                 buf.append(" after ")

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -265,8 +265,9 @@ abstract class DnsResolveContext<T> {
         SearchDomainUnknownHostException(Throwable cause, String originalHostname, String[] searchDomains) {
             super("Failed to resolve '" + originalHostname + "' and search domain query for configured domains" +
                     " failed as well: " + Arrays.toString(searchDomains));
+            setStackTrace(cause.getStackTrace());
             // Preserve the cause
-            initCause(cause);
+            initCause(cause.getCause());
         }
 
         // Suppress a warning since this method doesn't need synchronization

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2324,8 +2324,9 @@ public class DnsNameResolverTest {
         DnsNameResolver resolver = builder.build();
         Future<InetAddress> result = resolver.resolve("doesnotexist.netty.io").awaitUninterruptibly();
         Throwable cause = result.cause();
-        assertTrue(cause instanceof UnknownHostException);
-        assertTrue(cause.getCause() instanceof DnsNameResolverTimeoutException);
+        assertThat(cause, Matchers.instanceOf(UnknownHostException.class));
+        cause.getCause().printStackTrace();
+        assertThat(cause.getCause(), Matchers.instanceOf(DnsNameResolverTimeoutException.class));
         assertTrue(DnsNameResolver.isTimeoutError(cause));
         assertTrue(DnsNameResolver.isTransportOrTimeoutError(cause));
         resolver.close();


### PR DESCRIPTION
Motivation:

Often users are not aware of the fact that search domains will be tried as well. The existing exception message was often kind of confusing

Modifications:

Change exception message to be more clear

Result:

Less confused users
