### PR TITLE
Don't use wildcard imports in compression implementations

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2BlockCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2BlockCompressor.java
@@ -17,7 +17,9 @@ package io.netty5.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 
-import static io.netty5.handler.codec.compression.Bzip2Constants.*;
+import static io.netty5.handler.codec.compression.Bzip2Constants.BLOCK_HEADER_MAGIC_1;
+import static io.netty5.handler.codec.compression.Bzip2Constants.BLOCK_HEADER_MAGIC_2;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_SYMBOL_RANGE_SIZE;
 
 /**
  * Compresses and writes a single Bzip2 block.<br><br>

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2BlockDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2BlockDecompressor.java
@@ -15,7 +15,10 @@
  */
 package io.netty5.handler.codec.compression;
 
-import static io.netty5.handler.codec.compression.Bzip2Constants.*;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_DECODE_MAX_CODE_LENGTH;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_SYMBOL_RUNA;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_SYMBOL_RUNB;
+import static io.netty5.handler.codec.compression.Bzip2Constants.MAX_BLOCK_LENGTH;
 
 /**
  * Reads and decompresses a single Bzip2 block.<br><br>

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2Decompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2Decompressor.java
@@ -21,7 +21,20 @@ import io.netty.buffer.Unpooled;
 
 import java.util.function.Supplier;
 
-import static io.netty5.handler.codec.compression.Bzip2Constants.*;
+import static io.netty5.handler.codec.compression.Bzip2Constants.BASE_BLOCK_SIZE;
+import static io.netty5.handler.codec.compression.Bzip2Constants.BLOCK_HEADER_MAGIC_1;
+import static io.netty5.handler.codec.compression.Bzip2Constants.BLOCK_HEADER_MAGIC_2;
+import static io.netty5.handler.codec.compression.Bzip2Constants.END_OF_STREAM_MAGIC_1;
+import static io.netty5.handler.codec.compression.Bzip2Constants.END_OF_STREAM_MAGIC_2;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_MINIMUM_TABLES;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_MAX_ALPHABET_SIZE;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_MAXIMUM_TABLES;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_SELECTOR_LIST_MAX_LENGTH;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_SYMBOL_RANGE_SIZE;
+import static io.netty5.handler.codec.compression.Bzip2Constants.MAGIC_NUMBER;
+import static io.netty5.handler.codec.compression.Bzip2Constants.MIN_BLOCK_SIZE;
+import static io.netty5.handler.codec.compression.Bzip2Constants.MAX_BLOCK_SIZE;
+import static io.netty5.handler.codec.compression.Bzip2Constants.MAX_SELECTORS;
 
 /**
  * Uncompresses a {@link ByteBuf} encoded with the Bzip2 format.

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2HuffmanStageDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2HuffmanStageDecoder.java
@@ -15,7 +15,9 @@
  */
 package io.netty5.handler.codec.compression;
 
-import static io.netty5.handler.codec.compression.Bzip2Constants.*;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_DECODE_MAX_CODE_LENGTH;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_GROUP_RUN_LENGTH;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_MAX_ALPHABET_SIZE;
 
 /**
  * A decoder for the Bzip2 Huffman coding stage.

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2HuffmanStageEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2HuffmanStageEncoder.java
@@ -19,7 +19,8 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.Arrays;
 
-import static io.netty5.handler.codec.compression.Bzip2Constants.*;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_ENCODE_MAX_CODE_LENGTH;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_GROUP_RUN_LENGTH;
 
 /**
  * An encoder for the Bzip2 Huffman encoding stage.

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2MTFAndRLE2StageEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2MTFAndRLE2StageEncoder.java
@@ -15,7 +15,9 @@
  */
 package io.netty5.handler.codec.compression;
 
-import static io.netty5.handler.codec.compression.Bzip2Constants.*;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_MAX_ALPHABET_SIZE;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_SYMBOL_RUNA;
+import static io.netty5.handler.codec.compression.Bzip2Constants.HUFFMAN_SYMBOL_RUNB;
 
 /**
  * An encoder for the Bzip2 Move To Front Transform and Run-Length Encoding[2] stages.<br>

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Decompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Decompressor.java
@@ -25,7 +25,14 @@ import net.jpountz.lz4.LZ4FastDecompressor;
 import java.util.function.Supplier;
 import java.util.zip.Checksum;
 
-import static io.netty5.handler.codec.compression.Lz4Constants.*;
+import static io.netty5.handler.codec.compression.Lz4Constants.BLOCK_TYPE_COMPRESSED;
+import static io.netty5.handler.codec.compression.Lz4Constants.BLOCK_TYPE_NON_COMPRESSED;
+import static io.netty5.handler.codec.compression.Lz4Constants.COMPRESSION_LEVEL_BASE;
+import static io.netty5.handler.codec.compression.Lz4Constants.DEFAULT_SEED;
+import static io.netty5.handler.codec.compression.Lz4Constants.HEADER_LENGTH;
+import static io.netty5.handler.codec.compression.Lz4Constants.MAGIC_NUMBER;
+import static io.netty5.handler.codec.compression.Lz4Constants.MAX_BLOCK_SIZE;
+
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/codec/src/main/java/io/netty5/handler/codec/compression/SnappyCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/SnappyCompressor.java
@@ -21,7 +21,7 @@ import io.netty.buffer.Unpooled;
 
 import java.util.function.Supplier;
 
-import static io.netty5.handler.codec.compression.Snappy.*;
+import static io.netty5.handler.codec.compression.Snappy.calculateChecksum;
 
 /**
  * Compresses a {@link ByteBuf} using the Snappy framing format.


### PR DESCRIPTION
Motivation:

We should not use wildcards for static imports to match coding style

Modifications:

Replace wildcard imports

Result:

Cleanup
