### PR TITLE
Simplify PemEncoded lifecycle

### DIFF
--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslKeyMaterialProvider.java
@@ -76,7 +76,7 @@ class OpenSslKeyMaterialProvider {
         PemEncoded encoded = null;
         try {
             encoded = PemX509Certificate.toPEM(UnpooledByteBufAllocator.DEFAULT, true, certificates);
-            chainBio = toBIO(UnpooledByteBufAllocator.DEFAULT, encoded.retain());
+            chainBio = toBIO(UnpooledByteBufAllocator.DEFAULT, encoded);
             chain = SSL.parseX509Chain(chainBio);
         } catch (Exception e) {
             throw new SSLException("Certificate type not supported", e);

--- a/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
@@ -382,7 +382,8 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
     public boolean equals(Object o) {
         if (o == this) {
             return true;
-        } else if (!(o instanceof PemX509Certificate)) {
+        }
+        if (!(o instanceof PemX509Certificate)) {
             return false;
         }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslKeyMaterialProviderTest.java
@@ -148,7 +148,7 @@ public class OpenSslKeyMaterialProviderTest {
         OpenSslPrivateKey sslPrivateKey;
         try {
             pemKey = PemPrivateKey.toPEM(ByteBufAllocator.DEFAULT, true, privateKey);
-            pkeyBio = ReferenceCountedOpenSslContext.toBIO(ByteBufAllocator.DEFAULT, pemKey.retain());
+            pkeyBio = ReferenceCountedOpenSslContext.toBIO(ByteBufAllocator.DEFAULT, pemKey);
             sslPrivateKey = new OpenSslPrivateKey(SSL.parsePrivateKey(pkeyBio, null));
         } finally {
             ReferenceCountUtil.safeRelease(pemKey);


### PR DESCRIPTION
Motivation:
If ReferenceCountedOpenSslContext.toBIO and newBIO do not close their given arguments, then we don't need to call retain so much.
The PemEncoded values would then just live and die in their local scopes.

Modification:
Make the ReferenceCountedOpenSslContext.toBIO and newBIO methods no longer close their given arguments.
Remove calls to retain on these objects.
The only purpose of those retain calls was to counter-act the release in toBIO and newBIO.

Result:
Simpler code.