### PR TITLE
Copy localAddress as well when DnsNameResolverBuilder.copy() is called

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -204,7 +204,7 @@ public final class DnsNameResolverBuilder {
     }
 
     /**
-     * Configure the address that will be used to bind too. If `null` the default will be used.
+     * Configure the address that will be used to bind too. If {@code null} the default will be used.
      * @param localAddress the bind address
      * @return {@code this}
      */
@@ -572,7 +572,7 @@ public final class DnsNameResolverBuilder {
         copiedBuilder.ndots(ndots);
         copiedBuilder.decodeIdn(decodeIdn);
         copiedBuilder.completeOncePreferredResolved(completeOncePreferredResolved);
-
+        copiedBuilder.localAddress(localAddress);
         return copiedBuilder;
     }
 }


### PR DESCRIPTION
Motivation:

We missed to also copy the localAddress when copy() is called

Modifications:

Correctly set the localAddress as well

Result:

Make a complete copy
