### PR TITLE
Remove stream exception from InboundHttp2ToHttpAdapter::onRstStreamRead

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -285,8 +285,6 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         if (msg != null) {
             onRstStreamRead(stream, msg);
         }
-        ctx.fireExceptionCaught(Http2Exception.streamError(streamId, Http2Error.valueOf(errorCode),
-                "HTTP/2 to HTTP layer caught stream reset"));
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -44,7 +44,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.Http2TestUtil.Http2Runnable;
 import io.netty.util.AsciiString;
-import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +56,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.getEmbeddedHttp2Exception;
-import static io.netty.handler.codec.http2.Http2Exception.isStreamError;
 import static io.netty.handler.codec.http2.Http2TestUtil.of;
 import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -233,27 +231,6 @@ public class InboundHttp2ToHttpAdapterTest {
         } finally {
             request.release();
         }
-    }
-
-    @Test
-    public void clientRequestSingleHeaderNonAsciiShouldThrow() throws Exception {
-        boostrapEnv(1, 1, 1);
-        final Http2Headers http2Headers = new DefaultHttp2Headers()
-                .method(new AsciiString("GET"))
-                .scheme(new AsciiString("https"))
-                .authority(new AsciiString("example.org"))
-                .path(new AsciiString("/some/path/resource2"))
-                .add(new AsciiString("çã".getBytes(CharsetUtil.UTF_8)),
-                        new AsciiString("Ãã".getBytes(CharsetUtil.UTF_8)));
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() throws Http2Exception {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
-                clientChannel.flush();
-            }
-        });
-        awaitResponses();
-        assertTrue(isStreamError(clientException));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`InboundHttp2ToHttpAdapter` is responsible for simply translating HTTP/2 frames into HTTP/1.x objects. It is not responsible for validating proper HTTP/2 message flow. `InboundHttp2ToHttpAdapter` can be provided as a `Http2FrameListener` delegate to `DefaultHttp2ConnectionDecoder` which handles frame/stream validation defined in [RFC 7540](https://datatracker.ietf.org/doc/html/rfc7540). Also, receiving an RST_STREAM frame is not necessarily an exceptional condition, as there are a number of "valid" cases where a client/server may receive an RST_STREAM frame. The cases where an invalid RST_STREAM are received are handled in `DefaultHttp2ConnectionDecoder`.

Modifications:

- Remove stream exception from InboundHttp2ToHttpAdapter::onRstStreamRead
- Delete test that verified an exception was fired when an RST_STREAM frame is read

Result:

- Fixes #11836