### PR TITLE
Make NioSocketChannelTest run faster

### DIFF
--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioSocketChannelTest.java
@@ -60,7 +60,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-
 public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChannel> {
 
     /**
@@ -79,11 +78,11 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                 @Override
                 public void channelActive(ChannelHandlerContext ctx) throws Exception {
                     // Write a large enough data so that it is split into two loops.
-                    futures.add(ctx.write(ctx.alloc().buffer().writeZero(1048576))
+                    futures.add(ctx.write(ctx.alloc().buffer().writeZero(1024))
                                    .addListener(ctx, ChannelFutureListeners.CLOSE));
                     futures.add(ctx.write(ctx.alloc().buffer().writeZero(1048576)));
                     ctx.flush();
-                    futures.add(ctx.write(ctx.alloc().buffer().writeZero(1048576)));
+                    futures.add(ctx.write(ctx.alloc().buffer().writeZero(1024)));
                     ctx.flush();
                 }
             });
@@ -94,11 +93,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
 
             InputStream in = s.getInputStream();
             byte[] buf = new byte[8192];
-            for (;;) {
-                if (in.read(buf) == -1) {
-                    break;
-                }
-
+            while (in.read(buf) != -1) {
                 // Wait for a bit so that the write attempts are split into multiple flush attempts.
                 Thread.sleep(10);
             }


### PR DESCRIPTION
Motivation:
While investigating other things, I noticed that this test was taking 13 seconds to run.

Modification:
Change the volume of the data being processed in such a way that the test completes 10 seconds faster, without compromising what it is checking.

Result:
Slightly faster build, maybe.