### PR TITLE
Simplify internal Buffer allocations

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/api/AllocatorControl.java
+++ b/buffer/src/main/java/io/netty/buffer/api/AllocatorControl.java
@@ -29,39 +29,9 @@ import io.netty.util.internal.UnstableApi;
 @UnstableApi
 public interface AllocatorControl {
     /**
-     * Allocates a buffer that is not tethered to any particular {@link Buffer} object,
-     * and return the recoverable memory object from it.
-     * <p>
-     * This allows a buffer to implement {@link Buffer#ensureWritable(int)} by having new memory allocated to it,
-     * without that memory being attached to some other lifetime.
-     *
-     * @param originator The buffer that originated the request for an untethered memory allocated.
-     * @param size The size of the requested memory allocation, in bytes.
-     * @return A {@link UntetheredMemory} object that is the requested allocation.
-     */
-    UntetheredMemory allocateUntethered(Buffer originator, int size);
-
-    /**
      * Get the {@link BufferAllocator} instance that is the source of this allocator control.
      *
      * @return The {@link BufferAllocator} controlled by this {@link AllocatorControl}.
      */
     BufferAllocator getAllocator();
-
-    /**
-     * Memory that isn't attached to any particular buffer.
-     */
-    interface UntetheredMemory {
-        /**
-         * Produces the recoverable memory object associated with this piece of untethered memory.
-         * @implNote This method should only be called once, since it might be expensive.
-         */
-        <Memory> Memory memory();
-
-        /**
-         * Produces the drop instance associated with this piece of untethered memory.
-         * @implNote This method should only be called once, since it might be expensive, or interact with Cleaners.
-         */
-        <BufferType extends Buffer> Drop<BufferType> drop();
-    }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/ManagedBufferAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/api/ManagedBufferAllocator.java
@@ -19,7 +19,6 @@ import io.netty.buffer.api.internal.Statics;
 
 import java.util.function.Supplier;
 
-import static io.netty.buffer.api.internal.Statics.NO_OP_DROP;
 import static io.netty.buffer.api.internal.Statics.allocatorClosedException;
 import static io.netty.buffer.api.internal.Statics.standardDrop;
 
@@ -66,24 +65,6 @@ class ManagedBufferAllocator implements BufferAllocator, AllocatorControl {
     @Override
     public void close() {
         closed = true;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public UntetheredMemory allocateUntethered(Buffer originator, int size) {
-        Statics.assertValidBufferSize(size);
-        var buf = manager.allocateShared(this, size, NO_OP_DROP, allocationType);
-        return new UntetheredMemory() {
-            @Override
-            public <Memory> Memory memory() {
-                return (Memory) manager.unwrapRecoverableMemory(buf);
-            }
-
-            @Override
-            public <BufferType extends Buffer> Drop<BufferType> drop() {
-                return (Drop<BufferType>) standardDrop(manager);
-            }
-        };
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/MemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/MemoryManager.java
@@ -154,13 +154,16 @@ public interface MemoryManager {
      * @param allocatorControl Call-back interface for controlling the {@linkplain BufferAllocator allocator} that
      *                        requested the allocation of this buffer.
      * @param size The size of the buffer to allocate. This size is assumed to be valid for the implementation.
-     * @param drop The {@link Drop} instance to use when the buffer is {@linkplain Resource#close() closed}.
+     * @param dropDecorator A function to decorate the memory managers {@link Drop} instance.
+     *                     The {@link Drop} instance returned by this function will be used when the buffer is
+     *                     {@linkplain Resource#close() closed}.
      * @param allocationType The type of allocation to perform.
      *                      Typically, one of the {@linkplain StandardAllocationTypes}.
      * @return A {@link Buffer} instance with the given configuration.
      * @throws IllegalArgumentException For unknown {@link AllocationType}s.
      */
-    Buffer allocateShared(AllocatorControl allocatorControl, long size, Function<Drop<Buffer>, Drop<Buffer>> drop,
+    Buffer allocateShared(AllocatorControl allocatorControl, long size,
+                          Function<Drop<Buffer>, Drop<Buffer>> dropDecorator,
                           AllocationType allocationType);
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/api/MemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/MemoryManager.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader.Provider;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -141,7 +142,7 @@ public interface MemoryManager {
         MemoryManager manager = instance();
         ManagedBufferAllocator allocator = new ManagedBufferAllocator(manager, false);
         WrappingAllocation allocationType = new WrappingAllocation(array);
-        Buffer buffer = manager.allocateShared(allocator, array.length, ArcDrop.wrap(manager.drop()), allocationType);
+        Buffer buffer = manager.allocateShared(allocator, array.length, ArcDrop::wrap, allocationType);
         buffer.skipWritable(array.length);
         return buffer.makeReadOnly();
     }
@@ -159,7 +160,7 @@ public interface MemoryManager {
      * @return A {@link Buffer} instance with the given configuration.
      * @throws IllegalArgumentException For unknown {@link AllocationType}s.
      */
-    Buffer allocateShared(AllocatorControl allocatorControl, long size, Drop<Buffer> drop,
+    Buffer allocateShared(AllocatorControl allocatorControl, long size, Function<Drop<Buffer>, Drop<Buffer>> drop,
                           AllocationType allocationType);
 
     /**
@@ -172,18 +173,11 @@ public interface MemoryManager {
      *
      * @param readOnlyConstParent The read-only parent buffer for which a const buffer should be created. The parent
      *                            buffer is allocated in the usual way, with
-     *                            {@link #allocateShared(AllocatorControl, long, Drop, AllocationType)},
+     *                            {@link #allocateShared(AllocatorControl, long, Function, AllocationType)},
      *                            initialised with contents, and then made {@linkplain Buffer#makeReadOnly() read-only}.
      * @return A const buffer with the same size, contents, and read-only state of the given parent buffer.
      */
     Buffer allocateConstChild(Buffer readOnlyConstParent);
-
-    /**
-     * The buffer implementation-specific {@link Drop} implementation that will release the underlying memory.
-     *
-     * @return A new drop instance.
-     */
-    Drop<Buffer> drop();
 
     /**
      * Create an object that represents the internal memory of the given buffer.

--- a/buffer/src/main/java/io/netty/buffer/api/adaptor/ByteBufMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/adaptor/ByteBufMemoryManager.java
@@ -45,24 +45,24 @@ public final class ByteBufMemoryManager implements MemoryManager {
 
     @Override
     public Buffer allocateShared(AllocatorControl control, long size,
-                                 Function<Drop<Buffer>, Drop<Buffer>> adaptor,
+                                 Function<Drop<Buffer>, Drop<Buffer>> dropDecorator,
                                  AllocationType allocationType) {
         int capacity = Math.toIntExact(size);
         if (allocationType == StandardAllocationTypes.OFF_HEAP) {
             ByteBuf byteBuf = unpooledDirectAllocator.directBuffer(capacity, capacity);
             byteBuf.setZero(0, capacity);
-            return ByteBufBuffer.wrap(byteBuf, control, convert(adaptor.apply(drop())));
+            return ByteBufBuffer.wrap(byteBuf, control, convert(dropDecorator.apply(drop())));
         }
         if (allocationType == StandardAllocationTypes.ON_HEAP) {
             ByteBuf byteBuf = Unpooled.wrappedBuffer(new byte[capacity]);
             byteBuf.setIndex(0, 0);
-            return ByteBufBuffer.wrap(byteBuf, control, convert(adaptor.apply(drop())));
+            return ByteBufBuffer.wrap(byteBuf, control, convert(dropDecorator.apply(drop())));
         }
         if (allocationType instanceof WrappingAllocation) {
             byte[] array = ((WrappingAllocation) allocationType).getArray();
             ByteBuf byteBuf = Unpooled.wrappedBuffer(array);
             byteBuf.setIndex(0, 0);
-            return ByteBufBuffer.wrap(byteBuf, control, convert(adaptor.apply(drop())));
+            return ByteBufBuffer.wrap(byteBuf, control, convert(dropDecorator.apply(drop())));
         }
         throw new IllegalArgumentException("Unknown allocation type: " + allocationType);
     }

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
@@ -41,7 +41,7 @@ import static io.netty.buffer.api.internal.Statics.convert;
 public final class ByteBufferMemoryManager implements MemoryManager {
     @Override
     public Buffer allocateShared(AllocatorControl allocatorControl, long size,
-                                 Function<Drop<Buffer>, Drop<Buffer>> adaptor,
+                                 Function<Drop<Buffer>, Drop<Buffer>> dropDecorator,
                                  AllocationType allocationType) {
         int capacity = Math.toIntExact(size);
         final ByteBuffer buffer;
@@ -54,7 +54,7 @@ public final class ByteBufferMemoryManager implements MemoryManager {
         } else {
             throw new IllegalArgumentException("Unknown allocation type: " + allocationType);
         }
-        return createBuffer(buffer, allocatorControl, adaptor.apply(drop()));
+        return createBuffer(buffer, allocatorControl, dropDecorator.apply(drop()));
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/ByteBufferMemoryManager.java
@@ -25,6 +25,7 @@ import io.netty.buffer.api.internal.Statics;
 import io.netty.buffer.api.internal.WrappingAllocation;
 
 import java.nio.ByteBuffer;
+import java.util.function.Function;
 
 import static io.netty.buffer.api.internal.Statics.bbslice;
 import static io.netty.buffer.api.internal.Statics.convert;
@@ -39,7 +40,8 @@ import static io.netty.buffer.api.internal.Statics.convert;
  */
 public final class ByteBufferMemoryManager implements MemoryManager {
     @Override
-    public Buffer allocateShared(AllocatorControl allocatorControl, long size, Drop<Buffer> drop,
+    public Buffer allocateShared(AllocatorControl allocatorControl, long size,
+                                 Function<Drop<Buffer>, Drop<Buffer>> adaptor,
                                  AllocationType allocationType) {
         int capacity = Math.toIntExact(size);
         final ByteBuffer buffer;
@@ -52,7 +54,7 @@ public final class ByteBufferMemoryManager implements MemoryManager {
         } else {
             throw new IllegalArgumentException("Unknown allocation type: " + allocationType);
         }
-        return createBuffer(buffer, allocatorControl, drop);
+        return createBuffer(buffer, allocatorControl, adaptor.apply(drop()));
     }
 
     @Override
@@ -61,8 +63,7 @@ public final class ByteBufferMemoryManager implements MemoryManager {
         return buf.newConstChild();
     }
 
-    @Override
-    public Drop<Buffer> drop() {
+    private static Drop<Buffer> drop() {
         return Statics.NO_OP_DROP;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/api/bytebuffer/NioBuffer.java
@@ -366,14 +366,13 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComp
         // Allocate a bigger buffer.
         long newSize = capacity() + (long) Math.max(size - writableBytes(), minimumGrowth);
         Statics.assertValidBufferSize(newSize);
-        var untethered = control.allocateUntethered(this, (int) newSize);
-        ByteBuffer buffer = untethered.memory();
+        NioBuffer buffer = (NioBuffer) control.getAllocator().allocate((int) newSize);
 
         // Copy contents.
         copyInto(0, buffer, 0, capacity());
 
         // Release the old memory and install the new:
-        Drop<NioBuffer> drop = untethered.drop();
+        Drop<NioBuffer> drop = buffer.unsafeGetDrop();
         disconnectDrop(drop);
         attachNewBuffer(buffer, drop);
         return this;
@@ -389,10 +388,10 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComp
         this.woff = woff;
     }
 
-    private void attachNewBuffer(ByteBuffer buffer, Drop<NioBuffer> drop) {
-        base = buffer;
-        rmem = buffer;
-        wmem = buffer;
+    private void attachNewBuffer(NioBuffer buffer, Drop<NioBuffer> drop) {
+        base = buffer.base;
+        rmem = buffer.rmem;
+        wmem = buffer.wmem;
         drop.attach(this);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/api/internal/CleanerDrop.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/CleanerDrop.java
@@ -119,11 +119,6 @@ public final class CleanerDrop<T extends Buffer> implements Drop<T> {
 
     private static final class NoOpAllocatorControl implements AllocatorControl {
         @Override
-        public UntetheredMemory allocateUntethered(Buffer originator, int size) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public BufferAllocator getAllocator() {
             throw new UnsupportedOperationException();
         }

--- a/buffer/src/main/java/io/netty/buffer/api/internal/DropCaptor.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/DropCaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,20 +13,27 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.buffer.api.pool;
+package io.netty.buffer.api.internal;
 
-import io.netty.buffer.api.AllocatorControl;
-import io.netty.buffer.api.BufferAllocator;
+import io.netty.buffer.api.Drop;
 
-class PooledAllocatorControl implements AllocatorControl {
-    private final PooledBufferAllocator parent;
+import java.util.function.Function;
 
-    PooledAllocatorControl(PooledBufferAllocator parent) {
-        this.parent = parent;
+/**
+ * Utility class to capture or hold on to a drop instance.
+ *
+ * @param <T> The type argument to {@link Drop}.
+ */
+public class DropCaptor<T> implements Function<Drop<T>, Drop<T>> {
+    public Drop<T> drop;
+
+    public Drop<T> capture(Drop<T> drop) {
+        this.drop = drop;
+        return drop;
     }
 
     @Override
-    public BufferAllocator getAllocator() {
-        return parent;
+    public Drop<T> apply(Drop<T> drop) {
+        return capture(drop);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/internal/DropCaptor.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/DropCaptor.java
@@ -24,8 +24,8 @@ import java.util.function.Function;
  *
  * @param <T> The type argument to {@link Drop}.
  */
-public class DropCaptor<T> implements Function<Drop<T>, Drop<T>> {
-    public Drop<T> drop;
+public final class DropCaptor<T> implements Function<Drop<T>, Drop<T>> {
+    private Drop<T> drop;
 
     public Drop<T> capture(Drop<T> drop) {
         this.drop = drop;
@@ -35,5 +35,9 @@ public class DropCaptor<T> implements Function<Drop<T>, Drop<T>> {
     @Override
     public Drop<T> apply(Drop<T> drop) {
         return capture(drop);
+    }
+
+    public Drop<T> getDrop() {
+        return drop;
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty/buffer/api/internal/Statics.java
@@ -32,6 +32,7 @@ import java.lang.ref.Cleaner;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
 
 import static io.netty.util.CharsetUtil.US_ASCII;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -88,8 +89,8 @@ public interface Statics {
         return CleanerDrop.wrap(ArcDrop.wrap(drop), manager);
     }
 
-    static Drop<Buffer> standardDrop(MemoryManager manager) {
-        return standardDropWrap(manager.drop(), manager);
+    static Function<Drop<Buffer>, Drop<Buffer>> standardDrop(MemoryManager manager) {
+        return drop -> standardDropWrap(drop, manager);
     }
 
     static VarHandle findVarHandle(Lookup lookup, Class<?> recv, String name, Class<?> type) {

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunk.java
@@ -194,7 +194,7 @@ final class PoolChunk implements PoolChunkMetric {
         DropCaptor<Buffer> dropCaptor = new DropCaptor<>();
         base = manager.allocateShared(CONTROL, chunkSize, drop ->
             dropCaptor.capture(ArcDrop.wrap(CleanerDrop.wrap(drop, manager))), arena.allocationType);
-        baseDrop = dropCaptor.drop;
+        baseDrop = dropCaptor.getDrop();
         memory = manager.unwrapRecoverableMemory(base);
         baseDrop.attach(base);
         this.pageSize = pageSize;

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunk.java
@@ -17,12 +17,12 @@ package io.netty.buffer.api.pool;
 
 import io.netty.buffer.api.AllocatorControl;
 import io.netty.buffer.api.BufferAllocator;
-import io.netty.buffer.api.AllocatorControl.UntetheredMemory;
 import io.netty.buffer.api.Buffer;
 import io.netty.buffer.api.Drop;
 import io.netty.buffer.api.MemoryManager;
 import io.netty.buffer.api.internal.ArcDrop;
 import io.netty.buffer.api.internal.CleanerDrop;
+import io.netty.buffer.api.internal.DropCaptor;
 import io.netty.util.internal.LongLongHashMap;
 import io.netty.util.internal.LongPriorityQueue;
 
@@ -146,11 +146,6 @@ final class PoolChunk implements PoolChunkMetric {
     private static final int BITMAP_IDX_BIT_LENGTH = 32;
     private static final AllocatorControl CONTROL = new AllocatorControl() {
         @Override
-        public UntetheredMemory allocateUntethered(Buffer originator, int size) {
-            throw new AssertionError("PoolChunk base allocations should never need to resize.");
-        }
-
-        @Override
         public BufferAllocator getAllocator() {
             throw new AssertionError("PoolChunk base allocations should never need to access their allocator.");
         }
@@ -196,8 +191,10 @@ final class PoolChunk implements PoolChunkMetric {
         MemoryManager manager = arena.manager;
         // Unlike a standard wrapping, the CleanerDrop needs to be inside the ArcDrop here, because it can only drop
         // once. And we need the ArcDrop for the reference counting by every buffer allocated from this chunk.
-        baseDrop = ArcDrop.wrap(CleanerDrop.wrap(manager.drop(), manager));
-        base = manager.allocateShared(CONTROL, chunkSize, baseDrop, arena.allocationType);
+        DropCaptor<Buffer> dropCaptor = new DropCaptor<>();
+        base = manager.allocateShared(CONTROL, chunkSize, drop ->
+            dropCaptor.capture(ArcDrop.wrap(CleanerDrop.wrap(drop, manager))), arena.allocationType);
+        baseDrop = dropCaptor.drop;
         memory = manager.unwrapRecoverableMemory(base);
         baseDrop.attach(base);
         this.pageSize = pageSize;
@@ -289,7 +286,7 @@ final class PoolChunk implements PoolChunkMetric {
         return 100 - freePercentage;
     }
 
-    UntetheredMemory allocate(int size, int sizeIdx, PoolThreadCache cache, PooledAllocatorControl control) {
+    UntetheredMemory allocate(int size, int sizeIdx, PoolThreadCache cache) {
         final long handle;
         if (sizeIdx <= arena.smallMaxSizeIdx) {
             // small
@@ -308,7 +305,7 @@ final class PoolChunk implements PoolChunkMetric {
             }
         }
 
-        return allocateBuffer(handle, size, cache, control);
+        return allocateBuffer(handle, size, cache);
     }
 
     private long allocateRun(int runSize) {
@@ -540,22 +537,19 @@ final class PoolChunk implements PoolChunkMetric {
                | (long) inUsed << IS_USED_SHIFT;
     }
 
-    UntetheredMemory allocateBuffer(long handle, int size, PoolThreadCache threadCache,
-                                    PooledAllocatorControl control) {
+    UntetheredMemory allocateBuffer(long handle, int size, PoolThreadCache threadCache) {
         if (isSubpage(handle)) {
-            return allocateBufferWithSubpage(handle, size, threadCache, control);
+            return allocateBufferWithSubpage(handle, size, threadCache);
         } else {
             int offset = runOffset(handle) << pageShifts;
             int maxLength = runSize(pageShifts, handle);
             PoolThreadCache poolThreadCache = arena.parent.threadCache();
-            initAllocatorControl(control, poolThreadCache, handle, maxLength);
             return new UntetheredChunkAllocation(
                     memory, this, poolThreadCache, handle, maxLength, offset, size);
         }
     }
 
-    UntetheredMemory allocateBufferWithSubpage(long handle, int size, PoolThreadCache threadCache,
-                                                                PooledAllocatorControl control) {
+    UntetheredMemory allocateBufferWithSubpage(long handle, int size, PoolThreadCache threadCache) {
         int runOffset = runOffset(handle);
         int bitmapIdx = bitmapIdx(handle);
 
@@ -564,7 +558,6 @@ final class PoolChunk implements PoolChunkMetric {
         assert size <= s.elemSize : size + "<=" + s.elemSize;
 
         int offset = (runOffset << pageShifts) + bitmapIdx * s.elemSize;
-        initAllocatorControl(control, threadCache, handle, s.elemSize);
         return new UntetheredChunkAllocation(memory, this, threadCache, handle, s.elemSize, offset, size);
     }
 
@@ -600,15 +593,6 @@ final class PoolChunk implements PoolChunkMetric {
             var pooledDrop = new PooledDrop(chunk, threadCache, handle, maxLength);
             return (Drop<BufferType>) standardDropWrap(pooledDrop, chunk.arena.manager);
         }
-    }
-
-    private void initAllocatorControl(PooledAllocatorControl control, PoolThreadCache threadCache, long handle,
-                                      int normSize) {
-        control.arena = arena;
-        control.chunk = this;
-        control.threadCache = threadCache;
-        control.handle = handle;
-        control.normSize = normSize;
     }
 
     @Override
@@ -661,10 +645,6 @@ final class PoolChunk implements PoolChunkMetric {
 
     static boolean isUsed(long handle) {
         return (handle >> IS_USED_SHIFT & 1) == 1L;
-    }
-
-    static boolean isRun(long handle) {
-        return !isSubpage(handle);
     }
 
     static boolean isSubpage(long handle) {

--- a/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/PoolChunkList.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer.api.pool;
 
-import io.netty.buffer.api.AllocatorControl.UntetheredMemory;
 import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
@@ -92,7 +91,7 @@ final class PoolChunkList implements PoolChunkListMetric {
         this.prevList = prevList;
     }
 
-    UntetheredMemory allocate(int size, int sizeIdx, PoolThreadCache threadCache, PooledAllocatorControl control) {
+    UntetheredMemory allocate(int size, int sizeIdx, PoolThreadCache threadCache) {
         int normCapacity = arena.sizeIdx2size(sizeIdx);
         if (normCapacity > maxCapacity) {
             // Either this PoolChunkList is empty, or the requested capacity is larger than the capacity which can
@@ -101,7 +100,7 @@ final class PoolChunkList implements PoolChunkListMetric {
         }
 
         for (PoolChunk cur = head; cur != null; cur = cur.next) {
-            UntetheredMemory memory = cur.allocate(size, sizeIdx, threadCache, control);
+            UntetheredMemory memory = cur.allocate(size, sizeIdx, threadCache);
             if (memory != null) {
                 if (cur.freeBytes <= freeMinThreshold) {
                     remove(cur);

--- a/buffer/src/main/java/io/netty/buffer/api/pool/UnpooledUntetheredMemory.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/UnpooledUntetheredMemory.java
@@ -44,6 +44,6 @@ class UnpooledUntetheredMemory implements UntetheredMemory {
 
     @Override
     public <BufferType extends Buffer> Drop<BufferType> drop() {
-        return (Drop<BufferType>) standardDrop(manager).apply(dropCaptor.drop);
+        return (Drop<BufferType>) standardDrop(manager).apply(dropCaptor.getDrop());
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/api/pool/UntetheredMemory.java
+++ b/buffer/src/main/java/io/netty/buffer/api/pool/UntetheredMemory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.pool;
+
+import io.netty.buffer.api.Buffer;
+import io.netty.buffer.api.Drop;
+
+/**
+ * Memory that isn't attached to any particular buffer.
+ * <p>
+ * Used for transporting the details of a buffer allocation through the layers in {@link PooledBufferAllocator}.
+ */
+public interface UntetheredMemory {
+    /**
+     * Produces the recoverable memory object associated with this piece of untethered memory.
+     *
+     * @implNote This method should only be called once, since it might be expensive.
+     */
+    <Memory> Memory memory();
+
+    /**
+     * Produces the drop instance associated with this piece of untethered memory.
+     *
+     * @implNote This method should only be called once, since it might be expensive, or interact with Cleaners.
+     */
+    <BufferType extends Buffer> Drop<BufferType> drop();
+}

--- a/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
+++ b/buffer/src/main/java/io/netty/buffer/api/unsafe/UnsafeMemoryManager.java
@@ -52,7 +52,7 @@ public final class UnsafeMemoryManager implements MemoryManager {
 
     @Override
     public Buffer allocateShared(AllocatorControl control, long size,
-                                 Function<Drop<Buffer>, Drop<Buffer>> adaptor,
+                                 Function<Drop<Buffer>, Drop<Buffer>> dropDecorator,
                                  AllocationType allocationType) {
         final Object base;
         final long address;
@@ -77,7 +77,7 @@ public final class UnsafeMemoryManager implements MemoryManager {
         } else {
             throw new IllegalArgumentException("Unknown allocation type: " + allocationType);
         }
-        return createBuffer(memory, size32, control, adaptor.apply(drop()));
+        return createBuffer(memory, size32, control, dropDecorator.apply(drop()));
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/api/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/CleanerDropTest.java
@@ -122,9 +122,9 @@ public class CleanerDropTest {
 
         @Override
         public Buffer allocateShared(AllocatorControl allocatorControl, long size,
-                                     Function<Drop<Buffer>, Drop<Buffer>> adaptor,
+                                     Function<Drop<Buffer>, Drop<Buffer>> dropDecorator,
                                      AllocationType allocationType) {
-            return manager.allocateShared(allocatorControl, size, adaptor, allocationType);
+            return manager.allocateShared(allocatorControl, size, dropDecorator, allocationType);
         }
 
         @Override

--- a/buffer/src/test/java/io/netty/buffer/api/tests/CleanerDropTest.java
+++ b/buffer/src/test/java/io/netty/buffer/api/tests/CleanerDropTest.java
@@ -29,6 +29,7 @@ import java.util.ServiceConfigurationError;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -121,19 +122,14 @@ public class CleanerDropTest {
 
         @Override
         public Buffer allocateShared(AllocatorControl allocatorControl, long size,
-                                     Drop<Buffer> drop,
+                                     Function<Drop<Buffer>, Drop<Buffer>> adaptor,
                                      AllocationType allocationType) {
-            return manager.allocateShared(allocatorControl, size, drop, allocationType);
+            return manager.allocateShared(allocatorControl, size, adaptor, allocationType);
         }
 
         @Override
         public Buffer allocateConstChild(Buffer readOnlyConstParent) {
             return manager.allocateConstChild(readOnlyConstParent);
-        }
-
-        @Override
-        public Drop<Buffer> drop() {
-            return manager.drop();
         }
 
         @Override


### PR DESCRIPTION
Motivation:
There are two concerns addressed here:
1. The use of UntetheredMemory outside of the pooling allocator was more complexity than was strictly necessary, and also created an awkward API dance where the memory and its drop had to be combined again.
2. MemoryManager instances may want to create Buffers and their baseline Drop instance together, yet the allocator need to adapt or decorate the drop.

Modification:
Change the ensureWritable implementations to no longer rely on UntetheredMemory, but instead allocate a new Buffer instance and cannibalise its insides.
Move the UntetheredMemory interface into the buffer/api/pool package.
Remove the MemoryManager.drop method and change the MemoryManager.allocateShared to take an adaptor function.
The memory managers can then create per-Buffer drop instances if they so desire.
Simplify how the PooledBufferAllocator uses AllocatorControl; the PooledAllocatorControl is now just a reference to the parent allocator.

Result:
More general internal APIs and simpler implementation.