### PR TITLE
Check and skip if post parameter name is empty.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -556,7 +556,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
-                        // Some wired request body starts with a '&' char, eg: &name=J&age=17.
+                        // Some weird request bodies starts with an '&' char, eg: &name=J&age=17.
                         // In that case, key would be "", will get exception: java.lang.IllegalArgumentException: Param 'name' must not be empty;
                         // Just check and skip empty key.
                         if (key.length() > 0) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -431,9 +431,14 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
-                        currentAttribute = factory.createAttribute(request, key);
-                        currentAttribute.setValue(""); // empty
-                        addHttpData(currentAttribute);
+                        // Some wired request body starts with a '&' char, eg: &name=J&age=17.
+                        // In that case, key would be "", will get exception: java.lang.IllegalArgumentException: Param 'name' must not be empty;
+                        // Just check and skip empty key.
+                        if (key.length() > 0) {
+                            currentAttribute = factory.createAttribute(request, key);
+                            currentAttribute.setValue(""); // empty
+                            addHttpData(currentAttribute);
+                        }
                         currentAttribute = null;
                         firstpos = currentpos;
                         contRead = true;
@@ -551,9 +556,14 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
-                        currentAttribute = factory.createAttribute(request, key);
-                        currentAttribute.setValue(""); // empty
-                        addHttpData(currentAttribute);
+                        // Some wired request body starts with a '&' char, eg: &name=J&age=17.
+                        // In that case, key would be "", will get exception: java.lang.IllegalArgumentException: Param 'name' must not be empty;
+                        // Just check and skip empty key.
+                        if (key.length() > 0) {
+                            currentAttribute = factory.createAttribute(request, key);
+                            currentAttribute.setValue(""); // empty
+                            addHttpData(currentAttribute);
+                        }
                         currentAttribute = null;
                         firstpos = currentpos;
                         contRead = true;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -432,7 +432,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
                         // Some weird request bodies start with an '&' character, eg: &name=J&age=17.
-                        // In that case, key would be "", will get exception: 
+                        // In that case, key would be "", will get exception:
                         // java.lang.IllegalArgumentException: Param 'name' must not be empty;
                         // Just check and skip empty key.
                         if (key.length() > 0) {
@@ -558,7 +558,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
                         // Some weird request bodies start with an '&' char, eg: &name=J&age=17.
-                        // In that case, key would be "", will get exception: 
+                        // In that case, key would be "", will get exception:
                         // java.lang.IllegalArgumentException: Param 'name' must not be empty;
                         // Just check and skip empty key.
                         if (key.length() > 0) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -431,8 +431,9 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
-                        // Some weird request bodies starts with an '&' character, eg: &name=J&age=17.
-                        // In that case, key would be "", will get exception: java.lang.IllegalArgumentException: Param 'name' must not be empty;
+                        // Some weird request bodies start with an '&' character, eg: &name=J&age=17.
+                        // In that case, key would be "", will get exception: 
+                        // java.lang.IllegalArgumentException: Param 'name' must not be empty;
                         // Just check and skip empty key.
                         if (key.length() > 0) {
                             currentAttribute = factory.createAttribute(request, key);
@@ -556,8 +557,9 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
-                        // Some weird request bodies starts with an '&' char, eg: &name=J&age=17.
-                        // In that case, key would be "", will get exception: java.lang.IllegalArgumentException: Param 'name' must not be empty;
+                        // Some weird request bodies start with an '&' char, eg: &name=J&age=17.
+                        // In that case, key would be "", will get exception: 
+                        // java.lang.IllegalArgumentException: Param 'name' must not be empty;
                         // Just check and skip empty key.
                         if (key.length() > 0) {
                             currentAttribute = factory.createAttribute(request, key);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -431,7 +431,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
-                        // Some wired request body starts with a '&' char, eg: &name=J&age=17.
+                        // Some weird request bodies starts with an '&' character, eg: &name=J&age=17.
                         // In that case, key would be "", will get exception: java.lang.IllegalArgumentException: Param 'name' must not be empty;
                         // Just check and skip empty key.
                         if (key.length() > 0) {


### PR DESCRIPTION
Motivation:
Some weird request bodies start with an '&' character, eg: &name=J&age=17.
In that case, key would be "", will get an exception: java.lang.IllegalArgumentException: Param 'name' must not be empty;
Just check and skip empty key.

Modification:
Check if name is empty before create an Attribute

Result:

Signed-off-by: hailin84 myumen@gmail.com