### PR TITLE
Make CharSeqValueConverter.convertToMillis throw DateTimeParseException

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/ReadOnlyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ReadOnlyHttpHeaders.java
@@ -118,13 +118,27 @@ public final class ReadOnlyHttpHeaders extends HttpHeaders {
     @Override
     public Long getTimeMillis(CharSequence name) {
         CharSequence value = get0(name);
-        return value == null ? null : INSTANCE.convertToTimeMillis(value);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return INSTANCE.convertToTimeMillis(value);
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     @Override
     public long getTimeMillis(CharSequence name, long defaultValue) {
         CharSequence value = get0(name);
-        return value == null ? defaultValue : INSTANCE.convertToTimeMillis(value);
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return INSTANCE.convertToTimeMillis(value);
+        } catch (RuntimeException e) {
+            return defaultValue;
+        }
     }
 
     @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/ReadOnlyHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/ReadOnlyHttpHeadersTest.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
+import static io.netty.handler.codec.http.HttpHeaderNames.AGE;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderValues.APPLICATION_JSON;
@@ -130,6 +131,12 @@ public class ReadOnlyHttpHeadersTest {
     public void headerWithoutValue() {
         assertThrows(IllegalArgumentException.class, () -> new ReadOnlyHttpHeaders(false,
                                 ACCEPT, APPLICATION_JSON, CONTENT_LENGTH));
+    }
+
+    @Test
+    public void validateDateTimeFail() {
+        ReadOnlyHttpHeaders headers = new ReadOnlyHttpHeaders(false, AGE, "not a date");
+        assertNull(headers.getTimeMillis(AGE));
     }
 
     private static void assert3ParisEquals(Iterator<Entry<String, String>> itr) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -28,10 +28,11 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import static io.netty.handler.codec.CharSequenceValueConverter.*;
-import static io.netty.handler.codec.http2.DefaultHttp2Headers.*;
-import static io.netty.util.AsciiString.*;
-import static io.netty.util.internal.EmptyArrays.*;
+import static io.netty.handler.codec.CharSequenceValueConverter.INSTANCE;
+import static io.netty.handler.codec.http2.DefaultHttp2Headers.HTTP2_NAME_VALIDATOR;
+import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
+import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
+import static io.netty.util.internal.EmptyArrays.EMPTY_ASCII_STRINGS;
 import static io.netty.util.internal.ObjectUtil.checkNotNullArrayParam;
 
 /**
@@ -321,7 +322,14 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
     @Override
     public Long getTimeMillis(CharSequence name) {
         AsciiString value = get0(name);
-        return value != null ? INSTANCE.convertToTimeMillis(value) : null;
+        if (value != null) {
+            try {
+                return INSTANCE.convertToTimeMillis(value);
+            } catch (RuntimeException e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.handler.codec.CharSequenceValueConverter;
 import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -23,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import static io.netty.handler.codec.http2.DefaultHttp2HeadersTest.*;
+import static io.netty.handler.codec.http2.DefaultHttp2HeadersTest.verifyPseudoHeadersFirst;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -212,6 +213,15 @@ public class ReadOnlyHttp2HeadersTest {
                    headers.get(Http2Headers.PseudoHeaderName.PATH.value())));
         assertNull(headers.get(Http2Headers.PseudoHeaderName.STATUS.value()));
         assertNull(headers.get("a missing header"));
+
+        headers = ReadOnlyHttp2Headers.clientHeaders(
+                false, new AsciiString("meth"), new AsciiString("/foo"),
+                new AsciiString("schemer"), new AsciiString("respect_my_authority"),
+                new AsciiString("age"), new AsciiString(CharSequenceValueConverter.INSTANCE.convertTimeMillis(1000)),
+                new AsciiString("not-a-date"), new AsciiString("not a date"));
+        assertNull(headers.getTimeMillis("not-a-date"));
+        assertEquals(-1L, headers.getTimeMillis("not-a-date", -1));
+        assertEquals(1000L, headers.getTimeMillis("age", -1));
     }
 
     @Test

--- a/codec/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
+++ b/codec/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
@@ -15,9 +15,8 @@
 package io.netty.handler.codec;
 
 import io.netty.util.AsciiString;
-import io.netty.util.internal.PlatformDependent;
 
-import java.text.ParseException;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 /**
@@ -126,8 +125,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
     public long convertToTimeMillis(CharSequence value) {
         Date date = DateFormatter.parseHttpDate(value);
         if (date == null) {
-            PlatformDependent.throwException(new ParseException("header can't be parsed into a Date: " + value, 0));
-            return 0;
+            throw new DateTimeParseException("header can't be parsed into a Date: " + value, value, 0);
         }
         return date.getTime();
     }

--- a/codec/src/main/java/io/netty/handler/codec/ValueConverter.java
+++ b/codec/src/main/java/io/netty/handler/codec/ValueConverter.java
@@ -11,7 +11,8 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- */package io.netty.handler.codec;
+ */
+package io.netty.handler.codec;
 
 /**
  * Converts to/from a generic object to the type.

--- a/codec/src/test/java/io/netty/handler/codec/CharSequenceValueConverterTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/CharSequenceValueConverterTest.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec;
 import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
 
+import java.time.format.DateTimeParseException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -80,7 +82,8 @@ public class CharSequenceValueConverterTest {
     @Test
     public void testTimeMillis() {
         // Zero out the millis as this is what the convert is doing as well.
-        long millis = (System.currentTimeMillis() / 1000) * 1000;
+        long millis = System.currentTimeMillis() / 1000 * 1000;
         assertEquals(millis, converter.convertToTimeMillis(converter.convertTimeMillis(millis)));
+        assertThrows(DateTimeParseException.class, () -> converter.convertToTimeMillis("not a date"));
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -257,6 +257,8 @@ public class DefaultHeadersTest {
         assertTrue(headers.containsTimeMillis(of("millis"), millis));
         // This test doesn't work on midnight, January 1, 1970 UTC
         assertFalse(headers.containsTimeMillis(of("millis"), 0));
+        headers.add(of("not a date"), "not a date");
+        assertNull(headers.getTimeMillis(of("not a date")));
 
         headers.addObject(of("object"), "Hello World");
         assertTrue(headers.containsObject(of("object"), "Hello World"));
@@ -494,9 +496,7 @@ public class DefaultHeadersTest {
         headers.add(of("name2"), of("value4"));
         assertEquals(4, headers.size());
 
-        Iterator<Entry<CharSequence, CharSequence>> iter = headers.iterator();
-        while (iter.hasNext()) {
-            Entry<CharSequence, CharSequence> header = iter.next();
+        for (Entry<CharSequence, CharSequence> header : headers) {
             if (of("name1").equals(header.getKey()) && of("value2").equals(header.getValue())) {
                 header.setValue(of("updatedvalue2"));
                 assertEquals(of("updatedvalue2"), header.getValue());
@@ -790,7 +790,7 @@ public class DefaultHeadersTest {
         List<CharSequence> cookies = headers.getAll("Cookie");
 
         assertThat(cookies, hasSize(3));
-        assertThat(cookies, containsInAnyOrder((CharSequence) "a=b", "c=d", "e=f"));
+        assertThat(cookies, containsInAnyOrder("a=b", "c=d", "e=f"));
     }
 
     /**


### PR DESCRIPTION
Motivation:
The `convertToTimeMillis` method was using `PlatformDependent.throwException` to throw a checked exception that the method did not declare.
We should avoid doing that, and use proper exceptions instead.

Modification:
Make `convertToTimeMillis` throw the runtime `DateTimeParseException` instead.
As a kind of `RuntimeException`, we do not need to declare this exception, yet we can throw it.
Also update and add to the test coverage of this method.
Direct usages of this method have also been updated and more thoroughly tested.

Result:
One fewer places where we throw undeclared checked exceptions.
