### PR TITLE
JdkZlibEncoder can use pooled heap buffers for deflater input

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -210,7 +209,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
                 // skip all bytes as we will consume all of them
                 uncompressed.skipBytes(len);
             } else {
-                heapBuf = PooledByteBufAllocator.DEFAULT.heapBuffer(len, len);
+                heapBuf = ctx.alloc().heapBuffer(len, len);
                 uncompressed.readBytes(heapBuf, len);
                 inAry = heapBuf.array();
                 offset = heapBuf.arrayOffset() + heapBuf.readerIndex();

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -227,7 +227,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
             }
 
             deflater.setInput(inAry, offset, len);
-            for (; ;) {
+            for (;;) {
                 deflate(out);
                 if (deflater.needsInput()) {
                     // Consumed everything

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -227,15 +227,15 @@ public class JdkZlibEncoder extends ZlibEncoder {
             }
 
             deflater.setInput(inAry, offset, len);
-            for (; ; ) {
+            for (; ;) {
                 deflate(out);
                 if (deflater.needsInput()) {
                     // Consumed everything
                     break;
                 } else {
                     if (!out.isWritable()) {
-                        // We did not consume everything but the buffer is not writable anymore. Increase the capacity to
-                        // make more room.
+                        // We did not consume everything but the buffer is not writable anymore. Increase the capacity
+                        // to make more room.
                         out.ensureWritable(out.writerIndex());
                     }
                 }


### PR DESCRIPTION
Motivation:

Previously, when the input ByteBuf was not heap allocated we copied the
input into a new byte array allocated on the heap for every encode() call.
This puts high-throughput clients that use the JdkZlibEncoder under memory
pressure.

Modifications:

Now, when the input ByteBuf is not heap allocated we copy the input into a
heap ByteBuf allocated from the configured ByteBufAllocator (which might be pooled), releasing it after
the encode() has completed.

Result:

The result is less heap allocation and GC activity when the PooledByteBufAllocator is used (which is the default)

Fixes #11890

Signed-off-by: Daniel Ferstay <dferstay@splunk.com>