### PR TITLE
Correct javadocs for default maxOrder value

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -423,7 +423,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     }
 
     /**
-     * Default maximum order - System Property: io.netty.allocator.maxOrder - default 11
+     * Default maximum order - System Property: io.netty.allocator.maxOrder - default 9
      */
     public static int defaultMaxOrder() {
         return DEFAULT_MAX_ORDER;


### PR DESCRIPTION
Motivation:

f650303911e308dfdf10761273c2b8e4436ea0a4 changed the default maxOrder from 11 to 9 but we missed to update the javadocs

Modifications:

Fix javadocs

Result:

Javadocs reflect reality
