### PR TITLE
Reduce the default PooledByteBufAllocator chunk size from 16 MiB to 4 MiB

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -42,7 +42,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     private static final int DEFAULT_NUM_DIRECT_ARENA;
 
     private static final int DEFAULT_PAGE_SIZE;
-    private static final int DEFAULT_MAX_ORDER; // 8192 << 11 = 16 MiB per chunk
+    private static final int DEFAULT_MAX_ORDER; // 8192 << 9 = 4 MiB per chunk
     private static final int DEFAULT_SMALL_CACHE_SIZE;
     private static final int DEFAULT_NORMAL_CACHE_SIZE;
     static final int DEFAULT_MAX_CACHED_BUFFER_CAPACITY;
@@ -77,7 +77,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         DEFAULT_PAGE_SIZE = defaultPageSize;
         DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT = defaultAlignment;
 
-        int defaultMaxOrder = SystemPropertyUtil.getInt("io.netty.allocator.maxOrder", 11);
+        int defaultMaxOrder = SystemPropertyUtil.getInt("io.netty.allocator.maxOrder", 9);
         Throwable maxOrderFallbackCause = null;
         try {
             validateAndCalculateChunkSize(DEFAULT_PAGE_SIZE, defaultMaxOrder);

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -133,7 +133,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
                 /*nHeapArena=*/ 1,
                 /*nDirectArena=*/ 1,
                 /*pageSize=*/8192,
-                /*maxOrder=*/ 11,
+                /*maxOrder=*/ 9,
                 /*tinyCacheSize=*/ 0,
                 /*smallCacheSize=*/ 0,
                 /*normalCacheSize=*/ 0,
@@ -144,24 +144,24 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     public void testArenaMetricsNoCache() {
-        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 0, 0, 0), 100, 0, 100, 100);
+        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 9, 0, 0, 0), 100, 0, 100, 100);
     }
 
     @Test
     public void testArenaMetricsCache() {
-        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 1000, 1000, 1000), 100, 1, 1, 0);
+        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 9, 1000, 1000, 1000), 100, 1, 1, 0);
     }
 
     @Test
     public void testArenaMetricsNoCacheAlign() {
         Assumptions.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
-        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 0, 0, 0, true, 64), 100, 0, 100, 100);
+        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 9, 0, 0, 0, true, 64), 100, 0, 100, 100);
     }
 
     @Test
     public void testArenaMetricsCacheAlign() {
         Assumptions.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
-        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 1000, 1000, 1000, true, 64), 100, 1, 1, 0);
+        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 9, 1000, 1000, 1000, true, 64), 100, 1, 1, 0);
     }
 
     private static void testArenaMetrics0(
@@ -214,7 +214,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     public void testSmallSubpageMetric() {
-        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 9, 0, 0, 0);
         ByteBuf buffer = allocator.heapBuffer(500);
         try {
             PoolArenaMetric metric = allocator.metric().heapArenas().get(0);
@@ -227,7 +227,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     public void testAllocNotNull() {
-        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 9, 0, 0, 0);
         // Huge allocation
         testAllocNotNull(allocator, allocator.metric().chunkSize() + 1);
         // Normal allocation
@@ -277,7 +277,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     public void testCollapse() {
         int pageSize = 8192;
         //no cache
-        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 0, 1, 8192, 9, 0, 0, 0);
 
         ByteBuf b1 = allocator.buffer(pageSize * 4);
         ByteBuf b2 = allocator.buffer(pageSize * 5);
@@ -310,7 +310,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     @Test
     public void testAllocateSmallOffset() {
         int pageSize = 8192;
-        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 0, 1, 8192, 9, 0, 0, 0);
 
         int size = pageSize * 5;
 
@@ -527,10 +527,10 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
         // We use no caches and only one arena to maximize the chance of hitting the race-condition we
         // had before.
-        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 0, 1, 8192, 9, 0, 0, 0);
         List<AllocationThread> threads = new ArrayList<AllocationThread>();
         try {
-            for (int i = 0; i < 512; i++) {
+            for (int i = 0; i < 64; i++) {
                 AllocationThread thread = new AllocationThread(allocator);
                 thread.start();
                 threads.add(thread);
@@ -654,7 +654,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     public void testCacheWorksForNormalAllocations() {
         int maxCachedBufferCapacity = PooledByteBufAllocator.DEFAULT_MAX_CACHED_BUFFER_CAPACITY;
         final PooledByteBufAllocator allocator =
-                new PooledByteBufAllocator(true, 1, 1,
+                new PooledByteBufAllocator(true, 0, 1,
                         PooledByteBufAllocator.defaultPageSize(), PooledByteBufAllocator.defaultMaxOrder(),
                         128, 128, true);
         ByteBuf buffer = allocator.directBuffer(maxCachedBufferCapacity);
@@ -847,8 +847,8 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         int directMemoryCacheAlignment = 0;
         PooledByteBufAllocator alloc = new PooledByteBufAllocator(
                 PooledByteBufAllocator.defaultPreferDirect(),
-                PooledByteBufAllocator.defaultNumHeapArena(),
-                PooledByteBufAllocator.defaultNumDirectArena(),
+                1,
+                1,
                 PooledByteBufAllocator.defaultPageSize(),
                 PooledByteBufAllocator.defaultMaxOrder(),
                 smallCacheSize,


### PR DESCRIPTION
Motivation:
By default we allocate 2 arenas per core, and each arena that is put to use will allocate a chunk.
If we don't need a lot of memory, and certainly not compared to the number of cores on a system, then this will take up more memory than necessary, since each chunk is 16 MiB.
By reducing the chunk size to 4 MiB, we reduce the minimum memory usage by a good deal, in these cases where not much is needed.
The drawback is that we risk allocating more huge buffers, but this is a fair trade-off since Netty's use cases mostly involve very small buffers.

Modification:
Reduce the default max order from 11 to 9.
Also make similar configuration changes in PooledByteBufAllocatorTest, to reduce the memory usage during testing.

Result:
Netty now uses less memory when less memory is needed by the application.
This fixes #8536