### PR TITLE
Give netty-all an automatic module name

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -29,6 +29,7 @@
   <name>Netty/All-in-One</name>
 
   <properties>
+    <javaModuleName>io.netty.all</javaModuleName>
     <generatedSourceDir>${project.build.directory}/src</generatedSourceDir>
     <dependencyVersionsDir>${project.build.directory}/versions</dependencyVersionsDir>
     <japicmp.skip>true</japicmp.skip>


### PR DESCRIPTION
Motivation
The netty-all module still produces an empty jar file, so it causes trouble for modular projects if this has no module name.

Modification:
Add an automatic module name for netty-all.

Result:
The netty-all module can now be used in a modula project, under the `io.netty.all` name.

Fixes #12175
