### PR TITLE
HTTP/2 header validation must reject duplicate pseudo-headers

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -127,6 +127,23 @@ public class DefaultHttp2HeadersDecoderTest {
         }
     }
 
+    @Test
+    public void duplicatePseudoHeadersMustFailValidation() throws Exception {
+        final ByteBuf buf = encode(b(":authority"), b("abc"), b(":authority"), b("def"));
+        try {
+            final DefaultHttp2HeadersDecoder decoder = new DefaultHttp2HeadersDecoder(true);
+            Http2Exception e = assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    decoder.decodeHeaders(1, buf);
+                }
+            });
+            assertEquals(Http2Error.PROTOCOL_ERROR, e.error());
+        } finally {
+            buf.release();
+        }
+    }
+
     private static byte[] b(String string) {
         return string.getBytes(UTF_8);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -420,6 +420,7 @@ public class HpackDecoderTest {
             sb.append("61"); // 'a'
         }
         decode(sb.toString());
+        verify(mockHeaders).contains(of(":authority"));
         verify(mockHeaders).add(of(":authority"), of(value));
         verifyNoMoreInteractions(mockHeaders);
         reset(mockHeaders);


### PR DESCRIPTION
Motivation:
Duplicate HTTP/2 pseudo-headers are either client bugs (best case) or an indication of a request smuggling attack (worst case).
Header validation should reject this with a protocol error.
Doing so is also in line with the current HTTP/2 spec draft, which says:

> The same pseudo-header field name MUST NOT appear more than once in a field block. A field block for an HTTP request or response that contains a repeated pseudo-header field name MUST be treated as malformed (Section 8.1.1).

See https://httpwg.org/http2-spec/draft-ietf-httpbis-http2bis.html#name-http-control-data

Modification:
If header validation is enabled, and we parsed a pseudo-header, and if we find that the header object already has such a header, then we throw a stream protocol error.
Also added a test for this.

Result:
Header validation now rejects duplicate pseudo-headers, in line with best practices and the draft spec.