### PR TITLE
Add script which validates that netty-tcnative versions are in-sync

### DIFF
--- a/.github/scripts/check_bom_dependencies.sh
+++ b/.github/scripts/check_bom_dependencies.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# ----------------------------------------------------------------------------
+# Copyright 2021 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+set -e
+
+PARENT_TCNATIVE_VERSION=$(grep "<tcnative.version>" pom.xml | sed -n  's/.*<tcnative.version>\(.*\)<\/tcnative.version>/\1/p')
+BOM_TCNATIVE_VERSION=$(grep "<tcnative.version>" bom/pom.xml | sed -n  's/.*<tcnative.version>\(.*\)<\/tcnative.version>/\1/p')
+
+if [ "$PARENT_TCNATIVE_VERSION" != "$BOM_TCNATIVE_VERSION" ]; then
+    echo "tcnative version missmatch, parent: $PARENT_TCNATIVE_VERSION, bom: $BOM_TCNATIVE_VERSION"
+    exit 1
+fi
+exit 0
+
+

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Checking for test failures
         run: ./.github/scripts/check_build_result.sh build.output
 
+      - name: Checking bom dependency versions
+        run: ./.github/scripts/check_bom_dependencies.sh
+
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Verify with Maven
         run: ./mvnw -B -ntp --file pom.xml verify -DskipTests=true
 
+      - name: Checking bom dependency versions
+        run: ./.github/scripts/check_bom_dependencies.sh
+
   build-pr-windows:
     runs-on: windows-2016
     name: windows-x86_64-java11-boringssl


### PR DESCRIPTION
Motivation:

We most ensure the netty-tcnative versions between our parent pom and the bom pom are in sync

Modifications:

Add script and use it during github action run to verify that the versions are the same

Result:

No more problems due version missmatch