### PR TITLE
Port `LineBasedFrameDecoder` and `DelimiterBasedFrameDecoder` to `Buffer` API

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
@@ -115,7 +115,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
             int maxFrameLength, boolean stripDelimiter, boolean failFast,
             Buffer delimiter) {
         this(maxFrameLength, stripDelimiter, failFast, new Buffer[] {
-                delimiter.copy(delimiter.readerOffset(), delimiter.readableBytes())});
+                delimiter.copy(delimiter.readerOffset(), delimiter.readableBytes(), true)});
     }
 
     /**
@@ -178,7 +178,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
             for (int i = 0; i < delimiters.length; i ++) {
                 Buffer d = delimiters[i];
                 validateDelimiter(d);
-                this.delimiters[i] = d.copy(d.readerOffset(), d.readableBytes());
+                this.delimiters[i] = d.copy(d.readerOffset(), d.readableBytes(), true);
             }
             lineBasedDecoder = null;
         }

--- a/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
@@ -254,8 +254,20 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
     }
 
     private static void closeDelimiters(Buffer[] delimiters) {
+        RuntimeException re = null;
         for (Buffer delimiter : delimiters) {
-            delimiter.close();
+            try {
+                delimiter.close();
+            } catch (RuntimeException e) {
+                if (re == null) {
+                    re = e;
+                } else {
+                    re.addSuppressed(e);
+                }
+            }
+        }
+        if (re != null) {
+            throw re;
         }
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
@@ -337,7 +337,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
 
     private static void validateDelimiter(Buffer delimiter) {
         requireNonNull(delimiter, "delimiter");
-        if (delimiter.readableBytes() <= 0) {
+        if (delimiter.readableBytes() == 0) {
             throw new IllegalArgumentException("empty delimiter");
         }
     }

--- a/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
@@ -274,7 +274,9 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
 
     @Override
     protected void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
-        closeDelimiters(delimiters);
+        if (delimiters != null) {
+            closeDelimiters(delimiters);
+        }
         super.handlerRemoved0(ctx);
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
@@ -100,30 +100,6 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
      * @param maxFrameLength  the maximum length of the decoded frame.
      *                        A {@link TooLongFrameException} is thrown if
      *                        the length of the frame exceeds this value.
-     * @param stripDelimiter  whether the decoded frame should strip out the
-     *                        delimiter or not
-     * @param failFast  If <tt>true</tt>, a {@link TooLongFrameException} is
-     *                  thrown as soon as the decoder notices the length of the
-     *                  frame will exceed <tt>maxFrameLength</tt> regardless of
-     *                  whether the entire frame has been read.
-     *                  If <tt>false</tt>, a {@link TooLongFrameException} is
-     *                  thrown after the entire frame that exceeds
-     *                  <tt>maxFrameLength</tt> has been read.
-     * @param delimiter  the delimiter
-     */
-    public DelimiterBasedFrameDecoder(
-            int maxFrameLength, boolean stripDelimiter, boolean failFast,
-            Buffer delimiter) {
-        this(maxFrameLength, stripDelimiter, failFast, new Buffer[] {
-                delimiter.copy(delimiter.readerOffset(), delimiter.readableBytes(), true)});
-    }
-
-    /**
-     * Creates a new instance.
-     *
-     * @param maxFrameLength  the maximum length of the decoded frame.
-     *                        A {@link TooLongFrameException} is thrown if
-     *                        the length of the frame exceeds this value.
      * @param delimiters  the delimiters
      */
     public DelimiterBasedFrameDecoder(int maxFrameLength, Buffer... delimiters) {

--- a/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
@@ -73,33 +73,6 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
      * @param maxFrameLength  the maximum length of the decoded frame.
      *                        A {@link TooLongFrameException} is thrown if
      *                        the length of the frame exceeds this value.
-     * @param delimiter  the delimiter
-     */
-    public DelimiterBasedFrameDecoder(int maxFrameLength, Buffer delimiter) {
-        this(maxFrameLength, true, delimiter);
-    }
-
-    /**
-     * Creates a new instance.
-     *
-     * @param maxFrameLength  the maximum length of the decoded frame.
-     *                        A {@link TooLongFrameException} is thrown if
-     *                        the length of the frame exceeds this value.
-     * @param stripDelimiter  whether the decoded frame should strip out the
-     *                        delimiter or not
-     * @param delimiter  the delimiter
-     */
-    public DelimiterBasedFrameDecoder(
-            int maxFrameLength, boolean stripDelimiter, Buffer delimiter) {
-        this(maxFrameLength, stripDelimiter, true, delimiter);
-    }
-
-    /**
-     * Creates a new instance.
-     *
-     * @param maxFrameLength  the maximum length of the decoded frame.
-     *                        A {@link TooLongFrameException} is thrown if
-     *                        the length of the frame exceeds this value.
      * @param delimiters  the delimiters
      */
     public DelimiterBasedFrameDecoder(int maxFrameLength, Buffer... delimiters) {

--- a/codec/src/main/java/io/netty5/handler/codec/Delimiters.java
+++ b/codec/src/main/java/io/netty5/handler/codec/Delimiters.java
@@ -30,7 +30,7 @@ public final class Delimiters {
      */
     public static Buffer[] nulDelimiter() {
         return new Buffer[] {
-                onHeapUnpooled().copyOf(new byte[] { 0 }) };
+                onHeapUnpooled().copyOf(new byte[] { 0 }).makeReadOnly() };
     }
 
     /**
@@ -39,8 +39,8 @@ public final class Delimiters {
      */
     public static Buffer[] lineDelimiter() {
         return new Buffer[] {
-                onHeapUnpooled().copyOf(new byte[] { '\r', '\n' }),
-                onHeapUnpooled().copyOf(new byte[] { '\n' }),
+                onHeapUnpooled().copyOf(new byte[] { '\r', '\n' }).makeReadOnly(),
+                onHeapUnpooled().copyOf(new byte[] { '\n' }).makeReadOnly(),
         };
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/Delimiters.java
+++ b/codec/src/main/java/io/netty5/handler/codec/Delimiters.java
@@ -15,8 +15,9 @@
  */
 package io.netty5.handler.codec;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+
+import static io.netty5.buffer.api.BufferAllocator.onHeapUnpooled;
 
 /**
  * A set of commonly used delimiters for {@link DelimiterBasedFrameDecoder}.
@@ -27,19 +28,19 @@ public final class Delimiters {
      * Returns a {@code NUL (0x00)} delimiter, which could be used for
      * Flash XML socket or any similar protocols.
      */
-    public static ByteBuf[] nulDelimiter() {
-        return new ByteBuf[] {
-                Unpooled.wrappedBuffer(new byte[] { 0 }) };
+    public static Buffer[] nulDelimiter() {
+        return new Buffer[] {
+                onHeapUnpooled().copyOf(new byte[] { 0 }) };
     }
 
     /**
      * Returns {@code CR ('\r')} and {@code LF ('\n')} delimiters, which could
      * be used for text-based line protocols.
      */
-    public static ByteBuf[] lineDelimiter() {
-        return new ByteBuf[] {
-                Unpooled.wrappedBuffer(new byte[] { '\r', '\n' }),
-                Unpooled.wrappedBuffer(new byte[] { '\n' }),
+    public static Buffer[] lineDelimiter() {
+        return new Buffer[] {
+                onHeapUnpooled().copyOf(new byte[] { '\r', '\n' }),
+                onHeapUnpooled().copyOf(new byte[] { '\n' }),
         };
     }
 

--- a/codec/src/test/java/io/netty5/handler/codec/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/DelimiterBasedFrameDecoderTest.java
@@ -15,11 +15,10 @@
  */
 package io.netty5.handler.codec;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
@@ -33,96 +32,98 @@ public class DelimiterBasedFrameDecoderTest {
     public void testMultipleLinesStrippedDelimiters() {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, true,
                 Delimiters.lineDelimiter()));
-        ch.writeInbound(Unpooled.copiedBuffer("TestLine\r\ng\r\n", Charset.defaultCharset()));
+        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "TestLine\r\ng\r\n", Charset.defaultCharset()));
 
-        ByteBuf buf = ch.readInbound();
-        assertEquals("TestLine", buf.toString(Charset.defaultCharset()));
+        try (Buffer buf = ch.readInbound()) {
+            assertEquals("TestLine", buf.toString(Charset.defaultCharset()));
+        }
 
-        ByteBuf buf2 = ch.readInbound();
-        assertEquals("g", buf2.toString(Charset.defaultCharset()));
+        try (Buffer buf2 = ch.readInbound()) {
+            assertEquals("g", buf2.toString(Charset.defaultCharset()));
+        }
+
         assertNull(ch.readInbound());
         ch.finish();
-
-        buf.release();
-        buf2.release();
     }
 
     @Test
     public void testIncompleteLinesStrippedDelimiters() {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, true,
                 Delimiters.lineDelimiter()));
-        ch.writeInbound(Unpooled.copiedBuffer("Test", Charset.defaultCharset()));
+        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "Test", Charset.defaultCharset()));
         assertNull(ch.readInbound());
-        ch.writeInbound(Unpooled.copiedBuffer("Line\r\ng\r\n", Charset.defaultCharset()));
+        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "Line\r\ng\r\n", Charset.defaultCharset()));
 
-        ByteBuf buf = ch.readInbound();
-        assertEquals("TestLine", buf.toString(Charset.defaultCharset()));
+        try (Buffer buf = ch.readInbound()) {
+            assertEquals("TestLine", buf.toString(Charset.defaultCharset()));
+        }
 
-        ByteBuf buf2 = ch.readInbound();
-        assertEquals("g", buf2.toString(Charset.defaultCharset()));
+        try (Buffer buf2 = ch.readInbound()) {
+            assertEquals("g", buf2.toString(Charset.defaultCharset()));
+        }
+
         assertNull(ch.readInbound());
         ch.finish();
-
-        buf.release();
-        buf2.release();
     }
 
     @Test
     public void testMultipleLines() {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, false,
                 Delimiters.lineDelimiter()));
-        ch.writeInbound(Unpooled.copiedBuffer("TestLine\r\ng\r\n", Charset.defaultCharset()));
+        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "TestLine\r\ng\r\n", Charset.defaultCharset()));
 
-        ByteBuf buf = ch.readInbound();
-        assertEquals("TestLine\r\n", buf.toString(Charset.defaultCharset()));
+        try (Buffer buf = ch.readInbound()) {
+            assertEquals("TestLine\r\n", buf.toString(Charset.defaultCharset()));
+        }
 
-        ByteBuf buf2 = ch.readInbound();
-        assertEquals("g\r\n", buf2.toString(Charset.defaultCharset()));
+        try (Buffer buf2 = ch.readInbound()) {
+            assertEquals("g\r\n", buf2.toString(Charset.defaultCharset()));
+        }
+
         assertNull(ch.readInbound());
         ch.finish();
-
-        buf.release();
-        buf2.release();
     }
 
     @Test
     public void testIncompleteLines() {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, false,
                 Delimiters.lineDelimiter()));
-        ch.writeInbound(Unpooled.copiedBuffer("Test", Charset.defaultCharset()));
+        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "Test", Charset.defaultCharset()));
         assertNull(ch.readInbound());
-        ch.writeInbound(Unpooled.copiedBuffer("Line\r\ng\r\n", Charset.defaultCharset()));
+        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "Line\r\ng\r\n", Charset.defaultCharset()));
 
-        ByteBuf buf = ch.readInbound();
-        assertEquals("TestLine\r\n", buf.toString(Charset.defaultCharset()));
+        try (Buffer buf = ch.readInbound()) {
+            assertEquals("TestLine\r\n", buf.toString(Charset.defaultCharset()));
+        }
 
-        ByteBuf buf2 = ch.readInbound();
-        assertEquals("g\r\n", buf2.toString(Charset.defaultCharset()));
+        try (Buffer buf2 = ch.readInbound()) {
+            assertEquals("g\r\n", buf2.toString(Charset.defaultCharset()));
+        }
+
         assertNull(ch.readInbound());
         ch.finish();
-
-        buf.release();
-        buf2.release();
     }
 
     @Test
-    public void testDecode() throws Exception {
+    public void testDecode() {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new DelimiterBasedFrameDecoder(8192, true, Delimiters.lineDelimiter()));
 
-        ch.writeInbound(Unpooled.copiedBuffer("first\r\nsecond\nthird", CharsetUtil.US_ASCII));
+        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "first\r\nsecond\nthird", CharsetUtil.US_ASCII));
 
-        ByteBuf buf = ch.readInbound();
-        assertEquals("first", buf.toString(CharsetUtil.US_ASCII));
+        try (Buffer buf = ch.readInbound()) {
+            assertEquals("first", buf.toString(CharsetUtil.US_ASCII));
+        }
 
-        ByteBuf buf2 = ch.readInbound();
-        assertEquals("second", buf2.toString(CharsetUtil.US_ASCII));
+        try (Buffer buf2 = ch.readInbound()) {
+            assertEquals("second", buf2.toString(CharsetUtil.US_ASCII));
+        }
+
         assertNull(ch.readInbound());
         ch.finish();
+    }
 
-        ReferenceCountUtil.release(ch.readInbound());
-
-        buf.release();
-        buf2.release();
+    private static Buffer copiedBuffer(BufferAllocator allocator, String str, Charset charset) {
+        return allocator.copyOf(str.getBytes(charset));
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/DelimiterBasedFrameDecoderTest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DelimiterBasedFrameDecoderTest {
 
@@ -121,6 +124,25 @@ public class DelimiterBasedFrameDecoderTest {
 
         assertNull(ch.readInbound());
         ch.finish();
+    }
+
+    @Test
+    void testDelimitersClosed() {
+        Buffer[] delimiters = Delimiters.lineDelimiter();
+        new DelimiterBasedFrameDecoder(8192, false, delimiters);
+        assertFalse(delimiters[0].isAccessible());
+        assertFalse(delimiters[1].isAccessible());
+
+        delimiters = Delimiters.nulDelimiter();
+        new DelimiterBasedFrameDecoder(8192, false, delimiters);
+        assertFalse(delimiters[0].isAccessible());
+    }
+
+    @Test
+    void testEmptyDelimiter() {
+        Buffer delimiter = preferredAllocator().allocate(0);
+        assertThrows(IllegalArgumentException.class, () -> new DelimiterBasedFrameDecoder(8192, false, delimiter));
+        assertFalse(delimiter.isAccessible());
     }
 
     private static Buffer copiedBuffer(BufferAllocator allocator, String str, Charset charset) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -53,6 +53,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.netty5.handler.codec.BufferToByteBufHandler.BUFFER_TO_BYTEBUF_HANDLER;
+import static io.netty5.handler.codec.ByteBufToBufferHandler.BYTEBUF_TO_BUFFER_HANDLER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -139,22 +141,24 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         final StartTlsServerHandler sh = new StartTlsServerHandler(sse, autoRead);
         final StartTlsClientHandler ch = new StartTlsClientHandler(cse, autoRead);
 
-        sb.childHandler(new ChannelInitializer<Channel>() {
+        sb.childHandler(new ChannelInitializer<>() {
             @Override
-            public void initChannel(Channel sch) throws Exception {
+            public void initChannel(Channel sch) {
                 ChannelPipeline p = sch.pipeline();
                 p.addLast("logger", new LoggingHandler(LOG_LEVEL));
-                p.addLast(new LineBasedFrameDecoder(64), new StringDecoder(), new StringEncoder());
+                p.addLast(BYTEBUF_TO_BUFFER_HANDLER, new LineBasedFrameDecoder(64), BUFFER_TO_BYTEBUF_HANDLER);
+                p.addLast(new StringDecoder(), new StringEncoder());
                 p.addLast(sh);
             }
         });
 
-        cb.handler(new ChannelInitializer<Channel>() {
+        cb.handler(new ChannelInitializer<>() {
             @Override
-            public void initChannel(Channel sch) throws Exception {
+            public void initChannel(Channel sch) {
                 ChannelPipeline p = sch.pipeline();
                 p.addLast("logger", new LoggingHandler(LOG_LEVEL));
-                p.addLast(new LineBasedFrameDecoder(64), new StringDecoder(), new StringEncoder());
+                p.addLast(BYTEBUF_TO_BUFFER_HANDLER, new LineBasedFrameDecoder(64), BUFFER_TO_BYTEBUF_HANDLER);
+                p.addLast(new StringDecoder(), new StringEncoder());
                 p.addLast(ch);
             }
         });


### PR DESCRIPTION
Motivation:
Helps to have a pipeline working only with `Buffer` API.

Modification:
- Port `LineBasedFrameDecoder` and `DelimiterBasedFrameDecoder` to `Buffer` API.
- Adapt the junit tests

Result:
`LineBasedFrameDecoder` and `DelimiterBasedFrameDecoder` now are using the `Buffer` API.