### PR TITLE
Remove static field from c code base

### DIFF
--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -27,8 +27,6 @@ import java.net.PortUnreachableException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.channel.unix.Errors.ERRNO_EAGAIN_NEGATIVE;
 import static io.netty.channel.unix.Errors.ERRNO_EINPROGRESS_NEGATIVE;


### PR DESCRIPTION
Motivation:

This came up in another PR. We dont need to store the field in the jni layer which makes things easier.

Modifications:

Refactor code to just store it in the java class

Result:

Cleanup
