### PR TITLE
InboundHttp2ToHttpAdapter responds with 413 status code

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
@@ -195,6 +195,27 @@ public class Http2Exception extends Exception {
     }
 
     /**
+     * A specific stream error resulting from receiving a payload too large,
+     * typically by exceeding max content length of an aggregate of data frames.
+     * If the {@code id} is not {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a
+     * {@link StreamException} will be returned. Otherwise the error is considered a
+     * connection error and a {@link Http2Exception} is returned.
+     * @param id The stream id for which the error is isolated to.
+     * @param error The type of error as defined by the HTTP/2 specification.
+     * @param fmt String with the content and format for the additional debug data.
+     * @param args Objects which fit into the format defined by {@code fmt}.
+     * @return If the {@code id} is not
+     * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link PayloadTooLargeException}
+     * will be returned. Otherwise the error is considered a connection error and a {@link Http2Exception} is
+     * returned.
+     */
+    public static Http2Exception payloadTooLargeError(int id, Http2Error error, String fmt, Object... args) {
+        return CONNECTION_STREAM_ID == id ?
+                connectionError(error, fmt, args) :
+                new PayloadTooLargeException(id, error, String.format(fmt, args));
+    }
+
+    /**
      * Check if an exception is isolated to a single stream or the entire connection.
      * @param e The exception to check.
      * @return {@code true} if {@code e} is an instance of {@link StreamException}.
@@ -286,6 +307,14 @@ public class Http2Exception extends Exception {
 
         public boolean duringDecode() {
             return decode;
+        }
+    }
+
+    public static final class PayloadTooLargeException extends StreamException {
+        private static final long serialVersionUID = -2192855782930830401L;
+
+        public PayloadTooLargeException(int streamId, Http2Error error, String message) {
+            super(streamId, error, message);
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -25,10 +25,11 @@ import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.util.internal.UnstableApi;
 
-import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http2.Http2Error.ENHANCE_YOUR_CALM;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http2.Http2Exception.payloadTooLargeError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
@@ -235,7 +236,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         ByteBuf content = msg.content();
         final int dataReadableBytes = data.readableBytes();
         if (content.readableBytes() > maxContentLength - dataReadableBytes) {
-            throw connectionError(INTERNAL_ERROR,
+            throw payloadTooLargeError(streamId, ENHANCE_YOUR_CALM,
                     "Content length exceeded max of %d for stream id %d", maxContentLength, streamId);
         }
 


### PR DESCRIPTION
Motivation:
Currently InboundHttp2ToHttpAdapter throws a connection error when it reads a payload that exceeds maxContentLength. This is confusing to clients as the connection is closed with minimal context. Instead servers should respond with an HTTP status code 413 followed by an RST_STREAM frame.

Modifications:
- Created `PayloadTooLargeException` as a subclass of `StreamException`
- `InboundHttp2ToHttpAdapter` throws `PayloadTooLargeException` when it reads a payload that exceeds maxContentLength in bytes
- Modified `Http2ConnectionHandler::onStreamError` to handle `PayloadTooLargeException`s by responding with a status code 413 header frame followed by an RST_FRAME

Result:
When servers using InboundHttp2ToHttpAdapter read a payload exceeding maxContentLength a response with status code 413 will be sent followed by an RST_STREAM frame

Fixes #11994 
