### PR TITLE
Port `Base64` and accompanying encoder and decoder to `Buffer`

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty5/buffer/ByteBufUtil.java
@@ -16,6 +16,7 @@
 package io.netty5.buffer;
 
 import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.AsciiString;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.concurrent.FastThreadLocal;
@@ -68,6 +69,16 @@ public final class ByteBufUtil {
     static byte[] threadLocalTempArray(int minLength) {
         return minLength <= MAX_TL_ARRAY_LEN ? BYTE_ARRAYS.get()
             : PlatformDependent.allocateUninitializedArray(minLength);
+    }
+
+    /**
+     * Returns a <a href="https://en.wikipedia.org/wiki/Hex_dump">hex dump</a>
+     * of the readable bytes of the given {@link Buffer}.
+     */
+    public static String hexDump(Buffer buffer) {
+        byte[] array = new byte[buffer.readableBytes()];
+        buffer.copyInto(buffer.readerOffset(), array, 0, array.length);
+        return hexDump(array, 0, array.length);
     }
 
     /**

--- a/codec/src/main/java/io/netty5/handler/codec/base64/Base64Decoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/base64/Base64Decoder.java
@@ -18,6 +18,7 @@ package io.netty5.handler.codec.base64;
 import static java.util.Objects.requireNonNull;
 
 import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
@@ -44,7 +45,7 @@ import io.netty5.handler.codec.MessageToMessageDecoder;
  * </pre>
  */
 @Sharable
-public class Base64Decoder extends MessageToMessageDecoder<ByteBuf> {
+public class Base64Decoder extends MessageToMessageDecoder<Buffer> {
 
     private final Base64Dialect dialect;
 
@@ -58,7 +59,7 @@ public class Base64Decoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
-        ctx.fireChannelRead(Base64.decode(msg, msg.readerIndex(), msg.readableBytes(), dialect));
+    protected void decode(ChannelHandlerContext ctx, Buffer msg) throws Exception {
+        ctx.fireChannelRead(Base64.decode(msg, msg.readerOffset(), msg.readableBytes(), dialect));
     }
 }

--- a/codec/src/main/java/io/netty5/handler/codec/base64/Base64Encoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/base64/Base64Encoder.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
@@ -42,7 +43,7 @@ import io.netty5.handler.codec.MessageToMessageEncoder;
  * </pre>
  */
 @Sharable
-public class Base64Encoder extends MessageToMessageEncoder<ByteBuf> {
+public class Base64Encoder extends MessageToMessageEncoder<Buffer> {
 
     private final boolean breakLines;
     private final Base64Dialect dialect;
@@ -63,7 +64,7 @@ public class Base64Encoder extends MessageToMessageEncoder<ByteBuf> {
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
-        out.add(Base64.encode(msg, msg.readerIndex(), msg.readableBytes(), breakLines, dialect));
+    protected void encode(ChannelHandlerContext ctx, Buffer msg, List<Object> out) throws Exception {
+        out.add(Base64.encode(msg, msg.readerOffset(), msg.readableBytes(), breakLines, dialect));
     }
 }


### PR DESCRIPTION
Motivation:
We are migrating all codecs to `Buffer`, and these will also help us migrate the `SslHandler`.

Modification:
Change `Base64`, and its accompanying encoder and decoder, to use `Buffer`.

Result:
These encoders now use the `Buffer` API.