### PR TITLE
Don't set the writerIndex to incorrect value when scattering reads ar…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelOutboundBuffer.MessageProcessor;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.Limits;
+import io.netty.channel.unix.SegmentedDatagramPacket;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.Inet6Address;
@@ -162,6 +163,9 @@ final class NativeDatagramPacketArray {
     @UnstableApi
     public final class NativeDatagramPacket {
 
+        // IMPORTANT: Most of the below variables are accessed via JNI. Be aware if you change any of these you also
+        // need to change these in the related .c file!
+
         // This is the actual struct iovec*
         private long memoryAddress;
         private int count;
@@ -210,7 +214,6 @@ final class NativeDatagramPacketArray {
             if (recipientAddrLen != 0) {
                 recipient = newAddress(recipientAddr, recipientAddrLen, recipientPort, recipientScopeId, ipv4Bytes);
             }
-            buffer.writerIndex(count);
 
             // UDP_GRO
             if (segmentSize > 0) {


### PR DESCRIPTION
…e used for datagrams

Motivation:

Due a bug we did set the writerIndex(...) of datagrams to an incorrect value sometimes when scattering reads are used.

Modifications:

- Remove incorrect call to writerIndex(...)
- Add comment

Result:

Correct writerIndex is used
