### PR TITLE
Use subject principal forget native SSLSession.getLocalPrincipal() im…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2578,7 +2578,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             if (local == null || local.length == 0) {
                 return null;
             }
-            return ((java.security.cert.X509Certificate) local[0]).getIssuerX500Principal();
+            return ((java.security.cert.X509Certificate) local[0]).getSubjectX500Principal();
         }
 
         @Override


### PR DESCRIPTION
…plementation

Motivation:

We should use the subject principal for the local principal to be consistent. In our impl it not really makes a difference but still it is better to ensure the code is consistent

Modifications:

Use subject pricipal

Result:

Code is consistent
