### PR TITLE
Bump Brotli4j to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,7 +526,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.5.0</brotli4j.version>
+    <brotli4j.version>1.6.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:
Brotli4j 1.6.0 was released a few months back and it's the latest version of Brotli4j. However, Netty is still using 1.5.0. So it's time to upgrade.

Modification:
Upgraded Brotli4j from 1.5.0 to 1.6.0

Result:
Up-to-date version of Brotli4j
