### PR TITLE
Add CORS Access Control for Private Networks

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
@@ -70,6 +70,11 @@ public final class HttpHeaderNames {
     public static final AsciiString ACCESS_CONTROL_ALLOW_ORIGIN =
             AsciiString.cached("access-control-allow-origin");
     /**
+     * {@code "access-control-allow-origin"}
+     */
+    public static final AsciiString ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK =
+            AsciiString.cached("access-control-allow-private-network");
+    /**
      * {@code "access-control-expose-headers"}
      */
     public static final AsciiString ACCESS_CONTROL_EXPOSE_HEADERS =
@@ -88,6 +93,11 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString ACCESS_CONTROL_REQUEST_METHOD =
             AsciiString.cached("access-control-request-method");
+    /**
+     * {@code "access-control-request-private-network"}
+     */
+    public static final AsciiString ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK =
+            AsciiString.cached("access-control-request-private-network");
     /**
      * {@code "age"}
      */

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsConfig.java
@@ -45,6 +45,7 @@ public final class CorsConfig {
     private final boolean allowNullOrigin;
     private final Map<CharSequence, Callable<?>> preflightHeaders;
     private final boolean shortCircuit;
+    private final boolean allowPrivateNetwork;
 
     CorsConfig(final CorsConfigBuilder builder) {
         origins = new LinkedHashSet<String>(builder.origins);
@@ -58,6 +59,7 @@ public final class CorsConfig {
         allowNullOrigin = builder.allowNullOrigin;
         preflightHeaders = builder.preflightHeaders;
         shortCircuit = builder.shortCircuit;
+        allowPrivateNetwork = builder.allowPrivateNetwork;
     }
 
     /**
@@ -107,6 +109,20 @@ public final class CorsConfig {
      */
     public boolean isNullOriginAllowed() {
         return allowNullOrigin;
+    }
+
+    /**
+     * Web browsers may set the 'Access-Control-Request-Private-Network' request header if a resource is loaded
+     * from a local network.
+     * By default direct access to private network endpoints from public websites is not allowed.
+     *
+     * If isPrivateNetworkAllowed is true the server will response with the CORS response header
+     * 'Access-Control-Request-Private-Network'.
+     *
+     * @return {@code true} if private network access should be allowed.
+     */
+    public boolean isPrivateNetworkAllowed() {
+        return allowPrivateNetwork;
     }
 
     /**
@@ -253,7 +269,8 @@ public final class CorsConfig {
                 ", maxAge=" + maxAge +
                 ", allowedRequestMethods=" + allowedRequestMethods +
                 ", allowedRequestHeaders=" + allowedRequestHeaders +
-                ", preflightHeaders=" + preflightHeaders + ']';
+                ", preflightHeaders=" + preflightHeaders +
+                ", isPrivateNetworkAllowed=" + allowPrivateNetwork + ']';
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsConfigBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsConfigBuilder.java
@@ -77,6 +77,7 @@ public final class CorsConfigBuilder {
     final Map<CharSequence, Callable<?>> preflightHeaders = new HashMap<CharSequence, Callable<?>>();
     private boolean noPreflightHeaders;
     boolean shortCircuit;
+    boolean allowPrivateNetwork;
 
     /**
      * Creates a new Builder instance with the origin passed in.
@@ -349,6 +350,19 @@ public final class CorsConfigBuilder {
      */
     public CorsConfigBuilder shortCircuit() {
         shortCircuit = true;
+        return this;
+    }
+
+    /**
+     * Web browsers may set the 'Access-Control-Request-Private-Network' request header if a resource is loaded
+     * from a local network.
+     * By default direct access to private network endpoints from public websites is not allowed.
+     * Calling this method will set the CORS 'Access-Control-Request-Private-Network' response header to true.
+     *
+     * @return {@link CorsConfigBuilder} to support method chaining.
+     */
+    public CorsConfigBuilder allowPrivateNetwork() {
+        allowPrivateNetwork = true;
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -69,7 +69,7 @@ public class CorsHandler extends ChannelDuplexHandler {
      * config matches a certain origin, the first in the List will be used.
      *
      * @param configList     List of {@link CorsConfig}
-     * @param isShortCircuit Same as {@link CorsConfig#shortCircuit} but applicable to all supplied configs.
+     * @param isShortCircuit Same as {@link CorsConfig#isShortCircuit} but applicable to all supplied configs.
      */
     public CorsHandler(final List<CorsConfig> configList, boolean isShortCircuit) {
         checkNonEmpty(configList, "configList");
@@ -103,6 +103,7 @@ public class CorsHandler extends ChannelDuplexHandler {
             setAllowCredentials(response);
             setMaxAge(response);
             setPreflightHeaders(response);
+            setAllowPrivateNetwork(response);
         }
         if (!response.headers().contains(HttpHeaderNames.CONTENT_LENGTH)) {
             response.headers().set(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);
@@ -212,6 +213,16 @@ public class CorsHandler extends ChannelDuplexHandler {
 
     private void setMaxAge(final HttpResponse response) {
         response.headers().set(HttpHeaderNames.ACCESS_CONTROL_MAX_AGE, config.maxAge());
+    }
+
+    private void setAllowPrivateNetwork(final HttpResponse response) {
+        if (request.headers().contains(HttpHeaderNames.ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK)) {
+            if (config.isPrivateNetworkAllowed()) {
+                response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK, "true");
+            } else {
+                response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK, "false");
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Some browsers started to create warnings when requesting resources from a server on a private network. In the future these requests will quite likely be blocked.
See: [private-network-access-preflight](https://developer.chrome.com/blog/private-network-access-preflight/)

Modification:

Added HttpHeaderNames for `Access-Control-Request-Private-Network` and `Access-Control-Allow-Private-Network`
Modified the `CorsHandler` to act on the access control request
