### PR TITLE
Add check point to methods `FastThreadLocalThread.threadLocalMap()` and `FastThreadLocalThread.setThreadLocalMap(...)`

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -17,11 +17,16 @@ package io.netty.util.concurrent;
 
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.UnstableApi;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * A special {@link Thread} that provides fast access to {@link FastThreadLocal} variables.
  */
 public class FastThreadLocalThread extends Thread {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(FastThreadLocalThread.class);
+
     // This will be set to true if we have a chance to wrap the Runnable.
     private final boolean cleanupFastThreadLocals;
 
@@ -71,6 +76,9 @@ public class FastThreadLocalThread extends Thread {
      * Note that this method is for internal use only, and thus is subject to change at any time.
      */
     public final InternalThreadLocalMap threadLocalMap() {
+        if (this != Thread.currentThread() && logger.isWarnEnabled()) {
+            logger.warn("It's not thread-safe to get 'threadLocalMap' which doesn't belong to the caller thread");
+        }
         return threadLocalMap;
     }
 
@@ -79,6 +87,9 @@ public class FastThreadLocalThread extends Thread {
      * Note that this method is for internal use only, and thus is subject to change at any time.
      */
     public final void setThreadLocalMap(InternalThreadLocalMap threadLocalMap) {
+        if (this != Thread.currentThread() && logger.isWarnEnabled()) {
+            logger.warn("It's not thread-safe to set 'threadLocalMap' which doesn't belong to the caller thread");
+        }
         this.threadLocalMap = threadLocalMap;
     }
 


### PR DESCRIPTION
Motivation:

`FastThreadLocalThread.threadLocalMap()` and `FastThreadLocalThread.setThreadLocalMap(...)` should firstly check whether the target thread is the current thread, and print warn log if not.
Actually, IMHO, we can throw `Exception` here, but for compatible consideration, it's might be better that we just print log.
OR, we can change the field `threadLocalMap` to `volatile threadLocalMap`, which I think it's not good because it will hurts performance.

Modification:

Add check point of whether the target thread is the current thread to methods `FastThreadLocalThread.threadLocalMap()` and `FastThreadLocalThread.setThreadLocalMap(...)`, and print warn log if not.

Result:

Prints warn log if the target thread is not the current thread.
