### PR TITLE
Use correct exception message to notify about handler removal before …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -682,7 +682,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
             SSLException cause = null;
 
-            // If the handshake is not done yet we should fail the handshake promise and notify the rest of the
+            // If the handshake or SSLEngine closure is not done yet we should fail corresponding promise and notify the rest of the
             // pipeline.
             if (!handshakePromise.isDone()) {
                 cause = new SSLHandshakeException("SslHandler removed before handshake completed");

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -692,7 +692,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
             if (!sslClosePromise.isDone()) {
                 if (cause == null) {
-                    cause = new SSLHandshakeException("SslHandler removed before handshake completed");
+                    cause = new SSLHandshakeException("SslHandler removed before SSLEngine was closed");
                 }
                 notifyClosePromise(cause);
             }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -680,7 +680,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
             pendingUnencryptedWrites = null;
 
-            SSLHandshakeException cause = null;
+            SSLException cause = null;
 
             // If the handshake is not done yet we should fail the handshake promise and notify the rest of the
             // pipeline.
@@ -692,7 +692,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
             if (!sslClosePromise.isDone()) {
                 if (cause == null) {
-                    cause = new SSLHandshakeException("SslHandler removed before SSLEngine was closed");
+                    cause = new SSLException("SslHandler removed before SSLEngine was closed");
                 }
                 notifyClosePromise(cause);
             }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -682,7 +682,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
             SSLException cause = null;
 
-            // If the handshake or SSLEngine closure is not done yet we should fail corresponding promise and notify the rest of the
+            // If the handshake or SSLEngine closure is not done yet we should fail corresponding promise and
+            // notify the rest of the
             // pipeline.
             if (!handshakePromise.isDone()) {
                 cause = new SSLHandshakeException("SslHandler removed before handshake completed");


### PR DESCRIPTION
…engine was closed

Motivation:

We used a wrong exception msg when the handler was removed but the engine was not closeed yet. This is confusing for the user.

Modifications:

Fix exception message.

Result:

Fixes https://github.com/netty/netty/issues/12027
