### PR TITLE
Update to netty-tcnative 2.0.48.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.47.Final</tcnative.version>
+    <tcnative.version>2.0.48.Final</tcnative.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -542,7 +542,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.47.Final</tcnative.version>
+    <tcnative.version>2.0.48.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

A new version of netty-tcnative was released

Modifications:

Update to 2.0.48.Final

Result:

Use latest release
