### PR TITLE
Clean up code that depends on unused older versions of websocket

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpHeaderNames.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpHeaderNames.java
@@ -269,22 +269,6 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString RETRY_AFTER = AsciiString.cached("retry-after");
     /**
-     * {@code "sec-websocket-key1"}
-     */
-    public static final AsciiString SEC_WEBSOCKET_KEY1 = AsciiString.cached("sec-websocket-key1");
-    /**
-     * {@code "sec-websocket-key2"}
-     */
-    public static final AsciiString SEC_WEBSOCKET_KEY2 = AsciiString.cached("sec-websocket-key2");
-    /**
-     * {@code "sec-websocket-location"}
-     */
-    public static final AsciiString SEC_WEBSOCKET_LOCATION = AsciiString.cached("sec-websocket-location");
-    /**
-     * {@code "sec-websocket-origin"}
-     */
-    public static final AsciiString SEC_WEBSOCKET_ORIGIN = AsciiString.cached("sec-websocket-origin");
-    /**
      * {@code "sec-websocket-protocol"}
      */
     public static final AsciiString SEC_WEBSOCKET_PROTOCOL = AsciiString.cached("sec-websocket-protocol");
@@ -352,18 +336,6 @@ public final class HttpHeaderNames {
      * {@code "warning"}
      */
     public static final AsciiString WARNING = AsciiString.cached("warning");
-    /**
-     * {@code "websocket-location"}
-     */
-    public static final AsciiString WEBSOCKET_LOCATION = AsciiString.cached("websocket-location");
-    /**
-     * {@code "websocket-origin"}
-     */
-    public static final AsciiString WEBSOCKET_ORIGIN = AsciiString.cached("websocket-origin");
-    /**
-     * {@code "websocket-protocol"}
-     */
-    public static final AsciiString WEBSOCKET_PROTOCOL = AsciiString.cached("websocket-protocol");
     /**
      * {@code "www-authenticate"}
      */

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectDecoder.java
@@ -477,25 +477,17 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoderForBuffer {
         if (msg instanceof HttpResponse) {
             HttpResponse res = (HttpResponse) msg;
             int code = res.status().code();
-
-            // Correctly handle return codes of 1xx.
-            //
-            // See:
-            //     - https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html Section 4.4
-            //     - https://github.com/netty/netty/issues/222
+            // All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not include
+            // a message body. All other responses do include a message body,
+            // although the body might be of zero length.
+            // https://httpwg.org/specs/rfc7230.html#message.body
             if (code >= 100 && code < 200) {
-                // One exception: Hixie 76 websocket handshake response
-                return !(code == 101 && !res.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT)
-                         && res.headers().contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true));
+                return true;
             }
 
-            switch (code) {
-            case 204: case 304:
-                return true;
-            default:
-                return false;
-            }
+            return code == 204 || code == 304;
         }
+
         return false;
     }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpUtil.java
@@ -153,14 +153,6 @@ public final class HttpUtil {
             return Long.parseLong(value);
         }
 
-        // We know the content length if it's a Web Socket message even if
-        // Content-Length header is missing.
-        long webSocketContentLength = getWebSocketContentLength(message);
-        if (webSocketContentLength >= 0) {
-            return webSocketContentLength;
-        }
-
-        // Otherwise we don't.
         throw new NumberFormatException("header not found: " + HttpHeaderNames.CONTENT_LENGTH);
     }
 
@@ -180,14 +172,6 @@ public final class HttpUtil {
             return Long.parseLong(value);
         }
 
-        // We know the content length if it's a Web Socket message even if
-        // Content-Length header is missing.
-        long webSocketContentLength = getWebSocketContentLength(message);
-        if (webSocketContentLength >= 0) {
-            return webSocketContentLength;
-        }
-
-        // Otherwise we don't.
         return defaultValue;
     }
 
@@ -201,33 +185,6 @@ public final class HttpUtil {
      */
     public static int getContentLength(HttpMessage message, int defaultValue) {
         return (int) Math.min(Integer.MAX_VALUE, getContentLength(message, (long) defaultValue));
-    }
-
-    /**
-     * Returns the content length of the specified web socket message. If the
-     * specified message is not a web socket message, {@code -1} is returned.
-     */
-    private static int getWebSocketContentLength(HttpMessage message) {
-        // WebSocket messages have constant content-lengths.
-        HttpHeaders h = message.headers();
-        if (message instanceof HttpRequest) {
-            HttpRequest req = (HttpRequest) message;
-            if (HttpMethod.GET.equals(req.method()) &&
-                    h.contains(HttpHeaderNames.SEC_WEBSOCKET_KEY1) &&
-                    h.contains(HttpHeaderNames.SEC_WEBSOCKET_KEY2)) {
-                return 8;
-            }
-        } else if (message instanceof HttpResponse) {
-            HttpResponse res = (HttpResponse) message;
-            if (res.status().code() == 101 &&
-                    h.contains(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN) &&
-                    h.contains(HttpHeaderNames.SEC_WEBSOCKET_LOCATION)) {
-                return 16;
-            }
-        }
-
-        // Not a web socket message
-        return -1;
     }
 
     /**

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -18,6 +18,7 @@ package io.netty5.handler.codec.http;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
@@ -334,9 +335,12 @@ public class HttpClientCodecTest {
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
         assertThat(res.status(), sameInstance(HttpResponseStatus.SWITCHING_PROTOCOLS));
+        Resource.dispose(res);
 
-        LastHttpContent<?> lastHttpContent = ch.readInbound();
-        assertEquals(new EmptyLastHttpContent(ch.bufferAllocator()), lastHttpContent);
+        try (LastHttpContent<?> lastHttpContent = ch.readInbound();
+             EmptyLastHttpContent expected = new EmptyLastHttpContent(ch.bufferAllocator())) {
+            assertEquals(expected, lastHttpContent);
+        }
 
         assertFalse(ch.finish());
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -44,14 +44,13 @@ import java.util.concurrent.CountDownLatch;
 import static io.netty5.util.ReferenceCountUtil.release;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -322,27 +321,24 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testWebSocket00Response() {
-        byte[] data = ("HTTP/1.1 101 WebSocket Protocol Handshake\r\n" +
-                "Upgrade: WebSocket\r\n" +
-                "Connection: Upgrade\r\n" +
-                "Sec-WebSocket-Origin: http://localhost:8080\r\n" +
-                "Sec-WebSocket-Location: ws://localhost/some/path\r\n" +
-                "\r\n" +
-                "1234567812345678").getBytes();
+    public void testWebSocketResponse() {
+        byte[] data = ("HTTP/1.1 101 Switching Protocols\r\n" +
+                       "Upgrade: websocket\r\n" +
+                       "Connection: Upgrade\r\n" +
+                       "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo= \r\n" +
+                       "Sec-WebSocket-Protocol: chat\r\n\r\n")
+                .getBytes(CharsetUtil.US_ASCII);
         EmbeddedChannel ch = new EmbeddedChannel(new HttpClientCodec());
         assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data)));
 
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
-        assertThat(res.status(), is(HttpResponseStatus.SWITCHING_PROTOCOLS));
-        HttpContent<?> content = ch.readInbound();
-        assertThat(content.payload().readableBytes(), is(16));
-        content.close();
+        assertThat(res.status(), sameInstance(HttpResponseStatus.SWITCHING_PROTOCOLS));
 
-        assertThat(ch.finish(), is(false));
+        LastHttpContent<?> lastHttpContent = ch.readInbound();
+        assertEquals(new EmptyLastHttpContent(ch.bufferAllocator()), lastHttpContent);
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseDecoderTest.java
@@ -509,55 +509,58 @@ public class HttpResponseDecoderTest {
 
     @Test
     public void testWebSocketResponse() {
-        byte[] data = ("HTTP/1.1 101 WebSocket Protocol Handshake\r\n" +
-                "Upgrade: WebSocket\r\n" +
-                "Connection: Upgrade\r\n" +
-                "Sec-WebSocket-Origin: http://localhost:8080\r\n" +
-                "Sec-WebSocket-Location: ws://localhost/some/path\r\n" +
-                "\r\n" +
-                "1234567812345678").getBytes();
+        byte[] data = ("HTTP/1.1 101 Switching Protocols\r\n" +
+                       "Upgrade: websocket\r\n" +
+                       "Connection: Upgrade\r\n" +
+                       "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo= \r\n" +
+                       "Sec-WebSocket-Protocol: chat\r\n\r\n")
+                .getBytes(CharsetUtil.US_ASCII);
+
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
-        ch.writeInbound(ch.bufferAllocator().allocate(data.length).writeBytes(data));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data)));
 
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
-        assertThat(res.status(), is(HttpResponseStatus.SWITCHING_PROTOCOLS));
-        try (HttpContent<?> content = ch.readInbound()) {
-            assertThat(content.payload().readableBytes(), is(16));
-        }
+        assertThat(res.status(), sameInstance(HttpResponseStatus.SWITCHING_PROTOCOLS));
+        assertEquals(4, res.headers().size());
+        assertTrue(res.headers().contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true));
+        assertTrue(res.headers().contains(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true));
+        assertTrue(res.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+                                          false));
+        assertTrue(res.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat", false));
 
-        assertThat(ch.finish(), is(false));
+        LastHttpContent<?> lastHttpContent = ch.readInbound();
+        assertEquals(new EmptyLastHttpContent(ch.bufferAllocator()), lastHttpContent);
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertFalse(ch.finish());
     }
 
     // See https://github.com/netty/netty/issues/2173
     @Test
     public void testWebSocketResponseWithDataFollowing() {
-        byte[] data = ("HTTP/1.1 101 WebSocket Protocol Handshake\r\n" +
-                "Upgrade: WebSocket\r\n" +
-                "Connection: Upgrade\r\n" +
-                "Sec-WebSocket-Origin: http://localhost:8080\r\n" +
-                "Sec-WebSocket-Location: ws://localhost/some/path\r\n" +
-                "\r\n" +
-                "1234567812345678").getBytes();
-        byte[] otherData = {1, 2, 3, 4};
+        byte[] data = ("HTTP/1.1 101 Switching Protocols\r\n" +
+                       "Upgrade: websocket\r\n" +
+                       "Connection: Upgrade\r\n" +
+                       "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo= \r\n" +
+                       "Sec-WebSocket-Protocol: chat\r\n\r\n")
+                .getBytes(CharsetUtil.US_ASCII);
+        byte[] otherData = { 1, 2, 3, 4 };
 
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), data));
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), otherData));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(otherData)));
 
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
-        assertThat(res.status(), is(HttpResponseStatus.SWITCHING_PROTOCOLS));
+        assertThat(res.status(), sameInstance(HttpResponseStatus.SWITCHING_PROTOCOLS));
+
         try (HttpContent<?> content = ch.readInbound()) {
-            assertThat(content.payload().readableBytes(), is(16));
+            assertEquals(new EmptyLastHttpContent(ch.bufferAllocator()), content);
         }
 
-        assertThat(ch.finish(), is(true));
+        assertTrue(ch.finish());
 
-        try (Buffer expected = copiedBuffer(ch.bufferAllocator(), otherData);
-             Buffer buffer = ch.readInbound()) {
+        try (Buffer expected = copiedBuffer(ch.bufferAllocator(), otherData); Buffer buffer = ch.readInbound()) {
             assertEquals(expected, buffer);
         }
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketRequestBuilder.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketRequestBuilder.java
@@ -129,11 +129,7 @@ public class WebSocketRequestBuilder {
             headers.set(HttpHeaderNames.SEC_WEBSOCKET_KEY, key);
         }
         if (origin != null) {
-            if (version == WebSocketVersion.V13) {
-                headers.set(HttpHeaderNames.ORIGIN, origin);
-            } else {
-                headers.set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, origin);
-            }
+            headers.set(HttpHeaderNames.ORIGIN, origin);
         }
         if (version != null) {
             headers.set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, version.toHttpHeaderValue());

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -121,7 +121,6 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
             req.headers().set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET);
             req.headers().set(HttpHeaderNames.CONNECTION, "Upgrade");
             req.headers().set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==");
-            req.headers().set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://example.com");
             req.headers().set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat, superchat");
             req.headers().set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
@@ -52,9 +52,7 @@ public abstract class WebSocketServerHandshakerTest {
                .set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
-               .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://example.com")
                .set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat, superchat")
-               .set(HttpHeaderNames.WEBSOCKET_PROTOCOL, "chat, superchat")
                .set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, webSocketVersion().toAsciiString());
         HttpHeaders customResponseHeaders = new DefaultHttpHeaders();
         // set duplicate required headers and one custom
@@ -62,7 +60,6 @@ public abstract class WebSocketServerHandshakerTest {
                 .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                 .set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                 .set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "superchat")
-                .set(HttpHeaderNames.WEBSOCKET_PROTOCOL, "superchat")
                 .set("custom", "header");
 
         customResponseHeaders.set(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT, "12345");

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -15,10 +15,10 @@
  */
 package io.netty5.testsuite.transport.socket;
 
-import io.netty5.bootstrap.Bootstrap;
-import io.netty5.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
@@ -102,7 +103,7 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
         assertEquals(0, ch.counter.get());
         assertNull(ch.received);
         assertEquals(Unpooled.wrappedBuffer(new byte[]{'b', 'c', 'e'}), sh.received);
-        releaseReceivedBuffer(sh.received);
+        Resource.dispose(sh.received);
     }
 
     @Test
@@ -167,15 +168,7 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
         assertEquals(0, ch.counter.get());
         assertNull(ch.received);
         assertEquals(preferredAllocator().copyOf(new byte[] { 'b', 'c', 'e' }), sh.received);
-        releaseReceivedBuffer(sh.received);
-    }
-
-    private void releaseReceivedBuffer(Object buffer) {
-        if (buffer instanceof Buffer) {
-            ((Buffer) buffer).close();
-        } else {
-            ReferenceCountUtil.release(buffer);
-        }
+        Resource.dispose(sh.received);
     }
 
     private static class TestHandler extends SimpleChannelInboundHandler<Object> {


### PR DESCRIPTION
Motivation:

We are not currently using older versions of websocket. We can remove unused code

Modification:

Remove code that depends on unused older versions of websocket.

Result:

Removed unused code.
