### PR TITLE
EpollEventLoopGroup.setIoRatio un-deprecate

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -22,6 +22,7 @@ import io.netty.channel.EventLoopTaskQueueFactory;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.channel.SingleThreadEventLoop;
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorChooserFactory;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
@@ -158,12 +159,12 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     /**
-     * @deprecated This method will be removed in future releases, and is not guaranteed to have any impacts.
+     * Sets the percentage of the desired amount of time spent for I/O in the child event loops.  The default value is
+     * {@code 50}, which means the event loop will try to spend the same amount of time for I/O as for non-I/O tasks.
      */
-    @Deprecated
     public void setIoRatio(int ioRatio) {
-        if (ioRatio <= 0 || ioRatio > 100) {
-            throw new IllegalArgumentException("ioRatio: " + ioRatio + " (expected: 0 < ioRatio <= 100)");
+        for (EventExecutor e: this) {
+            ((EpollEventLoop) e).setIoRatio(ioRatio);
         }
     }
 


### PR DESCRIPTION
Motivation:
EpollEventLoopGroup.setIoRatio was deprecated and made to have
no effect as part of a change that set provide ioRatio==100 as
the default behavior where the next timer fire was managed
more precisely. However EpollEventLoop has changed back to
using ioRatio but there is no way to set this value.

Modifications:
- Un-deprecate the EpollEventLoopGroup.setIoRatio method. It
  is proposed this still be removed/revisited in 5.0 but while
  it is still used users should be able to configure it.

Result:
Epoll transport allows draining all tasks on each iteration
to reduce delay in executing tasks.