### PR TITLE
Use `Objects#requireNonNull`

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.dns;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 import io.netty.util.internal.UnstableApi;
 
 @UnstableApi
@@ -37,7 +37,7 @@ public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
      */
     public TcpDnsQueryDecoder(DnsRecordDecoder decoder, int maxFrameLength) {
         super(maxFrameLength, 0, 2, 0, 2);
-        this.decoder = ObjectUtil.checkNotNull(decoder, "decoder");
+        this.decoder = requireNonNull(decoder, "decoder");
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 import io.netty.util.internal.UnstableApi;
 
 import java.util.List;
@@ -40,7 +40,7 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
      * Creates a new encoder with the specified {@code encoder}.
      */
     public TcpDnsResponseEncoder(DnsRecordEncoder encoder) {
-        this.encoder = ObjectUtil.checkNotNull(encoder, "encoder");
+        this.encoder = requireNonNull(encoder, "encoder");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -30,6 +30,8 @@ import io.netty.handler.codec.compression.ZstdCompressor;
 import io.netty.handler.codec.compression.ZstdOptions;
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -32,6 +32,8 @@ import io.netty.handler.codec.compression.ZstdOptions;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseCombiner;
+import static java.util.Objects.requireNonNull;
+
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
@@ -109,7 +111,7 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
     public CompressorHttp2ConnectionEncoder(Http2ConnectionEncoder delegate,
                                             CompressionOptions... compressionOptionsArgs) {
         super(delegate);
-        ObjectUtil.checkNotNull(compressionOptionsArgs, "CompressionOptions");
+        requireNonNull(compressionOptionsArgs, "CompressionOptions");
         ObjectUtil.deepCheckNotNull("CompressionOptions", compressionOptionsArgs);
 
         for (CompressionOptions compressionOptions : compressionOptionsArgs) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http2;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import static java.util.Objects.requireNonNull;
+
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataChunkedInput.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataChunkedInput.java
@@ -18,7 +18,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.stream.ChunkedInput;
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A {@link ChunkedInput} that fetches data chunk by chunk for use with HTTP/2 Data Frames.
@@ -56,8 +56,8 @@ public final class Http2DataChunkedInput implements ChunkedInput<Http2DataFrame>
      * @param stream {@link Http2FrameStream} holding stream info
      */
     public Http2DataChunkedInput(ChunkedInput<ByteBuf> input, Http2FrameStream stream) {
-        this.input = ObjectUtil.checkNotNull(input, "input");
-        this.stream = ObjectUtil.checkNotNull(stream, "stream");
+        this.input = requireNonNull(input, "input");
+        this.stream = requireNonNull(stream, "stream");
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EmptyDataFrameConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EmptyDataFrameConnectionDecoder.java
@@ -16,6 +16,8 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Enforce a limit on the maximum number of consecutive empty DATA frames (without end_of_stream flag) that are allowed
  * before the connection will be closed.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EmptyDataFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EmptyDataFrameListener.java
@@ -18,6 +18,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Enforce a limit on the maximum number of consecutive empty DATA frames (without end_of_stream flag) that are allowed
  * before the connection will be closed.

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliCompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliCompressor.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -48,7 +48,7 @@ public final class BrotliCompressor implements Compressor {
      * @param parameters {@link Encoder.Parameters} Instance
      */
     private BrotliCompressor(Encoder.Parameters parameters) {
-        this.parameters = ObjectUtil.checkNotNull(parameters, "Parameters");
+        this.parameters = requireNonNull(parameters, "Parameters");
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliDecompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliDecompressor.java
@@ -22,6 +22,8 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.function.Supplier;

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliOptions.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.compression;
 
 import com.aayushatharva.brotli4j.encoder.Encoder;
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 
 /**
  * {@link BrotliOptions} holds {@link Encoder.Parameters} for
@@ -38,7 +38,7 @@ public final class BrotliOptions implements CompressionOptions {
             throw new IllegalStateException("Brotli is not available", Brotli.cause());
         }
 
-        this.parameters = ObjectUtil.checkNotNull(parameters, "Parameters");
+        this.parameters = requireNonNull(parameters, "Parameters");
     }
 
     public Encoder.Parameters parameters() {

--- a/codec/src/main/java/io/netty/handler/codec/compression/DeflateOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/DeflateOptions.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.compression;
 
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * {@link DeflateOptions} holds {@link #compressionLevel()},
  * {@link #memLevel()} and {@link #windowBits()} for Deflate compression.

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4Compressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4Compressor.java
@@ -20,6 +20,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.EncoderException;
+import static java.util.Objects.requireNonNull;
+
 import io.netty.util.internal.ObjectUtil;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Exception;
@@ -42,7 +44,6 @@ import static io.netty.handler.codec.compression.Lz4Constants.MAGIC_NUMBER;
 import static io.netty.handler.codec.compression.Lz4Constants.MAX_BLOCK_SIZE;
 import static io.netty.handler.codec.compression.Lz4Constants.MIN_BLOCK_SIZE;
 import static io.netty.handler.codec.compression.Lz4Constants.TOKEN_OFFSET;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Compresses a {@link ByteBuf} using the LZ4 format.

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdCompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdCompressor.java
@@ -21,6 +21,8 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.EncoderException;
 import io.netty.util.internal.ObjectUtil;
+
+import static java.util.Objects.requireNonNull;
 import java.nio.ByteBuffer;
 import java.util.function.Supplier;
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdOptions.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.compression;
 
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.MAX_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_BLOCK_SIZE;

--- a/common/src/main/java/io/netty/util/DomainWildcardMappingBuilder.java
+++ b/common/src/main/java/io/netty/util/DomainWildcardMappingBuilder.java
@@ -18,7 +18,7 @@ package io.netty.util;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Builder that allows to build {@link Mapping}s that support
@@ -48,7 +48,7 @@ public class DomainWildcardMappingBuilder<V> {
      *                        when nothing matches the input
      */
     public DomainWildcardMappingBuilder(int initialCapacity, V defaultValue) {
-        this.defaultValue = checkNotNull(defaultValue, "defaultValue");
+        this.defaultValue = requireNonNull(defaultValue, "defaultValue");
         map = new LinkedHashMap<String, V>(initialCapacity);
     }
 
@@ -71,16 +71,16 @@ public class DomainWildcardMappingBuilder<V> {
      */
     public DomainWildcardMappingBuilder<V> add(String hostname, V output) {
         map.put(normalizeHostName(hostname),
-                checkNotNull(output, "output"));
+                requireNonNull(output, "output"));
         return this;
     }
 
     private String normalizeHostName(String hostname) {
-        checkNotNull(hostname, "hostname");
+        requireNonNull(hostname, "hostname");
         if (hostname.isEmpty() || hostname.charAt(0) == '.') {
             throw new IllegalArgumentException("Hostname '" + hostname + "' not valid");
         }
-        hostname = ImmutableDomainWildcardMapping.normalize(checkNotNull(hostname, "hostname"));
+        hostname = ImmutableDomainWildcardMapping.normalize(requireNonNull(hostname, "hostname"));
         if (hostname.charAt(0) == '*') {
             if (hostname.length() < 3 || hostname.charAt(1) != '.') {
                 throw new IllegalArgumentException("Wildcard Hostname '" + hostname + "'not valid");

--- a/common/src/main/java/io/netty/util/NettyRuntime.java
+++ b/common/src/main/java/io/netty/util/NettyRuntime.java
@@ -16,6 +16,8 @@
 
 package io.netty.util;
 
+import static java.util.Objects.requireNonNull;
+
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 

--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util;
 
+import static java.util.Objects.requireNonNull;
+
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;

--- a/common/src/main/java/io/netty/util/concurrent/RejectedExecutionHandlers.java
+++ b/common/src/main/java/io/netty/util/concurrent/RejectedExecutionHandlers.java
@@ -17,6 +17,8 @@ package io.netty.util.concurrent;
 
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;

--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -17,7 +17,6 @@ package io.netty.util.internal;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Map;
 
 /**
@@ -31,15 +30,6 @@ public final class ObjectUtil {
     private static final int INT_ZERO = 0;
 
     private ObjectUtil() {
-    }
-
-    /**
-     * Checks that the given argument is not null. If it is, throws {@link NullPointerException}.
-     * Otherwise, returns the argument.
-     */
-    @Deprecated
-    public static <T> T checkNotNull(T arg, String text) {
-        return Objects.requireNonNull(arg, text);
     }
 
     /**
@@ -210,7 +200,7 @@ public final class ObjectUtil {
     public static <T> T[] checkNonEmpty(T[] array, String name) {
         //No String concatenation for check
         if (requireNonNull(array, name).length == 0) {
-            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+            throw new IllegalArgumentException("Param '" + name + "' must not be empty");
         }
         return array;
     }
@@ -222,8 +212,8 @@ public final class ObjectUtil {
      */
     public static byte[] checkNonEmpty(byte[] array, String name) {
         //No String concatenation for check
-        if (checkNotNull(array, name).length == 0) {
-            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        if (requireNonNull(array, name).length == 0) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be empty");
         }
         return array;
     }
@@ -235,7 +225,7 @@ public final class ObjectUtil {
      */
     public static char[] checkNonEmpty(char[] array, String name) {
         //No String concatenation for check
-        if (checkNotNull(array, name).length == 0) {
+        if (requireNonNull(array, name).length == 0) {
             throw new IllegalArgumentException("Param '" + name + "' must not be empty");
         }
         return array;
@@ -260,7 +250,7 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static String checkNonEmpty(final String value, final String name) {
-        if (checkNotNull(value, name).isEmpty()) {
+        if (requireNonNull(value, name).isEmpty()) {
             throw new IllegalArgumentException("Param '" + name + "' must not be empty");
         }
         return value;
@@ -272,8 +262,8 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static <K, V, T extends Map<K, V>> T checkNonEmpty(T value, String name) {
-        if (checkNotNull(value, name).isEmpty()) {
-            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        if (requireNonNull(value, name).isEmpty()) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be empty");
         }
         return value;
     }
@@ -284,14 +274,14 @@ public final class ObjectUtil {
      * Otherwise, returns the argument.
      */
     public static CharSequence checkNonEmpty(final CharSequence value, final String name) {
-        if (checkNotNull(value, name).length() == 0) {
-            throw new IllegalArgumentException("Param '" + name + "' must not be emtpy");
+        if (requireNonNull(value, name).length() == 0) {
+            throw new IllegalArgumentException("Param '" + name + "' must not be empty");
         }
         return value;
     }
 
     /**
-     * Trims the the given argument and checks whether it is neither null nor empty.
+     * Trims the given argument and checks whether it is neither null nor empty.
      * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
      * Otherwise, returns the trimmed argument.
      *
@@ -302,7 +292,7 @@ public final class ObjectUtil {
      * @throws IllegalArgumentException if the trimmed value is empty.
      */
     public static String checkNonEmptyAfterTrim(final String value, final String name) {
-        String trimmed = checkNotNull(value, name).trim();
+        String trimmed = requireNonNull(value, name).trim();
         return checkNonEmpty(trimmed, name);
     }
 

--- a/common/src/test/java/io/netty/util/internal/ObjectUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/ObjectUtilTest.java
@@ -16,6 +16,7 @@ package io.netty.util.internal;
 
 import org.junit.jupiter.api.Test;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,7 +76,7 @@ public class ObjectUtilTest {
     public void testCheckNotNull() {
         Exception actualEx = null;
         try {
-            ObjectUtil.checkNotNull(NON_NULL_OBJECT, NON_NULL_NAME);
+            requireNonNull(NON_NULL_OBJECT, NON_NULL_NAME);
         } catch (Exception e) {
             actualEx = e;
         }
@@ -83,7 +84,7 @@ public class ObjectUtilTest {
 
         actualEx = null;
         try {
-            ObjectUtil.checkNotNull(NULL_OBJECT, NULL_NAME);
+            requireNonNull(NULL_OBJECT, NULL_NAME);
         } catch (Exception e) {
             actualEx = e;
         }

--- a/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java
+++ b/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java
@@ -23,6 +23,8 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.util.concurrent.Future;
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * {@link ChannelHandler} which consolidates {@link Channel#flush()} / {@link ChannelHandlerContext#flush()}
  * operations (which also includes

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -18,7 +18,7 @@ package io.netty.handler.ipfilter;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
@@ -67,7 +67,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
      * @param rules {@link IpSubnetFilterRule} as an array
      */
     public IpSubnetFilter(IpSubnetFilterRule... rules) {
-        this(true, Arrays.asList(ObjectUtil.checkNotNull(rules, "rules")));
+        this(true, Arrays.asList(requireNonNull(rules, "rules")));
     }
 
     /**
@@ -78,7 +78,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
      * @param rules            {@link IpSubnetFilterRule} as an array
      */
     public IpSubnetFilter(boolean acceptIfNotFound, IpSubnetFilterRule... rules) {
-        this(acceptIfNotFound, Arrays.asList(ObjectUtil.checkNotNull(rules, "rules")));
+        this(acceptIfNotFound, Arrays.asList(requireNonNull(rules, "rules")));
     }
 
     /**
@@ -99,7 +99,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
      * @param rules            {@link IpSubnetFilterRule} as a {@link List}
      */
     public IpSubnetFilter(boolean acceptIfNotFound, List<IpSubnetFilterRule> rules) {
-        ObjectUtil.checkNotNull(rules, "rules");
+        requireNonNull(rules, "rules");
         this.acceptIfNotFound = acceptIfNotFound;
 
         int numAcceptIPv4 = 0;
@@ -112,7 +112,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
 
         // Iterate over rules and check for `null` rule.
         for (IpSubnetFilterRule ipSubnetFilterRule : rules) {
-            ObjectUtil.checkNotNull(ipSubnetFilterRule, "rule");
+            requireNonNull(ipSubnetFilterRule, "rule");
 
             if (ipSubnetFilterRule.getFilterRule() instanceof IpSubnetFilterRule.Ip4SubnetFilterRule) {
                 unsortedIPv4Rules.add(ipSubnetFilterRule);

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingX509KeyManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingX509KeyManagerFactory.java
@@ -17,6 +17,8 @@ package io.netty.handler.ssl;
 
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.KeyManagerFactorySpi;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateCompressionConfig.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -92,8 +92,8 @@ public final class OpenSslCertificateCompressionConfig implements
         private final AlgorithmMode mode;
 
         private AlgorithmConfig(OpenSslCertificateCompressionAlgorithm algorithm, AlgorithmMode mode) {
-            this.algorithm = ObjectUtil.checkNotNull(algorithm, "algorithm");
-            this.mode = ObjectUtil.checkNotNull(mode, "mode");
+            this.algorithm = requireNonNull(algorithm, "algorithm");
+            this.mode = requireNonNull(mode, "mode");
         }
 
         /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactory.java
@@ -17,7 +17,6 @@ package io.netty.handler.ssl;
 
 import static java.util.Objects.requireNonNull;
 import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -255,7 +254,7 @@ public final class OpenSslX509KeyManagerFactory extends KeyManagerFactory {
     public static OpenSslX509KeyManagerFactory newEngineBased(X509Certificate[] certificateChain, String password)
             throws CertificateException, IOException,
                    KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
-        checkNotNull(certificateChain, "certificateChain");
+        requireNonNull(certificateChain, "certificateChain");
         KeyStore store = new OpenSslKeyStore(certificateChain.clone(), false);
         store.load(null, null);
         OpenSslX509KeyManagerFactory factory = new OpenSslX509KeyManagerFactory();
@@ -288,7 +287,7 @@ public final class OpenSslX509KeyManagerFactory extends KeyManagerFactory {
     public static OpenSslX509KeyManagerFactory newKeyless(X509Certificate... certificateChain)
             throws CertificateException, IOException,
             KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
-        checkNotNull(certificateChain, "certificateChain");
+        requireNonNull(certificateChain, "certificateChain");
         KeyStore store = new OpenSslKeyStore(certificateChain.clone(), true);
         store.load(null, null);
         OpenSslX509KeyManagerFactory factory = new OpenSslX509KeyManagerFactory();

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextOption.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextOption.java
@@ -17,7 +17,7 @@ package io.netty.handler.ssl;
 
 import io.netty.util.AbstractConstant;
 import io.netty.util.ConstantPool;
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 
 
 /**
@@ -81,6 +81,6 @@ public class SslContextOption<T> extends AbstractConstant<SslContextOption<T>> {
      * may override this for special checks.
      */
     public void validate(T value) {
-        ObjectUtil.checkNotNull(value, "value");
+        requireNonNull(value, "value");
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactoryBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactoryBuilder.java
@@ -16,8 +16,8 @@
 
 package io.netty.handler.ssl.util;
 
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
+import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +44,7 @@ public final class FingerprintTrustManagerFactoryBuilder {
      * @param algorithm a hash algorithm
      */
     FingerprintTrustManagerFactoryBuilder(String algorithm) {
-        this.algorithm = checkNotNull(algorithm, "algorithm");
+        this.algorithm = requireNonNull(algorithm, "algorithm");
     }
 
     /**
@@ -54,7 +54,7 @@ public final class FingerprintTrustManagerFactoryBuilder {
      * @return the same builder
      */
     public FingerprintTrustManagerFactoryBuilder fingerprints(CharSequence... fingerprints) {
-        return fingerprints(Arrays.asList(checkNotNull(fingerprints, "fingerprints")));
+        return fingerprints(Arrays.asList(requireNonNull(fingerprints, "fingerprints")));
     }
 
     /**
@@ -64,7 +64,7 @@ public final class FingerprintTrustManagerFactoryBuilder {
      * @return the same builder
      */
     public FingerprintTrustManagerFactoryBuilder fingerprints(Iterable<? extends CharSequence> fingerprints) {
-        checkNotNull(fingerprints, "fingerprints");
+        requireNonNull(fingerprints, "fingerprints");
         for (CharSequence fingerprint : fingerprints) {
             checkNotNullWithIAE(fingerprint, "fingerprint");
             this.fingerprints.add(fingerprint.toString());

--- a/handler/src/main/java/io/netty/handler/ssl/util/LazyJavaxX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/LazyJavaxX509Certificate.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl.util;
 
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 
 import javax.security.cert.CertificateException;
 import javax.security.cert.CertificateExpiredException;
@@ -38,7 +38,7 @@ public final class LazyJavaxX509Certificate extends X509Certificate {
      * Creates a new instance which will lazy parse the given bytes. Be aware that the bytes will not be cloned.
      */
     public LazyJavaxX509Certificate(byte[] bytes) {
-        this.bytes = ObjectUtil.checkNotNull(bytes, "bytes");
+        this.bytes = requireNonNull(bytes, "bytes");
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl.util;
 
-import io.netty.util.internal.ObjectUtil;
+import static java.util.Objects.requireNonNull;
 
 import javax.security.auth.x500.X500Principal;
 import java.io.ByteArrayInputStream;
@@ -57,7 +57,7 @@ public final class LazyX509Certificate extends X509Certificate {
      * Creates a new instance which will lazy parse the given bytes. Be aware that the bytes will not be cloned.
      */
     public LazyX509Certificate(byte[] bytes) {
-        this.bytes = ObjectUtil.checkNotNull(bytes, "bytes");
+        this.bytes = requireNonNull(bytes, "bytes");
     }
 
     @Override

--- a/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
@@ -16,6 +16,8 @@
 package io.netty.resolver;
 
 import io.netty.util.CharsetUtil;
+import static java.util.Objects.requireNonNull;
+
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;

--- a/resolver/src/main/java/io/netty/resolver/HostsFileEntriesProvider.java
+++ b/resolver/src/main/java/io/netty/resolver/HostsFileEntriesProvider.java
@@ -37,7 +37,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A container of hosts file entries
@@ -182,8 +182,8 @@ public final class HostsFileEntriesProvider {
 
         @Override
         public HostsFileEntriesProvider parse(File file, Charset... charsets) throws IOException {
-            checkNotNull(file, "file");
-            checkNotNull(charsets, "charsets");
+            requireNonNull(file, "file");
+            requireNonNull(charsets, "charsets");
             if (charsets.length == 0) {
                 charsets = new Charset[]{Charset.defaultCharset()};
             }
@@ -206,7 +206,7 @@ public final class HostsFileEntriesProvider {
 
         @Override
         public HostsFileEntriesProvider parse(Reader reader) throws IOException {
-            checkNotNull(reader, "reader");
+            requireNonNull(reader, "reader");
             BufferedReader buff = new BufferedReader(reader);
             try {
                 Map<String, List<InetAddress>> ipv4Entries = new HashMap<String, List<InetAddress>>();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -27,6 +27,8 @@ import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DatagramChannelConfig;
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.NetworkInterface;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -30,7 +30,7 @@ import static io.netty.channel.kqueue.Native.CONNECT_TCP_FASTOPEN;
 import static io.netty.channel.unix.Errors.ERRNO_EINPROGRESS_NEGATIVE;
 import static io.netty.channel.unix.Errors.ioResult;
 import static io.netty.channel.unix.NativeInetAddress.ipv4MappedIpv6Address;
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A socket which provides access BSD native methods.
@@ -119,7 +119,7 @@ final class BsdSocket extends Socket {
      */
     int connectx(InetSocketAddress source, InetSocketAddress destination, IovArray data, boolean tcpFastOpen)
             throws IOException {
-        checkNotNull(destination, "Destination InetSocketAddress cannot be null.");
+        requireNonNull(destination, "Destination InetSocketAddress cannot be null.");
         int flags = tcpFastOpen ? CONNECT_TCP_FASTOPEN : 0;
 
         boolean sourceIPv6;

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -20,6 +20,8 @@ import io.netty.buffer.api.BufferAllocator;
 import io.netty.buffer.api.DefaultBufferAllocators;
 import io.netty.util.internal.ObjectUtil;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -41,7 +43,6 @@ import static io.netty.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
 import static io.netty.channel.ChannelOption.WRITE_SPIN_COUNT;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
-import static java.util.Objects.requireNonNull;
 
 /**
  * The default {@link ChannelConfig} implementation.


### PR DESCRIPTION
Motivation:
Currently, we rely upon `ObjectUtil#checkNotNull` for checking if an object is not `null`. This method existed because Java 6 or 7 didn't have `Objects#requireNonNull`. Now Netty 5 is based on Java so we can use ``Objects#requireNonNull`.

Modification:
Removed and changed `ObjectUtil#checkNotNull` to `Objects#requireNonNull`

Result:
Use standard code for `null` checks.
