### PR TITLE
Many small clean-ups in the SSL/TLS code

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
@@ -86,7 +86,7 @@ public abstract class ByteToMessageDecoderForBuffer extends ChannelHandlerAdapte
     /**
      * Cumulate {@link Buffer}s by add them to a {@link CompositeBuffer} and so do no memory copy whenever possible.
      * Be aware that {@link CompositeBuffer} use a more complex indexing implementation so depending on your use-case
-     * and the decoder implementation this may be slower then just use the {@link #MERGE_CUMULATOR}.
+     * and the decoder implementation this may be slower than just use the {@link #MERGE_CUMULATOR}.
      */
     public static final Cumulator COMPOSITE_CUMULATOR = new CompositeBufferCumulator();
 
@@ -399,23 +399,6 @@ public abstract class ByteToMessageDecoderForBuffer extends ChannelHandlerAdapte
         }
     }
 
-    private static Buffer expandCumulationAndWrite(BufferAllocator alloc, Buffer oldCumulation, Buffer in) {
-        final int newSize = safeFindNextPositivePowerOfTwo(oldCumulation.readableBytes() + in.readableBytes());
-        Buffer newCumulation = oldCumulation.readOnly() ? alloc.allocate(newSize) :
-                oldCumulation.ensureWritable(newSize);
-        try {
-            if (newCumulation != oldCumulation) {
-                newCumulation.writeBytes(oldCumulation);
-            }
-            newCumulation.writeBytes(in);
-            return newCumulation;
-        } finally {
-            if (newCumulation != oldCumulation) {
-                oldCumulation.close();
-            }
-        }
-    }
-
     /**
      * Cumulate {@link ByteBuf}s.
      */
@@ -675,6 +658,23 @@ public abstract class ByteToMessageDecoderForBuffer extends ChannelHandlerAdapte
                 }
                 cumulation.writeBytes(in);
                 return cumulation;
+            }
+        }
+
+        private static Buffer expandCumulationAndWrite(BufferAllocator alloc, Buffer oldCumulation, Buffer in) {
+            final int newSize = safeFindNextPositivePowerOfTwo(oldCumulation.readableBytes() + in.readableBytes());
+            Buffer newCumulation = oldCumulation.readOnly() ? alloc.allocate(newSize) :
+                    oldCumulation.ensureWritable(newSize);
+            try {
+                if (newCumulation != oldCumulation) {
+                    newCumulation.writeBytes(oldCumulation);
+                }
+                newCumulation.writeBytes(in);
+                return newCumulation;
+            } finally {
+                if (newCumulation != oldCumulation) {
+                    oldCumulation.close();
+                }
             }
         }
 

--- a/common/src/main/java/io/netty5/util/internal/EmptyArrays.java
+++ b/common/src/main/java/io/netty5/util/internal/EmptyArrays.java
@@ -26,6 +26,7 @@ public final class EmptyArrays {
 
     public static final int[] EMPTY_INTS = {};
     public static final byte[] EMPTY_BYTES = {};
+    public static final byte[][] EMPTY_BYTES_BYTES = {};
     public static final char[] EMPTY_CHARS = {};
     public static final Object[] EMPTY_OBJECTS = {};
     public static final Class<?>[] EMPTY_CLASSES = {};

--- a/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolAccessor.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolAccessor.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 /**

--- a/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNames.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNames.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 /**

--- a/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -197,7 +197,7 @@ public abstract class ApplicationProtocolNegotiationHandler implements ChannelHa
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         Throwable wrapped;
-        if (cause instanceof DecoderException && ((wrapped = cause.getCause()) instanceof SSLException)) {
+        if (cause instanceof DecoderException && (wrapped = cause.getCause()) instanceof SSLException) {
             try {
                 handshakeFailure(ctx, wrapped);
                 return;

--- a/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslEngine.java
@@ -40,18 +40,22 @@ final class BouncyCastleAlpnSslEngine extends JdkAlpnSslEngine {
                 });
     }
 
+    @Override
     public String getApplicationProtocol() {
         return BouncyCastleAlpnSslUtils.getApplicationProtocol(getWrappedEngine());
     }
 
+    @Override
     public String getHandshakeApplicationProtocol() {
         return BouncyCastleAlpnSslUtils.getHandshakeApplicationProtocol(getWrappedEngine());
     }
 
+    @Override
     public void setHandshakeApplicationProtocolSelector(BiFunction<SSLEngine, List<String>, String> selector) {
         BouncyCastleAlpnSslUtils.setHandshakeApplicationProtocolSelector(getWrappedEngine(), selector);
     }
 
+    @Override
     public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
         return BouncyCastleAlpnSslUtils.getHandshakeApplicationProtocolSelector(getWrappedEngine());
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslUtils.java
@@ -35,19 +35,19 @@ import static io.netty5.handler.ssl.SslUtils.getSSLContext;
 
 final class BouncyCastleAlpnSslUtils {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(BouncyCastleAlpnSslUtils.class);
-    private static final Class BC_SSL_PARAMETERS;
+    private static final Class<?> BC_SSL_PARAMETERS;
     private static final Method SET_PARAMETERS;
     private static final Method SET_APPLICATION_PROTOCOLS;
     private static final Method GET_APPLICATION_PROTOCOL;
     private static final Method GET_HANDSHAKE_APPLICATION_PROTOCOL;
     private static final Method SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR;
     private static final Method GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR;
-    private static final Class BC_APPLICATION_PROTOCOL_SELECTOR;
+    private static final Class<?> BC_APPLICATION_PROTOCOL_SELECTOR;
     private static final Method BC_APPLICATION_PROTOCOL_SELECTOR_SELECT;
 
     static {
-        Class bcSslEngine;
-        Class bcSslParameters;
+        Class<?> bcSslEngine;
+        Class<?> bcSslParameters;
         Method setParameters;
         Method setApplicationProtocols;
         Method getApplicationProtocol;
@@ -55,20 +55,20 @@ final class BouncyCastleAlpnSslUtils {
         Method setHandshakeApplicationProtocolSelector;
         Method getHandshakeApplicationProtocolSelector;
         Method bcApplicationProtocolSelectorSelect;
-        Class bcApplicationProtocolSelector;
+        Class<?> bcApplicationProtocolSelector;
 
         try {
             bcSslEngine = Class.forName("org.bouncycastle.jsse.BCSSLEngine");
-            final Class testBCSslEngine = bcSslEngine;
+            final Class<?> testBCSslEngine = bcSslEngine;
 
             bcSslParameters = Class.forName("org.bouncycastle.jsse.BCSSLParameters");
             Object bcSslParametersInstance = bcSslParameters.newInstance();
-            final Class testBCSslParameters = bcSslParameters;
+            final Class<?> testBCSslParameters = bcSslParameters;
 
             bcApplicationProtocolSelector =
                     Class.forName("org.bouncycastle.jsse.BCApplicationProtocolSelector");
 
-            final Class testBCApplicationProtocolSelector = bcApplicationProtocolSelector;
+            final Class<?> testBCApplicationProtocolSelector = bcApplicationProtocolSelector;
 
             bcApplicationProtocolSelectorSelect = AccessController.doPrivileged(
                     new PrivilegedExceptionAction<Method>() {
@@ -201,7 +201,7 @@ final class BouncyCastleAlpnSslUtils {
                     new InvocationHandler() {
                         @Override
                         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                            if (method.getName().equals("select")) {
+                            if ("select".equals(method.getName())) {
                                 try {
                                     return selector.apply((SSLEngine) args[0], (List<String>) args[1]);
                                 } catch (ClassCastException e) {
@@ -223,7 +223,6 @@ final class BouncyCastleAlpnSslUtils {
         }
     }
 
-    @SuppressWarnings("unchecked")
     static BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector(SSLEngine engine) {
         try {
             final Object selector = GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invoke(engine);

--- a/handler/src/main/java/io/netty5/handler/ssl/CipherSuiteConverter.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/CipherSuiteConverter.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty5.util.internal.UnstableApi;

--- a/handler/src/main/java/io/netty5/handler/ssl/ClientAuth.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ClientAuth.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 /**

--- a/handler/src/main/java/io/netty5/handler/ssl/ConscryptAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ConscryptAlpnSslEngine.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
 
+import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.SystemPropertyUtil;
 import org.conscrypt.AllocatedBuffer;
 import org.conscrypt.BufferAllocator;
@@ -71,7 +72,7 @@ abstract class ConscryptAlpnSslEngine extends JdkSslEngine {
         }
 
         // Set the list of supported ALPN protocols on the engine.
-        Conscrypt.setApplicationProtocols(engine, protocols.toArray(new String[0]));
+        Conscrypt.setApplicationProtocols(engine, protocols.toArray(EmptyArrays.EMPTY_STRINGS));
     }
 
     /**
@@ -183,8 +184,7 @@ abstract class ConscryptAlpnSslEngine extends JdkSslEngine {
 
         @Override
         public AllocatedBuffer retain() {
-            nettyBuffer.retain();
-            return this;
+            throw new UnsupportedOperationException("This method is not supposed to be used.");
         }
 
         @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/ExtendedOpenSslSession.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ExtendedOpenSslSession.java
@@ -18,6 +18,7 @@ package io.netty5.handler.ssl;
 import io.netty5.util.internal.EmptyArrays;
 
 import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSessionBindingEvent;
@@ -49,12 +50,10 @@ abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements Open
         this.wrapped = wrapped;
     }
 
-    // Use rawtypes an unchecked override to be able to also work on java7.
     @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public abstract List getRequestedServerNames();
+    public abstract List<SNIServerName> getRequestedServerNames();
 
-    // Do not mark as override so we can compile on java8.
+    @Override
     public List<byte[]> getStatusResponses() {
         // Just return an empty list for now until we support it as otherwise we will fail in java9
         // because of their sun.security.ssl.X509TrustManagerImpl class.

--- a/handler/src/main/java/io/netty5/handler/ssl/IdentityCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/IdentityCipherSuiteFilter.java
@@ -15,6 +15,8 @@
  */
 package io.netty5.handler.ssl;
 
+import io.netty5.util.internal.EmptyArrays;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -46,8 +48,8 @@ public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
             Set<String> supportedCiphers) {
         if (ciphers == null) {
             return defaultToDefaultCiphers ?
-                    defaultCiphers.toArray(new String[0]) :
-                    supportedCiphers.toArray(new String[0]);
+                    defaultCiphers.toArray(EmptyArrays.EMPTY_STRINGS) :
+                    supportedCiphers.toArray(EmptyArrays.EMPTY_STRINGS);
         } else {
             List<String> newCiphers = new ArrayList<>(supportedCiphers.size());
             for (String c : ciphers) {
@@ -56,7 +58,7 @@ public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
                 }
                 newCiphers.add(c);
             }
-            return newCiphers.toArray(new String[0]);
+            return newCiphers.toArray(EmptyArrays.EMPTY_STRINGS);
         }
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/Java7SslParametersUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/Java7SslParametersUtils.java
@@ -25,7 +25,7 @@ final class Java7SslParametersUtils {
     }
 
     /**
-     * Utility method that is used by {@link OpenSslEngine} and so allow use not not have any reference to
+     * Utility method that is used by {@link OpenSslEngine} and so allow use not have any reference to
      * {@link AlgorithmConstraints} in the code. This helps us to not get into trouble when using it in java
      * version < 7 and especially when using on android.
      */

--- a/handler/src/main/java/io/netty5/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/Java8SslUtils.java
@@ -61,7 +61,7 @@ final class Java8SslUtils {
         }
     }
 
-    static List getSniHostNames(List<String> names) {
+    static List<SNIServerName> getSniHostNames(List<String> names) {
         if (names == null || names.isEmpty()) {
             return Collections.emptyList();
         }
@@ -69,10 +69,10 @@ final class Java8SslUtils {
         for (String name: names) {
             sniServerNames.add(new SNIHostName(name.getBytes(StandardCharsets.UTF_8)));
         }
-        return sniServerNames;
+        return Collections.unmodifiableList(sniServerNames);
     }
 
-    static List getSniHostName(byte[] hostname) {
+    static List<SNIServerName> getSniHostName(byte[] hostname) {
         if (hostname == null || hostname.length == 0) {
             return Collections.emptyList();
         }

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslEngine.java
@@ -185,20 +185,22 @@ class JdkAlpnSslEngine extends JdkSslEngine {
         return null;
     }
 
-    // These methods will override the methods defined by Java 8u251 and later. As we may compile with an earlier
-    // java8 version we don't use @Override annotations here.
+    @Override
     public String getApplicationProtocol() {
         return JdkAlpnSslUtils.getApplicationProtocol(getWrappedEngine());
     }
 
+    @Override
     public String getHandshakeApplicationProtocol() {
         return JdkAlpnSslUtils.getHandshakeApplicationProtocol(getWrappedEngine());
     }
 
+    @Override
     public void setHandshakeApplicationProtocolSelector(BiFunction<SSLEngine, List<String>, String> selector) {
         JdkAlpnSslUtils.setHandshakeApplicationProtocolSelector(getWrappedEngine(), selector);
     }
 
+    @Override
     public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
         return JdkAlpnSslUtils.getHandshakeApplicationProtocolSelector(getWrappedEngine());
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslUtils.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.handler.ssl;
 
-
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.logging.InternalLogger;
@@ -81,7 +80,7 @@ final class JdkAlpnSslUtils {
                     AccessController.doPrivileged((PrivilegedExceptionAction<MethodHandle>) () ->
                             lookup.findVirtual(SSLEngine.class, "getHandshakeApplicationProtocolSelector",
                                     MethodType.methodType(BiFunction.class)));
-            // Invoke and specify the return type so the compiler doesnt try to use void
+            // Invoke and specify the return type so the compiler doesn't try to use void
             @SuppressWarnings("unchecked")
             BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelectorRes =
                     (BiFunction<SSLEngine, List<String>, String>)

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslContext.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
@@ -90,7 +89,9 @@ public class JdkSslContext extends SslContext {
         DEFAULT_CIPHERS_NON_TLSV13 = Collections.unmodifiableList(ciphersNonTLSv13);
 
         Set<String> suppertedCiphersNonTLSv13 = new LinkedHashSet<>(SUPPORTED_CIPHERS);
-        suppertedCiphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
+        for (String defaultTlsv13CipherSuite : SslUtils.DEFAULT_TLSV13_CIPHER_SUITES) {
+            suppertedCiphersNonTLSv13.remove(defaultTlsv13CipherSuite);
+        }
         SUPPORTED_CIPHERS_NON_TLSV13 = Collections.unmodifiableSet(suppertedCiphersNonTLSv13);
 
         if (logger.isDebugEnabled()) {
@@ -120,8 +121,7 @@ public class JdkSslContext extends SslContext {
         // Choose the sensible default list of cipher suites.
         final String[] supportedCiphers = engine.getSupportedCipherSuites();
         Set<String> supportedCiphersSet = new LinkedHashSet<>(supportedCiphers.length);
-        for (int i = 0; i < supportedCiphers.length; ++i) {
-            String supportedCipher = supportedCiphers[i];
+        for (String supportedCipher : supportedCiphers) {
             supportedCiphersSet.add(supportedCipher);
             // IBM's J9 JVM utilizes a custom naming scheme for ciphers and only returns ciphers with the "SSL_"
             // prefix instead of the "TLS_" prefix (as defined in the JSSE cipher suite names [1]). According to IBM's
@@ -135,7 +135,7 @@ public class JdkSslContext extends SslContext {
             if (supportedCipher.startsWith("SSL_")) {
                 final String tlsPrefixedCipherName = "TLS_" + supportedCipher.substring("SSL_".length());
                 try {
-                    engine.setEnabledCipherSuites(new String[]{tlsPrefixedCipherName});
+                    engine.setEnabledCipherSuites(new String[] { tlsPrefixedCipherName });
                     supportedCiphersSet.add(tlsPrefixedCipherName);
                 } catch (IllegalArgumentException ignored) {
                     // The cipher is not supported ... move on to the next cipher.

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslServerContext.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import java.io.File;
@@ -112,5 +111,4 @@ final class JdkSslServerContext extends JdkSslContext {
             throw new SSLException("failed to initialize the server-side SSL context", e);
         }
     }
-
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/JettyNpnSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JettyNpnSslEngine.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty5.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelectionListener;

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
@@ -185,7 +184,6 @@ public final class OpenSsl {
             final List<String> defaultCiphers = new ArrayList<>();
             final Set<String> availableOpenSslCipherSuites = new LinkedHashSet<>(128);
             boolean supportsKeyManagerFactory = false;
-            boolean useKeyManagerFactory = false;
             boolean tlsv13Supported = false;
             String[] namedGroups = DEFAULT_NAMED_GROUPS;
             String[] defaultConvertedNamedGroups = new String[namedGroups.length];
@@ -201,7 +199,7 @@ public final class OpenSsl {
 
                 StringBuilder ciphersBuilder = new StringBuilder(128);
                 for (String cipher: EXTRA_SUPPORTED_TLS_1_3_CIPHERS) {
-                    ciphersBuilder.append(cipher).append(":");
+                    ciphersBuilder.append(cipher).append(':');
                 }
                 ciphersBuilder.setLength(ciphersBuilder.length() - 1);
                 EXTRA_SUPPORTED_TLS_1_3_CIPHERS_STRING = ciphersBuilder.toString();
@@ -453,7 +451,7 @@ public final class OpenSsl {
                 if (logger.isInfoEnabled()) {
                     StringBuilder javaCiphers = new StringBuilder(128);
                     for (String cipher : ciphers.split(":")) {
-                        javaCiphers.append(CipherSuiteConverter.toJava(cipher, "TLS")).append(":");
+                        javaCiphers.append(CipherSuiteConverter.toJava(cipher, "TLS")).append(':');
                     }
                     javaCiphers.setLength(javaCiphers.length() - 1);
                     logger.info(
@@ -657,23 +655,23 @@ public final class OpenSsl {
         if ("linux".equals(os)) {
             Set<String> classifiers = PlatformDependent.normalizedLinuxClassifiers();
             for (String classifier : classifiers) {
-                libNames.add(staticLibName + "_" + os + '_' + arch + "_" + classifier);
+                libNames.add(staticLibName + '_' + os + '_' + arch + '_' + classifier);
             }
             // generic arch-dependent library
-            libNames.add(staticLibName + "_" + os + '_' + arch);
+            libNames.add(staticLibName + '_' + os + '_' + arch);
 
             // Fedora SSL lib so naming (libssl.so.10 vs libssl.so.1.0.0).
             // note: should already be included from the classifiers but if not, we use this as an
             //       additional fallback option here
-            libNames.add(staticLibName + "_" + os + '_' + arch + "_fedora");
+            libNames.add(staticLibName + '_' + os + '_' + arch + "_fedora");
         } else {
-            libNames.add(staticLibName + "_" + os + '_' + arch);
+            libNames.add(staticLibName + '_' + os + '_' + arch);
         }
-        libNames.add(staticLibName + "_" + arch);
+        libNames.add(staticLibName + '_' + arch);
         libNames.add(staticLibName);
 
         NativeLibraryLoader.loadFirstAvailable(PlatformDependent.getClassLoader(SSLContext.class),
-            libNames.toArray(new String[0]));
+            libNames.toArray(EmptyArrays.EMPTY_STRINGS));
     }
 
     private static boolean initializeTcNative(String engine) throws Exception {

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslCachingKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslCachingKeyMaterialProvider.java
@@ -43,7 +43,7 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
         if (material == null) {
             material = super.chooseKeyMaterial(allocator, alias);
             if (material == null) {
-                // No keymaterial should be used.
+                // No key material should be used.
                 return null;
             }
 

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslCertificateCompressionConfig.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslCertificateCompressionConfig.java
@@ -31,7 +31,7 @@ public final class OpenSslCertificateCompressionConfig implements
     private final List<AlgorithmConfig> pairList;
 
     private OpenSslCertificateCompressionConfig(AlgorithmConfig... pairs) {
-        pairList = Collections.unmodifiableList(Arrays.asList(pairs));
+        pairList = List.of(pairs);
     }
 
     @Override
@@ -42,7 +42,7 @@ public final class OpenSslCertificateCompressionConfig implements
     /**
      * Creates a new {@link Builder} for a config.
      *
-     * @return a bulder
+     * @return a builder
      */
     public static Builder newBuilder() {
         return new Builder();
@@ -52,7 +52,7 @@ public final class OpenSslCertificateCompressionConfig implements
      * Builder for an {@link OpenSslCertificateCompressionAlgorithm}.
      */
     public static final class Builder {
-        private final List<AlgorithmConfig> algorithmList = new ArrayList<AlgorithmConfig>();
+        private final List<AlgorithmConfig> algorithmList = new ArrayList<>();
 
         private Builder() { }
 
@@ -80,12 +80,12 @@ public final class OpenSslCertificateCompressionConfig implements
          * @return a new config.
          */
         public OpenSslCertificateCompressionConfig build() {
-            return new OpenSslCertificateCompressionConfig(algorithmList.toArray(new AlgorithmConfig[0]));
+            return new OpenSslCertificateCompressionConfig(algorithmList.toArray(AlgorithmConfig[]::new));
         }
     }
 
     /**
-     * The configuration for algorithm.
+     * The configuration for the algorithm.
      */
     public static final class AlgorithmConfig {
         private final OpenSslCertificateCompressionAlgorithm algorithm;
@@ -120,17 +120,17 @@ public final class OpenSslCertificateCompressionConfig implements
      */
     public enum AlgorithmMode {
         /**
-         * Compression supported and should be advertized.
+         * Compression supported and should be advertised.
          */
         Compress,
 
         /**
-         * Decompression supported and should be advertized.
+         * Decompression supported and should be advertised.
          */
         Decompress,
 
         /**
-         * Compression and Decompression are supported and both should be advertized.
+         * Compression and Decompression are supported and both should be advertised.
          */
         Both
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslClientSessionCache.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslClientSessionCache.java
@@ -27,7 +27,7 @@ import java.util.Map;
 final class OpenSslClientSessionCache extends OpenSslSessionCache {
     // TODO: Should we support to have a List of OpenSslSessions for a Host/Port key and so be able to
     // support sessions for different protocols / ciphers to the same remote peer ?
-    private final Map<HostPort, NativeSslSession> sessions = new HashMap<HostPort, NativeSslSession>();
+    private final Map<HostPort, NativeSslSession> sessions = new HashMap<>();
 
     OpenSslClientSessionCache(OpenSslEngineMap engineMap) {
         super(engineMap);
@@ -110,7 +110,7 @@ final class OpenSslClientSessionCache extends OpenSslSessionCache {
             this.host = host;
             this.port = port;
             // Calculate a hashCode that does ignore case.
-            this.hash = 31 * AsciiString.hashCode(host) + port;
+            hash = 31 * AsciiString.hashCode(host) + port;
         }
 
         @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslContextOption.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslContextOption.java
@@ -29,8 +29,7 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
     /**
      * If enabled heavy-operations may be offloaded from the {@link io.netty5.channel.EventLoop} if possible.
      */
-    public static final OpenSslContextOption<Boolean> USE_TASKS =
-            new OpenSslContextOption<Boolean>("USE_TASKS");
+    public static final OpenSslContextOption<Boolean> USE_TASKS = new OpenSslContextOption<>("USE_TASKS");
     /**
      * If enabled <a href="https://tools.ietf.org/html/rfc7918">TLS false start</a> will be enabled if supported.
      * When TLS false start is enabled the flow of {@link SslHandshakeCompletionEvent}s may be different compared when,
@@ -38,8 +37,7 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
      *
      * This is currently only supported when {@code BoringSSL} and ALPN is used.
      */
-    public static final OpenSslContextOption<Boolean> TLS_FALSE_START =
-            new OpenSslContextOption<Boolean>("TLS_FALSE_START");
+    public static final OpenSslContextOption<Boolean> TLS_FALSE_START = new OpenSslContextOption<>("TLS_FALSE_START");
 
     /**
      * Set the {@link OpenSslPrivateKeyMethod} to use. This allows to offload private-key operations
@@ -48,7 +46,7 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
      * This is currently only supported when {@code BoringSSL} is used.
      */
     public static final OpenSslContextOption<OpenSslPrivateKeyMethod> PRIVATE_KEY_METHOD =
-            new OpenSslContextOption<OpenSslPrivateKeyMethod>("PRIVATE_KEY_METHOD");
+            new OpenSslContextOption<>("PRIVATE_KEY_METHOD");
 
     /**
      * Set the {@link OpenSslAsyncPrivateKeyMethod} to use. This allows to offload private-key operations
@@ -57,7 +55,7 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
      * This is currently only supported when {@code BoringSSL} is used.
      */
     public static final OpenSslContextOption<OpenSslAsyncPrivateKeyMethod> ASYNC_PRIVATE_KEY_METHOD =
-            new OpenSslContextOption<OpenSslAsyncPrivateKeyMethod>("ASYNC_PRIVATE_KEY_METHOD");
+            new OpenSslContextOption<>("ASYNC_PRIVATE_KEY_METHOD");
 
     /**
      * Set the {@link OpenSslCertificateCompressionConfig} to use. This allows for the configuration of certificate
@@ -67,5 +65,5 @@ public final class OpenSslContextOption<T> extends SslContextOption<T> {
      * This is currently only supported when {@code BoringSSL} is used.
      */
     public static final OpenSslContextOption<OpenSslCertificateCompressionConfig> CERTIFICATE_COMPRESSION_ALGORITHMS =
-            new OpenSslContextOption<OpenSslCertificateCompressionConfig>("CERTIFICATE_COMPRESSION_ALGORITHMS");
+            new OpenSslContextOption<>("CERTIFICATE_COMPRESSION_ALGORITHMS");
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslKeyMaterialManager.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslKeyMaterialManager.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-
 /**
  * Manages key material for {@link OpenSslEngine}s and so set the right {@link PrivateKey}s and
  * {@link X509Certificate}s.

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethod.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethod.java
@@ -21,7 +21,7 @@ import io.netty5.util.internal.UnstableApi;
 import javax.net.ssl.SSLEngine;
 
 /**
- * Allow to customize private key signing / decrypting (when using RSA). Only supported when using BoringSSL atm.
+ * Allow customization of private key signing / decrypting (when using RSA). Only supported when using BoringSSL atm.
  */
 @UnstableApi
 public interface OpenSslPrivateKeyMethod {

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslServerSessionContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslServerSessionContext.java
@@ -20,7 +20,6 @@ import io.netty.internal.tcnative.SSLContext;
 
 import java.util.concurrent.locks.Lock;
 
-
 /**
  * {@link OpenSslSessionContext} implementation which offers extra methods which are only useful for the server-side.
  */

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslSession.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslSession.java
@@ -33,8 +33,8 @@ interface OpenSslSession extends SSLSession {
     OpenSslSessionId sessionId();
 
     /**
-     * Set the local certificate chain that is used. It is not expected that this array will be changed at all
-     * and so its ok to not copy the array.
+     * Set the local certificate chain that is used. It is unexpected this array will be changed at all,
+     * and so it's ok to not copy the array.
      */
     void setLocalCertificate(Certificate[] localCertificate);
 

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslSessionId.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslSessionId.java
@@ -31,9 +31,10 @@ final class OpenSslSessionId {
 
     OpenSslSessionId(byte[] id) {
         // We take ownership if the byte[] and so there is no need to clone it.
+        //noinspection AssignmentOrReturnOfFieldWithMutableType
         this.id = id;
         // cache the hashCode as the byte[] array will never change
-        this.hashCode = Arrays.hashCode(id);
+        hashCode = Arrays.hashCode(id);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslSessionStats.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslSessionStats.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty.internal.tcnative.SSLContext;

--- a/handler/src/main/java/io/netty5/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemReader.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
@@ -95,7 +94,7 @@ final class PemReader {
             throw new CertificateException("found no certificates in input stream");
         }
 
-        return certs.toArray(new ByteBuf[0]);
+        return certs.toArray(ByteBuf[]::new);
     }
 
     static ByteBuf readPrivateKey(File file) throws KeyException {

--- a/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -18,6 +18,7 @@ package io.netty5.handler.ssl;
 import io.netty.internal.tcnative.CertificateCallback;
 import io.netty.internal.tcnative.SSL;
 import io.netty.internal.tcnative.SSLContext;
+import io.netty5.util.internal.EmptyArrays;
 
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -246,7 +247,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
             }
             try {
                 final Set<String> keyTypesSet = supportedClientKeyTypes(keyTypeBytes);
-                final String[] keyTypes = keyTypesSet.toArray(new String[0]);
+                final String[] keyTypes = keyTypesSet.toArray(EmptyArrays.EMPTY_STRINGS);
                 final X500Principal[] issuers;
                 if (asn1DerEncodedPrincipals == null) {
                     issuers = null;

--- a/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
@@ -82,7 +82,8 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder {
                                 if (readableBytes < packetLength) {
                                     // client hello incomplete; try again to decode once more data is ready.
                                     return;
-                                } else if (packetLength == SslUtils.SSL_RECORD_HEADER_LENGTH) {
+                                }
+                                if (packetLength == SslUtils.SSL_RECORD_HEADER_LENGTH) {
                                     select(ctx, null);
                                     return;
                                 }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContext.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
@@ -28,6 +27,7 @@ import io.netty5.util.AttributeMap;
 import io.netty5.util.DefaultAttributeMap;
 import io.netty5.util.internal.EmptyArrays;
 
+import java.io.UncheckedIOException;
 import java.security.Provider;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -1206,16 +1206,11 @@ public abstract class SslContext {
 
         try {
             for (int i = 0; i < certs.length; i++) {
-                InputStream is = new ByteBufInputStream(certs[i], false);
-                try {
+                try (InputStream is = new ByteBufInputStream(certs[i], false)) {
                     x509Certs[i] = (X509Certificate) cf.generateCertificate(is);
-                } finally {
-                    try {
-                        is.close();
-                    } catch (IOException e) {
-                        // This is not expected to happen, but re-throw in case it does.
-                        throw new RuntimeException(e);
-                    }
+                } catch (IOException e) {
+                    // This is thrown from is.close(). It's not expected to happen, but re-throw in case it does.
+                    throw new UncheckedIOException(e);
                 }
             }
         } finally {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContextBuilder.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty5.handler.ssl.util.KeyManagerFactoryWrapper;
@@ -310,7 +309,7 @@ public final class SslContextBuilder {
      * {@link #trustManager(TrustManagerFactory trustManagerFactory)} also apply here.
      */
     public SslContextBuilder trustManager(TrustManager trustManager) {
-        this.trustManagerFactory = new TrustManagerFactoryWrapper(trustManager);
+        trustManagerFactory = new TrustManagerFactoryWrapper(trustManager);
         trustCertCollection = null;
         return this;
     }
@@ -494,9 +493,9 @@ public final class SslContextBuilder {
             requireNonNull(keyManager, "keyManager required for servers");
         }
         if (keyManager != null) {
-            this.keyManagerFactory = new KeyManagerFactoryWrapper(keyManager);
+            keyManagerFactory = new KeyManagerFactoryWrapper(keyManager);
         } else {
-            this.keyManagerFactory = null;
+            keyManagerFactory = null;
         }
         keyCertChain = null;
         key = null;

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContextOption.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContextOption.java
@@ -19,7 +19,6 @@ import io.netty5.util.AbstractConstant;
 import io.netty5.util.ConstantPool;
 import static java.util.Objects.requireNonNull;
 
-
 /**
  * A {@link SslContextOption} allows to configure a {@link SslContext} in a type-safe
  * way. Which {@link SslContextOption} is supported depends on the actual implementation

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -1045,7 +1045,7 @@ public class SslHandler extends ByteToMessageDecoder {
             ctx.fireExceptionCaught(cause);
 
             if (cause instanceof SSLException ||
-                    ((cause instanceof DecoderException) && cause.getCause() instanceof SSLException)) {
+                cause instanceof DecoderException && cause.getCause() instanceof SSLException) {
                 ctx.close();
             }
         }
@@ -1349,8 +1349,9 @@ public class SslHandler extends ByteToMessageDecoder {
 
                 if (status == Status.BUFFER_UNDERFLOW ||
                         // If we processed NEED_TASK we should try again even we did not consume or produce anything.
-                        handshakeStatus != HandshakeStatus.NEED_TASK && (consumed == 0 && produced == 0 ||
-                                (length == 0 && handshakeStatus == HandshakeStatus.NOT_HANDSHAKING))) {
+                        handshakeStatus != HandshakeStatus.NEED_TASK &&
+                        (consumed == 0 && produced == 0 || length == 0 &&
+                                                           handshakeStatus == HandshakeStatus.NOT_HANDSHAKING)) {
                     if (handshakeStatus == HandshakeStatus.NEED_UNWRAP) {
                         // The underlying engine is starving so we need to feed it with more data.
                         // See https://github.com/netty/netty/pull/5039

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandshakeCompletionEvent.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandshakeCompletionEvent.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.handler.ssl;
 
-
 /**
  * Event that is fired once the SSL handshake is complete, which may be because it was successful or there
  * was an error.

--- a/handler/src/main/java/io/netty5/handler/ssl/SslProvider.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl;
 
 import io.netty5.util.ReferenceCounted;

--- a/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
@@ -109,7 +109,7 @@ final class SslUtils {
 
     private static final boolean TLSV1_3_JDK_SUPPORTED;
     private static final boolean TLSV1_3_JDK_DEFAULT_ENABLED;
-    public static final TrustManager[] EMPTY_TRUST_MANAGERS = new TrustManager[0];
+   static final TrustManager[] EMPTY_TRUST_MANAGERS = new TrustManager[0];
 
     static {
         TLSV1_3_JDK_SUPPORTED = isTLSv13SupportedByJDK0(null);

--- a/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslUtils.java
@@ -109,6 +109,7 @@ final class SslUtils {
 
     private static final boolean TLSV1_3_JDK_SUPPORTED;
     private static final boolean TLSV1_3_JDK_DEFAULT_ENABLED;
+    public static final TrustManager[] EMPTY_TRUST_MANAGERS = new TrustManager[0];
 
     static {
         TLSV1_3_JDK_SUPPORTED = isTLSv13SupportedByJDK0(null);
@@ -189,7 +190,7 @@ final class SslUtils {
         } else {
             context = SSLContext.getInstance("TLS", provider);
         }
-        context.init(null, new TrustManager[0], null);
+        context.init(null, EMPTY_TRUST_MANAGERS, null);
         return context;
     }
 
@@ -201,7 +202,7 @@ final class SslUtils {
         } else {
             context = SSLContext.getInstance(getTlsVersion(), provider);
         }
-        context.init(null, new TrustManager[0], null);
+        context.init(null, EMPTY_TRUST_MANAGERS, null);
         return context;
     }
 
@@ -256,11 +257,11 @@ final class SslUtils {
     }
 
     /**
-     * Return how much bytes can be read out of the encrypted data. Be aware that this method will not increase
+     * Return how many bytes can be read out of the encrypted data. Be aware this method will not increase
      * the readerIndex of the given {@link ByteBuf}.
      *
      * @param   buffer
-     *                  The {@link ByteBuf} to read from. Be aware that it must have at least
+     *                  The {@link ByteBuf} to read from. Be aware it must have at least
      *                  {@link #SSL_RECORD_HEADER_LENGTH} bytes to read,
      *                  otherwise it will throw an {@link IllegalArgumentException}.
      * @return length
@@ -367,7 +368,7 @@ final class SslUtils {
             return getEncryptedPacketLength(buffer);
         }
 
-        // We need to copy 5 bytes into a temporary buffer so we can parse out the packet length easily.
+        // We need to copy 5 bytes into a temporary buffer, so we can parse out the packet length easily.
         ByteBuffer tmp = ByteBuffer.allocate(5);
 
         do {

--- a/handler/src/main/java/io/netty5/handler/ssl/SupportedCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SupportedCipherSuiteFilter.java
@@ -15,6 +15,8 @@
  */
 package io.netty5.handler.ssl;
 
+import io.netty5.util.internal.EmptyArrays;
+
 import static java.util.Objects.requireNonNull;
 
 import javax.net.ssl.SSLEngine;
@@ -51,7 +53,7 @@ public final class SupportedCipherSuiteFilter implements CipherSuiteFilter {
                 newCiphers.add(c);
             }
         }
-        return newCiphers.toArray(new String[0]);
+        return newCiphers.toArray(EmptyArrays.EMPTY_STRINGS);
     }
 
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/util/BouncyCastleSelfSignedCertGenerator.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/BouncyCastleSelfSignedCertGenerator.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import org.bouncycastle.asn1.x500.X500Name;
@@ -52,7 +51,7 @@ final class BouncyCastleSelfSignedCertGenerator {
                 owner, new BigInteger(64, random), notBefore, notAfter, owner, keypair.getPublic());
 
         ContentSigner signer = new JcaContentSignerBuilder(
-                algorithm.equalsIgnoreCase("EC") ? "SHA256withECDSA" : "SHA256WithRSAEncryption").build(key);
+                "EC".equalsIgnoreCase(algorithm) ? "SHA256withECDSA" : "SHA256WithRSAEncryption").build(key);
         X509CertificateHolder certHolder = builder.build(signer);
         X509Certificate cert = new JcaX509CertificateConverter().setProvider(PROVIDER).getCertificate(certHolder);
         cert.verify(keypair.getPublic());

--- a/handler/src/main/java/io/netty5/handler/ssl/util/FingerprintTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/FingerprintTrustManagerFactory.java
@@ -16,12 +16,10 @@
 
 package io.netty5.handler.ssl.util;
 
-import static java.util.Objects.requireNonNull;
-
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
-import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.concurrent.FastThreadLocal;
+import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.StringUtil;
 
 import javax.net.ssl.ManagerFactoryParameters;
@@ -37,8 +35,9 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * An {@link TrustManagerFactory} that trusts an X.509 certificate whose hash matches.
@@ -148,8 +147,8 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
      * @param fingerprints a list of fingerprints
      */
     FingerprintTrustManagerFactory(final String algorithm, byte[][] fingerprints) {
-        Objects.requireNonNull(algorithm, "algorithm");
-        Objects.requireNonNull(fingerprints, "fingerprints");
+        requireNonNull(algorithm, "algorithm");
+        requireNonNull(fingerprints, "fingerprints");
 
         if (fingerprints.length == 0) {
             throw new IllegalArgumentException("No fingerprints provided");
@@ -191,7 +190,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
             }
         };
 
-        this.fingerprints = list.toArray(new byte[0][]);
+        this.fingerprints = list.toArray(EmptyArrays.EMPTY_BYTES_BYTES);
     }
 
     static byte[][] toFingerprintArray(Iterable<String> fingerprints) {
@@ -211,7 +210,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
             list.add(StringUtil.decodeHexDump(f));
         }
 
-        return list.toArray(new byte[0][]);
+        return list.toArray(EmptyArrays.EMPTY_BYTES_BYTES);
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/util/FingerprintTrustManagerFactoryBuilder.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/FingerprintTrustManagerFactoryBuilder.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import static io.netty5.util.internal.ObjectUtil.checkNotNullWithIAE;
@@ -36,7 +35,7 @@ public final class FingerprintTrustManagerFactoryBuilder {
     /**
      * A list of fingerprints.
      */
-    private final List<String> fingerprints = new ArrayList<String>();
+    private final List<String> fingerprints = new ArrayList<>();
 
     /**
      * Creates a builder.
@@ -81,7 +80,7 @@ public final class FingerprintTrustManagerFactoryBuilder {
         if (fingerprints.isEmpty()) {
             throw new IllegalStateException("No fingerprints provided");
         }
-        return new FingerprintTrustManagerFactory(this.algorithm,
-                                                  FingerprintTrustManagerFactory.toFingerprintArray(this.fingerprints));
+        byte[][] fingerprints = FingerprintTrustManagerFactory.toFingerprintArray(this.fingerprints);
+        return new FingerprintTrustManagerFactory(algorithm, fingerprints);
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/util/InsecureTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/InsecureTrustManagerFactory.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import io.netty5.util.internal.EmptyArrays;

--- a/handler/src/main/java/io/netty5/handler/ssl/util/KeyManagerFactoryWrapper.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/KeyManagerFactoryWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import java.security.KeyStore;

--- a/handler/src/main/java/io/netty5/handler/ssl/util/LazyJavaxX509Certificate.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/LazyJavaxX509Certificate.java
@@ -102,9 +102,10 @@ public final class LazyJavaxX509Certificate extends X509Certificate {
     }
 
     /**
-     * Return the underyling {@code byte[]} without cloning it first. This {@code byte[]} <strong>must</strong> never
+     * Return the underlying {@code byte[]} without cloning it first. This {@code byte[]} <strong>must</strong> never
      * be mutated.
      */
+    @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
     byte[] getBytes() {
         return bytes;
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/SelfSignedCertificate.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import io.netty.buffer.ByteBuf;

--- a/handler/src/main/java/io/netty5/handler/ssl/util/SimpleKeyManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/SimpleKeyManagerFactory.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import io.netty5.util.concurrent.FastThreadLocal;
@@ -36,7 +35,7 @@ import java.util.Objects;
  */
 public abstract class SimpleKeyManagerFactory extends KeyManagerFactory {
 
-    private static final Provider PROVIDER = new Provider("", 0.0, "") {
+    private static final Provider PROVIDER = new Provider("", "0.0", "") {
         private static final long serialVersionUID = -2680540247105807895L;
     };
 

--- a/handler/src/main/java/io/netty5/handler/ssl/util/SimpleTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/SimpleTrustManagerFactory.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import static java.util.Objects.requireNonNull;
@@ -36,7 +35,7 @@ import java.security.Provider;
  */
 public abstract class SimpleTrustManagerFactory extends TrustManagerFactory {
 
-    private static final Provider PROVIDER = new Provider("", 0.0, "") {
+    private static final Provider PROVIDER = new Provider("", "0.0", "") {
         private static final long serialVersionUID = -2680540247105807895L;
     };
 

--- a/handler/src/main/java/io/netty5/handler/ssl/util/ThreadLocalInsecureRandom.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/ThreadLocalInsecureRandom.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import java.security.SecureRandom;

--- a/handler/src/main/java/io/netty5/handler/ssl/util/TrustManagerFactoryWrapper.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/TrustManagerFactoryWrapper.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
 
 import java.security.KeyStore;

--- a/handler/src/main/java/io/netty5/handler/ssl/util/X509KeyManagerWrapper.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/X509KeyManagerWrapper.java
@@ -13,9 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty5.handler.ssl.util;
-
 
 import java.net.Socket;
 import java.security.Principal;

--- a/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CloseNotifyTest.java
@@ -96,7 +96,7 @@ public class CloseNotifyTest {
             // send data:
             clientChannel.writeOutbound(writeAscii(ALLOC, "request_msg"));
             forwardData(clientChannel, serverChannel);
-            assertThat(serverEventQueue.poll(), equalTo((Object) "request_msg"));
+            assertThat(serverEventQueue.poll(), equalTo("request_msg"));
 
             // respond with data and close_notify:
             serverChannel.writeOutbound(writeAscii(ALLOC, "response_msg"));
@@ -106,7 +106,7 @@ public class CloseNotifyTest {
 
             // consume server response with close_notify:
             forwardAllWithCloseNotify(serverChannel, clientChannel);
-            assertThat(clientEventQueue.poll(), equalTo((Object) "response_msg"));
+            assertThat(clientEventQueue.poll(), equalTo("response_msg"));
             assertThat(clientEventQueue.poll(), instanceOf(SslCloseCompletionEvent.class));
 
             // make sure client automatically responds with close_notify:
@@ -114,7 +114,7 @@ public class CloseNotifyTest {
                 // JDK impl of TLSv1.3 does not automatically generate "close_notify" in response to the received
                 // "close_notify" alert. This is a legit behavior according to the spec:
                 // https://tools.ietf.org/html/rfc8446#section-6.1. Handle it differently:
-                assertCloseNotify((ByteBuf) clientChannel.readOutbound());
+                assertCloseNotify(clientChannel.readOutbound());
             }
         } finally {
             try {
@@ -125,7 +125,7 @@ public class CloseNotifyTest {
         }
 
         if (jdkTls13(provider, protocol)) {
-            assertCloseNotify((ByteBuf) clientChannel.readOutbound());
+            assertCloseNotify(clientChannel.readOutbound());
         } else {
             discardEmptyOutboundBuffers(clientChannel);
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -16,12 +16,12 @@
 
 package io.netty5.handler.ssl;
 
-import io.netty5.bootstrap.Bootstrap;
-import io.netty5.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -49,12 +49,10 @@ import io.netty5.util.IllegalReferenceCountException;
 import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.ReferenceCounted;
 import io.netty5.util.concurrent.Future;
-import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.ImmediateExecutor;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.EmptyArrays;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -164,10 +162,10 @@ public class SslHandlerTest {
             writeCauseLatch.await();
             Throwable writeCause = failureRef.get();
             assertNotNull(writeCause);
-            assertThat(writeCause, is(CoreMatchers.<Throwable>instanceOf(SSLException.class)));
+            assertThat(writeCause, is(instanceOf(SSLException.class)));
             Throwable cause = handler.handshakeFuture().cause();
             assertNotNull(cause);
-            assertThat(cause, is(CoreMatchers.<Throwable>instanceOf(SSLException.class)));
+            assertThat(cause, is(instanceOf(SSLException.class)));
         } finally {
             assertFalse(ch.finishAndReleaseAll());
         }
@@ -514,7 +512,7 @@ public class SslHandlerTest {
     }
 
     private static ChannelHandler newHandler(final SslContext sslCtx, final Promise<Void> promise) {
-        return new ChannelInitializer() {
+        return new ChannelInitializer<>() {
             @Override
             protected void initChannel(final Channel ch) {
                 final SslHandler sslHandler = sslCtx.newHandler(ch.alloc());
@@ -539,7 +537,6 @@ public class SslHandlerTest {
                             cause instanceof io.netty.util.IllegalReferenceCountException) {
                             promise.setFailure(cause);
                         }
-                        cause.printStackTrace();
                     }
 
                     @Override
@@ -1228,11 +1225,11 @@ public class SslHandlerTest {
 
             if (client) {
                 Throwable cause = clientSslHandler.handshakeFuture().await().cause();
-                assertThat(cause, CoreMatchers.<Throwable>instanceOf(SslHandshakeTimeoutException.class));
+                assertThat(cause, instanceOf(SslHandshakeTimeoutException.class));
                 assertFalse(serverSslHandler.handshakeFuture().await().isSuccess());
             } else {
                 Throwable cause = serverSslHandler.handshakeFuture().await().cause();
-                assertThat(cause, CoreMatchers.<Throwable>instanceOf(SslHandshakeTimeoutException.class));
+                assertThat(cause, instanceOf(SslHandshakeTimeoutException.class));
                 assertFalse(clientSslHandler.handshakeFuture().await().isSuccess());
             }
         } finally {
@@ -1519,15 +1516,13 @@ public class SslHandlerTest {
                             ch.pipeline().addLast(clientSslHandler);
                         }
                     }).connect(sc.localAddress()).get();
-            clientSslHandler.handshakeFuture().addListener((FutureListener<Channel>) f -> {
-                channel.close();
-            });
+            clientSslHandler.handshakeFuture().addListener(f -> channel.close());
             assertFalse(clientSslHandler.handshakeFuture().await().isSuccess());
             assertFalse(serverSslHandler.handshakeFuture().await().isSuccess());
 
             Object error = errorQueue.take();
             assertThat(error, Matchers.instanceOf(DecoderException.class));
-            assertThat(((Throwable) error).getCause(), Matchers.<Throwable>instanceOf(SSLException.class));
+            assertThat(((Throwable) error).getCause(), instanceOf(SSLException.class));
             Object terminal = errorQueue.take();
             assertSame(terminalEvent, terminal);
 
@@ -1642,23 +1637,23 @@ public class SslHandlerTest {
                     }).connect(sc.localAddress()).get();
 
             Throwable clientCause = clientSslHandler.handshakeFuture().await().cause();
-            assertThat(clientCause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
-            assertThat(clientCause.getCause(), not(CoreMatchers.<Throwable>instanceOf(ClosedChannelException.class)));
+            assertThat(clientCause, instanceOf(SSLException.class));
+            assertThat(clientCause.getCause(), not(instanceOf(ClosedChannelException.class)));
             Throwable serverCause = serverSslHandler.handshakeFuture().await().cause();
-            assertThat(serverCause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
-            assertThat(serverCause.getCause(), not(CoreMatchers.<Throwable>instanceOf(ClosedChannelException.class)));
+            assertThat(serverCause, instanceOf(SSLException.class));
+            assertThat(serverCause.getCause(), not(instanceOf(ClosedChannelException.class)));
             cc.close().syncUninterruptibly();
             sc.close().syncUninterruptibly();
 
             Throwable eventClientCause = clientEvent.get().cause();
-            assertThat(eventClientCause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
+            assertThat(eventClientCause, instanceOf(SSLException.class));
             assertThat(eventClientCause.getCause(),
-                    not(CoreMatchers.<Throwable>instanceOf(ClosedChannelException.class)));
+                    not(instanceOf(ClosedChannelException.class)));
             Throwable serverEventCause = serverEvent.get().cause();
 
-            assertThat(serverEventCause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
+            assertThat(serverEventCause, instanceOf(SSLException.class));
             assertThat(serverEventCause.getCause(),
-                    not(CoreMatchers.<Throwable>instanceOf(ClosedChannelException.class)));
+                    not(instanceOf(ClosedChannelException.class)));
         } finally {
             group.shutdownGracefully();
             ReferenceCountUtil.release(sslClientCtx);

--- a/handler/src/test/java/io/netty5/handler/ssl/SslUtilsTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslUtilsTest.java
@@ -35,7 +35,7 @@ public class SslUtilsTest {
 
     @SuppressWarnings("deprecation")
     @Test
-    public void testPacketLength() throws SSLException, NoSuchAlgorithmException {
+    public void testPacketLength() throws Exception {
         SSLEngine engineLE = newEngine();
         SSLEngine engineBE = newEngine();
 


### PR DESCRIPTION
Motivation:
We can make this code look a bit nicer.
Some of these things can be fixed because we now baseline on Java 11.

Modification:
Use modern Java features and fix warnings.

Result:
Simpler code.