### PR TITLE
Rename RecvByteBufAllocator to RecvBufferAllocator

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/TestChannelInitializer.java
@@ -23,7 +23,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,16 +43,16 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
             handler = null;
         }
         if (maxReads != null) {
-            channel.config().setRecvByteBufAllocator(new TestNumReadsRecvByteBufAllocator(maxReads));
+            channel.config().setRecvBufferAllocator(new TestNumReadsRecvBufferAllocator(maxReads));
         }
     }
 
     /**
      * Designed to read a single byte at a time to control the number of reads done at a fine granularity.
      */
-    static final class TestNumReadsRecvByteBufAllocator implements RecvByteBufAllocator {
+    static final class TestNumReadsRecvBufferAllocator implements RecvBufferAllocator {
         private final AtomicInteger numReads;
-        private TestNumReadsRecvByteBufAllocator(AtomicInteger numReads) {
+        private TestNumReadsRecvBufferAllocator(AtomicInteger numReads) {
             this.numReads = numReads;
         }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
-import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.FixedRecvBufferAllocator;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
@@ -464,7 +464,7 @@ public class DnsNameResolver extends InetNameResolver {
                 });
             }
         });
-        b.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(maxPayloadSize));
+        b.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(maxPayloadSize));
 
         channelFuture = responseHandler.channelActivePromise.asFuture();
         try {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.UncheckedBooleanSupplier;
 import org.junit.jupiter.api.Test;
@@ -62,7 +62,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                     .childOption(ChannelOption.AUTO_READ, true)
                     // We want to ensure that we attempt multiple individual read operations per read loop so we can
                     // test the auto read feature being turned off when data is first read.
-                    .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvByteBufAllocator())
+                    .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvBufferAllocator())
                     .childHandler(serverInitializer);
 
             serverChannel = sb.bind().get();
@@ -70,16 +70,16 @@ public class SocketAutoReadTest extends AbstractSocketTest {
             cb.option(ChannelOption.AUTO_READ, true)
                     // We want to ensure that we attempt multiple individual read operations per read loop so we can
                     // test the auto read feature being turned off when data is first read.
-                    .option(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvByteBufAllocator())
+                    .option(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvBufferAllocator())
                     .handler(clientInitializer);
 
             clientChannel = cb.connect(serverChannel.localAddress()).get();
 
-            // 3 bytes means 3 independent reads for TestRecvByteBufAllocator
+            // 3 bytes means 3 independent reads for TestRecvBufferAllocator
             clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[3]));
             serverInitializer.autoReadHandler.assertSingleRead();
 
-            // 3 bytes means 3 independent reads for TestRecvByteBufAllocator
+            // 3 bytes means 3 independent reads for TestRecvBufferAllocator
             serverInitializer.channel.writeAndFlush(Unpooled.wrappedBuffer(new byte[3]));
             clientInitializer.autoReadHandler.assertSingleRead();
 
@@ -160,7 +160,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
     /**
      * Designed to keep reading as long as autoread is enabled.
      */
-    private static final class TestRecvByteBufAllocator implements RecvByteBufAllocator {
+    private static final class TestRecvBufferAllocator implements RecvBufferAllocator {
         @Override
         public Handle newHandle() {
             return new Handle() {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
@@ -215,7 +215,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         try {
             cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
               .option(ChannelOption.AUTO_READ, autoRead)
-              .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvByteBufAllocator(numReadsPerReadLoop));
+              .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(numReadsPerReadLoop));
 
             sb.childHandler(new ChannelInitializer<Channel>() {
                 @Override
@@ -514,7 +514,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         try {
             cb.option(ChannelOption.ALLOW_HALF_CLOSURE, allowHalfClosed)
                     .option(ChannelOption.AUTO_READ, autoRead)
-                    .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvByteBufAllocator(numReadsPerReadLoop));
+                    .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(numReadsPerReadLoop));
 
             sb.childHandler(new ChannelInitializer<Channel>() {
                 @Override
@@ -606,9 +606,9 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     /**
      * Designed to read a single byte at a time to control the number of reads done at a fine granularity.
      */
-    private static final class TestNumReadsRecvByteBufAllocator implements RecvByteBufAllocator {
+    private static final class TestNumReadsRecvBufferAllocator implements RecvBufferAllocator {
         private final int numReads;
-        TestNumReadsRecvByteBufAllocator(int numReads) {
+        TestNumReadsRecvBufferAllocator(int numReads) {
             this.numReads = numReads;
         }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.UncheckedBooleanSupplier;
 import org.junit.jupiter.api.Test;
@@ -58,21 +58,21 @@ public class SocketReadPendingTest extends AbstractSocketTest {
               .option(ChannelOption.AUTO_READ, true)
               .childOption(ChannelOption.AUTO_READ, false)
               // We intend to do 2 reads per read loop wakeup
-              .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvByteBufAllocator(2))
+              .childOption(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
               .childHandler(serverInitializer);
 
             serverChannel = sb.bind().get();
 
             cb.option(ChannelOption.AUTO_READ, false)
               // We intend to do 2 reads per read loop wakeup
-              .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvByteBufAllocator(2))
+              .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(2))
               .handler(clientInitializer);
             clientChannel = cb.connect(serverChannel.localAddress()).get();
 
-            // 4 bytes means 2 read loops for TestNumReadsRecvByteBufAllocator
+            // 4 bytes means 2 read loops for TestNumReadsRecvBufferAllocator
             clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[4]));
 
-            // 4 bytes means 2 read loops for TestNumReadsRecvByteBufAllocator
+            // 4 bytes means 2 read loops for TestNumReadsRecvBufferAllocator
             assertTrue(serverInitializer.channelInitLatch.await(5, TimeUnit.SECONDS));
             serverInitializer.channel.writeAndFlush(Unpooled.wrappedBuffer(new byte[4]));
 
@@ -135,9 +135,9 @@ public class SocketReadPendingTest extends AbstractSocketTest {
     /**
      * Designed to read a single byte at a time to control the number of reads done at a fine granularity.
      */
-    private static final class TestNumReadsRecvByteBufAllocator implements RecvByteBufAllocator {
+    private static final class TestNumReadsRecvBufferAllocator implements RecvBufferAllocator {
         private final int numReads;
-        TestNumReadsRecvByteBufAllocator(int numReads) {
+        TestNumReadsRecvBufferAllocator(int numReads) {
             this.numReads = numReads;
         }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -27,7 +27,7 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
-import io.netty.channel.RecvByteBufAllocator.Handle;
+import io.netty.channel.RecvBufferAllocator.Handle;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.SocketChannelConfig;
@@ -410,7 +410,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     protected abstract class AbstractEpollUnsafe extends AbstractUnsafe {
         boolean readPending;
         boolean maybeMoreDataToRead;
-        private EpollRecvByteAllocatorHandle allocHandle;
+        private EpollRecvBufferAllocatorHandle allocHandle;
         private final Runnable epollInReadyRunnable = new Runnable() {
             @Override
             public void run() {
@@ -526,7 +526,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         }
 
         @Override
-        public EpollRecvByteAllocatorHandle recvBufAllocHandle() {
+        public EpollRecvBufferAllocatorHandle recvBufAllocHandle() {
             if (allocHandle == null) {
                 allocHandle = newEpollHandle(super.recvBufAllocHandle());
             }
@@ -534,11 +534,11 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         }
 
         /**
-         * Create a new {@link EpollRecvByteAllocatorHandle} instance.
+         * Create a new {@link EpollRecvBufferAllocatorHandle} instance.
          * @param handle The handle to wrap with EPOLL specific logic.
          */
-        EpollRecvByteAllocatorHandle newEpollHandle(Handle handle) {
-            return new EpollRecvByteAllocatorHandle(handle);
+        EpollRecvBufferAllocatorHandle newEpollHandle(Handle handle) {
+            return new EpollRecvBufferAllocatorHandle(handle);
         }
 
         @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -101,7 +101,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                 clearEpollIn0();
                 return;
             }
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            final EpollRecvBufferAllocatorHandle allocHandle = recvBufAllocHandle();
 
             final ChannelPipeline pipeline = pipeline();
             allocHandle.reset(config);
@@ -113,7 +113,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                 try {
                     do {
                         // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
-                        // EpollRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
+                        // EpollRecvBufferAllocatorHandle knows if it should try to read again or not when autoRead is
                         // enabled.
                         allocHandle.lastBytesRead(socket.accept(acceptedAddress));
                         if (allocHandle.lastBytesRead() == -1) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.EventLoop;
 import io.netty.channel.FileRegion;
-import io.netty.channel.RecvByteBufAllocator.Handle;
+import io.netty.channel.RecvBufferAllocator.Handle;
 import io.netty.channel.internal.ChannelUtils;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.unix.IovArray;
@@ -514,7 +514,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         }
 
         private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause, boolean close,
-                EpollRecvByteAllocatorHandle allocHandle) {
+                EpollRecvBufferAllocatorHandle allocHandle) {
             if (byteBuf != null) {
                 if (byteBuf.isReadable()) {
                     readPending = false;
@@ -537,8 +537,8 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         }
 
         @Override
-        EpollRecvByteAllocatorHandle newEpollHandle(Handle handle) {
-            return new EpollRecvByteAllocatorStreamingHandle(handle);
+        EpollRecvBufferAllocatorHandle newEpollHandle(Handle handle) {
+            return new EpollRecvBufferAllocatorStreamingHandle(handle);
         }
 
         @Override
@@ -548,7 +548,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                 clearEpollIn0();
                 return;
             }
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            final EpollRecvBufferAllocatorHandle allocHandle = recvBufAllocHandle();
 
             final ChannelPipeline pipeline = pipeline();
             final ByteBufAllocator allocator = config.getAllocator();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
 import static io.netty.channel.unix.Limits.SSIZE_MAX;
@@ -31,8 +31,8 @@ public class EpollChannelConfig extends DefaultChannelConfig {
         super(channel);
     }
 
-    EpollChannelConfig(AbstractEpollChannel channel, RecvByteBufAllocator recvByteBufAllocator) {
-        super(channel, recvByteBufAllocator);
+    EpollChannelConfig(AbstractEpollChannel channel, RecvBufferAllocator recvBufferAllocator) {
+        super(channel, recvBufferAllocator);
     }
 
     @Override
@@ -67,8 +67,8 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     }
 
     @Override
-    public EpollChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public EpollChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -463,7 +463,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 clearEpollIn0();
                 return;
             }
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            final EpollRecvBufferAllocatorHandle allocHandle = recvBufAllocHandle();
 
             final ChannelPipeline pipeline = pipeline();
             final ByteBufAllocator allocator = config.getAllocator();
@@ -527,8 +527,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         }
     }
 
-    private boolean connectedRead(EpollRecvByteAllocatorHandle allocHandle, ByteBuf byteBuf, int maxDatagramPacketSize)
-            throws Exception {
+    private boolean connectedRead(EpollRecvBufferAllocatorHandle allocHandle, ByteBuf byteBuf,
+                                  int maxDatagramPacketSize) throws Exception {
         try {
             int writable = maxDatagramPacketSize != 0 ? Math.min(byteBuf.writableBytes(), maxDatagramPacketSize)
                     : byteBuf.writableBytes();
@@ -609,14 +609,14 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         }
     }
 
-    private static void processPacket(ChannelPipeline pipeline, EpollRecvByteAllocatorHandle handle,
+    private static void processPacket(ChannelPipeline pipeline, EpollRecvBufferAllocatorHandle handle,
                                       int bytesRead, DatagramPacket packet) {
         handle.lastBytesRead(bytesRead);
         handle.incMessagesRead(1);
         pipeline.fireChannelRead(packet);
     }
 
-    private static void processPacketList(ChannelPipeline pipeline, EpollRecvByteAllocatorHandle handle,
+    private static void processPacketList(ChannelPipeline pipeline, EpollRecvBufferAllocatorHandle handle,
                                           int bytesRead, RecyclableArrayList packetList) {
         int messagesRead = packetList.size();
         handle.lastBytesRead(bytesRead);
@@ -626,7 +626,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         }
     }
 
-    private boolean recvmsg(EpollRecvByteAllocatorHandle allocHandle,
+    private boolean recvmsg(EpollRecvBufferAllocatorHandle allocHandle,
                             NativeDatagramPacketArray array, ByteBuf byteBuf) throws IOException {
         RecyclableArrayList datagramPackets = null;
         try {
@@ -671,8 +671,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         }
     }
 
-    private boolean scatteringRead(EpollRecvByteAllocatorHandle allocHandle, NativeDatagramPacketArray array,
-            ByteBuf byteBuf, int datagramSize, int numDatagram) throws IOException {
+    private boolean scatteringRead(EpollRecvBufferAllocatorHandle allocHandle, NativeDatagramPacketArray array,
+                                   ByteBuf byteBuf, int datagramSize, int numDatagram) throws IOException {
         RecyclableArrayList datagramPackets = null;
         try {
             int offset = byteBuf.writerIndex();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -20,9 +20,9 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.FixedRecvBufferAllocator;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DatagramChannelConfig;
 import io.netty.util.internal.ObjectUtil;
@@ -33,13 +33,13 @@ import java.net.NetworkInterface;
 import java.util.Map;
 
 public final class EpollDatagramChannelConfig extends EpollChannelConfig implements DatagramChannelConfig {
-    private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
+    private static final RecvBufferAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvBufferAllocator(2048);
     private boolean activeOnOpen;
     private volatile int maxDatagramSize;
 
     EpollDatagramChannelConfig(EpollDatagramChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
+        this.setRecvBufferAllocator(DEFAULT_RCVBUF_ALLOCATOR);
     }
 
     @Override
@@ -204,8 +204,8 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
     }
 
     @Override
-    public EpollDatagramChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public EpollDatagramChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 
@@ -519,7 +519,7 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
      * {@code recvmmsg} should be used when reading from the underlying socket. When {@code recvmmsg} is used
      * we may be able to read multiple {@link io.netty.channel.socket.DatagramPacket}s with one syscall and so
      * greatly improve the performance. This number will be used to slice {@link ByteBuf}s returned by the used
-     * {@link RecvByteBufAllocator}. You can use {@code 0} to disable the usage of recvmmsg, any other bigger value
+     * {@link RecvBufferAllocator}. You can use {@code 0} to disable the usage of recvmmsg, any other bigger value
      * will enable it.
      */
     public EpollDatagramChannelConfig setMaxDatagramPayloadSize(int maxDatagramSize) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -298,7 +298,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
                 clearEpollIn0();
                 return;
             }
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            final EpollRecvBufferAllocatorHandle allocHandle = recvBufAllocHandle();
 
             final ChannelPipeline pipeline = pipeline();
             final ByteBufAllocator allocator = config.getAllocator();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
@@ -19,9 +19,9 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.FixedRecvBufferAllocator;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.DomainDatagramChannelConfig;
 import io.netty.util.internal.UnstableApi;
@@ -35,13 +35,13 @@ import static io.netty.channel.ChannelOption.SO_SNDBUF;
 @UnstableApi
 public final class EpollDomainDatagramChannelConfig extends EpollChannelConfig implements DomainDatagramChannelConfig {
 
-    private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
+    private static final RecvBufferAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvBufferAllocator(2048);
 
     private boolean activeOnOpen;
 
     EpollDomainDatagramChannelConfig(EpollDomainDatagramChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
+        this.setRecvBufferAllocator(DEFAULT_RCVBUF_ALLOCATOR);
     }
 
     @Override
@@ -141,8 +141,8 @@ public final class EpollDomainDatagramChannelConfig extends EpollChannelConfig i
     }
 
     @Override
-    public EpollDomainDatagramChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public EpollDomainDatagramChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -152,7 +152,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
                 return;
             }
             final ChannelConfig config = config();
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            final EpollRecvBufferAllocatorHandle allocHandle = recvBufAllocHandle();
 
             final ChannelPipeline pipeline = pipeline();
             allocHandle.reset(config);
@@ -161,7 +161,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
             try {
                 readLoop: do {
                     // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
-                    // EpollRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
+                    // EpollRecvBufferAllocatorHandle knows if it should try to read again or not when autoRead is
                     // enabled.
                     allocHandle.lastBytesRead(socket.recvFd());
                     switch(allocHandle.lastBytesRead()) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -21,7 +21,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
@@ -103,8 +103,8 @@ public final class EpollDomainSocketChannelConfig extends EpollDuplexChannelConf
     }
 
     @Override
-    public EpollDomainSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public EpollDomainSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDuplexChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDuplexChannelConfig.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DuplexChannelConfig;
 
@@ -102,8 +102,8 @@ public class EpollDuplexChannelConfig extends EpollChannelConfig implements Dupl
     }
 
     @Override
-    public EpollDuplexChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public EpollDuplexChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvBufferAllocatorHandle.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvBufferAllocatorHandle.java
@@ -17,18 +17,18 @@ package io.netty.channel.epoll;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.RecvByteBufAllocator.DelegatingHandle;
-import io.netty.channel.RecvByteBufAllocator.Handle;
+import io.netty.channel.RecvBufferAllocator.DelegatingHandle;
+import io.netty.channel.RecvBufferAllocator.Handle;
 import io.netty.channel.unix.PreferredDirectByteBufAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 
-class EpollRecvByteAllocatorHandle extends DelegatingHandle {
+class EpollRecvBufferAllocatorHandle extends DelegatingHandle {
     private final PreferredDirectByteBufAllocator preferredDirectByteBufAllocator =
             new PreferredDirectByteBufAllocator();
     private final UncheckedBooleanSupplier defaultMaybeMoreDataSupplier = this::maybeMoreDataToRead;
     private boolean receivedRdHup;
 
-    EpollRecvByteAllocatorHandle(Handle handle) {
+    EpollRecvBufferAllocatorHandle(Handle handle) {
         super(handle);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvBufferAllocatorStreamingHandle.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvBufferAllocatorStreamingHandle.java
@@ -15,10 +15,10 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.channel.RecvByteBufAllocator.Handle;
+import io.netty.channel.RecvBufferAllocator.Handle;
 
-final class EpollRecvByteAllocatorStreamingHandle extends EpollRecvByteAllocatorHandle {
-    EpollRecvByteAllocatorStreamingHandle(Handle handle) {
+final class EpollRecvBufferAllocatorStreamingHandle extends EpollRecvBufferAllocatorHandle {
+    EpollRecvBufferAllocatorStreamingHandle(Handle handle) {
         super(handle);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
@@ -20,8 +20,8 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.ServerChannelRecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
+import io.netty.channel.ServerChannelRecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.ServerSocketChannelConfig;
 import io.netty.util.NetUtil;
@@ -40,7 +40,7 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
     private volatile int pendingFastOpenRequestsThreshold;
 
     EpollServerChannelConfig(AbstractEpollChannel channel) {
-        super(channel, new ServerChannelRecvByteBufAllocator());
+        super(channel, new ServerChannelRecvBufferAllocator());
     }
 
     @Override
@@ -196,8 +196,8 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
     }
 
     @Override
-    public EpollServerChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public EpollServerChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannelConfig.java
@@ -20,7 +20,7 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.ServerSocketChannelConfig;
 
@@ -142,8 +142,8 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
     }
 
     @Override
-    public EpollServerSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public EpollServerSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
@@ -20,7 +20,7 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.util.internal.PlatformDependent;
@@ -601,8 +601,8 @@ public final class EpollSocketChannelConfig extends EpollDuplexChannelConfig imp
     }
 
     @Override
-    public EpollSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public EpollSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -363,7 +363,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     public abstract class AbstractKQueueUnsafe extends AbstractUnsafe {
         boolean readPending;
         boolean maybeMoreDataToRead;
-        private KQueueRecvByteAllocatorHandle allocHandle;
+        private KQueueRecvBufferAllocatorHandle allocHandle;
         private final Runnable readReadyRunnable = new Runnable() {
             @Override
             public void run() {
@@ -373,12 +373,12 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         };
 
         final void readReady(long numberBytesPending) {
-            KQueueRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            KQueueRecvBufferAllocatorHandle allocHandle = recvBufAllocHandle();
             allocHandle.numberBytesPending(numberBytesPending);
             readReady(allocHandle);
         }
 
-        abstract void readReady(KQueueRecvByteAllocatorHandle allocHandle);
+        abstract void readReady(KQueueRecvBufferAllocatorHandle allocHandle);
 
         final void readReadyBefore() {
             maybeMoreDataToRead = false;
@@ -470,7 +470,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
         final void readEOF() {
             // This must happen before we attempt to read. This will ensure reading continues until an error occurs.
-            final KQueueRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            final KQueueRecvBufferAllocatorHandle allocHandle = recvBufAllocHandle();
             allocHandle.readEOF();
 
             if (isActive()) {
@@ -485,9 +485,9 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         }
 
         @Override
-        public KQueueRecvByteAllocatorHandle recvBufAllocHandle() {
+        public KQueueRecvBufferAllocatorHandle recvBufAllocHandle() {
             if (allocHandle == null) {
-                allocHandle = new KQueueRecvByteAllocatorHandle(super.recvBufAllocHandle());
+                allocHandle = new KQueueRecvBufferAllocatorHandle(super.recvBufAllocHandle());
             }
             return allocHandle;
         }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
@@ -88,7 +88,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
         private final byte[] acceptedAddress = new byte[26];
 
         @Override
-        void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
+        void readReady(KQueueRecvBufferAllocatorHandle allocHandle) {
             assert executor().inEventLoop();
             final ChannelConfig config = config();
             if (shouldBreakReadReady(config)) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -491,7 +491,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
         }
 
         @Override
-        void readReady(final KQueueRecvByteAllocatorHandle allocHandle) {
+        void readReady(final KQueueRecvBufferAllocatorHandle allocHandle) {
             final ChannelConfig config = config();
             if (shouldBreakReadReady(config)) {
                 clearReadFilter0();
@@ -558,7 +558,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
         }
 
         private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause, boolean close,
-                                         KQueueRecvByteAllocatorHandle allocHandle) {
+                                         KQueueRecvBufferAllocatorHandle allocHandle) {
             if (byteBuf != null) {
                 if (byteBuf.isReadable()) {
                     readPending = false;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
@@ -20,7 +20,7 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.internal.UnstableApi;
 
@@ -39,8 +39,8 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
         super(channel);
     }
 
-    KQueueChannelConfig(AbstractKQueueChannel channel, RecvByteBufAllocator recvByteBufAllocator) {
-        super(channel, recvByteBufAllocator);
+    KQueueChannelConfig(AbstractKQueueChannel channel, RecvBufferAllocator recvBufferAllocator) {
+        super(channel, recvBufferAllocator);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     }
 
     /**
-     * If this is {@code true} then the {@link RecvByteBufAllocator.Handle#guess()} will be overridden to always attempt
+     * If this is {@code true} then the {@link RecvBufferAllocator.Handle#guess()} will be overridden to always attempt
      * to read as many bytes as kqueue says are available.
      */
     public KQueueChannelConfig setRcvAllocTransportProvidesGuess(boolean transportProvidesGuess) {
@@ -80,7 +80,7 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     }
 
     /**
-     * If this is {@code true} then the {@link RecvByteBufAllocator.Handle#guess()} will be overridden to always attempt
+     * If this is {@code true} then the {@link RecvBufferAllocator.Handle#guess()} will be overridden to always attempt
      * to read as many bytes as kqueue says are available.
      */
     public boolean getRcvAllocTransportProvidesGuess() {
@@ -119,8 +119,8 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     }
 
     @Override
-    public KQueueChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public KQueueChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelOption.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelOption.java
@@ -16,7 +16,7 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.ChannelOption;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.unix.UnixChannelOption;
 import io.netty.util.internal.UnstableApi;
 
@@ -27,7 +27,7 @@ public final class KQueueChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<AcceptFilter> SO_ACCEPTFILTER =
             valueOf(KQueueChannelOption.class, "SO_ACCEPTFILTER");
     /**
-     * If this is {@code true} then the {@link RecvByteBufAllocator.Handle#guess()} will be overridden to always attempt
+     * If this is {@code true} then the {@link RecvBufferAllocator.Handle#guess()} will be overridden to always attempt
      * to read as many bytes as kqueue says are available.
      */
     public static final ChannelOption<Boolean> RCV_ALLOC_TRANSPORT_PROVIDES_GUESS =

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -347,7 +347,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     final class KQueueDatagramChannelUnsafe extends AbstractKQueueUnsafe {
 
         @Override
-        void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
+        void readReady(KQueueRecvBufferAllocatorHandle allocHandle) {
             assert executor().inEventLoop();
             final DatagramChannelConfig config = config();
             if (shouldBreakReadReady(config)) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
@@ -19,9 +19,9 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.FixedRecvBufferAllocator;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DatagramChannelConfig;
 import io.netty.util.internal.UnstableApi;
@@ -45,12 +45,12 @@ import static io.netty.channel.unix.UnixChannelOption.SO_REUSEPORT;
 
 @UnstableApi
 public final class KQueueDatagramChannelConfig extends KQueueChannelConfig implements DatagramChannelConfig {
-    private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
+    private static final RecvBufferAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvBufferAllocator(2048);
     private boolean activeOnOpen;
 
     KQueueDatagramChannelConfig(KQueueDatagramChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
+        this.setRecvBufferAllocator(DEFAULT_RCVBUF_ALLOCATOR);
     }
 
     @Override
@@ -219,8 +219,8 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig imple
     }
 
     @Override
-    public KQueueDatagramChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public KQueueDatagramChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -240,7 +240,7 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
     final class KQueueDomainDatagramChannelUnsafe extends AbstractKQueueUnsafe {
 
         @Override
-        void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
+        void readReady(KQueueRecvBufferAllocatorHandle allocHandle) {
             assert executor().inEventLoop();
             final DomainDatagramChannelConfig config = config();
             if (shouldBreakReadReady(config)) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannelConfig.java
@@ -19,9 +19,9 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.FixedRecvBufferAllocator;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.DomainDatagramChannelConfig;
 import io.netty.util.internal.UnstableApi;
@@ -36,13 +36,13 @@ import static io.netty.channel.ChannelOption.SO_SNDBUF;
 public final class KQueueDomainDatagramChannelConfig
         extends KQueueChannelConfig implements DomainDatagramChannelConfig {
 
-    private static final RecvByteBufAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
+    private static final RecvBufferAllocator DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvBufferAllocator(2048);
 
     private boolean activeOnOpen;
 
     KQueueDomainDatagramChannelConfig(KQueueDomainDatagramChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(DEFAULT_RCVBUF_ALLOCATOR);
+        this.setRecvBufferAllocator(DEFAULT_RCVBUF_ALLOCATOR);
     }
 
     @Override
@@ -147,8 +147,8 @@ public final class KQueueDomainDatagramChannelConfig
     }
 
     @Override
-    public KQueueDomainDatagramChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public KQueueDomainDatagramChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -126,7 +126,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
 
     private final class KQueueDomainUnsafe extends KQueueStreamUnsafe {
         @Override
-        void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
+        void readReady(KQueueRecvBufferAllocatorHandle allocHandle) {
             switch (config().getReadMode()) {
                 case BYTES:
                     super.readReady(allocHandle);
@@ -145,7 +145,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
                 return;
             }
             final ChannelConfig config = config();
-            final KQueueRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            final KQueueRecvBufferAllocatorHandle allocHandle = recvBufAllocHandle();
 
             final ChannelPipeline pipeline = pipeline();
             allocHandle.reset(config);
@@ -154,7 +154,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
             try {
                 readLoop: do {
                     // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
-                    // KQueueRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
+                    // KQueueRecvBufferAllocatorHandle knows if it should try to read again or not when autoRead is
                     // enabled.
                     int recvFd = socket.recvFd();
                     switch(recvFd) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.DomainSocketChannelConfig;
 import io.netty.channel.unix.DomainSocketReadMode;
@@ -105,8 +105,8 @@ public final class KQueueDomainSocketChannelConfig extends KQueueDuplexChannelCo
     }
 
     @Override
-    public KQueueDomainSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public KQueueDomainSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDuplexChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDuplexChannelConfig.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DuplexChannelConfig;
 
@@ -86,8 +86,8 @@ public class KQueueDuplexChannelConfig extends KQueueChannelConfig implements Du
     }
 
     @Override
-    public KQueueDuplexChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public KQueueDuplexChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueRecvBufferAllocatorHandle.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueRecvBufferAllocatorHandle.java
@@ -18,15 +18,15 @@ package io.netty.channel.kqueue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
-import io.netty.channel.RecvByteBufAllocator.DelegatingHandle;
-import io.netty.channel.RecvByteBufAllocator.Handle;
+import io.netty.channel.RecvBufferAllocator.DelegatingHandle;
+import io.netty.channel.RecvBufferAllocator.Handle;
 import io.netty.channel.unix.PreferredDirectByteBufAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 
-final class KQueueRecvByteAllocatorHandle extends DelegatingHandle {
+final class KQueueRecvBufferAllocatorHandle extends DelegatingHandle {
     private final PreferredDirectByteBufAllocator preferredDirectByteBufAllocator =
             new PreferredDirectByteBufAllocator();
 
@@ -35,7 +35,7 @@ final class KQueueRecvByteAllocatorHandle extends DelegatingHandle {
     private boolean readEOF;
     private long numberBytesPending;
 
-    KQueueRecvByteAllocatorHandle(Handle handle) {
+    KQueueRecvBufferAllocatorHandle(Handle handle) {
         super(handle);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerChannelConfig.java
@@ -20,8 +20,8 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.ServerChannelRecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
+import io.netty.channel.ServerChannelRecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.ServerSocketChannelConfig;
 import io.netty.util.NetUtil;
@@ -42,7 +42,7 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
     private volatile boolean enableTcpFastOpen;
 
     KQueueServerChannelConfig(AbstractKQueueChannel channel) {
-        super(channel, new ServerChannelRecvByteBufAllocator());
+        super(channel, new ServerChannelRecvBufferAllocator());
     }
 
     @Override
@@ -202,8 +202,8 @@ public class KQueueServerChannelConfig extends KQueueChannelConfig implements Se
     }
 
     @Override
-    public KQueueServerChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public KQueueServerChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
@@ -20,9 +20,8 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.socket.ServerSocketChannelConfig;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -175,8 +174,8 @@ public class KQueueServerSocketChannelConfig extends KQueueServerChannelConfig {
     }
 
     @Override
-    public KQueueServerSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public KQueueServerSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
@@ -20,7 +20,7 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.util.internal.PlatformDependent;
@@ -357,8 +357,8 @@ public final class KQueueSocketChannelConfig extends KQueueDuplexChannelConfig i
     }
 
     @Override
-    public KQueueSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public KQueueSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramScatteringReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramScatteringReadTest.java
@@ -16,7 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.AdaptiveRecvByteBufAllocator;
+import io.netty.channel.AdaptiveRecvBufferAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
@@ -96,7 +96,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
         int packetSize = 512;
         int numPackets = 4;
 
-        sb.option(ChannelOption.RCVBUF_ALLOCATOR, new AdaptiveRecvByteBufAllocator(
+        sb.option(ChannelOption.RCVBUF_ALLOCATOR, new AdaptiveRecvBufferAllocator(
                 packetSize, packetSize * (partial ? numPackets / 2 : numPackets), 64 * 1024));
         sb.option(EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE, packetSize);
 
@@ -207,7 +207,7 @@ public class EpollDatagramScatteringReadTest extends AbstractDatagramTest  {
     private void testScatteringReadWithSmallBuffer0(Bootstrap sb, Bootstrap cb, boolean connected) throws Throwable {
         int packetSize = 16;
 
-        sb.option(ChannelOption.RCVBUF_ALLOCATOR, new AdaptiveRecvByteBufAllocator(1400, 1400, 64 * 1024));
+        sb.option(ChannelOption.RCVBUF_ALLOCATOR, new AdaptiveRecvBufferAllocator(1400, 1400, 64 * 1024));
         sb.option(EpollChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE, 1400);
 
         Channel sc = null;

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
@@ -22,7 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.FixedRecvBufferAllocator;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
@@ -119,7 +119,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                 // Enable GRO and also ensure we can read everything with one read as otherwise
                 // we will drop things on the floor.
                 sb.option(EpollChannelOption.UDP_GRO, true);
-                sb.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(bufferCapacity));
+                sb.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(bufferCapacity));
             }
             sc = sb.handler(new SimpleChannelInboundHandler<DatagramPacket>() {
                 @Override

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -25,7 +25,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.FixedRecvBufferAllocator;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.SimpleChannelInboundHandler;
 import org.junit.jupiter.api.Test;
@@ -72,7 +72,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             // calls to consume everything.
             sb.childOption(ChannelOption.AUTO_READ, false);
             sb.childOption(ChannelOption.MAX_MESSAGES_PER_READ, 1);
-            sb.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(expectedBytes / 10));
+            sb.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
             sb.childHandler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) {
@@ -156,7 +156,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             // calls to consume everything.
             cb.option(ChannelOption.AUTO_READ, false);
             cb.option(ChannelOption.MAX_MESSAGES_PER_READ, 1);
-            cb.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(expectedBytes / 10));
+            cb.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
             cb.handler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainDatagramChannelConfig.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainDatagramChannelConfig.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
 /**
@@ -60,7 +60,7 @@ public interface DomainDatagramChannelConfig extends ChannelConfig {
     DomainDatagramChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
 
     @Override
-    DomainDatagramChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+    DomainDatagramChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator);
 
     /**
      * Sets the {@link java.net.StandardSocketOptions#SO_SNDBUF} option.

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/DomainSocketChannelConfig.java
@@ -18,7 +18,7 @@ package io.netty.channel.unix;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DuplexChannelConfig;
 
@@ -43,7 +43,7 @@ public interface DomainSocketChannelConfig extends DuplexChannelConfig {
     DomainSocketChannelConfig setAllocator(ByteBufAllocator allocator);
 
     @Override
-    DomainSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+    DomainSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator);
 
     @Override
     DomainSocketChannelConfig setAutoRead(boolean autoRead);

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -302,7 +302,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     protected abstract class AbstractUnsafe implements Unsafe {
 
         private volatile ChannelOutboundBuffer outboundBuffer = new ChannelOutboundBuffer(AbstractChannel.this);
-        private RecvByteBufAllocator.Handle recvHandle;
+        private RecvBufferAllocator.Handle recvHandle;
         private MessageSizeEstimator.Handle estimatorHandler;
 
         private boolean inFlush0;
@@ -314,9 +314,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public RecvByteBufAllocator.Handle recvBufAllocHandle() {
+        public RecvBufferAllocator.Handle recvBufAllocHandle() {
             if (recvHandle == null) {
-                recvHandle = config().getRecvByteBufAllocator().newHandle();
+                recvHandle = config().getRecvBufferAllocator().newHandle();
             }
             return recvHandle;
         }

--- a/transport/src/main/java/io/netty/channel/AdaptiveRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/AdaptiveRecvBufferAllocator.java
@@ -23,7 +23,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 
 /**
- * The {@link RecvByteBufAllocator} that automatically increases and
+ * The {@link RecvBufferAllocator} that automatically increases and
  * decreases the predicted buffer size on feed back.
  * <p>
  * It gradually increases the expected number of readable bytes if the previous
@@ -32,7 +32,7 @@ import static java.lang.Math.min;
  * amount of the allocated buffer two times consecutively.  Otherwise, it keeps
  * returning the same prediction.
  */
-public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllocator {
+public class AdaptiveRecvBufferAllocator extends DefaultMaxMessagesRecvBufferAllocator {
 
     static final int DEFAULT_MINIMUM = 64;
     // Use an initial value that is bigger than the common MTU of 1500
@@ -65,7 +65,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
      * @deprecated There is state for {@link #maxMessagesPerRead()} which is typically based upon channel type.
      */
     @Deprecated
-    public static final AdaptiveRecvByteBufAllocator DEFAULT = new AdaptiveRecvByteBufAllocator();
+    public static final AdaptiveRecvBufferAllocator DEFAULT = new AdaptiveRecvBufferAllocator();
 
     private static int getSizeTableIndex(final int size) {
         for (int low = 0, high = SIZE_TABLE.length - 1;;) {
@@ -154,7 +154,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
      * parameters, the expected buffer size starts from {@code 1024}, does not
      * go down below {@code 64}, and does not go up above {@code 65536}.
      */
-    public AdaptiveRecvByteBufAllocator() {
+    public AdaptiveRecvBufferAllocator() {
         this(DEFAULT_MINIMUM, DEFAULT_INITIAL, DEFAULT_MAXIMUM);
     }
 
@@ -165,7 +165,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
      * @param initial  the initial buffer size when no feedback was received
      * @param maximum  the inclusive upper bound of the expected buffer size
      */
-    public AdaptiveRecvByteBufAllocator(int minimum, int initial, int maximum) {
+    public AdaptiveRecvBufferAllocator(int minimum, int initial, int maximum) {
         checkPositive(minimum, "minimum");
         if (initial < minimum) {
             throw new IllegalArgumentException("initial: " + initial);
@@ -197,7 +197,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
     }
 
     @Override
-    public AdaptiveRecvByteBufAllocator respectMaybeMoreData(boolean respectMaybeMoreData) {
+    public AdaptiveRecvBufferAllocator respectMaybeMoreData(boolean respectMaybeMoreData) {
         super.respectMaybeMoreData(respectMaybeMoreData);
         return this;
     }

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -287,10 +287,10 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     interface Unsafe {
 
         /**
-         * Return the assigned {@link RecvByteBufAllocator.Handle} which will be used to allocate {@link ByteBuf}'s when
+         * Return the assigned {@link RecvBufferAllocator.Handle} which will be used to allocate {@link ByteBuf}'s when
          * receiving data.
          */
-        RecvByteBufAllocator.Handle recvBufAllocHandle();
+        RecvBufferAllocator.Handle recvBufAllocHandle();
 
         /**
          * Return the {@link SocketAddress} to which is bound local or

--- a/transport/src/main/java/io/netty/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/ChannelConfig.java
@@ -122,8 +122,8 @@ public interface ChannelConfig {
     ChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis);
 
     /**
-     * @deprecated Use {@link MaxMessagesRecvByteBufAllocator} and
-     * {@link MaxMessagesRecvByteBufAllocator#maxMessagesPerRead()}.
+     * @deprecated Use {@link MaxMessagesRecvBufferAllocator} and
+     * {@link MaxMessagesRecvBufferAllocator#maxMessagesPerRead()}.
      * <p>
      * Returns the maximum number of messages to read per read loop.
      * a {@link ChannelHandler#channelRead(ChannelHandlerContext, Object) channelRead()} event.
@@ -133,8 +133,8 @@ public interface ChannelConfig {
     int getMaxMessagesPerRead();
 
     /**
-     * @deprecated Use {@link MaxMessagesRecvByteBufAllocator} and
-     * {@link MaxMessagesRecvByteBufAllocator#maxMessagesPerRead(int)}.
+     * @deprecated Use {@link MaxMessagesRecvBufferAllocator} and
+     * {@link MaxMessagesRecvBufferAllocator#maxMessagesPerRead(int)}.
      * <p>
      * Sets the maximum number of messages to read per read loop.
      * If this value is greater than 1, an event loop might attempt to read multiple times to procure multiple messages.
@@ -192,14 +192,14 @@ public interface ChannelConfig {
     ChannelConfig setBufferAllocator(BufferAllocator allocator);
 
     /**
-     * Returns {@link RecvByteBufAllocator} which is used for the channel to allocate receive buffers.
+     * Returns {@link RecvBufferAllocator} which is used for the channel to allocate receive buffers.
      */
-    <T extends RecvByteBufAllocator> T getRecvByteBufAllocator();
+    <T extends RecvBufferAllocator> T getRecvBufferAllocator();
 
     /**
-     * Set the {@link RecvByteBufAllocator} which is used for the channel to allocate receive buffers.
+     * Set the {@link RecvBufferAllocator} which is used for the channel to allocate receive buffers.
      */
-    ChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+    ChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator);
 
     /**
      * Returns {@code true} if and only if {@link ChannelHandlerContext#read()} will be invoked automatically so that

--- a/transport/src/main/java/io/netty/channel/ChannelMetadata.java
+++ b/transport/src/main/java/io/netty/channel/ChannelMetadata.java
@@ -44,8 +44,8 @@ public final class ChannelMetadata {
      * @param hasDisconnect     {@code true} if and only if the channel has the {@code disconnect()} operation
      *                          that allows a user to disconnect and then call {@link Channel#connect(SocketAddress)}
      *                          again, such as UDP/IP.
-     * @param defaultMaxMessagesPerRead If a {@link MaxMessagesRecvByteBufAllocator} is in use, then this value will be
-     * set for {@link MaxMessagesRecvByteBufAllocator#maxMessagesPerRead()}. Must be {@code > 0}.
+     * @param defaultMaxMessagesPerRead If a {@link MaxMessagesRecvBufferAllocator} is in use, then this value will be
+     * set for {@link MaxMessagesRecvBufferAllocator#maxMessagesPerRead()}. Must be {@code > 0}.
      */
     public ChannelMetadata(boolean hasDisconnect, int defaultMaxMessagesPerRead) {
         checkPositive(defaultMaxMessagesPerRead, "defaultMaxMessagesPerRead");
@@ -63,8 +63,8 @@ public final class ChannelMetadata {
     }
 
     /**
-     * If a {@link MaxMessagesRecvByteBufAllocator} is in use, then this is the default value for
-     * {@link MaxMessagesRecvByteBufAllocator#maxMessagesPerRead()}.
+     * If a {@link MaxMessagesRecvBufferAllocator} is in use, then this is the default value for
+     * {@link MaxMessagesRecvBufferAllocator#maxMessagesPerRead()}.
      */
     public int defaultMaxMessagesPerRead() {
         return defaultMaxMessagesPerRead;

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -79,13 +79,13 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
 
     public static final ChannelOption<ByteBufAllocator> ALLOCATOR = valueOf("ALLOCATOR");
     public static final ChannelOption<BufferAllocator> BUFFER_ALLOCATOR = valueOf("BUFFER_ALLOCATOR");
-    public static final ChannelOption<RecvByteBufAllocator> RCVBUF_ALLOCATOR = valueOf("RCVBUF_ALLOCATOR");
+    public static final ChannelOption<RecvBufferAllocator> RCVBUF_ALLOCATOR = valueOf("RCVBUF_ALLOCATOR");
     public static final ChannelOption<MessageSizeEstimator> MESSAGE_SIZE_ESTIMATOR = valueOf("MESSAGE_SIZE_ESTIMATOR");
 
     public static final ChannelOption<Integer> CONNECT_TIMEOUT_MILLIS = valueOf("CONNECT_TIMEOUT_MILLIS");
     /**
-     * @deprecated Use {@link MaxMessagesRecvByteBufAllocator}
-     * and {@link MaxMessagesRecvByteBufAllocator#maxMessagesPerRead(int)}.
+     * @deprecated Use {@link MaxMessagesRecvBufferAllocator}
+     * and {@link MaxMessagesRecvBufferAllocator#maxMessagesPerRead(int)}.
      */
     @Deprecated
     public static final ChannelOption<Integer> MAX_MESSAGES_PER_READ = valueOf("MAX_MESSAGES_PER_READ");

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -61,7 +61,7 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     private volatile ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
     private volatile BufferAllocator bufferAllocator = DefaultGlobalBufferAllocator.DEFAULT_GLOBAL_BUFFER_ALLOCATOR;
-    private volatile RecvByteBufAllocator rcvBufAllocator;
+    private volatile RecvBufferAllocator rcvBufAllocator;
     private volatile MessageSizeEstimator msgSizeEstimator = DEFAULT_MSG_SIZE_ESTIMATOR;
 
     private volatile int connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT;
@@ -75,11 +75,11 @@ public class DefaultChannelConfig implements ChannelConfig {
     private volatile boolean pinEventExecutor = true;
 
     public DefaultChannelConfig(Channel channel) {
-        this(channel, new AdaptiveRecvByteBufAllocator());
+        this(channel, new AdaptiveRecvBufferAllocator());
     }
 
-    protected DefaultChannelConfig(Channel channel, RecvByteBufAllocator allocator) {
-        setRecvByteBufAllocator(allocator, channel.metadata());
+    protected DefaultChannelConfig(Channel channel, RecvBufferAllocator allocator) {
+        setRecvBufferAllocator(allocator, channel.metadata());
         this.channel = channel;
     }
 
@@ -140,7 +140,7 @@ public class DefaultChannelConfig implements ChannelConfig {
             return (T) getBufferAllocator();
         }
         if (option == RCVBUF_ALLOCATOR) {
-            return (T) getRecvByteBufAllocator();
+            return (T) getRecvBufferAllocator();
         }
         if (option == AUTO_READ) {
             return (T) Boolean.valueOf(isAutoRead());
@@ -182,7 +182,7 @@ public class DefaultChannelConfig implements ChannelConfig {
         } else if (option == BUFFER_ALLOCATOR) {
             setBufferAllocator((BufferAllocator) value);
         } else if (option == RCVBUF_ALLOCATOR) {
-            setRecvByteBufAllocator((RecvByteBufAllocator) value);
+            setRecvBufferAllocator((RecvBufferAllocator) value);
         } else if (option == AUTO_READ) {
             setAutoRead((Boolean) value);
         } else if (option == AUTO_CLOSE) {
@@ -224,37 +224,37 @@ public class DefaultChannelConfig implements ChannelConfig {
     /**
      * {@inheritDoc}
      * <p>
-     * @throws IllegalStateException if {@link #getRecvByteBufAllocator()} does not return an object of type
-     * {@link MaxMessagesRecvByteBufAllocator}.
+     * @throws IllegalStateException if {@link #getRecvBufferAllocator()} does not return an object of type
+     * {@link MaxMessagesRecvBufferAllocator}.
      */
     @Override
     @Deprecated
     public int getMaxMessagesPerRead() {
         try {
-            MaxMessagesRecvByteBufAllocator allocator = getRecvByteBufAllocator();
+            MaxMessagesRecvBufferAllocator allocator = getRecvBufferAllocator();
             return allocator.maxMessagesPerRead();
         } catch (ClassCastException e) {
-            throw new IllegalStateException("getRecvByteBufAllocator() must return an object of type " +
-                    "MaxMessagesRecvByteBufAllocator", e);
+            throw new IllegalStateException("getRecvBufferAllocator() must return an object of type " +
+                    "MaxMessagesRecvBufferAllocator", e);
         }
     }
 
     /**
      * {@inheritDoc}
      * <p>
-     * @throws IllegalStateException if {@link #getRecvByteBufAllocator()} does not return an object of type
-     * {@link MaxMessagesRecvByteBufAllocator}.
+     * @throws IllegalStateException if {@link #getRecvBufferAllocator()} does not return an object of type
+     * {@link MaxMessagesRecvBufferAllocator}.
      */
     @Override
     @Deprecated
     public ChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
         try {
-            MaxMessagesRecvByteBufAllocator allocator = getRecvByteBufAllocator();
+            MaxMessagesRecvBufferAllocator allocator = getRecvBufferAllocator();
             allocator.maxMessagesPerRead(maxMessagesPerRead);
             return this;
         } catch (ClassCastException e) {
-            throw new IllegalStateException("getRecvByteBufAllocator() must return an object of type " +
-                    "MaxMessagesRecvByteBufAllocator", e);
+            throw new IllegalStateException("getRecvBufferAllocator() must return an object of type " +
+                    "MaxMessagesRecvBufferAllocator", e);
         }
     }
 
@@ -320,29 +320,29 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends RecvByteBufAllocator> T getRecvByteBufAllocator() {
+    public <T extends RecvBufferAllocator> T getRecvBufferAllocator() {
         return (T) rcvBufAllocator;
     }
 
     @Override
-    public ChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+    public ChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
         rcvBufAllocator = requireNonNull(allocator, "allocator");
         return this;
     }
 
     /**
-     * Set the {@link RecvByteBufAllocator} which is used for the channel to allocate receive buffers.
+     * Set the {@link RecvBufferAllocator} which is used for the channel to allocate receive buffers.
      * @param allocator the allocator to set.
      * @param metadata Used to set the {@link ChannelMetadata#defaultMaxMessagesPerRead()} if {@code allocator}
-     * is of type {@link MaxMessagesRecvByteBufAllocator}.
+     * is of type {@link MaxMessagesRecvBufferAllocator}.
      */
-    private void setRecvByteBufAllocator(RecvByteBufAllocator allocator, ChannelMetadata metadata) {
+    private void setRecvBufferAllocator(RecvBufferAllocator allocator, ChannelMetadata metadata) {
         requireNonNull(allocator, "allocator");
         requireNonNull(metadata, "metadata");
-        if (allocator instanceof MaxMessagesRecvByteBufAllocator) {
-            ((MaxMessagesRecvByteBufAllocator) allocator).maxMessagesPerRead(metadata.defaultMaxMessagesPerRead());
+        if (allocator instanceof MaxMessagesRecvBufferAllocator) {
+            ((MaxMessagesRecvBufferAllocator) allocator).maxMessagesPerRead(metadata.defaultMaxMessagesPerRead());
         }
-        setRecvByteBufAllocator(allocator);
+        setRecvBufferAllocator(allocator);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvBufferAllocator.java
@@ -25,10 +25,10 @@ import java.util.Map.Entry;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
- * The {@link RecvByteBufAllocator} that yields a buffer size prediction based upon decrementing the value from
+ * The {@link RecvBufferAllocator} that yields a buffer size prediction based upon decrementing the value from
  * the max bytes per read.
  */
-public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufAllocator {
+public class DefaultMaxBytesRecvBufferAllocator implements MaxBytesRecvBufferAllocator {
     private volatile int maxBytesPerRead;
     private volatile int maxBytesPerIndividualRead;
 
@@ -103,11 +103,11 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
         }
     }
 
-    public DefaultMaxBytesRecvByteBufAllocator() {
+    public DefaultMaxBytesRecvBufferAllocator() {
         this(64 * 1024, 64 * 1024);
     }
 
-    public DefaultMaxBytesRecvByteBufAllocator(int maxBytesPerRead, int maxBytesPerIndividualRead) {
+    public DefaultMaxBytesRecvBufferAllocator(int maxBytesPerRead, int maxBytesPerIndividualRead) {
         checkMaxBytesPerReadPair(maxBytesPerRead, maxBytesPerIndividualRead);
         this.maxBytesPerRead = maxBytesPerRead;
         this.maxBytesPerIndividualRead = maxBytesPerIndividualRead;
@@ -124,7 +124,7 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
     }
 
     @Override
-    public DefaultMaxBytesRecvByteBufAllocator maxBytesPerRead(int maxBytesPerRead) {
+    public DefaultMaxBytesRecvBufferAllocator maxBytesPerRead(int maxBytesPerRead) {
         checkPositive(maxBytesPerRead, "maxBytesPerRead");
         // There is a dependency between this.maxBytesPerRead and this.maxBytesPerIndividualRead (a < b).
         // Write operations must be synchronized, but independent read operations can just be volatile.
@@ -147,7 +147,7 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
     }
 
     @Override
-    public DefaultMaxBytesRecvByteBufAllocator maxBytesPerIndividualRead(int maxBytesPerIndividualRead) {
+    public DefaultMaxBytesRecvBufferAllocator maxBytesPerIndividualRead(int maxBytesPerIndividualRead) {
         checkPositive(maxBytesPerIndividualRead, "maxBytesPerIndividualRead");
         // There is a dependency between this.maxBytesPerRead and this.maxBytesPerIndividualRead (a < b).
         // Write operations must be synchronized, but independent read operations can just be volatile.
@@ -180,8 +180,8 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
     }
 
     @Override
-    public DefaultMaxBytesRecvByteBufAllocator maxBytesPerReadPair(int maxBytesPerRead,
-            int maxBytesPerIndividualRead) {
+    public DefaultMaxBytesRecvBufferAllocator maxBytesPerReadPair(int maxBytesPerRead,
+                                                                  int maxBytesPerIndividualRead) {
         checkMaxBytesPerReadPair(maxBytesPerRead, maxBytesPerIndividualRead);
         // There is a dependency between this.maxBytesPerRead and this.maxBytesPerIndividualRead (a < b).
         // Write operations must be synchronized, but independent read operations can just be volatile.

--- a/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvBufferAllocator.java
@@ -22,23 +22,23 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 
 /**
- * Default implementation of {@link MaxMessagesRecvByteBufAllocator} which respects {@link ChannelConfig#isAutoRead()}
+ * Default implementation of {@link MaxMessagesRecvBufferAllocator} which respects {@link ChannelConfig#isAutoRead()}
  * and also prevents overflow.
  */
-public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessagesRecvByteBufAllocator {
+public abstract class DefaultMaxMessagesRecvBufferAllocator implements MaxMessagesRecvBufferAllocator {
     private final boolean ignoreBytesRead;
     private volatile int maxMessagesPerRead;
     private volatile boolean respectMaybeMoreData = true;
 
-    protected DefaultMaxMessagesRecvByteBufAllocator() {
+    protected DefaultMaxMessagesRecvBufferAllocator() {
         this(1);
     }
 
-    protected DefaultMaxMessagesRecvByteBufAllocator(int maxMessagesPerRead) {
+    protected DefaultMaxMessagesRecvBufferAllocator(int maxMessagesPerRead) {
         this(maxMessagesPerRead, false);
     }
 
-    DefaultMaxMessagesRecvByteBufAllocator(int maxMessagesPerRead, boolean ignoreBytesRead) {
+    DefaultMaxMessagesRecvBufferAllocator(int maxMessagesPerRead, boolean ignoreBytesRead) {
         this.ignoreBytesRead = ignoreBytesRead;
         maxMessagesPerRead(maxMessagesPerRead);
     }
@@ -49,7 +49,7 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
     }
 
     @Override
-    public MaxMessagesRecvByteBufAllocator maxMessagesPerRead(int maxMessagesPerRead) {
+    public MaxMessagesRecvBufferAllocator maxMessagesPerRead(int maxMessagesPerRead) {
         checkPositive(maxMessagesPerRead, "maxMessagesPerRead");
         this.maxMessagesPerRead = maxMessagesPerRead;
         return this;
@@ -67,7 +67,7 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
      * </ul>
      * @return {@code this}.
      */
-    public DefaultMaxMessagesRecvByteBufAllocator respectMaybeMoreData(boolean respectMaybeMoreData) {
+    public DefaultMaxMessagesRecvBufferAllocator respectMaybeMoreData(boolean respectMaybeMoreData) {
         this.respectMaybeMoreData = respectMaybeMoreData;
         return this;
     }
@@ -97,7 +97,7 @@ public abstract class DefaultMaxMessagesRecvByteBufAllocator implements MaxMessa
         private int totalBytesRead;
         private int attemptedBytesRead;
         private int lastBytesRead;
-        private final boolean respectMaybeMoreData = DefaultMaxMessagesRecvByteBufAllocator.this.respectMaybeMoreData;
+        private final boolean respectMaybeMoreData = DefaultMaxMessagesRecvBufferAllocator.this.respectMaybeMoreData;
         private final UncheckedBooleanSupplier defaultMaybeMoreSupplier = new UncheckedBooleanSupplier() {
             @Override
             public boolean get() {

--- a/transport/src/main/java/io/netty/channel/FixedRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/FixedRecvBufferAllocator.java
@@ -18,10 +18,10 @@ package io.netty.channel;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
- * The {@link RecvByteBufAllocator} that always yields the same buffer
+ * The {@link RecvBufferAllocator} that always yields the same buffer
  * size prediction.  This predictor ignores the feed back from the I/O thread.
  */
-public class FixedRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllocator {
+public class FixedRecvBufferAllocator extends DefaultMaxMessagesRecvBufferAllocator {
 
     private final int bufferSize;
 
@@ -42,7 +42,7 @@ public class FixedRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllo
      * Creates a new predictor that always returns the same prediction of
      * the specified buffer size.
      */
-    public FixedRecvByteBufAllocator(int bufferSize) {
+    public FixedRecvBufferAllocator(int bufferSize) {
         checkPositive(bufferSize, "bufferSize");
         this.bufferSize = bufferSize;
     }
@@ -53,7 +53,7 @@ public class FixedRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllo
     }
 
     @Override
-    public FixedRecvByteBufAllocator respectMaybeMoreData(boolean respectMaybeMoreData) {
+    public FixedRecvBufferAllocator respectMaybeMoreData(boolean respectMaybeMoreData) {
         super.respectMaybeMoreData(respectMaybeMoreData);
         return this;
     }

--- a/transport/src/main/java/io/netty/channel/MaxBytesRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/MaxBytesRecvBufferAllocator.java
@@ -18,10 +18,10 @@ package io.netty.channel;
 import java.util.Map.Entry;
 
 /**
- * {@link RecvByteBufAllocator} that limits a read operation based upon a maximum value per individual read
+ * {@link RecvBufferAllocator} that limits a read operation based upon a maximum value per individual read
  * and a maximum amount when a read operation is attempted by the event loop.
  */
-public interface MaxBytesRecvByteBufAllocator extends RecvByteBufAllocator {
+public interface MaxBytesRecvBufferAllocator extends RecvBufferAllocator {
     /**
      * Returns the maximum number of bytes to read per read loop.
      * a {@link ChannelHandler#channelRead(ChannelHandlerContext, Object) channelRead()} event.
@@ -33,7 +33,7 @@ public interface MaxBytesRecvByteBufAllocator extends RecvByteBufAllocator {
      * Sets the maximum number of bytes to read per read loop.
      * If this value is greater than 1, an event loop might attempt to read multiple times to procure bytes.
      */
-    MaxBytesRecvByteBufAllocator maxBytesPerRead(int maxBytesPerRead);
+    MaxBytesRecvBufferAllocator maxBytesPerRead(int maxBytesPerRead);
 
     /**
      * Returns the maximum number of bytes to read per individual read operation.
@@ -46,7 +46,7 @@ public interface MaxBytesRecvByteBufAllocator extends RecvByteBufAllocator {
      * Sets the maximum number of bytes to read per individual read operation.
      * If this value is greater than 1, an event loop might attempt to read multiple times to procure bytes.
      */
-    MaxBytesRecvByteBufAllocator maxBytesPerIndividualRead(int maxBytesPerIndividualRead);
+    MaxBytesRecvBufferAllocator maxBytesPerIndividualRead(int maxBytesPerIndividualRead);
 
     /**
      * Atomic way to get the maximum number of bytes to read for a read loop and per individual read operation.
@@ -61,5 +61,5 @@ public interface MaxBytesRecvByteBufAllocator extends RecvByteBufAllocator {
      * @param maxBytesPerRead see {@link #maxBytesPerRead(int)}
      * @param maxBytesPerIndividualRead see {@link #maxBytesPerIndividualRead(int)}
      */
-    MaxBytesRecvByteBufAllocator maxBytesPerReadPair(int maxBytesPerRead, int maxBytesPerIndividualRead);
+    MaxBytesRecvBufferAllocator maxBytesPerReadPair(int maxBytesPerRead, int maxBytesPerIndividualRead);
 }

--- a/transport/src/main/java/io/netty/channel/MaxMessagesRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/MaxMessagesRecvBufferAllocator.java
@@ -16,10 +16,10 @@
 package io.netty.channel;
 
 /**
- * {@link RecvByteBufAllocator} that limits the number of read operations that will be attempted when a read operation
+ * {@link RecvBufferAllocator} that limits the number of read operations that will be attempted when a read operation
  * is attempted by the event loop.
  */
-public interface MaxMessagesRecvByteBufAllocator extends RecvByteBufAllocator {
+public interface MaxMessagesRecvBufferAllocator extends RecvBufferAllocator {
     /**
      * Returns the maximum number of messages to read per read loop.
      * a {@link ChannelHandler#channelRead(ChannelHandlerContext, Object) channelRead()} event.
@@ -31,5 +31,5 @@ public interface MaxMessagesRecvByteBufAllocator extends RecvByteBufAllocator {
      * Sets the maximum number of messages to read per read loop.
      * If this value is greater than 1, an event loop might attempt to read multiple times to procure multiple messages.
      */
-    MaxMessagesRecvByteBufAllocator maxMessagesPerRead(int maxMessagesPerRead);
+    MaxMessagesRecvBufferAllocator maxMessagesPerRead(int maxMessagesPerRead);
 }

--- a/transport/src/main/java/io/netty/channel/RecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/RecvBufferAllocator.java
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
  * Allocates a new receive buffer whose capacity is probably large enough to read all inbound data and small enough
  * not to waste its space.
  */
-public interface RecvByteBufAllocator {
+public interface RecvBufferAllocator {
     /**
      * Creates a new handle.  The handle provides the actual operations and keeps the internal information which is
      * required for predicting an optimal buffer capacity.

--- a/transport/src/main/java/io/netty/channel/ServerChannelRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/ServerChannelRecvBufferAllocator.java
@@ -16,10 +16,10 @@
 package io.netty.channel;
 
 /**
- * {@link MaxMessagesRecvByteBufAllocator} implementation which should be used for {@link ServerChannel}s.
+ * {@link MaxMessagesRecvBufferAllocator} implementation which should be used for {@link ServerChannel}s.
  */
-public final class ServerChannelRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllocator {
-    public ServerChannelRecvByteBufAllocator() {
+public final class ServerChannelRecvBufferAllocator extends DefaultMaxMessagesRecvBufferAllocator {
+    public ServerChannelRecvBufferAllocator() {
         super(1, true);
     }
 

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -29,7 +29,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.EventLoop;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
@@ -752,7 +752,7 @@ public class EmbeddedChannel extends AbstractChannel {
         // that may change the state of the Channel and may schedule tasks for later execution.
         final Unsafe wrapped = new Unsafe() {
             @Override
-            public RecvByteBufAllocator.Handle recvBufAllocHandle() {
+            public RecvBufferAllocator.Handle recvBufAllocHandle() {
                 return EmbeddedUnsafe.this.recvBufAllocHandle();
             }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -24,7 +24,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.PreferHeapByteBufAllocator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.Future;
@@ -231,7 +231,7 @@ public class LocalChannel extends AbstractChannel {
     }
 
     private void readInbound() {
-        RecvByteBufAllocator.Handle handle = unsafe().recvBufAllocHandle();
+        RecvBufferAllocator.Handle handle = unsafe().recvBufAllocHandle();
         handle.reset(config());
         ChannelPipeline pipeline = pipeline();
         do {

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -22,9 +22,9 @@ import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.PreferHeapByteBufAllocator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.ServerChannel;
-import io.netty.channel.ServerChannelRecvByteBufAllocator;
+import io.netty.channel.ServerChannelRecvBufferAllocator;
 import io.netty.util.concurrent.Promise;
 
 import java.net.SocketAddress;
@@ -37,7 +37,7 @@ import java.util.Queue;
 public class LocalServerChannel extends AbstractServerChannel {
 
     private final ChannelConfig config =
-            new DefaultChannelConfig(this, new ServerChannelRecvByteBufAllocator()) { };
+            new DefaultChannelConfig(this, new ServerChannelRecvBufferAllocator()) { };
     private final Queue<Object> inboundBuffer = new ArrayDeque<>();
     private volatile int state; // 0 - open, 1 - active, 2 - closed
     private volatile LocalAddress localAddress;
@@ -122,7 +122,7 @@ public class LocalServerChannel extends AbstractServerChannel {
     }
 
     private void readInbound() {
-        RecvByteBufAllocator.Handle handle = unsafe().recvBufAllocHandle();
+        RecvBufferAllocator.Handle handle = unsafe().recvBufAllocHandle();
         handle.reset(config());
         ChannelPipeline pipeline = pipeline();
         do {

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -25,7 +25,7 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.FileRegion;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.internal.ChannelUtils;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
@@ -111,7 +111,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         }
 
         private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause, boolean close,
-                RecvByteBufAllocator.Handle allocHandle) {
+                RecvBufferAllocator.Handle allocHandle) {
             if (byteBuf != null) {
                 if (byteBuf.isReadable()) {
                     readPending = false;
@@ -142,7 +142,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
             }
             final ChannelPipeline pipeline = pipeline();
             final ByteBufAllocator allocator = config.getAllocator();
-            final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
+            final RecvBufferAllocator.Handle allocHandle = recvBufAllocHandle();
             allocHandle.reset(config);
 
             ByteBuf byteBuf = null;

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -20,7 +20,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.ServerChannel;
 
 import java.io.IOException;
@@ -56,7 +56,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         super.doBeginRead();
     }
 
-    protected boolean continueReading(RecvByteBufAllocator.Handle allocHandle) {
+    protected boolean continueReading(RecvBufferAllocator.Handle allocHandle) {
         return allocHandle.continueReading();
     }
 
@@ -69,7 +69,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
             assert executor().inEventLoop();
             final ChannelConfig config = config();
             final ChannelPipeline pipeline = pipeline();
-            final RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
+            final RecvBufferAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
             allocHandle.reset(config);
 
             boolean closed = false;

--- a/transport/src/main/java/io/netty/channel/socket/DatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramChannelConfig.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
 import java.net.InetAddress;
@@ -171,7 +171,7 @@ public interface DatagramChannelConfig extends ChannelConfig {
     DatagramChannelConfig setAllocator(ByteBufAllocator allocator);
 
     @Override
-    DatagramChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+    DatagramChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator);
 
     @Override
     DatagramChannelConfig setAutoRead(boolean autoRead);

--- a/transport/src/main/java/io/netty/channel/socket/DefaultDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultDatagramChannelConfig.java
@@ -17,13 +17,12 @@ package io.netty.channel.socket;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
-import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.FixedRecvBufferAllocator;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
@@ -54,7 +53,7 @@ public class DefaultDatagramChannelConfig extends DefaultChannelConfig implement
      * Creates a new instance.
      */
     public DefaultDatagramChannelConfig(DatagramChannel channel, DatagramSocket javaSocket) {
-        super(channel, new FixedRecvByteBufAllocator(2048));
+        super(channel, new FixedRecvBufferAllocator(2048));
         requireNonNull(javaSocket, "javaSocket");
         this.javaSocket = javaSocket;
     }
@@ -395,8 +394,8 @@ public class DefaultDatagramChannelConfig extends DefaultChannelConfig implement
     }
 
     @Override
-    public DatagramChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public DatagramChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/DefaultServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultServerSocketChannelConfig.java
@@ -21,8 +21,8 @@ import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.ServerChannelRecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
+import io.netty.channel.ServerChannelRecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.NetUtil;
 
@@ -49,7 +49,7 @@ public class DefaultServerSocketChannelConfig extends DefaultChannelConfig
      * Creates a new instance.
      */
     public DefaultServerSocketChannelConfig(ServerSocketChannel channel, ServerSocket javaSocket) {
-        super(channel, new ServerChannelRecvByteBufAllocator());
+        super(channel, new ServerChannelRecvBufferAllocator());
         this.javaSocket = requireNonNull(javaSocket, "javaSocket");
     }
 
@@ -179,8 +179,8 @@ public class DefaultServerSocketChannelConfig extends DefaultChannelConfig
     }
 
     @Override
-    public ServerSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public ServerSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java
@@ -17,12 +17,11 @@ package io.netty.channel.socket;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.api.BufferAllocator;
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.internal.PlatformDependent;
 
@@ -313,8 +312,8 @@ public class DefaultSocketChannelConfig extends DefaultChannelConfig
     }
 
     @Override
-    public SocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
+    public SocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator) {
+        super.setRecvBufferAllocator(allocator);
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/DuplexChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DuplexChannelConfig.java
@@ -20,7 +20,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
 /**
@@ -67,7 +67,7 @@ public interface DuplexChannelConfig extends ChannelConfig {
     DuplexChannelConfig setAllocator(ByteBufAllocator allocator);
 
     @Override
-    DuplexChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+    DuplexChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator);
 
     @Override
     DuplexChannelConfig setAutoRead(boolean autoRead);

--- a/transport/src/main/java/io/netty/channel/socket/ServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/ServerSocketChannelConfig.java
@@ -18,7 +18,7 @@ package io.netty.channel.socket;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
 import java.net.ServerSocket;
@@ -99,7 +99,7 @@ public interface ServerSocketChannelConfig extends ChannelConfig {
     ServerSocketChannelConfig setAllocator(ByteBufAllocator allocator);
 
     @Override
-    ServerSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+    ServerSocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator);
 
     @Override
     ServerSocketChannelConfig setAutoRead(boolean autoRead);

--- a/transport/src/main/java/io/netty/channel/socket/SocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/SocketChannelConfig.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
 import java.net.Socket;
@@ -156,7 +156,7 @@ public interface SocketChannelConfig extends DuplexChannelConfig {
     SocketChannelConfig setAllocator(ByteBufAllocator allocator);
 
     @Override
-    SocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+    SocketChannelConfig setRecvBufferAllocator(RecvBufferAllocator allocator);
 
     @Override
     SocketChannelConfig setAutoRead(boolean autoRead);

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -25,7 +25,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.EventLoop;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.channel.socket.DatagramChannelConfig;
 import io.netty.channel.socket.DatagramPacket;
@@ -232,7 +232,7 @@ public final class NioDatagramChannel
     protected int doReadMessages(List<Object> buf) throws Exception {
         DatagramChannel ch = javaChannel();
         DatagramChannelConfig config = config();
-        RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
+        RecvBufferAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
 
         ByteBuf data = allocHandle.allocate(config.getAllocator());
         allocHandle.attemptedBytesRead(data.writableBytes());
@@ -579,7 +579,7 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected boolean continueReading(RecvByteBufAllocator.Handle allocHandle) {
+    protected boolean continueReading(RecvBufferAllocator.Handle allocHandle) {
         // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
         // as we read anything).
         return allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER);

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -22,7 +22,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.EventLoop;
 import io.netty.channel.FileRegion;
-import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.RecvBufferAllocator;
 import io.netty.channel.nio.AbstractNioByteChannel;
 import io.netty.channel.socket.DefaultSocketChannelConfig;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -310,7 +310,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     @Override
     protected int doReadBytes(ByteBuf byteBuf) throws Exception {
-        final RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
+        final RecvBufferAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
         allocHandle.attemptedBytesRead(byteBuf.writableBytes());
         return byteBuf.writeBytes(javaChannel(), allocHandle.attemptedBytesRead());
     }

--- a/transport/src/test/java/io/netty/channel/AdaptiveRecvBufferAllocatorTest.java
+++ b/transport/src/test/java/io/netty/channel/AdaptiveRecvBufferAllocatorTest.java
@@ -18,7 +18,7 @@ package io.netty.channel;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.channel.RecvByteBufAllocator.Handle;
+import io.netty.channel.RecvBufferAllocator.Handle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AdaptiveRecvByteBufAllocatorTest {
+public class AdaptiveRecvBufferAllocatorTest {
     @Mock
     private ChannelConfig config;
     private final ByteBufAllocator alloc = UnpooledByteBufAllocator.DEFAULT;
@@ -37,8 +37,8 @@ public class AdaptiveRecvByteBufAllocatorTest {
     public void setup() {
         config = mock(ChannelConfig.class);
         when(config.isAutoRead()).thenReturn(true);
-        AdaptiveRecvByteBufAllocator recvByteBufAllocator = new AdaptiveRecvByteBufAllocator(64, 512, 1024 * 1024 * 10);
-        handle = recvByteBufAllocator.newHandle();
+        AdaptiveRecvBufferAllocator recvBufferAllocator = new AdaptiveRecvBufferAllocator(64, 512, 1024 * 1024 * 10);
+        handle = recvBufferAllocator.newHandle();
         handle.reset(config);
     }
 

--- a/transport/src/test/java/io/netty/channel/DefaultMaxMessagesRecvBufferAllocatorTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultMaxMessagesRecvBufferAllocatorTest.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DefaultMaxMessagesRecvByteBufAllocatorTest {
+public class DefaultMaxMessagesRecvBufferAllocatorTest {
 
-    private DefaultMaxMessagesRecvByteBufAllocator newAllocator(boolean ignoreReadBytes) {
-        return new DefaultMaxMessagesRecvByteBufAllocator(2, ignoreReadBytes) {
+    private DefaultMaxMessagesRecvBufferAllocator newAllocator(boolean ignoreReadBytes) {
+        return new DefaultMaxMessagesRecvBufferAllocator(2, ignoreReadBytes) {
             @Override
             public Handle newHandle() {
                 return new MaxMessageHandle() {
@@ -39,8 +39,8 @@ public class DefaultMaxMessagesRecvByteBufAllocatorTest {
 
     @Test
     public void testRespectReadBytes() {
-        DefaultMaxMessagesRecvByteBufAllocator allocator = newAllocator(false);
-        RecvByteBufAllocator.Handle handle = allocator.newHandle();
+        DefaultMaxMessagesRecvBufferAllocator allocator = newAllocator(false);
+        RecvBufferAllocator.Handle handle = allocator.newHandle();
 
         EmbeddedChannel channel = new EmbeddedChannel();
         handle.reset(channel.config());
@@ -57,8 +57,8 @@ public class DefaultMaxMessagesRecvByteBufAllocatorTest {
 
     @Test
     public void testIgnoreReadBytes() {
-        DefaultMaxMessagesRecvByteBufAllocator allocator = newAllocator(true);
-        RecvByteBufAllocator.Handle handle = allocator.newHandle();
+        DefaultMaxMessagesRecvBufferAllocator allocator = newAllocator(true);
+        RecvBufferAllocator.Handle handle = allocator.newHandle();
 
         EmbeddedChannel channel = new EmbeddedChannel();
         handle.reset(channel.config());


### PR DESCRIPTION
Motivation:
Using "Buffer" in the name is more general.
The relevant ChannelOption is already using "buf".
In a future PR, I want to make it possible for these to allocate either new- or old-api buffers.

Modification:
Rename RecvByteBufAllocator to RecvBufferAllocator.
Also rename sub-classes, and associated methods, and parameters, and local variables and fields where necessary.

Result:
A more general name for the receive buffer allocator.

This PR builds upon #12006.