### PR TITLE
Forbid negative deltas for `skipReadable` and `skipWritable`

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -126,11 +126,12 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     int readerOffset();
 
     /**
-     * Set the reader offset to {@code readerOffset() + delta}.
+     * Move the reader offset forward by the given delta.
      *
      * @param delta to accumulate.
-     * @throws IndexOutOfBoundsException if the new reader offset is less than zero or greater than the current
+     * @throws IndexOutOfBoundsException if the new reader offset is greater than the current
      * {@link #writerOffset()}.
+     * @throws IllegalArgumentException if the given delta is negative.
      * @throws BufferClosedException if this buffer is closed.
      */
     void skipReadable(int delta);
@@ -154,11 +155,11 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     int writerOffset();
 
     /**
-     * Set the write offset to {@code writerOffset() + delta}.
+     * Move the writer offset to ahead by the given delta.
      *
      * @param delta to accumulate.
-     * @throws IndexOutOfBoundsException if the new writer offset is less than the current {@link #readerOffset()} or
-     * greater than {@link #capacity()}.
+     * @throws IndexOutOfBoundsException if the new writer offset is greater than {@link #capacity()}.
+     * @throws IllegalArgumentException if the given delta is negative.
      * @throws BufferClosedException if this buffer is closed.
      * @throws BufferReadOnlyException if this buffer is {@linkplain #readOnly() read-only}.
      */

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -52,7 +52,7 @@ public class BufferStub implements Buffer {
 
     @Override
     public void skipReadable(int delta) {
-        readerOffset(readerOffset() + delta);
+        delegate.skipReadable(delta);
     }
 
     @Override
@@ -67,7 +67,7 @@ public class BufferStub implements Buffer {
 
     @Override
     public void skipWritable(int delta) {
-        writerOffset(writerOffset() + delta);
+        delegate.skipWritable(delta);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Math.addExact;
 import static java.lang.Math.toIntExact;
 
@@ -327,17 +328,13 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
 
     @Override
     public void skipReadable(int delta) {
-        if (delta < 0) {
-            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
-        }
+        checkPositiveOrZero(delta, "delta");
         readerOffset(readerOffset() + delta);
     }
 
     @Override
     public void skipWritable(int delta) {
-        if (delta < 0) {
-            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
-        }
+        checkPositiveOrZero(delta, "delta");
         writerOffset(writerOffset() + delta);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -327,11 +327,17 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
 
     @Override
     public void skipReadable(int delta) {
+        if (delta < 0) {
+            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
+        }
         readerOffset(readerOffset() + delta);
     }
 
     @Override
     public void skipWritable(int delta) {
+        if (delta < 0) {
+            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
+        }
         writerOffset(writerOffset() + delta);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -153,6 +153,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public void skipReadable(int delta) {
+        if (delta < 0) {
+            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
+        }
         delegate.readerIndex(delegate.readerIndex() + delta);
     }
 
@@ -169,6 +172,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public void skipWritable(int delta) {
+        if (delta < 0) {
+            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
+        }
         delegate.writerIndex(delegate.writerIndex() + delta);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -52,6 +52,7 @@ import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressOfDirectByteBuffer;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * An implementation of the {@link Buffer} interface, that wraps a {@link ByteBuf}.
@@ -153,9 +154,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public void skipReadable(int delta) {
-        if (delta < 0) {
-            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
-        }
+        checkPositiveOrZero(delta, "delta");
         delegate.readerIndex(delegate.readerIndex() + delta);
     }
 
@@ -172,9 +171,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public void skipWritable(int delta) {
-        if (delta < 0) {
-            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
-        }
+        checkPositiveOrZero(delta, "delta");
         delegate.writerIndex(delegate.writerIndex() + delta);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -128,11 +128,17 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     @Override
     public void skipReadable(int delta) {
+        if (delta < 0) {
+            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
+        }
         readerOffset(readerOffset() + delta);
     }
 
     @Override
     public void skipWritable(int delta) {
+        if (delta < 0) {
+            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
+        }
         writerOffset(writerOffset() + delta);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -43,6 +43,7 @@ import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 
 final class NioBuffer extends AdaptableBuffer<NioBuffer>
         implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent {
@@ -128,17 +129,13 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     @Override
     public void skipReadable(int delta) {
-        if (delta < 0) {
-            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
-        }
+        checkPositiveOrZero(delta, "delta");
         readerOffset(readerOffset() + delta);
     }
 
     @Override
     public void skipWritable(int delta) {
-        if (delta < 0) {
-            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
-        }
+        checkPositiveOrZero(delta, "delta");
         writerOffset(writerOffset() + delta);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -44,6 +44,7 @@ import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 
 final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent {
@@ -138,17 +139,13 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
     @Override
     public void skipReadable(int delta) {
-        if (delta < 0) {
-            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
-        }
+        checkPositiveOrZero(delta, "delta");
         readerOffset(readerOffset() + delta);
     }
 
     @Override
     public void skipWritable(int delta) {
-        if (delta < 0) {
-            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
-        }
+        checkPositiveOrZero(delta, "delta");
         writerOffset(writerOffset() + delta);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -138,11 +138,17 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
     @Override
     public void skipReadable(int delta) {
+        if (delta < 0) {
+            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
+        }
         readerOffset(readerOffset() + delta);
     }
 
     @Override
     public void skipWritable(int delta) {
+        if (delta < 0) {
+            throw new IllegalArgumentException("Delta cannot be negative: " + delta);
+        }
         writerOffset(writerOffset() + delta);
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferAndChannelTest.java
@@ -88,7 +88,7 @@ public class BufferAndChannelTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
-            buf.skipWritable(-5);
+            buf.writerOffset(buf.writerOffset() - 5);
             long position = channel.position();
             long size = channel.size();
             int bytesWritten = buf.transferTo(channel, 8);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
@@ -477,4 +477,30 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             assertThat(buf).isEqualTo(target);
         }
     }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void negativeSkipReadableOnReadableComponentMustThrow(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            buf.writeLong(0x0102030405060708L);
+            assertThat(buf.readInt()).isEqualTo(0x01020304);
+            buf.forEachReadable(0, (index, component) -> {
+                assertThrows(IllegalArgumentException.class, () -> component.skipReadable(-1));
+                return true;
+            });
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void negativeSkipWritableOnWritableComponentMustThrow(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            buf.forEachWritable(0, (index, component) -> {
+                assertThrows(IllegalArgumentException.class, () -> component.skipWritable(-1));
+                return true;
+            });
+        }
+    }
 }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEqualsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEqualsTest.java
@@ -63,7 +63,7 @@ public class BufferEqualsTest extends BufferTestSupport {
             buf1.writeBytes(data1);
             buf2.writeBytes(data2);
             buf2.skipReadable(3);
-            buf2.skipWritable(-5);
+            buf2.writerOffset(buf2.writerOffset() - 5);
 
             Assertions.assertEquals(buf1, buf2);
             Assertions.assertEquals(buf2, buf1);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSearchTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSearchTest.java
@@ -119,7 +119,8 @@ public class BufferSearchTest extends BufferTestSupport {
             byte needle = (byte) 0xA5;
             int offset = buf.capacity() - 1;
             buf.setByte(offset, needle);
-            buf.skipWritable(-1); // Pull the write-offset down by one, leaving needle just outside readable range.
+            // Pull the write-offset down by one, leaving needle just outside readable range.
+            buf.writerOffset(buf.writerOffset() - 1);
             while (buf.readableBytes() > 1) {
                 assertThat(buf.bytesBefore(needle))
                         .as("bytesBefore(%X)", needle)

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -125,7 +125,7 @@ public class PerMessageDeflateDecoderTest {
         BinaryWebSocketFrame compressedFrame1;
         ContinuationWebSocketFrame compressedFrame2;
         ContinuationWebSocketFrame compressedFrame3;
-        compressedPayload.skipWritable(-4);
+        compressedPayload.writerOffset(compressedPayload.writerOffset() - 4);
 
         int oneThird = compressedPayload.readableBytes() / 3;
         compressedFrame1 = new BinaryWebSocketFrame(false, RSV1 | RSV3, compressedPayload.readSplit(oneThird));
@@ -185,7 +185,7 @@ public class PerMessageDeflateDecoderTest {
         Buffer compressedFrameData = encoderChannel.bufferAllocator()
                 .allocate(compressedPayload1.readableBytes() + compressedPayload2.readableBytes() - 4);
         compressedFrameData.writeBytes(compressedPayload1);
-        compressedPayload2.skipWritable(-4);
+        compressedPayload2.writerOffset(compressedPayload2.writerOffset() - 4);
         compressedFrameData.writeBytes(compressedPayload2);
         BinaryWebSocketFrame compressedFrame = new BinaryWebSocketFrame(true, RSV1 | RSV3, compressedFrameData);
         compressedPayload1.close();
@@ -360,7 +360,7 @@ public class PerMessageDeflateDecoderTest {
         ContinuationWebSocketFrame compressedFrame3;
         ContinuationWebSocketFrame compressedFrameWithExtraData;
 
-        compressedPayload.skipWritable(-4);
+        compressedPayload.writerOffset(compressedPayload.writerOffset() - 4);
         int oneThird = compressedPayload.readableBytes() / 3;
         compressedFrame1 = new TextWebSocketFrame(false, RSV1, compressedPayload.readSplit(oneThird));
         compressedFrame2 = new ContinuationWebSocketFrame(false, RSV3, compressedPayload.readSplit(oneThird));

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -418,7 +418,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     }
 
     protected final int doWriteBytes(ChannelOutboundBuffer in, Buffer buf) throws Exception {
-        int initialReadableBytes = buf.readableBytes();
+        int initialReaderOffset = buf.readerOffset();
         buf.forEachReadable(0, (index, component) -> {
             long address = component.readableNativeAddress();
             assert address != 0;
@@ -428,10 +428,10 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             }
             return false;
         });
-        int readableBytesLeft = buf.readableBytes();
-        if (readableBytesLeft < initialReadableBytes) {
-            int bytesWritten = initialReadableBytes - readableBytesLeft;
-            buf.skipReadable(-bytesWritten); // Restore read offset for ChannelOutboundBuffer.
+        int readerOffset = buf.readerOffset();
+        if (initialReaderOffset < readerOffset) {
+            buf.readerOffset(initialReaderOffset); // Restore read offset for ChannelOutboundBuffer.
+            int bytesWritten = readerOffset - initialReaderOffset;
             in.removeBytes(bytesWritten);
             return 1; // Some data was written to the socket.
         }

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -340,7 +340,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     }
 
     protected final int doWriteBytes(ChannelOutboundBuffer in, Buffer buf) throws Exception {
-        int initialReadableBytes = buf.readableBytes();
+        int initialReaderOffset = buf.readerOffset();
         buf.forEachReadable(0, (index, component) -> {
             long address = component.readableNativeAddress();
             assert address != 0;
@@ -350,10 +350,10 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             }
             return false;
         });
-        int readableBytesLeft = buf.readableBytes();
-        if (readableBytesLeft < initialReadableBytes) {
-            int bytesWritten = initialReadableBytes - readableBytesLeft;
-            buf.skipReadable(-bytesWritten); // Restore read offset for ChannelOutboundBuffer.
+        int readerOffset = buf.readerOffset();
+        if (initialReaderOffset < readerOffset) {
+            buf.readerOffset(initialReaderOffset); // Restore read offset for ChannelOutboundBuffer.
+            int bytesWritten = readerOffset - initialReaderOffset;
             in.removeBytes(bytesWritten);
             return 1; // Some data was written to the socket.
         }


### PR DESCRIPTION
Motivation:
It seemed like a good idea to allow negative deltas to `skipReadable` and `skipWritable`.
However, after adding these methods to `ReadableComponent` and `WritableComponent`, it causes problems for composite buffers.
For instance, we are not told of component boundaries when we iterate them, thus we have no basis for determining how much we can skip in reverse on components.
Furthermore, changing the offsets on components of a composite buffer can also cause violations of internal invariants of composite buffers (misaligned offsets; gaps), leading to weird and difficult to debug issues.
Additionally, the `ByteBufBuffer` implementation was also running into trouble and throwing exception when its components were iterated, due to how the relevant `ByteBuffers` were extracted from the inner `ByteBuf`.

Modification:
The `skipReadable` and `skipWritable` methods now throw an `IllegalArgumentException` when given negative deltas.

Result:
Negative deltas are now forbidden, preventing strange and inconsistent behaviours across the buffer implementations.
