### PR TITLE
Reduce syscall overhead in native epoll transport when a lot of timeo…

### DIFF
--- a/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
@@ -390,17 +390,14 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
 
     /**
      * Returns the absolute point in time (relative to {@link #getCurrentTimeNanos()} ()}) at which the next
-     * closest scheduled task should run.
+     * closest scheduled task should run or {@code -1} if none is scheduled at the mment.
      *
      * This method must be called from the {@link EventExecutor} thread.
      */
     protected final long deadlineNanos() {
         assert inEventLoop();
         RunnableScheduledFuture<?> scheduledTask = peekScheduledTask();
-        if (scheduledTask == null) {
-            return getCurrentTimeNanos() + SCHEDULE_PURGE_INTERVAL;
-        }
-        return scheduledTask.deadlineNanos();
+        return scheduledTask == null ? -1 : scheduledTask.deadlineNanos();
     }
 
     /**

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollHandler.java
@@ -34,7 +34,7 @@ import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Math.min;
@@ -44,9 +44,10 @@ import static java.util.Objects.requireNonNull;
  * {@link IoHandler} which uses epoll under the covers. Only works on Linux!
  */
 public class EpollHandler implements IoHandler {
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollHandler.class);
     private static final long EPOLL_WAIT_MILLIS_THRESHOLD =
             SystemPropertyUtil.getLong("io.netty5.channel.epoll.epollWaitThreshold", 10);
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollHandler.class);
 
     static {
         // Ensure JNI is initialized by the time this class is loaded by this time!
@@ -69,7 +70,16 @@ public class EpollHandler implements IoHandler {
 
     private final SelectStrategy selectStrategy;
     private final IntSupplier selectNowSupplier = this::epollWaitNow;
-    private final AtomicInteger wakenUp = new AtomicInteger(1);
+
+    private static final long AWAKE = -1L;
+    private static final long NONE = Long.MAX_VALUE;
+
+    // nextWakeupNanos is:
+    //    AWAKE            when EL is awake
+    //    NONE             when EL is waiting with no wakeup scheduled
+    //    other value T    when EL is waiting with wakeup scheduled at time T
+    private final AtomicLong nextWakeupNanos = new AtomicLong(AWAKE);
+
     private boolean pendingWakeup;
 
     // See https://man7.org/linux/man-pages/man2/timerfd_create.2.html.
@@ -215,7 +225,7 @@ public class EpollHandler implements IoHandler {
 
     @Override
     public final void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && wakenUp.getAndSet(1) == 0) {
+        if (!inEventLoop && nextWakeupNanos.getAndSet(AWAKE) != AWAKE) {
             // write to the evfd which will then wake-up epoll_wait(...)
             Native.eventFdWrite(eventFd.intValue(), 1L);
         }
@@ -261,20 +271,19 @@ public class EpollHandler implements IoHandler {
         }
     }
 
-    private long epollWait(IoExecutionContext context) throws IOException {
-        int delaySeconds;
-        int delayNanos;
-        long curDeadlineNanos = context.deadlineNanos();
-        if (curDeadlineNanos == prevDeadlineNanos) {
-            delaySeconds = -1;
-            delayNanos = -1;
-        } else {
-            long totalDelay = context.delayNanos(System.nanoTime());
-            prevDeadlineNanos = curDeadlineNanos;
-            delaySeconds = (int) min(totalDelay / 1000000000L, Integer.MAX_VALUE);
-            delayNanos = (int) min(totalDelay - delaySeconds * 1000000000L, MAX_SCHEDULED_TIMERFD_NS);
+    private long epollWait(IoExecutionContext context, long deadlineNanos) throws IOException {
+        if (deadlineNanos == NONE) {
+            return Native.epollWait(epollFd, events, timerFd,
+                    Integer.MAX_VALUE, 0, EPOLL_WAIT_MILLIS_THRESHOLD); // disarm timer
         }
+        long totalDelay = context.delayNanos(System.nanoTime());
+        int delaySeconds = (int) min(totalDelay / 1000000000L, Integer.MAX_VALUE);
+        int delayNanos = (int) min(totalDelay - delaySeconds * 1000000000L, MAX_SCHEDULED_TIMERFD_NS);
         return Native.epollWait(epollFd, events, timerFd, delaySeconds, delayNanos, EPOLL_WAIT_MILLIS_THRESHOLD);
+    }
+
+    private int epollWaitNoTimerChange() throws IOException {
+        return Native.epollWait(epollFd, events, false);
     }
 
     private int epollWaitNow() throws IOException {
@@ -321,16 +330,29 @@ public class EpollHandler implements IoHandler {
                         // fall-through
                     }
 
-                    wakenUp.set(0);
+                    long curDeadlineNanos = context.deadlineNanos();
+                    if (curDeadlineNanos == -1L) {
+                        curDeadlineNanos = NONE; // nothing on the calendar
+                    }
+                    nextWakeupNanos.set(curDeadlineNanos);
                     try {
                         if (context.canBlock()) {
-                            long result = epollWait(context);
-                            strategy = Native.epollReady(result);
+                            if (curDeadlineNanos == prevDeadlineNanos) {
+                                // No timer activity needed
+                                strategy = epollWaitNoTimerChange();
+                            } else {
+                                // Timerfd needs to be re-armed or disarmed
+                                long result = epollWait(context, curDeadlineNanos);
+                                // The result contains the actual return value and if a timer was used or not.
+                                // We need to "unpack" using the helper methods exposed in Native.
+                                strategy = Native.epollReady(result);
+                                prevDeadlineNanos = Native.epollTimerWasUsed(result) ? curDeadlineNanos : NONE;
+                            }
                         }
                     } finally {
                         // Try get() first to avoid much more expensive CAS in the case we
                         // were woken via the wakeup() method (submitted task)
-                        if (wakenUp.get() == 1 || wakenUp.getAndSet(1) == 1) {
+                        if (nextWakeupNanos.get() == AWAKE || nextWakeupNanos.getAndSet(AWAKE) == AWAKE) {
                             pendingWakeup = true;
                         }
                     }
@@ -339,7 +361,9 @@ public class EpollHandler implements IoHandler {
             }
             if (strategy > 0) {
                 handled = strategy;
-                processReady(events, strategy);
+                if (processReady(events, strategy)) {
+                    prevDeadlineNanos = NONE;
+                }
             }
             if (allowGrowing && strategy == events.length()) {
                 //increase the size of the array as we needed the whole space for the events
@@ -379,15 +403,15 @@ public class EpollHandler implements IoHandler {
         }
     }
 
-    private void processReady(EpollEventArray events, int ready) {
+    // Returns true if a timerFd event was encountered
+    private boolean processReady(EpollEventArray events, int ready) {
+        boolean timerFired = false;
         for (int i = 0; i < ready; i ++) {
             final int fd = events.fd(i);
             if (fd == eventFd.intValue()) {
                 pendingWakeup = false;
             } else if (fd == timerFd.intValue()) {
-                // Just ignore as we use ET mode for the eventfd and timerfd.
-                //
-                // See also https://stackoverflow.com/a/12492308/1074097
+                timerFired = true;
             } else {
                 final long ev = events.events(i);
 
@@ -440,6 +464,7 @@ public class EpollHandler implements IoHandler {
                 }
             }
         }
+        return timerFired;
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/Native.java
@@ -199,7 +199,7 @@ public final class Native {
 
     /**
      * Non-blocking variant of
-     * {@link #epollWait(FileDescriptor, EpollEventArray, FileDescriptor, int, int)}
+     * {@link #epollWait(FileDescriptor, EpollEventArray, FileDescriptor, int, int, long)}
      * that will also hint to processor we are in a busy-wait loop.
      */
     public static int epollBusyWait(FileDescriptor epollFd, EpollEventArray events) throws IOException {
@@ -210,7 +210,7 @@ public final class Native {
         return ready;
     }
 
-    private static native int epollWait0(int efd, long address, int len, int timerFd,
+    private static native long epollWait0(int efd, long address, int len, int timerFd,
                                          int timeoutSec, int timeoutNs, long millisThreshold);
     private static native int epollWait(int efd, long address, int len, int timeout);
     private static native int epollBusyWait0(int efd, long address, int len);

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/Native.java
@@ -170,7 +170,8 @@ public final class Native {
                           int timeoutSec, int timeoutNs, long millisThreshold) throws IOException {
         if (timeoutSec == 0 && timeoutNs == 0) {
             // Zero timeout => poll (aka return immediately)
-            return epollWait(epollFd, events, 0);
+            // We shift this to be consistent with what is done in epollWait0(...)
+            return ((long) epollWait(epollFd, events, 0)) << 32;
         }
         if (timeoutSec == Integer.MAX_VALUE) {
             // Max timeout => wait indefinitely: disarm timerfd first

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/Native.java
@@ -144,28 +144,12 @@ public final class Native {
     private static native int eventFd();
     private static native int timerFd();
     public static native void eventFdWrite(int fd, long value);
-    public static native void eventFdRead(int fd);
-    static native void timerFdRead(int fd);
 
     public static FileDescriptor newEpollCreate() {
         return new FileDescriptor(epollCreate());
     }
 
     private static native int epollCreate();
-
-    /**
-     * @deprecated this method is no longer supported. This functionality is internal to this package.
-     */
-    @Deprecated
-    public static int epollWait(FileDescriptor epollFd, EpollEventArray events, FileDescriptor timerFd,
-                                int timeoutSec, int timeoutNs) throws IOException {
-        int ready = epollWait0(epollFd.intValue(), events.memoryAddress(), events.length(), timerFd.intValue(),
-                               timeoutSec, timeoutNs);
-        if (ready < 0) {
-            throw newIOException("epoll_wait", ready);
-        }
-        return ready;
-    }
 
     static int epollWait(FileDescriptor epollFd, EpollEventArray events, boolean immediatePoll) throws IOException {
         return epollWait(epollFd, events, immediatePoll ? 0 : -1);
@@ -182,6 +166,36 @@ public final class Native {
         return ready;
     }
 
+    static long epollWait(FileDescriptor epollFd, EpollEventArray events, FileDescriptor timerFd,
+                          int timeoutSec, int timeoutNs, long millisThreshold) throws IOException {
+        if (timeoutSec == 0 && timeoutNs == 0) {
+            // Zero timeout => poll (aka return immediately)
+            return epollWait(epollFd, events, 0);
+        }
+        if (timeoutSec == Integer.MAX_VALUE) {
+            // Max timeout => wait indefinitely: disarm timerfd first
+            timeoutSec = 0;
+            timeoutNs = 0;
+        }
+        long result = epollWait0(epollFd.intValue(), events.memoryAddress(), events.length(), timerFd.intValue(),
+                timeoutSec, timeoutNs, millisThreshold);
+        int ready = epollReady(result);
+        if (ready < 0) {
+            throw newIOException("epoll_wait", ready);
+        }
+        return result;
+    }
+
+    // IMPORTANT: This needs to be consistent with what is used in netty5_epoll_native.c
+    static int epollReady(long result) {
+        return (int) (result >> 32);
+    }
+
+    // IMPORTANT: This needs to be consistent with what is used in netty5_epoll_native.c
+    static boolean epollTimerWasUsed(long result) {
+        return (result & 0xff) != 0;
+    }
+
     /**
      * Non-blocking variant of
      * {@link #epollWait(FileDescriptor, EpollEventArray, FileDescriptor, int, int)}
@@ -195,7 +209,8 @@ public final class Native {
         return ready;
     }
 
-    private static native int epollWait0(int efd, long address, int len, int timerFd, int timeoutSec, int timeoutNs);
+    private static native int epollWait0(int efd, long address, int len, int timerFd,
+                                         int timeoutSec, int timeoutNs, long millisThreshold);
     private static native int epollWait(int efd, long address, int len, int timeout);
     private static native int epollBusyWait0(int efd, long address, int len);
 

--- a/transport-native-epoll/src/main/c/netty5_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty5_epoll_native.c
@@ -84,6 +84,7 @@
 
 // optional
 extern int epoll_create1(int flags) __attribute__((weak));
+extern int epoll_pwait2(int epfd, struct epoll_event *events, int maxevents, const struct timespec *timeout, const sigset_t *sigmask) __attribute__((weak));
 
 #ifndef __USE_GNU
 struct mmsghdr {
@@ -204,24 +205,6 @@ static void netty5_epoll_native_eventFdWrite(JNIEnv* env, jclass clazz, jint fd,
     }
 }
 
-static void netty5_epoll_native_eventFdRead(JNIEnv* env, jclass clazz, jint fd) {
-    uint64_t eventfd_t;
-
-    if (eventfd_read(fd, &eventfd_t) != 0) {
-        // something is serious wrong
-        netty5_unix_errors_throwRuntimeException(env, "eventfd_read() failed");
-    }
-}
-
-static void netty5_epoll_native_timerFdRead(JNIEnv* env, jclass clazz, jint fd) {
-    uint64_t timerFireCount;
-
-    if (read(fd, &timerFireCount, sizeof(uint64_t)) < 0) {
-        // it is expected that this is only called where there is known to be activity, so this is an error.
-        netty5_unix_errors_throwChannelExceptionErrorNo(env, "read() failed: ", errno);
-    }
-}
-
 static jint netty5_epoll_native_epollCreate(JNIEnv* env, jclass clazz) {
     jint efd;
     if (epoll_create1) {
@@ -262,26 +245,58 @@ static jint netty5_epoll_native_epollWait(JNIEnv* env, jclass clazz, jint efd, j
     } while((err = errno) == EINTR);
     return -err;
 }
+// This needs to be consistent with Native.java
+#define EPOLL_WAIT_RESULT(V, ARM_TIMER)  ((jlong) ((uint64_t) ((uint32_t) V) << 32 | ARM_TIMER))
 
-// This method is deprecated!
-static jint netty5_epoll_native_epollWait0(JNIEnv* env, jclass clazz, jint efd, jlong address, jint len, jint timerFd, jint tvSec, jint tvNsec) {
-    if (tvSec == 0 && tvNsec == 0) {
-        // Zeros = poll (aka return immediately).
-    	return netty5_epoll_native_epollWait(env, clazz, efd, address, len, 0);
-    }
+static jlong netty5_epoll_native_epollWait0(JNIEnv* env, jclass clazz, jint efd, jlong address, jint len, jint timerFd, jint tvSec, jint tvNsec, jlong millisThreshold) {
     // only reschedule the timer if there is a newer event.
     // -1 is a special value used by EpollEventLoop.
+    uint32_t armTimer = millisThreshold <= 0 ? 1 : 0;
     if (tvSec != ((jint) -1) && tvNsec != ((jint) -1)) {
+        if (millisThreshold > 0 && (tvSec != 0 || tvNsec != 0)) {
+            // Let's try to reduce the syscalls as much as possible as timerfd_settime(...) can be expensive:
+            // See https://github.com/netty/netty/issues/11695
+
+            if (epoll_pwait2) {
+                // We have epoll_pwait2(...), this means we can just pass in the itimerspec directly and not need an
+                // extra syscall even for very small timeouts.
+                struct timespec ts = { tvSec, tvNsec };
+                struct epoll_event *ev = (struct epoll_event*) (intptr_t) address;
+                int result, err;
+                do {
+                    result = epoll_pwait2(efd, ev, len, &ts, NULL);
+                    if (result >= 0) {
+                        return EPOLL_WAIT_RESULT(result, armTimer);
+                    }
+                } while((err = errno) == EINTR);
+                return EPOLL_WAIT_RESULT(-err, armTimer);
+            }
+
+            int millis = tvNsec / 1000000;
+            // Check if we can reduce the syscall overhead by just use epoll_wait. This is done in cases when we can
+            // tolerate some "drift".
+            if (tvNsec == 0 ||
+                    // Let's use the threshold to accept that we may be not 100 % accurate and ignore anything that
+                    // is smaller then 1 ms.
+                    millis >= millisThreshold ||
+                    tvSec > 0) {
+                millis += tvSec * 1000;
+                int result = netty_epoll_native_epollWait(env, clazz, efd, address, len, millis);
+                return EPOLL_WAIT_RESULT(result, armTimer);
+            }
+        }
         struct itimerspec ts;
         memset(&ts.it_interval, 0, sizeof(struct timespec));
         ts.it_value.tv_sec = tvSec;
         ts.it_value.tv_nsec = tvNsec;
         if (timerfd_settime(timerFd, 0, &ts, NULL) < 0) {
-            netty5_unix_errors_throwChannelExceptionErrorNo(env, "timerfd_settime() failed: ", errno);
+            netty_unix_errors_throwChannelExceptionErrorNo(env, "timerfd_settime() failed: ", errno);
             return -1;
         }
+        armTimer = 1;
     }
-    return netty5_epoll_native_epollWait(env, clazz, efd, address, len, -1);
+    int result = netty_epoll_native_epollWait(env, clazz, efd, address, len, -1);
+    return EPOLL_WAIT_RESULT(result, armTimer);
 }
 
 static inline void cpu_relax() {
@@ -640,10 +655,8 @@ static const JNINativeMethod fixed_method_table[] = {
   { "eventFd", "()I", (void *) netty5_epoll_native_eventFd },
   { "timerFd", "()I", (void *) netty5_epoll_native_timerFd },
   { "eventFdWrite", "(IJ)V", (void *) netty5_epoll_native_eventFdWrite },
-  { "eventFdRead", "(I)V", (void *) netty5_epoll_native_eventFdRead },
-  { "timerFdRead", "(I)V", (void *) netty5_epoll_native_timerFdRead },
   { "epollCreate", "()I", (void *) netty5_epoll_native_epollCreate },
-  { "epollWait0", "(IJIIII)I", (void *) netty5_epoll_native_epollWait0 }, // This method is deprecated!
+  { "epollWait0", "(IJIIIIJ)J", (void *) netty5_epoll_native_epollWait0 },
   { "epollWait", "(IJII)I", (void *) netty5_epoll_native_epollWait },
   { "epollBusyWait0", "(IJI)I", (void *) netty5_epoll_native_epollBusyWait0 },
   { "epollCtlAdd0", "(III)I", (void *) netty5_epoll_native_epollCtlAdd0 },

--- a/transport-native-epoll/src/main/c/netty5_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty5_epoll_native.c
@@ -281,7 +281,7 @@ static jlong netty5_epoll_native_epollWait0(JNIEnv* env, jclass clazz, jint efd,
                     millis >= millisThreshold ||
                     tvSec > 0) {
                 millis += tvSec * 1000;
-                int result = netty_epoll_native_epollWait(env, clazz, efd, address, len, millis);
+                int result = netty5_epoll_native_epollWait(env, clazz, efd, address, len, millis);
                 return EPOLL_WAIT_RESULT(result, armTimer);
             }
         }
@@ -290,12 +290,12 @@ static jlong netty5_epoll_native_epollWait0(JNIEnv* env, jclass clazz, jint efd,
         ts.it_value.tv_sec = tvSec;
         ts.it_value.tv_nsec = tvNsec;
         if (timerfd_settime(timerFd, 0, &ts, NULL) < 0) {
-            netty_unix_errors_throwChannelExceptionErrorNo(env, "timerfd_settime() failed: ", errno);
+            netty5_unix_errors_throwChannelExceptionErrorNo(env, "timerfd_settime() failed: ", errno);
             return -1;
         }
         armTimer = 1;
     }
-    int result = netty_epoll_native_epollWait(env, clazz, efd, address, len, -1);
+    int result = netty5_epoll_native_epollWait(env, clazz, efd, address, len, -1);
     return EPOLL_WAIT_RESULT(result, armTimer);
 }
 

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
@@ -81,7 +81,7 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
             final Thread t = new Thread(() -> {
                 try {
                     for (int i = 0; i < 2; i++) {
-                        long ready = Native.epollWait(epoll, array, timerFd, -1, -1, 0);
+                        long ready = Native.epollWait(epoll, array, timerFd, -1, -1, -1);
                         assertEquals(1, Native.epollReady(ready));
                         assertEquals(eventFd.intValue(), array.fd(0));
                         integer.incrementAndGet();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
@@ -115,6 +115,51 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
         }
     }
 
+    @Test
+    public void testResultNoTimeoutCorrectlyEncoded() throws Throwable {
+        final FileDescriptor epoll = Native.newEpollCreate();
+        final FileDescriptor eventFd = Native.newEventFd();
+        final FileDescriptor timerFd = Native.newTimerFd();
+        final EpollEventArray array = new EpollEventArray(1024);
+        try {
+            Native.epollCtlAdd(epoll.intValue(), eventFd.intValue(), Native.EPOLLIN | Native.EPOLLET);
+            final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
+            final Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        for (;;) {
+                            long ready = Native.epollWait(epoll, array, timerFd, 0, 0, 10);
+                            if (ready > 0) {
+                                assertEquals(1, Native.epollReady(ready));
+                                assertEquals(eventFd.intValue(), array.fd(0));
+                                return;
+                            }
+                            Thread.sleep(100);
+                        }
+                    } catch (IOException e) {
+                        causeRef.set(e);
+                    } catch (InterruptedException ignore) {
+                        // ignore
+                    }
+                }
+            });
+            t.start();
+            Native.eventFdWrite(eventFd.intValue(), 1);
+
+            t.join();
+            Throwable cause = causeRef.get();
+            if (cause != null) {
+                throw cause;
+            }
+        } finally {
+            array.free();
+            epoll.close();
+            eventFd.close();
+            timerFd.close();
+        }
+    }
+
     @Override
     protected IoHandlerFactory newIoHandlerFactory() {
         return EpollHandler.newFactory();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollEventLoopTest.java
@@ -81,8 +81,8 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
             final Thread t = new Thread(() -> {
                 try {
                     for (int i = 0; i < 2; i++) {
-                        int ready = Native.epollWait(epoll, array, timerFd, -1, -1);
-                        assertEquals(1, ready);
+                        long ready = Native.epollWait(epoll, array, timerFd, -1, -1, 0);
+                        assertEquals(1, Native.epollReady(ready));
                         assertEquals(eventFd.intValue(), array.fd(0));
                         integer.incrementAndGet();
                     }

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollTest.java
@@ -48,7 +48,8 @@ public class EpollTest {
             final AtomicReference<Throwable> ref = new AtomicReference<>();
             Thread t = new Thread(() -> {
                 try {
-                    assertEquals(1, Native.epollWait(epoll, eventArray, timerFd, -1, -1));
+                    assertEquals(1, Native.epollReady(
+                            Native.epollWait(epoll, eventArray, timerFd, -1, -1, -1)));
                     // This should have been woken up because of eventfd_write.
                     assertEquals(eventfd.intValue(), eventArray.fd(0));
                 } catch (Throwable cause) {

--- a/transport/src/main/java/io/netty5/channel/IoExecutionContext.java
+++ b/transport/src/main/java/io/netty5/channel/IoExecutionContext.java
@@ -27,13 +27,13 @@ public interface IoExecutionContext {
     boolean canBlock();
 
     /**
-     * Returns the amount of time left until the scheduled task with the closest dead line should run..
+     * Returns the amount of time left until the scheduled task with the closest deadline should run.
      */
     long delayNanos(long currentTimeNanos);
 
     /**
-     * Returns the absolute point in time (relative to {@link SingleThreadEventLoop#nanoTime()}) at which the the next
-     * closest scheduled task should run.
+     * Returns the absolute point in time at which the next
+     * closest scheduled task should run or {@code -1} if nothing is scheduled to run.
      */
     long deadlineNanos();
 }


### PR DESCRIPTION
…uts are scheduled(#12145)

Motivation:

At the moment we might end up calling timerfd_settime everytime a new timer is scheduled. This can produce quite some overhead. We should try to reduce the number of syscalls when possible.

Modifications:

- If we are using Linux Kernel >= 5.11 use directly epoll_pwait2(...)
- If the scheduled timeout is big enough just use epoll_wait(...) without timerfd_settime and accept some inaccuracy.

Result:

Fixes https://github.com/netty/netty/issues/11695
