### PR TITLE
Expose OpenSSL security level in the SSL handler

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContextOption.java
@@ -68,4 +68,12 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
      */
     public static final OpenSslContextOption<OpenSslCertificateCompressionConfig> CERTIFICATE_COMPRESSION_ALGORITHMS =
             new OpenSslContextOption<OpenSslCertificateCompressionConfig>("CERTIFICATE_COMPRESSION_ALGORITHMS");
+
+    /**
+     * Set the security level to use.<br>
+     * This is currently only supported when {@code OpenSSL} version 1.1.0 or newer is used.
+     * @see https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html
+     */
+    public static final OpenSslContextOption<Integer> SECURITY_LEVEL =
+            new OpenSslContextOption<Integer>("SECURITY_LEVEL");
 }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -227,6 +227,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         OpenSslPrivateKeyMethod privateKeyMethod = null;
         OpenSslAsyncPrivateKeyMethod asyncPrivateKeyMethod = null;
         OpenSslCertificateCompressionConfig certCompressionConfig = null;
+        Integer securityLevel = null;
 
         if (ctxOptions != null) {
             for (Map.Entry<SslContextOption<?>, Object> ctxOpt : ctxOptions) {
@@ -242,6 +243,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                     asyncPrivateKeyMethod = (OpenSslAsyncPrivateKeyMethod) ctxOpt.getValue();
                 } else if (option == OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS) {
                     certCompressionConfig = (OpenSslCertificateCompressionConfig) ctxOpt.getValue();
+                } else if (option == OpenSslContextOption.SECURITY_LEVEL) {
+                    securityLevel = (Integer) ctxOpt.getValue();
                 } else {
                     logger.debug("Skipping unsupported " + SslContextOption.class.getSimpleName()
                             + ": " + ctxOpt.getKey());
@@ -409,6 +412,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                             throw new IllegalStateException();
                     }
                 }
+            }
+            if (securityLevel != null) {
+                SSLContext.setSecurityLevel(ctx, securityLevel.intValue());
             }
             // Set the curves.
             SSLContext.setCurvesList(ctx, OpenSsl.NAMED_GROUPS);


### PR DESCRIPTION
Motivation:

From version 1.1.0, OpenSSL provides a "security level" configuration which specifies which minimum security parameters are allowed for connexions (SSL version, ciphers, signature algorithms, and so on).
Setting a value less secure than the platform's default one can be useful, for instance when wanting to connect to legacy servers.

Modifications:

Allow the user to set OpenSSL security level parameter as an SSL context option.
This PR depends on changes made in https://github.com/netty/netty-tcnative/pull/697

Result:

The user can specify a value for the OpenSSL security level, as an SSL context option.