### PR TITLE
AdoptOpenJDK has moved to different site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For the detailed information about building and developing Netty, please visit [
 
 You require the following to build Netty:
 
-* Latest stable [OpenJDK 8](https://adoptopenjdk.net)
+* Latest stable [OpenJDK 8](https://adoptium.net/)
 * Latest stable [Apache Maven](https://maven.apache.org/)
 * If you are on Linux or MacOS, you need [additional development packages](https://netty.io/wiki/native-transports.html) installed on your system, because you'll build the native transport.
 


### PR DESCRIPTION
Motivation:
AdoptOpenJDK has moved to https://adoptium.net/. So we should point OpenJDK URL to the new site.

Modification:
Changed https://adoptopenjdk.net to https://adoptium.net/

Result:
Latest OpenJDK Adopt site