### PR TITLE
Add ByteBufConvertible to Netty 4.1

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -2404,7 +2404,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, 
      * @return This {@code ByteBuf} instance.
      */
     @Override
-    public final ByteBuf asByteBuf() {
+    public ByteBuf asByteBuf() {
         return this;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -245,7 +245,7 @@ import java.nio.charset.UnsupportedCharsetException;
  * Please refer to {@link ByteBufInputStream} and
  * {@link ByteBufOutputStream}.
  */
-public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
+public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, ByteBufConvertible {
 
     /**
      * Returns the number of bytes (octets) this buffer can contain.
@@ -2397,6 +2397,15 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      */
     public boolean isContiguous() {
         return false;
+    }
+
+    /**
+     * A {@code ByteBuf} can turn into itself.
+     * @return This {@code ByteBuf} instance.
+     */
+    @Override
+    public final ByteBuf asByteBuf() {
+        return this;
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/ByteBufConvertible.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufConvertible.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+/**
+ * An interface that can be implemented by any object that know how to turn itself into a {@link ByteBuf}.
+ * All {@link ByteBuf} classes implement this interface, and return themselves.
+ */
+public interface ByteBufConvertible {
+    /**
+     * Turn this object into a {@link ByteBuf}.
+     * This does <strong>not</strong> increment the reference count of the {@link ByteBuf} instance.
+     * The conversion or exposure of the {@link ByteBuf} must be idempotent, so that this method can be called
+     * either once, or multiple times, without causing any change in program behaviour.
+     *
+     * @return A {@link ByteBuf} instance from this object.
+     */
+    ByteBuf asByteBuf();
+}


### PR DESCRIPTION
Motivation:
This interface is used in the main branch to bridge buffer implementations.
Moving it to 4.1 will allow Netty 5 to use the 4.1 ByteBuf implementation.

Modification:
Copy the ByteBufConvertible interface from the main branch to 4.1.
And make ByteBuf implement the interface in the same way it does in the main branch.

Result:
The current main branch code can theoretically be made to use the ByteBuf implementation from 4.1.