### PR TITLE
ensure the side which enbale SO_LINGER and call showdownOutput to start TCP half-closure in fin_wait2 state can still receive and process the data which is send by another side in the close_wait state

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -88,7 +88,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                             public void channelActive(final ChannelHandlerContext ctx) {
                                 SocketChannel channel = (SocketChannel)ctx.channel();
                                 channel.shutdownOutput();
-
                             }
 
                             @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -69,7 +69,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         Channel serverChannel = null;
         Channel clientChannel = null;
 
-        final AtomicBoolean clientReceiveDataOnFinalWait2 = new AtomicBoolean(false);
         final CountDownLatch waitHalfClosureDone = new CountDownLatch(1);
 
         final ByteBuf testHalfClosureSendMessage = Unpooled.buffer(16);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -47,9 +47,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.concurrent.TimeUnit.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.*;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class SocketHalfClosedTest extends AbstractSocketTest {
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -124,7 +124,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             serverChannel = sb.bind().sync().channel();
             clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
             waitHalfClosureDone.await();
-            assertTrue(clientReceiveDataOnFinalWait2.get());
         } finally {
             if (clientChannel != null) {
                 clientChannel.close().sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -104,7 +104,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                             @Override
                             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                                 if (ChannelInputShutdownEvent.INSTANCE == evt) {
-                                    ctx.writeAndFlush(ctx.alloc(16).writeZero(16));
+                                    ctx.writeAndFlush(ctx.alloc().buffer().writeZero(16));
                                 }
 
                                 if (ChannelInputShutdownReadComplete.INSTANCE == evt) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -95,7 +95,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                                 waitHalfClosureDone.countDown();
                                 ReferenceCountUtil.release(msg);
                             }
-
                         });
                   }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -77,7 +77,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         }
 
         try {
-
             sb.childOption(ChannelOption.SO_LINGER, 1)
               .childHandler(new ChannelInitializer<Channel>() {
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -92,7 +92,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
 
                             @Override
                             public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                                clientReceiveDataOnFinalWait2.set(true);
                                 waitHalfClosureDone.countDown();
                                 ReferenceCountUtil.release(msg);
                             }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -650,38 +650,19 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             final Throwable shutdownCause = cause == null ?
                     new ChannelOutputShutdownException("Channel output shutdown") :
                     new ChannelOutputShutdownException("Channel output shutdown", cause);
-            Executor closeExecutor = prepareToClose();
-            if (closeExecutor != null) {
-                closeExecutor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            // Execute the shutdown.
-                            doShutdownOutput();
-                            promise.setSuccess();
-                        } catch (Throwable err) {
-                            promise.setFailure(err);
-                        } finally {
-                            // Dispatch to the EventLoop
-                            eventLoop().execute(new Runnable() {
-                                @Override
-                                public void run() {
-                                    closeOutboundBufferForShutdown(pipeline, outboundBuffer, shutdownCause);
-                                }
-                            });
-                        }
-                    }
-                });
-            } else {
-                try {
-                    // Execute the shutdown.
-                    doShutdownOutput();
-                    promise.setSuccess();
-                } catch (Throwable err) {
-                    promise.setFailure(err);
-                } finally {
-                    closeOutboundBufferForShutdown(pipeline, outboundBuffer, shutdownCause);
-                }
+
+            // when a side enbale SO_LINGER and call showdownOutput to start TCP half-closure,we can not call doDeregister here
+            // because we should ensure this side in fin_wait2 state can still receive and process the data which is send by another side in the close_wait state。
+            // See
+            try {
+                //The shutdown function does not block regardless of the SO_LINGER setting on the socket,so we don't need to use
+                //GlobalEventExecutor to execute the shutdown
+                doShutdownOutput();
+                promise.setSuccess();
+            } catch (Throwable err) {
+                promise.setFailure(err);
+            } finally {
+                closeOutboundBufferForShutdown(pipeline, outboundBuffer, shutdownCause);
             }
         }
 

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -651,7 +651,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     new ChannelOutputShutdownException("Channel output shutdown") :
                     new ChannelOutputShutdownException("Channel output shutdown", cause);
 
-            // when a side enbale SO_LINGER and call showdownOutput to start TCP half-closure,we can not call doDeregister here
+            // When a side enables SO_LINGER and calls showdownOutput(...) to start TCP half-closure, we can not call doDeregister here
             // because we should ensure this side in fin_wait2 state can still receive and process the data which is send by another side in the close_wait state。
             // See https://github.com/netty/netty/issues/11981
             try {

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -653,7 +653,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
             // when a side enbale SO_LINGER and call showdownOutput to start TCP half-closure,we can not call doDeregister here
             // because we should ensure this side in fin_wait2 state can still receive and process the data which is send by another side in the close_wait state。
-            // See
+            // See https://github.com/netty/netty/issues/11981
             try {
                 //The shutdown function does not block regardless of the SO_LINGER setting on the socket,so we don't need to use
                 //GlobalEventExecutor to execute the shutdown

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -656,7 +656,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             // See https://github.com/netty/netty/issues/11981
             try {
                 //The shutdown function does not block regardless of the SO_LINGER setting on the socket,so we don't need to use
-                //GlobalEventExecutor to execute the shutdown
+                // GlobalEventExecutor to execute the shutdown
                 doShutdownOutput();
                 promise.setSuccess();
             } catch (Throwable err) {

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -655,7 +655,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             // because we should ensure this side in fin_wait2 state can still receive and process the data which is send by another side in the close_wait state。
             // See https://github.com/netty/netty/issues/11981
             try {
-                //The shutdown function does not block regardless of the SO_LINGER setting on the socket,so we don't need to use
+                // The shutdown function does not block regardless of the SO_LINGER setting on the socket,so we don't need to use
                 // GlobalEventExecutor to execute the shutdown
                 doShutdownOutput();
                 promise.setSuccess();

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -651,12 +651,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     new ChannelOutputShutdownException("Channel output shutdown") :
                     new ChannelOutputShutdownException("Channel output shutdown", cause);
 
-            // When a side enables SO_LINGER and calls showdownOutput(...) to start TCP half-closure, we can not call doDeregister here
-            // because we should ensure this side in fin_wait2 state can still receive and process the data which is send by another side in the close_wait state。
+            // When a side enables SO_LINGER and calls showdownOutput(...) to start TCP half-closure
+            // we can not call doDeregister here because we should ensure this side in fin_wait2 state
+            // can still receive and process the data which is send by another side in the close_wait state。
             // See https://github.com/netty/netty/issues/11981
             try {
-                // The shutdown function does not block regardless of the SO_LINGER setting on the socket,so we don't need to use
-                // GlobalEventExecutor to execute the shutdown
+                // The shutdown function does not block regardless of the SO_LINGER setting on the socket
+                // so we don't need to use GlobalEventExecutor to execute the shutdown
                 doShutdownOutput();
                 promise.setSuccess();
             } catch (Throwable err) {


### PR DESCRIPTION
Motivation:

we can not call `doDeregister` to cancel the key of the channel from the selector in the `io.netty.channel.AbstractChannel.AbstractUnsafe#shutdownOutput(io.netty.channel.ChannelPromise, java.lang.Throwable)` method。

- because we should ensure the side which enbale `SO_LINGER` and call `showdownOutput` to start TCP half-closure in fin_wait2 state can still receive and process the data which is send by another side in the close_wait state。

- and the shutdown function does not block regardless of the SO_LINGER setting on the socket,so we don't need to use GlobalEventExecutor to execute the shutdown

Modification:

In summary there is no need to call `prepareToClose()` in the `AbstractChannel.AbstractUnsafe#shutdownOutput` method

Result:

Fixes issue #11981 

client in the FIN_WAIT2 state can read and process these data which is sended by server in the CLOSE_WAIT state，when SO_LINGGER is used in the TCP half-closed scenario
