### PR TITLE
Rename JdkZlib* to Zlib*

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -22,7 +22,7 @@ import io.netty.handler.codec.compression.CompressionOptions;
 import io.netty.handler.codec.compression.Compressor;
 import io.netty.handler.codec.compression.DeflateOptions;
 import io.netty.handler.codec.compression.GzipOptions;
-import io.netty.handler.codec.compression.JdkZlibCompressor;
+import io.netty.handler.codec.compression.ZlibCompressor;
 import io.netty.handler.codec.compression.StandardCompressionOptions;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.codec.compression.Zstd;
@@ -198,11 +198,11 @@ public class HttpContentCompressor extends HttpContentEncoder {
         this.factories = new HashMap<>();
 
         if (this.gzipOptions != null) {
-            this.factories.put("gzip", JdkZlibCompressor.newFactory(
+            this.factories.put("gzip", ZlibCompressor.newFactory(
                     ZlibWrapper.GZIP, gzipOptions.compressionLevel()));
         }
         if (this.deflateOptions != null) {
-            this.factories.put("deflate", JdkZlibCompressor.newFactory(
+            this.factories.put("deflate", ZlibCompressor.newFactory(
                     ZlibWrapper.ZLIB, deflateOptions.compressionLevel()));
         }
         if (this.brotliOptions != null) {
@@ -267,7 +267,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
             }
 
             return new Result(
-                    targetContentEncoding, JdkZlibCompressor.newFactory(wrapper, compressionLevel).get());
+                    targetContentEncoding, ZlibCompressor.newFactory(wrapper, compressionLevel).get());
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java
@@ -24,7 +24,7 @@ import static io.netty.handler.codec.http.HttpHeaderValues.X_GZIP;
 import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.compression.BrotliDecompressor;
 import io.netty.handler.codec.compression.Decompressor;
-import io.netty.handler.codec.compression.JdkZlibDecompressor;
+import io.netty.handler.codec.compression.ZlibDecompressor;
 import io.netty.handler.codec.compression.ZlibWrapper;
 
 /**
@@ -57,12 +57,12 @@ public class HttpContentDecompressor extends HttpContentDecoder {
     protected Decompressor newContentDecoder(String contentEncoding) throws Exception {
         if (GZIP.contentEqualsIgnoreCase(contentEncoding) ||
             X_GZIP.contentEqualsIgnoreCase(contentEncoding)) {
-            return JdkZlibDecompressor.newFactory(ZlibWrapper.GZIP).get();
+            return ZlibDecompressor.newFactory(ZlibWrapper.GZIP).get();
         }
         if (DEFLATE.contentEqualsIgnoreCase(contentEncoding) ||
             X_DEFLATE.contentEqualsIgnoreCase(contentEncoding)) {
             final ZlibWrapper wrapper = strict ? ZlibWrapper.ZLIB : ZlibWrapper.ZLIB_OR_NONE;
-            JdkZlibDecompressor.newFactory(wrapper).get();
+            ZlibDecompressor.newFactory(wrapper).get();
         }
         if (Brotli.isAvailable() && BR.contentEqualsIgnoreCase(contentEncoding)) {
             return BrotliDecompressor.newFactory().get();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -24,7 +24,7 @@ import io.netty.handler.codec.compression.CompressionOptions;
 import io.netty.handler.codec.compression.Compressor;
 import io.netty.handler.codec.compression.DeflateOptions;
 import io.netty.handler.codec.compression.GzipOptions;
-import io.netty.handler.codec.compression.JdkZlibCompressor;
+import io.netty.handler.codec.compression.ZlibCompressor;
 import io.netty.handler.codec.compression.StandardCompressionOptions;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.codec.compression.ZstdCompressor;
@@ -278,14 +278,14 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
     private Compressor newCompressionChannel(final ChannelHandlerContext ctx, ZlibWrapper wrapper) {
         if (supportsCompressionOptions) {
             if (wrapper == ZlibWrapper.GZIP && gzipCompressionOptions != null) {
-                return JdkZlibCompressor.newFactory(wrapper, gzipCompressionOptions.compressionLevel()).get();
+                return ZlibCompressor.newFactory(wrapper, gzipCompressionOptions.compressionLevel()).get();
             } else if (wrapper == ZlibWrapper.ZLIB && deflateOptions != null) {
-                return JdkZlibCompressor.newFactory(wrapper, deflateOptions.compressionLevel()).get();
+                return ZlibCompressor.newFactory(wrapper, deflateOptions.compressionLevel()).get();
             } else {
                 throw new IllegalArgumentException("Unsupported ZlibWrapper: " + wrapper);
             }
         }
-        return JdkZlibCompressor.newFactory(wrapper, compressionLevel).get();
+        return ZlibCompressor.newFactory(wrapper, compressionLevel).get();
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -21,7 +21,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.compression.BrotliDecompressor;
 import io.netty.handler.codec.compression.Decompressor;
-import io.netty.handler.codec.compression.JdkZlibDecompressor;
+import io.netty.handler.codec.compression.ZlibDecompressor;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.util.internal.UnstableApi;
 
@@ -156,12 +156,12 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
     protected Decompressor newContentDecompressor(final ChannelHandlerContext ctx, CharSequence contentEncoding)
             throws Http2Exception {
         if (GZIP.contentEqualsIgnoreCase(contentEncoding) || X_GZIP.contentEqualsIgnoreCase(contentEncoding)) {
-            return JdkZlibDecompressor.newFactory(ZlibWrapper.GZIP).get();
+            return ZlibDecompressor.newFactory(ZlibWrapper.GZIP).get();
         }
         if (DEFLATE.contentEqualsIgnoreCase(contentEncoding) || X_DEFLATE.contentEqualsIgnoreCase(contentEncoding)) {
             final ZlibWrapper wrapper = strict ? ZlibWrapper.ZLIB : ZlibWrapper.ZLIB_OR_NONE;
             // To be strict, 'deflate' means ZLIB, but some servers were not implemented correctly.
-            return JdkZlibDecompressor.newFactory(wrapper).get();
+            return ZlibDecompressor.newFactory(wrapper).get();
         }
         if (Brotli.isAvailable() && BR.contentEqualsIgnoreCase(contentEncoding)) {
             return BrotliDecompressor.newFactory().get();

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
@@ -31,44 +31,44 @@ public final class ZlibCodecFactory {
     }
 
     public static ChannelHandler newZlibEncoder(int compressionLevel) {
-        return new CompressionHandler(JdkZlibCompressor.newFactory(compressionLevel));
+        return new CompressionHandler(ZlibCompressor.newFactory(compressionLevel));
     }
 
     public static ChannelHandler newZlibEncoder(ZlibWrapper wrapper) {
-        return new CompressionHandler(JdkZlibCompressor.newFactory(wrapper));
+        return new CompressionHandler(ZlibCompressor.newFactory(wrapper));
     }
 
     public static ChannelHandler newZlibEncoder(ZlibWrapper wrapper, int compressionLevel) {
-        return new CompressionHandler(JdkZlibCompressor.newFactory(wrapper, compressionLevel));
+        return new CompressionHandler(ZlibCompressor.newFactory(wrapper, compressionLevel));
     }
 
     public static ChannelHandler newZlibEncoder(ZlibWrapper wrapper, int compressionLevel,
                                                 int windowBits, int memLevel) {
-        return new CompressionHandler(JdkZlibCompressor.newFactory(wrapper, compressionLevel));
+        return new CompressionHandler(ZlibCompressor.newFactory(wrapper, compressionLevel));
     }
 
     public static ChannelHandler newZlibEncoder(byte[] dictionary) {
-        return new CompressionHandler(JdkZlibCompressor.newFactory(dictionary));
+        return new CompressionHandler(ZlibCompressor.newFactory(dictionary));
     }
 
     public static ChannelHandler newZlibEncoder(int compressionLevel, byte[] dictionary) {
-        return new CompressionHandler(JdkZlibCompressor.newFactory(compressionLevel, dictionary));
+        return new CompressionHandler(ZlibCompressor.newFactory(compressionLevel, dictionary));
     }
 
     public static ChannelHandler newZlibEncoder(int compressionLevel, int windowBits, int memLevel, byte[] dictionary) {
-        return new CompressionHandler(JdkZlibCompressor.newFactory(compressionLevel, dictionary));
+        return new CompressionHandler(ZlibCompressor.newFactory(compressionLevel, dictionary));
     }
 
     public static ChannelHandler newZlibDecoder() {
-        return new DecompressionHandler(JdkZlibDecompressor.newFactory(true));
+        return new DecompressionHandler(ZlibDecompressor.newFactory(true));
     }
 
     public static ChannelHandler newZlibDecoder(ZlibWrapper wrapper) {
-        return new DecompressionHandler(JdkZlibDecompressor.newFactory(wrapper, true));
+        return new DecompressionHandler(ZlibDecompressor.newFactory(wrapper, true));
     }
 
     public static ChannelHandler newZlibDecoder(byte[] dictionary) {
-        return new DecompressionHandler(JdkZlibDecompressor.newFactory(dictionary));
+        return new DecompressionHandler(ZlibDecompressor.newFactory(dictionary));
     }
 
     private ZlibCodecFactory() {

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibCompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibCompressor.java
@@ -30,7 +30,7 @@ import static io.netty.util.internal.ObjectUtil.checkInRange;
 /**
  * Compresses a {@link ByteBuf} using the deflate algorithm.
  */
-public final class JdkZlibCompressor implements Compressor {
+public final class ZlibCompressor implements Compressor {
     private final ZlibWrapper wrapper;
     private final Deflater deflater;
 
@@ -48,12 +48,12 @@ public final class JdkZlibCompressor implements Compressor {
     private State state = State.PROCESSING;
     private boolean writeHeader = true;
 
-    private JdkZlibCompressor(ZlibWrapper wrapper, int compressionLevel) {
+    private ZlibCompressor(ZlibWrapper wrapper, int compressionLevel) {
         this.wrapper = wrapper;
         deflater = new Deflater(compressionLevel, wrapper != ZlibWrapper.ZLIB);
     }
 
-    private JdkZlibCompressor(int compressionLevel, byte[] dictionary) {
+    private ZlibCompressor(int compressionLevel, byte[] dictionary) {
         wrapper = ZlibWrapper.ZLIB;
         deflater = new Deflater(compressionLevel);
         deflater.setDictionary(dictionary);
@@ -66,7 +66,7 @@ public final class JdkZlibCompressor implements Compressor {
      * @return the factory.
      * @throws CompressionException if failed to initialize zlib
      */
-    public static Supplier<JdkZlibCompressor> newFactory() {
+    public static Supplier<ZlibCompressor> newFactory() {
         return newFactory(6);
     }
 
@@ -81,7 +81,7 @@ public final class JdkZlibCompressor implements Compressor {
      *
      * @throws CompressionException if failed to initialize zlib
      */
-    public static Supplier<JdkZlibCompressor> newFactory(int compressionLevel) {
+    public static Supplier<ZlibCompressor> newFactory(int compressionLevel) {
         return newFactory(ZlibWrapper.ZLIB, compressionLevel);
     }
 
@@ -92,7 +92,7 @@ public final class JdkZlibCompressor implements Compressor {
      * @return the factory.
      * @throws CompressionException if failed to initialize zlib
      */
-    public static Supplier<JdkZlibCompressor> newFactory(ZlibWrapper wrapper) {
+    public static Supplier<ZlibCompressor> newFactory(ZlibWrapper wrapper) {
         return newFactory(wrapper, 6);
     }
 
@@ -107,7 +107,7 @@ public final class JdkZlibCompressor implements Compressor {
      * @return the factory.
      * @throws CompressionException if failed to initialize zlib
      */
-    public static Supplier<JdkZlibCompressor> newFactory(ZlibWrapper wrapper, int compressionLevel) {
+    public static Supplier<ZlibCompressor> newFactory(ZlibWrapper wrapper, int compressionLevel) {
         checkInRange(compressionLevel, 0, 9 , "compressionLevel");
         requireNonNull(wrapper, "wrapper");
         if (wrapper == ZlibWrapper.ZLIB_OR_NONE) {
@@ -116,7 +116,7 @@ public final class JdkZlibCompressor implements Compressor {
                             "allowed for compression.");
         }
 
-        return () -> new JdkZlibCompressor(wrapper, compressionLevel);
+        return () -> new ZlibCompressor(wrapper, compressionLevel);
     }
 
     /**
@@ -129,7 +129,7 @@ public final class JdkZlibCompressor implements Compressor {
      * @return the factory.
      * @throws CompressionException if failed to initialize zlib
      */
-    public static Supplier<JdkZlibCompressor> newFactory(byte[] dictionary) {
+    public static Supplier<ZlibCompressor> newFactory(byte[] dictionary) {
         return newFactory(6, dictionary);
     }
 
@@ -147,14 +147,14 @@ public final class JdkZlibCompressor implements Compressor {
      * @return the factory.
      * @throws CompressionException if failed to initialize zlib
      */
-    public static Supplier<JdkZlibCompressor> newFactory(int compressionLevel, byte[] dictionary) {
+    public static Supplier<ZlibCompressor> newFactory(int compressionLevel, byte[] dictionary) {
         if (compressionLevel < 0 || compressionLevel > 9) {
             throw new IllegalArgumentException(
                     "compressionLevel: " + compressionLevel + " (expected: 0-9)");
         }
         requireNonNull(dictionary, "dictionary");
 
-        return () -> new JdkZlibCompressor(compressionLevel, dictionary);
+        return () -> new ZlibCompressor(compressionLevel, dictionary);
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecompressor.java
@@ -31,7 +31,7 @@ import java.util.zip.Inflater;
 /**
  * Decompress a {@link ByteBuf} using the inflate algorithm.
  */
-public final class JdkZlibDecompressor implements Decompressor {
+public final class ZlibDecompressor implements Decompressor {
     private static final int FHCRC = 0x02;
     private static final int FEXTRA = 0x04;
     private static final int FNAME = 0x08;
@@ -70,8 +70,8 @@ public final class JdkZlibDecompressor implements Decompressor {
 
     private boolean decideZlibOrNone;
 
-    private JdkZlibDecompressor(ZlibWrapper wrapper, byte[] dictionary, boolean decompressConcatenated,
-                                int maxAllocation) {
+    private ZlibDecompressor(ZlibWrapper wrapper, byte[] dictionary, boolean decompressConcatenated,
+                             int maxAllocation) {
         this.maxAllocation = maxAllocation;
         this.decompressConcatenated = decompressConcatenated;
         switch (wrapper) {
@@ -103,7 +103,7 @@ public final class JdkZlibDecompressor implements Decompressor {
      *
      * @return the factory.
      */
-    public static Supplier<JdkZlibDecompressor> newFactory() {
+    public static Supplier<ZlibDecompressor> newFactory() {
         return newFactory(ZlibWrapper.ZLIB, null, false, 0);
     }
 
@@ -116,7 +116,7 @@ public final class JdkZlibDecompressor implements Decompressor {
      *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      * @return the factory.
      */
-    public static Supplier<JdkZlibDecompressor> newFactory(int maxAllocation) {
+    public static Supplier<ZlibDecompressor> newFactory(int maxAllocation) {
         return newFactory(ZlibWrapper.ZLIB, null, false, maxAllocation);
     }
 
@@ -127,7 +127,7 @@ public final class JdkZlibDecompressor implements Decompressor {
      *
      * @return the factory.
      */
-    public static Supplier<JdkZlibDecompressor> newFactory(byte[] dictionary) {
+    public static Supplier<ZlibDecompressor> newFactory(byte[] dictionary) {
         return newFactory(ZlibWrapper.ZLIB, dictionary, false, 0);
     }
 
@@ -141,7 +141,7 @@ public final class JdkZlibDecompressor implements Decompressor {
      *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      * @return the factory.
      */
-    public static Supplier<JdkZlibDecompressor> newFactory(byte[] dictionary, int maxAllocation) {
+    public static Supplier<ZlibDecompressor> newFactory(byte[] dictionary, int maxAllocation) {
         return newFactory(ZlibWrapper.ZLIB, dictionary, false, maxAllocation);
     }
 
@@ -152,7 +152,7 @@ public final class JdkZlibDecompressor implements Decompressor {
      *
      * @return the factory.
      */
-    public static Supplier<JdkZlibDecompressor> newFactory(ZlibWrapper wrapper) {
+    public static Supplier<ZlibDecompressor> newFactory(ZlibWrapper wrapper) {
         return newFactory(wrapper, null, false, 0);
     }
 
@@ -166,31 +166,31 @@ public final class JdkZlibDecompressor implements Decompressor {
      *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
      * @return the factory.
      */
-    public static Supplier<JdkZlibDecompressor> newFactory(ZlibWrapper wrapper, int maxAllocation) {
+    public static Supplier<ZlibDecompressor> newFactory(ZlibWrapper wrapper, int maxAllocation) {
         return newFactory(wrapper, null, false, maxAllocation);
     }
 
-    public static Supplier<JdkZlibDecompressor> newFactory(ZlibWrapper wrapper, boolean decompressConcatenated) {
+    public static Supplier<ZlibDecompressor> newFactory(ZlibWrapper wrapper, boolean decompressConcatenated) {
         return newFactory(wrapper, null, decompressConcatenated, 0);
     }
 
-    public static Supplier<JdkZlibDecompressor> newFactory(
+    public static Supplier<ZlibDecompressor> newFactory(
             ZlibWrapper wrapper, boolean decompressConcatenated, int maxAllocation) {
         return newFactory(wrapper, null, decompressConcatenated, maxAllocation);
     }
 
-    public static Supplier<JdkZlibDecompressor> newFactory(boolean decompressConcatenated) {
+    public static Supplier<ZlibDecompressor> newFactory(boolean decompressConcatenated) {
         return newFactory(ZlibWrapper.GZIP, null, decompressConcatenated, 0);
     }
 
-    public static Supplier<JdkZlibDecompressor> newFactory(boolean decompressConcatenated, int maxAllocation) {
+    public static Supplier<ZlibDecompressor> newFactory(boolean decompressConcatenated, int maxAllocation) {
         return newFactory(ZlibWrapper.GZIP, null, decompressConcatenated, maxAllocation);
     }
 
-    private static Supplier<JdkZlibDecompressor> newFactory(ZlibWrapper wrapper, byte[] dictionary,
-                                                            boolean decompressConcatenated, int maxAllocation) {
+    private static Supplier<ZlibDecompressor> newFactory(ZlibWrapper wrapper, byte[] dictionary,
+                                                         boolean decompressConcatenated, int maxAllocation) {
         requireNonNull(wrapper, "wrapper");
-        return () -> new JdkZlibDecompressor(wrapper, dictionary, decompressConcatenated, maxAllocation);
+        return () -> new ZlibDecompressor(wrapper, dictionary, decompressConcatenated, maxAllocation);
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -134,11 +134,11 @@ public class JdkZlibTest {
     }
 
     protected ChannelHandler createEncoder(ZlibWrapper wrapper) {
-        return new CompressionHandler(JdkZlibCompressor.newFactory(wrapper, 6));
+        return new CompressionHandler(ZlibCompressor.newFactory(wrapper, 6));
     }
 
     protected ChannelHandler createDecoder(ZlibWrapper wrapper, int maxAllocation) {
-        return new DecompressionHandler(JdkZlibDecompressor.newFactory(wrapper, maxAllocation));
+        return new DecompressionHandler(ZlibDecompressor.newFactory(wrapper, maxAllocation));
     }
 
     static Stream<Arguments> compressionConfigurations() {
@@ -548,7 +548,7 @@ public class JdkZlibTest {
     @Test
     public void testConcatenatedStreamsReadFully() throws IOException {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(
-                new DecompressionHandler(JdkZlibDecompressor.newFactory(true)));
+                new DecompressionHandler(ZlibDecompressor.newFactory(true)));
 
         try {
             byte[] bytes = IOUtils.toByteArray(getClass().getResourceAsStream("/multiple.gz"));
@@ -571,7 +571,7 @@ public class JdkZlibTest {
     @Test
     public void testConcatenatedStreamsReadFullyWhenFragmented() throws IOException {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(
-                new DecompressionHandler(JdkZlibDecompressor.newFactory(true)));
+                new DecompressionHandler(ZlibDecompressor.newFactory(true)));
 
         try {
             byte[] bytes = IOUtils.toByteArray(getClass().getResourceAsStream("/multiple.gz"));
@@ -611,7 +611,7 @@ public class JdkZlibTest {
         byte[] compressed = bytesOut.toByteArray();
         ByteBuf buffer = Unpooled.buffer().writeBytes(compressed).writeBytes(compressed);
         EmbeddedChannel channel = new EmbeddedChannel(
-                new DecompressionHandler(JdkZlibDecompressor.newFactory(ZlibWrapper.GZIP, true)));
+                new DecompressionHandler(ZlibDecompressor.newFactory(ZlibWrapper.GZIP, true)));
         // Write it into the Channel in a way that we were able to decompress the first data completely but not the
         // whole footer.
         assertTrue(channel.writeInbound(buffer.readRetainedSlice(compressed.length - 1)));


### PR DESCRIPTION
Motivation:

We only ship the JDK implementation anymore. No need to put JDK into the name

Modifications:

Rename classes

Result:

More consistent naming.