### PR TITLE
Fix ByteBufUtil.indexOf(buf, buf)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -279,7 +279,7 @@ public final class ByteBufUtil {
                         --i;
                     }
                     if (i <= memory) {
-                        return j;
+                        return j + bStartIndex;
                     }
                     j += per;
                     memory = m - per - 1;
@@ -304,7 +304,7 @@ public final class ByteBufUtil {
                         --i;
                     }
                     if (i < 0) {
-                        return j;
+                        return j + bStartIndex;
                     }
                     j += per;
                 } else {

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -132,13 +132,13 @@ public class ByteBufUtilTest {
         final ByteBuf needle = Unpooled.copiedBuffer("abc12", CharsetUtil.UTF_8);
         haystack.readerIndex(1);
         needle.readerIndex(1);
-        assertEquals(0, ByteBufUtil.indexOf(needle, haystack));
+        assertEquals(1, ByteBufUtil.indexOf(needle, haystack));
         haystack.readerIndex(2);
         needle.readerIndex(3);
-        assertEquals(1, ByteBufUtil.indexOf(needle, haystack));
+        assertEquals(3, ByteBufUtil.indexOf(needle, haystack));
         haystack.readerIndex(1);
         needle.readerIndex(2);
-        assertEquals(1, ByteBufUtil.indexOf(needle, haystack));
+        assertEquals(2, ByteBufUtil.indexOf(needle, haystack));
         haystack.release();
 
         haystack = new WrappedByteBuf(Unpooled.copiedBuffer("abc123", CharsetUtil.UTF_8));


### PR DESCRIPTION
Motivation:
The ByteBufUtil.indexOf(buf, buf) method has historically been returning absolute indexes in the haystack.
With the introduction of the Two-Way algorithm, it inadvertently got changed to return offsets relative to the haystacks reader index.
That's a compatibility breaking change.

Modification:
Restore the old behavior of returning absolute indexes.
The tests have also been updated, and I have manually verified that the updated tests pass on the old code that the Two-Way implementation replaced.

Result:
Compatibility is restored.
Fixes #11963

Note that the impact of this bug has been relatively minor inside Netty itself, since the produced index was only used for the error message when Http2ConnectionHandler failed to detect "HTTP/1" in the client preface.