### PR TITLE
Try to fix rare failure in DnsNameResolverTest

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3119,8 +3119,9 @@ public class DnsNameResolverTest {
 
             if (tcpFallback) {
                 // If we are configured to use TCP as a fallback also bind a TCP socket
-                serverSocket = new ServerSocket(dnsServer2.localAddress().getPort());
+                serverSocket = new ServerSocket();
                 serverSocket.setReuseAddress(true);
+                serverSocket.bind(new InetSocketAddress(dnsServer2.localAddress().getPort()));
 
                 builder.socketChannelType(NioSocketChannel.class);
             }


### PR DESCRIPTION
Motivation:
We occasionally see the following stack trace from DnsNameResolverTest:
java.net.BindException: Address already in use (Bind failed)
 	at java.base/java.net.PlainSocketImpl.socketBind(Native Method)
 	at java.base/java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:436)
 	at java.base/java.net.ServerSocket.bind(ServerSocket.java:395)
 	at java.base/java.net.ServerSocket.<init>(ServerSocket.java:257)
 	at java.base/java.net.ServerSocket.<init>(ServerSocket.java:149)
 	at io.netty.resolver.dns.DnsNameResolverTest.testTruncated0(DnsNameResolverTest.java:3122)
 	at io.netty.resolver.dns.DnsNameResolverTest.testTruncatedWithTcpFallback(DnsNameResolverTest.java:3050)

The failure is too rare to say for sure why it happens — I was not able to observe it locally — but it could be because we try to bind before we allow port reuse.
The server in question binds to port 0, so a random free port chosen by the OS, but it binds a UDP socket.
I don't know if UDP and TCP sockets conflict like that.

Modification:
Make sure that we allow port reuse on the socket before we bind it to a port.

Result:
We will hopefully see fewer test failures here.
We already tried to enable port reuse, which I suppose we did for a reason, but by enabling before binding, we should get the desired effect from it.
