### PR TITLE
enable mDNS for MacOS DNS resolver

### DIFF
--- a/resolver-dns-classes-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
+++ b/resolver-dns-classes-macos/src/main/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
@@ -134,10 +134,6 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
         Arrays.sort(resolvers, RESOLVER_COMPARATOR);
         Map<String, DnsServerAddresses> resolverMap = new HashMap<String, DnsServerAddresses>(resolvers.length);
         for (DnsResolver resolver: resolvers) {
-            // Skip mdns
-            if ("mdns".equalsIgnoreCase(resolver.options())) {
-                continue;
-            }
             InetSocketAddress[] nameservers = resolver.nameservers();
             if (nameservers == null || nameservers.length == 0) {
                 continue;


### PR DESCRIPTION
Motivation:

Possibility to use mDNS on MacOS to resolve hostnames.
Mostly, created by `telepresence.io` tool. Tunnel to Kubernetes cluster. 

Modification:

Removed code responsible to skip  mDNS nameservers

Result:

Fixes #12052 
