### PR TITLE
Add HTTP-specific TooLongFrameExceptions

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -24,7 +24,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.MessageAggregator;
-import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -273,7 +272,7 @@ public class HttpObjectAggregator
             }
         } else if (oversized instanceof HttpResponse) {
             ctx.close();
-            throw new TooLongFrameException("Response entity too large: " + oversized);
+            throw new TooLongHttpContentException("Response entity too large: " + oversized);
         } else {
             throw new IllegalStateException();
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -45,13 +45,13 @@ import java.util.List;
  * <td>The maximum length of the initial line
  *     (e.g. {@code "GET / HTTP/1.0"} or {@code "HTTP/1.0 200 OK"})
  *     If the length of the initial line exceeds this value, a
- *     {@link TooLongFrameException} will be raised.</td>
+ *     {@link TooLongHttpLineException} will be raised.</td>
  * </tr>
  * <tr>
  * <td>{@code maxHeaderSize}</td>
  * <td>{@value #DEFAULT_MAX_HEADER_SIZE}</td>
  * <td>The maximum length of all headers.  If the sum of the length of each
- *     header exceeds this value, a {@link TooLongFrameException} will be raised.</td>
+ *     header exceeds this value, a {@link TooLongHttpHeaderException} will be raised.</td>
  * </tr>
  * <tr>
  * <td>{@code maxChunkSize}</td>
@@ -981,7 +981,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         }
 
         protected TooLongFrameException newException(int maxLength) {
-            return new TooLongFrameException("HTTP header is larger than " + maxLength + " bytes.");
+            return new TooLongHttpHeaderException("HTTP header is larger than " + maxLength + " bytes.");
         }
     }
 
@@ -1013,7 +1013,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         @Override
         protected TooLongFrameException newException(int maxLength) {
-            return new TooLongFrameException("An HTTP line is larger than " + maxLength + " bytes.");
+            return new TooLongHttpLineException("An HTTP line is larger than " + maxLength + " bytes.");
         }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -17,8 +17,6 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.TooLongFrameException;
-
 
 /**
  * Decodes {@link ByteBuf}s into {@link HttpRequest}s and {@link HttpContent}s.
@@ -32,12 +30,12 @@ import io.netty.handler.codec.TooLongFrameException;
  * <td>{@code maxInitialLineLength}</td>
  * <td>The maximum length of the initial line (e.g. {@code "GET / HTTP/1.0"})
  *     If the length of the initial line exceeds this value, a
- *     {@link TooLongFrameException} will be raised.</td>
+ *     {@link TooLongHttpLineException} will be raised.</td>
  * </tr>
  * <tr>
  * <td>{@code maxHeaderSize}</td>
  * <td>The maximum length of all headers.  If the sum of the length of each
- *     header exceeds this value, a {@link TooLongFrameException} will be raised.</td>
+ *     header exceeds this value, a {@link TooLongHttpHeaderException} will be raised.</td>
  * </tr>
  * <tr>
  * <td>{@code maxChunkSize}</td>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -17,8 +17,6 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.TooLongFrameException;
-
 
 /**
  * Decodes {@link ByteBuf}s into {@link HttpResponse}s and
@@ -33,12 +31,12 @@ import io.netty.handler.codec.TooLongFrameException;
  * <td>{@code maxInitialLineLength}</td>
  * <td>The maximum length of the initial line (e.g. {@code "HTTP/1.0 200 OK"})
  *     If the length of the initial line exceeds this value, a
- *     {@link TooLongFrameException} will be raised.</td>
+ *     {@link TooLongHttpLineException} will be raised.</td>
  * </tr>
  * <tr>
  * <td>{@code maxHeaderSize}</td>
  * <td>The maximum length of all headers.  If the sum of the length of each
- *     header exceeds this value, a {@link TooLongFrameException} will be raised.</td>
+ *     header exceeds this value, a {@link TooLongHttpHeaderException} will be raised.</td>
  * </tr>
  * <tr>
  * <td>{@code maxChunkSize}</td>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpContentException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpContentException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.TooLongFrameException;
+
+/**
+ * An {@link TooLongFrameException} which is thrown when the length of the
+ * content decoded is greater than the allowed maximum.
+ */
+public class TooLongHttpContentException extends TooLongFrameException {
+
+    private static final long serialVersionUID = 3238341182129476117L;
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpContentException() {
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpContentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpContentException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpContentException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpContentException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpContentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,7 +21,7 @@ import io.netty.handler.codec.TooLongFrameException;
  * An {@link TooLongFrameException} which is thrown when the length of the
  * content decoded is greater than the allowed maximum.
  */
-public class TooLongHttpContentException extends TooLongFrameException {
+public final class TooLongHttpContentException extends TooLongFrameException {
 
     private static final long serialVersionUID = 3238341182129476117L;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpHeaderException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpHeaderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,7 +21,7 @@ import io.netty.handler.codec.TooLongFrameException;
  * An {@link TooLongFrameException} which is thrown when the length of the
  * header decoded is greater than the allowed maximum.
  */
-public class TooLongHttpHeaderException extends TooLongFrameException {
+public final class TooLongHttpHeaderException extends TooLongFrameException {
 
     private static final long serialVersionUID = -8295159138628369730L;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpHeaderException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpHeaderException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.TooLongFrameException;
+
+/**
+ * An {@link TooLongFrameException} which is thrown when the length of the
+ * header decoded is greater than the allowed maximum.
+ */
+public class TooLongHttpHeaderException extends TooLongFrameException {
+
+    private static final long serialVersionUID = -8295159138628369730L;
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpHeaderException() {
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpHeaderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpHeaderException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpHeaderException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpLineException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpLineException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.TooLongFrameException;
+
+/**
+ * An {@link TooLongFrameException} which is thrown when the length of the
+ * line decoded is greater than the allowed maximum.
+ */
+public class TooLongHttpLineException extends TooLongFrameException {
+
+    private static final long serialVersionUID = 1614751125592211890L;
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpLineException() {
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpLineException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpLineException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public TooLongHttpLineException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpLineException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/TooLongHttpLineException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,7 +21,7 @@ import io.netty.handler.codec.TooLongFrameException;
  * An {@link TooLongFrameException} which is thrown when the length of the
  * line decoded is greater than the allowed maximum.
  */
-public class TooLongHttpLineException extends TooLongFrameException {
+public final class TooLongHttpLineException extends TooLongFrameException {
 
     private static final long serialVersionUID = 1614751125592211890L;
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.DecoderResultProvider;
-import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
@@ -290,7 +289,7 @@ public class HttpObjectAggregatorTest {
         assertFalse(embedder.writeInbound(message));
         assertFalse(embedder.writeInbound(chunk1));
 
-        assertThrows(TooLongFrameException.class, new Executable() {
+        assertThrows(TooLongHttpContentException.class, new Executable() {
             @Override
             public void execute() {
                 embedder.writeInbound(chunk2);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
@@ -305,7 +304,7 @@ public class HttpRequestDecoderTest {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();
         assertTrue(request.decoderResult().isFailure());
-        assertTrue(request.decoderResult().cause() instanceof TooLongFrameException);
+        assertTrue(request.decoderResult().cause() instanceof TooLongHttpLineException);
         assertFalse(channel.finish());
     }
 
@@ -327,7 +326,7 @@ public class HttpRequestDecoderTest {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();
         assertTrue(request.decoderResult().isFailure());
-        assertTrue(request.decoderResult().cause() instanceof TooLongFrameException);
+        assertTrue(request.decoderResult().cause() instanceof TooLongHttpLineException);
         assertFalse(channel.finish());
     }
 
@@ -354,7 +353,7 @@ public class HttpRequestDecoderTest {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();
         assertTrue(request.decoderResult().isFailure());
-        assertTrue(request.decoderResult().cause() instanceof TooLongFrameException);
+        assertTrue(request.decoderResult().cause() instanceof TooLongHttpHeaderException);
         assertFalse(channel.finish());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.PrematureChannelClosureException;
-import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
@@ -98,7 +97,7 @@ public class HttpResponseDecoderTest {
         ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII));
 
         HttpResponse res = ch.readInbound();
-        assertTrue(res.decoderResult().cause() instanceof TooLongFrameException);
+        assertTrue(res.decoderResult().cause() instanceof TooLongHttpHeaderException);
 
         assertFalse(ch.finish());
         assertNull(ch.readInbound());


### PR DESCRIPTION
Motivation:

I want to examine an HTTP request's decoderResult's cause to determine if my application should return a REQUEST_ENTITY_TOO_LARGE, REQUEST_URI_TOO_LONG, REQUEST_HEADER_FIELDS_TOO_LARGE. Currently the cause is just a plain TooLongFrameException. Although they have different messages, it seems unsafe to examine the messages.

Modifications:

I have extended TooLongFrameException to have TooLongHttpContentException, TooLongHttpHeaderException, and TooLongHttpLineException. Then I updated the sites to throw a specific subclass. Theoretically, more specific subclasses can be added for spdy and websocket, but I held off for now.

Result:

I can examine the decoderResult's cause and properly select how to respond based on what specifically happened. The tests have been update to verify this.
