### PR TITLE
Update to log4j2 2.15.0 to fix security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,7 +517,7 @@
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
-    <log4j2.version>2.6.2</log4j2.version>
+    <log4j2.version>2.15.0</log4j2.version>
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <junit.version>5.7.0</junit.version>
     <testJavaHome>${java.home}</testJavaHome>


### PR DESCRIPTION
Motivation:

log4j 2.15.0 was released to fix a 0-day security issue. While the log4j dependency is fully optional we should still upgrade.

See https://www.lunasec.io/docs/blog/log4j-zero-day/

Modifications:

Upgrade to 2.15.0

Result:

Use non-affected log4j2 version
