### PR TITLE
Resolve TODO: Make handshake work without HttpObjectAggregator at all.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -297,8 +297,8 @@ public abstract class WebSocketServerHandshaker {
         String aggregatorCtx = ctx.name();
         if (HttpUtil.isContentLengthSet(req) || HttpUtil.isTransferEncodingChunked(req) ||
             version == WebSocketVersion.V00) {
-            // Add aggregator and ensure we feed the HttpRequest so it is aggregated. A limit of 8192 should be more then
-            // enough for the websockets handshake payload.
+            // Add aggregator and ensure we feed the HttpRequest so it is aggregated. A limit of 8192 should be
+            // more then enough for the websockets handshake payload.
             aggregatorCtx = "httpAggregator";
             p.addAfter(ctx.name(), aggregatorCtx, new HttpObjectAggregator(8192));
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -297,7 +297,7 @@ public abstract class WebSocketServerHandshaker {
         String aggregatorCtx = ctx.name();
         if (HttpUtil.isContentLengthSet(req) || HttpUtil.isTransferEncodingChunked(req) ||
             version == WebSocketVersion.V00) {
-            // Add aggregator and ensure we feed the HttpRequest so it is aggregated. A limit o 8192 should be more then
+            // Add aggregator and ensure we feed the HttpRequest so it is aggregated. A limit of 8192 should be more then
             // enough for the websockets handshake payload.
             aggregatorCtx = "httpAggregator";
             p.addAfter(ctx.name(), aggregatorCtx, new HttpObjectAggregator(8192));

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -295,7 +295,8 @@ public abstract class WebSocketServerHandshaker {
         }
 
         String aggregatorCtx = ctx.name();
-        if (HttpUtil.isContentLengthSet(req) || HttpUtil.isTransferEncodingChunked(req) || version == WebSocketVersion.V00) {
+        if (HttpUtil.isContentLengthSet(req) || HttpUtil.isTransferEncodingChunked(req) ||
+            version == WebSocketVersion.V00) {
             // Add aggregator and ensure we feed the HttpRequest so it is aggregated. A limit o 8192 should be more then
             // enough for the websockets handshake payload.
             aggregatorCtx = "httpAggregator";
@@ -323,8 +324,8 @@ public abstract class WebSocketServerHandshaker {
 
                 if (msg instanceof HttpRequest) {
                     HttpRequest httpRequest = (HttpRequest) msg;
-                    fullHttpRequest = new DefaultFullHttpRequest(httpRequest.protocolVersion(), httpRequest.method(), httpRequest.uri(),
-                        Unpooled.EMPTY_BUFFER, httpRequest.headers(), EmptyHttpHeaders.INSTANCE);
+                    fullHttpRequest = new DefaultFullHttpRequest(httpRequest.protocolVersion(), httpRequest.method(),
+                        httpRequest.uri(), Unpooled.EMPTY_BUFFER, httpRequest.headers(), EmptyHttpHeaders.INSTANCE);
                     if (httpRequest.decoderResult().isFailure()) {
                         fullHttpRequest.setDecoderResult(httpRequest.decoderResult());
                     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
@@ -178,6 +178,7 @@ public abstract class WebSocketServerHandshakerTest {
             assertEquals(LastHttpContent.EMPTY_LAST_CONTENT, lastHttpContent);
         } else {
             assertEquals("8jKS'y:G*Co,Wxa-", lastHttpContent.content().toString(CharsetUtil.US_ASCII));
+            assertTrue(lastHttpContent.release());
         }
 
         assertFalse(channel.finish());


### PR DESCRIPTION
Motivation:

Currently we support WebSocket versions: `0`, `7`, `8`, `13` and most of them is outdated, I think in Netty 5 we can only support the latest `13` version. However, we can remove the httpObjectAggregator from the handshake process and leave it only for version `0` and for backward compatibility if `contentLength` present. But i really don't know who send payload for WebSocket upgrade request.

Modification:

If contentLength header set or WebSocket version is 0 then use httpObjectAggregator otherwise use simple httpRequest.

Result:

Resolve TODO: Make handshake work without HttpObjectAggregator at all. Unfortunately for some cases we still need httpAggregator.
