### PR TITLE
Fix bugs in empty composite buffers

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCompositionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCompositionTest.java
@@ -182,6 +182,17 @@ public class BufferCompositionTest extends BufferTestSupport {
     }
 
     @Test
+    public void emptyCompositeBufferMustAllowSettingOffsetsToZero() {
+        try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
+            try (CompositeBuffer composite = CompositeBuffer.compose(allocator)) {
+                composite.readerOffset(0);
+                composite.writerOffset(0);
+                composite.resetOffsets();
+            }
+        }
+    }
+
+    @Test
     public void emptyCompositeBufferMustAllowExtendingWithBuffer() {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
             try (CompositeBuffer composite = CompositeBuffer.compose(allocator)) {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -525,6 +525,16 @@ public abstract class BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.writeLong(0x0102030405060708L);
+            try (Buffer buffer = bbAlloc.apply(0)) {
+                buf.copyInto(0, buffer, 0, buffer.capacity());
+            }
+
+            try (Buffer buffer = bbAlloc.apply(8)) {
+                buf.copyInto(0, buffer, 0, 0);
+                buffer.writerOffset(8);
+                assertEquals(0L, buffer.readLong());
+            }
+
             try (Buffer buffer = bbAlloc.apply(8)) {
                 buffer.writerOffset(8);
                 buf.copyInto(0, buffer, 0, buffer.capacity());
@@ -536,7 +546,6 @@ public abstract class BufferTestSupport {
                 assertEquals((byte) 0x06, buffer.readByte());
                 assertEquals((byte) 0x07, buffer.readByte());
                 assertEquals((byte) 0x08, buffer.readByte());
-                buffer.resetOffsets();
             }
 
             try (Buffer buffer = bbAlloc.apply(6)) {


### PR DESCRIPTION
Motivation:
Some edge cases were not properly handled when a composite buffer was empty.
Empty composite buffers have an empty (zero-length) array of component buffers, and this can cause trouble with the binary search on buffer offset, if we ever get into that code path.

Modification:
Take care to handle the case where a composite buffer is empty, in `readerOffset`, `copy`, and `copyInto`.

Result:
No more ArrayIndexOutOfBoundsException when calling these methods in empty composite buffers.
