### PR TITLE
Fix implicit narrowing

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -175,9 +175,9 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     private static void assertArenaMetrics(
             List<PoolArenaMetric> arenaMetrics, int expectedActive, int expectedAlloc, int expectedDealloc) {
-        int active = 0;
-        int alloc = 0;
-        int dealloc = 0;
+        long active = 0;
+        long alloc = 0;
+        long dealloc = 0;
         for (PoolArenaMetric arena : arenaMetrics) {
             active += arena.numActiveAllocations();
             alloc += arena.numAllocations();


### PR DESCRIPTION
Motivation:
Compound assignment can cause a long RHS to be implicitly narrowed to an int LHS result.
This can cause overflow bugs.

Modification:
Compute and compare the sums as longs in our test.

Result:
Fewer overflow risks.
