### PR TITLE
Use boringssl when building on macOS m1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,23 @@
     </profile>
 
     <profile>
+      <id>boringssl-osx-arch64</id>
+      <activation>
+        <os>
+          <!--
+           Automatically active on osx with aarch64 as we only release static boringssl version of
+           netty-tcnative for it.
+         -->
+          <family>osx</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
+        <tcnative.classifier />
+      </properties>
+    </profile>
+    <profile>
       <id>boringssl</id>
       <activation>
         <!--


### PR DESCRIPTION
Motivation:

We currently only release netty-tcnative statically compiled against boringssl for macOS m1.

Modifications:

Add profile which will automatically use boringssl version if on macOS m1

Result:

Can build on m1 without problems. See https://github.com/netty/netty/issues/11941
