### PR TITLE
Allow overwrite notifyConnect method

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -204,7 +204,7 @@ public class SimpleChannelPool implements ChannelPool {
         return promise;
     }
 
-    private void notifyConnect(ChannelFuture future, Promise<Channel> promise) {
+    protected void notifyConnect(ChannelFuture future, Promise<Channel> promise) {
         Channel channel = null;
         try {
             if (future.isSuccess()) {


### PR DESCRIPTION
Motivation:

Infinispan trySuccess in the promise only when the listener is called. The current Netty code doesn't allow overwritten this behavior

Modification:

Expose notifyConnect method

Result:

Projects that are using the Netty Channel Pool can implement custom code during notifyConnect