### PR TITLE
WebSocketServerProtocolHandshakeHandler should work without aggregation

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -23,6 +23,8 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequestDecoder;
@@ -34,6 +36,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,10 +63,19 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testHttpUpgradeRequest() {
+    public void testHttpUpgradeRequestFull() {
+        testHttpUpgradeRequest0(true);
+    }
+
+    @Test
+    public void testHttpUpgradeRequestNonFull() {
+        testHttpUpgradeRequest0(false);
+    }
+
+    private void testHttpUpgradeRequest0(boolean full) {
         EmbeddedChannel ch = createChannel(new MockOutboundHandler());
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
-        writeUpgradeRequest(ch);
+        writeUpgradeRequest(ch, full);
 
         FullHttpResponse response = responses.remove();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
@@ -451,7 +463,26 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     private static void writeUpgradeRequest(EmbeddedChannel ch) {
-        ch.writeInbound(WebSocketRequestBuilder.successful());
+        writeUpgradeRequest(ch, true);
+    }
+
+    private static void writeUpgradeRequest(EmbeddedChannel ch, boolean full) {
+        HttpRequest request = WebSocketRequestBuilder.successful();
+        if (full) {
+            ch.writeInbound(request);
+        } else {
+            if (request instanceof FullHttpRequest) {
+                FullHttpRequest fullHttpRequest = (FullHttpRequest) request;
+                HttpRequest req = new DefaultHttpRequest(fullHttpRequest.protocolVersion(), fullHttpRequest.method(),
+                        fullHttpRequest.uri(), fullHttpRequest.headers().copy());
+                ch.writeInbound(req);
+                ch.writeInbound(new DefaultHttpContent(fullHttpRequest.content().copy()));
+                ch.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
+                fullHttpRequest.release();
+            } else {
+                ch.writeInbound(request);
+            }
+        }
     }
 
     private static String getResponseMessage(FullHttpResponse response) {


### PR DESCRIPTION
Motivation:

WebSocketServerProtocolHandshakeHandler assumes the msg is FullHttpRequest which is not really needed.

Modifications:

- Rework logic so we not depend on the fact that aggregation is used.
- Add test

Result:

Fixes https://github.com/netty/netty/issues/11952