### PR TITLE
Support RFC 8879 Certificate Compression for TLSv1.3

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.47.Final</tcnative.version>
+    <tcnative.version>2.0.48.Final</tcnative.version>
   </properties>
 
   <build>

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionAlgorithm.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionAlgorithm.java
@@ -17,7 +17,11 @@ package io.netty.handler.ssl;
 
 import javax.net.ssl.SSLEngine;
 
-public interface OpenSslCompressionAlgorithm {
+/**
+ * Provides compression and decompression implementations for TLS Certificate Compression
+ * (<a href="https://tools.ietf.org/html/rfc8879">RFC 8879</a>).
+ */
+public interface OpenSslCertificateCompressionAlgorithm {
 
     /**
      * Compress the given input with the specified algorithm and return the compressed bytes.

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.ssl;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import io.netty.internal.tcnative.CertificateCompressionAlgo;
+import io.netty.internal.tcnative.SSL;
+import io.netty.internal.tcnative.SSLContext;
+
+public class OpenSslCertificateCompressionConfig implements
+        Iterable<OpenSslCertificateCompressionConfig.AlgorithmDirectionPair> {
+
+    private List<AlgorithmDirectionPair> algorithmList = new ArrayList<AlgorithmDirectionPair>();
+
+    /**
+     * Adds a certificate compression algorithm to the given {@link SSLContext}.
+     * For servers, algorithm preference order is dictated by the order of algorithm registration.
+     * Most preferred algorithm should be registered first.
+     *
+     * This method is currently only supported when {@code BoringSSL} is used.
+     *
+     * @param algorithm implementation of the compression and or decompression algorithm as a
+     * {@link CertificateCompressionAlgo}
+     * @param direction indicates whether decompression support should be advertized, compression should be applied for
+     *                  peers which support it, or both. This allows the caller to support one way compression only.
+     * <PRE>
+     * {@link SSL#SSL_CERT_COMPRESSION_DIRECTION_COMPRESS}
+     * {@link SSL#SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS}
+     * {@link SSL#SSL_CERT_COMPRESSION_DIRECTION_BOTH}
+     * </PRE>
+     * @return {@code OpenSslCertificateCompressionConfig} for a fluent API.
+     */
+    public OpenSslCertificateCompressionConfig addAlgorithm(CertificateCompressionAlgo algorithm, int direction) {
+        algorithmList.add(new AlgorithmDirectionPair(algorithm, direction));
+        return this;
+    }
+
+    @Override
+    public Iterator<AlgorithmDirectionPair> iterator() {
+        return algorithmList.iterator();
+    }
+
+    public static class AlgorithmDirectionPair {
+
+        public CertificateCompressionAlgo algorithm;
+        public int direction;
+
+        public AlgorithmDirectionPair(CertificateCompressionAlgo algorithm, int direction) {
+            this.algorithm = algorithm;
+            this.direction = direction;
+        }
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
@@ -84,7 +84,6 @@ public final class OpenSslCertificateCompressionConfig implements
         }
     }
 
-
     /**
      * The configuration for algorithm.
      */

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
@@ -49,7 +49,7 @@ public final class OpenSslCertificateCompressionConfig implements
     }
 
     /**
-     * Builder for an {@link OpenSslCompressionAlgorithm}.
+     * Builder for an {@link OpenSslCertificateCompressionAlgorithm}.
      */
     public static final class Builder {
         private final List<AlgorithmConfig> algorithmList = new ArrayList<AlgorithmConfig>();
@@ -62,20 +62,20 @@ public final class OpenSslCertificateCompressionConfig implements
          * Most preferred algorithm should be registered first.
          *
          * @param algorithm implementation of the compression and or decompression algorithm as a
-         * {@link OpenSslCompressionAlgorithm}
+         * {@link OpenSslCertificateCompressionAlgorithm}
          * @param mode indicates whether decompression support should be advertized, compression should be applied
          *                  for peers which support it, or both. This allows the caller to support one way compression
          *                  only.
          * @return self.
          */
-        public Builder addAlgorithm(OpenSslCompressionAlgorithm algorithm, AlgorithmMode mode) {
+        public Builder addAlgorithm(OpenSslCertificateCompressionAlgorithm algorithm, AlgorithmMode mode) {
             algorithmList.add(new AlgorithmConfig(algorithm, mode));
             return this;
         }
 
         /**
          * Build a new {@link OpenSslCertificateCompressionConfig} based on the previous
-         * added {@link OpenSslCompressionAlgorithm}s.
+         * added {@link OpenSslCertificateCompressionAlgorithm}s.
          *
          * @return a new config.
          */
@@ -88,10 +88,10 @@ public final class OpenSslCertificateCompressionConfig implements
      * The configuration for algorithm.
      */
     public static final class AlgorithmConfig {
-        private final OpenSslCompressionAlgorithm algorithm;
+        private final OpenSslCertificateCompressionAlgorithm algorithm;
         private final AlgorithmMode mode;
 
-        private AlgorithmConfig(OpenSslCompressionAlgorithm algorithm, AlgorithmMode mode) {
+        private AlgorithmConfig(OpenSslCertificateCompressionAlgorithm algorithm, AlgorithmMode mode) {
             this.algorithm = ObjectUtil.checkNotNull(algorithm, "algorithm");
             this.mode = ObjectUtil.checkNotNull(mode, "mode");
         }
@@ -106,17 +106,17 @@ public final class OpenSslCertificateCompressionConfig implements
         }
 
         /**
-         * The configured {@link OpenSslCompressionAlgorithm}.
+         * The configured {@link OpenSslCertificateCompressionAlgorithm}.
          *
          * @return the algorithm
          */
-        public OpenSslCompressionAlgorithm algorithm() {
+        public OpenSslCertificateCompressionAlgorithm algorithm() {
             return algorithm;
         }
     }
 
     /**
-     * The usage mode of the {@link OpenSslCompressionAlgorithm}.
+     * The usage mode of the {@link OpenSslCertificateCompressionAlgorithm}.
      */
     public enum AlgorithmMode {
         /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
@@ -86,7 +86,7 @@ public final class OpenSslCertificateCompressionConfig implements
 
 
     /**
-     * The configuration for
+     * The configuration for algorithm.
      */
     public static final class AlgorithmConfig {
         private final OpenSslCompressionAlgorithm algorithm;
@@ -99,7 +99,8 @@ public final class OpenSslCertificateCompressionConfig implements
 
         /**
          * The {@link AlgorithmMode}
-         * @return
+         *
+         * @return the usage mode.
          */
         public AlgorithmMode mode() {
             return mode;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCompressionAlgorithm.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCompressionAlgorithm.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SSLEngine;
+
+public interface OpenSslCompressionAlgorithm {
+
+    /**
+     * Compress the given input with the specified algorithm and return the compressed bytes.
+     *
+     * @param engine                    the {@link SSLEngine}
+     * @param uncompressedCertificate   the uncompressed certificate
+     * @return                          the compressed form of the certificate
+     * @throws Exception                thrown if an error occurs while compressing
+     */
+    byte[] compress(SSLEngine engine, byte[] uncompressedCertificate) throws Exception;
+
+    /**
+     * Decompress the given input with the specified algorithm and return the decompressed bytes.
+     *
+     * <h3>Implementation
+     * <a href="https://tools.ietf.org/html/rfc8879#section-5">Security Considerations</a></h3>
+     * <p>Implementations SHOULD bound the memory usage when decompressing the CompressedCertificate message.</p>
+     * <p>
+     * Implementations MUST limit the size of the resulting decompressed chain to the specified {@code uncompressedLen},
+     * and they MUST abort the connection (throw an exception) if the size of the output of the decompression
+     * function exceeds that limit.
+     * </p>
+     *
+     * @param engine                    the {@link SSLEngine}
+     * @param uncompressedLen           the expected length of the decompressed certificate that will be returned.
+     * @param compressedCertificate     the compressed form of the certificate
+     * @return                          the decompressed form of the certificate
+     * @throws Exception                thrown if an error occurs while decompressing or output size exceeds
+     *                                  {@code uncompressedLen}
+     */
+    byte[] decompress(SSLEngine engine, int uncompressedLen, byte[] compressedCertificate) throws Exception;
+
+    /**
+     * Return the ID for the compression algorithm provided for by a given implementation.
+     *
+     * @return compression algorithm ID as specified by
+     * <a href="https://datatracker.ietf.org/doc/html/rfc8879">RFC8879</a>.
+     */
+    int algorithmId();
+}

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
@@ -58,4 +58,14 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
      */
     public static final OpenSslContextOption<OpenSslAsyncPrivateKeyMethod> ASYNC_PRIVATE_KEY_METHOD =
             new OpenSslContextOption<OpenSslAsyncPrivateKeyMethod>("ASYNC_PRIVATE_KEY_METHOD");
+
+    /**
+     * Set the {@link OpenSslCertificateCompressionConfig} to use. This allows for the configuration of certificate
+     * compression algorithms which should be used, the priority of those algorithms and the directions in which
+     * they should be used.
+     *
+     * This is currently only supported when {@code BoringSSL} is used.
+     */
+    public static final OpenSslContextOption<OpenSslCertificateCompressionConfig> CERTIFICATE_COMPRESSION_ALGORITHMS =
+            new OpenSslContextOption<OpenSslCertificateCompressionConfig>("CERTIFICATE_COMPRESSION_ALGORITHMS");
 }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -1102,9 +1102,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     private static final class CompressionAlgorithm implements CertificateCompressionAlgo {
         private final OpenSslEngineMap engineMap;
-        private final OpenSslCompressionAlgorithm compressionAlgorithm;
+        private final OpenSslCertificateCompressionAlgorithm compressionAlgorithm;
 
-        CompressionAlgorithm(OpenSslEngineMap engineMap, OpenSslCompressionAlgorithm compressionAlgorithm) {
+        CompressionAlgorithm(OpenSslEngineMap engineMap, OpenSslCertificateCompressionAlgorithm compressionAlgorithm) {
             this.engineMap = engineMap;
             this.compressionAlgorithm = compressionAlgorithm;
         }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.util.LazyX509Certificate;
 import io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod;
+import io.netty.internal.tcnative.CertificateCompressionAlgo;
 import io.netty.internal.tcnative.CertificateVerifier;
 import io.netty.internal.tcnative.ResultCallback;
 import io.netty.internal.tcnative.SSL;
@@ -279,7 +280,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
             try {
                 int protocolOpts = SSL.SSL_PROTOCOL_SSLV3 | SSL.SSL_PROTOCOL_TLSV1 |
-                                   SSL.SSL_PROTOCOL_TLSV1_1 | SSL.SSL_PROTOCOL_TLSV1_2;
+                        SSL.SSL_PROTOCOL_TLSV1_1 | SSL.SSL_PROTOCOL_TLSV1_2;
                 if (tlsv13Supported) {
                     protocolOpts |= SSL.SSL_PROTOCOL_TLSV1_3;
                 }
@@ -319,29 +320,29 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             }
 
             int options = SSLContext.getOptions(ctx) |
-                          SSL.SSL_OP_NO_SSLv2 |
-                          SSL.SSL_OP_NO_SSLv3 |
-                          // Disable TLSv1 and TLSv1.1 by default as these are not considered secure anymore
-                          // and the JDK is doing the same:
-                          // https://www.oracle.com/java/technologies/javase/8u291-relnotes.html
-                          SSL.SSL_OP_NO_TLSv1 |
-                          SSL.SSL_OP_NO_TLSv1_1 |
+                    SSL.SSL_OP_NO_SSLv2 |
+                    SSL.SSL_OP_NO_SSLv3 |
+                    // Disable TLSv1 and TLSv1.1 by default as these are not considered secure anymore
+                    // and the JDK is doing the same:
+                    // https://www.oracle.com/java/technologies/javase/8u291-relnotes.html
+                    SSL.SSL_OP_NO_TLSv1 |
+                    SSL.SSL_OP_NO_TLSv1_1 |
 
-                          SSL.SSL_OP_CIPHER_SERVER_PREFERENCE |
+                    SSL.SSL_OP_CIPHER_SERVER_PREFERENCE |
 
-                          // We do not support compression at the moment so we should explicitly disable it.
-                          SSL.SSL_OP_NO_COMPRESSION |
+                    // We do not support compression at the moment so we should explicitly disable it.
+                    SSL.SSL_OP_NO_COMPRESSION |
 
-                          // Disable ticket support by default to be more inline with SSLEngineImpl of the JDK.
-                          // This also let SSLSession.getId() work the same way for the JDK implementation and the
-                          // OpenSSLEngine. If tickets are supported SSLSession.getId() will only return an ID on the
-                          // server-side if it could make use of tickets.
-                          SSL.SSL_OP_NO_TICKET;
+                    // Disable ticket support by default to be more inline with SSLEngineImpl of the JDK.
+                    // This also let SSLSession.getId() work the same way for the JDK implementation and the
+                    // OpenSSLEngine. If tickets are supported SSLSession.getId() will only return an ID on the
+                    // server-side if it could make use of tickets.
+                    SSL.SSL_OP_NO_TICKET;
 
             if (cipherBuilder.length() == 0) {
                 // No ciphers that are compatible with SSLv2 / SSLv3 / TLSv1 / TLSv1.1 / TLSv1.2
                 options |= SSL.SSL_OP_NO_SSLv2 | SSL.SSL_OP_NO_SSLv3 | SSL.SSL_OP_NO_TLSv1
-                           | SSL.SSL_OP_NO_TLSv1_1 | SSL.SSL_OP_NO_TLSv1_2;
+                        | SSL.SSL_OP_NO_TLSv1_1 | SSL.SSL_OP_NO_TLSv1_2;
             }
 
             SSLContext.setOptions(ctx, options);
@@ -356,7 +357,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             }
 
             List<String> nextProtoList = apn.protocols();
-                /* Set next protocols for next protocol negotiation extension, if specified */
+            /* Set next protocols for next protocol negotiation extension, if specified */
             if (!nextProtoList.isEmpty()) {
                 String[] appProtocols = nextProtoList.toArray(new String[0]);
                 int selectorBehavior = opensslSelectorFailureBehavior(apn.selectorFailureBehavior());
@@ -389,8 +390,24 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                 SSLContext.setPrivateKeyMethod(ctx, new AsyncPrivateKeyMethod(engineMap, asyncPrivateKeyMethod));
             }
             if (certCompressionConfig != null) {
-                for (OpenSslCertificateCompressionConfig.AlgorithmDirectionPair configPair : certCompressionConfig) {
-                    SSLContext.addCertificateCompressionAlgorithm(ctx, configPair.direction, configPair.algorithm);
+                for (OpenSslCertificateCompressionConfig.AlgorithmConfig configPair : certCompressionConfig) {
+                    final CertificateCompressionAlgo algo = new CompressionAlgorithm(engineMap, configPair.algorithm());
+                    switch (configPair.mode()) {
+                        case Decompress:
+                            SSLContext.addCertificateCompressionAlgorithm(
+                                    ctx, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS, algo);
+                            break;
+                        case Compress:
+                            SSLContext.addCertificateCompressionAlgorithm(
+                                    ctx, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS, algo);
+                            break;
+                        case Both:
+                            SSLContext.addCertificateCompressionAlgorithm(
+                                    ctx, SSL.SSL_CERT_COMPRESSION_DIRECTION_BOTH, algo);
+                            break;
+                        default:
+                            throw new IllegalStateException();
+                    }
                 }
             }
             // Set the curves.
@@ -972,6 +989,16 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         return new OpenSslKeyMaterialProvider(chooseX509KeyManager(factory.getKeyManagers()), password);
     }
 
+    private static ReferenceCountedOpenSslEngine retrieveEngine(OpenSslEngineMap engineMap, long ssl)
+            throws SSLException {
+        ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
+        if (engine == null) {
+            throw new SSLException("Could not find a " +
+                    StringUtil.simpleClassName(ReferenceCountedOpenSslEngine.class) + " for sslPointer " + ssl);
+        }
+        return engine;
+    }
+
     private static final class PrivateKeyMethod implements SSLPrivateKeyMethod {
 
         private final OpenSslEngineMap engineMap;
@@ -981,18 +1008,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             this.keyMethod = keyMethod;
         }
 
-        private ReferenceCountedOpenSslEngine retrieveEngine(long ssl) throws SSLException {
-            ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
-            if (engine == null) {
-                throw new SSLException("Could not find a " +
-                        StringUtil.simpleClassName(ReferenceCountedOpenSslEngine.class) + " for sslPointer " + ssl);
-            }
-            return engine;
-        }
-
         @Override
         public byte[] sign(long ssl, int signatureAlgorithm, byte[] digest) throws Exception {
-            ReferenceCountedOpenSslEngine engine = retrieveEngine(ssl);
+            ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
             try {
                 return verifyResult(keyMethod.sign(engine, signatureAlgorithm, digest));
             } catch (Exception e) {
@@ -1003,7 +1021,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
         @Override
         public byte[] decrypt(long ssl, byte[] input) throws Exception {
-            ReferenceCountedOpenSslEngine engine = retrieveEngine(ssl);
+            ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
             try {
                 return verifyResult(keyMethod.decrypt(engine, input));
             } catch (Exception e) {
@@ -1023,19 +1041,10 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             this.keyMethod = keyMethod;
         }
 
-        private ReferenceCountedOpenSslEngine retrieveEngine(long ssl) throws SSLException {
-            ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
-            if (engine == null) {
-                throw new SSLException("Could not find a " +
-                        StringUtil.simpleClassName(ReferenceCountedOpenSslEngine.class) + " for sslPointer " + ssl);
-            }
-            return engine;
-        }
-
         @Override
         public void sign(long ssl, int signatureAlgorithm, byte[] bytes, ResultCallback<byte[]> resultCallback) {
             try {
-                ReferenceCountedOpenSslEngine engine = retrieveEngine(ssl);
+                ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
                 keyMethod.sign(engine, signatureAlgorithm, bytes)
                         .addListener(new ResultCallbackListener(engine, ssl, resultCallback));
             } catch (SSLException e) {
@@ -1046,7 +1055,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         @Override
         public void decrypt(long ssl, byte[] bytes, ResultCallback<byte[]> resultCallback) {
             try {
-                ReferenceCountedOpenSslEngine engine = retrieveEngine(ssl);
+                ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
                 keyMethod.decrypt(engine, bytes)
                         .addListener(new ResultCallbackListener(engine, ssl, resultCallback));
             } catch (SSLException e) {
@@ -1089,5 +1098,32 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             throw new SignatureException();
         }
         return result;
+    }
+
+    private static final class CompressionAlgorithm implements CertificateCompressionAlgo {
+        private final OpenSslEngineMap engineMap;
+        private final OpenSslCompressionAlgorithm compressionAlgorithm;
+
+        CompressionAlgorithm(OpenSslEngineMap engineMap, OpenSslCompressionAlgorithm compressionAlgorithm) {
+            this.engineMap = engineMap;
+            this.compressionAlgorithm = compressionAlgorithm;
+        }
+
+        @Override
+        public byte[] compress(long ssl, byte[] bytes) throws Exception {
+            ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
+            return compressionAlgorithm.compress(engine, bytes);
+        }
+
+        @Override
+        public byte[] decompress(long ssl, int len, byte[] bytes) throws Exception {
+            ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
+            return compressionAlgorithm.decompress(engine, len, bytes);
+        }
+
+        @Override
+        public int algorithmId() {
+            return compressionAlgorithm.algorithmId();
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -225,6 +225,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         boolean useTasks = USE_TASKS;
         OpenSslPrivateKeyMethod privateKeyMethod = null;
         OpenSslAsyncPrivateKeyMethod asyncPrivateKeyMethod = null;
+        OpenSslCertificateCompressionConfig certCompressionConfig = null;
 
         if (ctxOptions != null) {
             for (Map.Entry<SslContextOption<?>, Object> ctxOpt : ctxOptions) {
@@ -238,6 +239,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                     privateKeyMethod = (OpenSslPrivateKeyMethod) ctxOpt.getValue();
                 } else if (option == OpenSslContextOption.ASYNC_PRIVATE_KEY_METHOD) {
                     asyncPrivateKeyMethod = (OpenSslAsyncPrivateKeyMethod) ctxOpt.getValue();
+                } else if (option == OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS) {
+                    certCompressionConfig = (OpenSslCertificateCompressionConfig) ctxOpt.getValue();
                 } else {
                     logger.debug("Skipping unsupported " + SslContextOption.class.getSimpleName()
                             + ": " + ctxOpt.getKey());
@@ -384,6 +387,11 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             }
             if (asyncPrivateKeyMethod != null) {
                 SSLContext.setPrivateKeyMethod(ctx, new AsyncPrivateKeyMethod(engineMap, asyncPrivateKeyMethod));
+            }
+            if (certCompressionConfig != null) {
+                for (OpenSslCertificateCompressionConfig.AlgorithmDirectionPair configPair : certCompressionConfig) {
+                    SSLContext.addCertificateCompressionAlgorithm(ctx, configPair.direction, configPair.algorithm);
+                }
             }
             // Set the curves.
             SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalEventLoopGroup;
+import io.netty.channel.local.LocalServerChannel;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.internal.tcnative.CertificateCompressionAlgo;
+import io.netty.internal.tcnative.SSL;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.function.Executable;
+
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OpenSslCertificateCompressionTest {
+
+    private static final int TEST_TIMEOUT = 12;
+
+    private static SelfSignedCertificate cert;
+    private TestCertCompressionAlgo testZLibAlgoServer;
+    private TestCertCompressionAlgo testBrotliAlgoServer;
+    private TestCertCompressionAlgo testZstdAlgoServer;
+    private TestCertCompressionAlgo testZlibAlgoClient;
+    private TestCertCompressionAlgo testBrotliAlgoClient;
+
+    @BeforeAll
+    public static void init() throws Exception {
+        assumeTrue(OpenSsl.isTlsv13Supported());
+        cert = new SelfSignedCertificate();
+    }
+
+    @BeforeEach
+    public void refreshAlgos() {
+        testZLibAlgoServer = new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZLIB);
+        testBrotliAlgoServer = new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_BROTLI);
+        testZstdAlgoServer = new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZSTD);
+        testZlibAlgoClient = new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZLIB);
+        testBrotliAlgoClient = new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_BROTLI);
+    }
+
+    @Test
+    @Timeout(TEST_TIMEOUT)
+    public void testSimple() throws Throwable {
+        assumeTrue(OpenSsl.isBoringSSL());
+        final SslContext clientSslContext = buildClientContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+        );
+        final SslContext serverSslContext = buildServerContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+        );
+
+        runCertCompressionTest(clientSslContext, serverSslContext);
+
+        assertCompress(testBrotliAlgoServer);
+        assertDecompress(testBrotliAlgoClient);
+    }
+
+    @Test
+    @Timeout(TEST_TIMEOUT)
+    public void testServerPriority() throws Throwable {
+        assumeTrue(OpenSsl.isBoringSSL());
+        final SslContext clientSslContext = buildClientContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                        .addAlgorithm(testZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+        );
+        final SslContext serverSslContext = buildServerContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testZLibAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                        .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+        );
+
+        runCertCompressionTest(clientSslContext, serverSslContext);
+
+        assertCompress(testZLibAlgoServer);
+        assertDecompress(testZlibAlgoClient);
+        assertNone(testBrotliAlgoClient, testBrotliAlgoServer);
+    }
+
+    @Test
+    @Timeout(TEST_TIMEOUT)
+    public void testServerPriorityReverse() throws Throwable {
+        assumeTrue(OpenSsl.isBoringSSL());
+        final SslContext clientSslContext = buildClientContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                        .addAlgorithm(testZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+        );
+        final SslContext serverSslContext = buildServerContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                        .addAlgorithm(testZLibAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+        );
+
+        runCertCompressionTest(clientSslContext, serverSslContext);
+
+        assertCompress(testBrotliAlgoServer);
+        assertDecompress(testBrotliAlgoClient);
+        assertNone(testZLibAlgoServer, testZlibAlgoClient);
+    }
+
+    @Test
+    @Timeout(TEST_TIMEOUT)
+    public void testFailedNegotiation() throws Throwable {
+        assumeTrue(OpenSsl.isBoringSSL());
+        final SslContext clientSslContext = buildClientContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                        .addAlgorithm(testZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+        );
+        final SslContext serverSslContext = buildServerContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testZstdAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+        );
+
+        runCertCompressionTest(clientSslContext, serverSslContext);
+
+        assertNone(testBrotliAlgoClient, testZlibAlgoClient, testZstdAlgoServer);
+    }
+
+    @Test
+    @Timeout(TEST_TIMEOUT)
+    public void testAlgoFailure() throws Throwable {
+        assumeTrue(OpenSsl.isBoringSSL());
+        TestCertCompressionAlgo badZlibAlgoClient =
+                new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZLIB) {
+            @Override
+            public byte[] decompress(long ctx, int uncompressed_len, byte[] input) {
+                return input;
+            }
+        };
+        final SslContext clientSslContext = buildClientContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(badZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+        );
+        final SslContext serverSslContext = buildServerContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testZLibAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+        );
+
+        Assertions.assertThrows(SSLHandshakeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                runCertCompressionTest(clientSslContext, serverSslContext);
+            }
+        });
+    }
+
+    @Test
+    @Timeout(TEST_TIMEOUT)
+    public void testAlgoException() throws Throwable {
+        assumeTrue(OpenSsl.isBoringSSL());
+        TestCertCompressionAlgo badZlibAlgoClient =
+                new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZLIB) {
+                    @Override
+                    public byte[] decompress(long ctx, int uncompressed_len, byte[] input) {
+                        throw new RuntimeException("broken");
+                    }
+                };
+        final SslContext clientSslContext = buildClientContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(badZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+        );
+        final SslContext serverSslContext = buildServerContext(
+                new OpenSslCertificateCompressionConfig()
+                        .addAlgorithm(testZLibAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+        );
+
+        Assertions.assertThrows(SSLHandshakeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                runCertCompressionTest(clientSslContext, serverSslContext);
+            }
+        });
+    }
+
+    @Test
+    @Timeout(TEST_TIMEOUT)
+    public void testTlsLessThan13() throws Throwable {
+        assumeTrue(OpenSsl.isBoringSSL());
+        final SslContext clientSslContext = SslContextBuilder.forClient()
+             .sslProvider(SslProvider.OPENSSL)
+             .protocols(SslProtocols.TLS_v1_2)
+             .trustManager(InsecureTrustManagerFactory.INSTANCE)
+             .option(OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS,
+                     new OpenSslCertificateCompressionConfig()
+                             .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS))
+             .build();
+        final SslContext serverSslContext = SslContextBuilder.forServer(cert.key(), cert.cert())
+               .sslProvider(SslProvider.OPENSSL)
+               .protocols(SslProtocols.TLS_v1_2)
+               .option(OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS,
+                       new OpenSslCertificateCompressionConfig()
+                               .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS))
+               .build();
+
+        runCertCompressionTest(clientSslContext, serverSslContext);
+
+        // BoringSSL returns success when calling SSL_CTX_add_cert_compression_alg
+        // but only applies compression for TLSv1.3
+        assertNone(testBrotliAlgoClient, testBrotliAlgoServer);
+    }
+
+    @Test
+    public void testDuplicateAdd() throws Throwable {
+        // Fails with "Failed trying to add certificate compression algorithm"
+        assumeTrue(OpenSsl.isBoringSSL());
+        Assertions.assertThrows(Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                buildClientContext(
+                        new OpenSslCertificateCompressionConfig()
+                                .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                                .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                );
+            }
+        });
+
+        Assertions.assertThrows(Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                buildServerContext(
+                        new OpenSslCertificateCompressionConfig()
+                                .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                                .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_BOTH)
+                );
+            }
+        });
+    }
+
+    @Test
+    public void testNotBoringAdd() throws Throwable {
+        // Fails with "TLS Cert Compression only supported by BoringSSL"
+        assumeTrue(!OpenSsl.isBoringSSL());
+        Assertions.assertThrows(Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                buildClientContext(
+                        new OpenSslCertificateCompressionConfig()
+                                .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                );
+            }
+        });
+
+        Assertions.assertThrows(Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                buildServerContext(
+                        new OpenSslCertificateCompressionConfig()
+                                .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                );
+            }
+        });
+    }
+
+    public void runCertCompressionTest(SslContext clientSslContext, SslContext serverSslContext) throws Throwable {
+        EventLoopGroup group = new LocalEventLoopGroup();
+        Promise<Object> clientPromise = group.next().newPromise();
+        Promise<Object> serverPromise = group.next().newPromise();
+        try {
+            ServerBootstrap sb = new ServerBootstrap();
+            sb.group(group).channel(LocalServerChannel.class)
+                    .childHandler(new CertCompressionTestChannelInitializer(serverPromise, serverSslContext));
+            Channel serverChannel = sb.bind(new LocalAddress("testCertificateCompression"))
+                    .syncUninterruptibly().channel();
+
+            Bootstrap bootstrap = new Bootstrap();
+            bootstrap.group(group).channel(LocalChannel.class)
+                    .handler(new CertCompressionTestChannelInitializer(clientPromise, clientSslContext));
+
+            Channel clientChannel = bootstrap.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+
+            assertTrue(clientPromise.await(5L, TimeUnit.SECONDS), "client timeout");
+            assertTrue(serverPromise.await(5L, TimeUnit.SECONDS), "server timeout");
+            clientPromise.sync();
+            serverPromise.sync();
+            clientChannel.close().syncUninterruptibly();
+            serverChannel.close().syncUninterruptibly();
+        } finally  {
+            group.shutdownGracefully();
+        }
+    }
+
+    private SslContext buildServerContext(OpenSslCertificateCompressionConfig compressionConfig) throws SSLException {
+        return SslContextBuilder.forServer(cert.key(), cert.cert())
+                .sslProvider(SslProvider.OPENSSL)
+                .protocols(SslProtocols.TLS_v1_3)
+            .option(OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS,
+                    compressionConfig)
+                .build();
+    }
+
+    private SslContext buildClientContext(OpenSslCertificateCompressionConfig compressionConfig) throws SSLException {
+        return SslContextBuilder.forClient()
+                .sslProvider(SslProvider.OPENSSL)
+                .protocols(SslProtocols.TLS_v1_3)
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+            .option(OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS,
+                    compressionConfig)
+                .build();
+    }
+
+    private void assertCompress(TestCertCompressionAlgo algo) {
+        assertTrue(algo.compressCalled && !algo.decompressCalled);
+    }
+
+    private void assertDecompress(TestCertCompressionAlgo algo) {
+        assertTrue(!algo.compressCalled && algo.decompressCalled);
+    }
+
+    private void assertNone(TestCertCompressionAlgo... algos) {
+        for (TestCertCompressionAlgo algo : algos) {
+            assertTrue(!algo.compressCalled && !algo.decompressCalled);
+        }
+    }
+
+    private static class CertCompressionTestChannelInitializer extends ChannelInitializer<Channel> {
+
+        private final Promise<Object> channelPromise;
+        private final SslContext sslContext;
+
+        CertCompressionTestChannelInitializer(Promise<Object> channelPromise, SslContext sslContext) {
+            this.channelPromise = channelPromise;
+            this.sslContext = sslContext;
+        }
+
+        @Override
+        protected void initChannel(Channel ch) {
+            ChannelPipeline pipeline = ch.pipeline();
+            pipeline.addLast(sslContext.newHandler(ch.alloc()));
+            pipeline.addLast(new SimpleChannelInboundHandler<Object>() {
+
+                @Override
+                public void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                    // Do nothing
+                }
+
+                @Override
+                public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                    if (evt instanceof SslHandshakeCompletionEvent) {
+                        if (((SslHandshakeCompletionEvent) evt).isSuccess()) {
+                            channelPromise.trySuccess(evt);
+                        } else {
+                            channelPromise.tryFailure(((SslHandshakeCompletionEvent) evt).cause());
+                        }
+                    }
+                    ctx.fireUserEventTriggered(evt);
+                }
+            });
+        }
+    }
+
+    private static class TestCertCompressionAlgo implements CertificateCompressionAlgo {
+
+        private static final int BASE_PADDING_SIZE = 10;
+        public boolean compressCalled;
+        public boolean decompressCalled;
+        private final int algorithmId;
+
+        TestCertCompressionAlgo(int algorithmId) {
+            this.algorithmId = algorithmId;
+        }
+
+        @Override
+        public byte[] compress(long ctx, byte[] input) throws Exception {
+            compressCalled = true;
+            byte[] output = new byte[input.length + BASE_PADDING_SIZE + algorithmId];
+            System.arraycopy(input, 0, output, BASE_PADDING_SIZE + algorithmId, input.length);
+            return output;
+        }
+
+        @Override
+        public byte[] decompress(long ctx, int uncompressed_len, byte[] input) {
+            decompressCalled = true;
+            byte[] output = new byte[input.length - (BASE_PADDING_SIZE + algorithmId)];
+            System.arraycopy(input, BASE_PADDING_SIZE + algorithmId, output, 0, output.length);
+            return output;
+        }
+
+        @Override
+        public int algorithmId() {
+            return algorithmId;
+        }
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
 import javax.net.ssl.SSLEngine;
@@ -47,8 +46,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenSslCertificateCompressionTest {
-
-    private static final int TEST_TIMEOUT = 12;
 
     private static SelfSignedCertificate cert;
     private TestCertCompressionAlgo testZLibAlgoServer;
@@ -73,7 +70,6 @@ public class OpenSslCertificateCompressionTest {
     }
 
     @Test
-    @Timeout(TEST_TIMEOUT)
     public void testSimple() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
@@ -95,7 +91,6 @@ public class OpenSslCertificateCompressionTest {
     }
 
     @Test
-    @Timeout(TEST_TIMEOUT)
     public void testServerPriority() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
@@ -120,7 +115,6 @@ public class OpenSslCertificateCompressionTest {
     }
 
     @Test
-    @Timeout(TEST_TIMEOUT)
     public void testServerPriorityReverse() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
@@ -146,7 +140,6 @@ public class OpenSslCertificateCompressionTest {
     }
 
     @Test
-    @Timeout(TEST_TIMEOUT)
     public void testFailedNegotiation() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
@@ -168,7 +161,6 @@ public class OpenSslCertificateCompressionTest {
     }
 
     @Test
-    @Timeout(TEST_TIMEOUT)
     public void testAlgoFailure() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         TestCertCompressionAlgo badZlibAlgoClient =
@@ -198,7 +190,6 @@ public class OpenSslCertificateCompressionTest {
     }
 
     @Test
-    @Timeout(TEST_TIMEOUT)
     public void testAlgoException() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         TestCertCompressionAlgo badZlibAlgoClient =
@@ -228,7 +219,6 @@ public class OpenSslCertificateCompressionTest {
     }
 
     @Test
-    @Timeout(TEST_TIMEOUT)
     public void testTlsLessThan13() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = SslContextBuilder.forClient()
@@ -416,7 +406,7 @@ public class OpenSslCertificateCompressionTest {
         }
     }
 
-    private static class TestCertCompressionAlgo implements OpenSslCompressionAlgorithm {
+    private static class TestCertCompressionAlgo implements OpenSslCertificateCompressionAlgorithm {
 
         private static final int BASE_PADDING_SIZE = 10;
         public boolean compressCalled;

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -78,7 +78,8 @@ public class OpenSslCertificateCompressionTest {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
-                        .addAlgorithm(testBrotliAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .addAlgorithm(testBrotliAlgoClient,
+                                OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
                         .build()
         );
         final SslContext serverSslContext = buildServerContext(
@@ -99,7 +100,8 @@ public class OpenSslCertificateCompressionTest {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
-                        .addAlgorithm(testBrotliAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .addAlgorithm(testBrotliAlgoClient,
+                                OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
                         .addAlgorithm(testZlibAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
                         .build()
         );
@@ -123,13 +125,15 @@ public class OpenSslCertificateCompressionTest {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
-                        .addAlgorithm(testBrotliAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .addAlgorithm(testBrotliAlgoClient,
+                                OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
                         .addAlgorithm(testZlibAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
                         .build()
         );
         final SslContext serverSslContext = buildServerContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
-                        .addAlgorithm(testBrotliAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .addAlgorithm(testBrotliAlgoServer,
+                                OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
                         .addAlgorithm(testZLibAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
                         .build()
         );
@@ -147,7 +151,8 @@ public class OpenSslCertificateCompressionTest {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
-                        .addAlgorithm(testBrotliAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .addAlgorithm(testBrotliAlgoClient,
+                                OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
                         .addAlgorithm(testZlibAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
                         .build()
         );

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -30,7 +30,6 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.internal.tcnative.CertificateCompressionAlgo;
-import io.netty.internal.tcnative.SSL;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -39,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import java.util.concurrent.TimeUnit;
@@ -77,12 +77,14 @@ public class OpenSslCertificateCompressionTest {
     public void testSimple() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testBrotliAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .build()
         );
         final SslContext serverSslContext = buildServerContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testBrotliAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .build()
         );
 
         runCertCompressionTest(clientSslContext, serverSslContext);
@@ -96,14 +98,16 @@ public class OpenSslCertificateCompressionTest {
     public void testServerPriority() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
-                        .addAlgorithm(testZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testBrotliAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .addAlgorithm(testZlibAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .build()
         );
         final SslContext serverSslContext = buildServerContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testZLibAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
-                        .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testZLibAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .addAlgorithm(testBrotliAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .build()
         );
 
         runCertCompressionTest(clientSslContext, serverSslContext);
@@ -118,14 +122,16 @@ public class OpenSslCertificateCompressionTest {
     public void testServerPriorityReverse() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
-                        .addAlgorithm(testZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testBrotliAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .addAlgorithm(testZlibAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .build()
         );
         final SslContext serverSslContext = buildServerContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
-                        .addAlgorithm(testZLibAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testBrotliAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .addAlgorithm(testZLibAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .build()
         );
 
         runCertCompressionTest(clientSslContext, serverSslContext);
@@ -140,13 +146,15 @@ public class OpenSslCertificateCompressionTest {
     public void testFailedNegotiation() throws Throwable {
         assumeTrue(OpenSsl.isBoringSSL());
         final SslContext clientSslContext = buildClientContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
-                        .addAlgorithm(testZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testBrotliAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .addAlgorithm(testZlibAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .build()
         );
         final SslContext serverSslContext = buildServerContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testZstdAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testZstdAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .build()
         );
 
         runCertCompressionTest(clientSslContext, serverSslContext);
@@ -161,17 +169,19 @@ public class OpenSslCertificateCompressionTest {
         TestCertCompressionAlgo badZlibAlgoClient =
                 new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZLIB) {
             @Override
-            public byte[] decompress(long ctx, int uncompressed_len, byte[] input) {
+            public byte[] decompress(SSLEngine engine, int uncompressed_len, byte[] input) {
                 return input;
             }
         };
         final SslContext clientSslContext = buildClientContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(badZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(badZlibAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .build()
         );
         final SslContext serverSslContext = buildServerContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testZLibAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testZLibAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .build()
         );
 
         Assertions.assertThrows(SSLHandshakeException.class, new Executable() {
@@ -189,17 +199,19 @@ public class OpenSslCertificateCompressionTest {
         TestCertCompressionAlgo badZlibAlgoClient =
                 new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZLIB) {
                     @Override
-                    public byte[] decompress(long ctx, int uncompressed_len, byte[] input) {
+                    public byte[] decompress(SSLEngine engine, int uncompressed_len, byte[] input) {
                         throw new RuntimeException("broken");
                     }
                 };
         final SslContext clientSslContext = buildClientContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(badZlibAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(badZlibAlgoClient, OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                        .build()
         );
         final SslContext serverSslContext = buildServerContext(
-                new OpenSslCertificateCompressionConfig()
-                        .addAlgorithm(testZLibAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                OpenSslCertificateCompressionConfig.newBuilder()
+                        .addAlgorithm(testZLibAlgoServer, OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                        .build()
         );
 
         Assertions.assertThrows(SSLHandshakeException.class, new Executable() {
@@ -219,15 +231,19 @@ public class OpenSslCertificateCompressionTest {
              .protocols(SslProtocols.TLS_v1_2)
              .trustManager(InsecureTrustManagerFactory.INSTANCE)
              .option(OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS,
-                     new OpenSslCertificateCompressionConfig()
-                             .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS))
+                     OpenSslCertificateCompressionConfig.newBuilder()
+                             .addAlgorithm(testBrotliAlgoClient,
+                                     OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                             .build())
              .build();
         final SslContext serverSslContext = SslContextBuilder.forServer(cert.key(), cert.cert())
                .sslProvider(SslProvider.OPENSSL)
                .protocols(SslProtocols.TLS_v1_2)
                .option(OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS,
-                       new OpenSslCertificateCompressionConfig()
-                               .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS))
+                       OpenSslCertificateCompressionConfig.newBuilder()
+                               .addAlgorithm(testBrotliAlgoServer,
+                                       OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                               .build())
                .build();
 
         runCertCompressionTest(clientSslContext, serverSslContext);
@@ -245,9 +261,12 @@ public class OpenSslCertificateCompressionTest {
             @Override
             public void execute() throws Throwable {
                 buildClientContext(
-                        new OpenSslCertificateCompressionConfig()
-                                .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
-                                .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                        OpenSslCertificateCompressionConfig.newBuilder()
+                                .addAlgorithm(testBrotliAlgoClient,
+                                        OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                                .addAlgorithm(testBrotliAlgoClient,
+                                        OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                                .build()
                 );
             }
         });
@@ -256,9 +275,11 @@ public class OpenSslCertificateCompressionTest {
             @Override
             public void execute() throws Throwable {
                 buildServerContext(
-                        new OpenSslCertificateCompressionConfig()
-                                .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
-                                .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_BOTH)
+                        OpenSslCertificateCompressionConfig.newBuilder()
+                                .addAlgorithm(testBrotliAlgoServer,
+                                        OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                                .addAlgorithm(testBrotliAlgoServer,
+                                        OpenSslCertificateCompressionConfig.AlgorithmMode.Both).build()
                 );
             }
         });
@@ -272,8 +293,10 @@ public class OpenSslCertificateCompressionTest {
             @Override
             public void execute() throws Throwable {
                 buildClientContext(
-                        new OpenSslCertificateCompressionConfig()
-                                .addAlgorithm(testBrotliAlgoClient, SSL.SSL_CERT_COMPRESSION_DIRECTION_DECOMPRESS)
+                        OpenSslCertificateCompressionConfig.newBuilder()
+                                .addAlgorithm(testBrotliAlgoClient,
+                                        OpenSslCertificateCompressionConfig.AlgorithmMode.Decompress)
+                                .build()
                 );
             }
         });
@@ -282,8 +305,10 @@ public class OpenSslCertificateCompressionTest {
             @Override
             public void execute() throws Throwable {
                 buildServerContext(
-                        new OpenSslCertificateCompressionConfig()
-                                .addAlgorithm(testBrotliAlgoServer, SSL.SSL_CERT_COMPRESSION_DIRECTION_COMPRESS)
+                        OpenSslCertificateCompressionConfig.newBuilder()
+                                .addAlgorithm(testBrotliAlgoServer,
+                                        OpenSslCertificateCompressionConfig.AlgorithmMode.Compress)
+                                .build()
                 );
             }
         });
@@ -386,7 +411,7 @@ public class OpenSslCertificateCompressionTest {
         }
     }
 
-    private static class TestCertCompressionAlgo implements CertificateCompressionAlgo {
+    private static class TestCertCompressionAlgo implements OpenSslCompressionAlgorithm {
 
         private static final int BASE_PADDING_SIZE = 10;
         public boolean compressCalled;
@@ -398,7 +423,7 @@ public class OpenSslCertificateCompressionTest {
         }
 
         @Override
-        public byte[] compress(long ctx, byte[] input) throws Exception {
+        public byte[] compress(SSLEngine engine, byte[] input) throws Exception {
             compressCalled = true;
             byte[] output = new byte[input.length + BASE_PADDING_SIZE + algorithmId];
             System.arraycopy(input, 0, output, BASE_PADDING_SIZE + algorithmId, input.length);
@@ -406,7 +431,7 @@ public class OpenSslCertificateCompressionTest {
         }
 
         @Override
-        public byte[] decompress(long ctx, int uncompressed_len, byte[] input) {
+        public byte[] decompress(SSLEngine engine, int uncompressed_len, byte[] input) {
             decompressCalled = true;
             byte[] output = new byte[input.length - (BASE_PADDING_SIZE + algorithmId)];
             System.arraycopy(input, BASE_PADDING_SIZE + algorithmId, output, 0, output.length);

--- a/pom.xml
+++ b/pom.xml
@@ -542,7 +542,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.47.Final</tcnative.version>
+    <tcnative.version>2.0.48.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -542,7 +542,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.48.Final-SNAPSHOT</tcnative.version>
+    <tcnative.version>2.0.48.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -542,7 +542,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.48.Final</tcnative.version>
+    <tcnative.version>2.0.48.Final-SNAPSHOT</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

Certificates in TLSv1.3 can be compressed but Netty does not yet support this. netty-tcnative support is available. This change provides a netty api which allows netty users to configure BoringSSL through netty-tcnative and enable certificate compression.

Modifications:

- `OpenSslCertificateCompressionConfig` class provides an interface, allowing netty users to configure netty-tcnative for certificate compression.
- Changes to `ReferenceCountedOpenSslContext` to consume and apply config.
- `OpenSslCertificateCompressionTest` to test this interface and the work done netty-tcnative

Result:

Netty provides support for certificate compression.