### PR TITLE
Make it possible to move read-/write-offset from buffer components

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -124,14 +124,11 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * Set the reader offset to {@code readerOffset() + delta}.
      *
      * @param delta to accumulate.
-     * @return This Buffer.
      * @throws IndexOutOfBoundsException if the new reader offset is less than zero or greater than the current
      * {@link #writerOffset()}.
      * @throws BufferClosedException if this buffer is closed.
      */
-    default Buffer skipReadable(int delta) {
-        return readerOffset(readerOffset() + delta);
-    }
+    void skipReadable(int delta);
 
     /**
      * Set the reader offset. Make the next read happen from the given offset into the buffer.
@@ -155,15 +152,12 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * Set the write offset to {@code writerOffset() + delta}.
      *
      * @param delta to accumulate.
-     * @return This Buffer.
      * @throws IndexOutOfBoundsException if the new writer offset is less than the current {@link #readerOffset()} or
      * greater than {@link #capacity()}.
      * @throws BufferClosedException if this buffer is closed.
      * @throws BufferReadOnlyException if this buffer is {@linkplain #readOnly() read-only}.
      */
-    default Buffer skipWritable(int delta) {
-        return writerOffset(writerOffset() + delta);
-    }
+    void skipWritable(int delta);
 
     /**
      * Set the writer offset. Make the next write happen at the given offset.

--- a/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
@@ -48,6 +48,11 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public void skipReadable(int delta) {
+        readerOffset(readerOffset() + delta);
+    }
+
+    @Override
     public Buffer readerOffset(int offset) {
         return delegate.readerOffset(offset);
     }
@@ -55,6 +60,11 @@ public class BufferStub implements Buffer {
     @Override
     public int writerOffset() {
         return delegate.writerOffset();
+    }
+
+    @Override
+    public void skipWritable(int delta) {
+        writerOffset(writerOffset() + delta);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -320,6 +320,16 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
+    public void skipReadable(int delta) {
+        readerOffset(readerOffset() + delta);
+    }
+
+    @Override
+    public void skipWritable(int delta) {
+        writerOffset(writerOffset() + delta);
+    }
+
+    @Override
     public CompositeBuffer fill(byte value) {
         if (closed) {
             throw bufferIsClosed(this);

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -805,7 +805,13 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         int visited = 0;
         for (Buffer buf : bufs) {
             if (buf.readableBytes() > 0) {
+                int roffBefore = buf.readerOffset();
                 int count = buf.forEachReadable(visited + initialIndex, processor);
+                int roffAfter = buf.readerOffset();
+                if (roffAfter != roffBefore) { // Check if ReadableComponent.addBytesRead was called.
+                    buf.readerOffset(roffBefore); // Reset component offset.
+                    skipReadable(roffAfter - roffBefore); // Then move *composite* buffer offset.
+                }
                 if (count > 0) {
                     visited += count;
                 } else {
@@ -824,7 +830,13 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         int visited = 0;
         for (Buffer buf : bufs) {
             if (buf.writableBytes() > 0) {
+                int woffBefore = buf.writerOffset();
                 int count = buf.forEachWritable(visited + initialIndex, processor);
+                int woffAfter = buf.writerOffset();
+                if (woffAfter != woffBefore) { // Check if WritableComponent.addBytesWritten was called.
+                    buf.writerOffset(woffBefore);
+                    skipWritable(woffAfter - woffBefore);
+                }
                 if (count > 0) {
                     visited += count;
                 } else {

--- a/buffer/src/main/java/io/netty/buffer/api/MemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/MemoryManager.java
@@ -141,7 +141,8 @@ public interface MemoryManager {
         ManagedBufferAllocator allocator = new ManagedBufferAllocator(manager, false);
         WrappingAllocation allocationType = new WrappingAllocation(array);
         Buffer buffer = manager.allocateShared(allocator, array.length, manager.drop(), allocationType);
-        return buffer.skipWritable(array.length).makeReadOnly();
+        buffer.skipWritable(array.length);
+        return buffer.makeReadOnly();
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/api/ReadableComponent.java
+++ b/buffer/src/main/java/io/netty/buffer/api/ReadableComponent.java
@@ -97,10 +97,17 @@ public interface ReadableComponent {
      * <p>
      * Care should be taken to ensure that the buffers lifetime extends beyond the cursor and the iteration, and that
      * the internal offsets of the component (such as {@link Buffer#readerOffset()} and {@link Buffer#writerOffset()})
-     * are not modified while the iteration takes place. Otherwise unpredictable behaviour might result.
+     * are not modified while the iteration takes place. Otherwise, unpredictable behaviour might result.
      *
      * @return A {@link ByteCursor} for iterating the readable bytes of this buffer.
      * @see Buffer#openCursor()
      */
     ByteCursor openCursor();
+
+    /**
+     * Move the read-offset to indicate that the given number of bytes were read from this component.
+     *
+     * @param byteCount The positive number of bytes read from this component.
+     */
+    void addBytesRead(int byteCount);
 }

--- a/buffer/src/main/java/io/netty/buffer/api/ReadableComponent.java
+++ b/buffer/src/main/java/io/netty/buffer/api/ReadableComponent.java
@@ -107,7 +107,8 @@ public interface ReadableComponent {
     /**
      * Move the read-offset to indicate that the given number of bytes were read from this component.
      *
-     * @param byteCount The positive number of bytes read from this component.
+     * @param byteCount The number of bytes read from this component.
+     * @see Buffer#skipReadable(int)
      */
-    void addBytesRead(int byteCount);
+    void skipReadable(int byteCount);
 }

--- a/buffer/src/main/java/io/netty/buffer/api/WritableComponent.java
+++ b/buffer/src/main/java/io/netty/buffer/api/WritableComponent.java
@@ -82,7 +82,8 @@ public interface WritableComponent {
     /**
      * Move the write-offset to indicate that the given number of bytes were written to this component.
      *
-     * @param byteCount The positive number of bytes written to this component.
+     * @param byteCount The number of bytes written to this component.
+     * @see Buffer#skipWritable(int)
      */
-    void addBytesWritten(int byteCount);
+    void skipWritable(int byteCount);
 }

--- a/buffer/src/main/java/io/netty/buffer/api/WritableComponent.java
+++ b/buffer/src/main/java/io/netty/buffer/api/WritableComponent.java
@@ -78,4 +78,11 @@ public interface WritableComponent {
      * @return A new {@link ByteBuffer}, with its own position and limit, for this memory component.
      */
     ByteBuffer writableBuffer();
+
+    /**
+     * Move the write-offset to indicate that the given number of bytes were written to this component.
+     *
+     * @param byteCount The positive number of bytes written to this component.
+     */
+    void addBytesWritten(int byteCount);
 }

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -434,6 +434,14 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     }
 
     @Override
+    public void addBytesRead(int byteCount) {
+        if (byteCount < 0) {
+            throw new IndexOutOfBoundsException("Cannot mark a negative amount of bytes as read: " + byteCount);
+        }
+        skipReadable(byteCount);
+    }
+
+    @Override
     public ByteBuffer readableBuffer() {
         return bbslice(rmem.asReadOnlyBuffer(), readerOffset(), readableBytes());
     }
@@ -461,6 +469,14 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     @Override
     public long writableNativeAddress() {
         return nativeAddress();
+    }
+
+    @Override
+    public void addBytesWritten(int byteCount) {
+        if (byteCount < 0) {
+            throw new IndexOutOfBoundsException("Cannot mark a negative amount of bytes as written: " + byteCount);
+        }
+        skipWritable(byteCount);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -122,6 +122,16 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     }
 
     @Override
+    public void skipReadable(int delta) {
+        readerOffset(readerOffset() + delta);
+    }
+
+    @Override
+    public void skipWritable(int delta) {
+        writerOffset(writerOffset() + delta);
+    }
+
+    @Override
     public Buffer fill(byte value) {
         int capacity = capacity();
         checkSet(0, capacity);
@@ -434,14 +444,6 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     }
 
     @Override
-    public void addBytesRead(int byteCount) {
-        if (byteCount < 0) {
-            throw new IndexOutOfBoundsException("Cannot mark a negative amount of bytes as read: " + byteCount);
-        }
-        skipReadable(byteCount);
-    }
-
-    @Override
     public ByteBuffer readableBuffer() {
         return bbslice(rmem.asReadOnlyBuffer(), readerOffset(), readableBytes());
     }
@@ -469,14 +471,6 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     @Override
     public long writableNativeAddress() {
         return nativeAddress();
-    }
-
-    @Override
-    public void addBytesWritten(int byteCount) {
-        if (byteCount < 0) {
-            throw new IndexOutOfBoundsException("Cannot mark a negative amount of bytes as written: " + byteCount);
-        }
-        skipWritable(byteCount);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -529,6 +529,14 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     }
 
     @Override
+    public void addBytesRead(int byteCount) {
+        if (byteCount < 0) {
+            throw new IndexOutOfBoundsException("Cannot mark a negative amount of bytes as read: " + byteCount);
+        }
+        skipReadable(byteCount);
+    }
+
+    @Override
     public ByteBuffer readableBuffer() {
         final ByteBuffer buf;
         if (hasReadableArray()) {
@@ -570,6 +578,14 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     @Override
     public long writableNativeAddress() {
         return nativeAddress();
+    }
+
+    @Override
+    public void addBytesWritten(int byteCount) {
+        if (byteCount < 0) {
+            throw new IndexOutOfBoundsException("Cannot mark a negative amount of bytes as written: " + byteCount);
+        }
+        skipWritable(byteCount);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -131,6 +131,16 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     }
 
     @Override
+    public void skipReadable(int delta) {
+        readerOffset(readerOffset() + delta);
+    }
+
+    @Override
+    public void skipWritable(int delta) {
+        writerOffset(writerOffset() + delta);
+    }
+
+    @Override
     public Buffer fill(byte value) {
         checkSet(0, capacity());
         if (rsize == CLOSED_SIZE) {
@@ -529,14 +539,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     }
 
     @Override
-    public void addBytesRead(int byteCount) {
-        if (byteCount < 0) {
-            throw new IndexOutOfBoundsException("Cannot mark a negative amount of bytes as read: " + byteCount);
-        }
-        skipReadable(byteCount);
-    }
-
-    @Override
     public ByteBuffer readableBuffer() {
         final ByteBuffer buf;
         if (hasReadableArray()) {
@@ -578,14 +580,6 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     @Override
     public long writableNativeAddress() {
         return nativeAddress();
-    }
-
-    @Override
-    public void addBytesWritten(int byteCount) {
-        if (byteCount < 0) {
-            throw new IndexOutOfBoundsException("Cannot mark a negative amount of bytes as written: " + byteCount);
-        }
-        skipWritable(byteCount);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferComponentIterationTest.java
@@ -384,4 +384,55 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             }
         }
     }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void forEachReadableMustBeAbleToIncrementReaderOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8);
+             Buffer target = allocator.allocate(5)) {
+            buf.writeLong(0x0102030405060708L);
+            int components = buf.forEachReadable(0, (index, component) -> {
+                while (target.writableBytes() > 0 && component.readableBytes() > 0) {
+                    target.writeByte(component.readableBuffer().get());
+                    assertThrows(IndexOutOfBoundsException.class, () -> component.addBytesRead(-1));
+                    assertThrows(IndexOutOfBoundsException.class, () -> component.addBytesRead(9));
+                    component.addBytesRead(0);
+                    component.addBytesRead(1);
+                }
+                return target.writableBytes() > 0;
+            });
+            assertThat(components).isNotEqualTo(0); // May be negative if iteration stops early.
+            assertThat(buf.readerOffset()).isEqualTo(5);
+            assertThat(buf.readableBytes()).isEqualTo(3);
+            assertThat(target.readableBytes()).isEqualTo(5);
+            assertThat(target).isEqualTo(allocator.copyOf(new byte[] {0x01, 0x02, 0x03, 0x04, 0x05}));
+            assertThat(buf).isEqualTo(allocator.copyOf(new byte[] {0x06, 0x07, 0x08}));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void forEachWritableMustBeAbleToIncrementWriterOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8).writeLong(0x0102030405060708L);
+             Buffer target = buf.copy()) {
+            buf.writerOffset(0); // Prime the buffer with data, but leave the write offset at zero.
+            int components = buf.forEachWritable(0, (index, component) -> {
+                while (component.writableBytes() > 0) {
+                    assertThat(component.writableBuffer().get()).isEqualTo(target.readByte());
+                    assertThrows(IndexOutOfBoundsException.class, () -> component.addBytesWritten(-1));
+                    assertThrows(IndexOutOfBoundsException.class, () -> component.addBytesWritten(9));
+                    component.addBytesWritten(0);
+                    component.addBytesWritten(1);
+                }
+                return true;
+            });
+            assertThat(components).isGreaterThan(0);
+            assertThat(buf.writerOffset()).isEqualTo(8);
+            assertThat(target.readerOffset()).isEqualTo(8);
+            target.readerOffset(0);
+            assertThat(buf).isEqualTo(target);
+        }
+    }
 }

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferComponentIterationTest.java
@@ -395,10 +395,9 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             int components = buf.forEachReadable(0, (index, component) -> {
                 while (target.writableBytes() > 0 && component.readableBytes() > 0) {
                     target.writeByte(component.readableBuffer().get());
-                    assertThrows(IndexOutOfBoundsException.class, () -> component.addBytesRead(-1));
-                    assertThrows(IndexOutOfBoundsException.class, () -> component.addBytesRead(9));
-                    component.addBytesRead(0);
-                    component.addBytesRead(1);
+                    assertThrows(IndexOutOfBoundsException.class, () -> component.skipReadable(9));
+                    component.skipReadable(0);
+                    component.skipReadable(1);
                 }
                 return target.writableBytes() > 0;
             });
@@ -421,10 +420,9 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             int components = buf.forEachWritable(0, (index, component) -> {
                 while (component.writableBytes() > 0) {
                     assertThat(component.writableBuffer().get()).isEqualTo(target.readByte());
-                    assertThrows(IndexOutOfBoundsException.class, () -> component.addBytesWritten(-1));
-                    assertThrows(IndexOutOfBoundsException.class, () -> component.addBytesWritten(9));
-                    component.addBytesWritten(0);
-                    component.addBytesWritten(1);
+                    assertThrows(IndexOutOfBoundsException.class, () -> component.skipWritable(9));
+                    component.skipWritable(0);
+                    component.skipWritable(1);
                 }
                 return true;
             });

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -185,7 +185,8 @@ public class PerMessageDeflateDecoderTest {
         Buffer compressedFrameData = encoderChannel.bufferAllocator()
                 .allocate(compressedPayload1.readableBytes() + compressedPayload2.readableBytes() - 4);
         compressedFrameData.writeBytes(compressedPayload1);
-        compressedFrameData.writeBytes(compressedPayload2.skipWritable(-4));
+        compressedPayload2.skipWritable(-4);
+        compressedFrameData.writeBytes(compressedPayload2);
         BinaryWebSocketFrame compressedFrame = new BinaryWebSocketFrame(true, RSV1 | RSV3, compressedFrameData);
         compressedPayload1.close();
         compressedPayload2.close();


### PR DESCRIPTION
Motivation:
Component iteration is the only way that we can access any underlying native pointers for a buffer.
We need to do this when we make native IO calls with a buffer.
If our plan was to just collect the pointers and sizes in iovecs, then there would not have been a problem.
But if we want to make our IO calls immediately, from within the iteration, then we will need a way to update the offsets.

Modification:
Add a pair of addBytesRead and addBytesWritten methods to ReadableComponent and WritableComponent, respectively.

Result:
It will now be possible to make native IO calls from within component iteration *and* update the buffer offsets, without using a capturing lambda.
This potentially saves some allocation overhead on every IO call.