### PR TITLE
Export correct package via OSGI

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -244,7 +244,7 @@
                 <supportedProjectType>bundle</supportedProjectType>
               </supportedProjectTypes>
               <instructions>
-                <Export-Package>${project.groupId}.*</Export-Package>
+                <Export-Package>io.netty5.*</Export-Package>
                 <Export-Package>!*.generated.*</Export-Package>
                 <!-- enforce JVM vendor package as optional -->
                 <Import-Package>sun.nio.ch;resolution:=optional,org.eclipse.jetty.npn;version="[1,2)";resolution:=optional,org.eclipse.jetty.alpn;version="[1,2)";resolution:=optional,*</Import-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -1194,7 +1194,7 @@
                 <supportedProjectType>bundle</supportedProjectType>
               </supportedProjectTypes>
               <instructions>
-                <Export-Package>${project.groupId}.*</Export-Package>
+                <Export-Package>io.netty5.*</Export-Package>
                 <!-- enforce JVM vendor package as optional -->
                 <Import-Package>sun.misc.*;resolution:=optional,sun.nio.ch;resolution:=optional,sun.security.*;resolution:=optional,org.eclipse.jetty.npn;version="[1,2)";resolution:=optional,org.eclipse.jetty.alpn;version="[1,2)";resolution:=optional,*</Import-Package>
                 <!-- override "internal" private package convention -->


### PR DESCRIPTION
Motivation:

We need to export the io.netty5.* package via OSGI

Modifications:

Fix export as it exported io.netty.*

Result:

Be able to use netty5 with osgi
