### PR TITLE
Reduce usage of InternalThreadLocalMap

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http.cookie;
 
 import io.netty.handler.codec.http.HttpConstants;
-import io.netty.util.internal.InternalThreadLocalMap;
 
 import java.util.BitSet;
 
@@ -74,10 +73,6 @@ final class CookieUtil {
         }
         bits.set(';', false);
         return bits;
-    }
-
-    static StringBuilder stringBuilder() {
-        return InternalThreadLocalMap.get().stringBuilder();
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -16,8 +16,8 @@
 package io.netty.handler.codec.http.cookie;
 
 import io.netty.handler.codec.http.cookie.CookieHeaderNames.SameSite;
+import io.netty.util.internal.StringUtil;
 
-import static io.netty.handler.codec.http.cookie.CookieUtil.stringBuilder;
 import static io.netty.handler.codec.http.cookie.CookieUtil.validateAttributeValue;
 import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 import static java.util.Objects.requireNonNull;
@@ -217,7 +217,7 @@ public class DefaultCookie implements Cookie {
 
     @Override
     public String toString() {
-        StringBuilder buf = stringBuilder()
+        StringBuilder buf = StringUtil.threadLocalStringBuilder()
             .append(name())
             .append('=')
             .append(value());

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http.cookie;
 import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 import static io.netty.handler.codec.http.cookie.CookieUtil.add;
 import static io.netty.handler.codec.http.cookie.CookieUtil.addQuoted;
-import static io.netty.handler.codec.http.cookie.CookieUtil.stringBuilder;
 import static io.netty.handler.codec.http.cookie.CookieUtil.stripTrailingSeparator;
 import static java.util.Objects.requireNonNull;
 
@@ -93,7 +93,7 @@ public final class ServerCookieEncoder extends CookieEncoder {
 
         validateCookie(name, value);
 
-        StringBuilder buf = stringBuilder();
+        StringBuilder buf = StringUtil.threadLocalStringBuilder();
 
         if (cookie.wrap()) {
             addQuoted(buf, name, value);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -34,7 +34,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
-import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.URI;
@@ -674,7 +674,7 @@ public final class HttpConversionUtil {
                         // combine the cookie values into 1 header entry.
                         // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
                         if (cookies == null) {
-                            cookies = InternalThreadLocalMap.get().stringBuilder();
+                            cookies = StringUtil.threadLocalStringBuilder();
                         } else if (cookies.length() > 0) {
                             cookies.append("; ");
                         }

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -15,14 +15,15 @@
  */
 package io.netty.util;
 
+import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -48,6 +49,15 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     private static final char MAX_CHAR_VALUE = 255;
 
     public static final int INDEX_NOT_FOUND = -1;
+
+    private static final int DEFAULT_ARRAY_LIST_INITIAL_CAPACITY = 8;
+
+    private static final FastThreadLocal<List<AsciiString>> ARRAYLISTS = new FastThreadLocal<>() {
+        @Override
+        protected List<AsciiString> initialValue() {
+            return new ArrayList<>(DEFAULT_ARRAY_LIST_INITIAL_CAPACITY);
+        }
+    };
 
     /**
      * If this value is modified outside the constructor then call {@link #arrayChanged()}.
@@ -1078,10 +1088,11 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
-     * Splits the specified {@link String} with the specified delimiter..
+     * Splits the specified {@link String} with the specified delimiter.
      */
     public AsciiString[] split(char delim) {
-        final List<AsciiString> res = InternalThreadLocalMap.get().arrayList();
+        final List<AsciiString> res = ARRAYLISTS.get();
+        res.clear();
 
         int start = 0;
         final int length = length();

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -15,7 +15,6 @@
  */
 package io.netty.util.concurrent;
 
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 
 import java.util.Collections;

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -157,20 +157,6 @@ public class FastThreadLocal<V> {
         return null;
     }
 
-    /**
-     * Returns the current value for the specified thread local map.
-     * The specified thread local map must be for the current thread.
-     */
-    @SuppressWarnings("unchecked")
-    public final V get(InternalThreadLocalMap threadLocalMap) {
-        Object v = threadLocalMap.indexedVariable(index);
-        if (v != InternalThreadLocalMap.UNSET) {
-            return (V) v;
-        }
-
-        return initialize(threadLocalMap);
-    }
-
     private V initialize(InternalThreadLocalMap threadLocalMap) {
         V v = null;
         try {

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -15,7 +15,6 @@
 */
 package io.netty.util.concurrent;
 
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -70,7 +69,7 @@ public class FastThreadLocalThread extends Thread {
      * Returns the internal data structure that keeps the thread-local variables bound to this thread.
      * Note that this method is for internal use only, and thus is subject to change at any time.
      */
-    public final InternalThreadLocalMap threadLocalMap() {
+    final InternalThreadLocalMap threadLocalMap() {
         return threadLocalMap;
     }
 
@@ -78,7 +77,7 @@ public class FastThreadLocalThread extends Thread {
      * Sets the internal data structure that keeps the thread-local variables bound to this thread.
      * Note that this method is for internal use only, and thus is subject to change at any time.
      */
-    public final void setThreadLocalMap(InternalThreadLocalMap threadLocalMap) {
+    final void setThreadLocalMap(InternalThreadLocalMap threadLocalMap) {
         this.threadLocalMap = threadLocalMap;
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/concurrent/InternalThreadLocalMap.java
@@ -14,10 +14,7 @@
  * under the License.
  */
 
-package io.netty.util.internal;
-
-import io.netty.util.concurrent.FastThreadLocal;
-import io.netty.util.concurrent.FastThreadLocalThread;
+package io.netty.util.concurrent;
 
 import java.util.Arrays;
 import java.util.BitSet;
@@ -28,7 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Note that this class is for internal use only and is subject to change at any time.  Use {@link FastThreadLocal}
  * unless you know what you are doing.
  */
-public final class InternalThreadLocalMap {
+final class InternalThreadLocalMap {
 
     private static final ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap =
             new ThreadLocal<>();
@@ -39,14 +36,14 @@ public final class InternalThreadLocalMap {
     private static final int ARRAY_LIST_CAPACITY_MAX_SIZE = Integer.MAX_VALUE - 8;
     private static final int INDEXED_VARIABLE_TABLE_INITIAL_SIZE = 32;
 
-    public static final Object UNSET = new Object();
+    static final Object UNSET = new Object();
 
     /** Used by {@link FastThreadLocal} */
     private Object[] indexedVariables;
 
     private BitSet cleanerFlags;
 
-    public static InternalThreadLocalMap getIfSet() {
+    static InternalThreadLocalMap getIfSet() {
         Thread thread = Thread.currentThread();
         if (thread instanceof FastThreadLocalThread) {
             return ((FastThreadLocalThread) thread).threadLocalMap();
@@ -54,7 +51,7 @@ public final class InternalThreadLocalMap {
         return slowThreadLocalMap.get();
     }
 
-    public static InternalThreadLocalMap get() {
+    static InternalThreadLocalMap get() {
         Thread thread = Thread.currentThread();
         if (thread instanceof FastThreadLocalThread) {
             return fastGet((FastThreadLocalThread) thread);
@@ -80,7 +77,7 @@ public final class InternalThreadLocalMap {
         return ret;
     }
 
-    public static void remove() {
+    static void remove() {
         Thread thread = Thread.currentThread();
         if (thread instanceof FastThreadLocalThread) {
             ((FastThreadLocalThread) thread).setThreadLocalMap(null);
@@ -89,11 +86,11 @@ public final class InternalThreadLocalMap {
         }
     }
 
-    public static void destroy() {
+    static void destroy() {
         slowThreadLocalMap.remove();
     }
 
-    public static int nextVariableIndex() {
+    static int nextVariableIndex() {
         int index = nextIndex.getAndIncrement();
         if (index >= ARRAY_LIST_CAPACITY_MAX_SIZE || index < 0) {
             nextIndex.set(ARRAY_LIST_CAPACITY_MAX_SIZE);
@@ -102,7 +99,7 @@ public final class InternalThreadLocalMap {
         return index;
     }
 
-    public static int lastVariableIndex() {
+    static int lastVariableIndex() {
         return nextIndex.get() - 1;
     }
 
@@ -116,7 +113,7 @@ public final class InternalThreadLocalMap {
         return array;
     }
 
-    public int size() {
+    int size() {
         int count = 0;
         for (Object o: indexedVariables) {
             if (o != UNSET) {
@@ -129,7 +126,7 @@ public final class InternalThreadLocalMap {
         return count - 1;
     }
 
-    public Object indexedVariable(int index) {
+    Object indexedVariable(int index) {
         Object[] lookup = indexedVariables;
         return index < lookup.length? lookup[index] : UNSET;
     }
@@ -137,7 +134,7 @@ public final class InternalThreadLocalMap {
     /**
      * @return {@code true} if and only if a new thread-local variable has been created
      */
-    public boolean setIndexedVariable(int index, Object value) {
+    boolean setIndexedVariable(int index, Object value) {
         Object[] lookup = indexedVariables;
         if (index < lookup.length) {
             Object oldValue = lookup[index];
@@ -171,7 +168,7 @@ public final class InternalThreadLocalMap {
         indexedVariables = newArray;
     }
 
-    public Object removeIndexedVariable(int index) {
+    Object removeIndexedVariable(int index) {
         Object[] lookup = indexedVariables;
         if (index < lookup.length) {
             Object v = lookup[index];
@@ -182,16 +179,16 @@ public final class InternalThreadLocalMap {
         }
     }
 
-    public boolean isIndexedVariableSet(int index) {
+    boolean isIndexedVariableSet(int index) {
         Object[] lookup = indexedVariables;
         return index < lookup.length && lookup[index] != UNSET;
     }
 
-    public boolean isCleanerFlagSet(int index) {
+    boolean isCleanerFlagSet(int index) {
         return cleanerFlags != null && cleanerFlags.get(index);
     }
 
-    public void setCleanerFlag(int index) {
+    void setCleanerFlag(int index) {
         if (cleanerFlags == null) {
             cleanerFlags = new BitSet();
         }

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -16,7 +16,6 @@
 
 package io.netty.util.concurrent;
 
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.ObjectCleaner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -24,7 +24,6 @@ import io.netty.buffer.api.Resource;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectPool.Handle;
 import io.netty.util.internal.PromiseNotificationUtil;
@@ -66,9 +65,9 @@ public final class ChannelOutboundBuffer {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ChannelOutboundBuffer.class);
 
-    private static final FastThreadLocal<BufferCache> NIO_BUFFERS = new FastThreadLocal<BufferCache>() {
+    private static final FastThreadLocal<BufferCache> NIO_BUFFERS = new FastThreadLocal<>() {
         @Override
-        protected BufferCache initialValue() throws Exception {
+        protected BufferCache initialValue() {
             BufferCache cache = new BufferCache();
             cache.buffers = new ByteBuffer[1024];
             return cache;
@@ -427,11 +426,11 @@ public final class ChannelOutboundBuffer {
         assert maxBytes > 0;
         long nioBufferSize = 0;
         int nioBufferCount = 0;
-        final InternalThreadLocalMap threadLocalMap = InternalThreadLocalMap.get();
-        BufferCache cache = NIO_BUFFERS.get(threadLocalMap);
+        BufferCache cache = NIO_BUFFERS.get();
         cache.dataSize = 0;
         cache.bufferCount = 0;
         ByteBuffer[] nioBuffers = cache.buffers;
+
         Entry entry = flushedEntry;
         while (isFlushedEntry(entry) && (entry.msg instanceof ByteBufConvertible || entry.msg instanceof Buffer)) {
             if (!entry.cancelled) {


### PR DESCRIPTION
Motivation:

We should not use InternalThreadLocalMap whenever possible and just use FastThreadLocal.

Modifications:

Replace usage of InternalThreadLocalMap with FastThreadLocal when possible

Result:

Cleanup
