### PR TITLE
Provide clarifications why SNI hostname has to be FQDN

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -478,7 +478,13 @@ final class SslUtils {
      * Validate that the given hostname can be used in SNI extension.
      */
     static boolean isValidHostNameForSNI(String hostname) {
+        /*
+         * These checks are based on sun.security.ssl.Utilities#rawToSNIHostName implementation
+         * [1] https://datatracker.ietf.org/doc/html/rfc6066#section-3
+         */
         return hostname != null &&
+               // SNI HostName has to be a FQDN according to TLS SNI Extension spec (see [1]),
+               // which means that is has to have at least a host name and a domain part.
                hostname.indexOf('.') > 0 &&
                !hostname.endsWith(".") && !hostname.startsWith("/") &&
                !NetUtil.isValidIpV4Address(hostname) &&

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -478,10 +478,7 @@ final class SslUtils {
      * Validate that the given hostname can be used in SNI extension.
      */
     static boolean isValidHostNameForSNI(String hostname) {
-        /*
-         * These checks are based on sun.security.ssl.Utilities#rawToSNIHostName implementation
-         * [1] https://datatracker.ietf.org/doc/html/rfc6066#section-3
-         */
+        // See  https://datatracker.ietf.org/doc/html/rfc6066#section-3
         return hostname != null &&
                // SNI HostName has to be a FQDN according to TLS SNI Extension spec (see [1]),
                // which means that is has to have at least a host name and a domain part.

--- a/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslUtilsTest.java
@@ -103,6 +103,11 @@ public class SslUtilsTest {
 
     @Test
     public void testValidHostNameForSni() {
-        assertFalse(SslUtils.isValidHostNameForSNI("/test.de"));
+        assertFalse(SslUtils.isValidHostNameForSNI("/test.de"), "SNI domain can't start with /");
+        assertFalse(SslUtils.isValidHostNameForSNI("test.de."), "SNI domain can't end with a dot/");
+        assertTrue(SslUtils.isValidHostNameForSNI("test.de"));
+        // see https://datatracker.ietf.org/doc/html/rfc6066#section-3
+        // it has to be test.local to qualify as SNI
+        assertFalse(SslUtils.isValidHostNameForSNI("test"), "SNI has to be FQDN");
     }
 }


### PR DESCRIPTION
Motivation:

It's not immediately clear why Netty discards non fully qualified domain names from the SNI extension and it may look like a bug.

Modification:

Provided clarifications why SNI hostname has to be FQDN with links to the RFC

Result:

Related to #12005
