### PR TITLE
Attach lifecycle traces to ByteBufAdaptor reference count errors

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufAdaptor.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufAdaptor.java
@@ -1759,7 +1759,8 @@ public final class ByteBufAdaptor extends ByteBuf {
     public boolean release(int decrement) {
         int refCount = 1 + Statics.countBorrows((ResourceSupport<?, ?>) buffer);
         if (!buffer.isAccessible() || decrement > refCount) {
-            throw new IllegalReferenceCountException(refCount, -decrement);
+            throw Statics.attachTrace((ResourceSupport<?, ?>) buffer,
+                                      new IllegalReferenceCountException(refCount, -decrement));
         }
         for (int i = 0; i < decrement; i++) {
             try {

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
@@ -236,6 +236,10 @@ public interface Statics {
         return ResourceSupport.countBorrows(obj);
     }
 
+    static <E extends Throwable> E attachTrace(ResourceSupport<?, ?> obj, E throwable) {
+        return ResourceSupport.getTracer(obj).attachTrace(throwable);
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     static void unsafeSetDrop(ResourceSupport<?, ?> obj, Drop<?> replacement) {
         obj.unsafeSetDrop((Drop) replacement);


### PR DESCRIPTION
Motivation:
Problems with reference counts can be difficult to debug without a lifecycle trace, so it's important that we attach traces to these exceptions.

Modification:
Add a `Statics` method for extracting the trace of a buffer and attaching it to a given exception.
Then use this when `release` is called on a `ByteBufAdaptor` that has already been fully released.

Result:
Easier to debug reference counting errors with `ByteBufAdaptor`.
