### PR TITLE
Make it possible to tell if an allocation type is direct

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/AllocationType.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/AllocationType.java
@@ -22,4 +22,9 @@ package io.netty5.buffer.api;
  * Standard implementations of this interface can be found in {@link StandardAllocationTypes}.
  */
 public interface AllocationType {
+    /**
+     * @return {@code true} if this allocation type produces off-heap, or direct buffers.
+     * Otherwise {@code false}, if the buffers are on-heap.
+     */
+    boolean isDirect();
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/StandardAllocationTypes.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/StandardAllocationTypes.java
@@ -27,5 +27,10 @@ public enum StandardAllocationTypes implements AllocationType {
     /**
      * The allocation should use native (non-heap) memory.
      */
-    OFF_HEAP
+    OFF_HEAP;
+
+    @Override
+    public boolean isDirect() {
+        return this == OFF_HEAP;
+    }
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/AdaptableBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/AdaptableBuffer.java
@@ -49,12 +49,12 @@ public abstract class AdaptableBuffer<T extends ResourceSupport<Buffer, T>>
             BufferAllocator allocator = control.getAllocator();
             final BufferAllocator onHeap;
             final BufferAllocator offHeap;
-            if (allocator.getAllocationType() == StandardAllocationTypes.ON_HEAP) {
-                onHeap = allocator;
-                offHeap = allocator.isPooling() ? BufferAllocator.offHeapPooled() : BufferAllocator.offHeapUnpooled();
-            } else {
+            if (allocator.getAllocationType().isDirect()) {
                 onHeap = allocator.isPooling() ? BufferAllocator.onHeapPooled() : BufferAllocator.onHeapUnpooled();
                 offHeap = allocator;
+            } else {
+                onHeap = allocator;
+                offHeap = allocator.isPooling() ? BufferAllocator.offHeapPooled() : BufferAllocator.offHeapUnpooled();
             }
             ByteBufAllocatorAdaptor alloc = new ByteBufAllocatorAdaptor(onHeap, offHeap);
             return adaptor = new ByteBufAdaptor(alloc, this, Integer.MAX_VALUE);

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/WrappingAllocation.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/WrappingAllocation.java
@@ -33,4 +33,9 @@ public final class WrappingAllocation implements AllocationType {
     public byte[] getArray() {
         return array;
     }
+
+    @Override
+    public boolean isDirect() {
+        return false;
+    }
 }

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -343,7 +343,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
      */
     protected final Buffer newDirectBuffer(Resource<?> holder, Buffer buf) {
         BufferAllocator allocator = bufferAllocator();
-        if (allocator.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+        if (!allocator.getAllocationType().isDirect()) {
             allocator = DefaultBufferAllocators.offHeapAllocator();
         }
         try (holder) {

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
@@ -400,7 +400,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
 
         private Throwable doReadBuffer(EpollRecvBufferAllocatorHandle allocHandle, ChannelPipeline pipeline) {
             BufferAllocator allocator = config().getBufferAllocator();
-            if (allocator.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+            if (!allocator.getAllocationType().isDirect()) {
                 allocator = DefaultBufferAllocators.offHeapAllocator();
             }
             Buffer buf = null;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollRecvBufferAllocatorHandle.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollRecvBufferAllocatorHandle.java
@@ -67,7 +67,7 @@ class EpollRecvBufferAllocatorHandle extends DelegatingHandle {
     @Override
     public Buffer allocate(BufferAllocator alloc) {
         // We need to ensure we always allocate a direct ByteBuf as we can only use a direct buffer to read via JNI.
-        if (alloc.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+        if (!alloc.getAllocationType().isDirect()) {
             return super.allocate(DefaultBufferAllocators.offHeapAllocator());
         }
         return super.allocate(alloc);

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -265,7 +265,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
      */
     protected final Buffer newDirectBuffer(Resource<?> holder, Buffer buf) {
         BufferAllocator allocator = bufferAllocator();
-        if (allocator.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+        if (!allocator.getAllocationType().isDirect()) {
             allocator = DefaultBufferAllocators.offHeapAllocator();
         }
         try (holder) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -349,7 +349,7 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
 
         private Throwable doReadBuffer(KQueueRecvBufferAllocatorHandle allocHandle, ChannelPipeline pipeline) {
             BufferAllocator allocator = config().getBufferAllocator();
-            if (allocator.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+            if (!allocator.getAllocationType().isDirect()) {
                 allocator = DefaultBufferAllocators.offHeapAllocator();
             }
             Buffer buf = null;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueRecvBufferAllocatorHandle.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueRecvBufferAllocatorHandle.java
@@ -65,7 +65,7 @@ final class KQueueRecvBufferAllocatorHandle extends DelegatingHandle {
     @Override
     public Buffer allocate(BufferAllocator alloc) {
         // We need to ensure we always allocate a direct ByteBuf as we can only use a direct buffer to read via JNI.
-        if (alloc.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+        if (!alloc.getAllocationType().isDirect()) {
             alloc = DefaultBufferAllocators.offHeapAllocator();
         }
         if (overrideGuess) {

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
@@ -460,7 +460,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         }
 
         BufferAllocator bufferAllocator = bufferAllocator();
-        if (bufferAllocator.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+        if (!bufferAllocator.getAllocationType().isDirect()) {
             bufferAllocator = DefaultBufferAllocators.offHeapAllocator();
         }
         if (bufferAllocator.isPooling()) {
@@ -481,7 +481,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     protected final Buffer newDirectBuffer(Resource<?> holder, Buffer buf) {
         try (holder) {
             BufferAllocator bufferAllocator = bufferAllocator();
-            if (bufferAllocator.getAllocationType() != StandardAllocationTypes.OFF_HEAP) {
+            if (!bufferAllocator.getAllocationType().isDirect()) {
                 bufferAllocator = DefaultBufferAllocators.offHeapAllocator();
             }
             if (bufferAllocator.isPooling()) {


### PR DESCRIPTION
Motivation:
This is the main use case for inspecting the allocation type of any buffer allocator.
We can simplify this and increase our confidence that it is correct by adding a getter for this property.

Modification:
Add an `isDirect` method on `AllocationType`.

Result:
It is now easier to tell if a `BufferAllocator` wil allocate direct buffers or not.