### PR TITLE
Fix race condition in setting ReferenceCountedOpenSslEngine.needTask flag

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1460,9 +1460,12 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 // The engine was destroyed in the meantime, just return.
                 return;
             }
-            // The task was run, reset needTask to false so getHandshakeStatus() returns the correct value.
-            needTask = false;
-            task.run();
+            try {
+                task.run();
+            } finally {
+                // The task was run, reset needTask to false so getHandshakeStatus() returns the correct value.
+                needTask = false;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #12139 

### What's changed

This PR reorders resetting `ReferenceCountedOpenSslEngine.needTask` flag within the `io.netty.handler.ssl.ReferenceCountedOpenSslEngine.TaskDecorator.run()` method. The flag shouldn't be unset before the task execution finishes.

### What's not changed

This PR doesn't change the `needTask` flag handling in `AsyncTask`s. I'm not sure when and how this type is used.

There could be also a problem if more tasks are allowed to be returned for subsequent `getDelegatedTask()` call.

```java
    List<Runnable> collectTasks(SSLEngine sslEngine) {
        List<Runnable> tasks = new LinkedList<Runnable>();
        Runnable task;
        while ((task = sslEngine.getDelegatedTask()) != null) {
            tasks.add(task);
        }
        return tasks;
    }
```

Then the single `boolean` variable is not enough to track task processing. It would rather deserve a task counter.
