### PR TITLE
Use NoOpTracer when Buffer lifecycle tracing is disabled

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/internal/LifecycleTracer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/LifecycleTracer.java
@@ -45,7 +45,7 @@ public abstract class LifecycleTracer {
      * @return A new tracer for a resource.
      */
     public static LifecycleTracer get() {
-        if (lifecycleTracingEnabled && LeakDetection.leakDetectionEnabled == 0) {
+        if (!lifecycleTracingEnabled && LeakDetection.leakDetectionEnabled == 0) {
             return NoOpTracer.INSTANCE;
         }
         StackTracer stackTracer = new StackTracer();


### PR DESCRIPTION
Motivation:
This was a logic error that enabled lifecycle tracing when the "enabled" setting was "false"

Modification:
Fix the logic error.

Result:
Lifecycle tracing is now off by default, matching the setting.