### PR TITLE
Rewrite and simplify Recycler

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty.util;
 
 import io.netty.util.concurrent.FastThreadLocal;
@@ -22,16 +21,11 @@ import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.lang.ref.WeakReference;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.WeakHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.ArrayDeque;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.netty.util.internal.MathUtil.safeFindNextPositivePowerOfTwo;
 import static java.lang.Math.max;
-import static java.lang.Math.min;
 
 /**
  * Light-weight object pool based on a thread-local stack.
@@ -39,21 +33,15 @@ import static java.lang.Math.min;
  * @param <T> the type of the pooled object
  */
 public abstract class Recycler<T> {
-
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Recycler.class);
-
-    @SuppressWarnings("rawtypes")
-    private static final Handle NOOP_HANDLE = new Handle() {
+    private static final Handle<?> NOOP_HANDLE = new Handle<Object>() {
         @Override
         public void recycle(Object object) {
             // NOOP
         }
     };
-    private static final AtomicInteger ID_GENERATOR = new AtomicInteger(Integer.MIN_VALUE);
-    private static final int OWN_THREAD_ID = ID_GENERATOR.getAndIncrement();
     private static final int DEFAULT_INITIAL_MAX_CAPACITY_PER_THREAD = 4 * 1024; // Use 4k instances as default.
     private static final int DEFAULT_MAX_CAPACITY_PER_THREAD;
-    private static final int INITIAL_CAPACITY;
     private static final int MAX_SHARED_CAPACITY_FACTOR;
     private static final int MAX_DELAYED_QUEUES_PER_THREAD;
     private static final int LINK_CAPACITY;
@@ -90,8 +78,6 @@ public abstract class Recycler<T> {
         RATIO = max(0, SystemPropertyUtil.getInt("io.netty.recycler.ratio", 8));
         DELAYED_QUEUE_RATIO = max(0, SystemPropertyUtil.getInt("io.netty.recycler.delayedQueue.ratio", RATIO));
 
-        INITIAL_CAPACITY = min(DEFAULT_MAX_CAPACITY_PER_THREAD, 256);
-
         if (logger.isDebugEnabled()) {
             if (DEFAULT_MAX_CAPACITY_PER_THREAD == 0) {
                 logger.debug("-Dio.netty.recycler.maxCapacityPerThread: disabled");
@@ -110,26 +96,11 @@ public abstract class Recycler<T> {
     }
 
     private final int maxCapacityPerThread;
-    private final int maxSharedCapacityFactor;
     private final int interval;
-    private final int maxDelayedQueuesPerThread;
-    private final int delayedQueueInterval;
-
-    private final FastThreadLocal<Stack<T>> threadLocal = new FastThreadLocal<Stack<T>>() {
+    private final FastThreadLocal<LocalPool<T>> threadLocal = new FastThreadLocal<LocalPool<T>>() {
         @Override
-        protected Stack<T> initialValue() {
-            return new Stack<T>(Recycler.this, Thread.currentThread(), maxCapacityPerThread, maxSharedCapacityFactor,
-                    interval, maxDelayedQueuesPerThread, delayedQueueInterval);
-        }
-
-        @Override
-        protected void onRemoval(Stack<T> value) {
-            // Let us remove the WeakOrderQueue from the WeakHashMap directly if its safe to remove some overhead
-            if (value.threadRef.get() == Thread.currentThread()) {
-               if (DELAYED_RECYCLED.isSet()) {
-                   DELAYED_RECYCLED.get().remove(value);
-               }
-            }
+        protected LocalPool<T> initialValue() {
+            return new LocalPool<T>(Recycler.this, maxCapacityPerThread, interval);
         }
     };
 
@@ -151,19 +122,11 @@ public abstract class Recycler<T> {
                 DELAYED_QUEUE_RATIO);
     }
 
+    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
     protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
                        int ratio, int maxDelayedQueuesPerThread, int delayedQueueRatio) {
         interval = max(0, ratio);
-        delayedQueueInterval = max(0, delayedQueueRatio);
-        if (maxCapacityPerThread <= 0) {
-            this.maxCapacityPerThread = 0;
-            this.maxSharedCapacityFactor = 1;
-            this.maxDelayedQueuesPerThread = 0;
-        } else {
-            this.maxCapacityPerThread = maxCapacityPerThread;
-            this.maxSharedCapacityFactor = max(1, maxSharedCapacityFactor);
-            this.maxDelayedQueuesPerThread = max(0, maxDelayedQueuesPerThread);
-        }
+        this.maxCapacityPerThread = max(0, maxCapacityPerThread);
     }
 
     @SuppressWarnings("unchecked")
@@ -171,13 +134,22 @@ public abstract class Recycler<T> {
         if (maxCapacityPerThread == 0) {
             return newObject((Handle<T>) NOOP_HANDLE);
         }
-        Stack<T> stack = threadLocal.get();
-        DefaultHandle<T> handle = stack.pop();
+        LocalPool<T> localPool = threadLocal.get();
+        DefaultHandle<T> handle = localPool.claim();
+        T obj;
         if (handle == null) {
-            handle = stack.newHandle();
-            handle.value = newObject(handle);
+            handle = localPool.newHandle();
+            if (handle != null) {
+                obj = newObject(handle);
+                handle.set(obj);
+            } else {
+                obj = newObject((Handle<T>) NOOP_HANDLE);
+            }
+        } else {
+            obj = handle.get();
         }
-        return (T) handle.value;
+
+        return obj;
     }
 
     /**
@@ -190,7 +162,7 @@ public abstract class Recycler<T> {
         }
 
         DefaultHandle<T> h = (DefaultHandle<T>) handle;
-        if (h.stack.parent != this) {
+        if (h.recycler != this) {
             return false;
         }
 
@@ -198,37 +170,43 @@ public abstract class Recycler<T> {
         return true;
     }
 
-    final int threadLocalCapacity() {
-        return threadLocal.get().elements.length;
+    void release(DefaultHandle<T> handle, LocalPool<T> sourceLocalPool) {
+        LocalPool<T> currentLocalPool = threadLocal.get();
+        if (currentLocalPool == sourceLocalPool) {
+            sourceLocalPool.release(handle);
+        } else {
+            sourceLocalPool.releaseExternal(handle);
+        }
     }
 
     final int threadLocalSize() {
-        return threadLocal.get().size;
+        return threadLocal.get().pooledHandles.size();
     }
 
     protected abstract T newObject(Handle<T> handle);
 
+    @SuppressWarnings("ClassNameSameAsAncestorName") // Can't change this due to compatibility.
     public interface Handle<T> extends ObjectPool.Handle<T>  { }
 
-    @SuppressWarnings("unchecked")
     private static final class DefaultHandle<T> implements Handle<T> {
-        private static final AtomicIntegerFieldUpdater<DefaultHandle<?>> LAST_RECYCLED_ID_UPDATER;
+        private static final int STATE_CLAIMED = 0;
+        private static final int STATE_AVAILABLE = 1;
+        private static final AtomicIntegerFieldUpdater<DefaultHandle<?>> STATE_UPDATER;
         static {
-            AtomicIntegerFieldUpdater<?> updater = AtomicIntegerFieldUpdater.newUpdater(
-                    DefaultHandle.class, "lastRecycledId");
-            LAST_RECYCLED_ID_UPDATER = (AtomicIntegerFieldUpdater<DefaultHandle<?>>) updater;
+            AtomicIntegerFieldUpdater<?> updater = AtomicIntegerFieldUpdater.newUpdater(DefaultHandle.class, "state");
+            //noinspection unchecked
+            STATE_UPDATER = (AtomicIntegerFieldUpdater<DefaultHandle<?>>) updater;
         }
 
-        volatile int lastRecycledId;
-        int recycleId;
+        @SuppressWarnings({"FieldMayBeFinal", "unused"}) // Updated by STATE_UPDATER.
+        private volatile int state; // State is initialised to STATE_CLAIMED (aka. 0) so they can be released.
+        private final Recycler<T> recycler;
+        private final LocalPool<T> localPool;
+        private T value;
 
-        boolean hasBeenRecycled;
-
-        Stack<?> stack;
-        Object value;
-
-        DefaultHandle(Stack<?> stack) {
-            this.stack = stack;
+        DefaultHandle(Recycler<T> recycler, LocalPool<T> localPool) {
+            this.recycler = recycler;
+            this.localPool = localPool;
         }
 
         @Override
@@ -236,511 +214,97 @@ public abstract class Recycler<T> {
             if (object != value) {
                 throw new IllegalArgumentException("object does not belong to handle");
             }
-
-            Stack<?> stack = this.stack;
-            if (lastRecycledId != recycleId || stack == null) {
-                throw new IllegalStateException("recycled already");
-            }
-
-            stack.push(this);
+            recycler.release(this, localPool);
         }
 
-        public boolean compareAndSetLastRecycledId(int expectLastRecycledId, int updateLastRecycledId) {
-            // Use "weak…" because we do not need synchronize-with ordering, only atomicity.
-            // Also, spurious failures are fine, since no code should rely on recycling for correctness.
-            return LAST_RECYCLED_ID_UPDATER.weakCompareAndSet(this, expectLastRecycledId, updateLastRecycledId);
-        }
-    }
-
-    private static final FastThreadLocal<Map<Stack<?>, WeakOrderQueue>> DELAYED_RECYCLED =
-            new FastThreadLocal<Map<Stack<?>, WeakOrderQueue>>() {
-        @Override
-        protected Map<Stack<?>, WeakOrderQueue> initialValue() {
-            return new WeakHashMap<Stack<?>, WeakOrderQueue>();
-        }
-    };
-
-    // a queue that makes only moderate guarantees about visibility: items are seen in the correct order,
-    // but we aren't absolutely guaranteed to ever see anything at all, thereby keeping the queue cheap to maintain
-    private static final class WeakOrderQueue extends WeakReference<Thread> {
-
-        static final WeakOrderQueue DUMMY = new WeakOrderQueue();
-
-        // Let Link extend AtomicInteger for intrinsics. The Link itself will be used as writerIndex.
-        @SuppressWarnings("serial")
-        static final class Link extends AtomicInteger {
-            final DefaultHandle<?>[] elements = new DefaultHandle[LINK_CAPACITY];
-
-            int readIndex;
-            Link next;
+        T get() {
+            return value;
         }
 
-        // Its important this does not hold any reference to either Stack or WeakOrderQueue.
-        private static final class Head {
-            private final AtomicInteger availableSharedCapacity;
-
-            Link link;
-
-            Head(AtomicInteger availableSharedCapacity) {
-                this.availableSharedCapacity = availableSharedCapacity;
-            }
-
-            /**
-             * Reclaim all used space and also unlink the nodes to prevent GC nepotism.
-             */
-            void reclaimAllSpaceAndUnlink() {
-                Link head = link;
-                link = null;
-                int reclaimSpace = 0;
-                while (head != null) {
-                    reclaimSpace += LINK_CAPACITY;
-                    Link next = head.next;
-                    // Unlink to help GC and guard against GC nepotism.
-                    head.next = null;
-                    head = next;
-                }
-                if (reclaimSpace > 0) {
-                    reclaimSpace(reclaimSpace);
-                }
-            }
-
-            private void reclaimSpace(int space) {
-                availableSharedCapacity.addAndGet(space);
-            }
-
-            void relink(Link link) {
-                reclaimSpace(LINK_CAPACITY);
-                this.link = link;
-            }
-
-            /**
-             * Creates a new {@link} and returns it if we can reserve enough space for it, otherwise it
-             * returns {@code null}.
-             */
-            Link newLink() {
-                return reserveSpaceForLink(availableSharedCapacity) ? new Link() : null;
-            }
-
-            static boolean reserveSpaceForLink(AtomicInteger availableSharedCapacity) {
-                for (;;) {
-                    int available = availableSharedCapacity.get();
-                    if (available < LINK_CAPACITY) {
-                        return false;
-                    }
-                    if (availableSharedCapacity.compareAndSet(available, available - LINK_CAPACITY)) {
-                        return true;
-                    }
-                }
-            }
+        void set(T value) {
+            this.value = value;
         }
 
-        // chain of data items
-        private final Head head;
-        private Link tail;
-        // pointer to another queue of delayed items for the same stack
-        private WeakOrderQueue next;
-        private final int id = ID_GENERATOR.getAndIncrement();
-        private final int interval;
-        private int handleRecycleCount;
-
-        private WeakOrderQueue() {
-            super(null);
-            head = new Head(null);
-            interval = 0;
-        }
-
-        private WeakOrderQueue(Stack<?> stack, Thread thread) {
-            super(thread);
-            tail = new Link();
-
-            // Its important that we not store the Stack itself in the WeakOrderQueue as the Stack also is used in
-            // the WeakHashMap as key. So just store the enclosed AtomicInteger which should allow to have the
-            // Stack itself GCed.
-            head = new Head(stack.availableSharedCapacity);
-            head.link = tail;
-            interval = stack.delayedQueueInterval;
-            handleRecycleCount = interval; // Start at interval so the first one will be recycled.
-        }
-
-        static WeakOrderQueue newQueue(Stack<?> stack, Thread thread) {
-            // We allocated a Link so reserve the space
-            if (!Head.reserveSpaceForLink(stack.availableSharedCapacity)) {
-                return null;
-            }
-            final WeakOrderQueue queue = new WeakOrderQueue(stack, thread);
-            // Done outside of the constructor to ensure WeakOrderQueue.this does not escape the constructor and so
-            // may be accessed while its still constructed.
-            stack.setHead(queue);
-
-            return queue;
-        }
-
-        WeakOrderQueue getNext() {
-            return next;
-        }
-
-        void setNext(WeakOrderQueue next) {
-            assert next != this;
-            this.next = next;
-        }
-
-        void reclaimAllSpaceAndUnlink() {
-            head.reclaimAllSpaceAndUnlink();
-            next = null;
-        }
-
-        void add(DefaultHandle<?> handle) {
-            if (!handle.compareAndSetLastRecycledId(0, id)) {
-                // Separate threads could be racing to add the handle to each their own WeakOrderQueue.
-                // We only add the handle to the queue if we win the race and observe that lastRecycledId is zero.
-                return;
-            }
-
-            // While we also enforce the recycling ratio when we transfer objects from the WeakOrderQueue to the Stack
-            // we better should enforce it as well early. Missing to do so may let the WeakOrderQueue grow very fast
-            // without control
-            if (!handle.hasBeenRecycled) {
-                if (handleRecycleCount < interval) {
-                    handleRecycleCount++;
-                    // Drop the item to prevent from recycling too aggressively.
-                    return;
-                }
-                handleRecycleCount = 0;
-            }
-
-            Link tail = this.tail;
-            int writeIndex;
-            if ((writeIndex = tail.get()) == LINK_CAPACITY) {
-                Link link = head.newLink();
-                if (link == null) {
-                    // Drop it.
-                    return;
-                }
-                // We allocate a Link so reserve the space
-                this.tail = tail = tail.next = link;
-
-                writeIndex = tail.get();
-            }
-            tail.elements[writeIndex] = handle;
-            handle.stack = null;
-            // we lazy set to ensure that setting stack to null appears before we unnull it in the owning thread;
-            // this also means we guarantee visibility of an element in the queue if we see the index updated
-            tail.lazySet(writeIndex + 1);
-        }
-
-        boolean hasFinalData() {
-            return tail.readIndex != tail.get();
-        }
-
-        // transfer as many items as we can from this queue to the stack, returning true if any were transferred
-        @SuppressWarnings("rawtypes")
-        boolean transfer(Stack<?> dst) {
-            Link head = this.head.link;
-            if (head == null) {
+        boolean availableToClaim() {
+            if (state != STATE_AVAILABLE) {
                 return false;
             }
+            return STATE_UPDATER.compareAndSet(this, STATE_AVAILABLE, STATE_CLAIMED);
+        }
 
-            if (head.readIndex == LINK_CAPACITY) {
-                if (head.next == null) {
-                    return false;
-                }
-                head = head.next;
-                this.head.relink(head);
-            }
-
-            final int srcStart = head.readIndex;
-            int srcEnd = head.get();
-            final int srcSize = srcEnd - srcStart;
-            if (srcSize == 0) {
-                return false;
-            }
-
-            final int dstSize = dst.size;
-            final int expectedCapacity = dstSize + srcSize;
-
-            if (expectedCapacity > dst.elements.length) {
-                final int actualCapacity = dst.increaseCapacity(expectedCapacity);
-                srcEnd = min(srcStart + actualCapacity - dstSize, srcEnd);
-            }
-
-            if (srcStart != srcEnd) {
-                final DefaultHandle[] srcElems = head.elements;
-                final DefaultHandle[] dstElems = dst.elements;
-                int newDstSize = dstSize;
-                for (int i = srcStart; i < srcEnd; i++) {
-                    DefaultHandle<?> element = srcElems[i];
-                    if (element.recycleId == 0) {
-                        element.recycleId = element.lastRecycledId;
-                    } else if (element.recycleId != element.lastRecycledId) {
-                        throw new IllegalStateException("recycled already");
-                    }
-                    srcElems[i] = null;
-
-                    if (dst.dropHandle(element)) {
-                        // Drop the object.
-                        continue;
-                    }
-                    element.stack = dst;
-                    dstElems[newDstSize ++] = element;
-                }
-
-                if (srcEnd == LINK_CAPACITY && head.next != null) {
-                    // Add capacity back as the Link is GCed.
-                    this.head.relink(head.next);
-                }
-
-                head.readIndex = srcEnd;
-                if (dst.size == newDstSize) {
-                    return false;
-                }
-                dst.size = newDstSize;
-                return true;
-            } else {
-                // The destination stack is full already.
-                return false;
+        void toAvailable() {
+            int prev = STATE_UPDATER.getAndSet(this, STATE_AVAILABLE);
+            if (prev == STATE_AVAILABLE) {
+                throw new IllegalStateException("Object has been recycled already.");
             }
         }
     }
 
-    private static final class Stack<T> {
-
-        // we keep a queue of per-thread queues, which is appended to once only, each time a new thread other
-        // than the stack owner recycles: when we run out of items in our stack we iterate this collection
-        // to scavenge those that can be reused. this permits us to incur minimal thread synchronisation whilst
-        // still recycling all items.
-        final Recycler<T> parent;
-
-        // We store the Thread in a WeakReference as otherwise we may be the only ones that still hold a strong
-        // Reference to the Thread itself after it died because DefaultHandle will hold a reference to the Stack.
-        //
-        // The biggest issue is if we do not use a WeakReference the Thread may not be able to be collected at all if
-        // the user will store a reference to the DefaultHandle somewhere and never clear this reference (or not clear
-        // it in a timely manner).
-        final WeakReference<Thread> threadRef;
-        final AtomicInteger availableSharedCapacity;
-        private final int maxDelayedQueues;
-
+    private static final class LocalPool<T> {
+        private final Recycler<T> parent;
         private final int maxCapacity;
-        private final int interval;
-        private final int delayedQueueInterval;
-        DefaultHandle<?>[] elements;
-        int size;
-        private int handleRecycleCount;
-        private WeakOrderQueue cursor, prev;
-        private volatile WeakOrderQueue head;
+        private final int ratioInterval;
+        private final ArrayDeque<DefaultHandle<T>> pooledHandles;
+        private final ArrayDeque<DefaultHandle<T>> externalInbox; // Must always be synchronised.
+        private int ratioCounter;
+        private volatile boolean flagInbox; // Signals that someone put a handle in the external inbox.
 
-        Stack(Recycler<T> parent, Thread thread, int maxCapacity, int maxSharedCapacityFactor,
-              int interval, int maxDelayedQueues, int delayedQueueInterval) {
+        LocalPool(Recycler<T> parent, int maxCapacity, int ratioInterval) {
             this.parent = parent;
-            threadRef = new WeakReference<Thread>(thread);
             this.maxCapacity = maxCapacity;
-            availableSharedCapacity = new AtomicInteger(max(maxCapacity / maxSharedCapacityFactor, LINK_CAPACITY));
-            elements = new DefaultHandle[min(INITIAL_CAPACITY, maxCapacity)];
-            this.interval = interval;
-            this.delayedQueueInterval = delayedQueueInterval;
-            handleRecycleCount = interval; // Start at interval so the first one will be recycled.
-            this.maxDelayedQueues = maxDelayedQueues;
+            this.ratioInterval = ratioInterval;
+            pooledHandles = new ArrayDeque<DefaultHandle<T>>();
+            externalInbox = new ArrayDeque<DefaultHandle<T>>();
+            ratioCounter = ratioInterval; // Start at interval so the first one will be recycled.
         }
 
-        // Marked as synchronized to ensure this is serialized.
-        synchronized void setHead(WeakOrderQueue queue) {
-            queue.setNext(head);
-            head = queue;
-        }
+        DefaultHandle<T> claim() {
+            if (flagInbox) {
+                drainInbox();
+            }
 
-        int increaseCapacity(int expectedCapacity) {
-            int newCapacity = elements.length;
-            int maxCapacity = this.maxCapacity;
+            ArrayDeque<DefaultHandle<T>> pooledHandles = this.pooledHandles;
+            DefaultHandle<T> handle;
             do {
-                newCapacity <<= 1;
-            } while (newCapacity < expectedCapacity && newCapacity < maxCapacity);
-
-            newCapacity = min(newCapacity, maxCapacity);
-            if (newCapacity != elements.length) {
-                elements = Arrays.copyOf(elements, newCapacity);
-            }
-
-            return newCapacity;
+                handle = pooledHandles.pollLast();
+            } while (handle != null && !handle.availableToClaim());
+            return handle;
         }
 
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        DefaultHandle<T> pop() {
-            int size = this.size;
-            if (size == 0) {
-                if (!scavenge()) {
-                    return null;
-                }
-                size = this.size;
-                if (size <= 0) {
-                    // double check, avoid races
-                    return null;
-                }
-            }
-            size --;
-            DefaultHandle ret = elements[size];
-            elements[size] = null;
-            // As we already set the element[size] to null we also need to store the updated size before we do
-            // any validation. Otherwise we may see a null value when later try to pop again without a new element
-            // added before.
-            this.size = size;
-
-            if (ret.lastRecycledId != ret.recycleId) {
-                throw new IllegalStateException("recycled multiple times");
-            }
-            ret.recycleId = 0;
-            ret.lastRecycledId = 0;
-            return ret;
-        }
-
-        private boolean scavenge() {
-            // continue an existing scavenge, if any
-            if (scavengeSome()) {
-                return true;
-            }
-
-            // reset our scavenge cursor
-            prev = null;
-            cursor = head;
-            return false;
-        }
-
-        private boolean scavengeSome() {
-            WeakOrderQueue prev;
-            WeakOrderQueue cursor = this.cursor;
-            if (cursor == null) {
-                prev = null;
-                cursor = head;
-                if (cursor == null) {
-                    return false;
-                }
-            } else {
-                prev = this.prev;
-            }
-
-            boolean success = false;
-            do {
-                if (cursor.transfer(this)) {
-                    success = true;
-                    break;
-                }
-                WeakOrderQueue next = cursor.getNext();
-                if (cursor.get() == null) {
-                    // If the thread associated with the queue is gone, unlink it, after
-                    // performing a volatile read to confirm there is no data left to collect.
-                    // We never unlink the first queue, as we don't want to synchronize on updating the head.
-                    if (cursor.hasFinalData()) {
-                        for (;;) {
-                            if (cursor.transfer(this)) {
-                                success = true;
-                            } else {
-                                break;
-                            }
-                        }
+        private void drainInbox() {
+            flagInbox = false;
+            ArrayDeque<DefaultHandle<T>> pooledHandles = this.pooledHandles;
+            DefaultHandle<T> handle;
+            synchronized (externalInbox) {
+                while ((handle = externalInbox.pollLast()) != null) {
+                    if (pooledHandles.size() < maxCapacity) {
+                        pooledHandles.offerLast(handle);
                     }
-
-                    if (prev != null) {
-                        // Ensure we reclaim all space before dropping the WeakOrderQueue to be GC'ed.
-                        cursor.reclaimAllSpaceAndUnlink();
-                        prev.setNext(next);
-                    }
-                } else {
-                    prev = cursor;
                 }
-
-                cursor = next;
-
-            } while (cursor != null && !success);
-
-            this.prev = prev;
-            this.cursor = cursor;
-            return success;
-        }
-
-        void push(DefaultHandle<?> item) {
-            Thread currentThread = Thread.currentThread();
-            if (threadRef.get() == currentThread) {
-                // The current Thread is the thread that belongs to the Stack, we can try to push the object now.
-                pushNow(item);
-            } else {
-                // The current Thread is not the one that belongs to the Stack
-                // (or the Thread that belonged to the Stack was collected already), we need to signal that the push
-                // happens later.
-                pushLater(item, currentThread);
             }
         }
 
-        private void pushNow(DefaultHandle<?> item) {
-            if (item.recycleId != 0 || !item.compareAndSetLastRecycledId(0, OWN_THREAD_ID)) {
-                throw new IllegalStateException("recycled already");
+        void release(DefaultHandle<T> handle) {
+            handle.toAvailable();
+            if (pooledHandles.size() < maxCapacity) {
+                pooledHandles.offerLast(handle);
             }
-            item.recycleId = OWN_THREAD_ID;
-
-            int size = this.size;
-            if (size >= maxCapacity || dropHandle(item)) {
-                // Hit the maximum capacity or should drop - drop the possibly youngest object.
-                return;
-            }
-            if (size == elements.length) {
-                elements = Arrays.copyOf(elements, min(size << 1, maxCapacity));
-            }
-
-            elements[size] = item;
-            this.size = size + 1;
         }
 
-        private void pushLater(DefaultHandle<?> item, Thread thread) {
-            if (maxDelayedQueues == 0) {
-                // We don't support recycling across threads and should just drop the item on the floor.
-                return;
+        void releaseExternal(DefaultHandle<T> handle) {
+            handle.toAvailable();
+            synchronized (externalInbox) {
+                externalInbox.offerLast(handle);
             }
-
-            // we don't want to have a ref to the queue as the value in our weak map
-            // so we null it out; to ensure there are no races with restoring it later
-            // we impose a memory ordering here (no-op on x86)
-            Map<Stack<?>, WeakOrderQueue> delayedRecycled = DELAYED_RECYCLED.get();
-            WeakOrderQueue queue = delayedRecycled.get(this);
-            if (queue == null) {
-                if (delayedRecycled.size() >= maxDelayedQueues) {
-                    // Add a dummy queue so we know we should drop the object
-                    delayedRecycled.put(this, WeakOrderQueue.DUMMY);
-                    return;
-                }
-                // Check if we already reached the maximum number of delayed queues and if we can allocate at all.
-                if ((queue = newWeakOrderQueue(thread)) == null) {
-                    // drop object
-                    return;
-                }
-                delayedRecycled.put(this, queue);
-            } else if (queue == WeakOrderQueue.DUMMY) {
-                // drop object
-                return;
-            }
-
-            queue.add(item);
-        }
-
-        /**
-         * Allocate a new {@link WeakOrderQueue} or return {@code null} if not possible.
-         */
-        private WeakOrderQueue newWeakOrderQueue(Thread thread) {
-            return WeakOrderQueue.newQueue(this, thread);
-        }
-
-        boolean dropHandle(DefaultHandle<?> handle) {
-            if (!handle.hasBeenRecycled) {
-                if (handleRecycleCount < interval) {
-                    handleRecycleCount++;
-                    // Drop the object.
-                    return true;
-                }
-                handleRecycleCount = 0;
-                handle.hasBeenRecycled = true;
-            }
-            return false;
+            flagInbox = true;
         }
 
         DefaultHandle<T> newHandle() {
-            return new DefaultHandle<T>(this);
+            if (++ratioCounter >= ratioInterval) {
+                ratioCounter = 0;
+                return new DefaultHandle<T>(parent, this);
+            }
+            return null;
         }
     }
 }

--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -25,8 +25,8 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static io.netty.util.internal.MathUtil.safeFindNextPositivePowerOfTwo;
 import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 /**
  * Light-weight object pool based on a thread-local stack.
@@ -48,11 +48,8 @@ public abstract class Recycler<T> {
     };
     private static final int DEFAULT_INITIAL_MAX_CAPACITY_PER_THREAD = 4 * 1024; // Use 4k instances as default.
     private static final int DEFAULT_MAX_CAPACITY_PER_THREAD;
-    private static final int MAX_SHARED_CAPACITY_FACTOR;
-    private static final int MAX_DELAYED_QUEUES_PER_THREAD;
-    private static final int LINK_CAPACITY;
     private static final int RATIO;
-    private static final int DELAYED_QUEUE_RATIO;
+    private static final int DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD;
 
     static {
         // In the future, we might have different maxCapacity for different object types.
@@ -65,48 +62,33 @@ public abstract class Recycler<T> {
         }
 
         DEFAULT_MAX_CAPACITY_PER_THREAD = maxCapacityPerThread;
-
-        MAX_SHARED_CAPACITY_FACTOR = max(2,
-                SystemPropertyUtil.getInt("io.netty.recycler.maxSharedCapacityFactor",
-                        2));
-
-        MAX_DELAYED_QUEUES_PER_THREAD = max(0,
-                SystemPropertyUtil.getInt("io.netty.recycler.maxDelayedQueuesPerThread",
-                        // We use the same value as default EventLoop number
-                        NettyRuntime.availableProcessors() * 2));
-
-        LINK_CAPACITY = safeFindNextPositivePowerOfTwo(
-                max(SystemPropertyUtil.getInt("io.netty.recycler.linkCapacity", 16), 16));
+        DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD = SystemPropertyUtil.getInt("io.netty.recycler.chunkSize", 32);
 
         // By default we allow one push to a Recycler for each 8th try on handles that were never recycled before.
         // This should help to slowly increase the capacity of the recycler while not be too sensitive to allocation
         // bursts.
         RATIO = max(0, SystemPropertyUtil.getInt("io.netty.recycler.ratio", 8));
-        DELAYED_QUEUE_RATIO = max(0, SystemPropertyUtil.getInt("io.netty.recycler.delayedQueue.ratio", RATIO));
 
         if (logger.isDebugEnabled()) {
             if (DEFAULT_MAX_CAPACITY_PER_THREAD == 0) {
                 logger.debug("-Dio.netty.recycler.maxCapacityPerThread: disabled");
-                logger.debug("-Dio.netty.recycler.maxSharedCapacityFactor: disabled");
-                logger.debug("-Dio.netty.recycler.linkCapacity: disabled");
                 logger.debug("-Dio.netty.recycler.ratio: disabled");
-                logger.debug("-Dio.netty.recycler.delayedQueue.ratio: disabled");
+                logger.debug("-Dio.netty.recycler.chunkSize: disabled");
             } else {
                 logger.debug("-Dio.netty.recycler.maxCapacityPerThread: {}", DEFAULT_MAX_CAPACITY_PER_THREAD);
-                logger.debug("-Dio.netty.recycler.maxSharedCapacityFactor: {}", MAX_SHARED_CAPACITY_FACTOR);
-                logger.debug("-Dio.netty.recycler.linkCapacity: {}", LINK_CAPACITY);
                 logger.debug("-Dio.netty.recycler.ratio: {}", RATIO);
-                logger.debug("-Dio.netty.recycler.delayedQueue.ratio: {}", DELAYED_QUEUE_RATIO);
+                logger.debug("-Dio.netty.recycler.chunkSize: {}", DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
             }
         }
     }
 
     private final int maxCapacityPerThread;
     private final int interval;
+    private final int chunkSize;
     private final FastThreadLocal<LocalPool<T>> threadLocal = new FastThreadLocal<LocalPool<T>>() {
         @Override
         protected LocalPool<T> initialValue() {
-            return new LocalPool<T>(maxCapacityPerThread, interval);
+            return new LocalPool<T>(maxCapacityPerThread, interval, chunkSize);
         }
     };
 
@@ -115,24 +97,50 @@ public abstract class Recycler<T> {
     }
 
     protected Recycler(int maxCapacityPerThread) {
-        this(maxCapacityPerThread, MAX_SHARED_CAPACITY_FACTOR);
+        this(maxCapacityPerThread, RATIO, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
     }
 
+    /**
+     * @deprecated Use one of the following instead:
+     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
+     */
+    @Deprecated
+    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
     protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor) {
-        this(maxCapacityPerThread, maxSharedCapacityFactor, RATIO, MAX_DELAYED_QUEUES_PER_THREAD);
+        this(maxCapacityPerThread, RATIO, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
     }
 
+    /**
+     * @deprecated Use one of the following instead:
+     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
+     */
+    @Deprecated
+    @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
     protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
                        int ratio, int maxDelayedQueuesPerThread) {
-        this(maxCapacityPerThread, maxSharedCapacityFactor, ratio, maxDelayedQueuesPerThread,
-                DELAYED_QUEUE_RATIO);
+        this(maxCapacityPerThread, ratio, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
     }
 
+    /**
+     * @deprecated Use one of the following instead:
+     * {@link #Recycler()}, {@link #Recycler(int)}, {@link #Recycler(int, int, int)}.
+     */
+    @Deprecated
     @SuppressWarnings("unused") // Parameters we can't remove due to compatibility.
     protected Recycler(int maxCapacityPerThread, int maxSharedCapacityFactor,
                        int ratio, int maxDelayedQueuesPerThread, int delayedQueueRatio) {
+        this(maxCapacityPerThread, ratio, DEFAULT_QUEUE_CHUNK_SIZE_PER_THREAD);
+    }
+
+    protected Recycler(int maxCapacityPerThread, int ratio, int chunkSize) {
         interval = max(0, ratio);
-        this.maxCapacityPerThread = max(0, maxCapacityPerThread);
+        if (maxCapacityPerThread <= 0) {
+            this.maxCapacityPerThread = 0;
+            this.chunkSize = 0;
+        } else {
+            this.maxCapacityPerThread = max(4, maxCapacityPerThread);
+            this.chunkSize = max(2, min(chunkSize, this.maxCapacityPerThread >> 1));
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -231,15 +239,13 @@ public abstract class Recycler<T> {
     }
 
     private static final class LocalPool<T> {
-        private final int maxCapacity;
         private final int ratioInterval;
         private final Queue<DefaultHandle<T>> pooledHandles;
         private int ratioCounter;
 
-        LocalPool(int maxCapacity, int ratioInterval) {
-            this.maxCapacity = maxCapacity;
+        LocalPool(int maxCapacity, int ratioInterval, int chunkSize) {
             this.ratioInterval = ratioInterval;
-            pooledHandles = PlatformDependent.newMpscQueue();
+            pooledHandles = PlatformDependent.newMpscQueue(chunkSize, maxCapacity);
             ratioCounter = ratioInterval; // Start at interval so the first one will be recycled.
         }
 
@@ -254,9 +260,7 @@ public abstract class Recycler<T> {
 
         void release(DefaultHandle<T> handle) {
             handle.toAvailable();
-            if (pooledHandles.size() < maxCapacity) {
-                pooledHandles.offer(handle);
-            }
+            pooledHandles.offer(handle);
         }
 
         DefaultHandle<T> newHandle() {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -974,8 +974,12 @@ public final class PlatformDependent {
             // This is forced by the MpscChunkedArrayQueue implementation as will try to round it
             // up to the next power of two and so will overflow otherwise.
             final int capacity = max(min(maxCapacity, MAX_ALLOWED_MPSC_CAPACITY), MIN_MAX_MPSC_CAPACITY);
-            return USE_MPSC_CHUNKED_ARRAY_QUEUE ? new MpscChunkedArrayQueue<T>(MPSC_CHUNK_SIZE, capacity)
-                                                : new MpscChunkedAtomicArrayQueue<T>(MPSC_CHUNK_SIZE, capacity);
+            return newChunkedMpscQueue(MPSC_CHUNK_SIZE, capacity);
+        }
+
+        static <T> Queue<T> newChunkedMpscQueue(final int chunkSize, final int capacity) {
+            return USE_MPSC_CHUNKED_ARRAY_QUEUE ? new MpscChunkedArrayQueue<T>(chunkSize, capacity)
+                    : new MpscChunkedAtomicArrayQueue<T>(chunkSize, capacity);
         }
 
         static <T> Queue<T> newMpscQueue() {
@@ -999,6 +1003,15 @@ public final class PlatformDependent {
      */
     public static <T> Queue<T> newMpscQueue(final int maxCapacity) {
         return Mpsc.newMpscQueue(maxCapacity);
+    }
+
+    /**
+     * Create a new {@link Queue} which is safe to use for multiple producers (different threads) and a single
+     * consumer (one thread!).
+     * The queue will grow and shrink its capacity in units of the given chunk size.
+     */
+    public static <T> Queue<T> newMpscQueue(final int chunkSize, final int maxCapacity) {
+        return Mpsc.newChunkedMpscQueue(chunkSize, maxCapacity);
     }
 
     /**

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -365,7 +365,7 @@ public class RecyclerTest {
     @Test
     public void testMaxCapacityWithRecycleAtDifferentThread() throws Exception {
         final int maxCapacity = 4; // Choose the number smaller than WeakOrderQueue.LINK_CAPACITY
-        final Recycler<HandledObject> recycler = newRecycler(maxCapacity);
+        final Recycler<HandledObject> recycler = newRecycler(maxCapacity, 0, 4, 0, 0);
 
         // Borrow 2 * maxCapacity objects.
         // Return the half from the same thread.
@@ -391,7 +391,7 @@ public class RecyclerTest {
         thread.start();
         thread.join();
 
-        assertEquals(1, recycler.threadLocalSize());
+        assertEquals(maxCapacity * 3 / 4, recycler.threadLocalSize());
 
         for (int i = 0; i < array.length; i ++) {
             recycler.get();

--- a/microbench/src/main/java/io/netty/microbench/util/RecyclerBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/RecyclerBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.util;
+
+import io.netty.util.Recycler;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Control;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = AbstractMicrobenchmarkBase.DEFAULT_WARMUP_ITERATIONS, time = 1)
+@Measurement(iterations = AbstractMicrobenchmarkBase.DEFAULT_MEASURE_ITERATIONS, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class RecyclerBenchmark extends AbstractMicrobenchmark {
+    private Recycler<DummyObject> recycler = new Recycler<DummyObject>() {
+        @Override
+        protected DummyObject newObject(Recycler.Handle<DummyObject> handle) {
+            return new DummyObject(handle);
+        }
+    };
+
+    @Override
+    protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
+        return super.newOptionsBuilder().addProfiler("gc");
+    }
+
+    @Benchmark
+    public DummyObject plainNew() {
+        return new DummyObject();
+    }
+
+    @Benchmark
+    public DummyObject recyclerGetAndOrphan() {
+        return recycler.get();
+    }
+
+    @Benchmark
+    public DummyObject recyclerGetAndRecycle() {
+        DummyObject o = recycler.get();
+        o.recycle();
+        return o;
+    }
+
+    @State(Scope.Benchmark)
+    public static class ProducerConsumerState {
+        final ArrayBlockingQueue<DummyObject> queue = new ArrayBlockingQueue<DummyObject>(100);
+    }
+
+    // The allocation stats are the main thing interesting about this benchmark
+    @Benchmark
+    @Group("producerConsumer")
+    public void producer(ProducerConsumerState state, Control control) throws Exception {
+        ArrayBlockingQueue<DummyObject> queue = state.queue;
+        DummyObject object = recycler.get();
+        while (!control.stopMeasurement) {
+            if (queue.offer(object)) {
+                break;
+            }
+        }
+    }
+
+    @Benchmark
+    @Group("producerConsumer")
+    public void consumer(ProducerConsumerState state, Control control) throws Exception {
+        DummyObject object;
+        do {
+            object = state.queue.poll();
+            if (object != null) {
+                object.recycle();
+                return;
+            }
+        } while (!control.stopMeasurement);
+    }
+
+    @SuppressWarnings("unused")
+    private static final class DummyObject {
+        private final Recycler.Handle<DummyObject> handle;
+        private long l1;
+        private long l2;
+        private long l3;
+        private long l4;
+        private long l5;
+        private Object o1;
+        private Object o2;
+        private Object o3;
+        private Object o4;
+        private Object o5;
+
+        DummyObject() {
+            this(null);
+        }
+
+        DummyObject(Recycler.Handle<DummyObject> handle) {
+            this.handle = handle;
+        }
+
+        public void recycle() {
+            handle.recycle(this);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
We have in the past gotten reports of weird errors that we haven't been able to reproduce, but which could be explained by bugs in the Recycler.
The reason is that the Recycler was mixing concurrency, and interactions with the GC, in ways that were difficult to reason about.
It is unwise to leave suspicous-looking code unaddressed.

Modification:
The Recycler has been rewritten to use a much simpler algorithm, and now completely avoids the use of weak references.

The WeakOrderQueue is gone, and there is no longer a concept of a shared max capacity - only thread-local capacity.

There is also no more scavenging.
It turns out that other code was relying on the ability to forget references to objects they acquired from a Recycler, and this is hard to support if there is a shared pool for moving handles between threads.

Each thread now has a local pool (an ArrayDeque), and an external inbox (also an ArrayDeque, but access is synchronised).
Calls to get() and recycle() in the same thread will just operate on the local pool like a stack.
Calls to recycle() from a thread that did not get() that object (the object was acquired in another thread) will place the object in the originating pools inbox.
When a thread then goes to get() another object, they will first check if they have anything in their inbox, and if so, drain it into their local pool.

Result:
The Recycler code is much easier to understand.
