### PR TITLE
Link required libraries for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You require the following to build Netty:
 
 * Latest stable [OpenJDK 8](https://adoptopenjdk.net)
 * Latest stable [Apache Maven](https://maven.apache.org/)
-* If you are on Linux, you need [additional development packages](https://netty.io/wiki/native-transports.html) installed on your system, because you'll build the native transport.
+* If you are on Linux or MacOS, you need [additional development packages](https://netty.io/wiki/native-transports.html) installed on your system, because you'll build the native transport.
 
 Note that this is build-time requirement.  JDK 5 (for 3.x) or 6 (for 4.0+ / 4.1+) is enough to run your Netty-based application.
 


### PR DESCRIPTION
Motivation:

When building Netty on MacOS it can fail due to missing libraries

Modification:

A link for Native transports wiki page

Result:

When reading the README, the developer will know what are the required libraries for MacOS