### PR TITLE
Create SimpleChannelPool::notifyConnectChannel method

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -210,15 +210,19 @@ public class SimpleChannelPool implements ChannelPool {
             if (future.isSuccess()) {
                 channel = future.channel();
                 handler.channelAcquired(channel);
-                if (!promise.trySuccess(channel)) {
-                    // Promise was completed in the meantime (like cancelled), just release the channel again
-                    release(channel);
-                }
+                notifyConnectChannel(promise, channel);
             } else {
                 promise.tryFailure(future.cause());
             }
         } catch (Throwable cause) {
             closeAndFail(channel, cause, promise);
+        }
+    }
+
+    protected void notifyConnectChannel(Promise<Channel> promise, Channel channel) {
+        if (!promise.trySuccess(channel)) {
+            // Promise was completed in the meantime (like cancelled), just release the channel again
+            release(channel);
         }
     }
 


### PR DESCRIPTION
Motivation:

A system could have different behavior when connecting to the channel for the first time

Modification:

Create a new method notifyConnectChannel that will be called only the channel is created for the first time

Result:

Projects that are using the Netty Channel Pool can implement custom code during notifyConnect