### PR TITLE
Include .hprof files when uploading artifacts

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -204,3 +204,4 @@ jobs:
           path: |
             **/target/surefire-reports/
             **/hs_err*.log
+            **/*.hprof


### PR DESCRIPTION
Motivation:
These are created when a test runs out of heap memory, and we need them to be able to effectively debug OOMEs in our builds.

Modification:
Make the upload-artifact action include any hprof files anywhere, when it wraps up the state of a failed build.

Result:
We should now get .hprof files included in the archives when a build fails with an OutOfMemoryError.