### PR TITLE
Add a `fast` maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,23 @@
       </properties>
     </profile>
     <profile>
+      <!-- Skip many checks for faster turn-around in local builds. -->
+      <id>fast</id>
+      <properties>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <checkstyle.skip>true</checkstyle.skip>
+        <japicmp.skip>true</japicmp.skip>
+        <revapi.skip>true</revapi.skip>
+        <xml.skip>true</xml.skip>
+        <skipShadingTestsuite>true</skipShadingTestsuite>
+        <skipDeploy>true</skipDeploy>
+        <skipTests>true</skipTests>
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <skipAutobahnTestsuite>true</skipAutobahnTestsuite>
+        <skipHttp2Testsuite>true</skipHttp2Testsuite>
+      </properties>
+    </profile>
+    <profile>
       <id>coverage</id>
       <properties>
         <argLine.coverage>${jacoco.argLine}</argLine.coverage>
@@ -537,6 +554,7 @@
     <log4j2.version>2.17.0</log4j2.version>
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <junit.version>5.7.0</junit.version>
+    <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>
     <testJvm>${testJavaHome}/bin/java</testJvm>
     <skipOsgiTestsuite>false</skipOsgiTestsuite>
@@ -1365,6 +1383,7 @@
               <value>io.netty.build.junit.TimedOutTestsListener</value>
             </property>
           </properties>
+          <skipTests>${skipTests}</skipTests>
           <jvm>${testJvm}</jvm>
            <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
           <trimStackTrace>false</trimStackTrace>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -36,7 +36,6 @@
       </activation>
       <properties>
         <jni.compiler.args.ldflags>LDFLAGS=-Wl,-weak_library,${unix.common.lib.unpacked.dir}/lib${unix.common.lib.name}.a -Wl,-platform_version,macos,10.6,10.6</jni.compiler.args.ldflags>
-        <skipTests>false</skipTests>
       </properties>
       <build>
         <plugins>
@@ -251,9 +250,6 @@
           <name>openbsd</name>
         </os>
       </activation>
-      <properties>
-        <skipTests>false</skipTests>
-      </properties>
       <build>
         <plugins>
           <plugin>
@@ -357,9 +353,6 @@
           <name>freebsd</name>
         </os>
       </activation>
-      <properties>
-        <skipTests>false</skipTests>
-      </properties>
       <build>
         <plugins>
           <plugin>
@@ -455,6 +448,28 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>Windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+    <profile>
+      <id>Linux</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>
@@ -468,7 +483,6 @@
     <jni.compiler.args.cflags>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
     <jni.compiler.args.ldflags>LDFLAGS=-z now -L${unix.common.lib.unpacked.dir} -Wl,--whole-archive -l${unix.common.lib.name} -Wl,--no-whole-archive</jni.compiler.args.ldflags>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
-    <skipTests>true</skipTests>
     <japicmp.skip>true</japicmp.skip>
   </properties>
 


### PR DESCRIPTION
Motivation:
To assist IDEs and other tools, it is often required to make `install` builds locally.
Since this can block work, it's desirable for these builds to be as fast as possible.

Modification:
Add a profile that skips many checks, to speed up the build.

Result:
It is now possible to make a clean build with `mvn clean install -Pfast -T1C` in (on my machine) under two minutes.