### PR TITLE
If it is the first execution, directly return minarena and reduce the…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -55,6 +55,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     private static final int MIN_PAGE_SIZE = 4096;
     private static final int MAX_CHUNK_SIZE = (int) (((long) Integer.MAX_VALUE + 1) / 2);
 
+    private static final int NEVER_USE = 0;
+
     private final Runnable trimTask = new Runnable() {
         @Override
         public void run() {
@@ -546,6 +548,11 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             }
 
             PoolArena<T> minArena = arenas[0];
+            //optimized
+            //If it is the first execution, directly return minarena and reduce the number of for loop comparisons below
+            if (minArena.numThreadCaches.get() == NEVER_USE){
+                return minArena;
+            }
             for (int i = 1; i < arenas.length; i++) {
                 PoolArena<T> arena = arenas[i];
                 if (arena.numThreadCaches.get() < minArena.numThreadCaches.get()) {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -55,7 +55,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     private static final int MIN_PAGE_SIZE = 4096;
     private static final int MAX_CHUNK_SIZE = (int) (((long) Integer.MAX_VALUE + 1) / 2);
 
-    private static final int NEVER_USE = 0;
+    private static final int CACHE_NOT_USED = 0;
 
     private final Runnable trimTask = new Runnable() {
         @Override
@@ -550,7 +550,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             PoolArena<T> minArena = arenas[0];
             //optimized
             //If it is the first execution, directly return minarena and reduce the number of for loop comparisons below
-            if (minArena.numThreadCaches.get() == NEVER_USE){
+            if (minArena.numThreadCaches.get() == CACHE_NOT_USED) {
                 return minArena;
             }
             for (int i = 1; i < arenas.length; i++) {


### PR DESCRIPTION
Motivation:

PoolThreadLocalCache.leastUsedArena(PoolArena<T>[] arenas) method,Can be optimized-
Therefore, if the PoolArena subscript is 0, first judge whether the value of numThreadCaches is 0 to avoid the following unnecessary comparison


Modification:

Add a judgment to judge whether the numthreadcaches value of the first subscript is 0 in advance：
private static final int NEVER_USE = 0;
if (minArena.numThreadCaches.get() == NEVER_USE){
    return minArena;
}

Result:

Reduces unnecessary comparisons