### PR TITLE
Use log4j2.version variable instead of fixed version for log4j-1.2-api in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,7 +786,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-1.2-api</artifactId>
-        <version>2.15.0</version>
+        <version>${log4j2.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>mail</artifactId>


### PR DESCRIPTION
This is simpler and prevents having to update 2 places, which is easily forgotten, see #11907 and #11909.