### PR TITLE
Default logger factory can only be set once

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -15,9 +15,7 @@
  */
 package io.netty.util.internal.logging;
 
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static java.util.Objects.requireNonNull;
 
@@ -49,10 +47,14 @@ public abstract class InternalLoggerFactory {
         }
 
         InternalLoggerFactory getFactory() {
-            if (reference == null) {
-                reference.compareAndSet(null, newDefaultFactory(InternalLoggerFactory.class.getName()));
+            InternalLoggerFactory factory = reference.get();
+            if (factory == null) {
+                factory = newDefaultFactory(InternalLoggerFactory.class.getName());
+                if (!reference.compareAndSet(null, factory)) {
+                    factory = reference.get();
+                }
             }
-            return reference.get();
+            return factory;
         }
 
         void setFactory(final InternalLoggerFactory factory) {


### PR DESCRIPTION
This is an updated version of #6106

Motivation:

InternalLoggerFactory either sets a default logger factory implementation based on the logging implementations on the classpath, or applications can set a logger factory explicitly.
If applications wait too long to set the logger factory, Netty will have already set a logger factory leading to some objects using one logging implementation and other objets using another logging implementation.
This can happen too if the application tries to set the logger factory twice, which is likely a bug in the application.
Yet, the Javadocs for `InternalLoggerFactory` warn against this saying that `InternalLoggerFactory#setLoggerFactory` "should be called as early as possible and shouldn't be called more than once".
Instead, Netty should guard against this.

Modications:

We replace the logger factory field with an atomic field on which we can do CAS operations to safely guard against it being set twice.
We also add an internal holder class that captures the static interface of `InternalLoggerFactory` that can aid in testing.

Result:

The logging factory can not be set twice, and applications that want to set the logging factory must do it before any Netty classes are initialized (or the default logger factory will be set).