### PR TITLE
Avoid producing heap dumps from *expected* OOME when running tests locally

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
@@ -271,6 +272,12 @@ public class FastThreadLocalTest {
         }
     }
 
+    @EnabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "" +
+            "This deliberately causes OutOfMemoryErrors, for which heap dumps are automatically generated. " +
+            "To avoid confusion, wasted time investigating heap dumps, and to avoid heap dumps accidentally " +
+            "getting committed to the Git repository, we should only enable this test when running in a CI " +
+            "environment. We make this check by assuming a 'CI' environment variable. " +
+            "This matches what Github Actions is doing for us currently.")
     @Test
     public void testInternalThreadLocalMapExpand() throws Exception {
         final AtomicReference<Throwable> throwable = new AtomicReference<Throwable>();


### PR DESCRIPTION
Motivation:
We have a test that deliberately causes an OutOfMemoryError.
We also tell our test JVMs to produce heap dumps if they encounter an OOME.
To avoid wasting time investigating these, we should disable this test when we run tests locally.

Modification:
Use the EnabledIfEnvironmentVariable annotation from JUnit 5, to disable FastThreadLocalTest.testInternalThreadLocalMapExpand unless there's a `CI=true` environment variable present.

Result:
This test no longer runs locally, but should still run in our Github Actions, which define such an environment variable by default.
