### PR TITLE
Update to log4j 2.17.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,7 +517,7 @@
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <junit.version>5.7.0</junit.version>
     <testJavaHome>${java.home}</testJavaHome>


### PR DESCRIPTION
See https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0

Motivation:

log4j 2.16 was recently discovered to be vulnerable to an infinite recursion DOS. Version 2.17 fixes [LOG4J2-3230](https://issues.apache.org/jira/browse/LOG4J2-3230).

Modification:

Change the POM from 2.16 to 2.17 for log4j.

Result:

This PR updates log4j to 2.17, which includes a patch for the issue.
