### PR TITLE
Fix testsuite which was broken due ba3a58e2efc14e6754dfd3d7c8a8b59f91…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1449,6 +1449,9 @@
               <configuration>
                 <resources>
                   <resource>
+                    <directory>src/test/resources</directory>
+                  </resource>
+                  <resource>
                     <directory>${project.build.outputDirectory}/</directory>
                     <excludes>
                       <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1439,6 +1439,30 @@
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.1</version>
+          <executions>
+            <execution>
+              <id>default-testResources</id>
+              <phase>test-compile</phase>
+              <goals>
+                <goal>testResources</goal>
+              </goals>
+              <configuration>
+                <resources>
+                  <resource>
+                    <directory>${project.build.outputDirectory}/</directory>
+                    <excludes>
+                      <!--
+                        Exclude native files as these are already in the classes directory. This is needed as
+                        otherwise NativeLibraryLoader will fail to load the native lib as it detects duplicates on
+                        the classpath.
+                      -->
+                      <exclude>META-INF/native/*.*</exclude>
+                    </excludes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.ops4j.pax.exam</groupId>


### PR DESCRIPTION
…c7f87e

Motivation:

ba3a58e2efc14e6754dfd3d7c8a8b59f91c7f87e intoduced a change which guards against loading native libraries if there are multiple of the same on the classpath. Unfortunally this also broke our native testsuites as the testsuites did include the native libs two times on the classpath.

Modifications:

Add an exclude which ensures we not copy the native libs to the test-classes folder and so end up with duplicates on the classpath

Result:

Testsuite passes again