### PR TITLE
InternalThreadLocalMap.UNSET field should not allow accessed from outside

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -23,7 +23,7 @@ import static io.netty.handler.codec.http.cookie.CookieUtil.stripTrailingSeparat
 import static java.util.Objects.requireNonNull;
 
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.concurrent.InternalThreadLocalMap;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http.cookie;
 
 import io.netty.handler.codec.http.HttpConstants;
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.concurrent.InternalThreadLocalMap;
 
 import java.util.BitSet;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -34,7 +34,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.concurrent.InternalThreadLocalMap;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.URI;

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -16,7 +16,7 @@
 package io.netty.util;
 
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.concurrent.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;

--- a/common/src/main/java/io/netty/util/CharsetUtil.java
+++ b/common/src/main/java/io/netty/util/CharsetUtil.java
@@ -15,7 +15,7 @@
  */
 package io.netty.util;
 
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.concurrent.InternalThreadLocalMap;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.Charset;

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -15,7 +15,6 @@
  */
 package io.netty.util.concurrent;
 
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 
 import java.util.Collections;

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -15,7 +15,6 @@
 */
 package io.netty.util.concurrent;
 
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.UnstableApi;
 
 /**

--- a/common/src/main/java/io/netty/util/concurrent/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/concurrent/InternalThreadLocalMap.java
@@ -54,7 +54,7 @@ public final class InternalThreadLocalMap {
     private static final int HANDLER_SHARABLE_CACHE_INITIAL_CAPACITY = 4;
     private static final int INDEXED_VARIABLE_TABLE_INITIAL_SIZE = 32;
 
-    public static final Object UNSET = new Object();
+    static final Object UNSET = new Object();
 
     /** Used by {@link FastThreadLocal} */
     private Object[] indexedVariables;

--- a/common/src/main/java/io/netty/util/concurrent/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/concurrent/InternalThreadLocalMap.java
@@ -14,10 +14,10 @@
  * under the License.
  */
 
-package io.netty.util.internal;
+package io.netty.util.concurrent;
 
-import io.netty.util.concurrent.FastThreadLocal;
-import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.TypeParameterMatcher;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.internal;
 
+import io.netty.util.concurrent.InternalThreadLocalMap;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;

--- a/common/src/main/java/io/netty/util/internal/TypeParameterMatcher.java
+++ b/common/src/main/java/io/netty/util/internal/TypeParameterMatcher.java
@@ -16,6 +16,8 @@
 
 package io.netty.util.internal;
 
+import io.netty.util.concurrent.InternalThreadLocalMap;
+
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -16,7 +16,6 @@
 
 package io.netty.util.concurrent;
 
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.ObjectCleaner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
@@ -16,7 +16,7 @@
 
 package io.netty.channel;
 
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.concurrent.InternalThreadLocalMap;
 
 import java.lang.reflect.AnnotatedType;
 import java.util.Map;

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -22,7 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.concurrent.InternalThreadLocalMap;
 import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectPool.Handle;
 import io.netty.util.internal.PromiseNotificationUtil;

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -28,7 +28,7 @@ import io.netty.channel.RecvByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.concurrent.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;


### PR DESCRIPTION
Motivation:

InternalThreadLocalMap.UNSET field should not allow accessed from outside.

Modification:

Moved the class `InternalThreadLocalMap` to package `io.netty.util.concurrent`, and change the access modifier of field `InternalThreadLocalMap.UNSET` to package private.

Result:

Fixes #11929. 
