### PR TITLE
Use windows-2019 in workflows

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./.github/scripts/check_bom_dependencies.sh
 
   build-pr-windows:
-    runs-on: windows-2016
+    runs-on: windows-2019
     name: windows-x86_64-java11-boringssl
     needs: verify-pr
     steps:


### PR DESCRIPTION
Motivation:

windows-2016 was removed so we need to use the next lowest which is 2019

Modifications:

- Use windows-2019

Result:

Builds on windows work again
