### PR TITLE
Avoid NullPointerException in DefaultHttp2HeadersDecoder.decodeHeaders failure path

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -523,9 +523,9 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
                     settings.put(id, Long.valueOf(value));
                 } catch (IllegalArgumentException e) {
                     if (id == SETTINGS_INITIAL_WINDOW_SIZE) {
-                        throw connectionError(FLOW_CONTROL_ERROR, e, e.getMessage());
+                        throw connectionError(FLOW_CONTROL_ERROR, e, "Failed setting initial window size: %s", e.getMessage());
                     }
-                    throw connectionError(PROTOCOL_ERROR, e, e.getMessage());
+                    throw connectionError(PROTOCOL_ERROR, e, "Protocol error: %s", e.getMessage());
                 }
             }
             listener.onSettingsRead(ctx, settings);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -133,7 +133,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
             // Default handler for any other types of errors that may have occurred. For example,
             // the Header builder throws IllegalArgumentException if the key or value was invalid
             // for any reason (e.g. the key was an invalid pseudo-header).
-            throw connectionError(COMPRESSION_ERROR, e, e.getMessage());
+            throw connectionError(COMPRESSION_ERROR, e, "Error decoding headers: %s", e.getMessage());
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -105,7 +106,7 @@ public class Http2Exception extends Exception {
      * @return An exception which can be translated into an HTTP/2 error.
      */
     public static Http2Exception connectionError(Http2Error error, String fmt, Object... args) {
-        return new Http2Exception(error, String.format(fmt, args));
+        return new Http2Exception(error, formatErrorMessage(fmt, args));
     }
 
     /**
@@ -119,7 +120,7 @@ public class Http2Exception extends Exception {
      */
     public static Http2Exception connectionError(Http2Error error, Throwable cause,
             String fmt, Object... args) {
-        return new Http2Exception(error, String.format(fmt, args), cause);
+        return new Http2Exception(error, formatErrorMessage(fmt, args), cause);
     }
 
     /**
@@ -131,7 +132,7 @@ public class Http2Exception extends Exception {
      * @return An exception which can be translated into an HTTP/2 error.
      */
     public static Http2Exception closedStreamError(Http2Error error, String fmt, Object... args) {
-        return new ClosedStreamCreationException(error, String.format(fmt, args));
+        return new ClosedStreamCreationException(error, formatErrorMessage(fmt, args));
     }
 
     /**
@@ -149,7 +150,7 @@ public class Http2Exception extends Exception {
     public static Http2Exception streamError(int id, Http2Error error, String fmt, Object... args) {
         return CONNECTION_STREAM_ID == id ?
                 connectionError(error, fmt, args) :
-                    new StreamException(id, error, String.format(fmt, args));
+                    new StreamException(id, error, formatErrorMessage(fmt, args));
     }
 
     /**
@@ -169,7 +170,7 @@ public class Http2Exception extends Exception {
             String fmt, Object... args) {
         return CONNECTION_STREAM_ID == id ?
                 connectionError(error, cause, fmt, args) :
-                    new StreamException(id, error, String.format(fmt, args), cause);
+                    new StreamException(id, error, formatErrorMessage(fmt, args), cause);
     }
 
     /**
@@ -191,7 +192,17 @@ public class Http2Exception extends Exception {
             String fmt, Object... args) {
         return CONNECTION_STREAM_ID == id ?
                 connectionError(error, fmt, args) :
-                    new HeaderListSizeException(id, error, String.format(fmt, args), onDecode);
+                    new HeaderListSizeException(id, error, formatErrorMessage(fmt, args), onDecode);
+    }
+
+    private static String formatErrorMessage(String fmt, Object[] args) {
+        if (fmt == null) {
+            if (args == null || args.length == 0) {
+                return "Unexpected error";
+            }
+            return "Unexpected error: " + Arrays.toString(args);
+        }
+        return String.format(fmt, args);
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ExceptionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ExceptionTest.java
@@ -1,0 +1,35 @@
+package io.netty.handler.codec.http2;
+
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.http.TooLongHttpLineException;
+import org.junit.jupiter.api.Test;
+
+import static io.netty.handler.codec.http2.Http2Error.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class Http2ExceptionTest {
+
+    @Test
+    public void connectionErrorHandlesMessage() {
+        DecoderException e = new TooLongHttpLineException("An HTTP line is larger than 1024 bytes.");
+        Http2Exception http2Exception = Http2Exception.connectionError(COMPRESSION_ERROR, e, e.getMessage());
+        assertEquals(COMPRESSION_ERROR, http2Exception.error());
+        assertEquals("An HTTP line is larger than 1024 bytes.", http2Exception.getMessage());
+    }
+
+    @Test
+    public void connectionErrorHandlesNullExceptionMessage() {
+        Exception e = new RuntimeException();
+        Http2Exception http2Exception = Http2Exception.connectionError(COMPRESSION_ERROR, e, e.getMessage());
+        assertEquals(COMPRESSION_ERROR, http2Exception.error());
+        assertEquals("Unexpected error", http2Exception.getMessage());
+    }
+
+    @Test
+    public void connectionErrorHandlesMultipleMessages() {
+        Exception e = new RuntimeException();
+        Http2Exception http2Exception = Http2Exception.connectionError(COMPRESSION_ERROR, e, e.getMessage(), "a", "b");
+        assertEquals(COMPRESSION_ERROR, http2Exception.error());
+        assertEquals("Unexpected error: [a, b]", http2Exception.getMessage());
+    }
+}


### PR DESCRIPTION
# Motivation:

I encountered the `NullPointerException` below from a gRPC service using Netty 4.1.75.Final running OpenJDK Zulu 17.0.2+8-LTS. The NPE is hiding the actual underlying connection failure exception while decoding headers, as `Http2Exception.connectionError` does not currently handle cases where an exception message may be null.

# Steps to reproduce locally:
1. Run unit test to simulate connection error without exception message
2. See 2 tests fail

# Modification:

* [Add Http2Exception.connectionError NPE reproducer unit test](https://github.com/netty/netty/commit/a52afab0e8aca3fd4d8653e64231ca5cbc7f525e)
* [Update Http2Exception formatter handles null format message](https://github.com/netty/netty/commit/7ea075b25c9d72f9c4b9d4c712b98ab4e1ce8d5e)
* [Ensure non-null connection error message formats](https://github.com/netty/netty/commit/9bf83455a45023d2aedfeb1dc73c87b50303162b)

# Result:

New unit tests pass, netty should now propagate underlying exception when http2 header decode fails.


# Exception seen:

```
java.lang.NullPointerException:
  at java.util.Formatter.parse(Formatter.java:2717)
  at java.util.Formatter.format(Formatter.java:2671)
  at java.util.Formatter.format(Formatter.java:2625)
  at java.lang.String.format(String.java:4140)
  at io.netty.handler.codec.http2.Http2Exception.connectionError(Http2Exception.java:122)
  at io.netty.handler.codec.http2.DefaultHttp2HeadersDecoder.decodeHeaders(DefaultHttp2HeadersDecoder.java:136)
  at io.netty.handler.codec.http2.DefaultHttp2FrameReader$HeadersBlockBuilder.headers(DefaultHttp2FrameReader.java:732)
  at io.netty.handler.codec.http2.DefaultHttp2FrameReader$1.processFragment(DefaultHttp2FrameReader.java:450)
  at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:457)
  at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:253)
  at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:159)
  at io.netty.handler.codec.http2.Http2InboundFrameLogger.readFrame(Http2InboundFrameLogger.java:41)
  at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:173)
  at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:378)
  at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:438)
  at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:510)
  at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:449)
  at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
  at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372)
  at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1235)
  at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1284)
  at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:510)
  at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:449)
  at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
  at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
  at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
  at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
  at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
  at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
  at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
  at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
  at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
  at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
  at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
  at java.lang.Thread.run(Thread.java:833)
```
