### PR TITLE
Use `long` instead of `int` in Http Codec

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -103,7 +103,7 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
      * If the length of the aggregated content exceeds this value,
      * {@link #handleOversizedMessage(ChannelHandlerContext, Object)} will be called.
      */
-    public HttpObjectAggregator(int maxContentLength) {
+    public HttpObjectAggregator(long maxContentLength) {
         this(maxContentLength, false);
     }
 
@@ -117,7 +117,7 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
      * then {@code true} means close the connection. otherwise the connection will remain open and data will be
      * consumed and discarded until the next request is received.
      */
-    public HttpObjectAggregator(int maxContentLength, boolean closeOnExpectationFailed) {
+    public HttpObjectAggregator(long maxContentLength, boolean closeOnExpectationFailed) {
         super(maxContentLength);
         this.closeOnExpectationFailed = closeOnExpectationFailed;
     }
@@ -154,7 +154,7 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
     }
 
     @Override
-    protected boolean isContentLengthInvalid(HttpMessage start, int maxContentLength) {
+    protected boolean isContentLengthInvalid(HttpMessage start, long maxContentLength) {
         try {
             return getContentLength(start, -1L) > maxContentLength;
         } catch (final NumberFormatException e) {
@@ -162,7 +162,7 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
         }
     }
 
-    private static FullHttpResponse continueResponse(HttpMessage start, int maxContentLength,
+    private static FullHttpResponse continueResponse(HttpMessage start, long maxContentLength,
                                                      ChannelPipeline pipeline) {
         if (HttpUtil.isUnsupportedExpectation(start)) {
             // if the request contains an unsupported expectation, we return 417
@@ -181,7 +181,7 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
     }
 
     @Override
-    protected Object newContinueResponse(HttpMessage start, int maxContentLength, ChannelPipeline pipeline) {
+    protected Object newContinueResponse(HttpMessage start, long maxContentLength, ChannelPipeline pipeline) {
         FullHttpResponse response = continueResponse(start, maxContentLength, pipeline);
         // we're going to respond based on the request expectation so there's no
         // need to propagate the expectation further.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.java
@@ -69,12 +69,12 @@ public class WebSocketFrameAggregator
     }
 
     @Override
-    protected boolean isContentLengthInvalid(WebSocketFrame start, int maxContentLength) {
+    protected boolean isContentLengthInvalid(WebSocketFrame start, long maxContentLength) {
         return false;
     }
 
     @Override
-    protected Object newContinueResponse(WebSocketFrame start, int maxContentLength, ChannelPipeline pipeline) {
+    protected Object newContinueResponse(WebSocketFrame start, long maxContentLength, ChannelPipeline pipeline) {
         return null;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregatorNew.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregatorNew.java
@@ -45,7 +45,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
  */
 public abstract class MessageAggregatorNew<I, S, C extends AutoCloseable, A extends AutoCloseable>
         extends MessageToMessageDecoder<I> {
-    private final int maxContentLength;
+    private final long maxContentLength;
     private A currentMessage;
     private boolean handlingOversizedMessage;
 
@@ -62,18 +62,18 @@ public abstract class MessageAggregatorNew<I, S, C extends AutoCloseable, A exte
      *        If the length of the aggregated content exceeds this value,
      *        {@link #handleOversizedMessage(ChannelHandlerContext, Object)} will be called.
      */
-    protected MessageAggregatorNew(int maxContentLength) {
+    protected MessageAggregatorNew(long maxContentLength) {
         validateMaxContentLength(maxContentLength);
         this.maxContentLength = maxContentLength;
     }
 
-    protected MessageAggregatorNew(int maxContentLength, Class<? extends I> inboundMessageType) {
+    protected MessageAggregatorNew(long maxContentLength, Class<? extends I> inboundMessageType) {
         super(inboundMessageType);
         validateMaxContentLength(maxContentLength);
         this.maxContentLength = maxContentLength;
     }
 
-    private static void validateMaxContentLength(int maxContentLength) {
+    private static void validateMaxContentLength(long maxContentLength) {
         checkPositiveOrZero(maxContentLength, "maxContentLength");
     }
 
@@ -147,7 +147,7 @@ public abstract class MessageAggregatorNew<I, S, C extends AutoCloseable, A exte
     /**
      * Returns the maximum allowed length of the aggregated message in bytes.
      */
-    public final int maxContentLength() {
+    public final long maxContentLength() {
         return maxContentLength;
     }
 
@@ -268,7 +268,7 @@ public abstract class MessageAggregatorNew<I, S, C extends AutoCloseable, A exte
      * @return {@code true} if the message {@code start}'s content length is known, and if it greater than
      * {@code maxContentLength}. {@code false} otherwise.
      */
-    protected abstract boolean isContentLengthInvalid(S start, int maxContentLength) throws Exception;
+    protected abstract boolean isContentLengthInvalid(S start, long maxContentLength) throws Exception;
 
     /**
      * Returns the 'continue response' for the specified start message if necessary. For example, this method is
@@ -276,15 +276,15 @@ public abstract class MessageAggregatorNew<I, S, C extends AutoCloseable, A exte
      *
      * @return the 'continue response', or {@code null} if there's no message to send
      */
-    protected abstract Object newContinueResponse(S start, int maxContentLength, ChannelPipeline pipeline)
+    protected abstract Object newContinueResponse(S start, long maxContentLength, ChannelPipeline pipeline)
             throws Exception;
 
     /**
      * Determine if the channel should be closed after the result of
-     * {@link #newContinueResponse(Object, int, ChannelPipeline)} is written.
-     * @param msg The return value from {@link #newContinueResponse(Object, int, ChannelPipeline)}.
+     * {@link #newContinueResponse(Object, long, ChannelPipeline)} is written.
+     * @param msg The return value from {@link #newContinueResponse(Object, long, ChannelPipeline)}.
      * @return {@code true} if the channel should be closed after the result of
-     * {@link #newContinueResponse(Object, int, ChannelPipeline)} is written. {@code false} otherwise.
+     * {@link #newContinueResponse(Object, long, ChannelPipeline)} is written. {@code false} otherwise.
      */
     protected abstract boolean closeAfterContinueResponse(Object msg) throws Exception;
 
@@ -293,7 +293,7 @@ public abstract class MessageAggregatorNew<I, S, C extends AutoCloseable, A exte
      * Messages will stop being ignored the next time {@link #tryContentMessage(Object)} returns a {@code non null}
      * value.
      *
-     * @param msg The return value from {@link #newContinueResponse(Object, int, ChannelPipeline)}.
+     * @param msg The return value from {@link #newContinueResponse(Object, long, ChannelPipeline)}.
      * @return {@code true} if all objects for the current request/response should be ignored or not.
      * {@code false} otherwise.
      */

--- a/codec/src/test/java/io/netty/handler/codec/MessageAggregatorNewTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/MessageAggregatorNewTest.java
@@ -84,12 +84,12 @@ public class MessageAggregatorNewTest {
         }
 
         @Override
-        protected boolean isContentLengthInvalid(Buffer start, int maxContentLength) {
+        protected boolean isContentLengthInvalid(Buffer start, long maxContentLength) {
             return start.readableBytes() > maxContentLength;
         }
 
         @Override
-        protected Object newContinueResponse(Buffer start, int maxContentLength, ChannelPipeline pipeline) {
+        protected Object newContinueResponse(Buffer start, long maxContentLength, ChannelPipeline pipeline) {
             return null;
         }
 


### PR DESCRIPTION
Motivation:
HTTP RFC does not specify any maximum limit of Content-Length so we should be using `long` instead of `int`.

Modification:
Changed `long` to `int`

Result:
Bigger Content-Length values