### PR TITLE
Add RecvBufferAllocator API for allocating Buffer instances

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/TestChannelInitializer.java
@@ -18,6 +18,8 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandler;
@@ -66,6 +68,11 @@ public class TestChannelInitializer extends ChannelInitializer<Channel> {
                 @Override
                 public ByteBuf allocate(ByteBufAllocator alloc) {
                     return alloc.ioBuffer(guess(), guess());
+                }
+
+                @Override
+                public Buffer allocate(BufferAllocator alloc) {
+                    return alloc.allocate(guess());
                 }
 
                 @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -20,6 +20,8 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandler;
@@ -167,9 +169,15 @@ public class SocketAutoReadTest extends AbstractSocketTest {
                 private ChannelConfig config;
                 private int attemptedBytesRead;
                 private int lastBytesRead;
+
                 @Override
                 public ByteBuf allocate(ByteBufAllocator alloc) {
                     return alloc.ioBuffer(guess(), guess());
+                }
+
+                @Override
+                public Buffer allocate(BufferAllocator alloc) {
+                    return alloc.allocate(guess());
                 }
 
                 @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -19,6 +19,8 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFutureListeners;
@@ -622,6 +624,11 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 @Override
                 public ByteBuf allocate(ByteBufAllocator alloc) {
                     return alloc.ioBuffer(guess(), guess());
+                }
+
+                @Override
+                public Buffer allocate(BufferAllocator alloc) {
+                    return alloc.allocate(guess());
                 }
 
                 @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
@@ -20,6 +20,8 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandler;
@@ -147,9 +149,15 @@ public class SocketReadPendingTest extends AbstractSocketTest {
                 private int attemptedBytesRead;
                 private int lastBytesRead;
                 private int numMessagesRead;
+
                 @Override
                 public ByteBuf allocate(ByteBufAllocator alloc) {
                     return alloc.ioBuffer(guess(), guess());
+                }
+
+                @Override
+                public Buffer allocate(BufferAllocator alloc) {
+                    return alloc.allocate(guess());
                 }
 
                 @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvBufferAllocatorHandle.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollRecvBufferAllocatorHandle.java
@@ -17,6 +17,10 @@ package io.netty.channel.epoll;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.DefaultBufferAllocators;
+import io.netty.buffer.api.StandardAllocationTypes;
 import io.netty.channel.RecvBufferAllocator.DelegatingHandle;
 import io.netty.channel.RecvBufferAllocator.Handle;
 import io.netty.channel.unix.PreferredDirectByteBufAllocator;
@@ -58,6 +62,15 @@ class EpollRecvBufferAllocatorHandle extends DelegatingHandle {
         // We need to ensure we always allocate a direct ByteBuf as we can only use a direct buffer to read via JNI.
         preferredDirectByteBufAllocator.updateAllocator(alloc);
         return delegate().allocate(preferredDirectByteBufAllocator);
+    }
+
+    @Override
+    public Buffer allocate(BufferAllocator alloc) {
+        // We need to ensure we always allocate a direct ByteBuf as we can only use a direct buffer to read via JNI.
+        if (alloc.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+            return super.allocate(DefaultBufferAllocators.offHeapAllocator());
+        }
+        return super.allocate(alloc);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvBufferAllocator.java
@@ -17,6 +17,8 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 
 import java.util.AbstractMap;
@@ -47,6 +49,11 @@ public class DefaultMaxBytesRecvBufferAllocator implements MaxBytesRecvBufferAll
         @Override
         public ByteBuf allocate(ByteBufAllocator alloc) {
             return alloc.ioBuffer(guess());
+        }
+
+        @Override
+        public Buffer allocate(BufferAllocator alloc) {
+            return alloc.allocate(guess());
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxMessagesRecvBufferAllocator.java
@@ -19,6 +19,8 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 
 /**
@@ -118,6 +120,11 @@ public abstract class DefaultMaxMessagesRecvBufferAllocator implements MaxMessag
         @Override
         public ByteBuf allocate(ByteBufAllocator alloc) {
             return alloc.ioBuffer(guess());
+        }
+
+        @Override
+        public Buffer allocate(BufferAllocator alloc) {
+            return alloc.allocate(guess());
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/RecvBufferAllocator.java
+++ b/transport/src/main/java/io/netty/channel/RecvBufferAllocator.java
@@ -17,6 +17,8 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.util.UncheckedBooleanSupplier;
 import io.netty.util.internal.UnstableApi;
 
@@ -40,6 +42,12 @@ public interface RecvBufferAllocator {
          * enough not to waste its space.
          */
         ByteBuf allocate(ByteBufAllocator alloc);
+
+        /**
+         * Creates a new receive buffer whose capacity is probably large enough to read all inbound data and small
+         * enough not to waste its space.
+         */
+        Buffer allocate(BufferAllocator alloc);
 
         /**
          * Similar to {@link #allocate(ByteBufAllocator)} except that it does not allocate anything but just tells the
@@ -130,6 +138,11 @@ public interface RecvBufferAllocator {
 
         @Override
         public ByteBuf allocate(ByteBufAllocator alloc) {
+            return delegate.allocate(alloc);
+        }
+
+        @Override
+        public Buffer allocate(BufferAllocator alloc) {
             return delegate.allocate(alloc);
         }
 

--- a/transport/src/test/java/io/netty/channel/AdaptiveRecvBufferAllocatorTest.java
+++ b/transport/src/test/java/io/netty/channel/AdaptiveRecvBufferAllocatorTest.java
@@ -18,6 +18,8 @@ package io.netty.channel;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
 import io.netty.channel.RecvBufferAllocator.Handle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +46,7 @@ public class AdaptiveRecvBufferAllocatorTest {
 
     @Test
     public void rampUpBeforeReadCompleteWhenLargeDataPending() {
-        // Simulate that there is always more data when we attempt to read so we should always ramp up.
+        // Simulate that there is always more data when we attempt to read, so we should always ramp up.
         allocReadExpected(handle, alloc, 512);
         allocReadExpected(handle, alloc, 8192);
         allocReadExpected(handle, alloc, 131072);
@@ -53,6 +55,21 @@ public class AdaptiveRecvBufferAllocatorTest {
 
         handle.reset(config);
         allocReadExpected(handle, alloc, 8388608);
+    }
+
+    @Test
+    public void rampUpBeforeReadCompleteWhenLargeDataPendingBuffer() {
+        // Simulate that there is always more data when we attempt to read, so we should always ramp up.
+        try (BufferAllocator alloc = BufferAllocator.onHeapUnpooled()) {
+            allocReadExpected(handle, alloc, 512);
+            allocReadExpected(handle, alloc, 8192);
+            allocReadExpected(handle, alloc, 131072);
+            allocReadExpected(handle, alloc, 2097152);
+            handle.readComplete();
+
+            handle.reset(config);
+            allocReadExpected(handle, alloc, 8388608);
+        }
     }
 
     @Test
@@ -88,6 +105,20 @@ public class AdaptiveRecvBufferAllocatorTest {
     }
 
     @Test
+    public void lastPartialReadDoesNotRampDownBuffer() {
+        try (BufferAllocator alloc = BufferAllocator.onHeapUnpooled()) {
+            allocReadExpected(handle, alloc, 512);
+            // Simulate there is just 1 byte remaining which is unread. However, the total bytes in the current read
+            // cycle means that we should stay at the current step for the next ready cycle.
+            allocRead(handle, alloc, 8192, 1);
+            handle.readComplete();
+
+            handle.reset(config);
+            allocReadExpected(handle, alloc, 8192);
+        }
+    }
+
+    @Test
     public void lastPartialReadCanRampUp() {
         allocReadExpected(handle, alloc, 512);
         // We simulate there is just 1 less byte than we try to read, but because of the adaptive steps the total amount
@@ -97,6 +128,20 @@ public class AdaptiveRecvBufferAllocatorTest {
 
         handle.reset(config);
         allocReadExpected(handle, alloc, 131072);
+    }
+
+    @Test
+    public void lastPartialReadCanRampUpBuffer() {
+        try (BufferAllocator alloc = BufferAllocator.onHeapUnpooled()) {
+            allocReadExpected(handle, alloc, 512);
+            // We simulate there is just 1 less byte than we try to read, but because of the adaptive steps the total
+            // amount of bytes read for this read cycle steps up to prepare for the next read cycle.
+            allocRead(handle, alloc, 8192, 8191);
+            handle.readComplete();
+
+            handle.reset(config);
+            allocReadExpected(handle, alloc, 131072);
+        }
     }
 
     private static void allocReadExpected(Handle handle, ByteBufAllocator alloc, int expectedSize) {
@@ -110,5 +155,18 @@ public class AdaptiveRecvBufferAllocatorTest {
         handle.lastBytesRead(lastRead);
         handle.incMessagesRead(1);
         buf.release();
+    }
+
+    private static void allocReadExpected(Handle handle, BufferAllocator alloc, int expectedSize) {
+        allocRead(handle, alloc, expectedSize, expectedSize);
+    }
+
+    private static void allocRead(Handle handle, BufferAllocator alloc, int expectedBufferSize, int lastRead) {
+        try (Buffer buf = handle.allocate(alloc)) {
+            assertEquals(expectedBufferSize, buf.capacity());
+            handle.attemptedBytesRead(expectedBufferSize);
+            handle.lastBytesRead(lastRead);
+            handle.incMessagesRead(1);
+        }
     }
 }


### PR DESCRIPTION
Motivation:
In order for transports to be able to read into new-api Buffers, we need the RecvBufferAllocator to be able to allocate such buffers.

Modification:
Add an allocate overload to RecvBufferAllocator.Handle that take a BufferAllocator and return a Buffer.
Update all implementing classes to support this new API, in addition to the existing ByteBuf API.

Result:
Our RecvBufferAllocator implementations can now allocate Buffers, in addition to ByteBufs.