### PR TITLE
Fix ArrayIndexOutOfBounds: 39 from PoolArena.findSubpagePoolHead

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -310,6 +310,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
             if (handle < 0) {
                 return false;
             }
+            assert !isSubpage(handle);
         }
 
         ByteBuffer nioBuffer = cachedNioBuffers != null? cachedNioBuffers.pollLast() : null;

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -417,9 +417,11 @@ final class PoolThreadCache {
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
         private  void freeEntry(Entry entry, boolean finalizer) {
+            // Capture entry state before we recycle the entry object.
             PoolChunk chunk = entry.chunk;
             long handle = entry.handle;
             ByteBuffer nioBuffer = entry.nioBuffer;
+            int normCapacity = entry.normCapacity;
 
             if (!finalizer) {
                 // recycle now so PoolChunk can be GC'ed. This will only be done if this is not freed because of
@@ -427,7 +429,7 @@ final class PoolThreadCache {
                 entry.recycle();
             }
 
-            chunk.arena.freeChunk(chunk, handle, entry.normCapacity, sizeClass, nioBuffer, finalizer);
+            chunk.arena.freeChunk(chunk, handle, normCapacity, sizeClass, nioBuffer, finalizer);
         }
 
         static final class Entry<T> {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -59,6 +59,11 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
                        long handle, int offset, int length, int maxLength, PoolThreadCache cache) {
         assert handle >= 0;
         assert chunk != null;
+        if (PoolChunk.isSubpage(handle)) {
+            if (chunk.arena.size2SizeIdx(maxLength) > chunk.arena.smallMaxSizeIdx) {
+                throw new AssertionError("Allocated small sub-page handle for a buffer size that isn't \"small.\"");
+            }
+        }
 
         this.chunk = chunk;
         memory = chunk.memory;

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -59,11 +59,8 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
                        long handle, int offset, int length, int maxLength, PoolThreadCache cache) {
         assert handle >= 0;
         assert chunk != null;
-        if (PoolChunk.isSubpage(handle)) {
-            if (chunk.arena.size2SizeIdx(maxLength) > chunk.arena.smallMaxSizeIdx) {
-                throw new AssertionError("Allocated small sub-page handle for a buffer size that isn't \"small.\"");
-            }
-        }
+        assert !PoolChunk.isSubpage(handle) || chunk.arena.size2SizeIdx(maxLength) <= chunk.arena.smallMaxSizeIdx:
+                "Allocated small sub-page handle for a buffer size that isn't \"small.\"";
 
         this.chunk = chunk;
         memory = chunk.memory;


### PR DESCRIPTION
Motivation:
We were getting occasional reports of an ArrayIndexOutOfBounds from PoolArena.findSubpagePoolHead, which always happened at index 39.
The sub-page size index array is 39 entries in length, so this access was one past the end.
This should not happen, because a size that *would* compute to index 39, would be a normal-sized allocation (rather than a small one) and thus not use sub-pages at all.
The reason this occurred, is because the "handle" associated with the allocation indicated that it was small, and thus upon freeing we would access the sub-page array, but the specific index was computed from the normalized allocation size, which was "normal" instead of "small".
This happened because of a use-after-free issue in PoolThreadCache, where the entire state of Entry objects were captured prior to return the entry to the recycler *except* for the normCapacity field.
The normCapacity field is what becomes the normSize down the stack, and accessing this field after a recycle could cause the access to race with a concurrent allocation.
So if the allocation was originally small and using sub-pages, then we would capture a sub-page handle, then recycle the entry object, which then got used in a normal-sized allocation, and *then* we read the normCapacity field of this other allocation.

Modification:
The fix is to capture the normCapacity field before calling Entry.recycle() in PoolThreadCache.freeEntry.
A couple of assertions have also been added, to possibly capture bugs like this at an earlier point in the execution.

Result:
We should no longer get this particular ArrayIndexOutOfBoundsException.

This fixes the issues reported by @EzajAnsari and @atanu1991 here: https://github.com/netty/netty/issues/10821#issuecomment-980849785