### PR TITLE
[netty 5] Add support to java 17 direct buffer constructor

### DIFF
--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
@@ -251,7 +251,8 @@ final class PlatformDependent0 {
                                                         .unreflectConstructor(constructor);
                                                 if (constructor.getParameterCount() == 4) {
                                                     Object[] nullArgs = new Object[] { null };
-                                                    MethodHandles.insertArguments(constructorHandle, 3, nullArgs);
+                                                    constructorHandle = MethodHandles
+                                                            .insertArguments(constructorHandle, 3, nullArgs);
                                                 }
                                                 return constructorHandle;
                                             } catch (SecurityException | IllegalAccessException e) {


### PR DESCRIPTION

Motivation:

With java 17, the direct buffer constructor has changed.

Modification:

This commit adds support to it.

Result:

netty 5 on Java 17 can use direct buffers.
