### PR TITLE
Change the access level of class `PoolThreadLocalCache` to private

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -497,7 +497,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         threadCache.remove();
     }
 
-    final class PoolThreadLocalCache extends FastThreadLocal<PoolThreadCache> {
+    private final class PoolThreadLocalCache extends FastThreadLocal<PoolThreadCache> {
         private final boolean useCacheForAllThreads;
 
         PoolThreadLocalCache(boolean useCacheForAllThreads) {


### PR DESCRIPTION
Motivation:

The inner class `PoolThreadLocalCache` is only used within the class `PooledByteBufAllocator`, so it's better to change its access level to private.

Modification:

Change the access level of class `PoolThreadLocalCache` to private.

Result:

Change the access level of class `PoolThreadLocalCache` to private.
