### PR TITLE
Fix a few cases where buffers backing private keys can leak

### DIFF
--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
@@ -274,7 +274,7 @@ public final class OpenSsl {
                             cert = SSL.parseX509Chain(certBio);
 
                             keyBio = ReferenceCountedOpenSslContext.toBIO(
-                                    UnpooledByteBufAllocator.DEFAULT, privateKey.retain());
+                                    UnpooledByteBufAllocator.DEFAULT, privateKey);
                             key = SSL.parsePrivateKey(keyBio, null);
 
                             SSL.setKeyMaterial(ssl, cert, key);

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslKeyMaterialProvider.java
@@ -115,7 +115,7 @@ class OpenSslKeyMaterialProvider {
         long chain = 0;
         long pkey = 0;
         try {
-            chainBio = toBIO(allocator, encoded.retain());
+            chainBio = toBIO(allocator, encoded);
             chain = SSL.parseX509Chain(chainBio);
 
             OpenSslKeyMaterial keyMaterial;


### PR DESCRIPTION
Motivation:
The life cycle of PEM encoded values got simplified in #12177, such that we no longer need to call `retain()` before turning PEM encoded values into BIOs.
However, that PR missed to remove a couple of `retain()` calls, which then caused those values to leak memory.

Modification:
Remove `retain()` calls that are no longer necessary.

Result:
No more leaking memory from PEM encoded values.