### PR TITLE
Avoid reading uninitialised memory when making domain socket address

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -414,6 +414,7 @@ static jobject _recvFromDomainSocket(JNIEnv* env, jint fd, void* buffer, jint po
     int err;
 
     do {
+        bzero(&addr, sizeof(addr)); // Zap addr so we can strlen(addr.sun_path) later. See unix(4).
         res = recvfrom(fd, buffer + pos, (size_t) (limit - pos), 0, (struct sockaddr*) &addr, &addrlen);
         // Keep on reading if it was interrupted
     } while (res == -1 && ((err = errno) == EINTR));


### PR DESCRIPTION
Motivation:
Stack variables contain uninitialised memory, unless explicitly initialised.
When we use `recvfrom` on a domain socket, it may not fill in any `NUL` byte terminator for the `sockaddr_un->sun_path`, since it technically provided the address length in the `addrlen` inout-parameter.
Thus, if we wish to later use strlen in `createDomainDatagramSocketAddress` to determine the length of the `sockaddr_un->sun_path`, we have to initialise the `sockaddr` to zero, so the `NUL` byte is already in place.
We have to do this on every iteration since we don't know the state of the memory after a failed or interrupted call.

Modification:
Always zero out the data allocated to the socket address, prior to calling `recvfrom` on domain sockets.

Result:
We no longer observe the occasional domain socket address that has some extra data in the end of its name.