### PR TITLE
Clean up RecvByteBufAllocator API

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -433,7 +433,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     }
 
     private final class Http2ChannelUnsafe implements Unsafe {
-        @SuppressWarnings("deprecation")
         private RecvByteBufAllocator.Handle recvHandle;
         private boolean writeDoneAndNoFlush;
         private boolean closeInitiated;
@@ -732,7 +731,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             }
         }
 
-        @SuppressWarnings("deprecation")
         void doRead0(Http2Frame frame, RecvByteBufAllocator.Handle allocHandle) {
             final int bytes;
             if (frame instanceof Http2DataFrame) {
@@ -916,16 +914,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         @Override
         public ChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
             throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-            if (!(allocator.newHandle() instanceof RecvByteBufAllocator.ExtendedHandle)) {
-                throw new IllegalArgumentException("allocator.newHandle() must return an object of type: " +
-                        RecvByteBufAllocator.ExtendedHandle.class);
-            }
-            super.setRecvByteBufAllocator(allocator);
-            return this;
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/TestChannelInitializer.java
@@ -57,11 +57,12 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
         }
 
         @Override
-        public ExtendedHandle newHandle() {
-            return new ExtendedHandle() {
+        public Handle newHandle() {
+            return new Handle() {
                 private int attemptedBytesRead;
                 private int lastBytesRead;
                 private int numMessagesRead;
+
                 @Override
                 public ByteBuf allocate(ByteBufAllocator alloc) {
                     return alloc.ioBuffer(guess(), guess());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -162,8 +162,8 @@ public class SocketAutoReadTest extends AbstractSocketTest {
      */
     private static final class TestRecvByteBufAllocator implements RecvByteBufAllocator {
         @Override
-        public ExtendedHandle newHandle() {
-            return new ExtendedHandle() {
+        public Handle newHandle() {
+            return new Handle() {
                 private ChannelConfig config;
                 private int attemptedBytesRead;
                 private int lastBytesRead;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -613,11 +613,12 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         }
 
         @Override
-        public ExtendedHandle newHandle() {
-            return new ExtendedHandle() {
+        public Handle newHandle() {
+            return new Handle() {
                 private int attemptedBytesRead;
                 private int lastBytesRead;
                 private int numMessagesRead;
+
                 @Override
                 public ByteBuf allocate(ByteBufAllocator alloc) {
                     return alloc.ioBuffer(guess(), guess());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
@@ -142,8 +142,8 @@ public class SocketReadPendingTest extends AbstractSocketTest {
         }
 
         @Override
-        public ExtendedHandle newHandle() {
-            return new ExtendedHandle() {
+        public Handle newHandle() {
+            return new Handle() {
                 private int attemptedBytesRead;
                 private int lastBytesRead;
                 private int numMessagesRead;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -27,7 +27,7 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvByteBufAllocator.Handle;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.SocketChannelConfig;
@@ -528,7 +528,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         @Override
         public EpollRecvByteAllocatorHandle recvBufAllocHandle() {
             if (allocHandle == null) {
-                allocHandle = newEpollHandle((RecvByteBufAllocator.ExtendedHandle) super.recvBufAllocHandle());
+                allocHandle = newEpollHandle(super.recvBufAllocHandle());
             }
             return allocHandle;
         }
@@ -537,7 +537,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
          * Create a new {@link EpollRecvByteAllocatorHandle} instance.
          * @param handle The handle to wrap with EPOLL specific logic.
          */
-        EpollRecvByteAllocatorHandle newEpollHandle(RecvByteBufAllocator.ExtendedHandle handle) {
+        EpollRecvByteAllocatorHandle newEpollHandle(Handle handle) {
             return new EpollRecvByteAllocatorHandle(handle);
         }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -15,9 +15,9 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.buffer.ByteBufConvertible;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufConvertible;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelMetadata;
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.EventLoop;
 import io.netty.channel.FileRegion;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvByteBufAllocator.Handle;
 import io.netty.channel.internal.ChannelUtils;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.unix.IovArray;
@@ -537,7 +537,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         }
 
         @Override
-        EpollRecvByteAllocatorHandle newEpollHandle(RecvByteBufAllocator.ExtendedHandle handle) {
+        EpollRecvByteAllocatorHandle newEpollHandle(Handle handle) {
             return new EpollRecvByteAllocatorStreamingHandle(handle);
         }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -16,9 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.buffer.ByteBufAllocator;
-
 import io.netty.buffer.api.BufferAllocator;
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -70,10 +68,6 @@ public class EpollChannelConfig extends DefaultChannelConfig {
 
     @Override
     public EpollChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        if (!(allocator.newHandle() instanceof RecvByteBufAllocator.ExtendedHandle)) {
-            throw new IllegalArgumentException("allocator.newHandle() must return an object of type: " +
-                    RecvByteBufAllocator.ExtendedHandle.class);
-        }
         super.setRecvByteBufAllocator(allocator);
         return this;
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorHandle.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorHandle.java
@@ -18,17 +18,17 @@ package io.netty.channel.epoll;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator.DelegatingHandle;
-import io.netty.channel.RecvByteBufAllocator.ExtendedHandle;
+import io.netty.channel.RecvByteBufAllocator.Handle;
 import io.netty.channel.unix.PreferredDirectByteBufAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 
-class EpollRecvByteAllocatorHandle extends DelegatingHandle implements ExtendedHandle {
+class EpollRecvByteAllocatorHandle extends DelegatingHandle {
     private final PreferredDirectByteBufAllocator preferredDirectByteBufAllocator =
             new PreferredDirectByteBufAllocator();
     private final UncheckedBooleanSupplier defaultMaybeMoreDataSupplier = this::maybeMoreDataToRead;
     private boolean receivedRdHup;
 
-    EpollRecvByteAllocatorHandle(ExtendedHandle handle) {
+    EpollRecvByteAllocatorHandle(Handle handle) {
         super(handle);
     }
 
@@ -40,16 +40,16 @@ class EpollRecvByteAllocatorHandle extends DelegatingHandle implements ExtendedH
         return receivedRdHup;
     }
 
+    /**
+     * EPOLL ET requires that we read until we get an EAGAIN
+     * (see Q9 in <a href="https://man7.org/linux/man-pages/man7/epoll.7.html">epoll man</a>). However, in order to
+     * respect auto read, we support reading to stop if auto read is off. It is expected that the
+     * {@link EpollSocketChannel} implementations will track if we are in edgeTriggered mode and all data was not
+     * read, and will force a EPOLLIN ready event.
+     *
+     * It is assumed RDHUP is handled externally by checking {@link #isReceivedRdHup()}.
+     */
     boolean maybeMoreDataToRead() {
-        /**
-         * EPOLL ET requires that we read until we get an EAGAIN
-         * (see Q9 in <a href="https://man7.org/linux/man-pages/man7/epoll.7.html">epoll man</a>). However in order to
-         * respect auto read we supporting reading to stop if auto read is off. It is expected that the
-         * {@link #EpollSocketChannel} implementations will track if we are in edgeTriggered mode and all data was not
-         * read, and will force a EPOLLIN ready event.
-         *
-         * It is assumed RDHUP is handled externally by checking {@link #isReceivedRdHup()}.
-         */
         return lastBytesRead() > 0;
     }
 
@@ -58,11 +58,6 @@ class EpollRecvByteAllocatorHandle extends DelegatingHandle implements ExtendedH
         // We need to ensure we always allocate a direct ByteBuf as we can only use a direct buffer to read via JNI.
         preferredDirectByteBufAllocator.updateAllocator(alloc);
         return delegate().allocate(preferredDirectByteBufAllocator);
-    }
-
-    @Override
-    public final boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
-        return ((ExtendedHandle) delegate()).continueReading(maybeMoreDataSupplier);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorStreamingHandle.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorStreamingHandle.java
@@ -15,21 +15,21 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvByteBufAllocator.Handle;
 
 final class EpollRecvByteAllocatorStreamingHandle extends EpollRecvByteAllocatorHandle {
-    EpollRecvByteAllocatorStreamingHandle(RecvByteBufAllocator.ExtendedHandle handle) {
+    EpollRecvByteAllocatorStreamingHandle(Handle handle) {
         super(handle);
     }
 
+    /**
+     * For stream oriented descriptors we can assume we are done reading if the last read attempt didn't produce
+     * a full buffer (see Q9 in <a href="https://man7.org/linux/man-pages/man7/epoll.7.html">epoll man</a>).
+     *
+     * If EPOLLRDHUP has been received we must read until we get a read error.
+     */
     @Override
     boolean maybeMoreDataToRead() {
-        /**
-         * For stream oriented descriptors we can assume we are done reading if the last read attempt didn't produce
-         * a full buffer (see Q9 in <a href="https://man7.org/linux/man-pages/man7/epoll.7.html">epoll man</a>).
-         *
-         * If EPOLLRDHUP has been received we must read until we get a read error.
-         */
         return lastBytesRead() == attemptedBytesRead() || isReceivedRdHup();
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -27,7 +27,6 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
-import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.SocketChannelConfig;
@@ -488,8 +487,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         @Override
         public KQueueRecvByteAllocatorHandle recvBufAllocHandle() {
             if (allocHandle == null) {
-                allocHandle = new KQueueRecvByteAllocatorHandle(
-                        (RecvByteBufAllocator.ExtendedHandle) super.recvBufAllocHandle());
+                allocHandle = new KQueueRecvByteAllocatorHandle(super.recvBufAllocHandle());
             }
             return allocHandle;
         }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
@@ -17,7 +17,6 @@ package io.netty.channel.kqueue;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
@@ -45,7 +44,6 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public Map<ChannelOption<?>, Object> getOptions() {
         return getOptions(super.getOptions(), RCV_ALLOC_TRANSPORT_PROVIDES_GUESS);
     }
@@ -122,10 +120,6 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
 
     @Override
     public KQueueChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        if (!(allocator.newHandle() instanceof RecvByteBufAllocator.ExtendedHandle)) {
-            throw new IllegalArgumentException("allocator.newHandle() must return an object of type: " +
-                    RecvByteBufAllocator.ExtendedHandle.class);
-        }
         super.setRecvByteBufAllocator(allocator);
         return this;
     }

--- a/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
@@ -28,7 +28,7 @@ import static java.lang.Math.min;
  * <p>
  * It gradually increases the expected number of readable bytes if the previous
  * read fully filled the allocated buffer.  It gradually decreases the expected
- * number of readable bytes if the read operation was not able to fill a certain
+ * number of readable bytes if the read operation was unable to fill a certain
  * amount of the allocated buffer two times consecutively.  Otherwise, it keeps
  * returning the same prediction.
  */
@@ -50,7 +50,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
             sizeTable.add(i);
         }
 
-        // Suppress a warning since i becomes negative when an integer overflow happens
+        // Suppress a warning since `i` becomes negative when an integer overflow happens
         for (int i = 512; i > 0; i <<= 1) { // lgtm[java/constant-comparison]
             sizeTable.add(i);
         }
@@ -162,7 +162,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
      * Creates a new predictor with the specified parameters.
      *
      * @param minimum  the inclusive lower bound of the expected buffer size
-     * @param initial  the initial buffer size when no feed back was received
+     * @param initial  the initial buffer size when no feedback was received
      * @param maximum  the inclusive upper bound of the expected buffer size
      */
     public AdaptiveRecvByteBufAllocator(int minimum, int initial, int maximum) {
@@ -191,7 +191,6 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
         this.initial = initial;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public Handle newHandle() {
         return new HandleImpl(minIndex, maxIndex, initial);

--- a/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvByteBufAllocator.java
@@ -15,14 +15,14 @@
  */
 package io.netty.channel;
 
-import static io.netty.util.internal.ObjectUtil.checkPositive;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 
 import java.util.AbstractMap;
 import java.util.Map.Entry;
+
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
  * The {@link RecvByteBufAllocator} that yields a buffer size prediction based upon decrementing the value from
@@ -32,7 +32,7 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
     private volatile int maxBytesPerRead;
     private volatile int maxBytesPerIndividualRead;
 
-    private final class HandleImpl implements ExtendedHandle {
+    private final class HandleImpl implements Handle {
         private int individualReadMax;
         private int bytesToRead;
         private int lastBytesRead;
@@ -113,7 +113,6 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
         this.maxBytesPerIndividualRead = maxBytesPerIndividualRead;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public Handle newHandle() {
         return new HandleImpl();

--- a/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocator.java
@@ -30,11 +30,11 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
     private volatile int maxMessagesPerRead;
     private volatile boolean respectMaybeMoreData = true;
 
-    public DefaultMaxMessagesRecvByteBufAllocator() {
+    protected DefaultMaxMessagesRecvByteBufAllocator() {
         this(1);
     }
 
-    public DefaultMaxMessagesRecvByteBufAllocator(int maxMessagesPerRead) {
+    protected DefaultMaxMessagesRecvByteBufAllocator(int maxMessagesPerRead) {
         this(maxMessagesPerRead, false);
     }
 
@@ -90,7 +90,7 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
     /**
      * Focuses on enforcing the maximum messages per read condition for {@link #continueReading()}.
      */
-    public abstract class MaxMessageHandle implements ExtendedHandle {
+    public abstract class MaxMessageHandle implements Handle {
         private ChannelConfig config;
         private int maxMessagePerRead;
         private int totalMessages;

--- a/transport/src/main/java/io/netty/channel/FixedRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/FixedRecvByteBufAllocator.java
@@ -47,7 +47,6 @@ public class FixedRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllo
         this.bufferSize = bufferSize;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public Handle newHandle() {
         return new HandleImpl(bufferSize);

--- a/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
@@ -33,10 +33,7 @@ public interface RecvByteBufAllocator {
      */
     Handle newHandle();
 
-    /**
-     * @deprecated Use {@link ExtendedHandle}.
-     */
-    @Deprecated
+    @UnstableApi
     interface Handle {
         /**
          * Creates a new receive buffer whose capacity is probably large enough to read all inbound data and small
@@ -102,19 +99,15 @@ public interface RecvByteBufAllocator {
         boolean continueReading();
 
         /**
-         * The read has completed.
-         */
-        void readComplete();
-    }
-
-    @SuppressWarnings("deprecation")
-    @UnstableApi
-    interface ExtendedHandle extends Handle {
-        /**
          * Same as {@link Handle#continueReading()} except "more data" is determined by the supplier parameter.
          * @param maybeMoreDataSupplier A supplier that determines if there maybe more data to read.
          */
         boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier);
+
+        /**
+         * The read has completed.
+         */
+        void readComplete();
     }
 
     /**
@@ -168,6 +161,11 @@ public interface RecvByteBufAllocator {
         @Override
         public boolean continueReading() {
             return delegate.continueReading();
+        }
+
+        @Override
+        public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
+            return delegate.continueReading(maybeMoreDataSupplier);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -80,12 +80,9 @@ public final class NioDatagramChannel
 
     private static DatagramChannel newSocket(SelectorProvider provider) {
         try {
-            /**
-             *  Use the {@link SelectorProvider} to open {@link SocketChannel} and so remove condition in
-             *  {@link SelectorProvider#provider()} which is called by each DatagramChannel.open() otherwise.
-             *
-             *  See <a href="https://github.com/netty/netty/issues/2308">#2308</a>.
-             */
+             // Use the SelectorProvider to open SocketChannel and so remove condition in
+             // SelectorProvider#provider() which is called by each DatagramChannel.open() otherwise.
+             // See <a href="https://github.com/netty/netty/issues/2308">#2308</a>.
             return provider.openDatagramChannel();
         } catch (IOException e) {
             throw new ChannelException("Failed to open a socket.", e);
@@ -583,12 +580,8 @@ public final class NioDatagramChannel
 
     @Override
     protected boolean continueReading(RecvByteBufAllocator.Handle allocHandle) {
-        if (allocHandle instanceof RecvByteBufAllocator.ExtendedHandle) {
-            // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
-            // as we read anything).
-            return ((RecvByteBufAllocator.ExtendedHandle) allocHandle)
-                    .continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER);
-        }
-        return allocHandle.continueReading();
+        // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
+        // as we read anything).
+        return allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER);
     }
 }


### PR DESCRIPTION
Motivation:
We have some deprecatd APIs in there, that were added in order to add features without breaking backwards compatibility.
This needs to be cleaned up.

Modification:
Collapse ExtendedHandle into Handle.
Make Handle no longer deprecated.
Update all the places that were referring to ExtendedHandle, and make them use Handle instead.
Also fix a number of small warnings along the way.

Result:
Cleaner code with fewer deprecations.
