### PR TITLE
Allow to construct ReadTimeoutException and WriteTimeoutException

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutException.java
@@ -28,9 +28,13 @@ public final class ReadTimeoutException extends TimeoutException {
     public static final ReadTimeoutException INSTANCE = PlatformDependent.javaVersion() >= 7 ?
             new ReadTimeoutException(true) : new ReadTimeoutException();
 
-    ReadTimeoutException() { }
+    public ReadTimeoutException() { }
+
+    public ReadTimeoutException(String message) {
+        super(message, false);
+    }
 
     private ReadTimeoutException(boolean shared) {
-        super(shared);
+        super(null, shared);
     }
 }

--- a/handler/src/main/java/io/netty/handler/timeout/TimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/TimeoutException.java
@@ -28,8 +28,8 @@ public class TimeoutException extends ChannelException {
     TimeoutException() {
     }
 
-    TimeoutException(boolean shared) {
-        super(null, null, shared);
+    TimeoutException(String message, boolean shared) {
+        super(message, null, shared);
     }
 
     // Suppress a warning since the method doesn't need synchronization

--- a/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutException.java
@@ -28,9 +28,13 @@ public final class WriteTimeoutException extends TimeoutException {
     public static final WriteTimeoutException INSTANCE = PlatformDependent.javaVersion() >= 7 ?
             new WriteTimeoutException(true) : new WriteTimeoutException();
 
-    private WriteTimeoutException() { }
+    public WriteTimeoutException() { }
+
+    public WriteTimeoutException(String message) {
+        super(message, false);
+    }
 
     private WriteTimeoutException(boolean shared) {
-        super(shared);
+        super(null, shared);
     }
 }


### PR DESCRIPTION
Motivation:

The userr might want to add more details to the exception so we should allow to construct it

Modifications:

Add public constructors

Result:

Fixes https://github.com/netty/netty/issues/12218
