### PR TITLE
Preserve the `io.netty` group id but change the artifact id

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-all</artifactId>
+  <artifactId>netty5-all</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/All-in-One</name>
@@ -37,8 +37,8 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-bom</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-bom</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -69,37 +69,37 @@
         <!-- These dependencies will also be "merged" into the dependency section by the flatten plugin -->
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
           <classifier>linux-x86_64</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
           <classifier>linux-aarch_64</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty5-transport-native-kqueue</artifactId>
           <classifier>osx-x86_64</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty5-transport-native-kqueue</artifactId>
           <classifier>osx-aarch_64</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <artifactId>netty5-resolver-dns-native-macos</artifactId>
           <classifier>osx-x86_64</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <artifactId>netty5-resolver-dns-native-macos</artifactId>
           <classifier>osx-aarch_64</classifier>
           <scope>runtime</scope>
         </dependency>
@@ -116,7 +116,7 @@
         <!-- All release modules -->
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>runtime</scope>
@@ -133,14 +133,14 @@
         <!-- All release modules -->
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty5-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <artifactId>netty5-resolver-dns-native-macos</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>runtime</scope>
@@ -213,52 +213,52 @@
     <!-- All release modules -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty5-codec</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-dns</artifactId>
+      <artifactId>netty5-codec-dns</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http2</artifactId>
+      <artifactId>netty5-codec-http2</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver</artifactId>
+      <artifactId>netty5-resolver</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver-dns</artifactId>
+      <artifactId>netty5-resolver-dns</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <scope>compile</scope>
     </dependency>
     <!--
@@ -266,17 +266,17 @@
       -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport-classes-epoll</artifactId>
+      <artifactId>netty5-transport-classes-epoll</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport-classes-kqueue</artifactId>
+      <artifactId>netty5-transport-classes-kqueue</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver-dns-classes-macos</artifactId>
+      <artifactId>netty5-resolver-dns-classes-macos</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -23,8 +23,8 @@
     <relativePath />
   </parent>
 
-  <groupId>io.netty5</groupId>
-  <artifactId>netty-bom</artifactId>
+  <groupId>io.netty</groupId>
+  <artifactId>netty5-bom</artifactId>
   <version>5.0.0.Final-SNAPSHOT</version>
   <packaging>pom</packaging>
 
@@ -84,226 +84,226 @@
     <dependencies>
       <!-- All release modules -->
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-buffer</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-buffer</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-codec</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-codec</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-codec-dns</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-codec-dns</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-codec-http</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-codec-http</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-codec-http2</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-codec-http2</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-common</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-common</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-dev-tools</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-dev-tools</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-handler</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-handler</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-resolver</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-resolver</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-resolver-dns</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-resolver-dns</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-example</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-example</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-all</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-all</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-resolver-dns-classes-macos</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-resolver-dns-classes-macos</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-resolver-dns-native-macos</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-resolver-dns-native-macos</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-resolver-dns-native-macos</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-resolver-dns-native-macos</artifactId>
         <version>${project.version}</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-resolver-dns-native-macos</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-resolver-dns-native-macos</artifactId>
         <version>${project.version}</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-unix-common</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-unix-common</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-unix-common</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-unix-common</artifactId>
         <version>${project.version}</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-unix-common</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-unix-common</artifactId>
         <version>${project.version}</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-unix-common</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-unix-common</artifactId>
         <version>${project.version}</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-unix-common</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-unix-common</artifactId>
         <version>${project.version}</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-classes-epoll</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-classes-epoll</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-epoll</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-epoll</artifactId>
         <version>${project.version}</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-epoll</artifactId>
         <version>${project.version}</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-classes-kqueue</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-classes-kqueue</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-kqueue</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-kqueue</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-kqueue</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-kqueue</artifactId>
         <version>${project.version}</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty5</groupId>
-        <artifactId>netty-transport-native-kqueue</artifactId>
+        <groupId>io.netty</groupId>
+        <artifactId>netty5-transport-native-kqueue</artifactId>
         <version>${project.version}</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <!-- Add netty-tcnative* as well as users need to ensure they use the correct version -->
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative-classes</artifactId>
         <version>${tcnative.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
         <version>${tcnative.version}</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
         <version>${tcnative.version}</version>
         <classifier>linux-x86_64-fedora</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
         <version>${tcnative.version}</version>
         <classifier>linux-aarch_64-fedora</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
         <version>${tcnative.version}</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${tcnative.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${tcnative.version}</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${tcnative.version}</version>
         <classifier>linux-aarch_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${tcnative.version}</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${tcnative.version}</version>
         <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
         <version>${tcnative.version}</version>
         <classifier>windows-x86_64</classifier>

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-buffer</artifactId>
+  <artifactId>netty5-buffer</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Buffer</name>
@@ -35,7 +35,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-codec-dns</artifactId>
+  <artifactId>netty5-codec-dns</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Codec/DNS</name>
@@ -35,22 +35,22 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty5-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-codec-http</artifactId>
+  <artifactId>netty5-codec-http</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Codec/HTTP</name>
@@ -35,27 +35,27 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty5-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -18,18 +18,18 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-codec-http2</artifactId>
+  <artifactId>netty5-codec-http2</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Codec/HTTP2</name>
 
   <properties>
-    <javaModuleName>io.netty5.codec.http2</javaModuleName>
+    <javaModuleName>io.netty.codec.http2</javaModuleName>
     <!-- Needed for SSL tests as these use the SelfSignedCertificate -->
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
   </properties>
@@ -37,32 +37,32 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty5-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -84,7 +84,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-codec</artifactId>
+  <artifactId>netty5-codec</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Codec</name>
@@ -35,17 +35,17 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-common</artifactId>
+  <artifactId>netty5-common</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Common</name>
@@ -85,8 +85,8 @@
     <!-- Add dependency on dev-tools as otherwise the build will fail if not installed first manually -->
     <!-- See https://github.com/netty/netty/issues/7842 -->
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-dev-tools</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-dev-tools</artifactId>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -23,8 +23,8 @@
     <relativePath />
   </parent>
 
-  <groupId>io.netty5</groupId>
-  <artifactId>netty-dev-tools</artifactId>
+  <groupId>io.netty</groupId>
+  <artifactId>netty5-dev-tools</artifactId>
   <version>5.0.0.Final-SNAPSHOT</version>
 
   <name>Netty/Dev-Tools</name>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-example</artifactId>
+  <artifactId>netty5-example</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Example</name>
@@ -35,47 +35,47 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty5-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http2</artifactId>
+      <artifactId>netty5-codec-http2</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-dns</artifactId>
+      <artifactId>netty5-codec-dns</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
     </dependency>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-handler</artifactId>
+  <artifactId>netty5-handler</artifactId>
   <packaging>jar</packaging>
 
   <properties>
@@ -35,35 +35,35 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver</artifactId>
+      <artifactId>netty5-resolver</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty5-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative-classes</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-microbench</artifactId>
+  <artifactId>netty5-microbench</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Microbench</name>
@@ -134,28 +134,28 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http2</artifactId>
+      <artifactId>netty5-codec-http2</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
+      <artifactId>netty5-transport-native-epoll</artifactId>
       <version>${project.version}</version>
       <classifier>${epoll.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
+      <artifactId>netty5-transport-native-kqueue</artifactId>
       <version>${project.version}</version>
       <classifier>${kqueue.classifier}</classifier>
     </dependency>
@@ -196,7 +196,7 @@
       <version>0.5.1</version>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>false</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     <version>9</version>
   </parent>
 
-  <groupId>io.netty5</groupId>
-  <artifactId>netty-parent</artifactId>
+  <groupId>io.netty</groupId>
+  <artifactId>netty5-parent</artifactId>
   <packaging>pom</packaging>
   <version>5.0.0.Final-SNAPSHOT</version>
 
@@ -555,7 +555,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-jni-util</artifactId>
         <version>0.0.3.Final</version>
         <classifier>sources</classifier>
@@ -564,7 +564,7 @@
 
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>netty-dev-tools</artifactId>
+        <artifactId>netty5-dev-tools</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -591,13 +591,13 @@
 
       <!-- Our own Tomcat Native fork - completely optional for the native lib, used for accelerating SSL with OpenSSL. -->
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative-classes</artifactId>
         <version>${tcnative.version}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>${tcnative.artifactId}</artifactId>
         <version>${tcnative.version}</version>
         <classifier>${tcnative.classifier}</classifier>
@@ -931,6 +931,7 @@
           </dependency>
         </dependencies>
         <configuration>
+          <skip>true</skip> <!-- Skip this until we've released Netty 5.0.0.Final -->
           <oldArtifacts>
             <artifact>io.netty:${project.artifactId}:RELEASE</artifact>
           </oldArtifacts>

--- a/pom.xml
+++ b/pom.xml
@@ -1653,7 +1653,7 @@
           <version>1.5</version>
           <configuration>
             <resourceBundles>
-              <resourceBundle>io.netty5:netty-dev-tools:${project.version}</resourceBundle>
+              <resourceBundle>io.netty:netty-dev-tools:${project.version}</resourceBundle>
             </resourceBundles>
             <outputDirectory>${netty.dev.tools.directory}</outputDirectory>
             <!-- don't include netty-dev-tools in artifacts -->

--- a/pom.xml
+++ b/pom.xml
@@ -932,9 +932,6 @@
         </dependencies>
         <configuration>
           <skip>true</skip> <!-- Skip this until we've released Netty 5.0.0.Final -->
-          <oldArtifacts>
-            <artifact>io.netty:${project.artifactId}:RELEASE</artifact>
-          </oldArtifacts>
           <versionFormat>.*\.Final</versionFormat>
           <analysisConfiguration>
             <revapi.versions>

--- a/resolver-dns-classes-macos/pom.xml
+++ b/resolver-dns-classes-macos/pom.xml
@@ -17,11 +17,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-resolver-dns-classes-macos</artifactId>
+  <artifactId>netty5-resolver-dns-classes-macos</artifactId>
 
   <name>Netty/Resolver/DNS/Classes/MacOS</name>
   <packaging>jar</packaging>
@@ -39,18 +39,18 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-resolver-dns</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-resolver-dns</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -17,11 +17,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-resolver-dns-native-macos</artifactId>
+  <artifactId>netty5-resolver-dns-native-macos</artifactId>
 
   <name>Netty/Resolver/DNS/Native/MacOS</name>
   <packaging>jar</packaging>
@@ -52,7 +52,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -122,8 +122,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>io.netty5</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--
@@ -158,7 +158,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -229,8 +229,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>io.netty5</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--
@@ -256,8 +256,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-resolver-dns-classes-macos</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-resolver-dns-classes-macos</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-resolver-dns</artifactId>
+  <artifactId>netty5-resolver-dns</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Resolver/DNS</name>
@@ -35,37 +35,37 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver</artifactId>
+      <artifactId>netty5-resolver</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty5-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-dns</artifactId>
+      <artifactId>netty5-codec-dns</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-resolver</artifactId>
+  <artifactId>netty5-resolver</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Resolver</name>
@@ -35,7 +35,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite-autobahn</artifactId>
+  <artifactId>netty5-testsuite-autobahn</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite/Autobahn</name>
@@ -37,22 +37,22 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite-http2</artifactId>
+  <artifactId>netty5-testsuite-http2</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite/Http2</name>
@@ -37,32 +37,32 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http2</artifactId>
+      <artifactId>netty5-codec-http2</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite-native-image-client-runtime-init</artifactId>
+  <artifactId>netty5-testsuite-native-image-client-runtime-init</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite/NativeImage/ClientRuntimeInit</name>
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite-native-image-client</artifactId>
+  <artifactId>netty5-testsuite-native-image-client</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite/NativeImage/Client</name>
@@ -37,12 +37,12 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver-dns</artifactId>
+      <artifactId>netty5-resolver-dns</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite-native-image</artifactId>
+  <artifactId>netty5-testsuite-native-image</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite/NativeImage</name>
@@ -37,27 +37,27 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite-native</artifactId>
+  <artifactId>netty5-testsuite-native</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite/Native</name>
@@ -74,19 +74,19 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty5-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <artifactId>netty5-resolver-dns-native-macos</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
@@ -103,20 +103,20 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty5-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <artifactId>netty5-resolver-dns-native-macos</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
@@ -133,21 +133,21 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty5-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <artifactId>netty5-resolver-dns-native-macos</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite-osgi</artifactId>
+  <artifactId>netty5-testsuite-osgi</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite/OSGI</name>
@@ -59,7 +59,7 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
@@ -76,7 +76,7 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty5-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
@@ -88,61 +88,61 @@
     <!-- All release modules -->
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty5-codec</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-dns</artifactId>
+      <artifactId>netty5-codec-dns</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http2</artifactId>
+      <artifactId>netty5-codec-http2</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver</artifactId>
+      <artifactId>netty5-resolver</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver-dns</artifactId>
+      <artifactId>netty5-resolver-dns</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite-shading</artifactId>
+  <artifactId>netty5-testsuite-shading</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite/Shading</name>
@@ -243,13 +243,13 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-common</artifactId>
+          <artifactId>netty5-common</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-handler</artifactId>
+          <artifactId>netty5-handler</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
@@ -278,13 +278,13 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-common</artifactId>
+          <artifactId>netty5-common</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
+          <artifactId>netty5-transport-native-kqueue</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
@@ -292,12 +292,12 @@
         <!-- Needed to test shading of netty-tcnative -->
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-handler</artifactId>
+          <artifactId>netty5-handler</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
-          <groupId>io.netty</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>${tcnative.artifactId}</artifactId>
           <version>${tcnative.version}</version>
           <classifier>${tcnative.classifier}</classifier>
@@ -321,13 +321,13 @@
       <dependencies>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-common</artifactId>
+          <artifactId>netty5-common</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
+          <artifactId>netty5-transport-native-epoll</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <scope>compile</scope>
@@ -335,12 +335,12 @@
         <!-- Needed to test shading of netty-tcnative -->
         <dependency>
           <groupId>${project.groupId}</groupId>
-          <artifactId>netty-handler</artifactId>
+          <artifactId>netty5-handler</artifactId>
           <version>${project.version}</version>
           <scope>compile</scope>
         </dependency>
         <dependency>
-          <groupId>io.netty</groupId>
+          <groupId>${project.groupId}</groupId>
           <artifactId>${tcnative.artifactId}</artifactId>
           <version>${tcnative.version}</version>
           <classifier>${tcnative.classifier}</classifier>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-testsuite</artifactId>
+  <artifactId>netty5-testsuite</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Testsuite</name>
@@ -31,31 +31,31 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec-http</artifactId>
+      <artifactId>netty5-codec-http</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-transport-blockhound-tests</artifactId>
+  <artifactId>netty5-transport-blockhound-tests</artifactId>
   <packaging>jar</packaging>
   <description>
     Tests for the BlockHound integration.
@@ -88,21 +88,21 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport</artifactId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-handler</artifactId>
+      <artifactId>netty5-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver-dns</artifactId>
+      <artifactId>netty5-resolver-dns</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>

--- a/transport-classes-epoll/pom.xml
+++ b/transport-classes-epoll/pom.xml
@@ -17,11 +17,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-transport-classes-epoll</artifactId>
+  <artifactId>netty5-transport-classes-epoll</artifactId>
 
   <name>Netty/Transport/Classes/Epoll</name>
   <packaging>jar</packaging>
@@ -32,23 +32,23 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/transport-classes-kqueue/pom.xml
+++ b/transport-classes-kqueue/pom.xml
@@ -17,11 +17,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-transport-classes-kqueue</artifactId>
+  <artifactId>netty5-transport-classes-kqueue</artifactId>
 
   <name>Netty/Transport/Classes/KQueue</name>
   <packaging>jar</packaging>
@@ -32,23 +32,23 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -17,11 +17,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-transport-native-epoll</artifactId>
+  <artifactId>netty5-transport-native-epoll</artifactId>
 
   <name>Netty/Transport/Native/Epoll</name>
   <packaging>jar</packaging>
@@ -127,7 +127,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -197,8 +197,8 @@
   
       <dependencies>
         <dependency>
-          <groupId>io.netty5</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--
@@ -276,7 +276,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -348,8 +348,8 @@
 
       <dependencies>
         <dependency>
-          <groupId>io.netty5</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--
@@ -364,44 +364,44 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-classes-epoll</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-classes-epoll</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-testsuite</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-native-unix-common-tests</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-testsuite</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -17,11 +17,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-transport-native-kqueue</artifactId>
+  <artifactId>netty5-transport-native-kqueue</artifactId>
 
   <name>Netty/Transport/Native/KQueue</name>
   <packaging>jar</packaging>
@@ -51,7 +51,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -125,8 +125,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>io.netty5</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--
@@ -160,7 +160,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -232,8 +232,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>io.netty5</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--
@@ -266,7 +266,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -336,8 +336,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>io.netty5</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--
@@ -370,7 +370,7 @@
                 </goals>
                 <configuration>
                   <includeGroupIds>${project.groupId}</includeGroupIds>
-                  <includeArtifactIds>netty-transport-native-unix-common</includeArtifactIds>
+                  <includeArtifactIds>netty5-transport-native-unix-common</includeArtifactIds>
                   <classifier>${jni.classifier}</classifier>
                   <outputDirectory>${unix.common.lib.dir}</outputDirectory>
                   <includes>META-INF/native/**</includes>
@@ -440,8 +440,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>io.netty5</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
+          <groupId>io.netty</groupId>
+          <artifactId>netty5-transport-native-unix-common</artifactId>
           <version>${project.version}</version>
           <classifier>${jni.classifier}</classifier>
           <!--
@@ -489,44 +489,44 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-classes-kqueue</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-classes-kqueue</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-testsuite</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-native-unix-common-tests</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-testsuite</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common-tests</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -17,11 +17,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-transport-native-unix-common-tests</artifactId>
+  <artifactId>netty5-transport-native-unix-common-tests</artifactId>
 
   <name>Netty/Transport/Native/Unix/Common/Tests</name>
   <packaging>jar</packaging>
@@ -31,13 +31,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -17,11 +17,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
-  <artifactId>netty-transport-native-unix-common</artifactId>
+  <artifactId>netty5-transport-native-unix-common</artifactId>
 
   <name>Netty/Transport/Native/Unix/Common</name>
   <packaging>jar</packaging>
@@ -538,18 +538,18 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-common</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.netty5</groupId>
-      <artifactId>netty-transport</artifactId>
+      <groupId>io.netty</groupId>
+      <artifactId>netty5-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -18,12 +18,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.netty5</groupId>
-    <artifactId>netty-parent</artifactId>
+    <groupId>io.netty</groupId>
+    <artifactId>netty5-parent</artifactId>
     <version>5.0.0.Final-SNAPSHOT</version>
   </parent>
 
-  <artifactId>netty-transport</artifactId>
+  <artifactId>netty5-transport</artifactId>
   <packaging>jar</packaging>
 
   <name>Netty/Transport</name>
@@ -35,17 +35,17 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty5-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <artifactId>netty5-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-resolver</artifactId>
+      <artifactId>netty5-resolver</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Motivation:
Changing the group id part of the Maven coordinates require us to have control over the netty5.io domain.
One domain might be fine, but it's clear that this will not scale in the future, for Netty 6, 7, etc.

Modification:
Instead of changing the group id, we annotate the artifact id, so e.g. `netty-common` becomes `netty5-common`.

Result:
We preserve our `io.netty` group id, while still allowing Netty 5 and 4 to co-exist as dependencies, and on the classpath.