### PR TITLE
Fixed high CPU usage when using spliceTo()

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -756,13 +756,18 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
             ByteBuf byteBuf = null;
             boolean close = false;
+            Queue<SpliceInTask> sQueue = null;
             try {
-                Queue<SpliceInTask> sQueue = null;
                 do {
                     if (sQueue != null || (sQueue = spliceQueue) != null) {
                         SpliceInTask spliceTask = sQueue.peek();
                         if (spliceTask != null) {
-                            if (spliceTask.spliceIn(allocHandle)) {
+                            boolean spliceInResult = spliceTask.spliceIn(allocHandle);
+
+                            if (allocHandle.isReceivedRdHup()) {
+                                shutdownInput(true);
+                            }
+                            if (spliceInResult) {
                                 // We need to check if it is still active as if not we removed all SpliceTasks in
                                 // doClose(...)
                                 if (isActive()) {
@@ -820,7 +825,13 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             } catch (Throwable t) {
                 handleReadException(pipeline, byteBuf, t, close, allocHandle);
             } finally {
-                epollInFinally(config);
+                if (sQueue == null) {
+                    epollInFinally(config);
+                } else {
+                    if (!config.isAutoRead()) {
+                        clearEpollIn();
+                    }
+                }
             }
         }
     }
@@ -856,6 +867,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             for (;;) {
                 // Splicing until there is nothing left to splice.
                 int localSplicedIn = Native.splice(socket.intValue(), -1, pipeOut.intValue(), -1, length);
+                handle.lastBytesRead(localSplicedIn);
                 if (localSplicedIn == 0) {
                     break;
                 }


### PR DESCRIPTION
Fixed the inability to receive channelInactive() events when using spliceTo(). Fixed high CPU usage when using spliceTo()

Motivation:

1. spliceTo() ignores RdHup, causing users to fail to receive channelInactive().
2. When using spliceTo,epollInFinally() is meaningless,and epollInFinally will result in infinite calls to spliceIn(). spliceIn will return in only two cases: (1)There is no data to splice(). (2)sufficient length has been spliced. So just wait The next EPOLLIN event fires.
3. lastBytesRead is not updated, which will cause handle.guess() to get smaller and smaller, resulting in high CPU usage.

Modifications:

1. check isReceivedRdHup
2. not call epollInFinally when using spliceTo()
3. update lastBytesRead in spliceIn()

Result:
1. channelInactive() is correctly called back
2. reduce cpu usage
