### PR TITLE
Fixes that allow the aggregate javadocs to be generated

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -31,7 +31,9 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <javaModuleName>io.netty5.example</javaModuleName>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -39,6 +39,7 @@
          code -->
     <kqueue.classifier />
     <japicmp.skip>true</japicmp.skip>
+    <javaModuleName>io.netty5.microbench</javaModuleName>
   </properties>
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.2.0</version>
+            <version>3.3.2</version>
             <executions>
               <execution>
                 <id>aggregate</id>
@@ -88,6 +88,21 @@
               </execution>
             </executions>
             <configuration>
+              <skippedModules>
+                netty5-all,netty5-bom,netty-testsuite,netty5-testsuite-autobahn,netty5-testsuite-http2,
+                netty5-testsuite-native,netty5-testsuite-native-image,netty5-testsuite-native-image-client,
+                netty5-testsuite-native-image-client-runtime-init,netty5-testsuite-osgi,netty5-testsuite-shading,
+                netty5-transport-blockhound-tests,netty5-transport-native-unix-common-tests,netty5-microbench,
+                netty5-dev-tools,netty5-example
+              </skippedModules>
+              <additionalOptions>
+                <!--
+                 All of our modules are Automatic Modules, so they read everything on the module path.
+                 So we need to add these JDK modules to the module path, because we have dependencies on them.
+                -->
+                <option>--add-modules</option>
+                <option>jdk.unsupported,java.logging,java.naming</option>
+              </additionalOptions>
               <sourceFileExcludes>
                 <exclude>**/com/sun/**/*.java</exclude>
                 <exclude>**/example/**/*.java</exclude>
@@ -106,7 +121,7 @@
               <windowtitle>Netty API Reference (${project.version})</windowtitle>
               <detectJavaApiLink>false</detectJavaApiLink>
               <links>
-                <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
                 <link>https://developers.google.com/protocol-buffers/docs/reference/java/</link>
                 <link>https://www.slf4j.org/apidocs/</link>
               </links>
@@ -1257,7 +1272,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.3.2</version>
         <configuration>
           <detectOfflineLinks>false</detectOfflineLinks>
           <breakiterator>true</breakiterator>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.testsuite_autobahn</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.testsuite_http2</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.testsuite_native_image_client_runtime_init</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.testsuite_native_image_client</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.testsuite_native_image</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -33,6 +33,7 @@
     <skipNativeTestsuite>false</skipNativeTestsuite>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.testsuite_native</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -34,6 +34,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.testsuite_osgi</javaModuleName>
   </properties>
 
   <profiles>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -40,6 +40,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.testsuite_shading</javaModuleName>
   </properties>
 
   <build>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -128,6 +128,7 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <javaModuleName>io.netty5.testsuite</javaModuleName>
   </properties>
 
   <build>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -83,6 +83,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty5.transport_blockhound_tests</javaModuleName>
   </properties>
 
   <dependencies>

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -29,6 +29,10 @@
     Tests for the static library which contains common unix utilities.
   </description>
 
+  <properties>
+    <javaModuleName>io.netty5.transport_native_unix_common_tests</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>


### PR DESCRIPTION
Motivation:
Generating javadocs in a post-9 world means we need to be more strict about modules.

Modification:
Add automatic module names to modules that were missing these.

Add a couple of JDK modules to the javadoc module path.
Automatic modules automatically reads from all modules on the module path, so these need to be present for our modules to be able to see e.g. `java.naming` and `jdk.unsupported`.

Result:
It is now possible to generate javadocs, though we still get tons of errors reported, due to not living up to the standard required for Java 11.
The javadoc tool still generates javadocs for us, though.