### PR TITLE
(Re-) add buffer methods to read/write booleans

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAccessor.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAccessor.java
@@ -24,6 +24,55 @@ package io.netty5.buffer.api;
 public interface BufferAccessor {
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors interface.">
     /**
+     * Read the boolean value at the current {@link Buffer#readerOffset()},
+     * and increases the reader offset by {@link Byte#BYTES}.
+     *
+     * @return The boolean value at the current reader offset.
+     * @throws IndexOutOfBoundsException If {@link Buffer#readableBytes} is less than {@link Byte#BYTES}.
+     */
+    default boolean readBoolean() {
+        return readByte() != 0;
+    }
+
+    /**
+     * Get the boolean value at the given reader offset.
+     * The {@link Buffer#readerOffset()} is not modified.
+     *
+     * @param roff The read offset, an absolute offset into this buffer, to read from.
+     * @return The boolean value at the given offset.
+     * @throws IndexOutOfBoundsException if the given offset is out of bounds of the buffer, that is, less than 0 or
+     *                                   greater than {@link Buffer#capacity()} minus {@link Byte#BYTES}.
+     */
+    default boolean getBoolean(int roff) {
+        return getByte(roff) != 0;
+    }
+
+    /**
+     * Write the given boolean value at the current {@link Buffer#writerOffset()},
+     * and increase the writer offset by {@link Byte#BYTES}.
+     *
+     * @param value The boolean value to write.
+     * @return This Buffer.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Byte#BYTES}.
+     */
+    default Buffer writeBoolean(boolean value) {
+        return writeByte((byte) (value ? 1 :0));
+    }
+
+    /**
+     * Set the given boolean value at the given write offset. The {@link Buffer#writerOffset()} is not modified.
+     *
+     * @param woff The write offset, an absolute offset into this buffer to write to.
+     * @param value The boolean value to write.
+     * @return This Buffer.
+     * @throws IndexOutOfBoundsException if the given offset is out of bounds of the buffer, that is, less than 0 or
+     *                                   greater than {@link Buffer#capacity()} minus {@link Byte#BYTES}.
+     */
+    default Buffer setBoolean(int woff, boolean value) {
+        return setByte(woff, (byte) (value ? 1 : 0));
+    }
+
+    /**
      * Read the byte value at the current {@link Buffer#readerOffset()},
      * and increases the reader offset by {@link Byte#BYTES}.
      * The value is read using a two's complement 8-bit encoding,

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAccessor.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAccessor.java
@@ -25,7 +25,10 @@ public interface BufferAccessor {
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors interface.">
     /**
      * Read the boolean value at the current {@link Buffer#readerOffset()},
-     * and increases the reader offset by {@link Byte#BYTES}.
+     * and increases the reader offset by {@link Byte#BYTES}. A boolean gets
+     * read as a byte from this buffer. All byte values which are not equal
+     * to zero are considered as the boolean value {@code true}, zero represents
+     * {@code false}.
      *
      * @return The boolean value at the current reader offset.
      * @throws IndexOutOfBoundsException If {@link Buffer#readableBytes} is less than {@link Byte#BYTES}.
@@ -37,6 +40,10 @@ public interface BufferAccessor {
     /**
      * Get the boolean value at the given reader offset.
      * The {@link Buffer#readerOffset()} is not modified.
+     * A boolean gets read as a byte from this buffer. All
+     * byte values which are not equal to zero are considered
+     * as the boolean value {@code true}, zero represents
+     * {@code false}.
      *
      * @param roff The read offset, an absolute offset into this buffer, to read from.
      * @return The boolean value at the given offset.
@@ -49,7 +56,10 @@ public interface BufferAccessor {
 
     /**
      * Write the given boolean value at the current {@link Buffer#writerOffset()},
-     * and increase the writer offset by {@link Byte#BYTES}.
+     * and increase the writer offset by {@link Byte#BYTES}. A boolean gets
+     * written as a byte to this buffer. All byte values which are not equal
+     * to zero are considered as the boolean value {@code true}, zero represents
+     * {@code false}.
      *
      * @param value The boolean value to write.
      * @return This Buffer.
@@ -60,7 +70,12 @@ public interface BufferAccessor {
     }
 
     /**
-     * Set the given boolean value at the given write offset. The {@link Buffer#writerOffset()} is not modified.
+     * Set the given boolean value at the given write offset.
+     * The {@link Buffer#writerOffset()} is not modified.
+     * A boolean gets written as a byte to this buffer. All
+     * byte values which are not equal to zero are considered
+     * as the boolean value {@code true}, zero represents
+     * {@code false}.
      *
      * @param woff The write offset, an absolute offset into this buffer to write to.
      * @param value The boolean value to write.

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -408,6 +408,7 @@ public abstract class BufferTestSupport {
     }
 
     public static void verifyReadInaccessible(Buffer buf) {
+        assertThrows(BufferClosedException.class, () -> buf.readBoolean());
         assertThrows(BufferClosedException.class, () -> buf.readByte());
         assertThrows(BufferClosedException.class, () -> buf.readUnsignedByte());
         assertThrows(BufferClosedException.class, () -> buf.readChar());
@@ -421,6 +422,7 @@ public abstract class BufferTestSupport {
         assertThrows(BufferClosedException.class, () -> buf.readLong());
         assertThrows(BufferClosedException.class, () -> buf.readDouble());
 
+        assertThrows(BufferClosedException.class, () -> buf.getBoolean(0));
         assertThrows(BufferClosedException.class, () -> buf.getByte(0));
         assertThrows(BufferClosedException.class, () -> buf.getUnsignedByte(0));
         assertThrows(BufferClosedException.class, () -> buf.getChar(0));


### PR DESCRIPTION
Motivation:
The buffer api provides read/write access to all primitive data types except booleans which makes reading and writing them a hassle. This is especially because `writeByte` now takes an actual byte rather than an integer which requires a cast making the write code look (something) like this: `writeByte((byte) (value ? 1 : 0))`. This looks really messy when you need to do this a lot.

Modification:
The `BufferAccessor` now has the same read/write methods (`readBoolean`, `getBoolean(offset)`, `writeBoolean(value)` and `setBoolean(offset, value)`) as all other primitive data types do.

Result:
Writing and reading a boolean from a buffer is now much easier and cleaner than before.
