### PR TITLE
Resolve TODO: Make handshake work without HttpObjectAggregator at all inside WebSocketClientHandshaker.

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -47,9 +47,15 @@ import org.junit.jupiter.api.Timeout;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
-import static io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker13.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.SWITCHING_PROTOCOLS;
+import static io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker13.WEBSOCKET_13_ACCEPT_GUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class WebSocketClientHandshakerTest {
     protected abstract WebSocketClientHandshaker newHandshaker(URI uri, String subprotocol, HttpHeaders headers,


### PR DESCRIPTION
Motivation:

We can remove  `HttpObjectAggregator` from `WebSocketClientHandshaker` for handshake response which version is is greater than 0.

Modification:

Remove the httpObjectAggregator from the handshake process and leave it only for version 0. 

Result:

Resolve TODO: Make handshake work without `HttpObjectAggregator` at all inside `WebSocketClientHandshaker`. 

