### PR TITLE
Fix race when handling delegating tasks in ReferenceCountedOpenSslEngine

### DIFF
--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -1711,7 +1711,7 @@ public abstract class SSLEngineTest {
         return result.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.FINISHED;
     }
 
-    private void runDelegatedTasks(boolean delegate, SSLEngineResult result, SSLEngine engine) throws Exception {
+    private void runDelegatedTasks(boolean delegate, SSLEngineResult result, SSLEngine engine) {
         if (result.getHandshakeStatus() == SSLEngineResult.HandshakeStatus.NEED_TASK) {
             for (;;) {
                 Runnable task = engine.getDelegatedTask();
@@ -1721,7 +1721,7 @@ public abstract class SSLEngineTest {
                 if (!delegate) {
                     task.run();
                 } else {
-                    delegatingExecutor.submit(task).get();
+                    delegatingExecutor.execute(task);
                 }
             }
         }


### PR DESCRIPTION
Motivation:

Due incorrect handling of delegating tasks in ReferenceCountedOpenSslEngine it was possible to observe handshake timeouts / failures.

Modification:

- Only reset needsTask variable after we actually ran the task.
- Add missing synchronized as otherwise we might end up calling native code concurrently which is not safe.
- Change how we excute delegating tasks in our SSLEngineTest. This change would result in timeouts / failures before the fix.

Result:

Fixes https://github.com/netty/netty/issues/12139
