### PR TITLE
Refactor SizeClasses to not call private methods in the constructor

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SizeClasses.java
+++ b/buffer/src/main/java/io/netty/buffer/SizeClasses.java
@@ -40,7 +40,7 @@ import static io.netty.buffer.PoolThreadCache.*;
  *
  *   smallMaxSizeIdx: Maximum small size class index.
  *
- *   lookupMaxclass: Maximum size class included in lookup table.
+ *   lookupMaxClass: Maximum size class included in lookup table.
  *   log2NormalMinClass: Log of minimum normal size class.
  * <p>
  *   The first size class and spacing are 1 << LOG2_QUANTUM.
@@ -95,56 +95,35 @@ abstract class SizeClasses implements SizeClassesMetric {
 
     private static final byte no = 0, yes = 1;
 
-    protected SizeClasses(int pageSize, int pageShifts, int chunkSize, int directMemoryCacheAlignment) {
-        this.pageSize = pageSize;
-        this.pageShifts = pageShifts;
-        this.chunkSize = chunkSize;
-        this.directMemoryCacheAlignment = directMemoryCacheAlignment;
-
-        int group = log2(chunkSize) + 1 - LOG2_QUANTUM;
-
-        //generate size classes
-        //[index, log2Group, log2Delta, nDelta, isMultiPageSize, isSubPage, log2DeltaLookup]
-        sizeClasses = new short[group << LOG2_SIZE_CLASS_GROUP][7];
-        nSizes = sizeClasses();
-
-        //generate lookup table
-        sizeIdx2sizeTab = new int[nSizes];
-        pageIdx2sizeTab = new int[nPSizes];
-        idx2SizeTab(sizeIdx2sizeTab, pageIdx2sizeTab);
-
-        size2idxTab = new int[lookupMaxSize >> LOG2_QUANTUM];
-        size2idxTab(size2idxTab);
-    }
-
     protected final int pageSize;
     protected final int pageShifts;
     protected final int chunkSize;
     protected final int directMemoryCacheAlignment;
 
     final int nSizes;
-    int nSubpages;
-    int nPSizes;
-
-    int smallMaxSizeIdx;
-
-    private int lookupMaxSize;
-
-    private final short[][] sizeClasses;
+    final int nSubpages;
+    final int nPSizes;
+    final int lookupMaxSize;
+    final int smallMaxSizeIdx;
 
     private final int[] pageIdx2sizeTab;
 
     // lookup table for sizeIdx <= smallMaxSizeIdx
     private final int[] sizeIdx2sizeTab;
 
-    // lookup table used for size <= lookupMaxclass
-    // spacing is 1 << LOG2_QUANTUM, so the size of array is lookupMaxclass >> LOG2_QUANTUM
+    // lookup table used for size <= lookupMaxClass
+    // spacing is 1 << LOG2_QUANTUM, so the size of array is lookupMaxClass >> LOG2_QUANTUM
     private final int[] size2idxTab;
 
-    private int sizeClasses() {
-        int normalMaxSize = -1;
+    protected SizeClasses(int pageSize, int pageShifts, int chunkSize, int directMemoryCacheAlignment) {
+        int group = log2(chunkSize) + 1 - LOG2_QUANTUM;
 
-        int index = 0;
+        //generate size classes
+        //[index, log2Group, log2Delta, nDelta, isMultiPageSize, isSubPage, log2DeltaLookup]
+        short[][] sizeClasses = new short[group << LOG2_SIZE_CLASS_GROUP][7];
+
+        int normalMaxSize = -1;
+        int nSizes = 0;
         int size = 0;
 
         int log2Group = LOG2_QUANTUM;
@@ -153,40 +132,68 @@ abstract class SizeClasses implements SizeClassesMetric {
 
         //First small group, nDelta start at 0.
         //first size class is 1 << LOG2_QUANTUM
-        int nDelta = 0;
-        while (nDelta < ndeltaLimit) {
-            size = sizeClass(index++, log2Group, log2Delta, nDelta++);
+        for (int nDelta = 0; nDelta < ndeltaLimit; nDelta++, nSizes++) {
+            short[] sizeClass = newSizeClass(nSizes, log2Group, log2Delta, nDelta, pageShifts);
+            sizeClasses[nSizes] = sizeClass;
+            size = sizeOf(sizeClass, directMemoryCacheAlignment);
         }
+
         log2Group += LOG2_SIZE_CLASS_GROUP;
 
         //All remaining groups, nDelta start at 1.
-        while (size < chunkSize) {
-            nDelta = 1;
-
-            while (nDelta <= ndeltaLimit && size < chunkSize) {
-                size = sizeClass(index++, log2Group, log2Delta, nDelta++);
-                normalMaxSize = size;
+        for (; size < chunkSize; log2Group++, log2Delta++) {
+            for (int nDelta = 1; nDelta <= ndeltaLimit && size < chunkSize; nDelta++, nSizes++) {
+                short[] sizeClass = newSizeClass(nSizes, log2Group, log2Delta, nDelta, pageShifts);
+                sizeClasses[nSizes] = sizeClass;
+                size = normalMaxSize = sizeOf(sizeClass, directMemoryCacheAlignment);
             }
-
-            log2Group++;
-            log2Delta++;
         }
 
         //chunkSize must be normalMaxSize
         assert chunkSize == normalMaxSize;
 
-        //return number of size index
-        return index;
+        int smallMaxSizeIdx = 0;
+        int lookupMaxSize = 0;
+        int nPSizes = 0;
+        int nSubpages = 0;
+        for (int idx = 0; idx < nSizes; idx++) {
+            short[] sz = sizeClasses[idx];
+            if (sz[PAGESIZE_IDX] == yes) {
+                nPSizes++;
+            }
+            if (sz[SUBPAGE_IDX] == yes) {
+                nSubpages++;
+                smallMaxSizeIdx = idx;
+            }
+            if (sz[LOG2_DELTA_LOOKUP_IDX] != no) {
+                lookupMaxSize = sizeOf(sz, directMemoryCacheAlignment);
+            }
+        }
+        this.smallMaxSizeIdx = smallMaxSizeIdx;
+        this.lookupMaxSize = lookupMaxSize;
+        this.nPSizes = nPSizes;
+        this.nSubpages = nSubpages;
+        this.nSizes = nSizes;
+
+        this.pageSize = pageSize;
+        this.pageShifts = pageShifts;
+        this.chunkSize = chunkSize;
+        this.directMemoryCacheAlignment = directMemoryCacheAlignment;
+
+        //generate lookup tables
+        sizeIdx2sizeTab = newIdx2SizeTab(sizeClasses, nSizes, directMemoryCacheAlignment);
+        pageIdx2sizeTab = newPageIdx2sizeTab(sizeClasses, nSizes, nPSizes, directMemoryCacheAlignment);
+        size2idxTab = newSize2idxTab(lookupMaxSize, sizeClasses);
     }
 
     //calculate size class
-    private int sizeClass(int index, int log2Group, int log2Delta, int nDelta) {
+    private static short[] newSizeClass(int index, int log2Group, int log2Delta, int nDelta, int pageShifts) {
         short isMultiPageSize;
         if (log2Delta >= pageShifts) {
             isMultiPageSize = yes;
         } else {
             int pageSize = 1 << pageShifts;
-            int size = (1 << log2Group) + (1 << log2Delta) * nDelta;
+            int size = calculateSize(log2Group, nDelta, log2Delta);
 
             isMultiPageSize = size == size / pageSize * pageSize? yes : no;
         }
@@ -206,52 +213,51 @@ abstract class SizeClasses implements SizeClassesMetric {
                               log2Size == LOG2_MAX_LOOKUP_SIZE && remove == no
                 ? log2Delta : no;
 
-        short[] sz = {
+        return new short[] {
                 (short) index, (short) log2Group, (short) log2Delta,
                 (short) nDelta, isMultiPageSize, isSubpage, (short) log2DeltaLookup
         };
-
-        sizeClasses[index] = sz;
-        int size = (1 << log2Group) + (nDelta << log2Delta);
-
-        if (sz[PAGESIZE_IDX] == yes) {
-            nPSizes++;
-        }
-        if (sz[SUBPAGE_IDX] == yes) {
-            nSubpages++;
-            smallMaxSizeIdx = index;
-        }
-        if (sz[LOG2_DELTA_LOOKUP_IDX] != no) {
-            lookupMaxSize = size;
-        }
-        return size;
     }
 
-    private void idx2SizeTab(int[] sizeIdx2sizeTab, int[] pageIdx2sizeTab) {
-        int pageIdx = 0;
+    private static int[] newIdx2SizeTab(short[][] sizeClasses, int nSizes, int directMemoryCacheAlignment) {
+        int[] sizeIdx2sizeTab = new int[nSizes];
 
         for (int i = 0; i < nSizes; i++) {
             short[] sizeClass = sizeClasses[i];
-            int log2Group = sizeClass[LOG2GROUP_IDX];
-            int log2Delta = sizeClass[LOG2DELTA_IDX];
-            int nDelta = sizeClass[NDELTA_IDX];
-
-            int size = (1 << log2Group) + (nDelta << log2Delta);
-            if (directMemoryCacheAlignment > 0) {
-                // We need to ensure we align the size before storing it as otherwise we will use the incorrect element
-                // size when creating the PoolSubPage
-                size = alignSize(size);
-            }
-
-            sizeIdx2sizeTab[i] = size;
-
-            if (sizeClass[PAGESIZE_IDX] == yes) {
-                pageIdx2sizeTab[pageIdx++] = size;
-            }
+            sizeIdx2sizeTab[i] = sizeOf(sizeClass, directMemoryCacheAlignment);
         }
+        return sizeIdx2sizeTab;
     }
 
-    private void size2idxTab(int[] size2idxTab) {
+    private static int calculateSize(int log2Group, int nDelta, int log2Delta) {
+        return (1 << log2Group) + (nDelta << log2Delta);
+    }
+
+    private static int sizeOf(short[] sizeClass, int directMemoryCacheAlignment) {
+        int log2Group = sizeClass[LOG2GROUP_IDX];
+        int log2Delta = sizeClass[LOG2DELTA_IDX];
+        int nDelta = sizeClass[NDELTA_IDX];
+
+        int size = calculateSize(log2Group, nDelta, log2Delta);
+
+        return alignSizeIfNeeded(size, directMemoryCacheAlignment);
+    }
+
+    private static int[] newPageIdx2sizeTab(short[][] sizeClasses, int nSizes, int nPSizes,
+                                            int directMemoryCacheAlignment) {
+        int[] pageIdx2sizeTab = new int[nPSizes];
+        int pageIdx = 0;
+        for (int i = 0; i < nSizes; i++) {
+            short[] sizeClass = sizeClasses[i];
+            if (sizeClass[PAGESIZE_IDX] == yes) {
+                pageIdx2sizeTab[pageIdx++] = sizeOf(sizeClass, directMemoryCacheAlignment);
+            }
+        }
+        return pageIdx2sizeTab;
+    }
+
+    private static int[] newSize2idxTab(int lookupMaxSize, short[][] sizeClasses) {
+        int[] size2idxTab = new int[lookupMaxSize >> LOG2_QUANTUM];
         int idx = 0;
         int size = 0;
 
@@ -264,6 +270,7 @@ abstract class SizeClasses implements SizeClassesMetric {
                 size = idx + 1 << LOG2_QUANTUM;
             }
         }
+        return size2idxTab;
     }
 
     @Override
@@ -315,9 +322,7 @@ abstract class SizeClasses implements SizeClassesMetric {
             return nSizes;
         }
 
-        if (directMemoryCacheAlignment > 0) {
-            size = alignSize(size);
-        }
+        size = alignSizeIfNeeded(size, directMemoryCacheAlignment);
 
         if (size <= lookupMaxSize) {
             //size-1 / MIN_TINY
@@ -380,7 +385,10 @@ abstract class SizeClasses implements SizeClassesMetric {
     }
 
     // Round size up to the nearest multiple of alignment.
-    private int alignSize(int size) {
+    private static int alignSizeIfNeeded(int size, int directMemoryCacheAlignment) {
+        if (directMemoryCacheAlignment <= 0) {
+            return size;
+        }
         int delta = size & directMemoryCacheAlignment - 1;
         return delta == 0? size : size + directMemoryCacheAlignment - delta;
     }
@@ -390,10 +398,7 @@ abstract class SizeClasses implements SizeClassesMetric {
         if (size == 0) {
             return sizeIdx2sizeTab[0];
         }
-        if (directMemoryCacheAlignment > 0) {
-            size = alignSize(size);
-        }
-
+        size = alignSizeIfNeeded(size, directMemoryCacheAlignment);
         if (size <= lookupMaxSize) {
             int ret = sizeIdx2sizeTab[size2idxTab[size - 1 >> LOG2_QUANTUM]];
             assert ret == normalizeSizeCompute(size);


### PR DESCRIPTION
Motivation:

Calling non-static methods from within the constructor that belong to the instance is considered a bad practice and can cause bugs. Beside of this it also has the side effect that we can not define all the fields final even tho these are not modified outside of the constructor.

Modifications:

- Refactor SizeClasses such so it will only use static methods from within its constructor
- Declare everything final that can
- Share some code

Result:

Cleaner / more optimal code that is also easier to maintain