### PR TITLE
Migrate websocket codec to use `Buffer`

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/BufferHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferHolder.java
@@ -153,4 +153,31 @@ public abstract class BufferHolder<T extends BufferHolder<T>> implements Resourc
         buf.touch(hint);
         return (T) this;
     }
+
+    /**
+     * This implementation of the {@code equals} operation is restricted to work only with instances of the same class.
+     * The reason for that is that Netty library already has a number of classes that extend {@link BufferHolder} and
+     * override {@code equals} method with an additional comparison logic, and we need the symmetric property of the
+     * {@code equals} operation to be preserved.
+     *
+     * @param other The reference object with which to compare.
+     * @return {@code true} if this object is the same as the obj argument; {@code false} otherwise.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other != null && getClass() == other.getClass()) {
+            return buf.equals(((BufferHolder<?>) other).buf);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getClass().hashCode();
+        result *= 31 + buf.hashCode();
+        return result;
+    }
 }

--- a/buffer/src/test/java/io/netty/buffer/api/BufferHolderTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/BufferHolderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api;
+
+import org.junit.jupiter.api.Test;
+
+import static io.netty.buffer.api.BufferAllocator.offHeapUnpooled;
+import static io.netty.buffer.api.BufferAllocator.onHeapUnpooled;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class BufferHolderTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        byte[] bytes = "data".getBytes(UTF_8);
+        try (BufferRef first = new BufferRef(onHeapUnpooled().copyOf(bytes).send());
+             BufferRef secnd = new BufferRef(offHeapUnpooled().copyOf(bytes).send())) {
+            assertEquals(first, secnd);
+            assertEquals(first.hashCode(), secnd.hashCode());
+        }
+    }
+
+    @SuppressWarnings({ "SimplifiableJUnitAssertion", "rawtypes", "EqualsBetweenInconvertibleTypes" })
+    @Test
+    public void testDifferentClassesAreNotEqual() {
+        // all objects here have EMPTY_BUFFER data but are instances of different classes
+        // so we want to check that none of them are equal to another.
+        BufferRef dflt = new BufferRef(onHeapUnpooled().allocate(0).send());
+        BufferRef2 other = new BufferRef2(onHeapUnpooled().allocate(0));
+        BufferHolder<?> constant1 = new BufferHolder(onHeapUnpooled().allocate(0)) {
+            @Override
+            protected BufferHolder receive(Buffer buf) {
+                return null;
+            }
+        };
+        BufferHolder<?> constant2 = new BufferHolder(onHeapUnpooled().allocate(0)) {
+            @Override
+            protected BufferHolder receive(Buffer buf) {
+                return null;
+            }
+        };
+        try {
+            // not using 'assertNotEquals' to be explicit about which object we are calling .equals() on
+            assertFalse(dflt.equals(other));
+            assertFalse(dflt.equals(constant1));
+            assertFalse(constant1.equals(dflt));
+            assertFalse(constant1.equals(other));
+            assertFalse(constant1.equals(constant2));
+        } finally {
+            dflt.close();
+            other.close();
+            constant1.close();
+            constant2.close();
+        }
+    }
+
+    private static final class BufferRef2 extends BufferHolder<BufferRef2> {
+        BufferRef2(Buffer buf) {
+            super(buf);
+        }
+
+        @Override
+        protected BufferRef2 receive(Buffer buf) {
+            return new BufferRef2(buf);
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 
 /**
  * Web Socket frame containing binary data.
@@ -25,76 +25,39 @@ public class BinaryWebSocketFrame extends WebSocketFrame {
 
     /**
      * Creates a new empty binary frame.
+     *
+     * @param allocator {@link BufferAllocator} to use for allocating data.
      */
-    public BinaryWebSocketFrame() {
-        super(Unpooled.buffer(0));
+    public BinaryWebSocketFrame(BufferAllocator allocator) {
+        super(allocator.allocate(0));
     }
 
     /**
      * Creates a new binary frame with the specified binary data. The final fragment flag is set to true.
      *
-     * @param binaryData
-     *            the content of the frame.
+     * @param binaryData the content of the frame.
      */
-    public BinaryWebSocketFrame(ByteBuf binaryData) {
+    public BinaryWebSocketFrame(Buffer binaryData) {
         super(binaryData);
     }
 
     /**
      * Creates a new binary frame with the specified binary data and the final fragment flag.
      *
-     * @param finalFragment
-     *            flag indicating if this frame is the final fragment
-     * @param rsv
-     *            reserved bits used for protocol extensions
-     * @param binaryData
-     *            the content of the frame.
+     * @param finalFragment flag indicating if this frame is the final fragment
+     * @param rsv reserved bits used for protocol extensions
+     * @param binaryData the content of the frame.
      */
-    public BinaryWebSocketFrame(boolean finalFragment, int rsv, ByteBuf binaryData) {
+    public BinaryWebSocketFrame(boolean finalFragment, int rsv, Buffer binaryData) {
         super(finalFragment, rsv, binaryData);
     }
 
-    @Override
-    public BinaryWebSocketFrame copy() {
-        return (BinaryWebSocketFrame) super.copy();
+    private BinaryWebSocketFrame(BinaryWebSocketFrame copyFrom, Buffer data) {
+        super(copyFrom, data);
     }
 
     @Override
-    public BinaryWebSocketFrame duplicate() {
-        return (BinaryWebSocketFrame) super.duplicate();
-    }
-
-    @Override
-    public BinaryWebSocketFrame retainedDuplicate() {
-        return (BinaryWebSocketFrame) super.retainedDuplicate();
-    }
-
-    @Override
-    public BinaryWebSocketFrame replace(ByteBuf content) {
-        return new BinaryWebSocketFrame(isFinalFragment(), rsv(), content);
-    }
-
-    @Override
-    public BinaryWebSocketFrame retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public BinaryWebSocketFrame retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public BinaryWebSocketFrame touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public BinaryWebSocketFrame touch(Object hint) {
-        super.touch(hint);
-        return this;
+    protected WebSocketFrame receive(Buffer buf) {
+        return new BinaryWebSocketFrame(this, buf);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
@@ -16,22 +16,11 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.api.Buffer;
-import io.netty.buffer.api.BufferAllocator;
 
 /**
  * Web Socket frame containing binary data.
  */
 public class BinaryWebSocketFrame extends WebSocketFrame {
-
-    /**
-     * Creates a new empty binary frame.
-     *
-     * @param allocator {@link BufferAllocator} to use for allocating data.
-     */
-    public BinaryWebSocketFrame(BufferAllocator allocator) {
-        super(allocator.allocate(0));
-    }
-
     /**
      * Creates a new binary frame with the specified binary data. The final fragment flag is set to true.
      *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.api.Buffer;
 import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.DefaultGlobalBufferAllocator;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 
@@ -26,16 +27,6 @@ import java.nio.charset.StandardCharsets;
  * Web Socket Frame for closing the connection.
  */
 public class CloseWebSocketFrame extends WebSocketFrame {
-
-    /**
-     * Creates a new empty close frame.
-     *
-     * @param allocator {@link BufferAllocator} to use for allocating data.
-     */
-    public CloseWebSocketFrame(BufferAllocator allocator) {
-        super(allocator.allocate(0));
-    }
-
     /**
      * Creates a new empty close frame with closing status code and reason text
      *
@@ -104,7 +95,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
             reasonText = StringUtil.EMPTY_STRING;
         }
 
-        Buffer binaryData;
+        final Buffer binaryData;
         if (!reasonText.isEmpty()) {
             byte[] reasonTextBytes = reasonText.getBytes(StandardCharsets.UTF_8);
             binaryData = allocator.allocate(2 + reasonTextBytes.length);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -15,10 +15,12 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Web Socket Frame for closing the connection.
@@ -27,104 +29,107 @@ public class CloseWebSocketFrame extends WebSocketFrame {
 
     /**
      * Creates a new empty close frame.
+     *
+     * @param allocator {@link BufferAllocator} to use for allocating data.
      */
-    public CloseWebSocketFrame() {
-        super(Unpooled.buffer(0));
+    public CloseWebSocketFrame(BufferAllocator allocator) {
+        super(allocator.allocate(0));
     }
 
     /**
      * Creates a new empty close frame with closing status code and reason text
      *
-     * @param status
-     *            Status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+     * @param allocator {@link BufferAllocator} to use for allocating data.
+     * @param status Status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
      *            example, <tt>1000</tt> indicates normal closure.
      */
-    public CloseWebSocketFrame(WebSocketCloseStatus status) {
-        this(requireValidStatusCode(status.code()), status.reasonText());
+    public CloseWebSocketFrame(BufferAllocator allocator, WebSocketCloseStatus status) {
+        this(allocator, requireValidStatusCode(status.code()), status.reasonText());
     }
 
     /**
      * Creates a new empty close frame with closing status code and reason text
      *
-     * @param status
-     *            Status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
-     *            example, <tt>1000</tt> indicates normal closure.
-     * @param reasonText
-     *            Reason text. Set to null if no text.
-     */
-    public CloseWebSocketFrame(WebSocketCloseStatus status, String reasonText) {
-        this(requireValidStatusCode(status.code()), reasonText);
-    }
-
-    /**
-     * Creates a new empty close frame with closing status code and reason text
-     *
-     * @param statusCode
-     *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+     * @param allocator {@link BufferAllocator} to use for allocating data.
+     * @param status Status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
      *            example, <tt>1000</tt> indicates normal closure.
      * @param reasonText
      *            Reason text. Set to null if no text.
      */
-    public CloseWebSocketFrame(int statusCode, String reasonText) {
-        this(true, 0, requireValidStatusCode(statusCode), reasonText);
+    public CloseWebSocketFrame(BufferAllocator allocator, WebSocketCloseStatus status, String reasonText) {
+        this(allocator, requireValidStatusCode(status.code()), reasonText);
+    }
+
+    /**
+     * Creates a new empty close frame with closing status code and reason text
+     *
+     * @param allocator {@link BufferAllocator} to use for allocating data.
+     * @param statusCode Integer status code as per <a href=
+     * "https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For example, <tt>1000</tt> indicates normal
+     * closure.
+     * @param reasonText Reason text. Set to null if no text.
+     */
+    public CloseWebSocketFrame(BufferAllocator allocator, int statusCode, String reasonText) {
+        this(allocator, true, 0, requireValidStatusCode(statusCode), reasonText);
     }
 
     /**
      * Creates a new close frame with no losing status code and no reason text
      *
-     * @param finalFragment
-     *            flag indicating if this frame is the final fragment
-     * @param rsv
-     *            reserved bits used for protocol extensions.
+     * @param allocator {@link BufferAllocator} to use for allocating data.
+     * @param finalFragment flag indicating if this frame is the final fragment
+     * @param rsv reserved bits used for protocol extensions.
      */
-    public CloseWebSocketFrame(boolean finalFragment, int rsv) {
-        this(finalFragment, rsv, Unpooled.buffer(0));
+    public CloseWebSocketFrame(BufferAllocator allocator, boolean finalFragment, int rsv) {
+        this(finalFragment, rsv, allocator.allocate(0));
     }
 
     /**
      * Creates a new close frame with closing status code and reason text
      *
-     * @param finalFragment
-     *            flag indicating if this frame is the final fragment
-     * @param rsv
-     *            reserved bits used for protocol extensions
-     * @param statusCode
-     *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
-     *            example, <tt>1000</tt> indicates normal closure.
-     * @param reasonText
-     *            Reason text. Set to null if no text.
+     * @param finalFragment flag indicating if this frame is the final fragment
+     * @param rsv reserved bits used for protocol extensions
+     * @param statusCode Integer status code as per <a href=
+     * "https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For example, <tt>1000</tt> indicates normal
+     * closure.
+     * @param reasonText Reason text. Set to null if no text.
      */
-    public CloseWebSocketFrame(boolean finalFragment, int rsv, int statusCode, String reasonText) {
-        super(finalFragment, rsv, newBinaryData(requireValidStatusCode(statusCode), reasonText));
+    public CloseWebSocketFrame(BufferAllocator allocator, boolean finalFragment, int rsv, int statusCode,
+                               String reasonText) {
+        super(finalFragment, rsv, newBinaryData(allocator, requireValidStatusCode(statusCode), reasonText));
     }
 
-    private static ByteBuf newBinaryData(int statusCode, String reasonText) {
+    private static Buffer newBinaryData(BufferAllocator allocator, short statusCode, String reasonText) {
         if (reasonText == null) {
             reasonText = StringUtil.EMPTY_STRING;
         }
 
-        ByteBuf binaryData = Unpooled.buffer(2 + reasonText.length());
-        binaryData.writeShort(statusCode);
+        Buffer binaryData;
         if (!reasonText.isEmpty()) {
-            binaryData.writeCharSequence(reasonText, CharsetUtil.UTF_8);
+            byte[] reasonTextBytes = reasonText.getBytes(StandardCharsets.UTF_8);
+            binaryData = allocator.allocate(2 + reasonTextBytes.length);
+            binaryData.writeShort(statusCode);
+            binaryData.writeBytes(reasonTextBytes);
+        } else {
+            binaryData = allocator.allocate(2).writeShort(statusCode);
         }
 
-        binaryData.readerIndex(0);
         return binaryData;
     }
 
     /**
      * Creates a new close frame
      *
-     * @param finalFragment
-     *            flag indicating if this frame is the final fragment
-     * @param rsv
-     *            reserved bits used for protocol extensions
-     * @param binaryData
-     *            the content of the frame. Must be 2 byte integer followed by optional UTF-8 encoded string.
+     * @param finalFragment flag indicating if this frame is the final fragment
+     * @param rsv reserved bits used for protocol extensions
+     * @param binaryData the content of the frame. Must be 2 byte integer followed by optional UTF-8 encoded string.
      */
-    public CloseWebSocketFrame(boolean finalFragment, int rsv, ByteBuf binaryData) {
+    public CloseWebSocketFrame(boolean finalFragment, int rsv, Buffer binaryData) {
         super(finalFragment, rsv, binaryData);
+    }
+
+    private CloseWebSocketFrame(CloseWebSocketFrame copyFrom, Buffer data) {
+        super(copyFrom, data);
     }
 
     /**
@@ -132,12 +137,12 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      * a status code is set, -1 is returned.
      */
     public int statusCode() {
-        ByteBuf binaryData = content();
+        Buffer binaryData = binaryData();
         if (binaryData == null || binaryData.capacity() == 0) {
             return -1;
         }
 
-        binaryData.readerIndex(0);
+        binaryData.readerOffset(0);
         return binaryData.getShort(0);
     }
 
@@ -146,65 +151,26 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      * text is not supplied, an empty string is returned.
      */
     public String reasonText() {
-        ByteBuf binaryData = content();
+        Buffer binaryData = binaryData();
         if (binaryData == null || binaryData.capacity() <= 2) {
             return "";
         }
 
-        binaryData.readerIndex(2);
+        binaryData.readerOffset(2);
         String reasonText = binaryData.toString(CharsetUtil.UTF_8);
-        binaryData.readerIndex(0);
+        binaryData.readerOffset(0);
 
         return reasonText;
     }
 
     @Override
-    public CloseWebSocketFrame copy() {
-        return (CloseWebSocketFrame) super.copy();
+    protected WebSocketFrame receive(Buffer buf) {
+        return new CloseWebSocketFrame(this, buf);
     }
 
-    @Override
-    public CloseWebSocketFrame duplicate() {
-        return (CloseWebSocketFrame) super.duplicate();
-    }
-
-    @Override
-    public CloseWebSocketFrame retainedDuplicate() {
-        return (CloseWebSocketFrame) super.retainedDuplicate();
-    }
-
-    @Override
-    public CloseWebSocketFrame replace(ByteBuf content) {
-        return new CloseWebSocketFrame(isFinalFragment(), rsv(), content);
-    }
-
-    @Override
-    public CloseWebSocketFrame retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public CloseWebSocketFrame retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public CloseWebSocketFrame touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public CloseWebSocketFrame touch(Object hint) {
-        super.touch(hint);
-        return this;
-    }
-
-    static int requireValidStatusCode(int statusCode) {
+    static short requireValidStatusCode(int statusCode) {
         if (WebSocketCloseStatus.isValidStatusCode(statusCode)) {
-            return statusCode;
+            return (short) statusCode;
         } else {
             throw new IllegalArgumentException("WebSocket close status code does NOT comply with RFC-6455: " +
                     statusCode);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
@@ -24,16 +24,6 @@ import io.netty.util.CharsetUtil;
  * fragmented messages where the contents of a messages is contained more than 1 frame.
  */
 public class ContinuationWebSocketFrame extends WebSocketFrame {
-
-    /**
-     * Creates a new empty continuation frame.
-     *
-     * @param allocator {@link BufferAllocator} to use for allocating data.
-     */
-    public ContinuationWebSocketFrame(BufferAllocator allocator) {
-        this(allocator.allocate(0));
-    }
-
     /**
      * Creates a new continuation frame with the specified binary data. The final fragment flag is
      * set to true.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
@@ -16,22 +16,11 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.api.Buffer;
-import io.netty.buffer.api.BufferAllocator;
 
 /**
  * Web Socket frame containing binary data.
  */
 public class PingWebSocketFrame extends WebSocketFrame {
-
-    /**
-     * Creates a new empty ping frame.
-     *
-     * @param allocator {@link BufferAllocator} to use for allocating data.
-     */
-    public PingWebSocketFrame(BufferAllocator allocator) {
-        super(true, 0, allocator.allocate(0));
-    }
-
     /**
      * Creates a new ping frame with the specified binary data.
      *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 
 /**
  * Web Socket frame containing binary data.
@@ -25,76 +25,39 @@ public class PingWebSocketFrame extends WebSocketFrame {
 
     /**
      * Creates a new empty ping frame.
+     *
+     * @param allocator {@link BufferAllocator} to use for allocating data.
      */
-    public PingWebSocketFrame() {
-        super(true, 0, Unpooled.buffer(0));
+    public PingWebSocketFrame(BufferAllocator allocator) {
+        super(true, 0, allocator.allocate(0));
     }
 
     /**
      * Creates a new ping frame with the specified binary data.
      *
-     * @param binaryData
-     *            the content of the frame.
+     * @param binaryData the content of the frame.
      */
-    public PingWebSocketFrame(ByteBuf binaryData) {
+    public PingWebSocketFrame(Buffer binaryData) {
         super(binaryData);
     }
 
     /**
      * Creates a new ping frame with the specified binary data.
      *
-     * @param finalFragment
-     *            flag indicating if this frame is the final fragment
-     * @param rsv
-     *            reserved bits used for protocol extensions
-     * @param binaryData
-     *            the content of the frame.
+     * @param finalFragment flag indicating if this frame is the final fragment
+     * @param rsv reserved bits used for protocol extensions
+     * @param binaryData the content of the frame.
      */
-    public PingWebSocketFrame(boolean finalFragment, int rsv, ByteBuf binaryData) {
+    public PingWebSocketFrame(boolean finalFragment, int rsv, Buffer binaryData) {
         super(finalFragment, rsv, binaryData);
     }
 
-    @Override
-    public PingWebSocketFrame copy() {
-        return (PingWebSocketFrame) super.copy();
+    private PingWebSocketFrame(PingWebSocketFrame copyFrom, Buffer data) {
+        super(copyFrom, data);
     }
 
     @Override
-    public PingWebSocketFrame duplicate() {
-        return (PingWebSocketFrame) super.duplicate();
-    }
-
-    @Override
-    public PingWebSocketFrame retainedDuplicate() {
-        return (PingWebSocketFrame) super.retainedDuplicate();
-    }
-
-    @Override
-    public PingWebSocketFrame replace(ByteBuf content) {
-        return new PingWebSocketFrame(isFinalFragment(), rsv(), content);
-    }
-
-    @Override
-    public PingWebSocketFrame retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public PingWebSocketFrame retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public PingWebSocketFrame touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public PingWebSocketFrame touch(Object hint) {
-        super.touch(hint);
-        return this;
+    protected WebSocketFrame receive(Buffer buf) {
+        return new PingWebSocketFrame(this, buf);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
@@ -16,23 +16,12 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.api.Buffer;
-import io.netty.buffer.api.BufferAllocator;
 import io.netty.buffer.api.Send;
 
 /**
  * Web Socket frame containing binary data.
  */
 public class PongWebSocketFrame extends WebSocketFrame {
-
-    /**
-     * Creates a new empty pong frame.
-     *
-     * @param allocator {@link BufferAllocator} to use for allocating data.
-     */
-    public PongWebSocketFrame(BufferAllocator allocator) {
-        super(allocator.allocate(0));
-    }
-
     /**
      * Creates a new pong frame with the specified binary data.
      *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
@@ -15,8 +15,9 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.Send;
 
 /**
  * Web Socket frame containing binary data.
@@ -25,76 +26,48 @@ public class PongWebSocketFrame extends WebSocketFrame {
 
     /**
      * Creates a new empty pong frame.
+     *
+     * @param allocator {@link BufferAllocator} to use for allocating data.
      */
-    public PongWebSocketFrame() {
-        super(Unpooled.buffer(0));
+    public PongWebSocketFrame(BufferAllocator allocator) {
+        super(allocator.allocate(0));
     }
 
     /**
      * Creates a new pong frame with the specified binary data.
      *
-     * @param binaryData
-     *            the content of the frame.
+     * @param binaryData the content of the frame.
      */
-    public PongWebSocketFrame(ByteBuf binaryData) {
+    public PongWebSocketFrame(Buffer binaryData) {
+        super(binaryData);
+    }
+
+    /**
+     * Creates a new pong frame with the specified binary data.
+     *
+     * @param binaryData the content of the frame.
+     */
+    public PongWebSocketFrame(Send<Buffer> binaryData) {
         super(binaryData);
     }
 
     /**
      * Creates a new pong frame with the specified binary data
      *
-     * @param finalFragment
-     *            flag indicating if this frame is the final fragment
-     * @param rsv
-     *            reserved bits used for protocol extensions
-     * @param binaryData
-     *            the content of the frame.
+     * @param finalFragment flag indicating if this frame is the final fragment
+     * @param rsv reserved bits used for protocol extensions
+     * @param binaryData the content of the frame.
      */
-    public PongWebSocketFrame(boolean finalFragment, int rsv, ByteBuf binaryData) {
+    public PongWebSocketFrame(boolean finalFragment, int rsv, Buffer binaryData) {
         super(finalFragment, rsv, binaryData);
     }
 
-    @Override
-    public PongWebSocketFrame copy() {
-        return (PongWebSocketFrame) super.copy();
+    private PongWebSocketFrame(PongWebSocketFrame copyFrom, Buffer data) {
+        super(copyFrom, data);
     }
 
     @Override
-    public PongWebSocketFrame duplicate() {
-        return (PongWebSocketFrame) super.duplicate();
-    }
-
-    @Override
-    public PongWebSocketFrame retainedDuplicate() {
-        return (PongWebSocketFrame) super.retainedDuplicate();
-    }
-
-    @Override
-    public PongWebSocketFrame replace(ByteBuf content) {
-        return new PongWebSocketFrame(isFinalFragment(), rsv(), content);
-    }
-
-    @Override
-    public PongWebSocketFrame retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public PongWebSocketFrame retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public PongWebSocketFrame touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public PongWebSocketFrame touch(Object hint) {
-        super.touch(hint);
-        return this;
+    protected WebSocketFrame receive(Buffer buf) {
+        return new PongWebSocketFrame(this, buf);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.util.CharsetUtil;
 
 /**
@@ -26,50 +26,53 @@ public class TextWebSocketFrame extends WebSocketFrame {
 
     /**
      * Creates a new empty text frame.
+     *
+     * @param allocator {@link BufferAllocator} to use for allocating data.
      */
-    public TextWebSocketFrame() {
-        super(Unpooled.buffer(0));
+    public TextWebSocketFrame(BufferAllocator allocator) {
+        super(allocator.allocate(0));
     }
 
     /**
      * Creates a new text frame with the specified text string. The final fragment flag is set to true.
      *
-     * @param text
-     *            String to put in the frame.
+     * @param allocator {@link BufferAllocator} to use for allocating data.
+     * @param text String to put in the frame.
      */
-    public TextWebSocketFrame(String text) {
-        super(fromText(text));
+    public TextWebSocketFrame(BufferAllocator allocator, String text) {
+        super(fromText(allocator, text));
     }
 
     /**
      * Creates a new text frame with the specified binary data. The final fragment flag is set to true.
      *
-     * @param binaryData
-     *            the content of the frame.
+     * @param binaryData the content of the frame.
      */
-    public TextWebSocketFrame(ByteBuf binaryData) {
+    public TextWebSocketFrame(Buffer binaryData) {
         super(binaryData);
     }
 
     /**
      * Creates a new text frame with the specified text string. The final fragment flag is set to true.
      *
-     * @param finalFragment
-     *            flag indicating if this frame is the final fragment
-     * @param rsv
-     *            reserved bits used for protocol extensions
-     * @param text
-     *            String to put in the frame.
+     * @param allocator {@link BufferAllocator} to use for allocating data.
+     * @param finalFragment flag indicating if this frame is the final fragment
+     * @param rsv reserved bits used for protocol extensions
+     * @param text String to put in the frame.
      */
-    public TextWebSocketFrame(boolean finalFragment, int rsv, String text) {
-        super(finalFragment, rsv, fromText(text));
+    public TextWebSocketFrame(BufferAllocator allocator, boolean finalFragment, int rsv, String text) {
+        super(finalFragment, rsv, fromText(allocator, text));
     }
 
-    private static ByteBuf fromText(String text) {
+    private TextWebSocketFrame(TextWebSocketFrame copyFrom, Buffer data) {
+        super(copyFrom, data);
+    }
+
+    private static Buffer fromText(BufferAllocator allocator, String text) {
         if (text == null || text.isEmpty()) {
-            return Unpooled.EMPTY_BUFFER;
+            return allocator.allocate(0);
         } else {
-            return Unpooled.copiedBuffer(text, CharsetUtil.UTF_8);
+            return allocator.copyOf(text.getBytes(CharsetUtil.UTF_8));
         }
     }
 
@@ -83,7 +86,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
      * @param binaryData
      *            the content of the frame.
      */
-    public TextWebSocketFrame(boolean finalFragment, int rsv, ByteBuf binaryData) {
+    public TextWebSocketFrame(boolean finalFragment, int rsv, Buffer binaryData) {
         super(finalFragment, rsv, binaryData);
     }
 
@@ -91,50 +94,11 @@ public class TextWebSocketFrame extends WebSocketFrame {
      * Returns the text data in this frame.
      */
     public String text() {
-        return content().toString(CharsetUtil.UTF_8);
+        return binaryData().toString(CharsetUtil.UTF_8);
     }
 
     @Override
-    public TextWebSocketFrame copy() {
-        return (TextWebSocketFrame) super.copy();
-    }
-
-    @Override
-    public TextWebSocketFrame duplicate() {
-        return (TextWebSocketFrame) super.duplicate();
-    }
-
-    @Override
-    public TextWebSocketFrame retainedDuplicate() {
-        return (TextWebSocketFrame) super.retainedDuplicate();
-    }
-
-    @Override
-    public TextWebSocketFrame replace(ByteBuf content) {
-        return new TextWebSocketFrame(isFinalFragment(), rsv(), content);
-    }
-
-    @Override
-    public TextWebSocketFrame retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public TextWebSocketFrame retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public TextWebSocketFrame touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public TextWebSocketFrame touch(Object hint) {
-        super.touch(hint);
-        return this;
+    protected WebSocketFrame receive(Buffer buf) {
+        return new TextWebSocketFrame(this, buf);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
@@ -23,16 +23,6 @@ import io.netty.util.CharsetUtil;
  * Web Socket text frame.
  */
 public class TextWebSocketFrame extends WebSocketFrame {
-
-    /**
-     * Creates a new empty text frame.
-     *
-     * @param allocator {@link BufferAllocator} to use for allocating data.
-     */
-    public TextWebSocketFrame(BufferAllocator allocator) {
-        super(allocator.allocate(0));
-    }
-
     /**
      * Creates a new text frame with the specified text string. The final fragment flag is set to true.
      *

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8FrameValidator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8FrameValidator.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
 import io.netty.channel.ChannelFutureListeners;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -48,7 +48,7 @@ public class Utf8FrameValidator implements ChannelHandler {
                         if ((frame instanceof TextWebSocketFrame) ||
                                 (utf8Validator != null && utf8Validator.isChecking())) {
                             // Check UTF-8 correctness for this payload
-                            checkUTF8String(frame.content());
+                            checkUTF8String(frame.binaryData());
 
                             // This does a second check to make sure UTF-8
                             // correctness for entire text message
@@ -61,12 +61,12 @@ public class Utf8FrameValidator implements ChannelHandler {
                     if (fragmentedFramesCount == 0) {
                         // First text or binary frame for a fragmented set
                         if (frame instanceof TextWebSocketFrame) {
-                            checkUTF8String(frame.content());
+                            checkUTF8String(frame.binaryData());
                         }
                     } else {
                         // Subsequent frames - only check if init frame is text
                         if (utf8Validator != null && utf8Validator.isChecking()) {
-                            checkUTF8String(frame.content());
+                            checkUTF8String(frame.binaryData());
                         }
                     }
 
@@ -74,7 +74,7 @@ public class Utf8FrameValidator implements ChannelHandler {
                     fragmentedFramesCount++;
                 }
             } catch (CorruptedWebSocketFrameException e) {
-                frame.release();
+                frame.close();
                 throw e;
             }
         }
@@ -82,7 +82,7 @@ public class Utf8FrameValidator implements ChannelHandler {
         ctx.fireChannelRead(msg);
     }
 
-    private void checkUTF8String(ByteBuf buffer) {
+    private void checkUTF8String(Buffer buffer) {
         if (utf8Validator == null) {
             utf8Validator = new Utf8Validator();
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8Validator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8Validator.java
@@ -35,7 +35,8 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.ByteCursor;
 import io.netty.util.ByteProcessor;
 
 /**
@@ -63,14 +64,19 @@ final class Utf8Validator implements ByteProcessor {
             12, 36, 12, 12, 12, 36, 12, 12, 12, 12, 12, 36, 12, 36, 12, 12, 12, 36, 12, 12, 12, 12,
             12, 12, 12, 12, 12, 12 };
 
-    @SuppressWarnings("RedundantFieldInitialization")
     private int state = UTF8_ACCEPT;
     private int codep;
     private boolean checking;
 
-    public void check(ByteBuf buffer) {
+    public void check(Buffer buffer) {
         checking = true;
-        buffer.forEachByte(this);
+        buffer.forEachReadable(0, (index, component) -> {
+            ByteCursor cursor = component.openCursor();
+            while (cursor.readByte()) {
+                process(cursor.getByte());
+            }
+            return true;
+        });
     }
 
     public void finish() {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket13FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket13FrameDecoder.java
@@ -157,7 +157,7 @@ public class WebSocket13FrameDecoder extends ByteToMessageDecoderForBuffer imple
 
         switch (state) {
         case READING_FIRST: {
-            if (in.readableBytes() <= 0) {
+            if (in.readableBytes() == 0) {
                 return;
             }
 
@@ -176,7 +176,7 @@ public class WebSocket13FrameDecoder extends ByteToMessageDecoderForBuffer imple
             state = State.READING_SECOND;
         }
         case READING_SECOND: {
-            if (in.readableBytes() <= 0) {
+            if (in.readableBytes() == 0) {
                 return;
             }
             // MASK, PAYLOAD LEN 1

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
@@ -53,15 +53,13 @@
 
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
+import io.netty.buffer.api.Buffer;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -101,7 +99,7 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
 
     @Override
     protected void encode(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
-        final ByteBuf data = msg.content();
+        final Buffer data = msg.binaryData();
         byte[] mask;
 
         byte opcode;
@@ -139,8 +137,7 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                     + length);
         }
 
-        boolean release = true;
-        ByteBuf buf = null;
+        Buffer buf = null;
         try {
             int maskLength = maskPayload ? 4 : 0;
             if (length <= 125) {
@@ -148,8 +145,8 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
-                buf = ctx.alloc().buffer(size);
-                buf.writeByte(b0);
+                buf = ctx.bufferAllocator().allocate(size);
+                buf.writeByte((byte) b0);
                 byte b = (byte) (maskPayload ? 0x80 | (byte) length : (byte) length);
                 buf.writeByte(b);
             } else if (length <= 0xFFFF) {
@@ -157,75 +154,64 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
-                buf = ctx.alloc().buffer(size);
-                buf.writeByte(b0);
-                buf.writeByte(maskPayload ? 0xFE : 126);
-                buf.writeByte(length >>> 8 & 0xFF);
-                buf.writeByte(length & 0xFF);
+                buf = ctx.bufferAllocator().allocate(size);
+                buf.writeByte((byte) b0);
+                buf.writeByte((byte) (maskPayload ? 0xFE : 126));
+                buf.writeByte((byte) (length >>> 8 & 0xFF));
+                buf.writeByte((byte) (length & 0xFF));
             } else {
                 int size = 10 + maskLength;
                 if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
-                buf = ctx.alloc().buffer(size);
-                buf.writeByte(b0);
-                buf.writeByte(maskPayload ? 0xFF : 127);
+                buf = ctx.bufferAllocator().allocate(size);
+                buf.writeByte((byte) b0);
+                buf.writeByte((byte) (maskPayload ? 0xFF : 127));
                 buf.writeLong(length);
             }
 
             // Write payload
             if (maskPayload) {
-                int random = ThreadLocalRandom.current().nextInt();
-                mask = ByteBuffer.allocate(4).putInt(random).array();
+                mask = new byte[4];
+                ThreadLocalRandom.current().nextBytes(mask);
                 buf.writeBytes(mask);
 
-                ByteOrder srcOrder = data.order();
-                ByteOrder dstOrder = buf.order();
-
                 int counter = 0;
-                int i = data.readerIndex();
-                int end = data.writerIndex();
+                int i = data.readerOffset();
+                int end = data.writerOffset();
 
-                if (srcOrder == dstOrder) {
-                    // Use the optimized path only when byte orders match
-                    // Remark: & 0xFF is necessary because Java will do signed expansion from
-                    // byte to int which we don't want.
-                    int intMask = ((mask[0] & 0xFF) << 24)
-                                | ((mask[1] & 0xFF) << 16)
-                                | ((mask[2] & 0xFF) << 8)
-                                | (mask[3] & 0xFF);
+                // Remark: & 0xFF is necessary because Java will do signed expansion from
+                // byte to int which we don't want.
+                int intMask = (mask[0] & 0xFF) << 24
+                              | (mask[1] & 0xFF) << 16
+                              | (mask[2] & 0xFF) << 8
+                              | mask[3] & 0xFF;
 
-                    // If the byte order of our buffers it little endian we have to bring our mask
-                    // into the same format, because getInt() and writeInt() will use a reversed byte order
-                    if (srcOrder == ByteOrder.LITTLE_ENDIAN) {
-                        intMask = Integer.reverseBytes(intMask);
-                    }
-
-                    for (; i + 3 < end; i += 4) {
-                        int intData = data.getInt(i);
-                        buf.writeInt(intData ^ intMask);
-                    }
+                for (; i + 3 < end; i += 4) {
+                    int intData = data.getInt(i);
+                    buf.writeInt(intData ^ intMask);
                 }
                 for (; i < end; i++) {
                     byte byteData = data.getByte(i);
-                    buf.writeByte(byteData ^ mask[counter++ % 4]);
+                    buf.writeByte((byte) (byteData ^ mask[counter++ % 4]));
                 }
                 out.add(buf);
             } else {
                 if (buf.writableBytes() >= data.readableBytes()) {
                     // merge buffers as this is cheaper then a gathering write if the payload is small enough
                     buf.writeBytes(data);
+                    data.close();
                     out.add(buf);
                 } else {
                     out.add(buf);
-                    out.add(data.retain());
+                    out.add(data);
                 }
             }
-            release = false;
-        } finally {
-            if (release && buf != null) {
-                buf.release();
+        } catch (Throwable t) {
+            if (buf != null) {
+                buf.close();
             }
+            throw t;
         }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketChunkedInput.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketChunkedInput.java
@@ -15,12 +15,13 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import static java.util.Objects.requireNonNull;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.stream.ChunkedInput;
+
+import static io.netty.buffer.api.adaptor.ByteBufAdaptor.extract;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link ChunkedInput} that fetches data chunk by chunk for use with WebSocket chunked transfers.
@@ -100,7 +101,7 @@ public final class WebSocketChunkedInput implements ChunkedInput<WebSocketFrame>
         if (buf == null) {
             return null;
         }
-        return new ContinuationWebSocketFrame(input.isEndOfInput(), rsv, buf);
+        return new ContinuationWebSocketFrame(input.isEndOfInput(), rsv, extract(buf));
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrame.java
@@ -15,14 +15,18 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.DefaultByteBufHolder;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferHolder;
+import io.netty.buffer.api.Resource;
+import io.netty.buffer.api.Send;
 import io.netty.util.internal.StringUtil;
+
+import static java.nio.charset.Charset.defaultCharset;
 
 /**
  * Base class for web socket frames.
  */
-public abstract class WebSocketFrame extends DefaultByteBufHolder {
+public abstract class WebSocketFrame extends BufferHolder<WebSocketFrame> {
 
     /**
      * Flag to indicate if this frame is the final fragment in a message. The first fragment (frame) may also be the
@@ -35,14 +39,33 @@ public abstract class WebSocketFrame extends DefaultByteBufHolder {
      */
     private final int rsv;
 
-    protected WebSocketFrame(ByteBuf binaryData) {
+    protected WebSocketFrame(Buffer binaryData) {
         this(true, 0, binaryData);
     }
 
-    protected WebSocketFrame(boolean finalFragment, int rsv, ByteBuf binaryData) {
+    protected WebSocketFrame(Send<Buffer> binaryData) {
+        super(binaryData);
+        finalFragment = true;
+        rsv = 0;
+    }
+
+    protected WebSocketFrame(boolean finalFragment, int rsv, Buffer binaryData) {
         super(binaryData);
         this.finalFragment = finalFragment;
         this.rsv = rsv;
+    }
+
+    /**
+     * This is a copy-constructor, used by sub-classes to implement {@link Resource#send()}.
+     * The life cycle of the {@code binaryData} buffer is not manipulated by this constructor, but instead stored as-is.
+     *
+     * @param copyFrom The original frame instance to copy from.
+     * @param binaryData The binary data of the original frame.
+     */
+    protected WebSocketFrame(WebSocketFrame copyFrom, Buffer binaryData) {
+        super(binaryData);
+        finalFragment = copyFrom.finalFragment;
+        rsv = copyFrom.rsv;
     }
 
     /**
@@ -60,50 +83,12 @@ public abstract class WebSocketFrame extends DefaultByteBufHolder {
         return rsv;
     }
 
-    @Override
-    public WebSocketFrame copy() {
-        return (WebSocketFrame) super.copy();
+    public Buffer binaryData() {
+        return getBuffer();
     }
-
-    @Override
-    public WebSocketFrame duplicate() {
-        return (WebSocketFrame) super.duplicate();
-    }
-
-    @Override
-    public WebSocketFrame retainedDuplicate() {
-        return (WebSocketFrame) super.retainedDuplicate();
-    }
-
-    @Override
-    public abstract WebSocketFrame replace(ByteBuf content);
 
     @Override
     public String toString() {
-        return StringUtil.simpleClassName(this) + "(data: " + contentToString() + ')';
-    }
-
-    @Override
-    public WebSocketFrame retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public WebSocketFrame retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public WebSocketFrame touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public WebSocketFrame touch(Object hint) {
-        super.touch(hint);
-        return this;
+        return StringUtil.simpleClassName(this) + "(data: " + getBuffer().toString(defaultCharset()) + ')';
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.java
@@ -121,11 +121,11 @@ public class WebSocketFrameAggregator
         payload.extendWith(content.binaryData().send());
     }
 
-    private boolean isStartMessage(Object msg) {
+    private static boolean isStartMessage(Object msg) {
         return msg instanceof TextWebSocketFrame || msg instanceof BinaryWebSocketFrame;
     }
 
-    private boolean isContentMessage(Object msg) {
+    private static boolean isContentMessage(Object msg) {
         return msg instanceof ContinuationWebSocketFrame;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -64,7 +64,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             // We need to `send` the binary data to the pong frame, because the MessageToMessageDecoder
             // is going to close the ping frame, which would otherwise cause the data to be freed.
             try (frame) {
-                ctx.channel().writeAndFlush(new PongWebSocketFrame(frame.binaryData().send()));
+                ctx.writeAndFlush(new PongWebSocketFrame(frame.binaryData().send()));
             }
             readIfNeeded(ctx);
             return;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -57,15 +57,6 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
      */
     public enum ServerHandshakeStateEvent {
         /**
-         * The Handshake was completed successfully and the channel was upgraded to websockets.
-         *
-         * @deprecated in favor of {@link HandshakeComplete} class,
-         * it provides extra information about the handshake
-         */
-        @Deprecated
-        HANDSHAKE_COMPLETE,
-
-        /**
          * The Handshake was timed out
          */
         HANDSHAKE_TIMEOUT
@@ -236,11 +227,11 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         if (serverConfig.handleCloseFrames() && frame instanceof CloseWebSocketFrame) {
             WebSocketServerHandshaker handshaker = getHandshaker(ctx.channel());
             if (handshaker != null) {
-                frame.retain();
                 Promise<Void> promise = ctx.newPromise();
                 closeSent(promise);
                 handshaker.close(ctx, (CloseWebSocketFrame) frame).cascadeTo(promise);
             } else {
+                frame.close();
                 ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ctx, ChannelFutureListeners.CLOSE);
             }
             return;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -26,7 +26,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.ServerHandshakeStateEvent;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
@@ -97,9 +96,6 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelHandler {
                             ctx.fireExceptionCaught(future.cause());
                         } else {
                             localHandshakePromise.trySuccess(null);
-                            // Kept for compatibility
-                            ctx.fireUserEventTriggered(
-                                    ServerHandshakeStateEvent.HANDSHAKE_COMPLETE);
                             ctx.fireUserEventTriggered(
                                     new WebSocketServerProtocolHandler.HandshakeComplete(
                                             req.uri(), req.headers(), handshaker.selectedSubprotocol()));

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoder.java
@@ -64,7 +64,7 @@ class PerFrameDeflateEncoder extends DeflateEncoder {
 
         return (msg instanceof TextWebSocketFrame || msg instanceof BinaryWebSocketFrame ||
                 msg instanceof ContinuationWebSocketFrame) &&
-               wsFrame.content().readableBytes() > 0 &&
+               wsFrame.binaryData().readableBytes() > 0 &&
                (wsFrame.rsv() & WebSocketExtension.RSV1) == 0;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoder.java
@@ -90,5 +90,4 @@ class PerMessageDeflateDecoder extends DeflateDecoder {
             compressing = true;
         }
     }
-
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoder.java
@@ -70,9 +70,9 @@ class PerMessageDeflateEncoder extends DeflateEncoder {
             return false;
         }
 
-        return ((wsFrame instanceof TextWebSocketFrame || wsFrame instanceof BinaryWebSocketFrame) &&
-                (wsFrame.rsv() & WebSocketExtension.RSV1) == 0) ||
-               (wsFrame instanceof ContinuationWebSocketFrame && compressing);
+        return (wsFrame instanceof TextWebSocketFrame || wsFrame instanceof BinaryWebSocketFrame) &&
+                (wsFrame.rsv() & WebSocketExtension.RSV1) == 0 ||
+               wsFrame instanceof ContinuationWebSocketFrame && compressing;
     }
 
     @Override
@@ -97,5 +97,4 @@ class PerMessageDeflateEncoder extends DeflateEncoder {
             compressing = true;
         }
     }
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrameTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrameTest.java
@@ -15,6 +15,7 @@ package io.netty.handler.codec.http.websocketx;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
+import static io.netty.buffer.api.DefaultGlobalBufferAllocator.DEFAULT_GLOBAL_BUFFER_ALLOCATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -22,50 +23,34 @@ class CloseWebSocketFrameTest {
 
     @Test
     void testInvalidCode() {
-        doTestInvalidCode(new ThrowableAssert.ThrowingCallable() {
+        doTestInvalidCode(() ->
+                new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR, WebSocketCloseStatus.ABNORMAL_CLOSURE));
 
-            @Override
-            public void call() throws RuntimeException {
-                new CloseWebSocketFrame(WebSocketCloseStatus.ABNORMAL_CLOSURE);
-            }
-        });
+        doTestInvalidCode(() ->
+                new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR, WebSocketCloseStatus.ABNORMAL_CLOSURE,
+                "invalid code"));
 
-        doTestInvalidCode(new ThrowableAssert.ThrowingCallable() {
+        doTestInvalidCode(() ->
+                new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR, 1006, "invalid code"));
 
-            @Override
-            public void call() throws RuntimeException {
-                new CloseWebSocketFrame(WebSocketCloseStatus.ABNORMAL_CLOSURE, "invalid code");
-            }
-        });
-
-        doTestInvalidCode(new ThrowableAssert.ThrowingCallable() {
-
-            @Override
-            public void call() throws RuntimeException {
-                new CloseWebSocketFrame(1006, "invalid code");
-            }
-        });
-
-        doTestInvalidCode(new ThrowableAssert.ThrowingCallable() {
-
-            @Override
-            public void call() throws RuntimeException {
-                new CloseWebSocketFrame(true, 0, 1006, "invalid code");
-            }
-        });
+        doTestInvalidCode(() ->
+                new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR, true, 0, 1006, "invalid code"));
     }
 
     @Test
     void testValidCode() {
-        doTestValidCode(new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE),
+        doTestValidCode(new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR, WebSocketCloseStatus.NORMAL_CLOSURE),
                 WebSocketCloseStatus.NORMAL_CLOSURE.code(), WebSocketCloseStatus.NORMAL_CLOSURE.reasonText());
 
-        doTestValidCode(new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE, "valid code"),
+        doTestValidCode(new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR,
+                        WebSocketCloseStatus.NORMAL_CLOSURE, "valid code"),
                 WebSocketCloseStatus.NORMAL_CLOSURE.code(), "valid code");
 
-        doTestValidCode(new CloseWebSocketFrame(1000, "valid code"), 1000, "valid code");
+        doTestValidCode(new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR, 1000, "valid code"),
+                1000, "valid code");
 
-        doTestValidCode(new CloseWebSocketFrame(true, 0, 1000, "valid code"), 1000, "valid code");
+        doTestValidCode(new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR, true, 0, 1000, "valid code"),
+                1000, "valid code");
     }
 
     private static void doTestInvalidCode(ThrowableAssert.ThrowingCallable callable) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -15,20 +15,18 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
-import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.ServerHandshakeStateEvent;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -42,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("buffer migration")
 public class WebSocketHandshakeHandOverTest {
 
     private boolean serverReceivedHandshake;
@@ -84,32 +81,33 @@ public class WebSocketHandshakeHandOverTest {
     }
 
     @Test
-    public void testHandover() throws Exception {
-        EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<Object>() {
+    public void testHandover() {
+        EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<>() {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-                if (evt == ServerHandshakeStateEvent.HANDSHAKE_COMPLETE) {
+                if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     serverReceivedHandshake = true;
-                    // immediately send a message to the client on connect
-                    ctx.writeAndFlush(new TextWebSocketFrame("abc"));
-                } else if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     serverHandshakeComplete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
+                    // immediately send a message to the client on connect
+                    ctx.writeAndFlush(new TextWebSocketFrame(ctx.bufferAllocator(), "abc"));
                 }
             }
+
             @Override
-            protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
+            protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
             }
         });
 
-        EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<Object>() {
+        EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<>() {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     clientReceivedHandshake = true;
                 }
             }
+
             @Override
-            protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
+            protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
                 if (msg instanceof TextWebSocketFrame) {
                     clientReceivedMessage = true;
                 }
@@ -132,24 +130,20 @@ public class WebSocketHandshakeHandOverTest {
 
     @Test
     public void testClientHandshakeTimeout() throws Throwable {
-        EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<Object>() {
+        EmbeddedChannel serverChannel = createServerChannel(new SimpleChannelInboundHandler<>() {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-                if (evt == ServerHandshakeStateEvent.HANDSHAKE_COMPLETE) {
-                    serverReceivedHandshake = true;
-                    // immediately send a message to the client on connect
-                    ctx.writeAndFlush(new TextWebSocketFrame("abc"));
-                } else if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
+                if (evt instanceof WebSocketServerProtocolHandler.HandshakeComplete) {
                     serverHandshakeComplete = (WebSocketServerProtocolHandler.HandshakeComplete) evt;
                 }
             }
 
             @Override
-            protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
+            protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
             }
         });
 
-        EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<Object>() {
+        EmbeddedChannel clientChannel = createClientChannel(new SimpleChannelInboundHandler<>() {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
@@ -160,7 +154,7 @@ public class WebSocketHandshakeHandOverTest {
             }
 
             @Override
-            protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
+            protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
                 if (msg instanceof TextWebSocketFrame) {
                     clientReceivedMessage = true;
                 }
@@ -197,7 +191,7 @@ public class WebSocketHandshakeHandOverTest {
      * future is notified in such cases.
      */
     @Test
-    public void testHandshakeFutureIsNotifiedOnChannelClose() throws Exception {
+    public void testHandshakeFutureIsNotifiedOnChannelClose() {
         EmbeddedChannel clientChannel = createClientChannel(null);
         EmbeddedChannel serverChannel = createServerChannel(null);
 
@@ -235,22 +229,23 @@ public class WebSocketHandshakeHandOverTest {
 
         EmbeddedChannel serverChannel = createServerChannel(
                 new CloseNoOpServerProtocolHandler("/test"),
-                new SimpleChannelInboundHandler<Object>() {
+                new SimpleChannelInboundHandler<>() {
                     @Override
-                    protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
+                    protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
                     }
                 });
 
-        EmbeddedChannel clientChannel = createClientChannel(handshaker, new SimpleChannelInboundHandler<Object>() {
+        EmbeddedChannel clientChannel = createClientChannel(handshaker, new SimpleChannelInboundHandler<>() {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     ctx.channel().closeFuture().addListener(future -> clientForceClosed = true);
-                    handshaker.close(ctx.channel(), new CloseWebSocketFrame());
+                    handshaker.close(ctx.channel(), new CloseWebSocketFrame(ctx.bufferAllocator()));
                 }
             }
+
             @Override
-            protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
+            protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
             }
         });
 
@@ -287,20 +282,17 @@ public class WebSocketHandshakeHandOverTest {
      * @param dstChannel The destination channel
      */
     private static void transferAllDataWithMerge(EmbeddedChannel srcChannel, EmbeddedChannel dstChannel)  {
-        ByteBuf mergedBuffer = null;
+        Buffer mergedBuffer = null;
         for (;;) {
             Object srcData = srcChannel.readOutbound();
 
             if (srcData != null) {
-                assertTrue(srcData instanceof ByteBuf);
-                ByteBuf srcBuf = (ByteBuf) srcData;
-                try {
+                assertTrue(srcData instanceof Buffer);
+                try (Buffer srcBuf = (Buffer) srcData) {
                     if (mergedBuffer == null) {
-                        mergedBuffer = Unpooled.buffer();
+                        mergedBuffer = srcChannel.bufferAllocator().allocate(1024);
                     }
                     mergedBuffer.writeBytes(srcBuf);
-                } finally {
-                    srcBuf.release();
                 }
             } else {
                 break;
@@ -312,14 +304,14 @@ public class WebSocketHandshakeHandOverTest {
         }
     }
 
-    private static EmbeddedChannel createClientChannel(ChannelHandler handler) throws Exception {
+    private static EmbeddedChannel createClientChannel(ChannelHandler handler) {
         return createClientChannel(handler, WebSocketClientProtocolConfig.newBuilder()
             .webSocketUri("ws://localhost:1234/test")
             .subprotocol("test-proto-2")
             .build());
     }
 
-    private static EmbeddedChannel createClientChannel(ChannelHandler handler, long timeoutMillis) throws Exception {
+    private static EmbeddedChannel createClientChannel(ChannelHandler handler, long timeoutMillis) {
         return createClientChannel(handler, WebSocketClientProtocolConfig.newBuilder()
             .webSocketUri("ws://localhost:1234/test")
             .subprotocol("test-proto-2")
@@ -330,16 +322,16 @@ public class WebSocketHandshakeHandOverTest {
     private static EmbeddedChannel createClientChannel(ChannelHandler handler, WebSocketClientProtocolConfig config) {
         return new EmbeddedChannel(
                 new HttpClientCodec(),
-                new HttpObjectAggregator(8192),
+                new HttpObjectAggregator<DefaultHttpContent>(8192),
                 new WebSocketClientProtocolHandler(config),
                 handler);
     }
 
     private static EmbeddedChannel createClientChannel(WebSocketClientHandshaker handshaker,
-                                                       ChannelHandler handler) throws Exception {
+                                                       ChannelHandler handler) {
         return new EmbeddedChannel(
                 new HttpClientCodec(),
-                new HttpObjectAggregator(8192),
+                new HttpObjectAggregator<DefaultHttpContent>(8192),
                 // Note that we're switching off close frames handling on purpose to test forced close on timeout.
                 new WebSocketClientProtocolHandler(handshaker, false, false),
                 handler);
@@ -355,7 +347,7 @@ public class WebSocketHandshakeHandOverTest {
                                                        ChannelHandler handler) {
         return new EmbeddedChannel(
                 new HttpServerCodec(),
-                new HttpObjectAggregator(8192),
+                new HttpObjectAggregator<DefaultHttpContent>(8192),
                 webSocketHandler,
                 handler);
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -240,7 +240,8 @@ public class WebSocketHandshakeHandOverTest {
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     ctx.channel().closeFuture().addListener(future -> clientForceClosed = true);
-                    handshaker.close(ctx.channel(), new CloseWebSocketFrame(ctx.bufferAllocator()));
+                    handshaker.close(ctx.channel(), new CloseWebSocketFrame(
+                            true, 0, ctx.bufferAllocator().allocate(0)));
                 }
             }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
@@ -120,7 +120,7 @@ public class WebSocketProtocolHandlerTest {
     public void testPongFrameDropFrameFalse() {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler(false) { });
 
-        PongWebSocketFrame pingResponse = new PongWebSocketFrame(channel.bufferAllocator());
+        PongWebSocketFrame pingResponse = new PongWebSocketFrame(true, 0, DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertTrue(channel.writeInbound(pingResponse));
 
         assertPropagatedInbound(pingResponse, channel);
@@ -133,7 +133,7 @@ public class WebSocketProtocolHandlerTest {
     public void testPongFrameDropFrameTrue() {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler(true) { });
 
-        PongWebSocketFrame pingResponse = new PongWebSocketFrame(channel.bufferAllocator());
+        PongWebSocketFrame pingResponse = new PongWebSocketFrame(true, 0, DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertFalse(channel.writeInbound(pingResponse)); // message was not propagated inbound
     }
 
@@ -141,7 +141,7 @@ public class WebSocketProtocolHandlerTest {
     public void testTextFrame() {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler() { });
 
-        TextWebSocketFrame textFrame = new TextWebSocketFrame(channel.bufferAllocator());
+        TextWebSocketFrame textFrame = new TextWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertTrue(channel.writeInbound(textFrame));
 
         assertPropagatedInbound(textFrame, channel);
@@ -165,7 +165,8 @@ public class WebSocketProtocolHandlerTest {
             }
         }, handler);
 
-        Future<Void> future = channel.writeAndFlush(new CloseWebSocketFrame(channel.bufferAllocator()));
+        Future<Void> future = channel.writeAndFlush(new CloseWebSocketFrame(
+                true, 0, channel.bufferAllocator().allocate(0)));
         ChannelHandlerContext ctx = channel.pipeline().context(WebSocketProtocolHandler.class);
         handler.close(ctx);
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http.websocketx;
 
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -24,7 +25,6 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.api.DefaultGlobalBufferAllocator.DEFAULT_GLOBAL_BUFFER_ALLOCATOR;
@@ -88,7 +88,6 @@ public abstract class WebSocketServerHandshakerTest {
         }
     }
 
-    @Disabled("buffer migration")
     @Test
     public void testWebSocketServerHandshakeException() {
         WebSocketServerHandshaker serverHandshaker = newHandshaker("ws://example.com/chat",
@@ -99,7 +98,7 @@ public abstract class WebSocketServerHandshakerTest {
                 DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         request.headers().set("x-client-header", "value");
         try {
-            serverHandshaker.handshake(null, request, null);
+            serverHandshaker.handshake(new EmbeddedChannel(), request, null);
         } catch (WebSocketServerHandshakeException exception) {
             assertNotNull(exception.getMessage());
             assertEquals(request.headers(), exception.request().headers());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtf8FrameValidatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtf8FrameValidatorTest.java
@@ -16,12 +16,10 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CorruptedFrameException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -42,7 +40,7 @@ public class WebSocketUtf8FrameValidatorTest {
 
     private void assertCorruptedFrameExceptionHandling(byte[] data) {
         EmbeddedChannel channel = new EmbeddedChannel(new Utf8FrameValidator());
-        TextWebSocketFrame frame = new TextWebSocketFrame(Unpooled.copiedBuffer(data));
+        TextWebSocketFrame frame = new TextWebSocketFrame(channel.bufferAllocator().copyOf(data));
         try {
             channel.writeInbound(frame);
             fail();
@@ -58,6 +56,6 @@ public class WebSocketUtf8FrameValidatorTest {
             buf.release();
         }
         assertNull(channel.readOutbound());
-        assertEquals(0, frame.refCnt());
+        assertFalse(frame.isAccessible());
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionFilterTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionFilterTest.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import org.junit.jupiter.api.Test;
 
+import static io.netty.buffer.api.DefaultGlobalBufferAllocator.DEFAULT_GLOBAL_BUFFER_ALLOCATOR;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,57 +33,69 @@ public class WebSocketExtensionFilterTest {
     public void testNeverSkip() {
         WebSocketExtensionFilter neverSkip = WebSocketExtensionFilter.NEVER_SKIP;
 
-        BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame();
+        BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertFalse(neverSkip.mustSkip(binaryFrame));
-        assertTrue(binaryFrame.release());
+        assertTrue(binaryFrame.isAccessible());
+        binaryFrame.close();
 
-        TextWebSocketFrame textFrame = new TextWebSocketFrame();
+        TextWebSocketFrame textFrame = new TextWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertFalse(neverSkip.mustSkip(textFrame));
-        assertTrue(textFrame.release());
+        assertTrue(textFrame.isAccessible());
+        textFrame.close();
 
-        PingWebSocketFrame pingFrame = new PingWebSocketFrame();
+        PingWebSocketFrame pingFrame = new PingWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertFalse(neverSkip.mustSkip(pingFrame));
-        assertTrue(pingFrame.release());
+        assertTrue(pingFrame.isAccessible());
+        pingFrame.close();
 
-        PongWebSocketFrame pongFrame = new PongWebSocketFrame();
+        PongWebSocketFrame pongFrame = new PongWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertFalse(neverSkip.mustSkip(pongFrame));
-        assertTrue(pongFrame.release());
+        assertTrue(pongFrame.isAccessible());
+        pongFrame.close();
 
-        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame();
+        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertFalse(neverSkip.mustSkip(closeFrame));
-        assertTrue(closeFrame.release());
+        assertTrue(closeFrame.isAccessible());
+        closeFrame.close();
 
-        ContinuationWebSocketFrame continuationFrame = new ContinuationWebSocketFrame();
+        ContinuationWebSocketFrame continuationFrame = new ContinuationWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertFalse(neverSkip.mustSkip(continuationFrame));
-        assertTrue(continuationFrame.release());
+        assertTrue(continuationFrame.isAccessible());
+        continuationFrame.close();
     }
 
     @Test
     public void testAlwaysSkip() {
         WebSocketExtensionFilter neverSkip = WebSocketExtensionFilter.ALWAYS_SKIP;
 
-        BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame();
+        BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertTrue(neverSkip.mustSkip(binaryFrame));
-        assertTrue(binaryFrame.release());
+        assertTrue(binaryFrame.isAccessible());
+        binaryFrame.close();
 
-        TextWebSocketFrame textFrame = new TextWebSocketFrame();
+        TextWebSocketFrame textFrame = new TextWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertTrue(neverSkip.mustSkip(textFrame));
-        assertTrue(textFrame.release());
+        assertTrue(textFrame.isAccessible());
+        textFrame.close();
 
-        PingWebSocketFrame pingFrame = new PingWebSocketFrame();
+        PingWebSocketFrame pingFrame = new PingWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertTrue(neverSkip.mustSkip(pingFrame));
-        assertTrue(pingFrame.release());
+        assertTrue(pingFrame.isAccessible());
+        pingFrame.close();
 
-        PongWebSocketFrame pongFrame = new PongWebSocketFrame();
+        PongWebSocketFrame pongFrame = new PongWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertTrue(neverSkip.mustSkip(pongFrame));
-        assertTrue(pongFrame.release());
+        assertTrue(pongFrame.isAccessible());
+        pongFrame.close();
 
-        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame();
+        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertTrue(neverSkip.mustSkip(closeFrame));
-        assertTrue(closeFrame.release());
+        assertTrue(closeFrame.isAccessible());
+        closeFrame.close();
 
-        ContinuationWebSocketFrame continuationFrame = new ContinuationWebSocketFrame();
+        ContinuationWebSocketFrame continuationFrame = new ContinuationWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
         assertTrue(neverSkip.mustSkip(continuationFrame));
-        assertTrue(continuationFrame.release());
+        assertTrue(continuationFrame.isAccessible());
+        continuationFrame.close();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionFilterTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionFilterTest.java
@@ -33,32 +33,33 @@ public class WebSocketExtensionFilterTest {
     public void testNeverSkip() {
         WebSocketExtensionFilter neverSkip = WebSocketExtensionFilter.NEVER_SKIP;
 
-        BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertFalse(neverSkip.mustSkip(binaryFrame));
         assertTrue(binaryFrame.isAccessible());
         binaryFrame.close();
 
-        TextWebSocketFrame textFrame = new TextWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        TextWebSocketFrame textFrame = new TextWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertFalse(neverSkip.mustSkip(textFrame));
         assertTrue(textFrame.isAccessible());
         textFrame.close();
 
-        PingWebSocketFrame pingFrame = new PingWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        PingWebSocketFrame pingFrame = new PingWebSocketFrame(true, 0, DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertFalse(neverSkip.mustSkip(pingFrame));
         assertTrue(pingFrame.isAccessible());
         pingFrame.close();
 
-        PongWebSocketFrame pongFrame = new PongWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        PongWebSocketFrame pongFrame = new PongWebSocketFrame(true, 0, DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertFalse(neverSkip.mustSkip(pongFrame));
         assertTrue(pongFrame.isAccessible());
         pongFrame.close();
 
-        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(true, 0, DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertFalse(neverSkip.mustSkip(closeFrame));
         assertTrue(closeFrame.isAccessible());
         closeFrame.close();
 
-        ContinuationWebSocketFrame continuationFrame = new ContinuationWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        ContinuationWebSocketFrame continuationFrame = new ContinuationWebSocketFrame(
+                DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertFalse(neverSkip.mustSkip(continuationFrame));
         assertTrue(continuationFrame.isAccessible());
         continuationFrame.close();
@@ -68,32 +69,33 @@ public class WebSocketExtensionFilterTest {
     public void testAlwaysSkip() {
         WebSocketExtensionFilter neverSkip = WebSocketExtensionFilter.ALWAYS_SKIP;
 
-        BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertTrue(neverSkip.mustSkip(binaryFrame));
         assertTrue(binaryFrame.isAccessible());
         binaryFrame.close();
 
-        TextWebSocketFrame textFrame = new TextWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        TextWebSocketFrame textFrame = new TextWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertTrue(neverSkip.mustSkip(textFrame));
         assertTrue(textFrame.isAccessible());
         textFrame.close();
 
-        PingWebSocketFrame pingFrame = new PingWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        PingWebSocketFrame pingFrame = new PingWebSocketFrame(true, 0, DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertTrue(neverSkip.mustSkip(pingFrame));
         assertTrue(pingFrame.isAccessible());
         pingFrame.close();
 
-        PongWebSocketFrame pongFrame = new PongWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        PongWebSocketFrame pongFrame = new PongWebSocketFrame(true, 0, DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertTrue(neverSkip.mustSkip(pongFrame));
         assertTrue(pongFrame.isAccessible());
         pongFrame.close();
 
-        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(true, 0, DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertTrue(neverSkip.mustSkip(closeFrame));
         assertTrue(closeFrame.isAccessible());
         closeFrame.close();
 
-        ContinuationWebSocketFrame continuationFrame = new ContinuationWebSocketFrame(DEFAULT_GLOBAL_BUFFER_ALLOCATOR);
+        ContinuationWebSocketFrame continuationFrame = new ContinuationWebSocketFrame(
+                DEFAULT_GLOBAL_BUFFER_ALLOCATOR.allocate(0));
         assertTrue(neverSkip.mustSkip(continuationFrame));
         assertTrue(continuationFrame.isAccessible());
         continuationFrame.close();

--- a/codec/src/main/java/io/netty/handler/codec/BufferToByteBufHandler.java
+++ b/codec/src/main/java/io/netty/handler/codec/BufferToByteBufHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a

--- a/codec/src/main/java/io/netty/handler/codec/BufferToByteBufHandler.java
+++ b/codec/src/main/java/io/netty/handler/codec/BufferToByteBufHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.api.Buffer;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.util.concurrent.Future;
+
+import static io.netty.buffer.api.adaptor.ByteBufAdaptor.intoByteBuf;
+
+/**
+ * A {@link ChannelHandler} that converts {@link ByteBuf} read or written from/to a {@link ChannelPipeline} to a
+ * {@link Buffer}.
+ */
+public final class BufferToByteBufHandler extends ChannelHandlerAdapter {
+    public static final ChannelHandler BUFFER_TO_BYTEBUF_HANDLER = new BufferToByteBufHandler();
+
+    private BufferToByteBufHandler() {
+        // singleton
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof Buffer) {
+            msg = intoByteBuf((Buffer) msg);
+        }
+
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+        if (!(msg instanceof Buffer)) {
+            return ctx.write(msg);
+        }
+        return ctx.write(intoByteBuf((Buffer) msg));
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+}

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
@@ -112,24 +112,25 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
     }
 
     private void handleWebSocketFrame(ChannelHandlerContext ctx, WebSocketFrame frame) {
-
         // Check for closing frame
-        if (frame instanceof CloseWebSocketFrame) {
-            handshaker.close(ctx, (CloseWebSocketFrame) frame.retain());
-            return;
-        }
-        if (frame instanceof PingWebSocketFrame) {
-            ctx.write(new PongWebSocketFrame(frame.content().retain()));
-            return;
-        }
-        if (frame instanceof TextWebSocketFrame) {
-            // Echo the frame
-            ctx.write(frame.retain());
-            return;
-        }
-        if (frame instanceof BinaryWebSocketFrame) {
-            // Echo the frame
-            ctx.write(frame.retain());
+        try (frame) {
+            if (frame instanceof CloseWebSocketFrame) {
+                handshaker.close(ctx, (CloseWebSocketFrame) frame.send().receive());
+                return;
+            }
+            if (frame instanceof PingWebSocketFrame) {
+                ctx.write(new PongWebSocketFrame(frame.binaryData().send()));
+                return;
+            }
+            if (frame instanceof TextWebSocketFrame) {
+                // Echo the frame
+                ctx.write(frame.send().receive());
+                return;
+            }
+            if (frame instanceof BinaryWebSocketFrame) {
+                // Echo the frame
+                ctx.write(frame.send().receive());
+            }
         }
     }
 

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -16,7 +16,6 @@
 package io.netty.example.http.websocketx.client;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
@@ -25,6 +24,7 @@ import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.nio.NioHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
@@ -113,7 +113,7 @@ public final class WebSocketClient {
                      }
                      p.addLast(
                              new HttpClientCodec(),
-                             new HttpObjectAggregator(8192),
+                             new HttpObjectAggregator<DefaultHttpContent>(8192),
                              WebSocketClientCompressionHandler.INSTANCE,
                              handler);
                  }
@@ -128,14 +128,15 @@ public final class WebSocketClient {
                 if (msg == null) {
                     break;
                 } else if ("bye".equalsIgnoreCase(msg)) {
-                    ch.writeAndFlush(new CloseWebSocketFrame());
+                    ch.writeAndFlush(new CloseWebSocketFrame(ch.bufferAllocator()));
                     ch.closeFuture().sync();
                     break;
                 } else if ("ping".equalsIgnoreCase(msg)) {
-                    WebSocketFrame frame = new PingWebSocketFrame(Unpooled.wrappedBuffer(new byte[] { 8, 1, 8, 1 }));
+                    WebSocketFrame frame =
+                            new PingWebSocketFrame(ch.bufferAllocator().copyOf(new byte[] { 8, 1, 8, 1 }));
                     ch.writeAndFlush(frame);
                 } else {
-                    WebSocketFrame frame = new TextWebSocketFrame(msg);
+                    WebSocketFrame frame = new TextWebSocketFrame(ch.bufferAllocator(), msg);
                     ch.writeAndFlush(frame);
                 }
             }

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -128,7 +128,7 @@ public final class WebSocketClient {
                 if (msg == null) {
                     break;
                 } else if ("bye".equalsIgnoreCase(msg)) {
-                    ch.writeAndFlush(new CloseWebSocketFrame(ch.bufferAllocator()));
+                    ch.writeAndFlush(new CloseWebSocketFrame(true, 0, ch.bufferAllocator().allocate(0)));
                     ch.closeFuture().sync();
                     break;
                 } else if ("ping".equalsIgnoreCase(msg)) {

--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketFrameHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketFrameHandler.java
@@ -34,7 +34,7 @@ public class WebSocketFrameHandler extends SimpleChannelInboundHandler<WebSocket
         if (frame instanceof TextWebSocketFrame) {
             // Send the uppercase string back.
             String request = ((TextWebSocketFrame) frame).text();
-            ctx.channel().writeAndFlush(new TextWebSocketFrame(request.toUpperCase(Locale.US)));
+            ctx.channel().writeAndFlush(new TextWebSocketFrame(ctx.bufferAllocator(), request.toUpperCase(Locale.US)));
         } else {
             String message = "unsupported frame type: " + frame.getClass().getName();
             throw new UnsupportedOperationException(message);

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -84,7 +84,6 @@
           </cases>
           <excludeCases />
           <failOnNonStrict>false</failOnNonStrict>
-          <!-- Disable: buffer migration -->
           <skip>true</skip>
         </configuration>
         <executions>

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerHandler.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerHandler.java
@@ -104,13 +104,13 @@ public class AutobahnServerHandler implements ChannelHandler {
         if (frame instanceof CloseWebSocketFrame) {
             handshaker.close(ctx, (CloseWebSocketFrame) frame);
         } else if (frame instanceof PingWebSocketFrame) {
-            ctx.write(new PongWebSocketFrame(frame.isFinalFragment(), frame.rsv(), frame.content()));
+            ctx.write(new PongWebSocketFrame(frame.isFinalFragment(), frame.rsv(), frame.binaryData()));
         } else if (frame instanceof TextWebSocketFrame ||
                 frame instanceof BinaryWebSocketFrame ||
                 frame instanceof ContinuationWebSocketFrame) {
             ctx.write(frame);
         } else if (frame instanceof PongWebSocketFrame) {
-            frame.release();
+            frame.close();
             // Ignore
         } else {
             throw new UnsupportedOperationException(String.format("%s frame types not supported", frame.getClass()


### PR DESCRIPTION
__Motivation__

`ByteBuf` APIs are deprecated in favor of `Buffer`.

__Modification__

- Migrated all usages (apart from internal compression API interaction) from `ByteBuf` to `Buffer`

__Result__

Deprecated API usage is reduced.