### PR TITLE
Allow more permissive char set in SNI headers

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -22,7 +22,6 @@ import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLParameters;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -70,7 +70,7 @@ final class Java8SslUtils {
         }
         List<SNIServerName> sniServerNames = new ArrayList<SNIServerName>(names.size());
         for (String name: names) {
-            sniServerNames.add(new SNIHostName(name.getBytes(StandardCharsets.UTF_8)));
+            sniServerNames.add(new SNIHostName(name.getBytes(CharsetUtil.UTF_8)));
         }
         return sniServerNames;
     }

--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -21,6 +21,7 @@ import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLParameters;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -69,7 +70,7 @@ final class Java8SslUtils {
         }
         List<SNIServerName> sniServerNames = new ArrayList<SNIServerName>(names.size());
         for (String name: names) {
-            sniServerNames.add(new SNIHostName(name));
+            sniServerNames.add(new SNIHostName(name.getBytes(StandardCharsets.UTF_8)));
         }
         return sniServerNames;
     }

--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import io.netty.util.internal.SuppressJava6Requirement;
+import io.netty.util.CharsetUtil;
 
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIMatcher;


### PR DESCRIPTION
Motivation:

As explained in issue #11819, certain chars such as ":" in the SNI header cause the netty pipeline to blow up.

Modifications:

By converting strings to byte arrays first, we can allow chars like ":"

Result:

Netty will have a more permissive char set allowed for SNI headers.
Fixes #11819.
