### PR TITLE
Swap equals method call in SelfSignedCertificate

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -59,7 +59,6 @@ import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 

--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -220,7 +220,7 @@ public final class SelfSignedCertificate {
     public SelfSignedCertificate(String fqdn, SecureRandom random, int bits, Date notBefore, Date notAfter,
                                  String algorithm) throws CertificateException {
 
-        if (!algorithm.equalsIgnoreCase("EC") && !algorithm.equalsIgnoreCase("RSA")) {
+        if (!"EC".equalsIgnoreCase(algorithm) && !"RSA".equalsIgnoreCase(algorithm)) {
             throw new IllegalArgumentException("Algorithm not valid: " + algorithm);
         }
 


### PR DESCRIPTION
Motivation:

Users may set the algorithm in the constructor of `SelfSignedCertificate`, and need to swap `equalsIgnoreCase` method to call in `SelfSignedCertificate`,can avoid throwing `NullPointerException`

Modification:

Swap `equalsIgnoreCase` method to call in `SelfSignedCertificate`


Result:

`SelfSignedCertificate` will not throw NullPointerException

