### PR TITLE
Move variable keepAlive declaration close to where it is used.

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp1Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp1Handler.java
@@ -52,7 +52,6 @@ public class HelloWorldHttp1Handler extends SimpleChannelInboundHandler<FullHttp
         if (HttpUtil.is100ContinueExpected(req)) {
             ctx.write(new DefaultFullHttpResponse(HTTP_1_1, CONTINUE, Unpooled.EMPTY_BUFFER));
         }
-        boolean keepAlive = HttpUtil.isKeepAlive(req);
 
         ByteBuf content = ctx.alloc().buffer();
         content.writeBytes(HelloWorldHttp2Handler.RESPONSE_BYTES.duplicate());
@@ -62,6 +61,7 @@ public class HelloWorldHttp1Handler extends SimpleChannelInboundHandler<FullHttp
         response.headers().set(CONTENT_TYPE, "text/plain; charset=UTF-8");
         response.headers().setInt(CONTENT_LENGTH, response.content().readableBytes());
 
+        boolean keepAlive = HttpUtil.isKeepAlive(req);
         if (keepAlive) {
             if (req.protocolVersion().equals(HTTP_1_0)) {
                 response.headers().set(CONNECTION, KEEP_ALIVE);


### PR DESCRIPTION
Motivation:
Variable declaration should close to where it is used.

Modification:
Move variable keepAlive declaration close to where it is used

Result:

Cleaner code