### PR TITLE
when the thread which create the reclaimed object was GC'ed,there is no need to recycle this object to the weakOrderQueue node belongs to the recycling thread any more

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -661,10 +661,13 @@ public abstract class Recycler<T> {
             if (threadRef.get() == currentThread) {
                 // The current Thread is the thread that belongs to the Stack, we can try to push the object now.
                 pushNow(item);
+            } else if (threadRef.get() == null) {
+                // when the thread that belonged to the Stack was died or GC'ed，
+                // There is no need to add this item to WeakOrderQueue-linked-list which belonged to the Stack any more
+                item.stack = null;
             } else {
                 // The current Thread is not the one that belongs to the Stack
-                // (or the Thread that belonged to the Stack was collected already), we need to signal that the push
-                // happens later.
+                // we need to signal that the push happens later.
                 pushLater(item, currentThread);
             }
         }


### PR DESCRIPTION
Motivation:

fix issue #11864 
Multithreading reclaiming objects in the Recycler object pool，when the thread which create the reclaimed object was GC'ed,there is no need to recycle this object to the weakOrderQueue node belongs to the recycling thread any more


Modification:

- Specially handle the `threadRef.get() == null` situation to avoid continuing to add objects to the `weakOrderQueu node` which belongs to the recycling thread。

- because the object will no longer be used,There is no need to recycle it。

Result:

Fixes #11864 

