### PR TITLE
Define tcnative as optional again

### DIFF
--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative-classes</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -680,6 +680,7 @@
         <artifactId>netty-tcnative-classes</artifactId>
         <version>${tcnative.version}</version>
         <scope>compile</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/11745 introduced some change but missed to mark the tcnative classes jar as optional

Modifications:

Mark the dependency as optional again

Result:

Fixes https://github.com/netty/netty/issues/12101 and https://github.com/netty/netty/issues/12132
