### PR TITLE
NetUtil static block should be whitelisted for blockhound

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -134,6 +134,10 @@ class Hidden {
                     "io.netty.resolver.HostsFileEntriesProvider$ParserImpl",
                     "parse");
 
+            builder.allowBlockingCallsInside(
+                    "io.netty.util.NetUil$SoMaxConnAction",
+                    "run");
+
             builder.nonBlockingThreadPredicate(new Function<Predicate<Thread>, Predicate<Thread>>() {
                 @Override
                 public Predicate<Thread> apply(final Predicate<Thread> p) {


### PR DESCRIPTION
Motivation:

When the NetUtil class is loaded it might produce a blockhound warning due it reading the proc filesystem. Let's whitelist this

Modifications:

Whitelist the reading of the proc filesystemm during NetUtil init

Result:

Less warnings when using blockhound