### PR TITLE
Clarify javadocs of ByteBuf methods that take InputStream / FileChannel / Scatterin…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -1313,7 +1313,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @param length the maximum number of bytes to transfer
      *
      * @return the actual number of bytes read in from the specified channel.
-     *         {@code -1} if the specified channel is closed.
+     *         {@code -1} if the specified channel is closed or it reached EOF.
      *
      * @throws IndexOutOfBoundsException
      *         if the specified {@code index} is less than {@code 0} or
@@ -2029,7 +2029,8 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @param position the file position at which the transfer is to begin
      * @param length the maximum number of bytes to transfer
      *
-     * @return the actual number of bytes read in from the specified channel
+     * @return the actual number of bytes read in from the specified channel.
+     *         {@code -1} if the specified channel is closed or it reached EOF.
      *
      * @throws IOException
      *         if the specified channel threw an exception during I/O

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -1274,7 +1274,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @param length the number of bytes to transfer
      *
      * @return the actual number of bytes read in from the specified channel.
-     *         {@code -1} if the specified channel is closed.
+     *         {@code -1} if the specified {@link InputStream} reached EOF.
      *
      * @throws IndexOutOfBoundsException
      *         if the specified {@code index} is less than {@code 0} or
@@ -1293,7 +1293,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @param length the maximum number of bytes to transfer
      *
      * @return the actual number of bytes read in from the specified channel.
-     *         {@code -1} if the specified channel is closed.
+     *         {@code -1} if the specified channel is closed or it reached EOF.
      *
      * @throws IndexOutOfBoundsException
      *         if the specified {@code index} is less than {@code 0} or
@@ -1994,7 +1994,8 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *
      * @param length the number of bytes to transfer
      *
-     * @return the actual number of bytes read in from the specified stream
+     * @return the actual number of bytes read in from the specified channel.
+     *         {@code -1} if the specified {@link InputStream} reached EOF.
      *
      * @throws IOException if the specified stream threw an exception during I/O
      */
@@ -2009,7 +2010,8 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *
      * @param length the maximum number of bytes to transfer
      *
-     * @return the actual number of bytes read in from the specified channel
+     * @return the actual number of bytes read in from the specified channel.
+     *         {@code -1} if the specified channel is closed or it reached EOF.
      *
      * @throws IOException
      *         if the specified channel threw an exception during I/O


### PR DESCRIPTION
…gByteChannel

Motivation:

We should clarify in which scenarias the methods return -1.

Modifications:

Clarify the javadocs to reflect current behaviour

Result:

Javadocs are correct
