### PR TITLE
Avoid masking the cause of availability failures for the Mac DNS provider

### DIFF
--- a/resolver-dns-classes-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
+++ b/resolver-dns-classes-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
@@ -49,7 +49,7 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
                 public int compare(DnsResolver r1, DnsResolver r2) {
                     // Note: order is descending (from higher to lower) so entries with lower search order override
                     // entries with higher search order.
-                    return r1.searchOrder() < r2.searchOrder() ? 1 : (r1.searchOrder() == r2.searchOrder() ? 0 : -1);
+                    return r1.searchOrder() < r2.searchOrder() ? 1 : r1.searchOrder() == r2.searchOrder() ? 0 : -1;
                 }
             };
 
@@ -118,10 +118,12 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
 
     public MacOSDnsServerAddressStreamProvider() {
         ensureAvailability();
+        currentMappings = retrieveCurrentMappings();
+        lastRefresh = new AtomicLong(System.nanoTime());
     }
 
-    private volatile Map<String, DnsServerAddresses> currentMappings = retrieveCurrentMappings();
-    private final AtomicLong lastRefresh = new AtomicLong(System.nanoTime());
+    private volatile Map<String, DnsServerAddresses> currentMappings;
+    private final AtomicLong lastRefresh;
 
     private static Map<String, DnsServerAddresses> retrieveCurrentMappings() {
         DnsResolver[] resolvers = resolvers();


### PR DESCRIPTION
Motivation:
If the MacOSDnsServerAddressStreamProvider is unavailable, we'd the root cause of it to show up.

Modification:
Move the initialisation of the `MacOSDnsServerAddressStreamProvider.currentMappings` field to the constructor.
Object initialisers run before the constructor does, so since `MacOSDnsServerAddressStreamProvider.retrieveCurrentMappings` relies on the native code, it would throw an `UnsatisfiedLinkError` before `ensureAvailability` would get to run.
This way, it was masking the root cause of the unavailability.
Now, the `currentMappings` is initialised *after* we've called `ensureAvailability`, so we don't lose the root cause if we cannot use native DNS on Mac.

Result:
Easier to debug problems with initialising native MacOS DNS.