### PR TITLE
Add Buffer methods to read/write on NIO channels

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -17,7 +17,12 @@ package io.netty.buffer.api;
 
 import io.netty.buffer.api.internal.Statics;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 
 /**
@@ -271,6 +276,45 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @throws BufferClosedException if this or the destination buffer is closed.
      */
     void copyInto(int srcPos, Buffer dest, int destPos, int length);
+
+    /**
+     * Read from this buffer and write to the given channel.
+     * The number of bytes actually written to the channel are returned.
+     * No more than the given {@code length} of bytes, or the number of {@linkplain #readableBytes() readable bytes},
+     * will be written to the channel, whichever is smaller.
+     * If the channel has a position, then it will be advanced by the number of bytes written.
+     * The {@linkplain #readerOffset() reader-offset} of this buffer will likewise be advanced by the number of bytes
+     * written.
+     *
+     * @implNote {@linkplain CompositeBuffer composite buffers} may offer an optimized implementation of this method,
+     * if the given channel implements {@link GatheringByteChannel}.
+     *
+     * @param channel The channel to write to.
+     * @param length The maximum number of bytes to write.
+     * @return The actual number of bytes written, possibly zero.
+     * @throws IOException If the write-operation on the channel failed for some reason.
+     */
+    int readIntoChannelWrite(WritableByteChannel channel, int length) throws IOException;
+
+    /**
+     * Write to this buffer, by reading data from the given channel.
+     * The number of bytes actually read from the channel are returned, or -1 is returned if the channel has reached
+     * the end-of-stream.
+     * No more than the given {@code length} of bytes, or the number of {@linkplain #writableBytes() writable bytes},
+     * will be read from the channel, whichever is smaller.
+     * If the channel has a position, then it will be advanced by the number of bytes read.
+     * The {@linkplain #writerOffset() writer-offset} of this buffer will likewise be advanced by the number of bytes
+     * read.
+     *
+     * @implNote {@linkplain CompositeBuffer composite buffers} may offer an optimized implementation of this method,
+     * if the given channel implements {@link ScatteringByteChannel}.
+     *
+     * @param channel The channel to read from.
+     * @param length The maximum number of bytes to read.
+     * @return The actual number of bytes read, possibly zero, or -1 if the end-of-stream has been reached.
+     * @throws IOException If the read-operation on the channel failed for some reason.
+     */
+    int writeFromChannelRead(ReadableByteChannel channel, int length) throws IOException;
 
     /**
      * Writes into this buffer, all the bytes from the given {@code source} using the passed {@code charset}.

--- a/buffer/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/Buffer.java
@@ -294,10 +294,10 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @return The actual number of bytes written, possibly zero.
      * @throws IOException If the write-operation on the channel failed for some reason.
      */
-    int readIntoChannelWrite(WritableByteChannel channel, int length) throws IOException;
+    int transferTo(WritableByteChannel channel, int length) throws IOException;
 
     /**
-     * Write to this buffer, by reading data from the given channel.
+     * Read from the given channel and write to this buffer.
      * The number of bytes actually read from the channel are returned, or -1 is returned if the channel has reached
      * the end-of-stream.
      * No more than the given {@code length} of bytes, or the number of {@linkplain #writableBytes() writable bytes},
@@ -314,7 +314,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @return The actual number of bytes read, possibly zero, or -1 if the end-of-stream has been reached.
      * @throws IOException If the read-operation on the channel failed for some reason.
      */
-    int writeFromChannelRead(ReadableByteChannel channel, int length) throws IOException;
+    int transferFrom(ReadableByteChannel channel, int length) throws IOException;
 
     /**
      * Writes into this buffer, all the bytes from the given {@code source} using the passed {@code charset}.

--- a/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
@@ -116,13 +116,13 @@ public class BufferStub implements Buffer {
     }
 
     @Override
-    public int readIntoChannelWrite(WritableByteChannel channel, int length) throws IOException {
-        return delegate.readIntoChannelWrite(channel, length);
+    public int transferTo(WritableByteChannel channel, int length) throws IOException {
+        return delegate.transferTo(channel, length);
     }
 
     @Override
-    public int writeFromChannelRead(ReadableByteChannel channel, int length) throws IOException {
-        return delegate.writeFromChannelRead(channel, length);
+    public int transferFrom(ReadableByteChannel channel, int length) throws IOException {
+        return delegate.transferFrom(channel, length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty/buffer/api/BufferStub.java
@@ -15,7 +15,10 @@
  */
 package io.netty.buffer.api;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 
 /**
@@ -110,6 +113,16 @@ public class BufferStub implements Buffer {
     @Override
     public void copyInto(int srcPos, Buffer dest, int destPos, int length) {
         delegate.copyInto(srcPos, dest, destPos, length);
+    }
+
+    @Override
+    public int readIntoChannelWrite(WritableByteChannel channel, int length) throws IOException {
+        return delegate.readIntoChannelWrite(channel, length);
+    }
+
+    @Override
+    public int writeFromChannelRead(ReadableByteChannel channel, int length) throws IOException {
+        return delegate.writeFromChannelRead(channel, length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -454,7 +454,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
-    public int readIntoChannelWrite(WritableByteChannel channel, int length) throws IOException {
+    public int transferTo(WritableByteChannel channel, int length) throws IOException {
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }
@@ -480,7 +480,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
-    public int writeFromChannelRead(ReadableByteChannel channel, int length) throws IOException {
+    public int transferFrom(ReadableByteChannel channel, int length) throws IOException {
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }
@@ -504,6 +504,9 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             for (int i = 0; i < bufferCount; i++) {
                 int bytesRead = channel.read(byteBuffers[i]);
                 if (bytesRead == -1) {
+                    if (i == 0) {
+                        return -1; // If we're end-of-stream on the first read, immediately return -1.
+                    }
                     break;
                 }
                 skipWritable(bytesRead);

--- a/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/DefaultCompositeBuffer.java
@@ -459,6 +459,9 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             throw bufferIsClosed(this);
         }
         length = Math.min(readableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
         checkReadBounds(readerOffset(), length);
         ByteBufferCollector collector = new ByteBufferCollector(countReadableComponents());
         forEachReadable(0, collector);
@@ -490,6 +493,9 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             throw bufferIsReadOnly(this);
         }
         length = Math.min(writableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
         checkWriteBounds(writerOffset(), length);
         ByteBufferCollector collector = new ByteBufferCollector(countWritableComponents());
         forEachWritable(0, collector);

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -215,7 +215,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     }
 
     @Override
-    public int readIntoChannelWrite(WritableByteChannel channel, int length) throws IOException {
+    public int transferTo(WritableByteChannel channel, int length) throws IOException {
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }
@@ -227,7 +227,7 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
     }
 
     @Override
-    public int writeFromChannelRead(ReadableByteChannel channel, int length) throws IOException {
+    public int transferFrom(ReadableByteChannel channel, int length) throws IOException {
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -220,6 +220,9 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
             throw bufferIsClosed(this);
         }
         length = Math.min(readableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
         checkGet(readerOffset(), length);
         int bytesWritten = channel.write(readableBuffer().limit(length));
         skipReadable(bytesWritten);
@@ -235,6 +238,9 @@ class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent,
             throw bufferIsReadOnly(this);
         }
         length = Math.min(writableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
         checkSet(writerOffset(), length);
         int bytesRead = channel.read(writableBuffer().limit(length));
         if (bytesRead != -1) {

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -279,6 +279,9 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
             throw bufferIsClosed(this);
         }
         length = Math.min(readableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
         checkGet(readerOffset(), length);
         int bytesWritten = channel.write(readableBuffer().limit(length));
         skipReadable(bytesWritten);
@@ -294,6 +297,9 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
             throw bufferIsReadOnly(this);
         }
         length = Math.min(writableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
         checkSet(writerOffset(), length);
         int bytesRead = channel.read(writableBuffer().limit(length));
         if (bytesRead != -1) {

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -274,7 +274,7 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     }
 
     @Override
-    public int readIntoChannelWrite(WritableByteChannel channel, int length) throws IOException {
+    public int transferTo(WritableByteChannel channel, int length) throws IOException {
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }
@@ -286,7 +286,7 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
     }
 
     @Override
-    public int writeFromChannelRead(ReadableByteChannel channel, int length) throws IOException {
+    public int transferFrom(ReadableByteChannel channel, int length) throws IOException {
         if (!isAccessible()) {
             throw bufferIsClosed(this);
         }

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeBuffer.java
@@ -30,10 +30,13 @@ import io.netty.buffer.api.internal.AdaptableBuffer;
 import io.netty.buffer.api.internal.Statics;
 import io.netty.util.internal.PlatformDependent;
 
+import java.io.IOException;
 import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 
 import static io.netty.buffer.api.internal.Statics.bbslice;
 import static io.netty.buffer.api.internal.Statics.bufferIsClosed;
@@ -268,6 +271,35 @@ class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComp
             Reference.reachabilityFence(memory);
             Reference.reachabilityFence(dest);
         }
+    }
+
+    @Override
+    public int readIntoChannelWrite(WritableByteChannel channel, int length) throws IOException {
+        if (!isAccessible()) {
+            throw bufferIsClosed(this);
+        }
+        length = Math.min(readableBytes(), length);
+        checkGet(readerOffset(), length);
+        int bytesWritten = channel.write(readableBuffer().limit(length));
+        skipReadable(bytesWritten);
+        return bytesWritten;
+    }
+
+    @Override
+    public int writeFromChannelRead(ReadableByteChannel channel, int length) throws IOException {
+        if (!isAccessible()) {
+            throw bufferIsClosed(this);
+        }
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
+        length = Math.min(writableBytes(), length);
+        checkSet(writerOffset(), length);
+        int bytesRead = channel.read(writableBuffer().limit(length));
+        if (bytesRead != -1) {
+            skipWritable(bytesRead);
+        }
+        return bytesRead;
     }
 
     /**

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferAndChannelTest.java
@@ -205,6 +205,17 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
+    public void transferToZeroBytesMustNotThrowOnClosedChannel(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer empty = allocator.allocate(0);
+             Buffer notEmpty = allocator.allocate(4).writeInt(42)) {
+            empty.transferTo(closedChannel, 4);
+            notEmpty.transferTo(closedChannel, 0);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
     public void transferFromMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator()) {
             ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
@@ -428,6 +439,17 @@ public class BufferAndChannelTest extends BufferTestSupport {
             assertThat(buf.readableBytes()).isEqualTo(8);
             assertThat(channel.position()).isEqualTo(position);
             assertThat(channel.size()).isEqualTo(size);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferFromZeroBytesMustNotThrowOnClosedChannel(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer empty = allocator.allocate(0);
+             Buffer notEmpty = allocator.allocate(4)) {
+            empty.transferFrom(closedChannel, 4);
+            notEmpty.transferFrom(closedChannel, 0);
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferAndChannelTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.tests;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.BufferClosedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BufferAndChannelTest extends BufferTestSupport {
+    private static FileChannel closedChannel;
+    private static FileChannel channel;
+
+    @BeforeAll
+    static void setUpChannels() throws IOException {
+        closedChannel = tempFileChannel();
+        closedChannel.close();
+        channel = tempFileChannel();
+    }
+
+    @AfterAll
+    static void tearDownChannels() throws IOException {
+        channel.close();
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator()) {
+            long position = channel.position();
+            long size = channel.size();
+            Buffer empty = allocator.allocate(8);
+            empty.close();
+            assertThrows(BufferClosedException.class, () -> empty.readIntoChannelWrite(channel, 8));
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+            Buffer withData = allocator.allocate(8);
+            withData.writeLong(0x0102030405060708L);
+            withData.close();
+            assertThrows(BufferClosedException.class, () -> withData.readIntoChannelWrite(channel, 8));
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readMustCapAtReadableBytes(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            buf.writeLong(0x0102030405060708L);
+            buf.skipWritable(-5);
+            long position = channel.position();
+            long size = channel.size();
+            int bytesWritten = buf.readIntoChannelWrite(channel, 8);
+            assertThat(bytesWritten).isEqualTo(3);
+            assertThat(channel.position()).isEqualTo(3 + position);
+            assertThat(channel.size()).isEqualTo(3 + size);
+            assertThat(buf.writableBytes()).isEqualTo(5);
+            assertThat(buf.readableBytes()).isZero();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readMustCapAtLength(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            buf.writeLong(0x0102030405060708L);
+            long position = channel.position();
+            long size = channel.size();
+            int bytesWritten = buf.readIntoChannelWrite(channel, 3);
+            assertThat(bytesWritten).isEqualTo(3);
+            assertThat(channel.position()).isEqualTo(3 + position);
+            assertThat(channel.size()).isEqualTo(3 + size);
+            assertThat(buf.readableBytes()).isEqualTo(5);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readMustThrowIfChannelIsClosed(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            buf.writeLong(0x0102030405060708L);
+            assertThrows(ClosedChannelException.class, () -> buf.readIntoChannelWrite(closedChannel, 8));
+            assertTrue(buf.isAccessible());
+            assertThat(buf.readableBytes()).isEqualTo(8);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readMustThrowIfChannelIsNull(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            buf.writeLong(0x0102030405060708L);
+            assertThrows(NullPointerException.class, () -> buf.readIntoChannelWrite(null, 8));
+            assertTrue(buf.isAccessible());
+            assertThat(buf.readableBytes()).isEqualTo(8);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readMustThrowIfLengthIsNegative(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            buf.writeLong(0x0102030405060708L);
+            assertThrows(IllegalArgumentException.class, () -> buf.readIntoChannelWrite(channel, -1));
+            assertThat(buf.readableBytes()).isEqualTo(8);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readMustIgnoreZeroLengthOperations(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            long position = channel.position();
+            long size = channel.size();
+            buf.writeLong(0x0102030405060708L);
+            int bytesWritten = buf.readIntoChannelWrite(channel, 0);
+            assertThat(bytesWritten).isZero();
+            assertThat(buf.readableBytes()).isEqualTo(8);
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void readMustMoveDataToChannel(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            long value = ThreadLocalRandom.current().nextLong();
+            buf.writeLong(value);
+            long position = channel.position();
+            int bytesWritten = buf.readIntoChannelWrite(channel, 8);
+            assertThat(bytesWritten).isEqualTo(8);
+            ByteBuffer buffer = ByteBuffer.allocate(8);
+            int bytesRead = channel.read(buffer, position);
+            assertThat(bytesRead).isEqualTo(8);
+            buffer.flip();
+            assertEquals(value, buffer.getLong());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator()) {
+            ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
+            long position = channel.position();
+            assertThat(channel.write(data, position)).isEqualTo(8);
+            long size = channel.size();
+            Buffer empty = allocator.allocate(0);
+            empty.close();
+            assertThrows(BufferClosedException.class, () -> empty.writeFromChannelRead(channel, 8));
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+            Buffer withAvailableSpace = allocator.allocate(8);
+            withAvailableSpace.close();
+            assertThrows(BufferClosedException.class, () -> withAvailableSpace.writeFromChannelRead(channel, 8));
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+        } finally {
+            channel.position(channel.size()); // Maintain invariants; avoid test isolation failures.
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustCapAtWritableBytes(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(3)) {
+            ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
+            long position = channel.position();
+            assertThat(channel.write(data, position)).isEqualTo(8);
+            long size = channel.size();
+            int bytesRead = buf.writeFromChannelRead(channel, 8);
+            assertThat(bytesRead).isEqualTo(3);
+            assertThat(channel.position()).isEqualTo(3 + position);
+            assertThat(channel.size()).isEqualTo(size);
+            assertThat(buf.writableBytes()).isZero();
+            assertThat(buf.readableBytes()).isEqualTo(3);
+        } finally {
+            channel.position(channel.size());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustCapAtLength(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
+            long position = channel.position();
+            assertThat(channel.write(data, position)).isEqualTo(8);
+            long size = channel.size();
+            int bytesRead = buf.writeFromChannelRead(channel, 3);
+            assertThat(bytesRead).isEqualTo(3);
+            assertThat(channel.position()).isEqualTo(3 + position);
+            assertThat(channel.size()).isEqualTo(size);
+            assertThat(buf.writableBytes()).isEqualTo(5);
+            assertThat(buf.readableBytes()).isEqualTo(3);
+        } finally {
+            channel.position(channel.size());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustThrowIfChannelIsClosed(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            assertThrows(ClosedChannelException.class, () -> buf.writeFromChannelRead(closedChannel, 8));
+            assertTrue(buf.isAccessible());
+            assertThat(buf.writableBytes()).isEqualTo(8);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustThrowIfChannelIsNull(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            assertThrows(NullPointerException.class, () -> buf.writeFromChannelRead(null, 8));
+            assertTrue(buf.isAccessible());
+            assertThat(buf.writableBytes()).isEqualTo(8);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustThrowIfLengthIsNegative(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            long position = channel.position();
+            ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
+            assertThat(channel.write(data, position)).isEqualTo(8);
+            long size = channel.size();
+            assertThrows(IllegalArgumentException.class, () -> buf.writeFromChannelRead(channel, -1));
+            assertTrue(buf.isAccessible());
+            assertThat(buf.writableBytes()).isEqualTo(8);
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+        } finally {
+            channel.position(channel.size());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustIgnoreZeroLengthOperations(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            long position = channel.position();
+            ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
+            assertThat(channel.write(data, position)).isEqualTo(8);
+            long size = channel.size();
+            int bytesRead = buf.writeFromChannelRead(channel, 0);
+            assertThat(bytesRead).isEqualTo(0);
+            assertThat(buf.readableBytes()).isZero();
+            assertThat(buf.writableBytes()).isEqualTo(8);
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+        } finally {
+            channel.position(channel.size());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustMoveDataFromChannel(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            long value = ThreadLocalRandom.current().nextLong();
+            ByteBuffer data = ByteBuffer.allocate(8).putLong(value).flip();
+            long position = channel.position();
+            assertThat(channel.write(data, position)).isEqualTo(8);
+            long size = channel.size();
+            int bytesRead = buf.writeFromChannelRead(channel, 8);
+            assertThat(bytesRead).isEqualTo(8);
+            assertThat(channel.position()).isEqualTo(8 + position);
+            assertThat(channel.size()).isEqualTo(size);
+            assertThat(buf.readableBytes()).isEqualTo(8);
+            assertEquals(value, buf.readLong());
+        } finally {
+            channel.position(channel.size());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustNotReadBeyondEndOfChannel(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            ByteBuffer data = ByteBuffer.allocate(8).putInt(0x01020304).flip();
+            long position = channel.position();
+            assertThat(channel.write(data, position)).isEqualTo(4);
+            long size = channel.size();
+            int bytesRead = buf.writeFromChannelRead(channel, 8);
+            assertThat(bytesRead).isEqualTo(4);
+            assertThat(buf.readableBytes()).isEqualTo(4);
+            assertThat(channel.position()).isEqualTo(4 + position);
+            assertThat(channel.size()).isEqualTo(size);
+        } finally {
+            channel.position(channel.size());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeMustReturnMinusOneForEndOfStream(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            long position = channel.position();
+            long size = channel.size();
+            int bytesRead = buf.writeFromChannelRead(channel, 8);
+            assertThat(bytesRead).isEqualTo(-1);
+            assertThat(buf.readableBytes()).isEqualTo(0);
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+        } finally {
+            channel.position(channel.size());
+        }
+    }
+
+    private static FileChannel tempFileChannel() throws IOException {
+        Path path = Files.createTempFile("BufferAndChannelTest", "txt");
+        return FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE);
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/api/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/BufferAndChannelTest.java
@@ -18,8 +18,13 @@ package io.netty.buffer.api.tests;
 import io.netty.buffer.api.Buffer;
 import io.netty.buffer.api.BufferAllocator;
 import io.netty.buffer.api.BufferClosedException;
+import io.netty.buffer.api.BufferReadOnlyException;
+import io.netty.buffer.api.CompositeBuffer;
+import io.netty.buffer.api.DefaultBufferAllocators;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -27,11 +32,16 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,10 +51,10 @@ public class BufferAndChannelTest extends BufferTestSupport {
     private static FileChannel channel;
 
     @BeforeAll
-    static void setUpChannels() throws IOException {
-        closedChannel = tempFileChannel();
+    static void setUpChannels(@TempDir Path parentDirectory) throws IOException {
+        closedChannel = tempFileChannel(parentDirectory);
         closedChannel.close();
-        channel = tempFileChannel();
+        channel = tempFileChannel(parentDirectory);
     }
 
     @AfterAll
@@ -54,19 +64,19 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void readMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
+    public void transferToMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator()) {
             long position = channel.position();
             long size = channel.size();
             Buffer empty = allocator.allocate(8);
             empty.close();
-            assertThrows(BufferClosedException.class, () -> empty.readIntoChannelWrite(channel, 8));
+            assertThrows(BufferClosedException.class, () -> empty.transferTo(channel, 8));
             assertThat(channel.position()).isEqualTo(position);
             assertThat(channel.size()).isEqualTo(size);
             Buffer withData = allocator.allocate(8);
             withData.writeLong(0x0102030405060708L);
             withData.close();
-            assertThrows(BufferClosedException.class, () -> withData.readIntoChannelWrite(channel, 8));
+            assertThrows(BufferClosedException.class, () -> withData.transferTo(channel, 8));
             assertThat(channel.position()).isEqualTo(position);
             assertThat(channel.size()).isEqualTo(size);
         }
@@ -74,14 +84,14 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void readMustCapAtReadableBytes(Fixture fixture) throws IOException {
+    public void transferToMustCapAtReadableBytes(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
             buf.skipWritable(-5);
             long position = channel.position();
             long size = channel.size();
-            int bytesWritten = buf.readIntoChannelWrite(channel, 8);
+            int bytesWritten = buf.transferTo(channel, 8);
             assertThat(bytesWritten).isEqualTo(3);
             assertThat(channel.position()).isEqualTo(3 + position);
             assertThat(channel.size()).isEqualTo(3 + size);
@@ -92,13 +102,13 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void readMustCapAtLength(Fixture fixture) throws IOException {
+    public void transferToMustCapAtLength(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
             long position = channel.position();
             long size = channel.size();
-            int bytesWritten = buf.readIntoChannelWrite(channel, 3);
+            int bytesWritten = buf.transferTo(channel, 3);
             assertThat(bytesWritten).isEqualTo(3);
             assertThat(channel.position()).isEqualTo(3 + position);
             assertThat(channel.size()).isEqualTo(3 + size);
@@ -108,11 +118,11 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void readMustThrowIfChannelIsClosed(Fixture fixture) throws IOException {
+    public void transferToMustThrowIfChannelIsClosed(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
-            assertThrows(ClosedChannelException.class, () -> buf.readIntoChannelWrite(closedChannel, 8));
+            assertThrows(ClosedChannelException.class, () -> buf.transferTo(closedChannel, 8));
             assertTrue(buf.isAccessible());
             assertThat(buf.readableBytes()).isEqualTo(8);
         }
@@ -120,11 +130,11 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void readMustThrowIfChannelIsNull(Fixture fixture) throws IOException {
+    public void transferToMustThrowIfChannelIsNull(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
-            assertThrows(NullPointerException.class, () -> buf.readIntoChannelWrite(null, 8));
+            assertThrows(NullPointerException.class, () -> buf.transferTo(null, 8));
             assertTrue(buf.isAccessible());
             assertThat(buf.readableBytes()).isEqualTo(8);
         }
@@ -132,24 +142,24 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void readMustThrowIfLengthIsNegative(Fixture fixture) throws IOException {
+    public void transferToMustThrowIfLengthIsNegative(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
-            assertThrows(IllegalArgumentException.class, () -> buf.readIntoChannelWrite(channel, -1));
+            assertThrows(IllegalArgumentException.class, () -> buf.transferTo(channel, -1));
             assertThat(buf.readableBytes()).isEqualTo(8);
         }
     }
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void readMustIgnoreZeroLengthOperations(Fixture fixture) throws IOException {
+    public void transferToMustIgnoreZeroLengthOperations(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long position = channel.position();
             long size = channel.size();
             buf.writeLong(0x0102030405060708L);
-            int bytesWritten = buf.readIntoChannelWrite(channel, 0);
+            int bytesWritten = buf.transferTo(channel, 0);
             assertThat(bytesWritten).isZero();
             assertThat(buf.readableBytes()).isEqualTo(8);
             assertThat(channel.position()).isEqualTo(position);
@@ -159,13 +169,13 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void readMustMoveDataToChannel(Fixture fixture) throws IOException {
+    public void transferToMustMoveDataToChannel(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long value = ThreadLocalRandom.current().nextLong();
             buf.writeLong(value);
             long position = channel.position();
-            int bytesWritten = buf.readIntoChannelWrite(channel, 8);
+            int bytesWritten = buf.transferTo(channel, 8);
             assertThat(bytesWritten).isEqualTo(8);
             ByteBuffer buffer = ByteBuffer.allocate(8);
             int bytesRead = channel.read(buffer, position);
@@ -177,7 +187,25 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
+    public void transferToMustMoveReadOnlyDataToChannel(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            long value = ThreadLocalRandom.current().nextLong();
+            buf.writeLong(value).makeReadOnly();
+            long position = channel.position();
+            int bytesWritten = buf.transferTo(channel, 8);
+            assertThat(bytesWritten).isEqualTo(8);
+            ByteBuffer buffer = ByteBuffer.allocate(8);
+            int bytesRead = channel.read(buffer, position);
+            assertThat(bytesRead).isEqualTo(8);
+            buffer.flip();
+            assertEquals(value, buffer.getLong());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferFromMustThrowIfBufferIsClosed(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator()) {
             ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
             long position = channel.position();
@@ -185,29 +213,29 @@ public class BufferAndChannelTest extends BufferTestSupport {
             long size = channel.size();
             Buffer empty = allocator.allocate(0);
             empty.close();
-            assertThrows(BufferClosedException.class, () -> empty.writeFromChannelRead(channel, 8));
+            assertThrows(BufferClosedException.class, () -> empty.transferFrom(channel, 8));
             assertThat(channel.position()).isEqualTo(position);
             assertThat(channel.size()).isEqualTo(size);
             Buffer withAvailableSpace = allocator.allocate(8);
             withAvailableSpace.close();
-            assertThrows(BufferClosedException.class, () -> withAvailableSpace.writeFromChannelRead(channel, 8));
+            assertThrows(BufferClosedException.class, () -> withAvailableSpace.transferFrom(channel, 8));
             assertThat(channel.position()).isEqualTo(position);
             assertThat(channel.size()).isEqualTo(size);
         } finally {
-            channel.position(channel.size()); // Maintain invariants; avoid test isolation failures.
+            channel.position(channel.size());
         }
     }
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustCapAtWritableBytes(Fixture fixture) throws IOException {
+    public void transferFromMustCapAtWritableBytes(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(3)) {
             ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
             long position = channel.position();
             assertThat(channel.write(data, position)).isEqualTo(8);
             long size = channel.size();
-            int bytesRead = buf.writeFromChannelRead(channel, 8);
+            int bytesRead = buf.transferFrom(channel, 8);
             assertThat(bytesRead).isEqualTo(3);
             assertThat(channel.position()).isEqualTo(3 + position);
             assertThat(channel.size()).isEqualTo(size);
@@ -220,14 +248,14 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustCapAtLength(Fixture fixture) throws IOException {
+    public void transferFromMustCapAtLength(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
             long position = channel.position();
             assertThat(channel.write(data, position)).isEqualTo(8);
             long size = channel.size();
-            int bytesRead = buf.writeFromChannelRead(channel, 3);
+            int bytesRead = buf.transferFrom(channel, 3);
             assertThat(bytesRead).isEqualTo(3);
             assertThat(channel.position()).isEqualTo(3 + position);
             assertThat(channel.size()).isEqualTo(size);
@@ -240,10 +268,10 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustThrowIfChannelIsClosed(Fixture fixture) {
+    public void transferFromMustThrowIfChannelIsClosed(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
-            assertThrows(ClosedChannelException.class, () -> buf.writeFromChannelRead(closedChannel, 8));
+            assertThrows(ClosedChannelException.class, () -> buf.transferFrom(closedChannel, 8));
             assertTrue(buf.isAccessible());
             assertThat(buf.writableBytes()).isEqualTo(8);
         }
@@ -251,10 +279,10 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustThrowIfChannelIsNull(Fixture fixture) {
+    public void transferFromMustThrowIfChannelIsNull(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
-            assertThrows(NullPointerException.class, () -> buf.writeFromChannelRead(null, 8));
+            assertThrows(NullPointerException.class, () -> buf.transferFrom(null, 8));
             assertTrue(buf.isAccessible());
             assertThat(buf.writableBytes()).isEqualTo(8);
         }
@@ -262,14 +290,14 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustThrowIfLengthIsNegative(Fixture fixture) throws IOException {
+    public void transferFromMustThrowIfLengthIsNegative(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long position = channel.position();
             ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
             assertThat(channel.write(data, position)).isEqualTo(8);
             long size = channel.size();
-            assertThrows(IllegalArgumentException.class, () -> buf.writeFromChannelRead(channel, -1));
+            assertThrows(IllegalArgumentException.class, () -> buf.transferFrom(channel, -1));
             assertTrue(buf.isAccessible());
             assertThat(buf.writableBytes()).isEqualTo(8);
             assertThat(channel.position()).isEqualTo(position);
@@ -281,14 +309,14 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustIgnoreZeroLengthOperations(Fixture fixture) throws IOException {
+    public void transferFromMustIgnoreZeroLengthOperations(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long position = channel.position();
             ByteBuffer data = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
             assertThat(channel.write(data, position)).isEqualTo(8);
             long size = channel.size();
-            int bytesRead = buf.writeFromChannelRead(channel, 0);
+            int bytesRead = buf.transferFrom(channel, 0);
             assertThat(bytesRead).isEqualTo(0);
             assertThat(buf.readableBytes()).isZero();
             assertThat(buf.writableBytes()).isEqualTo(8);
@@ -301,7 +329,7 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustMoveDataFromChannel(Fixture fixture) throws IOException {
+    public void transferFromMustMoveDataFromChannel(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long value = ThreadLocalRandom.current().nextLong();
@@ -309,7 +337,7 @@ public class BufferAndChannelTest extends BufferTestSupport {
             long position = channel.position();
             assertThat(channel.write(data, position)).isEqualTo(8);
             long size = channel.size();
-            int bytesRead = buf.writeFromChannelRead(channel, 8);
+            int bytesRead = buf.transferFrom(channel, 8);
             assertThat(bytesRead).isEqualTo(8);
             assertThat(channel.position()).isEqualTo(8 + position);
             assertThat(channel.size()).isEqualTo(size);
@@ -322,14 +350,14 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustNotReadBeyondEndOfChannel(Fixture fixture) throws IOException {
+    public void transferFromMustNotReadBeyondEndOfChannel(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             ByteBuffer data = ByteBuffer.allocate(8).putInt(0x01020304).flip();
             long position = channel.position();
             assertThat(channel.write(data, position)).isEqualTo(4);
             long size = channel.size();
-            int bytesRead = buf.writeFromChannelRead(channel, 8);
+            int bytesRead = buf.transferFrom(channel, 8);
             assertThat(bytesRead).isEqualTo(4);
             assertThat(buf.readableBytes()).isEqualTo(4);
             assertThat(channel.position()).isEqualTo(4 + position);
@@ -341,12 +369,12 @@ public class BufferAndChannelTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void writeMustReturnMinusOneForEndOfStream(Fixture fixture) throws IOException {
+    public void transferFromMustReturnMinusOneForEndOfStream(Fixture fixture) throws IOException {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             long position = channel.position();
             long size = channel.size();
-            int bytesRead = buf.writeFromChannelRead(channel, 8);
+            int bytesRead = buf.transferFrom(channel, 8);
             assertThat(bytesRead).isEqualTo(-1);
             assertThat(buf.readableBytes()).isEqualTo(0);
             assertThat(channel.position()).isEqualTo(position);
@@ -356,8 +384,147 @@ public class BufferAndChannelTest extends BufferTestSupport {
         }
     }
 
-    private static FileChannel tempFileChannel() throws IOException {
-        Path path = Files.createTempFile("BufferAndChannelTest", "txt");
-        return FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE);
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferFromMustReturnMinusOneForEndOfStreamNonScattering(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            long position = channel.position();
+            long size = channel.size();
+            ReadableByteChannel nonScatteringChannel = new ReadableByteChannel() {
+                @Override
+                public int read(ByteBuffer dst) throws IOException {
+                    return channel.read(dst);
+                }
+
+                @Override
+                public boolean isOpen() {
+                    return channel.isOpen();
+                }
+
+                @Override
+                public void close() throws IOException {
+                    channel.close();
+                }
+            };
+            int bytesRead = buf.transferFrom(nonScatteringChannel, 8);
+            assertThat(bytesRead).isEqualTo(-1);
+            assertThat(buf.readableBytes()).isEqualTo(0);
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+        } finally {
+            channel.position(channel.size());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void transferFromMustThrowIfBufferIsReadOnly(Fixture fixture) throws IOException {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8).writeLong(0x0102030405060708L).makeReadOnly()) {
+            long position = channel.position();
+            long size = channel.size();
+            assertThrows(BufferReadOnlyException.class, () -> buf.transferFrom(channel, 8));
+            assertThat(buf.readableBytes()).isEqualTo(8);
+            assertThat(channel.position()).isEqualTo(position);
+            assertThat(channel.size()).isEqualTo(size);
+        }
+    }
+
+    @Test
+    public void partialFailureOfTransferToMustKeepChannelAndBufferPositionsInSync(@TempDir Path parentDir)
+            throws IOException {
+        BufferAllocator allocator = DefaultBufferAllocators.onHeapAllocator();
+        Path path = parentDir.resolve("transferTo");
+        try (FileChannel channel = FileChannel.open(path, READ, WRITE, CREATE);
+             Buffer buf = CompositeBuffer.compose(
+                allocator,
+                allocator.allocate(4).writeInt(0x01020304).send(),
+                allocator.allocate(4).writeInt(0x05060708).send())) {
+            WritableByteChannel channelWrapper = new WritableByteChannel() {
+                private boolean pastFirstCall;
+
+                @Override
+                public int write(ByteBuffer src) throws IOException {
+                    if (pastFirstCall) {
+                        throw new IOException("boom");
+                    }
+                    pastFirstCall = true;
+                    return channel.write(src);
+                }
+
+                @Override
+                public boolean isOpen() {
+                    return channel.isOpen();
+                }
+
+                @Override
+                public void close() throws IOException {
+                    channel.close();
+                }
+            };
+
+            long position = channel.position();
+            long size = channel.size();
+            var e = assertThrows(IOException.class, () -> buf.transferTo(channelWrapper, 8));
+            assertThat(e).hasMessage("boom");
+            assertThat(channel.position()).isEqualTo(4 + position);
+            assertThat(channel.size()).isEqualTo(4 + size);
+            assertThat(buf.readableBytes()).isEqualTo(4);
+            assertThat(buf.readerOffset()).isEqualTo(4);
+        }
+    }
+
+    @Test
+    public void partialFailureOfTransferFromMustKeepChannelAndBufferPositionsInSync(@TempDir Path parentDir)
+            throws IOException {
+        BufferAllocator allocator = DefaultBufferAllocators.onHeapAllocator();
+        Path path = parentDir.resolve("transferFrom");
+        try (FileChannel channel = FileChannel.open(path, READ, WRITE, CREATE);
+             Buffer buf = CompositeBuffer.compose(
+                allocator,
+                allocator.allocate(4).send(),
+                allocator.allocate(4).send())) {
+            ByteBuffer byteBuffer = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
+            assertThat(channel.write(byteBuffer)).isEqualTo(8);
+            channel.position(0);
+
+            ReadableByteChannel channelWrapper = new ReadableByteChannel() {
+                private boolean pastFirstCall;
+
+                @Override
+                public int read(ByteBuffer dst) throws IOException {
+                    if (pastFirstCall) {
+                        throw new IOException("boom");
+                    }
+                    pastFirstCall = true;
+                    return channel.read(dst);
+                }
+
+                @Override
+                public boolean isOpen() {
+                    return channel.isOpen();
+                }
+
+                @Override
+                public void close() throws IOException {
+                    channel.close();
+                }
+            };
+
+            long position = channel.position();
+            long size = channel.size();
+            var e = assertThrows(IOException.class, () -> buf.transferFrom(channelWrapper, 8));
+            assertThat(e).hasMessage("boom");
+            assertThat(channel.position()).isEqualTo(4 + position);
+            assertThat(channel.size()).isEqualTo(size);
+            assertThat(buf.readableBytes()).isEqualTo(4);
+            assertThat(buf.writerOffset()).isEqualTo(4);
+        }
+    }
+
+    private static FileChannel tempFileChannel(Path parentDirectory) throws IOException {
+        Path path = Files.createTempFile(parentDirectory, "BufferAndChannelTest", "txt");
+        return FileChannel.open(path, READ, WRITE, DELETE_ON_CLOSE);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -499,7 +499,7 @@
     <logging.logLevel>debug</logging.logLevel>
     <log4j2.version>2.17.1</log4j2.version>
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
-    <junit.version>5.7.0</junit.version>
+    <junit.version>5.8.2</junit.version>
     <graalvm.version>19.3.6</graalvm.version>
     <brotli4j.version>1.4.2</brotli4j.version>
     <skipTests>false</skipTests>


### PR DESCRIPTION
Motivation:
The NIO transport needs to perform IO on NIO channels using Buffer instances, but NIO needs ByteBuffer instances.
Bridging this gap in the most efficient way possible depends on the Buffer implementation.
Therefor, Buffer needs methods to do IO on NIO channels.

Modification:
Add readIntoChannelWrite and writeFromChannelRead methods to Buffer.
The names may look awkward, but that is a consequence of trying to avoid confusion, when we are doing reads from the perspective of the buffer, but writes from the perspective of the channel, and vice versa.
The DefaultCompositeBuffer additionally has vectored implementations for Scatter/Gather channels.

Result:
It'll be possible to implement Buffer support in the NIO transport, in a more efficient way.
