### PR TITLE
ByteBuffer from component iteration must keep unsafe memory alive

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/WrappedUnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedUnpooledUnsafeDirectByteBuf.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 final class WrappedUnpooledUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
 
     WrappedUnpooledUnsafeDirectByteBuf(ByteBufAllocator alloc, long memoryAddress, int size, boolean doFree) {
-        super(alloc, PlatformDependent.directBuffer(memoryAddress, size), size, doFree);
+        super(alloc, PlatformDependent.directBuffer(memoryAddress, size, null), size, doFree);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/ReadableComponent.java
+++ b/buffer/src/main/java/io/netty/buffer/api/ReadableComponent.java
@@ -103,5 +103,4 @@ public interface ReadableComponent {
      * @see Buffer#openCursor()
      */
     ByteCursor openCursor();
-    // todo for Unsafe-based impl, DBB.attachment needs to keep underlying memory alive
 }

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -534,7 +534,7 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         if (hasReadableArray()) {
             buf = bbslice(ByteBuffer.wrap(readableArray()), readableArrayOffset(), readableArrayLength());
         } else {
-            buf = PlatformDependent.directBuffer(address + roff, readableBytes());
+            buf = PlatformDependent.directBuffer(address + roff, readableBytes(), memory);
         }
         return buf.asReadOnlyBuffer();
     }
@@ -578,7 +578,7 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
         if (hasWritableArray()) {
             buf = bbslice(ByteBuffer.wrap(writableArray()), writableArrayOffset(), writableArrayLength());
         } else {
-            buf = PlatformDependent.directBuffer(address + woff, writableBytes());
+            buf = PlatformDependent.directBuffer(address + woff, writableBytes(), memory);
         }
         return buf;
     }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -404,9 +404,9 @@ public final class PlatformDependent {
         return PlatformDependent0.directBufferAddress(buffer);
     }
 
-    public static ByteBuffer directBuffer(long memoryAddress, int size) {
+    public static ByteBuffer directBuffer(long memoryAddress, int size, Object attachment) {
         if (PlatformDependent0.hasDirectBufferNoCleanerConstructor()) {
-            return PlatformDependent0.newDirectBuffer(memoryAddress, size);
+            return PlatformDependent0.newDirectBuffer(memoryAddress, size, attachment);
         }
         throw new UnsupportedOperationException(
                 "sun.misc.Unsafe or java.nio.DirectByteBuffer.<init>(long, int) not available");

--- a/common/src/test/java/io/netty/util/internal/PlatformDependent0Test.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependent0Test.java
@@ -44,14 +44,14 @@ public class PlatformDependent0Test {
 
     @Test
     public void testNewDirectBufferZeroMemoryAddress() {
-        PlatformDependent0.newDirectBuffer(0, 10);
+        PlatformDependent0.newDirectBuffer(0, 10, null);
     }
 
     private static void testNewDirectBufferMemoryAddress(long address) {
         assumeTrue(PlatformDependent0.hasDirectBufferNoCleanerConstructor());
 
         int capacity = 10;
-        ByteBuffer buffer = PlatformDependent0.newDirectBuffer(address, capacity);
+        ByteBuffer buffer = PlatformDependent0.newDirectBuffer(address, capacity, null);
         assertEquals(address, PlatformDependent0.directBufferAddress(buffer));
         assertEquals(capacity, buffer.capacity());
     }


### PR DESCRIPTION
Motivation:
It is possible to use forEachReadable or forEachWritable to create a ByteBuffer that is backed by native memory from a Buffer.
If we are using Unsafe, then we cannot rely on the underlying ByteBuffer implementation to keep the native memory alive for as long as it is accessible.
We must guard against the situation where forEachReadable/Writable is used on an UnsafeBuffer, then a readable/writeableBuffer is created, and this buffer is siphoned out of the iteration, and then kept alive for longer than the UnsafeBuffer.
We can only keep the UnsafeMemory alive, though.
We cannot guard against use-after-free, because we don't have a way to nerf a ByteBuffer once it has been released.

Modification:
Change the PlatformDependent.directBuffer method to take an attachment object, and pass it to the DirectByteBuffer constructor.
Then use this from the UnsafeBuffer *Component implementation to ensure that the underlying UnsafeMemory is kept alive and strongly reachable by any ByteBuffer instances we create.

Result:
Reduce the possibility of causing JVM crash through misuse of the ability to get ByteBuffers out of an UnsafeBuffer.