### PR TITLE
Improve support for new-api Buffer writes in transports

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/BufferInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferInputStream.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.Send;
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An {@link InputStream} which reads data from a {@link Buffer}.
+ * <p>
+ * A read operation against this stream will occur at the {@code readerOffset}
+ * of its underlying buffer and the {@code readerOffset} will increase during
+ * the read operation.  Please note that it only reads up to the number of
+ * readable bytes determined at the moment of construction.  Therefore,
+ * updating {@link Buffer#writerOffset()} will not affect the return
+ * value of {@link #available()}.
+ * <p>
+ * This stream implements {@link DataInput} for your convenience.
+ * The endianness of the stream is always big endian.
+ *
+ * @see BufferOutputStream
+ */
+public class BufferInputStream extends InputStream implements DataInput {
+    private final Buffer buffer;
+    private final int startIndex;
+    private final int endIndex;
+    private boolean closed;
+    private int markReaderOffset;
+
+    /**
+     * Creates a new stream which reads data from the specified {@code buffer} starting at the current
+     * {@code readerOffset} and ending at the current {@code writerOffset}.
+     * <p>
+     * When this {@link BufferInputStream} is {@linkplain #close() closed, then the sent buffer will also be closed.
+     *
+     * @param buffer The buffer which provides the content for this {@link InputStream}.
+     */
+    public BufferInputStream(Send<Buffer> buffer) {
+        requireNonNull(buffer, "buffer");
+        this.buffer = buffer.receive();
+        int readableBytes = this.buffer.readableBytes();
+        startIndex = this.buffer.readerOffset();
+        endIndex = startIndex + readableBytes;
+        markReaderOffset = startIndex;
+    }
+
+    /**
+     * Returns the number of read bytes by this stream so far.
+     */
+    public int readBytes() {
+        return buffer.readerOffset() - startIndex;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            // The Closable interface says "If the stream is already closed then invoking this method has no effect."
+            return;
+        }
+        try (buffer) {
+            closed = true;
+            super.close();
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        return endIndex - buffer.readerOffset();
+    }
+
+    // Suppress a warning since the class is not thread-safe
+    @Override
+    public void mark(int readlimit) { // lgtm[java/non-sync-override]
+        markReaderOffset = buffer.readerOffset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int available = available();
+        if (available == 0) {
+            return -1;
+        }
+        return buffer.readByte() & 0xff;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int available = available();
+        if (available == 0) {
+            return -1;
+        }
+
+        len = Math.min(available, len);
+        buffer.readBytes(b, off, len);
+        return len;
+    }
+
+    // Suppress a warning since the class is not thread-safe
+    @Override
+    public void reset() throws IOException { // lgtm[java/non-sync-override]
+        buffer.readerOffset(markReaderOffset);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        if (n > Integer.MAX_VALUE) {
+            return skipBytes(Integer.MAX_VALUE);
+        } else {
+            return skipBytes((int) n);
+        }
+    }
+
+    @Override
+    public boolean readBoolean() throws IOException {
+        checkAvailable(1);
+        return read() != 0;
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        int available = available();
+        if (available == 0) {
+            throw new EOFException();
+        }
+        return buffer.readByte();
+    }
+
+    @Override
+    public char readChar() throws IOException {
+        return (char) readShort();
+    }
+
+    @Override
+    public double readDouble() throws IOException {
+        return Double.longBitsToDouble(readLong());
+    }
+
+    @Override
+    public float readFloat() throws IOException {
+        return Float.intBitsToFloat(readInt());
+    }
+
+    @Override
+    public void readFully(byte[] b) throws IOException {
+        readFully(b, 0, b.length);
+    }
+
+    @Override
+    public void readFully(byte[] b, int off, int len) throws IOException {
+        checkAvailable(len);
+        buffer.readBytes(b, off, len);
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        checkAvailable(4);
+        return buffer.readInt();
+    }
+
+    private StringBuilder lineBuf;
+
+    @Override
+    public String readLine() throws IOException {
+        int available = available();
+        if (available == 0) {
+            return null;
+        }
+
+        if (lineBuf != null) {
+            lineBuf.setLength(0);
+        }
+
+        loop: do {
+            int c = buffer.readUnsignedByte();
+            --available;
+            switch (c) {
+                case '\n':
+                    break loop;
+
+                case '\r':
+                    if (available > 0 && (char) buffer.getUnsignedByte(buffer.readerOffset()) == '\n') {
+                        buffer.skipReadable(1);
+                    }
+                    break loop;
+
+                default:
+                    if (lineBuf == null) {
+                        lineBuf = new StringBuilder();
+                    }
+                    lineBuf.append((char) c);
+            }
+        } while (available > 0);
+
+        return lineBuf != null && lineBuf.length() > 0 ? lineBuf.toString() : StringUtil.EMPTY_STRING;
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        checkAvailable(8);
+        return buffer.readLong();
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        checkAvailable(2);
+        return buffer.readShort();
+    }
+
+    @Override
+    public String readUTF() throws IOException {
+        return DataInputStream.readUTF(this);
+    }
+
+    @Override
+    public int readUnsignedByte() throws IOException {
+        return readByte() & 0xff;
+    }
+
+    @Override
+    public int readUnsignedShort() throws IOException {
+        return readShort() & 0xffff;
+    }
+
+    @Override
+    public int skipBytes(int n) throws IOException {
+        int nBytes = Math.min(available(), n);
+        buffer.skipReadable(nBytes);
+        return nBytes;
+    }
+
+    /**
+     * Expose the internally owned buffer.
+     * Use only for testing purpose.
+     *
+     * @return The internal buffer instance.
+     */
+    @UnstableApi
+    Buffer buffer() {
+        return buffer;
+    }
+
+    private void checkAvailable(int fieldSize) throws IOException {
+        if (fieldSize < 0) {
+            throw new IndexOutOfBoundsException("fieldSize cannot be a negative number");
+        }
+        if (fieldSize > available()) {
+            throw new EOFException("fieldSize is too long! Length is " + fieldSize
+                    + ", but maximum is " + available());
+        }
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/BufferInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferInputStream.java
@@ -59,8 +59,7 @@ public class BufferInputStream extends InputStream implements DataInput {
      * @param buffer The buffer which provides the content for this {@link InputStream}.
      */
     public BufferInputStream(Send<Buffer> buffer) {
-        requireNonNull(buffer, "buffer");
-        this.buffer = buffer.receive();
+        this.buffer = requireNonNull(buffer, "buffer").receive();
         int readableBytes = this.buffer.readableBytes();
         startIndex = this.buffer.readerOffset();
         endIndex = startIndex + readableBytes;
@@ -88,7 +87,7 @@ public class BufferInputStream extends InputStream implements DataInput {
 
     @Override
     public int available() throws IOException {
-        return endIndex - buffer.readerOffset();
+        return Math.max(0, endIndex - buffer.readerOffset());
     }
 
     // Suppress a warning since the class is not thread-safe
@@ -262,7 +261,6 @@ public class BufferInputStream extends InputStream implements DataInput {
      *
      * @return The internal buffer instance.
      */
-    @UnstableApi
     Buffer buffer() {
         return buffer;
     }

--- a/buffer/src/main/java/io/netty/buffer/BufferInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferInputStream.java
@@ -103,6 +103,7 @@ public class BufferInputStream extends InputStream implements DataInput {
 
     @Override
     public int read() throws IOException {
+        checkOpen();
         int available = available();
         if (available == 0) {
             return -1;
@@ -112,6 +113,7 @@ public class BufferInputStream extends InputStream implements DataInput {
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
+        checkOpen();
         int available = available();
         if (available == 0) {
             return -1;
@@ -265,7 +267,14 @@ public class BufferInputStream extends InputStream implements DataInput {
         return buffer;
     }
 
+    private void checkOpen() throws IOException {
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
+    }
+
     private void checkAvailable(int fieldSize) throws IOException {
+        checkOpen();
         if (fieldSize < 0) {
             throw new IndexOutOfBoundsException("fieldSize cannot be a negative number");
         }

--- a/buffer/src/main/java/io/netty/buffer/BufferInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferInputStream.java
@@ -43,7 +43,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see BufferOutputStream
  */
-public class BufferInputStream extends InputStream implements DataInput {
+public final class BufferInputStream extends InputStream implements DataInput {
     private final Buffer buffer;
     private final int startIndex;
     private final int endIndex;
@@ -132,11 +132,7 @@ public class BufferInputStream extends InputStream implements DataInput {
 
     @Override
     public long skip(long n) throws IOException {
-        if (n > Integer.MAX_VALUE) {
-            return skipBytes(Integer.MAX_VALUE);
-        } else {
-            return skipBytes((int) n);
-        }
+        return skipBytes((int) Math.min(Integer.MAX_VALUE, n));
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
@@ -148,11 +148,11 @@ public class BufferOutputStream extends OutputStream implements DataOutput {
 
     @Override
     public void writeUTF(String s) throws IOException {
+        if (closed) {
+            throw new IOException("The stream is closed");
+        }
         DataOutputStream out = utf8out;
         if (out == null) {
-            if (closed) {
-                throw new IOException("The stream is closed");
-            }
             // Suppress a warning since the stream is closed in the close() method
             utf8out = out = new DataOutputStream(this); // lgtm[java/output-resource-leak]
         }

--- a/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
@@ -47,8 +47,7 @@ public class BufferOutputStream extends OutputStream implements DataOutput {
      * Creates a new stream which writes data to the specified {@code buffer}.
      */
     public BufferOutputStream(Buffer buffer) {
-        requireNonNull(buffer, "buffer");
-        this.buffer = buffer;
+        this.buffer = requireNonNull(buffer, "buffer");
         startIndex = buffer.writerOffset();
     }
 
@@ -71,6 +70,9 @@ public class BufferOutputStream extends OutputStream implements DataOutput {
 
     @Override
     public void write(byte[] b) throws IOException {
+        if (b.length == 0) {
+            return;
+        }
         prepareWrite(b.length);
         buffer.writeBytes(b);
     }
@@ -180,7 +182,10 @@ public class BufferOutputStream extends OutputStream implements DataOutput {
         }
     }
 
-    private void prepareWrite(int len) {
+    private void prepareWrite(int len) throws IOException {
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
         buffer.ensureWritable(len, buffer.capacity() >> 2, true);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see BufferInputStream
  */
-public class BufferOutputStream extends OutputStream implements DataOutput {
+public final class BufferOutputStream extends OutputStream implements DataOutput {
     private final Buffer buffer;
     private final int startIndex;
     private DataOutputStream utf8out; // lazily-instantiated

--- a/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.util.CharsetUtil;
+
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * An {@link OutputStream} which writes data to a {@link Buffer}.
+ * <p>
+ * A write operation against this stream will occur at the {@code writerOffset}
+ * of its underlying buffer and the {@code writerOffset} will increase during
+ * the write operation.
+ * <p>
+ * This stream implements {@link DataOutput} for your convenience.
+ * The endianness of the stream is always big endian.
+ *
+ * @see BufferInputStream
+ */
+public class BufferOutputStream extends OutputStream implements DataOutput {
+    private final Buffer buffer;
+    private final int startIndex;
+    private DataOutputStream utf8out; // lazily-instantiated
+    private boolean closed;
+
+    /**
+     * Creates a new stream which writes data to the specified {@code buffer}.
+     */
+    public BufferOutputStream(Buffer buffer) {
+        requireNonNull(buffer, "buffer");
+        this.buffer = buffer;
+        startIndex = buffer.writerOffset();
+    }
+
+    /**
+     * Returns the number of written bytes by this stream so far.
+     */
+    public int writtenBytes() {
+        return buffer.writerOffset() - startIndex;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        if (len == 0) {
+            return;
+        }
+
+        prepareWrite(len);
+        buffer.writeBytes(b, off, len);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        prepareWrite(b.length);
+        buffer.writeBytes(b);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        prepareWrite(Integer.BYTES);
+        buffer.writeByte((byte) b);
+    }
+
+    @Override
+    public void writeBoolean(boolean v) throws IOException {
+        prepareWrite(1);
+        buffer.writeByte((byte) (v ? 1 : 0));
+    }
+
+    @Override
+    public void writeByte(int v) throws IOException {
+        prepareWrite(1);
+        buffer.writeByte((byte) v);
+    }
+
+    @Override
+    public void writeBytes(String s) throws IOException {
+        prepareWrite(s.length()); // US ASCII has no multibyte values, so this works.
+        buffer.writeCharSequence(s, CharsetUtil.US_ASCII);
+    }
+
+    @Override
+    public void writeChar(int v) throws IOException {
+        prepareWrite(Character.BYTES);
+        buffer.writeChar((char) v);
+    }
+
+    @Override
+    public void writeChars(String s) throws IOException {
+        int len = s.length();
+        prepareWrite(len * Character.BYTES);
+        for (int i = 0 ; i < len ; i ++) {
+            buffer.writeChar(s.charAt(i));
+        }
+    }
+
+    @Override
+    public void writeDouble(double v) throws IOException {
+        prepareWrite(Double.BYTES);
+        buffer.writeDouble(v);
+    }
+
+    @Override
+    public void writeFloat(float v) throws IOException {
+        prepareWrite(Float.BYTES);
+        buffer.writeFloat(v);
+    }
+
+    @Override
+    public void writeInt(int v) throws IOException {
+        prepareWrite(Integer.BYTES);
+        buffer.writeInt(v);
+    }
+
+    @Override
+    public void writeLong(long v) throws IOException {
+        prepareWrite(Long.BYTES);
+        buffer.writeLong(v);
+    }
+
+    @Override
+    public void writeShort(int v) throws IOException {
+        prepareWrite(Short.BYTES);
+        buffer.writeShort((short) v);
+    }
+
+    @Override
+    public void writeUTF(String s) throws IOException {
+        DataOutputStream out = utf8out;
+        if (out == null) {
+            if (closed) {
+                throw new IOException("The stream is closed");
+            }
+            // Suppress a warning since the stream is closed in the close() method
+            utf8out = out = new DataOutputStream(this); // lgtm[java/output-resource-leak]
+        }
+        out.writeUTF(s);
+    }
+
+    /**
+     * Returns the buffer where this stream is writing data.
+     */
+    public Buffer buffer() {
+        return buffer;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        try {
+            super.close();
+        } finally {
+            if (utf8out != null) {
+                utf8out.close();
+            }
+        }
+    }
+
+    private void prepareWrite(int len) {
+        buffer.ensureWritable(len, buffer.capacity() >> 2, true);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/BufferOutputStream.java
@@ -60,21 +60,18 @@ public class BufferOutputStream extends OutputStream implements DataOutput {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        if (len == 0) {
-            return;
-        }
-
         prepareWrite(len);
-        buffer.writeBytes(b, off, len);
+        if (len > 0) {
+            buffer.writeBytes(b, off, len);
+        }
     }
 
     @Override
     public void write(byte[] b) throws IOException {
-        if (b.length == 0) {
-            return;
-        }
         prepareWrite(b.length);
-        buffer.writeBytes(b);
+        if (b.length > 0) {
+            buffer.writeBytes(b);
+        }
     }
 
     @Override
@@ -186,6 +183,8 @@ public class BufferOutputStream extends OutputStream implements DataOutput {
         if (closed) {
             throw new IOException("Stream closed");
         }
-        buffer.ensureWritable(len, buffer.capacity() >> 2, true);
+        if (len > 0) {
+            buffer.ensureWritable(len, buffer.capacity() >> 2, true);
+        }
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -180,16 +180,12 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     /**
      * Returns the number of readable bytes which is equal to {@code (writerOffset() - readerOffset())}.
      */
-    default int readableBytes() {
-        return writerOffset() - readerOffset();
-    }
+    int readableBytes();
 
     /**
      * Returns the number of writable bytes which is equal to {@code (capacity() - writerOffset())}.
      */
-    default int writableBytes() {
-        return capacity() - writerOffset();
-    }
+    int writableBytes();
 
     /**
      * Fills the buffer with the given byte value. This method does not respect the {@link #readerOffset()} or {@link

--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -339,8 +339,8 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     }
 
     /**
-     * Writes into this buffer, all the bytes from the given byte array.
-     * This updates the {@linkplain #writerOffset() write offset} of this buffer by the length of the array.
+     * Writes into this buffer, the given number of bytes from the byte array.
+     * This updates the {@linkplain #writerOffset() write offset} of this buffer by the length argument.
      *
      * @param source The byte array to read from.
      * @param srcPos Position in the {@code source} from where bytes should be written to this buffer.
@@ -353,6 +353,22 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
         for (int i = 0; i < length; i++) {
             setByte(woff + i, source[srcPos + i]);
         }
+        return this;
+    }
+
+    /**
+     * Read from this buffer, into the destination array, the given number of bytes.
+     * This updates the {@linkplain #readerOffset() read offset} of this buffer by the length argument.
+     *
+     * @param destination The byte array to write into.
+     * @param destPos Position in the {@code destination} to where bytes should be written from this buffer.
+     * @param length The number of bytes to copy.
+     * @return This buffer.
+     */
+    default Buffer readBytes(byte[] destination, int destPos, int length) {
+        int roff = readerOffset();
+        copyInto(roff, destination, destPos, length);
+        readerOffset(roff + length);
         return this;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -310,6 +310,16 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
+    public int readableBytes() {
+        return writerOffset() - readerOffset();
+    }
+
+    @Override
+    public int writableBytes() {
+        return capacity() - writerOffset();
+    }
+
+    @Override
     public CompositeBuffer fill(byte value) {
         if (closed) {
             throw bufferIsClosed(this);

--- a/buffer/src/main/java/io/netty/buffer/api/ReadableComponent.java
+++ b/buffer/src/main/java/io/netty/buffer/api/ReadableComponent.java
@@ -85,6 +85,13 @@ public interface ReadableComponent {
     ByteBuffer readableBuffer();
 
     /**
+     * Get the number of readable bytes from this component.
+     *
+     * @return The number of bytes that can be read from this readable component.
+     */
+    int readableBytes();
+
+    /**
      * Open a cursor to iterate the readable bytes of this component.
      * Any offsets internal to the component are not modified by the cursor.
      * <p>

--- a/buffer/src/main/java/io/netty/buffer/api/WritableComponent.java
+++ b/buffer/src/main/java/io/netty/buffer/api/WritableComponent.java
@@ -65,6 +65,13 @@ public interface WritableComponent {
     long writableNativeAddress();
 
     /**
+     * Get the space available to be written to this component, as a number of bytes.
+     *
+     * @return The maximum number of bytes that can be written to this component.
+     */
+    int writableBytes();
+
+    /**
      * Get a {@link ByteBuffer} instance for this memory component, which can be used for modifying the buffer
      * contents.
      *

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -112,6 +112,16 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     }
 
     @Override
+    public int readableBytes() {
+        return writerOffset() - readerOffset();
+    }
+
+    @Override
+    public int writableBytes() {
+        return capacity() - writerOffset();
+    }
+
+    @Override
     public Buffer fill(byte value) {
         int capacity = capacity();
         checkSet(0, capacity);

--- a/buffer/src/main/java/io/netty/buffer/api/internal/LifecycleTracer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/LifecycleTracer.java
@@ -45,7 +45,7 @@ public abstract class LifecycleTracer {
      * @return A new tracer for a resource.
      */
     public static LifecycleTracer get() {
-        if (!lifecycleTracingEnabled && LeakDetection.leakDetectionEnabled == 0) {
+        if (lifecycleTracingEnabled && LeakDetection.leakDetectionEnabled == 0) {
             return NoOpTracer.INSTANCE;
         }
         StackTracer stackTracer = new StackTracer();

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -121,6 +121,16 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     }
 
     @Override
+    public int readableBytes() {
+        return writerOffset() - readerOffset();
+    }
+
+    @Override
+    public int writableBytes() {
+        return capacity() - writerOffset();
+    }
+
+    @Override
     public Buffer fill(byte value) {
         checkSet(0, capacity());
         if (rsize == CLOSED_SIZE) {

--- a/buffer/src/test/java/io/netty/buffer/BufferStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BufferStreamTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.io.EOFException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests channel buffer streams
+ */
+public class BufferStreamTest {
+
+    @Test
+    public void testAll() throws Exception {
+        Buffer buf = BufferAllocator.onHeapUnpooled().allocate(65536);
+
+        try {
+            new BufferOutputStream(null);
+            fail();
+        } catch (NullPointerException e) {
+            // Expected
+        }
+
+        BufferOutputStream out = new BufferOutputStream(buf);
+        try {
+            assertSame(buf, out.buffer());
+            out.writeBoolean(true);
+            out.writeBoolean(false);
+            out.writeByte(42);
+            out.writeByte(224);
+            out.writeBytes("Hello, World!");
+            out.writeChars("Hello, World");
+            out.writeChar('!');
+            out.writeDouble(42.0);
+            out.writeFloat(42.0f);
+            out.writeInt(42);
+            out.writeLong(42);
+            out.writeShort(42);
+            out.writeShort(49152);
+            out.writeUTF("Hello, World!");
+            out.writeBytes("The first line\r\r\n");
+            out.write(EMPTY_BYTES);
+            out.write(new byte[]{1, 2, 3, 4});
+            out.write(new byte[]{1, 3, 3, 4}, 0, 0);
+        } finally {
+            out.close();
+        }
+
+        try {
+            new BufferInputStream(null);
+            fail();
+        } catch (NullPointerException e) {
+            // Expected
+        }
+
+        try (BufferInputStream in = new BufferInputStream(buf.send())) {
+            assertTrue(in.markSupported());
+            in.mark(Integer.MAX_VALUE);
+
+            assertEquals(in.buffer().writerOffset(), in.skip(Long.MAX_VALUE));
+            assertEquals(0, in.buffer().readableBytes());
+
+            in.reset();
+            assertEquals(0, in.buffer().readerOffset());
+
+            assertEquals(4, in.skip(4));
+            assertEquals(4, in.buffer().readerOffset());
+            in.reset();
+
+            assertTrue(in.readBoolean());
+            assertFalse(in.readBoolean());
+            assertEquals(42, in.readByte());
+            assertEquals(224, in.readUnsignedByte());
+
+            byte[] tmp = new byte[13];
+            in.readFully(tmp);
+            assertEquals("Hello, World!", new String(tmp, StandardCharsets.ISO_8859_1));
+
+            assertEquals('H', in.readChar());
+            assertEquals('e', in.readChar());
+            assertEquals('l', in.readChar());
+            assertEquals('l', in.readChar());
+            assertEquals('o', in.readChar());
+            assertEquals(',', in.readChar());
+            assertEquals(' ', in.readChar());
+            assertEquals('W', in.readChar());
+            assertEquals('o', in.readChar());
+            assertEquals('r', in.readChar());
+            assertEquals('l', in.readChar());
+            assertEquals('d', in.readChar());
+            assertEquals('!', in.readChar());
+
+            assertEquals(42.0, in.readDouble(), 0.0);
+            assertEquals(42.0f, in.readFloat(), 0.0);
+            assertEquals(42, in.readInt());
+            assertEquals(42, in.readLong());
+            assertEquals(42, in.readShort());
+            assertEquals(49152, in.readUnsignedShort());
+
+            assertEquals("Hello, World!", in.readUTF());
+            assertEquals("The first line", in.readLine());
+            assertEquals("", in.readLine());
+
+            assertEquals(4, in.read(tmp));
+            assertEquals(1, tmp[0]);
+            assertEquals(2, tmp[1]);
+            assertEquals(3, tmp[2]);
+            assertEquals(4, tmp[3]);
+
+            assertEquals(-1, in.read());
+            assertEquals(-1, in.read(tmp));
+
+            try {
+                in.readByte();
+                fail();
+            } catch (EOFException e) {
+                // Expected
+            }
+
+            try {
+                in.readFully(tmp, 0, -1);
+                fail();
+            } catch (IndexOutOfBoundsException e) {
+                // Expected
+            }
+
+            try {
+                in.readFully(tmp);
+                fail();
+            } catch (EOFException e) {
+                // Expected
+            }
+            assertEquals(in.buffer().readerOffset(), in.readBytes());
+        }
+    }
+
+    @Test
+    public void testReadLine() throws Exception {
+        Charset utf8 = StandardCharsets.UTF_8;
+        Buffer buf = BufferAllocator.onHeapUnpooled().allocate(256);
+        BufferInputStream in = new BufferInputStream(buf.send());
+
+        String s = in.readLine();
+        assertNull(s);
+        in.close();
+
+        Buffer buf2 = BufferAllocator.onHeapUnpooled().allocate(256);
+        int charCount = 7; //total chars in the string below without new line characters
+        byte[] abc = "\na\n\nb\r\nc\nd\ne".getBytes(utf8);
+        buf2.writeBytes(abc);
+
+        BufferInputStream in2 = new BufferInputStream(buf2.send());
+        in2.mark(charCount);
+        assertEquals("", in2.readLine());
+        assertEquals("a", in2.readLine());
+        assertEquals("", in2.readLine());
+        assertEquals("b", in2.readLine());
+        assertEquals("c", in2.readLine());
+        assertEquals("d", in2.readLine());
+        assertEquals("e", in2.readLine());
+        assertNull(in.readLine());
+
+        in2.reset();
+        int count = 0;
+        while (in2.readLine() != null) {
+            ++count;
+            if (count > charCount) {
+                fail("readLine() should have returned null");
+            }
+        }
+        assertEquals(charCount, count);
+        in2.close();
+    }
+
+    @Test
+    public void testRead() throws Exception {
+        Buffer buf = BufferAllocator.onHeapUnpooled().allocate(16);
+        buf.writeBytes(new byte[]{1, 2, 3, 4, 5, 6});
+
+        try (BufferInputStream in = new BufferInputStream(buf.send())) {
+            assertEquals(1, in.read());
+            assertEquals(2, in.read());
+            assertEquals(3, in.read());
+            assertEquals(4, in.read());
+            assertEquals(5, in.read());
+            assertEquals(6, in.read());
+            assertEquals(-1, in.read());
+        }
+    }
+
+    @Test
+    public void testReadLineLengthRespected2() throws Exception {
+        Buffer buf = BufferAllocator.onHeapUnpooled().allocate(16);
+        buf.writeBytes(new byte[] { 'A', 'B', '\n', 'C', 'E', 'F'});
+
+        try (BufferInputStream in2 = new BufferInputStream(buf.send())) {
+            assertEquals("AB", in2.readLine());
+            assertEquals("CEF", in2.readLine());
+            assertNull(in2.readLine());
+        }
+    }
+
+    @Test
+    public void testReadByteLengthRespected() throws Exception {
+        Buffer buf = BufferAllocator.onHeapUnpooled().allocate(16);
+
+        try (BufferInputStream in = new BufferInputStream(buf.send())) {
+            assertThrows(EOFException.class, in::readByte);
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/BufferStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BufferStreamTest.java
@@ -242,6 +242,7 @@ public class BufferStreamTest {
         Buffer buf = BufferAllocator.onHeapUnpooled().allocate(16);
         BufferOutputStream stream = new BufferOutputStream(buf);
         stream.close();
+        buf.close();
         assertThrows(IOException.class, () -> stream.write(0));
         assertThrows(IOException.class, () -> stream.write(new byte[1]));
         assertThrows(IOException.class, () -> stream.write(new byte[1], 0, 1));
@@ -261,5 +262,35 @@ public class BufferStreamTest {
         assertThrows(IOException.class, () -> stream.writeDouble(0));
         assertThrows(IOException.class, () -> stream.writeUTF("0"));
         assertThrows(IOException.class, () -> stream.writeUTF(""));
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void readsToClosedStreamMustThrow() throws IOException {
+        Buffer buf = BufferAllocator.onHeapUnpooled().allocate(16);
+        BufferInputStream stream = new BufferInputStream(buf.send());
+        stream.close();
+        assertThrows(IOException.class, () -> stream.read());
+        assertThrows(IOException.class, () -> stream.read(new byte[1]));
+        assertThrows(IOException.class, () -> stream.read(new byte[1], 0, 1));
+        assertThrows(IOException.class, () -> stream.readFully(new byte[1]));
+        assertThrows(IOException.class, () -> stream.readFully(new byte[1], 0, 1));
+        assertThrows(IOException.class, () -> stream.readNBytes(0));
+        assertThrows(IOException.class, () -> stream.read(EMPTY_BYTES));
+        assertThrows(IOException.class, () -> stream.read(new byte[1], 0, 0));
+        assertThrows(IOException.class, () -> stream.readBoolean());
+        assertThrows(IOException.class, () -> stream.readByte());
+        assertThrows(IOException.class, () -> stream.readUnsignedByte());
+        assertThrows(IOException.class, () -> stream.readAllBytes());
+        assertThrows(IOException.class, () -> stream.readNBytes(1));
+        assertThrows(IOException.class, () -> stream.readChar());
+        assertThrows(IOException.class, () -> stream.readFloat());
+        assertThrows(IOException.class, () -> stream.readInt());
+        assertThrows(IOException.class, () -> stream.readShort());
+        assertThrows(IOException.class, () -> stream.readUnsignedShort());
+        assertThrows(IOException.class, () -> stream.readLong());
+        assertThrows(IOException.class, () -> stream.readDouble());
+        assertThrows(IOException.class, () -> stream.readUTF());
+        stream.readBytes(); // Query method... not actually reading
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/BufferStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BufferStreamTest.java
@@ -246,8 +246,8 @@ public class BufferStreamTest {
         assertThrows(IOException.class, () -> stream.write(0));
         assertThrows(IOException.class, () -> stream.write(new byte[1]));
         assertThrows(IOException.class, () -> stream.write(new byte[1], 0, 1));
-        stream.write(EMPTY_BYTES);
-        stream.write(new byte[1], 0, 0);
+        assertThrows(IOException.class, () -> stream.write(EMPTY_BYTES));
+        assertThrows(IOException.class, () -> stream.write(new byte[1], 0, 0));
         assertThrows(IOException.class, () -> stream.writeBoolean(true));
         assertThrows(IOException.class, () -> stream.writeByte(0));
         assertThrows(IOException.class, () -> stream.writeBytes("0"));

--- a/buffer/src/test/java/io/netty/buffer/BufferStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BufferStreamTest.java
@@ -20,6 +20,7 @@ import io.netty.buffer.api.BufferAllocator;
 import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -234,5 +235,31 @@ public class BufferStreamTest {
         try (BufferInputStream in = new BufferInputStream(buf.send())) {
             assertThrows(EOFException.class, in::readByte);
         }
+    }
+
+    @Test
+    public void writesToClosedStreamMustThrow() throws IOException {
+        Buffer buf = BufferAllocator.onHeapUnpooled().allocate(16);
+        BufferOutputStream stream = new BufferOutputStream(buf);
+        stream.close();
+        assertThrows(IOException.class, () -> stream.write(0));
+        assertThrows(IOException.class, () -> stream.write(new byte[1]));
+        assertThrows(IOException.class, () -> stream.write(new byte[1], 0, 1));
+        stream.write(EMPTY_BYTES);
+        stream.write(new byte[1], 0, 0);
+        assertThrows(IOException.class, () -> stream.writeBoolean(true));
+        assertThrows(IOException.class, () -> stream.writeByte(0));
+        assertThrows(IOException.class, () -> stream.writeBytes("0"));
+        assertThrows(IOException.class, () -> stream.writeBytes(""));
+        assertThrows(IOException.class, () -> stream.writeChar(0));
+        assertThrows(IOException.class, () -> stream.writeChars("0"));
+        assertThrows(IOException.class, () -> stream.writeChars(""));
+        assertThrows(IOException.class, () -> stream.writeFloat(0));
+        assertThrows(IOException.class, () -> stream.writeInt(0));
+        assertThrows(IOException.class, () -> stream.writeShort(0));
+        assertThrows(IOException.class, () -> stream.writeLong(0));
+        assertThrows(IOException.class, () -> stream.writeDouble(0));
+        assertThrows(IOException.class, () -> stream.writeUTF("0"));
+        assertThrows(IOException.class, () -> stream.writeUTF(""));
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferBulkAccessTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferBulkAccessTest.java
@@ -317,4 +317,20 @@ public class BufferBulkAccessTest extends BufferTestSupport {
             assertThat(toByteArray(buffer)).containsExactly(1, 3, 4);
         }
     }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readBytesWithOffsetMustWriteAllBytesIntoByteArray(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(8)) {
+            buffer.writeLong(0x0102030405060708L);
+            byte[] array = new byte[4];
+            assertThat(buffer.readByte()).isEqualTo((byte) 1);
+            assertThat(buffer.readByte()).isEqualTo((byte) 2);
+            buffer.readBytes(array, 1, 2);
+            assertThat(buffer.writerOffset()).isEqualTo(8);
+            assertThat(buffer.readerOffset()).isEqualTo(4);
+            assertThat(array).containsExactly(0, 0x03, 0x04, 0);
+        }
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -75,7 +75,8 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
     @Override
     public Send<FullHttpRequest> send() {
         return payload.send().map(FullHttpRequest.class,
-                payload -> new DefaultFullHttpRequest(protocolVersion(), method(), uri(), payload));
+                payload -> new DefaultFullHttpRequest(
+                        protocolVersion(), method(), uri(), payload, headers(), trailingHeader));
     }
 
     @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -495,7 +495,7 @@ public class HttpContentCompressorTest {
         assertThat(o, is(instanceOf(FullHttpResponse.class)));
 
         res = (FullHttpResponse) o;
-        assertSame(continueResponse, res);
+        assertEquals(continueResponse, res);
         res.close();
 
         o = ch.readOutbound();
@@ -709,6 +709,12 @@ public class HttpContentCompressorTest {
             this.payload = payload;
         }
 
+        AssembledHttpResponse(
+                HttpVersion version, HttpResponseStatus status, HttpHeaders headers, Buffer payload) {
+            super(version, status, headers);
+            this.payload = payload;
+        }
+
         @Override
         public Buffer payload() {
             return payload;
@@ -717,7 +723,7 @@ public class HttpContentCompressorTest {
         @Override
         public Send<AssembledHttpResponse> send() {
             return payload.send().map(AssembledHttpResponse.class,
-                    p -> new AssembledHttpResponse(protocolVersion(), status(), p));
+                    p -> new AssembledHttpResponse(protocolVersion(), status(), headers(), p));
         }
 
         @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
@@ -442,10 +442,10 @@ public class HttpContentEncoderTest {
         assertNull(ch.readInbound());
 
         HttpResponse response = ch.readOutbound();
-        assertSame(res, response);
+        assertEquals(res, response);
 
         LastHttpContent<?> content = ch.readOutbound();
-        assertSame(lastContent, content);
+        assertEquals(lastContent, content);
         content.close();
         assertNull(ch.readOutbound());
     }

--- a/handler/src/test/java/io/netty/handler/timeout/BufferIdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/BufferIdleStateHandlerTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.timeout;
+
+import io.netty.buffer.api.BufferAllocator;
+
+public class BufferIdleStateHandlerTest extends AbstractIdleStateHandlerTest {
+    @Override
+    protected Object bufferOf(byte[] array) {
+        return BufferAllocator.onHeapUnpooled().copyOf(array);
+    }
+}

--- a/handler/src/test/java/io/netty/handler/timeout/ByteBufIdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/ByteBufIdleStateHandlerTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.timeout;
+
+import io.netty.buffer.Unpooled;
+
+public class ByteBufIdleStateHandlerTest extends AbstractIdleStateHandlerTest {
+    @Override
+    protected Object bufferOf(byte[] array) {
+        return Unpooled.wrappedBuffer(array);
+    }
+}

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -252,14 +252,17 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
                 if (cause != null) {
                     throw cause;
                 }
-                fail();
+                fail("timed out waiting for latch(" +
+                     "initial count: " + count + ", current count: " + latch.getCount() + "), wrap type: " + wrapType);
             }
             if (!clientLatch.await(10, TimeUnit.SECONDS)) {
                 Throwable cause = clientErrorRef.get();
                 if (cause != null) {
                     throw cause;
                 }
-                fail();
+                fail("timed out waiting for clientLatch(" +
+                     "initial count: " + count + ", current count: " + clientLatch.getCount() +
+                     "), wrap type: " + wrapType);
             }
             assertTrue(isConnected(cc));
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
@@ -136,8 +136,8 @@ public final class IovArray implements MessageProcessor, ReadableComponentProces
 
         // If there is at least 1 entry then we enforce the maximum bytes. We want to accept at least one entry so we
         // will attempt to write some data and make progress.
-        if ((maxBytes - len < size && count > 0) ||
-                // Check if we have enough space left
+        if (maxBytes - len < size && count > 0 ||
+            // Check if we have enough space left
                 memory.capacity() < (count + 1) * IOV_SIZE) {
             // If the size + len will overflow SSIZE_MAX we stop populate the IovArray. This is done as linux
             //  not allow to write more bytes then SSIZE_MAX with one writev(...) call and so will
@@ -226,7 +226,7 @@ public final class IovArray implements MessageProcessor, ReadableComponentProces
     }
 
     @Override
-    public boolean processMessage(Object msg) throws Exception {
+    public boolean processMessage(Object msg) {
         if (msg instanceof io.netty.buffer.api.Buffer) {
             var buffer = (io.netty.buffer.api.Buffer) msg;
             buffer.forEachReadable(0, this);

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
@@ -18,6 +18,8 @@ package io.netty.channel.unix;
 import io.netty.buffer.ByteBufConvertible;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.ReadableComponent;
+import io.netty.buffer.api.ReadableComponentProcessor;
 import io.netty.channel.ChannelOutboundBuffer.MessageProcessor;
 import io.netty.util.internal.PlatformDependent;
 
@@ -46,7 +48,7 @@ import static java.lang.Math.min;
  * <a href="https://rkennke.wordpress.com/2007/07/30/efficient-jni-programming-iv-wrapping-native-data-objects/"
  * >Efficient JNI programming IV: Wrapping native data objects</a>.
  */
-public final class IovArray implements MessageProcessor {
+public final class IovArray implements MessageProcessor, ReadableComponentProcessor<RuntimeException> {
 
     /** The size of an address which should be 8 for 64 bits and 4 for 32 bits. */
     private static final int ADDRESS_SIZE = Buffer.addressSize();
@@ -225,7 +227,10 @@ public final class IovArray implements MessageProcessor {
 
     @Override
     public boolean processMessage(Object msg) throws Exception {
-        if (msg instanceof ByteBufConvertible) {
+        if (msg instanceof io.netty.buffer.api.Buffer) {
+            var buffer = (io.netty.buffer.api.Buffer) msg;
+            buffer.forEachReadable(0, this);
+        } else if (msg instanceof ByteBufConvertible) {
             ByteBuf buffer = ((ByteBufConvertible) msg).asByteBuf();
             return add(buffer, buffer.readerIndex(), buffer.readableBytes());
         }
@@ -234,5 +239,10 @@ public final class IovArray implements MessageProcessor {
 
     private static int idx(int index) {
         return IOV_SIZE * index;
+    }
+
+    @Override
+    public boolean process(int index, ReadableComponent component) {
+        return add(memoryAddress, component.readableNativeAddress(), component.readableBytes());
     }
 }

--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueueForBuffer.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueueForBuffer.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.CompositeBuffer;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.ArrayDeque;
+
+import static io.netty.util.ReferenceCountUtil.safeRelease;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import static java.util.Objects.requireNonNull;
+
+@SuppressWarnings("unchecked")
+@UnstableApi
+public abstract class AbstractCoalescingBufferQueueForBuffer {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(
+            AbstractCoalescingBufferQueueForBuffer.class);
+    private final ArrayDeque<Object> bufAndListenerPairs;
+    private final PendingBytesTracker tracker;
+    private int readableBytes;
+
+    /**
+     * Create a new instance.
+     *
+     * @param channel the {@link Channel} which will have the {@link Channel#isWritable()} reflect the amount of queued
+     *                buffers or {@code null} if there is no writability state updated.
+     * @param initSize the initial size of the underlying queue.
+     */
+    protected AbstractCoalescingBufferQueueForBuffer(Channel channel, int initSize) {
+        bufAndListenerPairs = new ArrayDeque<>(initSize);
+        tracker = channel == null ? null : PendingBytesTracker.newTracker(channel);
+    }
+
+    /**
+     * Add a buffer to the front of the queue and associate a promise with it that should be completed when
+     * all the buffer's bytes have been consumed from the queue and written.
+     * @param buf to add to the head of the queue
+     * @param promise to complete when all the bytes have been consumed and written, can be void.
+     */
+    public final void addFirst(Buffer buf, Promise<Void> promise) {
+        addFirst(buf, f -> f.cascadeTo(promise));
+    }
+
+    private void addFirst(Buffer buf, FutureListener<Void> listener) {
+        if (listener != null) {
+            bufAndListenerPairs.addFirst(listener);
+        }
+        bufAndListenerPairs.addFirst(buf);
+        incrementReadableBytes(buf.readableBytes());
+    }
+
+    /**
+     * Add a buffer to the end of the queue.
+     */
+    public final void add(Buffer buf) {
+        add(buf, (FutureListener<Void>) null);
+    }
+
+    /**
+     * Add a buffer to the end of the queue and associate a promise with it that should be completed when
+     * all the buffer's bytes have been consumed from the queue and written.
+     * @param buf to add to the tail of the queue
+     * @param promise to complete when all the bytes have been consumed and written, can be void.
+     */
+    public final void add(Buffer buf, Promise<Void> promise) {
+        // buffers are added before promises so that we naturally 'consume' the entire buffer during removal
+        // before we complete it's promise.
+        add(buf, f -> f.cascadeTo(promise));
+    }
+
+    /**
+     * Add a buffer to the end of the queue and associate a listener with it that should be completed when
+     * all the buffers  bytes have been consumed from the queue and written.
+     * @param buf to add to the tail of the queue
+     * @param listener to notify when all the bytes have been consumed and written, can be {@code null}.
+     */
+    public final void add(Buffer buf, FutureListener<Void> listener) {
+        // buffers are added before promises so that we naturally 'consume' the entire buffer during removal
+        // before we complete it's promise.
+        bufAndListenerPairs.add(buf);
+        if (listener != null) {
+            bufAndListenerPairs.add(listener);
+        }
+        incrementReadableBytes(buf.readableBytes());
+    }
+
+    /**
+     * Remove the first {@link Buffer} from the queue.
+     * @param aggregatePromise used to aggregate the promises and listeners for the returned buffer.
+     * @return the first {@link Buffer} from the queue.
+     */
+    public final Buffer removeFirst(Promise<Void> aggregatePromise) {
+        Object entry = bufAndListenerPairs.poll();
+        if (entry == null) {
+            return null;
+        }
+        assert entry instanceof Buffer;
+        Buffer result = (Buffer) entry;
+
+        decrementReadableBytes(result.readableBytes());
+
+        entry = bufAndListenerPairs.peek();
+        if (entry instanceof FutureListener) {
+            aggregatePromise.asFuture().addListener((FutureListener<Void>) entry);
+            bufAndListenerPairs.poll();
+        }
+        return result;
+    }
+
+    /**
+     * Remove a {@link Buffer} from the queue with the specified number of bytes. Any added buffer whose bytes are
+     * fully consumed during removal will have their promise completed when the passed aggregate {@link Promise}
+     * completes.
+     *
+     * @param alloc The allocator used if a new {@link Buffer} is generated during the aggregation process.
+     * @param bytes the maximum number of readable bytes in the returned {@link Buffer}, if {@code bytes} is greater
+     *              than {@link #readableBytes} then a buffer of length {@link #readableBytes} is returned.
+     * @param aggregatePromise used to aggregate the promises and listeners for the constituent buffers.
+     * @return a {@link Buffer} composed of the enqueued buffers.
+     */
+    public final Buffer remove(BufferAllocator alloc, int bytes, Promise<Void> aggregatePromise) {
+        checkPositiveOrZero(bytes, "bytes");
+        requireNonNull(aggregatePromise, "aggregatePromise");
+
+        // Use isEmpty rather than readableBytes==0 as we may have a promise associated with an empty buffer.
+        if (bufAndListenerPairs.isEmpty()) {
+            assert readableBytes == 0;
+            return removeEmptyValue();
+        }
+        bytes = Math.min(bytes, readableBytes);
+
+        Buffer toReturn = null;
+        Buffer entryBuffer = null;
+        int originalBytes = bytes;
+        try {
+            for (;;) {
+                Object entry = bufAndListenerPairs.poll();
+                if (entry == null) {
+                    break;
+                }
+                if (entry instanceof FutureListener) {
+                    aggregatePromise.asFuture().addListener((FutureListener<Void>) entry);
+                    continue;
+                }
+                entryBuffer = (Buffer) entry;
+                if (entryBuffer.readableBytes() > bytes) {
+                    // Add the buffer back to the queue as we can't consume all of it.
+                    bufAndListenerPairs.addFirst(entryBuffer);
+                    if (bytes > 0) {
+                        // Take a slice of what we can consume and retain it.
+                        entryBuffer = entryBuffer.readSplit(bytes);
+                        toReturn = toReturn == null ? composeFirst(alloc, entryBuffer)
+                                                    : compose(alloc, toReturn, entryBuffer);
+                        bytes = 0;
+                    }
+                    break;
+                }
+                bytes -= entryBuffer.readableBytes();
+                toReturn = toReturn == null ? composeFirst(alloc, entryBuffer)
+                                            : compose(alloc, toReturn, entryBuffer);
+                entryBuffer = null;
+            }
+        } catch (Throwable cause) {
+            safeRelease(entryBuffer);
+            safeRelease(toReturn);
+            aggregatePromise.setFailure(cause);
+            throw cause;
+        }
+        decrementReadableBytes(originalBytes - bytes);
+        return toReturn;
+    }
+
+    /**
+     * The number of readable bytes.
+     */
+    public final int readableBytes() {
+        return readableBytes;
+    }
+
+    /**
+     * Are there pending buffers in the queue.
+     */
+    public final boolean isEmpty() {
+        return bufAndListenerPairs.isEmpty();
+    }
+
+    /**
+     *  Release all buffers in the queue and complete all listeners and promises.
+     */
+    public final void releaseAndFailAll(ChannelOutboundInvoker invoker, Throwable cause) {
+        releaseAndCompleteAll(invoker.newFailedFuture(cause));
+    }
+
+    /**
+     * Copy all pending entries in this queue into the destination queue.
+     * @param dest to copy pending buffers to.
+     */
+    public final void copyTo(AbstractCoalescingBufferQueueForBuffer dest) {
+        dest.bufAndListenerPairs.addAll(bufAndListenerPairs);
+        dest.incrementReadableBytes(readableBytes);
+    }
+
+    /**
+     * Writes all remaining elements in this queue.
+     * @param ctx The context to write all elements to.
+     */
+    public final void writeAndRemoveAll(ChannelHandlerContext ctx) {
+        Throwable pending = null;
+        Buffer previousBuf = null;
+        for (;;) {
+            Object entry = bufAndListenerPairs.poll();
+            try {
+                if (entry == null) {
+                    if (previousBuf != null) {
+                        decrementReadableBytes(previousBuf.readableBytes());
+                        // If the write fails we want to at least propagate the exception through the ChannelPipeline
+                        // as otherwise the user will not be made aware of the failure at all.
+                        ctx.write(previousBuf)
+                           .addListener(ctx.channel(), ChannelFutureListeners.FIRE_EXCEPTION_ON_FAILURE);
+                    }
+                    break;
+                }
+
+                if (entry instanceof Buffer) {
+                    if (previousBuf != null) {
+                        decrementReadableBytes(previousBuf.readableBytes());
+                        // If the write fails we want to at least propagate the exception through the ChannelPipeline
+                        // as otherwise the user will not be made aware of the failure at all.
+                        ctx.write(previousBuf)
+                           .addListener(ctx.channel(), ChannelFutureListeners.FIRE_EXCEPTION_ON_FAILURE);
+                    }
+                    previousBuf = (Buffer) entry;
+                } else if (entry instanceof Promise) {
+                    decrementReadableBytes(previousBuf.readableBytes());
+                    ctx.write(previousBuf).cascadeTo((Promise<? super Void>) entry);
+                    previousBuf = null;
+                } else {
+                    decrementReadableBytes(previousBuf.readableBytes());
+                    ctx.write(previousBuf).addListener((FutureListener<Void>) entry);
+                    previousBuf = null;
+                }
+            } catch (Throwable t) {
+                if (pending == null) {
+                    pending = t;
+                } else {
+                    logger.info("Throwable being suppressed because Throwable {} is already pending", pending, t);
+                }
+            }
+        }
+        if (pending != null) {
+            throw new IllegalStateException(pending);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "bytes: " + readableBytes + " buffers: " + (size() >> 1);
+    }
+
+    /**
+     * Calculate the result of {@code current + next}.
+     */
+    protected abstract Buffer compose(BufferAllocator alloc, Buffer cumulation, Buffer next);
+
+    /**
+     * Compose {@code cumulation} and {@code next} into a new {@link CompositeBuffer}.
+     */
+    protected final Buffer composeIntoComposite(BufferAllocator alloc, Buffer cumulation, Buffer next) {
+        // Create a composite buffer to accumulate this pair and potentially all the buffers
+        // in the queue. Using +2 as we have already dequeued current and next.
+        try (next) {
+            return CompositeBuffer.compose(alloc, cumulation.send(), next.send());
+        }
+    }
+
+    /**
+     * Compose {@code cumulation} and {@code next} into a new {@link Buffer} suitable for IO.
+     * @param alloc The allocator to use to allocate the new buffer.
+     * @param cumulation The current cumulation.
+     * @param next The next buffer.
+     * @return The result of {@code cumulation + next}.
+     */
+    protected final Buffer copyAndCompose(BufferAllocator alloc, Buffer cumulation, Buffer next) {
+        try (cumulation; next) {
+            int sum = cumulation.readableBytes() + next.readableBytes();
+            return alloc.allocate(sum).writeBytes(cumulation).writeBytes(next);
+        }
+    }
+
+    /**
+     * Calculate the first {@link Buffer} which will be used in subsequent calls to
+     * {@link #compose(BufferAllocator, Buffer, Buffer)}.
+     */
+    protected Buffer composeFirst(BufferAllocator allocator, Buffer first) {
+        return first;
+    }
+
+    /**
+     * The value to return when {@link #remove(BufferAllocator, int, Promise)} is called but the queue is empty.
+     * @return the {@link Buffer} which represents an empty queue.
+     */
+    protected abstract Buffer removeEmptyValue();
+
+    /**
+     * Get the number of elements in this queue added via one of the {@link #add(Buffer)} methods.
+     * @return the number of elements in this queue.
+     */
+    protected final int size() {
+        return bufAndListenerPairs.size();
+    }
+
+    private void releaseAndCompleteAll(Future<Void> future) {
+        Throwable pending = null;
+        for (;;) {
+            Object entry = bufAndListenerPairs.poll();
+            if (entry == null) {
+                break;
+            }
+            try {
+                if (entry instanceof Buffer) {
+                    Buffer buffer = (Buffer) entry;
+                    decrementReadableBytes(buffer.readableBytes());
+                    safeRelease(buffer);
+                } else {
+                    ((FutureListener<Void>) entry).operationComplete(future);
+                }
+            } catch (Throwable t) {
+                if (pending == null) {
+                    pending = t;
+                } else {
+                    logger.info("Throwable being suppressed because Throwable {} is already pending", pending, t);
+                }
+            }
+        }
+        if (pending != null) {
+            throw new IllegalStateException(pending);
+        }
+    }
+
+    private void incrementReadableBytes(int increment) {
+        int nextReadableBytes = readableBytes + increment;
+        if (nextReadableBytes < readableBytes) {
+            throw new IllegalStateException("buffer queue length overflow: " + readableBytes + " + " + increment);
+        }
+        readableBytes = nextReadableBytes;
+        if (tracker != null) {
+            tracker.incrementPendingOutboundBytes(increment);
+        }
+    }
+
+    private void decrementReadableBytes(int decrement) {
+        readableBytes -= decrement;
+        assert readableBytes >= 0;
+        if (tracker != null) {
+            tracker.decrementPendingOutboundBytes(decrement);
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/CoalescingBufferQueueForBuffer.java
+++ b/transport/src/main/java/io/netty/channel/CoalescingBufferQueueForBuffer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.CompositeBuffer;
+import io.netty.util.concurrent.Promise;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A FIFO queue of bytes where producers add bytes by repeatedly adding {@link Buffer} and consumers take bytes in
+ * arbitrary lengths. This allows producers to add lots of small buffers and the consumer to take all the bytes out in a
+ * single buffer. Conversely, the producer may add larger buffers and the consumer could take the bytes in many small
+ * buffers.
+ *
+ * <p>Bytes are added and removed with promises. If the last byte of a buffer added with a promise is removed then
+ * that promise will complete when the promise passed to {@link #remove} completes.
+ *
+ * <p>This functionality is useful for aggregating or partitioning writes into fixed size buffers for framing protocols
+ * such as HTTP2.
+ */
+public final class CoalescingBufferQueueForBuffer extends AbstractCoalescingBufferQueueForBuffer {
+    private final Channel channel;
+
+    public CoalescingBufferQueueForBuffer(Channel channel) {
+        this(channel, 4);
+    }
+
+    public CoalescingBufferQueueForBuffer(Channel channel, int initSize) {
+        this(channel, initSize, false);
+    }
+
+    public CoalescingBufferQueueForBuffer(Channel channel, int initSize, boolean updateWritability) {
+        super(updateWritability ? channel : null, initSize);
+        this.channel = requireNonNull(channel, "channel");
+    }
+
+    /**
+     * Remove a {@link Buffer} from the queue with the specified number of bytes. Any added buffer whose bytes are fully
+     * consumed during removal will have it's promise completed when the passed aggregate {@link Promise} completes.
+     *
+     * @param bytes the maximum number of readable bytes in the returned {@link Buffer}, if {@code bytes} is greater
+     *              than {@link #readableBytes()} then a buffer of length {@link #readableBytes()} is returned.
+     * @param aggregatePromise used to aggregate the promises and listeners for the constituent buffers.
+     * @return a {@link Buffer} composed of the enqueued buffers.
+     */
+    public Buffer remove(int bytes, Promise<Void> aggregatePromise) {
+        return remove(channel.bufferAllocator(), bytes, aggregatePromise);
+    }
+
+    /**
+     *  Release all buffers in the queue and complete all listeners and promises.
+     */
+    public void releaseAndFailAll(Throwable cause) {
+        releaseAndFailAll(channel, cause);
+    }
+
+    @Override
+    protected Buffer compose(BufferAllocator alloc, Buffer cumulation, Buffer next) {
+        if (cumulation instanceof CompositeBuffer) {
+            CompositeBuffer composite = (CompositeBuffer) cumulation;
+            composite.extendWith(next.send());
+            return composite;
+        }
+        return composeIntoComposite(alloc, cumulation, next);
+    }
+
+    @Override
+    protected Buffer removeEmptyValue() {
+        return BufferAllocator.offHeapUnpooled().allocate(0);
+    }
+}

--- a/transport/src/test/java/io/netty/channel/AbstractCoalescingBufferQueueForBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractCoalescingBufferQueueForBufferTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 The Netty Project
+
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+
+ * https://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+
+import java.nio.channels.ClosedChannelException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AbstractCoalescingBufferQueueForBufferTest {
+
+    // See https://github.com/netty/netty/issues/10286
+    @Test
+    public void testDecrementAllWhenWriteAndRemoveAll() {
+        testDecrementAll(true);
+    }
+
+    // See https://github.com/netty/netty/issues/10286
+    @Test
+    public void testDecrementAllWhenReleaseAndFailAll() {
+        testDecrementAll(false);
+    }
+
+    private static void testDecrementAll(boolean write) {
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() {
+            @Override
+            public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+                ReferenceCountUtil.release(msg);
+                return ctx.newSucceededFuture();
+            }
+        }, new ChannelHandlerAdapter() { });
+        final AbstractCoalescingBufferQueueForBuffer queue = new AbstractCoalescingBufferQueueForBuffer(channel, 128) {
+            @Override
+            protected Buffer compose(BufferAllocator alloc, Buffer cumulation, Buffer next) {
+                return composeIntoComposite(alloc, cumulation, next);
+            }
+
+            @Override
+            protected Buffer removeEmptyValue() {
+                return BufferAllocator.offHeapUnpooled().allocate(0);
+            }
+        };
+
+        final byte[] bytes = new byte[128];
+        queue.add(BufferAllocator.offHeapUnpooled().copyOf(bytes), future -> {
+            queue.add(BufferAllocator.offHeapUnpooled().copyOf(bytes));
+            assertEquals(bytes.length, queue.readableBytes());
+        });
+
+        assertEquals(bytes.length, queue.readableBytes());
+
+        ChannelHandlerContext ctx = channel.pipeline().lastContext();
+        if (write) {
+            queue.writeAndRemoveAll(ctx);
+        } else {
+            queue.releaseAndFailAll(ctx, new ClosedChannelException());
+        }
+        Buffer buffer = queue.remove(channel.bufferAllocator(), 128, channel.newPromise());
+        assertFalse(buffer.readableBytes() > 0);
+        buffer.close();
+
+        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.readableBytes());
+
+        assertFalse(channel.finish());
+    }
+}

--- a/transport/src/test/java/io/netty/channel/BaseChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/BaseChannelTest.java
@@ -19,6 +19,8 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalHandler;
 import io.netty.channel.local.LocalServerChannel;
@@ -64,6 +66,12 @@ class BaseChannelTest {
         return buf;
     }
 
+    static Buffer createTestBuffer(int len) {
+        Buffer buf = BufferAllocator.onHeapUnpooled().allocate(len);
+        buf.writerOffset(len);
+        return buf;
+    }
+
     void assertLog(String firstExpected, String... otherExpected) {
         String actual = loggingHandler.getLog();
         if (firstExpected.equals(actual)) {
@@ -77,10 +85,6 @@ class BaseChannelTest {
 
         // Let the comparison fail with the first expectation.
         assertEquals(firstExpected, actual);
-    }
-
-    void clearLog() {
-        loggingHandler.clear();
     }
 
     void setInterest(LoggingHandler.Event... events) {

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -17,6 +17,10 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.CompositeBuffer;
+import io.netty.buffer.api.Send;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Promise;
@@ -25,13 +29,13 @@ import org.junit.jupiter.api.Test;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Executors;
+import java.util.stream.Stream;
 
 import static io.netty.buffer.Unpooled.buffer;
 import static io.netty.buffer.Unpooled.compositeBuffer;
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static io.netty.buffer.Unpooled.directBuffer;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -54,7 +58,7 @@ public class ChannelOutboundBufferTest {
     }
 
     @Test
-    public void testNioBuffersSingleBacked() {
+    public void testNioBuffersSingleBackedByteBuf() {
         TestChannel channel = new TestChannel();
 
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
@@ -70,7 +74,7 @@ public class ChannelOutboundBufferTest {
         assertEquals(1, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
         for (int i = 0;  i < buffer.nioBufferCount(); i++) {
             if (i == 0) {
-                assertEquals(buffers[i], nioBuf);
+                assertEquals(buffers[0], nioBuf);
             } else {
                 assertNull(buffers[i]);
             }
@@ -79,7 +83,36 @@ public class ChannelOutboundBufferTest {
     }
 
     @Test
-    public void testNioBuffersExpand() {
+    public void testNioBuffersSingleBacked() {
+        TestChannel channel = new TestChannel();
+
+        ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
+        assertEquals(0, buffer.nioBufferCount());
+
+        Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        buffer.addMessage(buf, buf.readableBytes(), channel.newPromise());
+        assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
+        buffer.addFlush();
+        ByteBuffer[] buffers = buffer.nioBuffers();
+        assertNotNull(buffers);
+        assertEquals(1, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
+        for (int i = 0;  i < buffer.nioBufferCount(); i++) {
+            if (i == 0) {
+                assertEquals(1, buf.countReadableComponents());
+                buf.forEachReadable(0, (index, component) -> {
+                    assertEquals(0, index, "Expected buffer to only have a single component.");
+                    assertEquals(buffers[0], component.readableBuffer());
+                    return true;
+                });
+            } else {
+                assertNull(buffers[i]);
+            }
+        }
+        release(buffer);
+    }
+
+    @Test
+    public void testNioBuffersExpandByteBuf() {
         TestChannel channel = new TestChannel();
 
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
@@ -100,7 +133,35 @@ public class ChannelOutboundBufferTest {
     }
 
     @Test
-    public void testNioBuffersExpand2() {
+    public void testNioBuffersExpand() {
+        TestChannel channel = new TestChannel();
+
+        ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
+
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        for (int i = 0; i < 64; i++) {
+            buffer.addMessage(buf.copy(), buf.readableBytes(), channel.newPromise());
+        }
+        assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
+        buffer.addFlush();
+        ByteBuffer[] buffers = buffer.nioBuffers();
+        assertEquals(64, buffer.nioBufferCount());
+        assertEquals(1, buf.countReadableComponents());
+        buf.forEachReadable(0, (index, component) -> {
+            assertEquals(0, index);
+            ByteBuffer expected = component.readableBuffer();
+            for (int i = 0;  i < buffer.nioBufferCount(); i++) {
+                assertEquals(expected, buffers[i]);
+            }
+            return true;
+        });
+
+        release(buffer);
+        buf.close();
+    }
+
+    @Test
+    public void testNioBuffersExpand2ByteBuf() {
         TestChannel channel = new TestChannel();
 
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
@@ -128,7 +189,42 @@ public class ChannelOutboundBufferTest {
     }
 
     @Test
-    public void testNioBuffersMaxCount() {
+    public void testNioBuffersExpand2() {
+        TestChannel channel = new TestChannel();
+
+        ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
+
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        var sends = Stream.generate(() -> buf.copy().send()).limit(65).toArray(Send[]::new);
+        @SuppressWarnings("unchecked")
+        CompositeBuffer comp = CompositeBuffer.compose(BufferAllocator.offHeapUnpooled(), sends);
+
+        buffer.addMessage(comp, comp.readableBytes(), channel.newPromise());
+
+        assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
+        buffer.addFlush();
+        ByteBuffer[] buffers = buffer.nioBuffers();
+        assertEquals(65, buffer.nioBufferCount());
+        assertEquals(1, buf.countReadableComponents());
+        buf.forEachReadable(0, (index, component) -> {
+            assertEquals(0, index);
+            ByteBuffer expected = component.readableBuffer();
+            for (int i = 0;  i < buffer.nioBufferCount(); i++) {
+                if (i < 65) {
+                    assertEquals(expected, buffers[i]);
+                } else {
+                    assertNull(buffers[i]);
+                }
+            }
+            return true;
+        });
+
+        release(buffer);
+        buf.close();
+    }
+
+    @Test
+    public void testNioBuffersMaxCountByteBuf() {
         TestChannel channel = new TestChannel();
 
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
@@ -150,6 +246,73 @@ public class ChannelOutboundBufferTest {
         }
         release(buffer);
         buf.release();
+    }
+
+    @Test
+    public void testNioBuffersMaxCount() {
+        TestChannel channel = new TestChannel();
+
+        ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
+
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        assertEquals(4, buf.readableBytes());
+        var sends = Stream.generate(() -> buf.copy().send()).limit(65).toArray(Send[]::new);
+        @SuppressWarnings("unchecked")
+        CompositeBuffer comp = CompositeBuffer.compose(BufferAllocator.offHeapUnpooled(), sends);
+
+        assertEquals(65, comp.countComponents());
+        buffer.addMessage(comp, comp.readableBytes(), channel.newPromise());
+        assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
+        buffer.addFlush();
+        final int maxCount = 10;    // less than comp.nioBufferCount()
+        ByteBuffer[] buffers = buffer.nioBuffers(maxCount, Integer.MAX_VALUE);
+        assertTrue(buffer.nioBufferCount() <= maxCount, "Should not be greater than maxCount");
+        buf.forEachReadable(0, (index, component) -> {
+            assertEquals(0, index);
+            ByteBuffer expected = component.readableBuffer();
+            for (int i = 0;  i < buffer.nioBufferCount(); i++) {
+                assertEquals(expected, buffers[i]);
+            }
+            return true;
+        });
+        release(buffer);
+        buf.close();
+    }
+
+    @Test
+    public void removeBytesByteBuf() {
+        TestChannel channel = new TestChannel();
+        ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
+        ByteBuf buf = directBuffer().writeBytes("buf1".getBytes(CharsetUtil.US_ASCII));
+        int size = buf.readableBytes();
+        buffer.addMessage(buf, size, channel.newPromise());
+        buffer.addFlush();
+        assertEquals(0, buffer.currentProgress());
+        buffer.removeBytes(size / 2);
+        assertEquals(size / 2, buffer.currentProgress());
+        assertThat(buffer.current()).isNotNull();
+        buffer.removeBytes(size);
+        assertNull(buffer.current());
+        assertTrue(buffer.isEmpty());
+        assertEquals(0, buffer.currentProgress());
+    }
+
+    @Test
+    public void removeBytes() {
+        TestChannel channel = new TestChannel();
+        ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
+        Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        int size = buf.readableBytes();
+        buffer.addMessage(buf, size, channel.newPromise());
+        buffer.addFlush();
+        assertEquals(0, buffer.currentProgress());
+        buffer.removeBytes(size / 2);
+        assertEquals(size / 2, buffer.currentProgress());
+        assertThat(buffer.current()).isNotNull();
+        buffer.removeBytes(size);
+        assertNull(buffer.current());
+        assertTrue(buffer.isEmpty());
+        assertEquals(0, buffer.currentProgress());
     }
 
     private static void release(ChannelOutboundBuffer buffer) {
@@ -284,20 +447,20 @@ public class ChannelOutboundBufferTest {
         ch.write(buffer().writeZero(128));
         // Ensure exceeding the low watermark does not make channel unwritable.
         ch.write(buffer().writeZero(2));
-        assertThat(buf.toString(), is(""));
+        assertThat(buf.toString()).isEmpty();
 
         ch.unsafe().outboundBuffer().addFlush();
 
         // Ensure exceeding the high watermark makes channel unwritable.
         ch.write(buffer().writeZero(127));
-        assertThat(buf.toString(), is("false "));
+        assertThat(buf.toString()).isEqualTo("false ");
 
         // Ensure going down to the low watermark makes channel writable again by flushing the first write.
-        assertThat(ch.unsafe().outboundBuffer().remove(), is(true));
-        assertThat(ch.unsafe().outboundBuffer().remove(), is(true));
-        assertThat(ch.unsafe().outboundBuffer().totalPendingWriteBytes(),
-                is(127L + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD));
-        assertThat(buf.toString(), is("false true "));
+        assertTrue(ch.unsafe().outboundBuffer().remove());
+        assertTrue(ch.unsafe().outboundBuffer().remove());
+        assertThat(ch.unsafe().outboundBuffer().totalPendingWriteBytes()).isEqualTo(
+                127L + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD);
+        assertThat(buf.toString()).isEqualTo("false true ");
 
         safeClose(ch);
     }
@@ -320,18 +483,18 @@ public class ChannelOutboundBufferTest {
 
         // Ensure that the default value of a user-defined writability flag is true.
         for (int i = 1; i <= 30; i ++) {
-            assertThat(cob.getUserDefinedWritability(i), is(true));
+            assertTrue(cob.getUserDefinedWritability(i));
         }
 
         // Ensure that setting a user-defined writability flag to false affects channel.isWritable();
         cob.setUserDefinedWritability(1, false);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertThat(buf.toString()).isEqualTo("false ");
 
         // Ensure that setting a user-defined writability flag to true affects channel.isWritable();
         cob.setUserDefinedWritability(1, true);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false true "));
+        assertThat(buf.toString()).isEqualTo("false true ");
 
         safeClose(ch);
     }
@@ -355,23 +518,23 @@ public class ChannelOutboundBufferTest {
         // Ensure that setting a user-defined writability flag to false affects channel.isWritable()
         cob.setUserDefinedWritability(1, false);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertThat(buf.toString()).isEqualTo("false ");
 
         // Ensure that setting another user-defined writability flag to false does not trigger
         // channelWritabilityChanged.
         cob.setUserDefinedWritability(2, false);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertThat(buf.toString()).isEqualTo("false ");
 
         // Ensure that setting only one user-defined writability flag to true does not affect channel.isWritable()
         cob.setUserDefinedWritability(1, true);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertThat(buf.toString()).isEqualTo("false ");
 
         // Ensure that setting all user-defined writability flags to true affects channel.isWritable()
         cob.setUserDefinedWritability(2, true);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false true "));
+        assertThat(buf.toString()).isEqualTo("false true ");
 
         safeClose(ch);
     }
@@ -395,23 +558,23 @@ public class ChannelOutboundBufferTest {
         ch.executor().execute(() -> {
             // Trigger channelWritabilityChanged() by writing a lot.
             ch.write(buffer().writeZero(257));
-            assertThat(buf.toString(), is("false "));
+            assertThat(buf.toString()).isEqualTo("false ");
 
             // Ensure that setting a user-defined writability flag to false does not trigger channelWritabilityChanged()
             cob.setUserDefinedWritability(1, false);
             ch.runPendingTasks();
-            assertThat(buf.toString(), is("false "));
+            assertThat(buf.toString()).isEqualTo("false ");
 
             // Ensure reducing the totalPendingWriteBytes down to zero does not trigger channelWritabilityChanged()
             // because of the user-defined writability flag.
             ch.flush();
-            assertThat(cob.totalPendingWriteBytes(), is(0L));
-            assertThat(buf.toString(), is("false "));
+            assertThat(cob.totalPendingWriteBytes()).isEqualTo(0L);
+            assertThat(buf.toString()).isEqualTo("false ");
 
             // Ensure that setting the user-defined writability flag to true triggers channelWritabilityChanged()
             cob.setUserDefinedWritability(1, true);
             ch.runPendingTasks();
-            assertThat(buf.toString(), is("false true "));
+            assertThat(buf.toString()).isEqualTo("false true ");
         });
 
         safeClose(ch);
@@ -419,12 +582,15 @@ public class ChannelOutboundBufferTest {
 
     private static void safeClose(EmbeddedChannel ch) {
         ch.finish();
-        for (;;) {
-            ByteBuf m = ch.readOutbound();
-            if (m == null) {
-                break;
+        Object m;
+        do {
+            m = ch.readOutbound();
+            if (m instanceof ByteBuf) {
+                ((ByteBuf) m).release();
             }
-            m.release();
-        }
+            if (m instanceof Buffer) {
+                ((Buffer) m).close();
+            }
+        } while (m != null);
     }
 }

--- a/transport/src/test/java/io/netty/channel/CoalescingBufferQueueForBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingBufferQueueForBufferTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link CoalescingBufferQueue}.
+ */
+public class CoalescingBufferQueueForBufferTest {
+
+    private Buffer cat;
+    private Buffer mouse;
+
+    private Promise<Void> catPromise, emptyPromise;
+    private FutureListener<Void> mouseListener;
+
+    private boolean mouseDone;
+    private boolean mouseSuccess;
+
+    private EmbeddedChannel channel;
+    private CoalescingBufferQueueForBuffer writeQueue;
+
+    @BeforeEach
+    public void setup() {
+        mouseDone = false;
+        mouseSuccess = false;
+        channel = new EmbeddedChannel();
+        writeQueue = new CoalescingBufferQueueForBuffer(channel, 16, true);
+        catPromise = newPromise();
+        mouseListener = future -> {
+            mouseDone = true;
+            mouseSuccess = future.isSuccess();
+        };
+        emptyPromise = newPromise();
+
+        cat = BufferAllocator.offHeapUnpooled().copyOf("cat".getBytes(CharsetUtil.US_ASCII));
+        mouse = BufferAllocator.offHeapUnpooled().copyOf("mouse".getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @AfterEach
+    public void finish() {
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testAddFirstPromiseRetained() {
+        writeQueue.add(cat, catPromise);
+        assertQueueSize(3, false);
+        writeQueue.add(mouse, mouseListener);
+        assertQueueSize(8, false);
+        Promise<Void> aggregatePromise = newPromise();
+        assertEquals("catmous", dequeue(7, aggregatePromise));
+        Buffer remainder = BufferAllocator.offHeapUnpooled().copyOf("mous".getBytes(CharsetUtil.US_ASCII));
+        writeQueue.addFirst(remainder, aggregatePromise);
+        Promise<Void> aggregatePromise2 = newPromise();
+        assertEquals("mouse", dequeue(5, aggregatePromise2));
+        aggregatePromise2.setSuccess(null);
+        assertTrue(catPromise.isSuccess());
+        assertTrue(mouseSuccess);
+        assertFalse(cat.isAccessible());
+        assertFalse(mouse.isAccessible());
+    }
+
+    @Test
+    public void testAggregateWithFullRead() {
+        writeQueue.add(cat, catPromise);
+        assertQueueSize(3, false);
+        writeQueue.add(mouse, mouseListener);
+        assertQueueSize(8, false);
+        Promise<Void> aggregatePromise = newPromise();
+        assertEquals("catmouse", dequeue(8, aggregatePromise));
+        assertQueueSize(0, true);
+        assertFalse(catPromise.isSuccess());
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess(null);
+        assertTrue(catPromise.isSuccess());
+        assertTrue(mouseSuccess);
+        assertFalse(cat.isAccessible());
+        assertFalse(mouse.isAccessible());
+    }
+
+    @Test
+    public void testAggregateWithPartialRead() {
+        writeQueue.add(cat, catPromise);
+        writeQueue.add(mouse, mouseListener);
+        Promise<Void> aggregatePromise = newPromise();
+        assertEquals("catm", dequeue(4, aggregatePromise));
+        assertQueueSize(4, false);
+        assertFalse(catPromise.isSuccess());
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess(null);
+        assertTrue(catPromise.isSuccess());
+        assertFalse(mouseDone);
+
+        aggregatePromise = newPromise();
+        assertEquals("ouse", dequeue(Integer.MAX_VALUE, aggregatePromise));
+        assertQueueSize(0, true);
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess(null);
+        assertTrue(mouseSuccess);
+        assertFalse(cat.isAccessible());
+        assertFalse(mouse.isAccessible());
+    }
+
+    @Test
+    public void testReadExactAddedBufferSizeReturnsOriginal() {
+        writeQueue.add(cat, catPromise);
+        writeQueue.add(mouse, mouseListener);
+
+        Promise<Void> aggregatePromise = newPromise();
+        assertSame(cat, writeQueue.remove(3, aggregatePromise));
+        assertFalse(catPromise.isSuccess());
+        aggregatePromise.setSuccess(null);
+        assertTrue(catPromise.isSuccess());
+        assertTrue(cat.isAccessible());
+        cat.close();
+
+        aggregatePromise = newPromise();
+        assertSame(mouse, writeQueue.remove(5, aggregatePromise));
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess(null);
+        assertTrue(mouseSuccess);
+        assertTrue(mouse.isAccessible());
+        mouse.close();
+    }
+
+    @Test
+    public void testReadEmptyQueueReturnsEmptyBuffer() {
+        // Not used in this test.
+        cat.close();
+        mouse.close();
+
+        assertQueueSize(0, true);
+        Promise<Void> aggregatePromise = newPromise();
+        assertEquals("", dequeue(Integer.MAX_VALUE, aggregatePromise));
+        assertQueueSize(0, true);
+    }
+
+    @Test
+    public void testReleaseAndFailAll() {
+        writeQueue.add(cat, catPromise);
+        writeQueue.add(mouse, mouseListener);
+        RuntimeException cause = new RuntimeException("ooops");
+        writeQueue.releaseAndFailAll(cause);
+        Promise<Void> aggregatePromise = newPromise();
+        assertQueueSize(0, true);
+        assertFalse(cat.isAccessible());
+        assertFalse(mouse.isAccessible());
+        assertSame(cause, catPromise.cause());
+        assertEquals("", dequeue(Integer.MAX_VALUE, aggregatePromise));
+        assertQueueSize(0, true);
+    }
+
+    @Test
+    public void testEmptyBuffersAreCoalesced() {
+        mouse.close(); // Not used
+        Buffer empty = BufferAllocator.offHeapUnpooled().allocate(0);
+        assertQueueSize(0, true);
+        writeQueue.add(cat, catPromise);
+        writeQueue.add(empty, emptyPromise);
+        assertQueueSize(3, false);
+        Promise<Void> aggregatePromise = newPromise();
+        assertEquals("cat", dequeue(3, aggregatePromise));
+        assertQueueSize(0, true);
+        assertFalse(catPromise.isSuccess());
+        assertFalse(emptyPromise.isSuccess());
+        aggregatePromise.setSuccess(null);
+        assertTrue(catPromise.isSuccess());
+        assertTrue(emptyPromise.isSuccess());
+        assertFalse(cat.isAccessible());
+        assertFalse(empty.isAccessible());
+    }
+
+    @Test
+    public void testMerge() {
+        writeQueue.add(cat, catPromise);
+        CoalescingBufferQueueForBuffer otherQueue = new CoalescingBufferQueueForBuffer(channel);
+        otherQueue.add(mouse, mouseListener);
+        otherQueue.copyTo(writeQueue);
+        assertQueueSize(8, false);
+        Promise<Void> aggregatePromise = newPromise();
+        assertEquals("catmouse", dequeue(8, aggregatePromise));
+        assertQueueSize(0, true);
+        assertFalse(catPromise.isSuccess());
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess(null);
+        assertTrue(catPromise.isSuccess());
+        assertTrue(mouseSuccess);
+        assertFalse(cat.isAccessible());
+        assertFalse(mouse.isAccessible());
+    }
+
+    @Test
+    public void testWritabilityChanged() {
+        testWritabilityChanged0(false);
+    }
+
+    @Test
+    public void testWritabilityChangedFailAll() {
+        testWritabilityChanged0(true);
+    }
+
+    private void testWritabilityChanged0(boolean fail) {
+        channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(3, 4));
+        assertTrue(channel.isWritable());
+        writeQueue.add(BufferAllocator.offHeapUnpooled().copyOf(new byte[] { 1, 2, 3 }));
+        assertTrue(channel.isWritable());
+        writeQueue.add(BufferAllocator.offHeapUnpooled().copyOf(new byte[] { 4, 5 }));
+        assertFalse(channel.isWritable());
+        assertEquals(5, writeQueue.readableBytes());
+
+        if (fail) {
+            writeQueue.releaseAndFailAll(new IllegalStateException());
+        } else {
+            Buffer buffer = writeQueue.removeFirst(channel.newPromise());
+            assertEquals(1, buffer.readByte());
+            assertEquals(2, buffer.readByte());
+            assertEquals(3, buffer.readByte());
+            assertEquals(0, buffer.readableBytes());
+            buffer.close();
+            assertTrue(channel.isWritable());
+
+            buffer = writeQueue.removeFirst(channel.newPromise());
+            assertEquals(4, buffer.readByte());
+            assertEquals(5, buffer.readByte());
+            assertEquals(0, buffer.readableBytes());
+            buffer.close();
+        }
+
+        assertTrue(channel.isWritable());
+        assertTrue(writeQueue.isEmpty());
+    }
+
+    private Promise<Void> newPromise() {
+        return channel.newPromise();
+    }
+
+    private void assertQueueSize(int size, boolean isEmpty) {
+        assertEquals(size, writeQueue.readableBytes());
+        if (isEmpty) {
+            assertTrue(writeQueue.isEmpty());
+        } else {
+            assertFalse(writeQueue.isEmpty());
+        }
+    }
+
+    private String dequeue(int numBytes, Promise<Void> aggregatePromise) {
+        Buffer removed = writeQueue.remove(numBytes, aggregatePromise);
+        String result = removed.toString(CharsetUtil.US_ASCII);
+        ReferenceCountUtil.safeRelease(removed);
+        return result;
+    }
+}

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ReentrantChannelTest extends BaseChannelTest {
 
     @Test
-    public void testWritabilityChanged() throws Exception {
+    public void testWritabilityChangedByteBuf() throws Exception {
 
         LocalAddress addr = new LocalAddress("testWritabilityChanged");
 
@@ -100,11 +100,80 @@ public class ReentrantChannelTest extends BaseChannelTest {
                 "WRITABILITY: writable=true\n");
     }
 
+    @Test
+    public void testWritabilityChanged() throws Exception {
+
+        LocalAddress addr = new LocalAddress("testWritabilityChanged");
+
+        ServerBootstrap sb = getLocalServerBootstrap();
+        sb.bind(addr).sync();
+
+        Bootstrap cb = getLocalClientBootstrap();
+
+        setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
+
+        Channel clientChannel = cb.connect(addr).get();
+        clientChannel.config().setWriteBufferLowWaterMark(512);
+        clientChannel.config().setWriteBufferHighWaterMark(1024);
+
+        // What is supposed to happen from this point:
+        //
+        // 1. Because this write attempt has been made from a non-I/O thread,
+        //    ChannelOutboundBuffer.pendingWriteBytes will be increased before
+        //    write() event is really evaluated.
+        //    -> channelWritabilityChanged() will be triggered,
+        //       because the Channel became unwritable.
+        //
+        // 2. The write() event is handled by the pipeline in an I/O thread.
+        //    -> write() will be triggered.
+        //
+        // 3. Once the write() event is handled, ChannelOutboundBuffer.pendingWriteBytes
+        //    will be decreased.
+        //    -> channelWritabilityChanged() will be triggered,
+        //       because the Channel became writable again.
+        //
+        // 4. The message is added to the ChannelOutboundBuffer and thus
+        //    pendingWriteBytes will be increased again.
+        //    -> channelWritabilityChanged() will be triggered.
+        //
+        // 5. The flush() event causes the write request in theChannelOutboundBuffer
+        //    to be removed.
+        //    -> flush() and channelWritabilityChanged() will be triggered.
+        //
+        // Note that the channelWritabilityChanged() in the step 4 can occur between
+        // the flush() and the channelWritabilityChanged() in the step 5, because
+        // the flush() is invoked from a non-I/O thread while the other are from
+        // an I/O thread.
+
+        Future<Void> future = clientChannel.write(createTestBuffer(2000));
+
+        clientChannel.flush();
+        future.sync();
+
+        clientChannel.close().sync();
+
+        assertLog(
+                // Case 1:
+                "WRITABILITY: writable=false\n" +
+                "WRITE\n" +
+                "WRITABILITY: writable=false\n" +
+                "WRITABILITY: writable=false\n" +
+                "FLUSH\n" +
+                "WRITABILITY: writable=true\n",
+                // Case 2:
+                "WRITABILITY: writable=false\n" +
+                "WRITE\n" +
+                "WRITABILITY: writable=false\n" +
+                "FLUSH\n" +
+                "WRITABILITY: writable=true\n" +
+                "WRITABILITY: writable=true\n");
+    }
+
     /**
      * Similar to {@link #testWritabilityChanged()} with slight variation.
      */
     @Test
-    public void testFlushInWritabilityChanged() throws Exception {
+    public void testFlushInWritabilityChangedByteBuf() throws Exception {
 
         LocalAddress addr = new LocalAddress("testFlushInWritabilityChanged");
 
@@ -153,8 +222,61 @@ public class ReentrantChannelTest extends BaseChannelTest {
                 "WRITABILITY: writable=true\n");
     }
 
+    /**
+     * Similar to {@link #testWritabilityChanged()} with slight variation.
+     */
     @Test
-    public void testWriteFlushPingPong() throws Exception {
+    public void testFlushInWritabilityChanged() throws Exception {
+
+        LocalAddress addr = new LocalAddress("testFlushInWritabilityChanged");
+
+        ServerBootstrap sb = getLocalServerBootstrap();
+        sb.bind(addr).sync();
+
+        Bootstrap cb = getLocalClientBootstrap();
+
+        setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
+
+        Channel clientChannel = cb.connect(addr).get();
+        clientChannel.config().setWriteBufferLowWaterMark(512);
+        clientChannel.config().setWriteBufferHighWaterMark(1024);
+
+        clientChannel.pipeline().addLast(new ChannelHandler() {
+            @Override
+            public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+                if (!ctx.channel().isWritable()) {
+                    ctx.channel().flush();
+                }
+                ctx.fireChannelWritabilityChanged();
+            }
+        });
+
+        assertTrue(clientChannel.isWritable());
+
+        clientChannel.write(createTestBuffer(2000)).sync();
+        clientChannel.close().sync();
+
+        assertLog(
+                // Case 1:
+                "WRITABILITY: writable=false\n" +
+                "FLUSH\n" +
+                "WRITE\n" +
+                "WRITABILITY: writable=false\n" +
+                "WRITABILITY: writable=false\n" +
+                "FLUSH\n" +
+                "WRITABILITY: writable=true\n",
+                // Case 2:
+                "WRITABILITY: writable=false\n" +
+                "FLUSH\n" +
+                "WRITE\n" +
+                "WRITABILITY: writable=false\n" +
+                "FLUSH\n" +
+                "WRITABILITY: writable=true\n" +
+                "WRITABILITY: writable=true\n");
+    }
+
+    @Test
+    public void testWriteFlushPingPongByteBuf() throws Exception {
 
         LocalAddress addr = new LocalAddress("testWriteFlushPingPong");
 
@@ -211,7 +333,64 @@ public class ReentrantChannelTest extends BaseChannelTest {
     }
 
     @Test
-    public void testCloseInFlush() throws Exception {
+    public void testWriteFlushPingPong() throws Exception {
+
+        LocalAddress addr = new LocalAddress("testWriteFlushPingPong");
+
+        ServerBootstrap sb = getLocalServerBootstrap();
+        sb.bind(addr).sync();
+
+        Bootstrap cb = getLocalClientBootstrap();
+
+        setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
+
+        Channel clientChannel = cb.connect(addr).get();
+
+        clientChannel.pipeline().addLast(new ChannelHandler() {
+
+            int writeCount;
+            int flushCount;
+
+            @Override
+            public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
+                if (writeCount < 5) {
+                    writeCount++;
+                    ctx.channel().flush();
+                }
+                return ctx.write(msg);
+            }
+
+            @Override
+            public void flush(ChannelHandlerContext ctx) {
+                if (flushCount < 5) {
+                    flushCount++;
+                    ctx.channel().write(createTestBuffer(2000));
+                }
+                ctx.flush();
+            }
+        });
+
+        clientChannel.writeAndFlush(createTestBuffer(2000));
+        clientChannel.close().sync();
+
+        assertLog(
+                "WRITE\n" +
+                "FLUSH\n" +
+                "WRITE\n" +
+                "FLUSH\n" +
+                "WRITE\n" +
+                "FLUSH\n" +
+                "WRITE\n" +
+                "FLUSH\n" +
+                "WRITE\n" +
+                "FLUSH\n" +
+                "WRITE\n" +
+                "FLUSH\n" +
+                "CLOSE\n");
+    }
+
+    @Test
+    public void testCloseInFlushByteBuf() throws Exception {
 
         LocalAddress addr = new LocalAddress("testCloseInFlush");
 
@@ -238,6 +417,77 @@ public class ReentrantChannelTest extends BaseChannelTest {
         clientChannel.closeFuture().sync();
 
         assertLog("WRITE\nFLUSH\nCLOSE\n");
+    }
+
+    @Test
+    public void testCloseInFlush() throws Exception {
+
+        LocalAddress addr = new LocalAddress("testCloseInFlush");
+
+        ServerBootstrap sb = getLocalServerBootstrap();
+        sb.bind(addr).sync();
+
+        Bootstrap cb = getLocalClientBootstrap();
+
+        setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
+
+        Channel clientChannel = cb.connect(addr).get();
+
+        clientChannel.pipeline().addLast(new ChannelHandler() {
+
+            @Override
+            public Future<Void> write(final ChannelHandlerContext ctx, Object msg) {
+                Future<Void> f = ctx.write(msg).addListener(ctx, ChannelFutureListeners.CLOSE);
+                ctx.channel().flush();
+                return f;
+            }
+        });
+
+        clientChannel.write(createTestBuffer(2000)).sync();
+        clientChannel.closeFuture().sync();
+
+        assertLog("WRITE\nFLUSH\nCLOSE\n");
+    }
+
+    @Test
+    public void testFlushFailureByteBuf() throws Exception {
+
+        LocalAddress addr = new LocalAddress("testFlushFailure");
+
+        ServerBootstrap sb = getLocalServerBootstrap();
+        sb.bind(addr).sync();
+
+        Bootstrap cb = getLocalClientBootstrap();
+
+        setInterest(Event.WRITE, Event.FLUSH, Event.CLOSE, Event.EXCEPTION);
+
+        Channel clientChannel = cb.connect(addr).get();
+
+        clientChannel.pipeline().addLast(new ChannelHandler() {
+
+            @Override
+            public void flush(ChannelHandlerContext ctx) {
+                throw new IllegalStateException("intentional failure");
+            }
+
+        }, new ChannelHandler() {
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                ctx.close();
+            }
+        });
+
+        try {
+            clientChannel.writeAndFlush(createTestBuf(2000)).sync();
+            fail();
+        } catch (Throwable cce) {
+            // FIXME:  shouldn't this contain the "intentional failure" exception?
+            assertThat(cce.getCause(), Matchers.instanceOf(ClosedChannelException.class));
+        }
+
+        clientChannel.closeFuture().sync();
+
+        assertLog("WRITE\nCLOSE\n");
     }
 
     @Test
@@ -269,7 +519,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         });
 
         try {
-            clientChannel.writeAndFlush(createTestBuf(2000)).sync();
+            clientChannel.writeAndFlush(createTestBuffer(2000)).sync();
             fail();
         } catch (Throwable cce) {
             // FIXME:  shouldn't this contain the "intentional failure" exception?

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -34,7 +34,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testWritabilityChangedByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testWritabilityChanged");
+        LocalAddress addr = new LocalAddress("testWritabilityChangedByteBuf");
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -175,7 +175,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testFlushInWritabilityChangedByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testFlushInWritabilityChanged");
+        LocalAddress addr = new LocalAddress("testFlushInWritabilityChangedByteBuf");
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -278,7 +278,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testWriteFlushPingPongByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testWriteFlushPingPong");
+        LocalAddress addr = new LocalAddress("testWriteFlushPingPongByteBuf");
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -422,7 +422,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testCloseInFlush() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testCloseInFlush");
+        LocalAddress addr = new LocalAddress("testCloseInFlushByteBuf");
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();
@@ -452,7 +452,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
     @Test
     public void testFlushFailureByteBuf() throws Exception {
 
-        LocalAddress addr = new LocalAddress("testFlushFailure");
+        LocalAddress addr = new LocalAddress("testFlushFailureByteBuf");
 
         ServerBootstrap sb = getLocalServerBootstrap();
         sb.bind(addr).sync();


### PR DESCRIPTION
Motivation:
The transports have previously been relying on the ByteBufConvertible interface for being able to
write the new Buffers to channels.
When ByteBuf is eventually removed, so will that conversion interface.

Modification:
Add first-class support for _writing_ `io.netty.buffer.api.Buffer` instances to channels.
The most important changes are in the ChannelOutboundBuffer, which now has proper support for Buffer.
The transports then rely on the ChannelOutboundBuffer for producing ByteBuffers that are then written to channels.
Test coverage has also been expanded to include Buffer writes in many places.
A number of ByteBuf-specific utility classes have also gotten Buffer-specific counterparts.

Result:
Conversion of the transports to have first-class support for Buffer is far from complete, but this is an important step in the right direction.