### PR TITLE
do not periodically re-read /etc/hosts by default

### DIFF
--- a/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
@@ -47,7 +47,7 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
 
     static {
         DEFAULT_REFRESH_INTERVAL = SystemPropertyUtil.getLong(
-                "io.netty.hostsFileRefreshInterval", /*seconds*/0);
+                "io.netty.hostsFileRefreshInterval", /*nanos*/0);
 
         if (logger.isDebugEnabled()) {
             logger.debug("-Dio.netty.hostsFileRefreshInterval: {}", DEFAULT_REFRESH_INTERVAL);

--- a/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
@@ -16,6 +16,7 @@
 package io.netty.resolver;
 
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -27,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -47,7 +47,7 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
 
     static {
         DEFAULT_REFRESH_INTERVAL = SystemPropertyUtil.getLong(
-                "io.netty.hostsFileRefreshInterval", TimeUnit.SECONDS.toNanos(60));
+                "io.netty.hostsFileRefreshInterval", /*seconds*/0);
 
         if (logger.isDebugEnabled()) {
             logger.debug("-Dio.netty.hostsFileRefreshInterval: {}", DEFAULT_REFRESH_INTERVAL);
@@ -61,7 +61,7 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
     // for testing purpose only
     DefaultHostsFileEntriesResolver(HostsFileEntriesProvider.Parser hostsFileParser, long refreshInterval) {
         this.hostsFileParser = hostsFileParser;
-        this.refreshInterval = refreshInterval;
+        this.refreshInterval = ObjectUtil.checkPositiveOrZero(refreshInterval, "refreshInterval");
         HostsFileEntriesProvider entries = parseEntries(hostsFileParser);
         inet4Entries = entries.ipv4Entries();
         inet6Entries = entries.ipv6Entries();
@@ -103,9 +103,13 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
     }
 
     private void ensureHostsFileEntriesAreFresh() {
+        long interval = refreshInterval;
+        if (interval == 0) {
+            return;
+        }
         long last = lastRefresh.get();
         long currentTime = System.nanoTime();
-        if (currentTime - last > refreshInterval) {
+        if (currentTime - last > interval) {
             if (lastRefresh.compareAndSet(last, currentTime)) {
                 HostsFileEntriesProvider entries = parseEntries(hostsFileParser);
                 inet4Entries = entries.ipv4Entries();

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -158,16 +158,17 @@ public class DefaultHostsFileEntriesResolverTest {
     }
 
     @Test
-    public void shouldRefreshHostsFileContentAfterRefreshInterval() {
+    public void shouldRefreshHostsFileContentAfterRefreshInterval() throws Exception {
         Map<String, List<InetAddress>> v4Addresses = Maps.newHashMap(LOCALHOST_V4_ADDRESSES);
         Map<String, List<InetAddress>> v6Addresses = Maps.newHashMap(LOCALHOST_V6_ADDRESSES);
         DefaultHostsFileEntriesResolver resolver =
-                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), -1);
+                new DefaultHostsFileEntriesResolver(givenHostsParserWith(v4Addresses, v6Addresses), /*nanos*/1);
         String newHost = UUID.randomUUID().toString();
 
         InetAddress address = resolver.address(newHost, ResolvedAddressTypes.IPV6_ONLY);
         assertNull(address);
-
+        /*let refreshIntervalNanos = 1 elapse*/
+        Thread.sleep(1);
         v4Addresses.put(newHost, Collections.<InetAddress>singletonList(NetUtil.LOCALHOST4));
         v6Addresses.put(newHost, Collections.<InetAddress>singletonList(NetUtil.LOCALHOST6));
 


### PR DESCRIPTION
Motivation:

After https://github.com/netty/netty/pull/11922, by default `io.netty.resolver.DefaultHostsFileEntriesResolver` synchronously reads `/etc/hosts` every 60 seconds, while prior above change It read `/etc/hosts` once upon instantiation.

Modification:

By default `io.netty.resolver.DefaultHostsFileEntriesResolver` reads `/etc/hosts` once upon instantiation. This corresponds to io.netty.hostsFileRefreshInterval = 0

Negative values for io.netty.hostsFileRefreshInterval are forbidden

Result:

By default `io.netty.resolver.DefaultHostsFileEntriesResolver` reads `/etc/hosts` once upon instantiation, which corresponds to  behavior before https://github.com/netty/netty/pull/11922