### PR TITLE
Fix issue #11920: Slf4JLoggerFactory does not initialize when using no-op logger

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -59,7 +59,7 @@ public abstract class InternalLoggerFactory {
 
     private static InternalLoggerFactory useSlf4JLoggerFactory(String name) {
         try {
-            InternalLoggerFactory f = Slf4JLoggerFactory.INSTANCE_WITH_NOP_CHECK;
+            InternalLoggerFactory f = Slf4JLoggerFactory.getInstanceWithNopCheck();
             f.newInstance(name).debug("Using SLF4J as the default logging framework");
             return f;
         } catch (LinkageError ignore) {

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -30,8 +30,6 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
     @SuppressWarnings("deprecation")
     public static final InternalLoggerFactory INSTANCE = new Slf4JLoggerFactory();
 
-    static final InternalLoggerFactory INSTANCE_WITH_NOP_CHECK = new Slf4JLoggerFactory(true);
-
     /**
      * @deprecated Use {@link #INSTANCE} instead.
      */
@@ -55,5 +53,13 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
     static InternalLogger wrapLogger(Logger logger) {
         return logger instanceof LocationAwareLogger ?
                 new LocationAwareSlf4JLogger((LocationAwareLogger) logger) : new Slf4JLogger(logger);
+    }
+
+    static InternalLoggerFactory getInstanceWithNopCheck() {
+        return NopInstanceHolder.INSTANCE_WITH_NOP_CHECK;
+    }
+
+    private static class NopInstanceHolder {
+        private static final InternalLoggerFactory INSTANCE_WITH_NOP_CHECK = new Slf4JLoggerFactory(true);
     }
 }

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -59,7 +59,7 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
         return NopInstanceHolder.INSTANCE_WITH_NOP_CHECK;
     }
 
-    private static class NopInstanceHolder {
+    private static final class NopInstanceHolder {
         private static final InternalLoggerFactory INSTANCE_WITH_NOP_CHECK = new Slf4JLoggerFactory(true);
     }
 }


### PR DESCRIPTION
Motivation:

Fixes issue #11920: Slf4JLoggerFactory does not initialize when using no-op logger.

Modification:

Move the INSTANCE_WITH_NOP_CHECK to a nested class so that the failure does not affect the outer class.

Result:

Fixes #11920. 

