### PR TITLE
Update to log4j 2.17.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,7 +534,7 @@
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <junit.version>5.7.0</junit.version>
     <testJavaHome>${java.home}</testJavaHome>


### PR DESCRIPTION
Motivation:

log4j 2.17 is vulnerable to RCE via JDBC Appender when attacker controls configuration ( CVE-2021-44832 ).

Modification:

Bump log4j property to 2.17.1.

Result:

Updates log4j to 2.17.1, which includes a patch for the issue.