### PR TITLE
Just return early when forEach* method is called and the Buffer is no…

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -930,10 +930,11 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         if (!isAccessible()) {
             throw attachTrace(bufferIsClosed(this));
         }
-        if (readableBytes() == 0) {
+        int readableBytes = readableBytes();
+        if (readableBytes == 0) {
             return 0;
         }
-        checkReadBounds(readerOffset(), Math.max(1, readableBytes()));
+        checkReadBounds(readerOffset(), readableBytes);
         int visited = 0;
         for (Buffer buf : bufs) {
             if (buf.readableBytes() > 0) {
@@ -961,10 +962,11 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         if (!isAccessible()) {
             throw attachTrace(bufferIsClosed(this));
         }
-        if (writableBytes() == 0) {
+        int writableBytes = writableBytes();
+        if (writableBytes == 0) {
             return 0;
         }
-        checkWriteBounds(writerOffset(), Math.max(1, writableBytes()));
+        checkWriteBounds(writerOffset(), writableBytes);
         int visited = 0;
         for (Buffer buf : bufs) {
             if (buf.writableBytes() > 0) {

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -927,6 +927,12 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     @Override
     public <E extends Exception> int forEachReadable(int initialIndex, ReadableComponentProcessor<E> processor)
             throws E {
+        if (!isAccessible()) {
+            throw attachTrace(bufferIsClosed(this));
+        }
+        if (readableBytes() == 0) {
+            return 0;
+        }
         checkReadBounds(readerOffset(), Math.max(1, readableBytes()));
         int visited = 0;
         for (Buffer buf : bufs) {
@@ -952,6 +958,12 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     @Override
     public <E extends Exception> int forEachWritable(int initialIndex, WritableComponentProcessor<E> processor)
             throws E {
+        if (!isAccessible()) {
+            throw attachTrace(bufferIsClosed(this));
+        }
+        if (writableBytes() == 0) {
+            return 0;
+        }
         checkWriteBounds(writerOffset(), Math.max(1, writableBytes()));
         int visited = 0;
         for (Buffer buf : bufs) {

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -494,18 +494,19 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         if (!isAccessible()) {
             throw attachTrace(bufferIsClosed(this));
         }
-        if (readableBytes() == 0) {
+        int readableBytes = readableBytes();
+        if (readableBytes == 0) {
             return 0;
         }
         if (delegate.nioBufferCount() == 1) {
-            ByteBuffer byteBuffer = delegate.nioBuffer(readerOffset(), readableBytes()).asReadOnlyBuffer();
+            ByteBuffer byteBuffer = delegate.nioBuffer(readerOffset(), readableBytes).asReadOnlyBuffer();
             if (processor.process(initialIndex, new ReadableBufferComponent(byteBuffer, this))) {
                 return 1;
             } else {
                 return -1;
             }
         }
-        ByteBuffer[] byteBuffers = delegate.nioBuffers(readerOffset(), readableBytes());
+        ByteBuffer[] byteBuffers = delegate.nioBuffers(readerOffset(), readableBytes);
         for (int i = 0; i < byteBuffers.length; i++) {
             ReadableBufferComponent component = new ReadableBufferComponent(byteBuffers[i], this);
             if (!processor.process(initialIndex + i, component)) {
@@ -524,18 +525,19 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         if (readOnly()) {
             throw bufferIsReadOnly(this);
         }
-        if (writableBytes() == 0) {
+        int writableBytes = writableBytes();
+        if (writableBytes == 0) {
             return 0;
         }
         if (delegate.nioBufferCount() == 1) {
-            ByteBuffer byteBuffer = delegate.nioBuffer(writerOffset(), writableBytes());
+            ByteBuffer byteBuffer = delegate.nioBuffer(writerOffset(), writableBytes);
             if (processor.process(initialIndex, new WritableBufferComponent(byteBuffer, this))) {
                 return 1;
             } else {
                 return -1;
             }
         }
-        ByteBuffer[] byteBuffers = delegate.nioBuffers(writerOffset(), writableBytes());
+        ByteBuffer[] byteBuffers = delegate.nioBuffers(writerOffset(), writableBytes);
         for (int i = 0; i < byteBuffers.length; i++) {
             WritableBufferComponent component = new WritableBufferComponent(byteBuffers[i], this);
             if (!processor.process(initialIndex + i, component)) {

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -533,10 +533,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComp
         if (!isAccessible()) {
             throw attachTrace(bufferIsClosed(this));
         }
-        if (readableBytes() == 0) {
+        int readableBytes = readableBytes();
+        if (readableBytes == 0) {
             return 0;
         }
-        checkRead(readerOffset(), Math.max(1, readableBytes()));
+        checkRead(readerOffset(), readableBytes);
         return processor.process(initialIndex, this)? 1 : -1;
     }
 
@@ -546,10 +547,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComp
         if (!isAccessible()) {
             throw attachTrace(bufferIsClosed(this));
         }
-        if (writableBytes() == 0) {
+        int writableBytes = writableBytes();
+        if (writableBytes == 0) {
             return 0;
         }
-        checkWrite(writerOffset(), Math.max(1, writableBytes()));
+        checkWrite(writerOffset(), writableBytes);
         return processor.process(initialIndex, this)? 1 : -1;
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -530,6 +530,12 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComp
     @Override
     public <E extends Exception> int forEachReadable(int initialIndex, ReadableComponentProcessor<E> processor)
             throws E {
+        if (!isAccessible()) {
+            throw attachTrace(bufferIsClosed(this));
+        }
+        if (readableBytes() == 0) {
+            return 0;
+        }
         checkRead(readerOffset(), Math.max(1, readableBytes()));
         return processor.process(initialIndex, this)? 1 : -1;
     }
@@ -537,6 +543,12 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComp
     @Override
     public <E extends Exception> int forEachWritable(int initialIndex, WritableComponentProcessor<E> processor)
             throws E {
+        if (!isAccessible()) {
+            throw attachTrace(bufferIsClosed(this));
+        }
+        if (writableBytes() == 0) {
+            return 0;
+        }
         checkWrite(writerOffset(), Math.max(1, writableBytes()));
         return processor.process(initialIndex, this)? 1 : -1;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -647,10 +647,11 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements Readab
         if (!isAccessible()) {
             throw attachTrace(bufferIsClosed(this));
         }
-        if (readableBytes() == 0) {
+        int readableBytes = readableBytes();
+        if (readableBytes == 0) {
             return 0;
         }
-        checkRead(readerOffset(), Math.max(1, readableBytes()));
+        checkRead(readerOffset(), readableBytes);
         return processor.process(initialIndex, this)? 1 : -1;
     }
 
@@ -660,10 +661,11 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements Readab
         if (!isAccessible()) {
             throw attachTrace(bufferIsClosed(this));
         }
-        if (writableBytes() == 0) {
+        int writableBytes = writableBytes();
+        if (writableBytes == 0) {
             return 0;
         }
-        checkWrite(writerOffset(), Math.max(1, writableBytes()));
+        checkWrite(writerOffset(), writableBytes);
         return processor.process(initialIndex, this)? 1 : -1;
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -644,6 +644,12 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements Readab
     @Override
     public <E extends Exception> int forEachReadable(int initialIndex, ReadableComponentProcessor<E> processor)
             throws E {
+        if (!isAccessible()) {
+            throw attachTrace(bufferIsClosed(this));
+        }
+        if (readableBytes() == 0) {
+            return 0;
+        }
         checkRead(readerOffset(), Math.max(1, readableBytes()));
         return processor.process(initialIndex, this)? 1 : -1;
     }
@@ -651,6 +657,12 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements Readab
     @Override
     public <E extends Exception> int forEachWritable(int initialIndex, WritableComponentProcessor<E> processor)
             throws E {
+        if (!isAccessible()) {
+            throw attachTrace(bufferIsClosed(this));
+        }
+        if (writableBytes() == 0) {
+            return 0;
+        }
         checkWrite(writerOffset(), Math.max(1, writableBytes()));
         return processor.process(initialIndex, this)? 1 : -1;
     }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BufferComponentIterationTest extends BufferTestSupport {
     @ParameterizedTest
@@ -249,6 +250,19 @@ public class BufferComponentIterationTest extends BufferTestSupport {
     }
 
     @ParameterizedTest
+    @MethodSource("allocators")
+    public void forEachReadableMustReturnZeroWhenNotReadable(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(0)) {
+            int count = buf.forEachReadable(0, (index, component) -> {
+                fail();
+                return true;
+            });
+            assertEquals(0, count);
+        }
+    }
+
+    @ParameterizedTest
     @MethodSource("nonCompositeAllocators")
     public void forEachWritableMustVisitBuffer(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
@@ -318,6 +332,19 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             buf.writerOffset(9);
             assertEquals((byte) 0xFF, buf.readByte());
             assertEquals(0x0102030405060708L, buf.readLong());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void forEachWritableMustReturnZeroWhenNotWritable(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(0)) {
+            int count = buf.forEachWritable(0, (index, component) -> {
+                fail();
+                return true;
+            });
+            assertEquals(0, count);
         }
     }
 


### PR DESCRIPTION
…t readable / writable

Motivation:

We should just return when there is nothing to read or write and not throw when forEach* methods are called.

Modifications:

- Add early returns
- Add unit tests

Result:

More consistent and less surpising behaviour
