### PR TITLE
Ensure we always run the register task of native libraries

### DIFF
--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
@@ -53,11 +53,9 @@ public final class Unix {
      * @param registerTask
      */
     @UnstableApi
-    public static void registerInternal(Runnable registerTask) {
-        if (registered.compareAndSet(false, true)) {
-            registerTask.run();
-            Socket.initialize();
-        }
+    public static synchronized void registerInternal(Runnable registerTask) {
+        registerTask.run();
+        Socket.initialize();
     }
 
     /**


### PR DESCRIPTION
Motivation:

At some point we introduced guards to ensure we not bind native methods multiple times. While this seemed to have fixed the problem it introduced other problems
 as these methods sometimes not only bind native methods but also init static fields. This could later then cause things like segfaults if we depend on static fields to not be NULL.

Modification:

- Remove atomic guard
- Use static synchronized for proper sequencing
- Always call Socket.initialize()

Result:

No more segfaults due NULL fields