### PR TITLE
AssertionError crashes in PoolArena

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -160,7 +160,8 @@ abstract class PoolArena<T> extends SizeClasses implements PoolArenaMetric {
             final PoolSubpage<T> s = head.next;
             needsNormalAllocation = s == head;
             if (!needsNormalAllocation) {
-                assert s.doNotDestroy && s.elemSize == sizeIdx2size(sizeIdx);
+                assert s.doNotDestroy && s.elemSize == sizeIdx2size(sizeIdx) : "doNotDestroy=" +
+                        s.doNotDestroy + ", elemSize=" + s.elemSize + ", sizeIdx=" + sizeIdx;
                 long handle = s.allocate();
                 assert handle >= 0;
                 s.chunk.initBufWithSubpage(buf, null, handle, reqCapacity, cache);


### PR DESCRIPTION
Motivation:

When AssertionError is thrown it is not immediately obvious what state is "bad".

Modifications:

Add state variables when throwing assertion.

Result:

Debug #12093