### PR TITLE
Add missing java module name

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -31,6 +31,7 @@
 
   <properties>
     <japicmp.skip>true</japicmp.skip>
+    <javaModuleName>io.netty.example</javaModuleName>
   </properties>
   <dependencies>
     <dependency>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -39,6 +39,7 @@
          code -->
     <kqueue.classifier />
     <japicmp.skip>true</japicmp.skip>
+    <javaModuleName>io.netty.microbench</javaModuleName>
   </properties>
   <profiles>
     <profile>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.testsuite_autobahn</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.testsuite_http2</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-native-image-client-runtime-init/pom.xml
+++ b/testsuite-native-image-client-runtime-init/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.testsuite_native_image_client_runtime_init</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-native-image-client/pom.xml
+++ b/testsuite-native-image-client/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.testsuite_native_image_client</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -32,6 +32,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.testsuite_native_image</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -33,6 +33,7 @@
     <skipNativeTestsuite>false</skipNativeTestsuite>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.testsuite_native</javaModuleName>
   </properties>
 
   <dependencies>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -34,6 +34,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.testsuite_osgi</javaModuleName>
   </properties>
 
   <profiles>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -40,6 +40,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.testsuite_shading</javaModuleName>
   </properties>
 
   <build>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -130,6 +130,7 @@
     <!-- Needed for SSL tests as these use the SelfSignedCertificate --> 
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
     <japicmp.skip>true</japicmp.skip>
+    <javaModuleName>io.netty.testsuite</javaModuleName>
   </properties>
 
   <build>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -87,6 +87,7 @@
     <japicmp.skip>true</japicmp.skip>
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
+    <javaModuleName>io.netty.transport_blockhound_tests</javaModuleName>
   </properties>
 
   <dependencies>

--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -29,6 +29,10 @@
     Tests for the static library which contains common unix utilities.
   </description>
 
+  <properties>
+    <javaModuleName>io.netty.transport_native_unix_common_tests</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>


### PR DESCRIPTION
Motivation:

We should ensure we add a valid module name in the manifest

Modifications:

Add missing declarations

Result:

Have a valid module name in the manifest
