### PR TITLE
Propagate BindException in DnsNameResolver

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -120,24 +120,32 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
     }
 
     private void sendQuery(final DnsQuery query, final boolean flush, final ChannelPromise writePromise) {
-        if (parent.channelFuture.isDone()) {
+        if (parent.channelReadyPromise.isSuccess()) {
             writeQuery(query, flush, writePromise);
         } else {
-            parent.channelFuture.addListener(new GenericFutureListener<Future<? super Channel>>() {
-                @Override
-                public void operationComplete(Future<? super Channel> future) {
-                    if (future.isSuccess()) {
-                        // If the query is done in a late fashion (as the channel was not ready yet) we always flush
-                        // to ensure we did not race with a previous flush() that was done when the Channel was not
-                        // ready yet.
-                        writeQuery(query, true, writePromise);
-                    } else {
-                        Throwable cause = future.cause();
-                        promise.tryFailure(cause);
-                        writePromise.setFailure(cause);
+            Throwable cause = parent.channelReadyPromise.cause();
+            if (cause != null) {
+                // the promise failed before so we should also fail this query.
+                promise.tryFailure(cause);
+                writePromise.setFailure(cause);
+            } else {
+                // The promise is not complete yet, let's delay the query.
+                parent.channelReadyPromise.addListener(new GenericFutureListener<Future<? super Channel>>() {
+                    @Override
+                    public void operationComplete(Future<? super Channel> future) {
+                        if (future.isSuccess()) {
+                            // If the query is done in a late fashion (as the channel was not ready yet) we always flush
+                            // to ensure we did not race with a previous flush() that was done when the Channel was not
+                            // ready yet.
+                            writeQuery(query, true, writePromise);
+                        } else {
+                            Throwable cause = future.cause();
+                            promise.tryFailure(cause);
+                            writePromise.setFailure(cause);
+                        }
                     }
-                }
-            });
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

If a user binds the DnsNameResolver to an address that is already in use we should include this as a cause of the failure so its easy to spot whats wrong

Modifications:

- Correctly propagate the BindException
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/12001