### PR TITLE
Simplify ByteToMessageDecoderForBuffer

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
@@ -618,19 +618,12 @@ public abstract class ByteToMessageDecoderForBuffer extends ChannelHandlerAdapte
             CompositeBuffer composite;
             try (in) {
                 if (CompositeBuffer.isComposite(cumulation)) {
-                    CompositeBuffer tmp = (CompositeBuffer) cumulation;
-                    // Since we are extending the composite buffer below, we have to make sure there is no space to
-                    // write in the existing cumulation.
-                    if (tmp.writerOffset() < tmp.capacity()) {
-                        composite = tmp.split();
-                        tmp.close();
-                    } else {
-                        composite = tmp;
-                    }
+                    composite = (CompositeBuffer) cumulation;
                 } else {
                     composite = CompositeBuffer.compose(alloc, cumulation.send());
                 }
-                composite.extendWith((in.readOnly() ? in.copy() : in).send());
+                // Using split() even on the writable buffer, in order to prevent gaps in the composite buffer.
+                composite.extendWith((in.readOnly() ? in.copy() : in.split()).send());
                 return composite;
             }
         }


### PR DESCRIPTION
Motivation:
The logic for avoiding offset gaps in the composite buffer cumulator can be simplified.

Modification:
Discard unread, unwritten, buffer sections before adding them to the composite buffer.
We are not going to write into those regions anyway.

Result:
Simpler code.
