### PR TITLE
Fix: Make ByteToMessageDecoder not call read() in channelReadComplete, if no channelRead fired.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -535,9 +535,6 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     }
 
     @Override
-    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        selfFiredChannelRead = false;
-    }
 
     static ByteBuf expandCumulation(ByteBufAllocator alloc, ByteBuf oldCumulation, ByteBuf in) {
         int oldBytes = oldCumulation.readableBytes();

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -162,7 +162,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
      */
     private boolean firedChannelRead;
 
-    private boolean selfFiredChannelRead = false;
+    private boolean selfFiredChannelRead;
 
     /**
      * A bitmask where the bits are defined as

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -534,8 +534,6 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
         }
     }
 
-    @Override
-
     static ByteBuf expandCumulation(ByteBufAllocator alloc, ByteBuf oldCumulation, ByteBuf in) {
         int oldBytes = oldCumulation.readableBytes();
         int newBytes = in.readableBytes();

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -560,6 +560,5 @@ public class ByteToMessageDecoderTest {
         assertEquals(0, interceptor.readsTriggered);
         assertNotNull(channel.pipeline().get(FixedLengthFrameDecoder.class));
         assertFalse(channel.finish());
-
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -556,8 +556,10 @@ public class ByteToMessageDecoderTest {
                 }
         );
 
-        channel.writeInbound(Unpooled.wrappedBuffer(new byte[]{1}));
+        assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(new byte[]{1})));
         assertEquals(0, interceptor.readsTriggered);
+        assertNotNull(channel.pipeline().get(FixedLengthFrameDecoder.class));
+        assertFalse(channel.finish());
 
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -435,7 +435,7 @@ public class ByteToMessageDecoderTest {
         }
     }
 
-    private static class ReadInterceptingHandler extends ChannelOutboundHandlerAdapter {
+    private static final class ReadInterceptingHandler extends ChannelOutboundHandlerAdapter {
         private int readsTriggered;
 
         @Override


### PR DESCRIPTION
Motivation:

When ByteToMessageDecoder added in channelRead(), the following channelReadComplete() will lead ByteToMessageDecoder to call a read(),
which is not expected.

Modifications:

Add a field variable tracking the state of if ByteToMessageDecoder.channelRead() is fired after the handler is added. And if it was NOT fired, then the next channelReadComplete() would not call read()

Result:

ByteToMessageDecoder will no longer call read() in channelReadComplete() if no channelRead() fired.

Fixes #11965  
