### PR TITLE
Update tcnative version in bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.44.Final</tcnative.version>
+    <tcnative.version>2.0.46.Final</tcnative.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Motivaiton:
The bom is out of sync with the project version
of tcnative. This results in unresolved
dependencies when using the bom.