### PR TITLE
Eagerly clear thread-local recycler pools

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -90,6 +90,12 @@ public abstract class Recycler<T> {
         protected LocalPool<T> initialValue() {
             return new LocalPool<T>(maxCapacityPerThread, interval, chunkSize);
         }
+
+        @Override
+        protected void onRemoval(LocalPool<T> value) throws Exception {
+            super.onRemoval(value);
+            value.pooledHandles.clear();
+        }
     };
 
     protected Recycler() {


### PR DESCRIPTION
Motivation:
An object acquired in thread A but strongly referenced from thread B, will keep the entire thread-local pool for A alive past the termination of A.

Modification:
Add an onRemoval callback to the thread-local that holds the local pool instances.
A call to FastThreadLocal.remove() will then clear the queue, reducing the memory pressure from objects strongly held in other threads.

Result:
Reduced memory overhead when recyclable objects are held past the life-time of the thread-local pool they were allocated from.
