### PR TITLE
Reduce syscall overhead in native epoll transport when a lot of timeo…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -150,8 +150,6 @@ public final class Native {
     private static native int timerFd();
     public static native void eventFdWrite(int fd, long value);
     public static native void eventFdRead(int fd);
-    static native void timerFdRead(int fd);
-    static native void timerFdSetTime(int fd, int sec, int nsec) throws IOException;
 
     public static FileDescriptor newEpollCreate() {
         return new FileDescriptor(epollCreate());

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -84,6 +84,7 @@
 
 // optional
 extern int epoll_create1(int flags) __attribute__((weak));
+extern int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents, const struct timespec *timeout, const sigset_t *sigmask) __attribute__((weak));
 
 #ifndef __USE_GNU
 struct mmsghdr {
@@ -213,15 +214,6 @@ static void netty_epoll_native_eventFdRead(JNIEnv* env, jclass clazz, jint fd) {
     }
 }
 
-static void netty_epoll_native_timerFdRead(JNIEnv* env, jclass clazz, jint fd) {
-    uint64_t timerFireCount;
-
-    if (read(fd, &timerFireCount, sizeof(uint64_t)) < 0) {
-        // it is expected that this is only called where there is known to be activity, so this is an error.
-        netty_unix_errors_throwChannelExceptionErrorNo(env, "read() failed: ", errno);
-    }
-}
-
 static jint netty_epoll_native_epollCreate(JNIEnv* env, jclass clazz) {
     jint efd;
     if (epoll_create1) {
@@ -250,16 +242,6 @@ static jint netty_epoll_native_epollCreate(JNIEnv* env, jclass clazz) {
     return efd;
 }
 
-static void netty_epoll_native_timerFdSetTime(JNIEnv* env, jclass clazz, jint timerFd, jint tvSec, jint tvNsec) {
-    struct itimerspec ts;
-    memset(&ts.it_interval, 0, sizeof(struct timespec));
-    ts.it_value.tv_sec = tvSec;
-    ts.it_value.tv_nsec = tvNsec;
-    if (timerfd_settime(timerFd, 0, &ts, NULL) < 0) {
-        netty_unix_errors_throwIOExceptionErrorNo(env, "timerfd_settime() failed: ", errno);
-    }
-}
-
 static jint netty_epoll_native_epollWait(JNIEnv* env, jclass clazz, jint efd, jlong address, jint len, jint timeout) {
     struct epoll_event *ev = (struct epoll_event*) (intptr_t) address;
     int result, err;
@@ -273,19 +255,46 @@ static jint netty_epoll_native_epollWait(JNIEnv* env, jclass clazz, jint efd, jl
     return -err;
 }
 
-// This method is deprecated!
 static jint netty_epoll_native_epollWait0(JNIEnv* env, jclass clazz, jint efd, jlong address, jint len, jint timerFd, jint tvSec, jint tvNsec) {
     // only reschedule the timer if there is a newer event.
     // -1 is a special value used by EpollEventLoop.
     if (tvSec != ((jint) -1) && tvNsec != ((jint) -1)) {
-    	struct itimerspec ts;
-    	memset(&ts.it_interval, 0, sizeof(struct timespec));
-    	ts.it_value.tv_sec = tvSec;
-    	ts.it_value.tv_nsec = tvNsec;
-    	if (timerfd_settime(timerFd, 0, &ts, NULL) < 0) {
-    		netty_unix_errors_throwChannelExceptionErrorNo(env, "timerfd_settime() failed: ", errno);
-    		return -1;
-    	}
+        // Let's try to reduce the syscalls as much as possible as timerfd_settime(...) can be expensive:
+        // See https://github.com/netty/netty/issues/11695
+        if (!epoll_pwait2) {
+            int millis = tvNsec / 1000000;
+            // Check if we can reduce the syscall overhead by just use epoll_wait. This is done in cases when we can
+            // tolerate some "drift".
+            if (tvNsec == 0 ||
+                    // Let's just use 10 milliseconds and anything bigger then 1 second as a threshold to accept that
+                    // we may be not 100 % accurate and ignore anything that is smaller then 1 ms.
+                    millis > 10 ||
+                    tvSec > 0) {
+                millis += tv_sec * 1000;
+                return netty_epoll_native_epollWait(env, clazz, efd, address, len, millis);
+            }
+        }
+        struct itimerspec ts;
+        memset(&ts.it_interval, 0, sizeof(struct timespec));
+        ts.it_value.tv_sec = tvSec;
+        ts.it_value.tv_nsec = tvNsec;
+        if (epoll_pwait2) {
+            // We have epoll_pwait2(...), this means we can just pass in the itimerspec directly and not need an
+            // extra syscall even for very small timeouts.
+            struct epoll_event *ev = (struct epoll_event*) (intptr_t) address;
+            int result, err;
+            do {
+                result = epoll_pwait2(efd, ev, len, &ts);
+                if (result >= 0) {
+                    return result;
+                }
+            } while((err = errno) == EINTR);
+            return -err;
+        }
+        if (timerfd_settime(timerFd, 0, &ts, NULL) < 0) {
+            netty_unix_errors_throwChannelExceptionErrorNo(env, "timerfd_settime() failed: ", errno);
+            return -1;
+        }
     }
     return netty_epoll_native_epollWait(env, clazz, efd, address, len, -1);
 }
@@ -666,8 +675,6 @@ static const JNINativeMethod fixed_method_table[] = {
   { "timerFd", "()I", (void *) netty_epoll_native_timerFd },
   { "eventFdWrite", "(IJ)V", (void *) netty_epoll_native_eventFdWrite },
   { "eventFdRead", "(I)V", (void *) netty_epoll_native_eventFdRead },
-  { "timerFdRead", "(I)V", (void *) netty_epoll_native_timerFdRead },
-  { "timerFdSetTime", "(III)V", (void *) netty_epoll_native_timerFdSetTime },
   { "epollCreate", "()I", (void *) netty_epoll_native_epollCreate },
   { "epollWait0", "(IJIIII)I", (void *) netty_epoll_native_epollWait0 }, // This method is deprecated!
   { "epollWait", "(IJII)I", (void *) netty_epoll_native_epollWait },


### PR DESCRIPTION
…uts are scheduled

Motivation:

At the moment we might end up calling timerfd_settime everytime a new timer is scheduled. This can produce quite some overhead. We should try to reduce the number of syscalls when possible.

Modifications:

- If we are using Linux Kernel >= 5.11 use directly epoll_pwait2(...)
- If the scheduled timeout is big enough just use epoll_wait(...) without timerfd_settime and accept some inaccuracy.

Result:

Fixes https://github.com/netty/netty/issues/11695
