### PR TITLE
Update to log4j 2.15.0 to fix security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,7 +786,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-1.2-api</artifactId>
-        <version>2.14.1</version>
+        <version>2.15.0</version>
         <exclusions>
           <exclusion>
             <artifactId>mail</artifactId>


### PR DESCRIPTION
Motivation:

log4j 2.15.0 was released to fix a 0-day security issue. While the log4j dependency is fully optional we should still upgrade

Modifications:

Upgrade to 2.15.0

Result:

Use non-affected log4j version
