### PR TITLE
Re-read /etc/hosts upon change

### DIFF
--- a/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
@@ -56,15 +56,15 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
         String normalized = normalize(inetHost);
         switch (resolvedAddressTypes) {
             case IPV4_ONLY:
-                return firstAddress(retrieveCurrentInet4Entries().get(normalized));
+                return firstAddress(retrieveInet4Entries(normalized));
             case IPV6_ONLY:
-                return firstAddress(retrieveCurrentInet6Entries().get(normalized));
+                return firstAddress(retrieveInet6Entries(normalized));
             case IPV4_PREFERRED:
-                InetAddress inet4Address = firstAddress(retrieveCurrentInet4Entries().get(normalized));
-                return inet4Address != null ? inet4Address : firstAddress(inet6Entries.get(normalized));
+                InetAddress inet4Address = firstAddress(retrieveInet4Entries(normalized));
+                return inet4Address != null ? inet4Address : firstAddress(retrieveInet6Entries(normalized));
             case IPV6_PREFERRED:
-                InetAddress inet6Address = firstAddress(retrieveCurrentInet6Entries().get(normalized));
-                return inet6Address != null ? inet6Address : firstAddress(retrieveCurrentInet4Entries().get(normalized));
+                InetAddress inet6Address = firstAddress(retrieveInet6Entries(normalized));
+                return inet6Address != null ? inet6Address : firstAddress(retrieveInet4Entries(normalized));
             default:
                 throw new IllegalArgumentException("Unknown ResolvedAddressTypes " + resolvedAddressTypes);
         }
@@ -82,30 +82,30 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
         String normalized = normalize(inetHost);
         switch (resolvedAddressTypes) {
             case IPV4_ONLY:
-                return retrieveCurrentInet4Entries().get(normalized);
+                return retrieveInet4Entries(normalized);
             case IPV6_ONLY:
-                return retrieveCurrentInet6Entries().get(normalized);
+                return retrieveInet6Entries(normalized);
             case IPV4_PREFERRED:
-                List<InetAddress> allInet4Addresses = retrieveCurrentInet4Entries().get(normalized);
-                return allInet4Addresses != null ? allAddresses(allInet4Addresses, retrieveCurrentInet6Entries().get(normalized)) :
-                        retrieveCurrentInet6Entries().get(normalized);
+                List<InetAddress> allInet4Addresses = retrieveInet4Entries(normalized);
+                return allInet4Addresses != null ? allAddresses(allInet4Addresses, retrieveInet6Entries(normalized)) :
+                        retrieveInet6Entries(normalized);
             case IPV6_PREFERRED:
-                List<InetAddress> allInet6Addresses = retrieveCurrentInet6Entries().get(normalized);
-                return allInet6Addresses != null ? allAddresses(allInet6Addresses, retrieveCurrentInet4Entries().get(normalized)) :
-                        retrieveCurrentInet4Entries().get(normalized);
+                List<InetAddress> allInet6Addresses = retrieveInet6Entries(normalized);
+                return allInet6Addresses != null ? allAddresses(allInet6Addresses, retrieveInet4Entries(normalized)) :
+                        retrieveInet4Entries(normalized);
             default:
                 throw new IllegalArgumentException("Unknown ResolvedAddressTypes " + resolvedAddressTypes);
         }
     }
 
-    private Map<String, List<InetAddress>> retrieveCurrentInet4Entries() {
+    private List<InetAddress> retrieveInet4Entries(String host) {
         ensureHostsFileEntriesAreFresh();
-        return this.inet4Entries;
+        return this.inet4Entries.get(host);
     }
 
-    private Map<String, List<InetAddress>> retrieveCurrentInet6Entries() {
+    private List<InetAddress> retrieveInet6Entries(String host) {
         ensureHostsFileEntriesAreFresh();
-        return this.inet6Entries;
+        return this.inet6Entries.get(host);
     }
 
     private void ensureHostsFileEntriesAreFresh() {

--- a/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
@@ -95,8 +95,9 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
 
     private void ensureHostsFileEntriesAreFresh() {
         long last = lastRefresh.get();
-        if (System.nanoTime() - last > refreshInterval) {
-            if (lastRefresh.compareAndSet(last, System.nanoTime())) {
+        long currentTime = System.nanoTime();
+        if (currentTime - last > refreshInterval) {
+            if (lastRefresh.compareAndSet(last, currentTime)) {
                 HostsFileEntriesProvider entries = parseEntries(hostsFileParser);
                 inet4Entries = entries.ipv4Entries();
                 inet6Entries = entries.ipv6Entries();

--- a/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
@@ -18,6 +18,8 @@ package io.netty.resolver;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.InetAddress;
 import java.nio.charset.Charset;
@@ -32,6 +34,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * Default {@link HostsFileEntriesResolver} that resolves hosts file entries only once.
  */
 public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesResolver {
+
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(DefaultHostsFileEntriesResolver.class);
     private static final long DEFAULT_REFRESH_INTERVAL;
 
     private final long refreshInterval;
@@ -43,6 +48,10 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
     static {
         DEFAULT_REFRESH_INTERVAL = SystemPropertyUtil.getLong(
                 "io.netty.hostsFileRefreshInterval", TimeUnit.SECONDS.toNanos(60));
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("-Dio.netty.hostsFileRefreshInterval: {}", DEFAULT_REFRESH_INTERVAL);
+        }
     }
 
     public DefaultHostsFileEntriesResolver() {

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -48,7 +48,7 @@ public class DefaultHostsFileEntriesResolverTest {
             Collections.singletonMap("localhost", Collections.<InetAddress>singletonList(NetUtil.LOCALHOST6));
 
     @BeforeAll
-    static void beforeAll() {
+    public static void beforeAll() {
         System.setProperty("io.netty.hostsFileRefreshInterval", String.valueOf(TimeUnit.MINUTES.toNanos(1)));
     }
 
@@ -148,7 +148,7 @@ public class DefaultHostsFileEntriesResolverTest {
     }
 
     @Test
-    void shouldNotRefreshHostsFileContentBeforeRefreshIntervalElapsed() {
+    public void shouldNotRefreshHostsFileContentBeforeRefreshIntervalElapsed() {
         Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(LOCALHOST_V4_ADDRESSES);
         Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(LOCALHOST_V6_ADDRESSES);
         DefaultHostsFileEntriesResolver resolver =
@@ -163,7 +163,7 @@ public class DefaultHostsFileEntriesResolverTest {
     }
 
     @Test
-    void shouldRefreshHostsFileContentAfterRefreshInterval() {
+    public void shouldRefreshHostsFileContentAfterRefreshInterval() {
         System.setProperty("io.netty.hostsFileRefreshInterval", String.valueOf(TimeUnit.MINUTES.toNanos(-1)));
         Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(LOCALHOST_V4_ADDRESSES);
         Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(LOCALHOST_V6_ADDRESSES);

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -25,7 +25,10 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -38,7 +41,7 @@ public class DefaultHostsFileEntriesResolverTest {
             Collections.singletonMap("localhost", Collections.<InetAddress>singletonList(NetUtil.LOCALHOST4));
     private final Map<String, List<InetAddress>> localhostV6Addresses =
             Collections.singletonMap("localhost", Collections.<InetAddress>singletonList(NetUtil.LOCALHOST6));
-    private final long entriesTTL = TimeUnit.SECONDS.toNanos(10);
+    private final long entriesTTL = TimeUnit.MINUTES.toNanos(1);
 
     /**
      * show issue https://github.com/netty/netty/issues/5182
@@ -143,10 +146,10 @@ public class DefaultHostsFileEntriesResolverTest {
 
     @Test
     void shouldNotRefreshHostsFileContentBeforeRefreshIntervalElapsed() {
-        HashMap<String, List<InetAddress>> v4Addresses = Maps.newHashMap(localhostV4Addresses);
-        HashMap<String, List<InetAddress>> v6Addresses = Maps.newHashMap(localhostV4Addresses);
+        Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(localhostV4Addresses);
+        Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(localhostV4Addresses);
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), TimeUnit.MINUTES.toNanos(1));
+                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), entriesTTL);
         String newHost = UUID.randomUUID().toString();
 
         v4Addresses.put(newHost, Collections.<InetAddress>singletonList(NetUtil.LOCALHOST4));
@@ -158,8 +161,8 @@ public class DefaultHostsFileEntriesResolverTest {
 
     @Test
     void shouldRefreshHostsFileContentAfterRefreshInterval() {
-        HashMap<String, List<InetAddress>> v4Addresses = Maps.newHashMap(localhostV4Addresses);
-        HashMap<String, List<InetAddress>> v6Addresses = Maps.newHashMap(localhostV4Addresses);
+        Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(localhostV4Addresses);
+        Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(localhostV4Addresses);
         DefaultHostsFileEntriesResolver resolver =
                 new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), -1);
         String newHost = UUID.randomUUID().toString();

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -41,11 +41,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.any;
 
 public class DefaultHostsFileEntriesResolverTest {
-    private final Map<String, List<InetAddress>> localhostV4Addresses =
+    private static final Map<String, List<InetAddress>> LOCALHOST_V4_ADDRESSES =
             Collections.singletonMap("localhost", Collections.<InetAddress>singletonList(NetUtil.LOCALHOST4));
-    private final Map<String, List<InetAddress>> localhostV6Addresses =
+    private static final Map<String, List<InetAddress>> LOCALHOST_V6_ADDRESSES =
             Collections.singletonMap("localhost", Collections.<InetAddress>singletonList(NetUtil.LOCALHOST6));
-    private final long entriesTTL = TimeUnit.MINUTES.toNanos(1);
+    private static final long ENTRIES_TTL = TimeUnit.MINUTES.toNanos(1);
 
     /**
      * show issue https://github.com/netty/netty/issues/5182
@@ -61,12 +61,12 @@ public class DefaultHostsFileEntriesResolverTest {
     @Test
     public void shouldntFindWhenAddressTypeDoesntMatch() {
         HostsFileEntriesProvider.Parser parser = givenHostsParserWith(
-                localhostV4Addresses,
+                LOCALHOST_V4_ADDRESSES,
                 Collections.<String, List<InetAddress>>emptyMap()
         );
 
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(parser, entriesTTL);
+                new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV6_ONLY);
         assertNull(address, "Should pick an IPv6 address");
@@ -75,12 +75,12 @@ public class DefaultHostsFileEntriesResolverTest {
     @Test
     public void shouldPickIpv4WhenBothAreDefinedButIpv4IsPreferred() {
         HostsFileEntriesProvider.Parser parser = givenHostsParserWith(
-                localhostV4Addresses,
-                localhostV6Addresses
+                LOCALHOST_V4_ADDRESSES,
+                LOCALHOST_V6_ADDRESSES
         );
 
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(parser, entriesTTL);
+                new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV4_PREFERRED);
         assertThat("Should pick an IPv4 address", address, instanceOf(Inet4Address.class));
@@ -89,12 +89,12 @@ public class DefaultHostsFileEntriesResolverTest {
     @Test
     public void shouldPickIpv6WhenBothAreDefinedButIpv6IsPreferred() {
         HostsFileEntriesProvider.Parser parser = givenHostsParserWith(
-                localhostV4Addresses,
-                localhostV6Addresses
+                LOCALHOST_V4_ADDRESSES,
+                LOCALHOST_V6_ADDRESSES
         );
 
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(parser, entriesTTL);
+                new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV6_PREFERRED);
         assertThat("Should pick an IPv6 address", address, instanceOf(Inet6Address.class));
@@ -103,12 +103,12 @@ public class DefaultHostsFileEntriesResolverTest {
     @Test
     public void shouldntFindWhenAddressesTypeDoesntMatch() {
         HostsFileEntriesProvider.Parser parser = givenHostsParserWith(
-                localhostV4Addresses,
+                LOCALHOST_V4_ADDRESSES,
                 Collections.<String, List<InetAddress>>emptyMap()
         );
 
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(parser, entriesTTL);
+                new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV6_ONLY);
         assertNull(addresses, "Should pick an IPv6 address");
@@ -117,12 +117,12 @@ public class DefaultHostsFileEntriesResolverTest {
     @Test
     public void shouldPickIpv4FirstWhenBothAreDefinedButIpv4IsPreferred() {
         HostsFileEntriesProvider.Parser parser = givenHostsParserWith(
-                localhostV4Addresses,
-                localhostV6Addresses
+                LOCALHOST_V4_ADDRESSES,
+                LOCALHOST_V6_ADDRESSES
         );
 
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(parser, entriesTTL);
+                new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV4_PREFERRED);
         assertNotNull(addresses);
@@ -134,12 +134,12 @@ public class DefaultHostsFileEntriesResolverTest {
     @Test
     public void shouldPickIpv6FirstWhenBothAreDefinedButIpv6IsPreferred() {
         HostsFileEntriesProvider.Parser parser = givenHostsParserWith(
-                localhostV4Addresses,
-                localhostV6Addresses
+                LOCALHOST_V4_ADDRESSES,
+                LOCALHOST_V6_ADDRESSES
         );
 
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(parser, entriesTTL);
+                new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV6_PREFERRED);
         assertNotNull(addresses);
@@ -150,10 +150,10 @@ public class DefaultHostsFileEntriesResolverTest {
 
     @Test
     void shouldNotRefreshHostsFileContentBeforeRefreshIntervalElapsed() {
-        Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(localhostV4Addresses);
-        Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(localhostV4Addresses);
+        Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(LOCALHOST_V4_ADDRESSES);
+        Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(LOCALHOST_V6_ADDRESSES);
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), entriesTTL);
+                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), ENTRIES_TTL);
         String newHost = UUID.randomUUID().toString();
 
         v4Addresses.put(newHost, Collections.<InetAddress>singletonList(NetUtil.LOCALHOST4));
@@ -165,8 +165,8 @@ public class DefaultHostsFileEntriesResolverTest {
 
     @Test
     void shouldRefreshHostsFileContentAfterRefreshInterval() {
-        Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(localhostV4Addresses);
-        Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(localhostV4Addresses);
+        Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(LOCALHOST_V4_ADDRESSES);
+        Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(LOCALHOST_V6_ADDRESSES);
         DefaultHostsFileEntriesResolver resolver =
                 new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), -1);
         String newHost = UUID.randomUUID().toString();

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -17,7 +17,6 @@ package io.netty.resolver;
 
 import com.google.common.collect.Maps;
 import io.netty.util.NetUtil;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -46,11 +45,7 @@ public class DefaultHostsFileEntriesResolverTest {
             Collections.singletonMap("localhost", Collections.<InetAddress>singletonList(NetUtil.LOCALHOST4));
     private static final Map<String, List<InetAddress>> LOCALHOST_V6_ADDRESSES =
             Collections.singletonMap("localhost", Collections.<InetAddress>singletonList(NetUtil.LOCALHOST6));
-
-    @BeforeAll
-    public static void beforeAll() {
-        System.setProperty("io.netty.hostsFileRefreshInterval", String.valueOf(TimeUnit.MINUTES.toNanos(1)));
-    }
+    private static final long ENTRIES_TTL = TimeUnit.MINUTES.toNanos(1);
 
     /**
      * show issue https://github.com/netty/netty/issues/5182
@@ -70,7 +65,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 Collections.<String, List<InetAddress>>emptyMap()
         );
 
-        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser);
+        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV6_ONLY);
         assertNull(address, "Should pick an IPv6 address");
@@ -83,7 +78,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 LOCALHOST_V6_ADDRESSES
         );
 
-        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser);
+        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV4_PREFERRED);
         assertThat("Should pick an IPv4 address", address, instanceOf(Inet4Address.class));
@@ -96,7 +91,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 LOCALHOST_V6_ADDRESSES
         );
 
-        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser);
+        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV6_PREFERRED);
         assertThat("Should pick an IPv6 address", address, instanceOf(Inet6Address.class));
@@ -109,7 +104,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 Collections.<String, List<InetAddress>>emptyMap()
         );
 
-        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser);
+        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV6_ONLY);
         assertNull(addresses, "Should pick an IPv6 address");
@@ -122,7 +117,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 LOCALHOST_V6_ADDRESSES
         );
 
-        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser);
+        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV4_PREFERRED);
         assertNotNull(addresses);
@@ -138,7 +133,7 @@ public class DefaultHostsFileEntriesResolverTest {
                 LOCALHOST_V6_ADDRESSES
         );
 
-        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser);
+        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV6_PREFERRED);
         assertNotNull(addresses);
@@ -152,7 +147,7 @@ public class DefaultHostsFileEntriesResolverTest {
         Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(LOCALHOST_V4_ADDRESSES);
         Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(LOCALHOST_V6_ADDRESSES);
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses));
+                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), ENTRIES_TTL);
         String newHost = UUID.randomUUID().toString();
 
         v4Addresses.put(newHost, Collections.<InetAddress>singletonList(NetUtil.LOCALHOST4));
@@ -164,11 +159,10 @@ public class DefaultHostsFileEntriesResolverTest {
 
     @Test
     public void shouldRefreshHostsFileContentAfterRefreshInterval() {
-        System.setProperty("io.netty.hostsFileRefreshInterval", String.valueOf(TimeUnit.MINUTES.toNanos(-1)));
         Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(LOCALHOST_V4_ADDRESSES);
         Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(LOCALHOST_V6_ADDRESSES);
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses));
+                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), -1);
         String newHost = UUID.randomUUID().toString();
 
         InetAddress address = resolver.address(newHost, ResolvedAddressTypes.IPV6_ONLY);

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -181,7 +181,7 @@ public class DefaultHostsFileEntriesResolverTest {
         assertEquals(NetUtil.LOCALHOST6, resolver.address(newHost, ResolvedAddressTypes.IPV6_ONLY));
     }
 
-    public HostsFileEntriesProvider.Parser givenHostsParserWith(final Map<String, List<InetAddress>> inet4Entries,
+    private HostsFileEntriesProvider.Parser givenHostsParserWith(final Map<String, List<InetAddress>> inet4Entries,
                                                                 final Map<String, List<InetAddress>> inet6Entries) {
         HostsFileEntriesProvider.Parser mockParser = mock(HostsFileEntriesProvider.Parser.class);
 

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -33,8 +33,12 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.any;
 
 public class DefaultHostsFileEntriesResolverTest {
     private final Map<String, List<InetAddress>> localhostV4Addresses =


### PR DESCRIPTION
Re-read /etc/hosts periodically in `DefaultHostsFileEntriesResolver`

Motivation:

`io.netty.resolver.DefaultHostsFileEntriesResolver` parses `/etc/hosts` only once, upon creation.
With these changes `DefaultHostsFileEntriesResolver` will periodically re-read configuration.

Modification:
1. Made `HostsFileEntriesProvider.Parser` dependency injectable via constructor to be able to test my changes
2. Added entries `expiry` check and re-read before resolving addresses
3. `address` now uses `addresses` function inside

Result:
`DefaultHostsFileEntriesResolver` now re-reads data from hosts file every 10 seconds. 

Fixes #<GitHub issue number>. 
#11661

