### PR TITLE
Use ChannelHandlerContext.isRemoved() to check if the handler was alr…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -169,7 +169,7 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
 
     private void removeSelfIfPresent(ChannelHandlerContext ctx) {
         ChannelPipeline pipeline = ctx.pipeline();
-        if (pipeline.context(this) != null) {
+        if (!ctx.isRemoved()) {
             pipeline.remove(this);
         }
     }

--- a/transport/src/main/java/io/netty/channel/ChannelInitializer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInitializer.java
@@ -132,9 +132,8 @@ public abstract class ChannelInitializer<C extends Channel> extends ChannelInbou
                 // We do so to prevent multiple calls to initChannel(...).
                 exceptionCaught(ctx, cause);
             } finally {
-                ChannelPipeline pipeline = ctx.pipeline();
-                if (pipeline.context(this) != null) {
-                    pipeline.remove(this);
+                if (!ctx.isRemoved()) {
+                    ctx.pipeline().remove(this);
                 }
             }
             return true;


### PR DESCRIPTION
…eady removed

Motivation:

We have a method to check if a handler was removed already, we should use it.

Modifications:

Replace usage of context(this) != null with isRemoved()

Result:

Cleanup / small perf improvement
