### PR TITLE
Use BeforeAll instead of static block to load Brotli4j library

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -47,14 +47,18 @@ public class BrotliDecoderTest {
     private static byte[] COMPRESSED_BYTES_LARGE;
 
     @BeforeAll
-    static void setUp() throws IOException {
-        assumeTrue(Brotli.isAvailable());
+    static void setUp() {
+        try {
+            Brotli.ensureAvailability();
 
-        RANDOM = new Random();
-        fillArrayWithCompressibleData(BYTES_SMALL);
-        fillArrayWithCompressibleData(BYTES_LARGE);
-        COMPRESSED_BYTES_SMALL = compress(BYTES_SMALL);
-        COMPRESSED_BYTES_LARGE = compress(BYTES_LARGE);
+            RANDOM = new Random();
+            fillArrayWithCompressibleData(BYTES_SMALL);
+            fillArrayWithCompressibleData(BYTES_LARGE);
+            COMPRESSED_BYTES_SMALL = compress(BYTES_SMALL);
+            COMPRESSED_BYTES_LARGE = compress(BYTES_LARGE);
+        } catch (Throwable throwable) {
+            throw new ExceptionInInitializerError(throwable);
+        }
     }
 
     private static final ByteBuf WRAPPED_BYTES_SMALL = Unpooled.unreleasableBuffer(

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,27 +35,26 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @DisabledIf(value = "isNotSupported", disabledReason = "Brotli is not supported on this platform")
 public class BrotliDecoderTest {
 
-    private static final Random RANDOM;
+    private static Random RANDOM;
     private static final byte[] BYTES_SMALL = new byte[256];
     private static final byte[] BYTES_LARGE = new byte[256 * 1024];
-    private static final byte[] COMPRESSED_BYTES_SMALL;
-    private static final byte[] COMPRESSED_BYTES_LARGE;
+    private static byte[] COMPRESSED_BYTES_SMALL;
+    private static byte[] COMPRESSED_BYTES_LARGE;
 
-    static {
-        try {
-            Brotli.ensureAvailability();
-            RANDOM = new Random();
-            fillArrayWithCompressibleData(BYTES_SMALL);
-            fillArrayWithCompressibleData(BYTES_LARGE);
-            COMPRESSED_BYTES_SMALL = compress(BYTES_SMALL);
-            COMPRESSED_BYTES_LARGE = compress(BYTES_LARGE);
-        } catch (Throwable throwable) {
-            throw new ExceptionInInitializerError(throwable);
-        }
+    @BeforeAll
+    static void setUp() throws IOException {
+        assumeTrue(Brotli.isAvailable());
+
+        RANDOM = new Random();
+        fillArrayWithCompressibleData(BYTES_SMALL);
+        fillArrayWithCompressibleData(BYTES_LARGE);
+        COMPRESSED_BYTES_SMALL = compress(BYTES_SMALL);
+        COMPRESSED_BYTES_LARGE = compress(BYTES_LARGE);
     }
 
     private static final ByteBuf WRAPPED_BYTES_SMALL = Unpooled.unreleasableBuffer(

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
@@ -23,17 +23,19 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.PlatformDependent;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.DisabledIf;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @DisabledIf(value = "isNotSupported", disabledReason = "Brotli is not supported on this platform")
 public class BrotliEncoderTest extends AbstractEncoderTest {
 
-    static {
-        try {
-            Brotli.ensureAvailability();
-        } catch (Throwable throwable) {
-            throw new ExceptionInInitializerError(throwable);
-        }
+    @BeforeAll
+    static void setUp() {
+        assumeTrue(Brotli.isAvailable());
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
@@ -23,9 +23,7 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.PlatformDependent;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.DisabledIf;
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue;

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
@@ -26,14 +26,16 @@ import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 @DisabledIf(value = "isNotSupported", disabledReason = "Brotli is not supported on this platform")
 public class BrotliEncoderTest extends AbstractEncoderTest {
 
     @BeforeAll
     static void setUp() {
-        assumeTrue(Brotli.isAvailable());
+        try {
+            Brotli.ensureAvailability();
+        } catch (Throwable throwable) {
+            throw new ExceptionInInitializerError(throwable);
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:
As of today, Brotli4j does not support macOS aarch64. Currently, in `BrotliEncoderTest`, we use the static block to load the Brotli4j library. However, this could lead to failure when performing this action on macOS aarch64.

The `DisabledIf` loads the `BrotliEncoderTest` class to see if the platform is supported or not. Loading this class triggers the static block which eventually leads to `ExceptionInInitializerError`.

Modification:
Use `BeforeAll` instead of static block.

Result:
Fixes #12024
