### PR TITLE
Option io.netty.clearBuffers to clear buffers upon release

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -72,6 +72,7 @@ public final class ByteBufUtil {
 
     static final int WRITE_CHUNK_SIZE = 8192;
     static final ByteBufAllocator DEFAULT_ALLOCATOR;
+    static final boolean CLEAR_BUFFERS;
 
     static {
         String allocType = SystemPropertyUtil.get(
@@ -97,6 +98,9 @@ public final class ByteBufUtil {
 
         MAX_CHAR_BUFFER_SIZE = SystemPropertyUtil.getInt("io.netty.maxThreadLocalCharBufferSize", 16 * 1024);
         logger.debug("-Dio.netty.maxThreadLocalCharBufferSize: {}", MAX_CHAR_BUFFER_SIZE);
+
+        CLEAR_BUFFERS = SystemPropertyUtil.getBoolean("io.netty.clearBuffers", false);
+        logger.debug("-Dio.netty.clearBuffers: {}", CLEAR_BUFFERS);
     }
 
     static final int MAX_TL_ARRAY_LEN = 1024;
@@ -1634,6 +1638,9 @@ public final class ByteBufUtil {
             if (capacity() > THREAD_LOCAL_BUFFER_SIZE) {
                 super.deallocate();
             } else {
+                if (CLEAR_BUFFERS) {
+                    UnsafeByteBufUtil.setZero(memoryAddress, capacity());
+                }
                 clear();
                 handle.recycle(this);
             }
@@ -1668,6 +1675,9 @@ public final class ByteBufUtil {
             if (capacity() > THREAD_LOCAL_BUFFER_SIZE) {
                 super.deallocate();
             } else {
+                if (CLEAR_BUFFERS) {
+                    ByteBufUtil.setZero(buffer, 0, buffer.capacity());
+                }
                 clear();
                 handle.recycle(this);
             }
@@ -1910,4 +1920,36 @@ public final class ByteBufUtil {
     }
 
     private ByteBufUtil() { }
+
+    public static void setZero(ByteBuffer buffer, int offset, int length) {
+        if (length == 0) {
+            return;
+        }
+
+        if (buffer.hasArray()) {
+            setZero(buffer.array(), buffer.arrayOffset() + offset, length);
+        } else {
+            // is position and limit used at all?
+            final int position = buffer.position();
+            final int limit = buffer.limit();
+            buffer.clear();
+            for (int i = 0; i < length; ++i) {
+                buffer.put(offset + i, (byte) 0);
+            }
+            buffer.position(position);
+            buffer.limit(limit);
+        }
+    }
+
+    public static void setZero(byte[] array, int offset, int length) {
+        if (length == 0) {
+            return;
+        }
+
+        if (PlatformDependent.hasUnsafe()) {
+            PlatformDependent.setMemory(array, offset, length, (byte) 0);
+        } else {
+            Arrays.fill(array, offset, offset + length, (byte) 0);
+        }
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -40,6 +40,8 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
     ByteBuffer tmpNioBuf;
     private ByteBufAllocator allocator;
 
+    protected abstract void memoryClean();
+
     @SuppressWarnings("unchecked")
     protected PooledByteBuf(Handle<? extends PooledByteBuf<T>> recyclerHandle, int maxCapacity) {
         super(maxCapacity);
@@ -168,6 +170,10 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected final void deallocate() {
+        if (ByteBufUtil.CLEAR_BUFFERS) {
+            memoryClean();
+        }
+
         if (handle >= 0) {
             final long handle = this.handle;
             this.handle = -1;

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -310,4 +310,9 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     public long memoryAddress() {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    protected void memoryClean() {
+        ByteBufUtil.setZero(memory, offset, length);
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -251,4 +251,9 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
     protected final ByteBuffer newInternalNioBuffer(byte[] memory) {
         return ByteBuffer.wrap(memory);
     }
+
+    @Override
+    protected void memoryClean() {
+        ByteBufUtil.setZero(memory, offset, length);
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -270,4 +270,9 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         writerIndex = wIndex + length;
         return this;
     }
+
+    @Override
+    protected void memoryClean() {
+        UnsafeByteBufUtil.setZero(memoryAddress, length);
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
@@ -163,4 +163,9 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
         }
         return super.newSwappedByteBuf();
     }
+
+    @Override
+    protected void memoryClean() {
+        UnsafeByteBufUtil.setZero(memory, 0, length);
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -108,6 +108,9 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
      * Free a direct {@link ByteBuffer}
      */
     protected void freeDirect(ByteBuffer buffer) {
+        if (ByteBufUtil.CLEAR_BUFFERS) {
+            ByteBufUtil.setZero(buffer, 0, buffer.capacity());
+        }
         PlatformDependent.freeDirectBuffer(buffer);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -86,7 +86,9 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     protected void freeArray(byte[] array) {
-        // NOOP
+        if (ByteBufUtil.CLEAR_BUFFERS) {
+            ByteBufUtil.setZero(array, 0, array.length);
+        }
     }
 
     private void setArray(byte[] initialArray) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -36,6 +36,9 @@ class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
 
     @Override
     protected void freeDirect(ByteBuffer buffer) {
+        if (ByteBufUtil.CLEAR_BUFFERS) {
+            ByteBufUtil.setZero(buffer, 0, buffer.capacity());
+        }
         PlatformDependent.freeDirectNoCleaner(buffer);
     }
 


### PR DESCRIPTION
Motivation:

It's good practice to clear sensitive data from application memory, to minimize vector for memory scrapping attacks. Netty doesn't allow to strictly control all buffers by user.

Creating own allocator does not seem feasible as netty often creates temporary/intermediate buffers using Unpooled static methods. Creating custom allocator will also require to duplicate a lot of underlying code like PoolArena, to achieve same performance.

Modification:

New system property "io.netty.clearBuffers" of boolean type was added to control whether buffers should be zeroed upon release. Defaults to false to maintain old behaviour and avoid performance hit when not needed. 

We have no idea how to perform reliable/repeatable unit tests.

Microbench tests wasn't changed as it would duplicate several tests time, and we wasn't sure if it's worth it as it's some kind of experimental/niche feature.

Result:

All tests are passed. Change does not introduce any performance penalty when feature is disabled. If feature is enabled, performance degradation seems to be within errors margins (on platforms that supports Unsafe).
