### PR TITLE
Allow attaching additional metadata to ResourceLeakTrackers on creation

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -300,7 +300,7 @@ public class ResourceLeakDetector<T> {
                 continue;
             }
 
-            String records = ref.toString();
+            String records = ref.getReportAndClearRecords();
             if (reportedLeaks.add(records)) {
                 if (records.isEmpty()) {
                     reportUntracedLeak(resourceType);
@@ -519,7 +519,16 @@ public class ResourceLeakDetector<T> {
 
         @Override
         public String toString() {
+            TraceRecord oldHead = headUpdater.get(this);
+            return generateReport(oldHead);
+        }
+
+        String getReportAndClearRecords() {
             TraceRecord oldHead = headUpdater.getAndSet(this, null);
+            return generateReport(oldHead);
+        }
+
+        private String generateReport(TraceRecord oldHead) {
             if (oldHead == null) {
                 // Already closed
                 return EMPTY_STRING;


### PR DESCRIPTION
Motivation:
Attaching metadata to the creation record of a ResourceLeakTracker allows implementations to give more context information about where the leak originated from, such as the currently running test case, or, for fuzzing tests, the input that caused the leak.

Modification:
Add a protected method getInitialHint to ResourceLeakDetector that is called to populate the hint of the first TraceRecord of a leak. The method returns null by default, keeping the old behavior.

Result:
Subclasses can override the new method to supply metadata that is then interpreted the same way as a hint passed to ResourceLeakTracker.track, and attached to the "Created at:" record.

Fixes #12080  

---

The test case for this is dodgy, because it needs to trigger GC to trigger the reportLeak, and triggering GC is unreliable. This test was flaky for me locally, so I disabled it for now (much of the class is untested already anyway). I think it shouldn't be removed entirely, it's a decent usage example and may help someone with debugging in the future. I'm open to suggestions to make this test case better