### PR TITLE
 Correctly calculate the elementSize when cache alignment is configured

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunk.java
@@ -561,7 +561,7 @@ final class PoolChunk implements PoolChunkMetric {
 
         PoolSubpage s = subpages[runOffset];
         assert s.doNotDestroy;
-        assert size <= s.elemSize;
+        assert size <= s.elemSize : size + "<=" + s.elemSize;
 
         int offset = (runOffset << pageShifts) + bitmapIdx * s.elemSize;
         initAllocatorControl(control, threadCache, handle, s.elemSize);

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferAllocateTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferAllocateTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.tests;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BufferAllocateTest extends BufferTestSupport {
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void allocateDifferentSizes(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator()) {
+            // Allocate zero size buffers.
+            allocateBufferPair(allocator,  0);
+
+            // Allocate buffer with the default element size of the subpage
+            allocateBufferPair(allocator,  16);
+
+            // Allocate buffer with a size bigger as the default element size of the subpage but still smaller than
+            // the alignment (if any is used).
+            allocateBufferPair(allocator,  17);
+
+            allocateBufferPair(allocator,  128);
+            allocateBufferPair(allocator,  512);
+            allocateBufferPair(allocator,  1024);
+            allocateBufferPair(allocator,  8 * 1024);
+            allocateBufferPair(allocator,  16 * 1024);
+            allocateBufferPair(allocator,  32 * 1024);
+            allocateBufferPair(allocator,  1000 * 1024);
+            allocateBufferPair(allocator,  8 * 1000 * 1024);
+            allocateBufferPair(allocator,  32 * 1000 * 1024);
+        }
+    }
+
+    private static void allocateBufferPair(BufferAllocator allocator, int size) {
+        try (Buffer buf = allocator.allocate(size); Buffer buf2 = allocator.allocate(size)) {
+            assertThat(buf.capacity()).isGreaterThanOrEqualTo(size);
+            assertThat(buf2.capacity()).isGreaterThanOrEqualTo(size);
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferAllocateTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferAllocateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferTestSupport.java
@@ -22,6 +22,7 @@ import io.netty.buffer.api.BufferClosedException;
 import io.netty.buffer.api.CompositeBuffer;
 import io.netty.buffer.api.MemoryManager;
 import io.netty.buffer.api.internal.ResourceSupport;
+import io.netty.buffer.api.pool.PooledBufferAllocator;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -125,7 +126,14 @@ public abstract class BufferTestSupport {
                 new Fixture("heap", BufferAllocator::onHeapUnpooled, HEAP),
                 new Fixture("direct", BufferAllocator::offHeapUnpooled, DIRECT),
                 new Fixture("pooledHeap", BufferAllocator::onHeapPooled, POOLED, HEAP),
-                new Fixture("pooledDirect", BufferAllocator::offHeapPooled, POOLED, DIRECT));
+                new Fixture("pooledDirect", BufferAllocator::offHeapPooled, POOLED, DIRECT),
+                new Fixture("pooledDirect", () ->
+                        new PooledBufferAllocator(MemoryManager.instance(), true,
+                                PooledBufferAllocator.defaultNumDirectArena(), PooledBufferAllocator.defaultPageSize(),
+                                PooledBufferAllocator.defaultMaxOrder(), PooledBufferAllocator.defaultSmallCacheSize(),
+                                PooledBufferAllocator.defaultNormalCacheSize(), true, 64),
+                        POOLED, DIRECT)
+        );
     }
 
     static List<Fixture> initialFixturesForEachImplementation() {


### PR DESCRIPTION
Motivation:

We need to take the cache alignment into account when we pre-calculate the ementSize otherwise we fail later.

Modifications:

- Fix pre-calculation
- Add unit test

Result:

Forward port of https://github.com/netty/netty/issues/11955 for the new buffer api