### PR TITLE
Resolve TODO: Rename WebSocketServerExtension#newReponseData to newRe…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtension.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtension.java
@@ -22,11 +22,19 @@ package io.netty.handler.codec.http.websocketx.extensions;
 public interface WebSocketServerExtension extends WebSocketExtension {
 
     /**
+     * @deprecated Use {@link #newResponseData()} instead.
+     * <p>
      * Return an extension configuration to submit to the client as an acknowledge.
      *
      * @return the acknowledged extension configuration.
      */
-    //TODO: after migrating to JDK 8 rename this to 'newResponseData()' and mark old as deprecated with default method
+    @Deprecated
     WebSocketExtensionData newReponseData();
 
+    /**
+     * Return an extension configuration to submit to the client as an acknowledge.
+     *
+     * @return the acknowledged extension configuration.
+     */
+    WebSocketExtensionData newResponseData();
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
@@ -117,7 +117,13 @@ public final class DeflateFrameServerExtensionHandshaker implements WebSocketSer
         }
 
         @Override
+        @Deprecated
         public WebSocketExtensionData newReponseData() {
+            return new WebSocketExtensionData(extensionName, Collections.<String, String>emptyMap());
+        }
+
+        @Override
+        public WebSocketExtensionData newResponseData() {
             return new WebSocketExtensionData(extensionName, Collections.<String, String>emptyMap());
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -212,7 +212,26 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
         }
 
         @Override
+        @Deprecated
         public WebSocketExtensionData newReponseData() {
+            HashMap<String, String> parameters = new HashMap<String, String>(4);
+            if (serverNoContext) {
+                parameters.put(SERVER_NO_CONTEXT, null);
+            }
+            if (clientNoContext) {
+                parameters.put(CLIENT_NO_CONTEXT, null);
+            }
+            if (serverWindowSize != MAX_WINDOW_SIZE) {
+                parameters.put(SERVER_MAX_WINDOW, Integer.toString(serverWindowSize));
+            }
+            if (clientWindowSize != MAX_WINDOW_SIZE) {
+                parameters.put(CLIENT_MAX_WINDOW, Integer.toString(clientWindowSize));
+            }
+            return new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters);
+        }
+
+        @Override
+        public WebSocketExtensionData newResponseData() {
             HashMap<String, String> parameters = new HashMap<String, String>(4);
             if (serverNoContext) {
                 parameters.put(SERVER_NO_CONTEXT, null);


### PR DESCRIPTION
…sponseData

Motivation:

Rename WebSocketServerExtension#newReponseData to newResponseData.

Modification:

 Add @Deprecated to WebSocketServerExtension#newReponseData, and  rename to newResponseData.

Result:

 Resolve TODO: Rename WebSocketServerExtension#newReponseData to newResponseData.

If there is no issue then describe the changes introduced by this PR.
