### PR TITLE
Add a bypass for getting a non-read-only ByteBuffer from ReadableComponent

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -27,6 +27,7 @@ import io.netty5.buffer.api.ReadableComponentProcessor;
 import io.netty5.buffer.api.WritableComponent;
 import io.netty5.buffer.api.WritableComponentProcessor;
 import io.netty5.buffer.api.internal.AdaptableBuffer;
+import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
 import io.netty5.buffer.api.internal.Statics;
 
 import java.io.IOException;
@@ -43,7 +44,8 @@ import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
 
-final class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComponent, WritableComponent {
+final class NioBuffer extends AdaptableBuffer<NioBuffer>
+        implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent {
     private static final ByteBuffer CLOSED_BUFFER = ByteBuffer.allocate(0);
 
     private ByteBuffer base;
@@ -506,6 +508,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer> implements ReadableComp
     @Override
     public ByteBuffer readableBuffer() {
         return bbslice(rmem.asReadOnlyBuffer(), readerOffset(), readableBytes());
+    }
+
+    @Override
+    public ByteBuffer mutableReadableBuffer() {
+        return bbslice(rmem, readerOffset(), readableBytes());
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/NotReadOnlyReadableComponent.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/NotReadOnlyReadableComponent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.api.internal;
+
+import io.netty5.buffer.api.ReadableComponent;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Safety by-pass that let us get {@link java.nio.ByteBuffer}s from a {@link io.netty5.buffer.api.ReadableComponent}
+ * that is not read-only.
+ * <p>
+ * This is for instance used by the {@code SslHandler}, because some {@link javax.net.ssl.SSLEngine} implementations
+ * cannot unwrap or decode packets from read-only buffers.
+ */
+public interface NotReadOnlyReadableComponent {
+    /**
+     * Get a {@link ByteBuffer} instance for this memory component.
+     * <p>
+     * <strong>Note</strong> that unlike the {@link ReadableComponent#readableBuffer()} method, the {@link ByteBuffer}
+     * returned here is writable.
+     *
+     * @return A new {@link ByteBuffer}, with its own position and limit, for this memory component.
+     */
+    ByteBuffer mutableReadableBuffer();
+}

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
@@ -20,6 +20,7 @@ import io.netty5.buffer.api.BufferClosedException;
 import io.netty5.buffer.api.BufferReadOnlyException;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
+import io.netty5.buffer.api.ReadableComponent;
 import io.netty5.util.AsciiString;
 import io.netty5.util.internal.PlatformDependent;
 
@@ -145,6 +146,13 @@ public interface Statics {
             i--;
             dest.setByte(destPos + i, src.getByte(srcPos + i));
         }
+    }
+
+    static ByteBuffer tryGetWritableBufferFromReadableComponent(ReadableComponent component) {
+        if (component instanceof NotReadOnlyReadableComponent) {
+            return ((NotReadOnlyReadableComponent) component).mutableReadableBuffer();
+        }
+        return null;
     }
 
     /**

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -27,6 +27,7 @@ import io.netty5.buffer.api.ReadableComponentProcessor;
 import io.netty5.buffer.api.WritableComponent;
 import io.netty5.buffer.api.WritableComponentProcessor;
 import io.netty5.buffer.api.internal.AdaptableBuffer;
+import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.util.internal.PlatformDependent;
 
@@ -44,7 +45,8 @@ import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
 
-final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements ReadableComponent, WritableComponent {
+final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
+        implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent {
     private static final int CLOSED_SIZE = -1;
     private static final boolean ACCESS_UNALIGNED = PlatformDependent.isUnaligned();
     private static final boolean FLIP_BYTES = ByteOrder.BIG_ENDIAN != ByteOrder.nativeOrder();
@@ -599,13 +601,18 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer> implements Readab
 
     @Override
     public ByteBuffer readableBuffer() {
+        return mutableReadableBuffer().asReadOnlyBuffer();
+    }
+
+    @Override
+    public ByteBuffer mutableReadableBuffer() {
         final ByteBuffer buf;
         if (hasReadableArray()) {
             buf = bbslice(ByteBuffer.wrap(readableArray()), readableArrayOffset(), readableArrayLength());
         } else {
             buf = PlatformDependent.directBuffer(address + roff, readableBytes(), memory);
         }
-        return buf.asReadOnlyBuffer();
+        return buf;
     }
 
     @Override


### PR DESCRIPTION
Motivation:
The JDK `SSLEngine` implementation apparently cannot *decode* TLS packets out of `ByteBuffers` that are read-only.

Modification:
Make it possible to bypass the read-only restriction on `ReadableComponent.readableBuffer()`.

Result:
When the `SslHandler` is ported to use `Buffer`, it will not run into this problem that would have prevented us from being able to decode any TLS packets.