### PR TITLE
Correct javadoc to be consistent with the current behavior

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -430,7 +430,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     }
 
     /**
-     * Default thread caching behavior - System Property: io.netty.allocator.useCacheForAllThreads - default true
+     * Default thread caching behavior - System Property: io.netty.allocator.useCacheForAllThreads - default false
      */
     public static boolean defaultUseCacheForAllThreads() {
         return DEFAULT_USE_CACHE_FOR_ALL_THREADS;


### PR DESCRIPTION
Motivation:

4797b88d89304763fd92eeff73d077effa53685e change that default value related to ThreadLocal caches of buffers but did miss to update the javadocs

Modifications:

Correct javadocs

Result:

Javadocs reflect reality
