### PR TITLE
Buffer native addresses should be off-set

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -38,6 +38,7 @@ import static io.netty.buffer.api.internal.Statics.bbslice;
 import static io.netty.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty.buffer.api.internal.Statics.checkLength;
+import static io.netty.buffer.api.internal.Statics.nativeAddressWithOffset;
 
 class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent, WritableComponent {
     private static final ByteBuffer CLOSED_BUFFER = ByteBuffer.allocate(0);
@@ -439,11 +440,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
 
     @Override
     public long readableNativeAddress() {
-        long address = nativeAddress();
-        if (address == 0) {
-            return 0;
-        }
-        return address + roff;
+        return nativeAddressWithOffset(nativeAddress(), roff);
     }
 
     @Override
@@ -473,11 +470,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
 
     @Override
     public long writableNativeAddress() {
-        long address = nativeAddress();
-        if (address == 0) {
-            return 0;
-        }
-        return address + woff;
+        return nativeAddressWithOffset(nativeAddress(), woff);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -28,7 +28,6 @@ import io.netty.buffer.api.WritableComponent;
 import io.netty.buffer.api.WritableComponentProcessor;
 import io.netty.buffer.api.internal.AdaptableBuffer;
 import io.netty.buffer.api.internal.Statics;
-import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -145,7 +144,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     }
 
     private long nativeAddress() {
-        return rmem.isDirect() && PlatformDependent.hasUnsafe()? PlatformDependent.directBufferAddress(rmem) : 0;
+        return Statics.nativeAddressOfDirectByteBuffer(rmem);
     }
 
     @Override
@@ -440,7 +439,11 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
 
     @Override
     public long readableNativeAddress() {
-        return nativeAddress();
+        long address = nativeAddress();
+        if (address == 0) {
+            return 0;
+        }
+        return address + roff;
     }
 
     @Override
@@ -470,7 +473,11 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
 
     @Override
     public long writableNativeAddress() {
-        return nativeAddress();
+        long address = nativeAddress();
+        if (address == 0) {
+            return 0;
+        }
+        return address + woff;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/internal/JniBufferAccess.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/JniBufferAccess.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.internal;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.nio.ByteBuffer;
+
+final class JniBufferAccess {
+    static final boolean IS_AVAILABLE;
+    static final MethodHandle MEMORY_ADDRESS;
+
+    static {
+        boolean isAvailable = false;
+        MethodHandle memoryAddress = null;
+        try {
+            Class<?> bufferAccess = Class.forName("io.netty.channel.unix.Buffer");
+            Lookup lookup = MethodHandles.lookup();
+            bufferAccess = lookup.accessClass(bufferAccess);
+            MethodType type = MethodType.methodType(long.class, ByteBuffer.class);
+            memoryAddress = lookup.findStatic(bufferAccess, "memoryAddress", type);
+            isAvailable = true;
+        } catch (Throwable e) {
+            InternalLogger logger = InternalLoggerFactory.getInstance(JniBufferAccess.class);
+            logger.debug("JNI bypass for accessing native address of DirectByteBuffer is unavailable.", e);
+        }
+        IS_AVAILABLE = isAvailable;
+        MEMORY_ADDRESS = memoryAddress;
+    }
+
+    private JniBufferAccess() {
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/Statics.java
@@ -341,6 +341,22 @@ public interface Statics {
         return hashCode;
     }
 
+    /**
+     * Compute an offset into a native address.
+     * Zero is used as a marker for when a native address is not available,
+     * and an offset into a zero address will remain zero.
+     *
+     * @param address The native address, or zero if no native address is available.
+     * @param offset The offset into the native address we wish to compute.
+     * @return An offsetted native address, or zero if no native address was available.
+     */
+    static long nativeAddressWithOffset(long address, int offset) {
+        if (address == 0) {
+            return 0;
+        }
+        return address + offset;
+    }
+
     static long nativeAddressOfDirectByteBuffer(ByteBuffer byteBuffer) {
         if (!byteBuffer.isDirect()) {
             return 0;

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -39,6 +39,7 @@ import static io.netty.buffer.api.internal.Statics.bbslice;
 import static io.netty.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty.buffer.api.internal.Statics.checkLength;
+import static io.netty.buffer.api.internal.Statics.nativeAddressWithOffset;
 
 class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComponent, WritableComponent {
     private static final int CLOSED_SIZE = -1;
@@ -535,11 +536,7 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
 
     @Override
     public long readableNativeAddress() {
-        long address = nativeAddress();
-        if (address == 0) {
-            return 0;
-        }
-        return address + roff;
+        return nativeAddressWithOffset(nativeAddress(), roff);
     }
 
     @Override
@@ -583,11 +580,7 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
 
     @Override
     public long writableNativeAddress() {
-        long address = nativeAddress();
-        if (address == 0) {
-            return 0;
-        }
-        return address + woff;
+        return nativeAddressWithOffset(nativeAddress(), woff);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -535,7 +535,11 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
 
     @Override
     public long readableNativeAddress() {
-        return nativeAddress();
+        long address = nativeAddress();
+        if (address == 0) {
+            return 0;
+        }
+        return address + roff;
     }
 
     @Override
@@ -579,7 +583,11 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
 
     @Override
     public long writableNativeAddress() {
-        return nativeAddress();
+        long address = nativeAddress();
+        if (address == 0) {
+            return 0;
+        }
+        return address + woff;
     }
 
     @Override


### PR DESCRIPTION
Motivation:
It's hard to make use of the native addresses when they are always pointing to the base of the allocation, rather than where the readable or writable data actually starts.

Modification:
Make the native addresses point to where the readable, or writable, region starts, respectively.
Also, if Unsafe is not available, we will optimistically fall back to the JNI bypass in the native transport module, iff we can find it, and it's available.

Result:
This makes it possible to do native IO calls using readableNativeAddress() and readableBytes(), or writableNativeAddress() and writableBytes(), respectively.
No funky and fragile external offset computation needed.