### PR TITLE
Lifecycle tracer enable should not do the opposite

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/internal/LifecycleTracer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/LifecycleTracer.java
@@ -45,7 +45,7 @@ public abstract class LifecycleTracer {
      * @return A new tracer for a resource.
      */
     public static LifecycleTracer get() {
-        if (lifecycleTracingEnabled && LeakDetection.leakDetectionEnabled == 0) {
+        if (!lifecycleTracingEnabled && LeakDetection.leakDetectionEnabled == 0) {
             return NoOpTracer.INSTANCE;
         }
         StackTracer stackTracer = new StackTracer();


### PR DESCRIPTION
Motivation:
When lifecycle tracing is NOT enabled AND no leak detectors are installed, THEN we should use the NoOpTracer.

Modification:
Fix the logic that disables lifecycle tracing of buffers.

Result:
Buffers now have lifecycle traces, when tracing is enabled.