### PR TITLE
Cleanup DnsNameResolverBuilder

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -37,7 +37,7 @@ import static io.netty.util.internal.ObjectUtil.intValue;
  * A {@link DnsNameResolver} builder.
  */
 public final class DnsNameResolverBuilder {
-    volatile EventLoop eventLoop;
+    private EventLoop eventLoop;
     private ChannelFactory<? extends DatagramChannel> channelFactory;
     private ChannelFactory<? extends SocketChannel> socketChannelFactory;
     private DnsCache resolveCache;
@@ -91,7 +91,8 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
-    protected ChannelFactory<? extends DatagramChannel> channelFactory() {
+    // Package-private for testing only.
+    ChannelFactory<? extends DatagramChannel> channelFactory() {
         return this.channelFactory;
     }
 
@@ -379,7 +380,8 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
-    protected DnsServerAddressStreamProvider nameServerProvider() {
+    // Package-private for testing only.
+    DnsServerAddressStreamProvider nameServerProvider() {
         return this.dnsServerAddressStreamProvider;
     }
 


### PR DESCRIPTION
Motivation:

There is no need to mark fields as volatile and also it is odd to have protected methods in a final class

Modifications:

- Remove volatile
- Replace protected with package-private

Result:

Cleanup