### PR TITLE
Correctly include fedora in netty-tcnative classifiers

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -307,7 +307,13 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
         <version>${tcnative.version}</version>
-        <classifier>linux-aarch_64</classifier>
+        <classifier>linux-x86_64-fedora</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative</artifactId>
+        <version>${tcnative.version}</version>
+        <classifier>linux-aarch_64-fedora</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
Motivation:

We did not include -fedora in the linux-aarch_64 classifier of netty-tcnative and also didnt list linux_x86_64-fedora at all.

Modifications:

- Fix one classifier and add the missing one

Result:

Fixes https://github.com/netty/netty/issues/11834
