### PR TITLE
Allow aliasing between read-only buffers

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -602,6 +602,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * <p>
      * The returned buffer will not be read-only, regardless of the {@linkplain #readOnly() read-only state} of this
      * buffer.
+     * This has the same effect as calling {@link #copy(int, int, boolean)} with a {@code false} read-only argument.
      *
      * @param offset The offset where copying should start from. This is the offset of the first byte copied.
      * @param length The number of bytes to copy, and the capacity of the returned buffer.
@@ -611,7 +612,36 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * buffer.
      * @throws BufferClosedException if this buffer is closed.
      */
-    Buffer copy(int offset, int length);
+    default Buffer copy(int offset, int length) {
+        return copy(offset, length, false);
+    }
+
+    /**
+     * Returns a copy of the given region of this buffer.
+     * Modifying the content of the returned buffer will not affect this buffers contents.
+     * The two buffers will  maintain separate offsets.
+     * This method does not modify {@link #readerOffset()} or {@link #writerOffset()} of this buffer.
+     * <p>
+     * The copy is created with a {@linkplain #writerOffset() write offset} equal to the length of the copy,
+     * so that the entire contents of the copy is ready to be read.
+     * <p>
+     * The returned buffer will be read-only if, and only if, the {@code readOnly} argument is {@code true}, and it
+     * will not be read-only if the argument is {@code false}.
+     * This is the case regardless of the {@linkplain #readOnly() read-only state} of this buffer.
+     * <p>
+     * If this buffer is read-only, and a read-only copy is requested, then implementations <em>may</em> use structural
+     * sharing and have both buffers backed by the same underlying memory.
+     *
+     * @param offset The offset where copying should start from. This is the offset of the first byte copied.
+     * @param length The number of bytes to copy, and the capacity of the returned buffer.
+     * @param readOnly The desired {@link #readOnly()} state of the returned buffer.
+     * @return A new buffer instance, with independent {@link #readerOffset()} and {@link #writerOffset()},
+     * that contains a copy of the given region of this buffer.
+     * @throws IllegalArgumentException if the {@code offset} or {@code length} reaches outside the bounds of the
+     * buffer.
+     * @throws BufferClosedException if this buffer is closed.
+     */
+    Buffer copy(int offset, int length, boolean readOnly);
 
     /**
      * Splits the buffer into two, at the {@code offset} from the current {@linkplain #readerOffset()} reader offset}

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -186,8 +186,8 @@ public class BufferStub implements Buffer {
     }
 
     @Override
-    public Buffer copy(int offset, int length) {
-        return delegate.copy(offset, length);
+    public Buffer copy(int offset, int length, boolean readOnly) {
+        return delegate.copy(offset, length, readOnly);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
@@ -203,7 +203,12 @@ public interface CompositeBuffer extends Buffer {
     }
 
     @Override
-    CompositeBuffer copy(int offset, int length);
+    default CompositeBuffer copy(int offset, int length) {
+        return (CompositeBuffer) Buffer.super.copy(offset, length);
+    }
+
+    @Override
+    CompositeBuffer copy(int offset, int length, boolean readOnly);
 
     @Override
     default CompositeBuffer split() {

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -372,7 +372,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
-    public CompositeBuffer copy(int offset, int length) {
+    public CompositeBuffer copy(int offset, int length, boolean readOnly) {
         checkLength(length);
         checkGetBounds(offset, length);
         if (closed) {
@@ -390,7 +390,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
             for (i = searchOffsets(offset); cap > 0; i++) {
                 var buf = bufs[i];
                 int avail = buf.capacity() - off;
-                copies[j++] = buf.copy(off, Math.min(cap, avail));
+                copies[j++] = buf.copy(off, Math.min(cap, avail), readOnly);
                 cap -= avail;
                 off = 0;
             }

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -414,11 +414,14 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     }
 
     @Override
-    public Buffer copy(int offset, int length) {
+    public Buffer copy(int offset, int length, boolean readOnly) {
         Buffer copy = control.getAllocator().allocate(length);
         try {
             copyInto(offset, copy, 0, length);
             copy.skipWritable(length);
+            if (readOnly) {
+                copy.makeReadOnly();
+            }
             return copy;
         } catch (Throwable e) {
             copy.close();


### PR DESCRIPTION
Motivation:
Aliasing is only a problem when mutation is involved.
Since making a buffer read-only is irreversible, we can permit them to share the underlying memory.

Modification:
Add a `Buffer.copy` method that takes an argument for whether the resulting buffer should be read-only or not.
If both original and copy buffers are read-only, then reuse the existing structural sharing mechanics of the const buffers, to make both read-only buffers share the same underlying memory.

Result:
Copying read-only buffers can now offer a useful optimisation.
