### PR TITLE
Release DnsQuery in case of failure to prevent leak

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.handler.codec.dns.DnsSection;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -126,8 +127,7 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
             Throwable cause = parent.channelReadyPromise.cause();
             if (cause != null) {
                 // the promise failed before so we should also fail this query.
-                promise.tryFailure(cause);
-                writePromise.setFailure(cause);
+                failQuery(query, cause, writePromise);
             } else {
                 // The promise is not complete yet, let's delay the query.
                 parent.channelReadyPromise.addListener(new GenericFutureListener<Future<? super Channel>>() {
@@ -140,12 +140,20 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
                             writeQuery(query, true, writePromise);
                         } else {
                             Throwable cause = future.cause();
-                            promise.tryFailure(cause);
-                            writePromise.setFailure(cause);
+                            failQuery(query, cause, writePromise);
                         }
                     }
                 });
             }
+        }
+    }
+
+    private void failQuery(DnsQuery query, Throwable cause, ChannelPromise writePromise) {
+        try {
+            promise.tryFailure(cause);
+            writePromise.setFailure(cause);
+        } finally {
+            ReferenceCountUtil.release(query);
         }
     }
 


### PR DESCRIPTION
Motivation:

We need to release the DnsQuery incase of an failure as otherwise we will see a buffer leak.

This showed up in an unrelated PR:

```
https://netty.io/wiki/reference-counted-objects.html for more information.
2022-01-25T20:20:04.3902792Z Recent access records:
2022-01-25T20:20:04.3903007Z Created at:
2022-01-25T20:20:04.3903377Z 	io.netty.handler.codec.dns.AbstractDnsMessage.<init>(AbstractDnsMessage.java:44)
2022-01-25T20:20:04.3903869Z 	io.netty.handler.codec.dns.DefaultDnsQuery.<init>(DefaultDnsQuery.java:42)
2022-01-25T20:20:04.3904340Z 	io.netty.handler.codec.dns.DatagramDnsQuery.<init>(DatagramDnsQuery.java:56)
2022-01-25T20:20:04.3904825Z 	io.netty.handler.codec.dns.DatagramDnsQuery.<init>(DatagramDnsQuery.java:43)
2022-01-25T20:20:04.3905363Z 	io.netty.resolver.dns.DatagramDnsQueryContext.newQuery(DatagramDnsQueryContext.java:39)
2022-01-25T20:20:04.3905887Z 	io.netty.resolver.dns.DnsQueryContext.query(DnsQueryContext.java:101)
2022-01-25T20:20:04.3906342Z 	io.netty.resolver.dns.DnsNameResolver.query0(DnsNameResolver.java:1272)
2022-01-25T20:20:04.3906823Z 	io.netty.resolver.dns.DnsResolveContext.query(DnsResolveContext.java:436)
2022-01-25T20:20:04.3907310Z 	io.netty.resolver.dns.DnsResolveContext.query(DnsResolveContext.java:1113)
2022-01-25T20:20:04.3907816Z 	io.netty.resolver.dns.DnsResolveContext.internalResolve(DnsResolveContext.java:358)
2022-01-25T20:20:04.3908388Z 	io.netty.resolver.dns.DnsResolveContext.doSearchDomainQuery(DnsResolveContext.java:284)
2022-01-25T20:20:04.3909157Z 	io.netty.resolver.dns.DnsAddressResolveContext.doSearchDomainQuery(DnsAddressResolveContext.java:96)
2022-01-25T20:20:04.3909755Z 	io.netty.resolver.dns.DnsResolveContext$1.operationComplete(DnsResolveContext.java:240)
2022-01-25T20:20:04.3910277Z 	io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:578)
2022-01-25T20:20:04.3910835Z 	io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:552)
2022-01-25T20:20:04.3911598Z 	io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:491)
2022-01-25T20:20:04.3912122Z 	io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:616)
2022-01-25T20:20:04.3912617Z 	io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:609)
2022-01-25T20:20:04.3913131Z 	io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:117)
2022-01-25T20:20:04.3913659Z 	io.netty.resolver.dns.DnsResolveContext.finishResolve(DnsResolveContext.java:1055)
2022-01-25T20:20:04.3914230Z 	io.netty.resolver.dns.DnsResolveContext.tryToFinishResolve(DnsResolveContext.java:1000)
2022-01-25T20:20:04.3914751Z 	io.netty.resolver.dns.DnsResolveContext.query(DnsResolveContext.java:418)
2022-01-25T20:20:04.3915350Z 	io.netty.resolver.dns.DnsResolveContext.access$600(DnsResolveContext.java:66)
2022-01-25T20:20:04.3915878Z 	io.netty.resolver.dns.DnsResolveContext$2.operationComplete(DnsResolveContext.java:467)
2022-01-25T20:20:04.3916394Z 	io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:578)
2022-01-25T20:20:04.3916945Z 	io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:571)
2022-01-25T20:20:04.3917507Z 	io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:550)
2022-01-25T20:20:04.3918064Z 	io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:491)
2022-01-25T20:20:04.3918573Z 	io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:616)
2022-01-25T20:20:04.3919083Z 	io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:609)
2022-01-25T20:20:04.3919599Z 	io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:117)
2022-01-25T20:20:04.3920103Z 	io.netty.resolver.dns.DnsQueryContext$2.operationComplete(DnsQueryContext.java:143)
2022-01-25T20:20:04.3920609Z 	io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:578)
2022-01-25T20:20:04.3921163Z 	io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:552)
2022-01-25T20:20:04.3921717Z 	io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:491)
2022-01-25T20:20:04.3922223Z 	io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:616)
2022-01-25T20:20:04.3922730Z 	io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:609)
2022-01-25T20:20:04.3923241Z 	io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:117)
2022-01-25T20:20:04.3923744Z 	io.netty.resolver.dns.DnsNameResolver$4.operationComplete(DnsNameResolver.java:519)
2022-01-25T20:20:04.3924223Z 	io.netty.resolver.dns.DnsNameResolver$4.operationComplete(DnsNameResolver.java:514)
2022-01-25T20:20:04.3924741Z 	io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:578)
2022-01-25T20:20:04.3925296Z 	io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:552)
2022-01-25T20:20:04.3925851Z 	io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:491)
2022-01-25T20:20:04.3926356Z 	io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:616)
2022-01-25T20:20:04.3926864Z 	io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:609)
2022-01-25T20:20:04.3927377Z 	io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:117)
2022-01-25T20:20:04.3927877Z 	io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetFailure(AbstractChannel.java:999)
2022-01-25T20:20:04.3928373Z 	io.netty.channel.AbstractChannel$AbstractUnsafe.bind(AbstractChannel.java:564)
2022-01-25T20:20:04.3928993Z 	io.netty.channel.DefaultChannelPipeline$HeadContext.bind(DefaultChannelPipeline.java:1334)
2022-01-25T20:20:04.3929596Z 	io.netty.channel.AbstractChannelHandlerContext.invokeBind(AbstractChannelHandlerContext.java:506)
2022-01-25T20:20:04.3930214Z 	io.netty.channel.AbstractChannelHandlerContext.bind(AbstractChannelHandlerContext.java:491)
2022-01-25T20:20:04.3930779Z 	io.netty.channel.DefaultChannelPipeline.bind(DefaultChannelPipeline.java:973)
2022-01-25T20:20:04.3931251Z 	io.netty.channel.AbstractChannel.bind(AbstractChannel.java:260)
2022-01-25T20:20:04.3931695Z 	io.netty.bootstrap.AbstractBootstrap$2.run(AbstractBootstrap.java:356)
2022-01-25T20:20:04.3932341Z 	io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
2022-01-25T20:20:04.3932960Z 	io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
2022-01-25T20:20:04.3933500Z 	io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503)
2022-01-25T20:20:04.3933996Z 	io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
2022-01-25T20:20:04.3934524Z 	io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
2022-01-25T20:20:04.3935119Z 	io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2022-01-25T20:20:04.3935585Z 	java.base/java.lang.Thread.run(Thread.java:833)
2022-01-25T20:20:04.3936557Z 20:20:01.725 [nioEventLoopGroup-33-1] ERROR io.netty.util.ResourceLeakDetector - LEAK: DnsMessage.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
2022-01-25T20:20:04.3937139Z Recent access records:
2022-01-25T20:20:04.3937351Z Created at:
2022-01-25T20:20:04.3937716Z 	io.netty.handler.codec.dns.AbstractDnsMessage.<init>(AbstractDnsMessage.java:44)
2022-01-25T20:20:04.3938209Z 	io.netty.handler.codec.dns.DefaultDnsQuery.<init>(DefaultDnsQuery.java:42)
2022-01-25T20:20:04.3938682Z 	io.netty.handler.codec.dns.DatagramDnsQuery.<init>(DatagramDnsQuery.java:56)
2022-01-25T20:20:04.3939165Z 	io.netty.handler.codec.dns.DatagramDnsQuery.<init>(DatagramDnsQuery.java:43)
2022-01-25T20:20:04.3939702Z 	io.netty.resolver.dns.DatagramDnsQueryContext.newQuery(DatagramDnsQueryContext.java:39)
2022-01-25T20:20:04.3940233Z 	io.netty.resolver.dns.DnsQueryContext.query(DnsQueryContext.java:101)
2022-01-25T20:20:04.3940686Z 	io.netty.resolver.dns.DnsNameResolver.query0(DnsNameResolver.java:1272)
2022-01-25T20:20:04.3941168Z 	io.netty.resolver.dns.DnsResolveContext.query(DnsResolveContext.java:436)
2022-01-25T20:20:04.3941657Z 	io.netty.resolver.dns.DnsResolveContext.query(DnsResolveContext.java:1113)
2022-01-25T20:20:04.3942162Z 	io.netty.resolver.dns.DnsResolveContext.internalResolve(DnsResolveContext.java:358)
2022-01-25T20:20:04.3942731Z 	io.netty.resolver.dns.DnsResolveContext.doSearchDomainQuery(DnsResolveContext.java:284)
2022-01-25T20:20:04.3943371Z 	io.netty.resolver.dns.DnsAddressResolveContext.doSearchDomainQuery(DnsAddressResolveContext.java:96)
2022-01-25T20:20:04.3943968Z 	io.netty.resolver.dns.DnsResolveContext.resolve(DnsResolveContext.java:249)
2022-01-25T20:20:04.3944498Z 	io.netty.resolver.dns.DnsNameResolver.doResolveAllUncached0(DnsNameResolver.java:1158)
2022-01-25T20:20:04.3945026Z 	io.netty.resolver.dns.DnsNameResolver.access$500(DnsNameResolver.java:91)
2022-01-25T20:20:04.3945483Z 	io.netty.resolver.dns.DnsNameResolver$7.run(DnsNameResolver.java:1137)
2022-01-25T20:20:04.3946006Z 	io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
2022-01-25T20:20:04.3946625Z 	io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
2022-01-25T20:20:04.3947162Z 	io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:503)
2022-01-25T20:20:04.3947662Z 	io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
2022-01-25T20:20:04.3948181Z 	io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
2022-01-25T20:20:04.3948842Z 	io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2022-01-25T20:20:04.3949289Z 	java.base/java.lang.Thread.run(Thread.java:833)
2022-01-25T20:20:04.3950155Z 20:20:01.726 [nioEventLoopGroup-33-1] DEBUG i.netty.resolver.dns.DnsNameResolver - [id: 0x9d025e67, L:/0.0.0.0:33141] RECEIVED: UDP [25881: /127.0.0.1:37922], DatagramDnsResponse(from: /127.0.0.1:37922, to: /0.0.0.0:33141, 25881, QUERY(0), NXDomain(3), RD)
2022-01-25T20:20:04.3950787Z 	DefaultDnsQuestion(lookup-address.netty.io. IN CNAME)
2022-01-25T20:20:04.3952826Z 20:20:01.726 [NioDatagramAcceptor-65] DEBUG o.a.d.s.d.p.DnsProtocolHandler - /127.0.0.1:33141 SENT:  org.apache.directory.server.dns.messages.DnsMessage@4c6a5830[transactionId=25881,opCode=QUERY,truncated=false,messageType=RESPONSE,recursionDesired=true,additionalRecords=[],responseCode=NAME_ERROR,authorityRecords=[],acceptNonAuthenticatedData=false,recursionAvailable=false,answerRecords=[],questionRecords=[org.apache.directory.server.dns.messages.QuestionRecord@6c937f18[domainName=lookup-address.netty.io,recordClass=IN,recordType=CNAME]],authoritativeAnswer=false,reserved=false]
2022-01-25T20:20:04.3954224Z 20:20:01.726 [main] DEBUG o.a.d.s.d.p.DnsProtocolHandler - /127.0.0.1:33141 CLOSED
2022-01-25T20:20:04.3954856Z 20:20:01.727 [main] INFO  o.a.directory.server.dns.DnsServer - DNS service stopped.
```

Modifications:

Release query on failure

Result:

No more leaks
