### PR TITLE
Limit workaround on JDK-6427854 to Java <1.7

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -76,22 +76,25 @@ public final class NioEventLoop extends SingleThreadEventLoop {
     // Workaround for JDK NIO bug.
     //
     // See:
-    // - https://bugs.java.com/view_bug.do?bug_id=6427854
+    // - https://bugs.openjdk.java.net/browse/JDK-6427854 for first few dev (unreleased) builds of JDK 7
+    // - https://bugs.openjdk.java.net/browse/JDK-6527572 for JDK prior to 5.0u15-rev and 6u10
     // - https://github.com/netty/netty/issues/203
     static {
-        final String key = "sun.nio.ch.bugLevel";
-        final String bugLevel = SystemPropertyUtil.get(key);
-        if (bugLevel == null) {
-            try {
-                AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                    @Override
-                    public Void run() {
-                        System.setProperty(key, "");
-                        return null;
-                    }
-                });
-            } catch (final SecurityException e) {
-                logger.debug("Unable to get/set System Property: " + key, e);
+        if (PlatformDependent.javaVersion() < 7) {
+            final String key = "sun.nio.ch.bugLevel";
+            final String bugLevel = SystemPropertyUtil.get(key);
+            if (bugLevel == null) {
+                try {
+                    AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                        @Override
+                        public Void run() {
+                            System.setProperty(key, "");
+                            return null;
+                        }
+                    });
+                } catch (final SecurityException e) {
+                    logger.debug("Unable to get/set System Property: " + key, e);
+                }
             }
         }
 


### PR DESCRIPTION
Motivation:

The workaround introduced by #203 (completed by #5644) on bug [JDK-6427854](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6427854) turns out to be no longer applicable since Java 1.7.

Only first few builds of JDK 7 were affected by the bug, which got fixed in **build 8**. Since JDK 7 was feature complete in
[build 123](https://blogs.oracle.com/java/post/jdk-7-feature-complete), there's no need to therefore apply the workaround from Java 1.7 onward.

Modifications:

This commit makes sure the workaround (consisting in setting the system property `sun.nio.ch.bugLevel` to an empty string unless defined) doesn't get applied when the detected Java version is greater than or equal to 1.7.

Result:

The workaround gets only applied for Java versions strictly prior to 1.7.

Conditioning the workaround to the Java version will incidentally help get rid of it when bumping up the minimum JDK support as proposed in various issues s.a. #8259 and #8540.