### PR TITLE
The Utf8FrameValidator only handles its own protocol violation exception

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8FrameValidator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8FrameValidator.java
@@ -16,19 +16,27 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.CorruptedFrameException;
 
 /**
  *
  */
 public class Utf8FrameValidator extends ChannelInboundHandlerAdapter {
 
+    private final boolean closeOnProtocolViolation;
+
     private int fragmentedFramesCount;
     private Utf8Validator utf8Validator;
+
+    public Utf8FrameValidator() {
+        this(true);
+    }
+
+    public Utf8FrameValidator(boolean closeOnProtocolViolation) {
+        this.closeOnProtocolViolation = closeOnProtocolViolation;
+    }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
@@ -74,8 +82,7 @@ public class Utf8FrameValidator extends ChannelInboundHandlerAdapter {
                     fragmentedFramesCount++;
                 }
             } catch (CorruptedWebSocketFrameException e) {
-                frame.release();
-                throw e;
+                protocolViolation(ctx, frame, e);
             }
         }
 
@@ -89,11 +96,20 @@ public class Utf8FrameValidator extends ChannelInboundHandlerAdapter {
         utf8Validator.check(buffer);
     }
 
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        if (cause instanceof CorruptedFrameException && ctx.channel().isOpen()) {
-            ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+    private void protocolViolation(ChannelHandlerContext ctx, WebSocketFrame frame,
+                                   CorruptedWebSocketFrameException ex) {
+        frame.release();
+        if (closeOnProtocolViolation && ctx.channel().isOpen()) {
+            WebSocketCloseStatus closeStatus = ex.closeStatus();
+            String reasonText = ex.getMessage();
+            if (reasonText == null) {
+                reasonText = closeStatus.reasonText();
+            }
+
+            CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(closeStatus.code(), reasonText);
+            ctx.writeAndFlush(closeFrame).addListener(ChannelFutureListener.CLOSE);
         }
-        super.exceptionCaught(ctx, cause);
+
+        throw ex;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8FrameValidator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/Utf8FrameValidator.java
@@ -112,4 +112,9 @@ public class Utf8FrameValidator extends ChannelInboundHandlerAdapter {
 
         throw ex;
     }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        super.exceptionCaught(ctx, cause);
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -228,7 +228,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         if (serverConfig.decoderConfig().withUTF8Validator() && cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.
             cp.addBefore(ctx.name(), Utf8FrameValidator.class.getName(),
-                    new Utf8FrameValidator());
+                    new Utf8FrameValidator(serverConfig.decoderConfig().closeOnProtocolViolation()));
         }
     }
 


### PR DESCRIPTION
Motivation:

Currently `Utf8FrameValidator` catches all `CorruptedWebSocketFrameException` and trying to close the channel if it's open. This is incorrect behavior because `WebsocketFrameDecoder` throws the same type of exception, but with a different status code and reason, and does not close the channel if the `closeOnProtocolViolation` property is set to false.

Modification:

Correct that the Utf8FrameValidator only handles its own protocol violation exception  and sends the CloseWebsocketFrame with the appropriate status code and reason. Pass the `closeOnProtocolViolation` property to the `Utf8FrameValidator`;

Result:
The Utf8FrameValidator only handle its own protocol violation exception and consolidate with decoder config.
