### PR TITLE
Allow to configure non-built-in socket options

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollChannelConfigTest.java
@@ -69,7 +69,6 @@ public class EpollChannelConfigTest {
         }
     }
 
-
     @Test
     public void testIntegerOption() throws Exception {
         Epoll.ensureAvailability();

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollSocketTest.java
@@ -66,4 +66,18 @@ public class EpollSocketTest extends SocketTest<LinuxSocket> {
     protected LinuxSocket newSocket() {
         return LinuxSocket.newSocketStream();
     }
+
+    @Override
+    protected int level() {
+        // Value for SOL_SOCKET
+        // See https://github.com/torvalds/linux/blob/v5.17/include/uapi/asm-generic/socket.h
+        return 1;
+    }
+
+    @Override
+    protected int optname() {
+        // Value for SO_REUSEADDR
+        // See https://github.com/torvalds/linux/blob/v5.17/include/uapi/asm-generic/socket.h
+        return 2;
+    }
 }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
@@ -94,7 +94,6 @@ public class KQueueChannelConfigTest {
         }
     }
 
-
     @Test
     public void testIntegerOption() throws Exception {
         EventLoopGroup group = new MultithreadEventLoopGroup(1, KQueueHandler.newFactory());

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueChannelConfigTest.java
@@ -21,11 +21,17 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.unix.Buffer;
+import io.netty5.channel.unix.IntegerUnixChannelOption;
+import io.netty5.channel.unix.RawUnixChannelOption;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class KQueueChannelConfigTest {
@@ -83,6 +89,47 @@ public class KQueueChannelConfigTest {
                     .handler(new ChannelHandler() { })
                     .bind(new InetSocketAddress(0)).get();
             ch.close().syncUninterruptibly();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+
+    @Test
+    public void testIntegerOption() throws Exception {
+        EventLoopGroup group = new MultithreadEventLoopGroup(1, KQueueHandler.newFactory());
+        try {
+            KQueueSocketChannel channel = new KQueueSocketChannel(group.next());
+            IntegerUnixChannelOption opt = new IntegerUnixChannelOption("INT_OPT", 0xffff, 0x0004);
+            Integer zero = 0;
+            assertEquals(zero, channel.config().getOption(opt));
+            channel.config().setOption(opt, 1);
+            assertNotEquals(zero, channel.config().getOption(opt));
+            channel.fd().close();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testRawOption() throws Exception {
+        EventLoopGroup group = new MultithreadEventLoopGroup(1, KQueueHandler.newFactory());
+        try {
+            KQueueSocketChannel channel = new KQueueSocketChannel(group.next());
+            // Value for SOL_SOCKET and SO_REUSEADDR
+            // See https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/socket.h.auto.html
+            RawUnixChannelOption opt = new RawUnixChannelOption("RAW_OPT", 0xffff, 0x0004, 4);
+
+            ByteBuffer disabled = Buffer.allocateDirectWithNativeOrder(4);
+            disabled.putInt(0).flip();
+            assertEquals(disabled, channel.config().getOption(opt));
+
+            ByteBuffer enabled = Buffer.allocateDirectWithNativeOrder(4);
+            enabled.putInt(1).flip();
+
+            channel.config().setOption(opt, enabled);
+            assertNotEquals(disabled, channel.config().getOption(opt));
+            channel.fd().close();
         } finally {
             group.shutdownGracefully();
         }

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueSocketTest.java
@@ -86,4 +86,18 @@ public class KQueueSocketTest extends SocketTest<BsdSocket> {
     protected BsdSocket newSocket() {
         return BsdSocket.newSocketStream();
     }
+
+    @Override
+    protected int level() {
+        // Value for SOL_SOCKET
+        // See https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/socket.h.auto.html
+        return 0xffff;
+    }
+
+    @Override
+    protected int optname() {
+        // Value for SO_REUSEADDR
+        // See https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/socket.h.auto.html
+        return 0x0004;
+    }
 }

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/SocketTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/SocketTest.java
@@ -16,14 +16,18 @@
 package io.netty5.channel.unix.tests;
 
 import io.netty5.channel.unix.Socket;
+import io.netty5.channel.unix.Buffer;
+import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class SocketTest<T extends Socket> {
@@ -95,5 +99,38 @@ public abstract class SocketTest<T extends Socket> {
         final int value = 0x08;
         socket.setTrafficClass(value);
         assertEquals(value, socket.getTrafficClass());
+    }
+
+    @Test
+    public void testIntOpt() throws IOException {
+        socket.setReuseAddress(false);
+        socket.setIntOpt(level(), optname(), 1);
+        // Anything which is != 0 is considered enabled
+        assertNotEquals(0, socket.getIntOpt(level(), optname()));
+        socket.setIntOpt(level(), optname(), 0);
+        // This should be disabled again
+        assertEquals(0, socket.getIntOpt(level(), optname()));
+    }
+
+    @Test
+    public void testRawOpt() throws IOException {
+        ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(4);
+        buffer.putInt(1).flip();
+        socket.setRawOpt(level(), optname(), buffer);
+
+        ByteBuffer out = ByteBuffer.allocate(4);
+        socket.getRawOpt(level(), optname(), out);
+        assertFalse(out.hasRemaining());
+
+        out.flip();
+        assertNotEquals(ByteBuffer.allocate(0), out);
+    }
+
+    protected int level() {
+        throw new AssumptionViolatedException("Not supported");
+    }
+
+    protected int optname() {
+        throw new AssumptionViolatedException("Not supported");
     }
 }

--- a/transport-native-unix-common/src/main/c/netty5_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty5_unix_socket.c
@@ -1052,6 +1052,38 @@ static jint netty5_unix_socket_isBroadcast(JNIEnv* env, jclass clazz, jint fd) {
     return optval;
 }
 
+static void netty5_unix_socket_setIntOpt(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname, jint optval) {
+    netty5_unix_socket_setOption(env, fd, level, optname, &optval, sizeof(optval));
+}
+
+static void netty5_unix_socket_setRawOptArray(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname, jbyteArray inArray, jint offset, jint len) {
+    jbyte* optval = (*env)->GetByteArrayElements(env, inArray, 0);
+    netty5_unix_socket_setOption(env, fd, level, optname, optval + offset, len);
+    (*env)->ReleaseByteArrayElements(env, inArray, optval, 0);
+}
+
+static void netty5_unix_socket_setRawOptAddress(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname, jlong inAddress, jint len) {
+    netty5_unix_socket_setOption(env, fd, level, optname, (void *) inAddress, len);
+}
+
+static jint netty5_unix_socket_getIntOpt(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname) {
+    jint optval;
+    if (netty5_unix_socket_getOption(env, fd, level, optname, &optval, sizeof(optval)) == -1) {
+        return -1;
+    }
+    return optval;
+}
+
+static void netty5_unix_socket_getRawOptArray(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname, jbyteArray outArray, jint offset, jint len) {
+    jbyte* optval = (*env)->GetByteArrayElements(env, outArray, 0);
+    netty5_unix_socket_getOption(env, fd, level, optname, optval + offset, len);
+    (*env)->ReleaseByteArrayElements(env, outArray, optval, 0);
+}
+
+static void netty5_unix_socket_getRawOptAddress(JNIEnv* env, jclass clazz, jint fd, jint level, jint optname, jlong outAddress, jint len) {
+    netty5_unix_socket_getOption(env, fd, level, optname, (void *) outAddress, len);
+}
+
 static jint netty_unit_socket_msgFastopen(JNIEnv* env, jclass clazz) {
     return MSG_FASTOPEN;
 }
@@ -1108,7 +1140,13 @@ static const JNINativeMethod fixed_method_table[] = {
   { "getSoError", "(I)I", (void *) netty5_unix_socket_getSoError },
   { "isIPv6Preferred0", "(Z)Z", (void *) netty5_unix_socket_isIPv6Preferred0 },
   { "isIPv6", "(I)Z", (void *) netty5_unix_socket_isIPv6 },
-  { "msgFastopen", "()I", (void *) netty_unit_socket_msgFastopen }
+  { "msgFastopen", "()I", (void *) netty_unit_socket_msgFastopen },
+  { "setIntOpt", "(IIII)V", (void *) netty5_unix_socket_setIntOpt },
+  { "setRawOptArray", "(III[BII)V", (void *) netty5_unix_socket_setRawOptArray },
+  { "setRawOptAddress", "(IIIJI)V", (void *) netty5_unix_socket_setRawOptAddress },
+  { "getIntOpt", "(III)I", (void *) netty5_unix_socket_getIntOpt },
+  { "getRawOptArray", "(III[BII)V", (void *) netty5_unix_socket_getRawOptArray },
+  { "getRawOptAddress", "(IIIJI)V", (void *) netty5_unix_socket_getRawOptAddress }
 };
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
 

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/GenericUnixChannelOption.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/GenericUnixChannelOption.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.unix;
+
+/**
+ * A generic socket option. See <a href="https://linux.die.net/man/2/setsockopt">man setsockopt</a>.
+ *
+ * @param <T> the value type
+ */
+public abstract class GenericUnixChannelOption<T> extends UnixChannelOption<T> {
+
+    private final int level;
+    private final int optname;
+
+    GenericUnixChannelOption(String name, int level, int optname) {
+        super(name);
+        this.level = level;
+        this.optname = optname;
+    }
+
+    /**
+     * Returns the level. See <a href="https://linux.die.net/man/2/setsockopt">man setsockopt</a>
+     *
+     * @return the level.
+     */
+    public int level() {
+        return level;
+    }
+
+    /**
+     * Returns the optname. See <a href="https://linux.die.net/man/2/setsockopt">man setsockopt</a>
+     *
+     * @return the level.
+     */
+    public int optname() {
+        return optname;
+    }
+}

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/IntegerUnixChannelOption.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/IntegerUnixChannelOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,19 +15,18 @@
  */
 package io.netty5.channel.unix;
 
-import io.netty5.channel.ChannelOption;
-
-public class UnixChannelOption<T> extends ChannelOption<T> {
-    public static final ChannelOption<Boolean> SO_REUSEPORT = valueOf(UnixChannelOption.class, "SO_REUSEPORT");
-    public static final ChannelOption<DomainSocketReadMode> DOMAIN_SOCKET_READ_MODE =
-            ChannelOption.valueOf(UnixChannelOption.class, "DOMAIN_SOCKET_READ_MODE");
-
-    @SuppressWarnings({ "unused", "deprecation" })
-    protected UnixChannelOption() {
-        super(null);
-    }
-
-    UnixChannelOption(String name) {
-        super(name);
+/**
+ * A {@link GenericUnixChannelOption} which uses an {@link Integer} as {@code optval}.
+ */
+public final class IntegerUnixChannelOption extends GenericUnixChannelOption<Integer> {
+    /**
+     * Creates a new instance.
+     *
+     * @param name      the name that is used.
+     * @param level     the level.
+     * @param optname   the optname.
+     */
+    public IntegerUnixChannelOption(String name, int level, int optname) {
+        super(name, level, optname);
     }
 }

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/RawUnixChannelOption.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/RawUnixChannelOption.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.channel.unix;
+
+
+import io.netty.util.internal.ObjectUtil;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A {@link GenericUnixChannelOption} which uses an {@link ByteBuffer} as {@code optval}. The user is responsible
+ * to fill the {@link ByteBuffer} in a correct manner, so it works with the {@param level} and {@param optname}.
+ */
+public final class RawUnixChannelOption extends GenericUnixChannelOption<ByteBuffer> {
+
+    private final int length;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param name      the name that is used.
+     * @param level     the level.
+     * @param length    the expected length of the optvalue.
+     * @param optname   the optname.
+     */
+    public RawUnixChannelOption(String name, int level, int optname, int length) {
+        super(name, level, optname);
+        this.length = ObjectUtil.checkPositive(length, "length");
+    }
+
+    /**
+     * The length of the optval.
+     *
+     * @return the length.
+     */
+    public int length() {
+        return length;
+    }
+
+    @Override
+    public void validate(ByteBuffer value) {
+        super.validate(value);
+        if (value.remaining() != length) {
+            throw new IllegalArgumentException("Length of value does not match. Expected "
+                    + length + ", but got " + value.remaining());
+        }
+    }
+}

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Socket.java
@@ -458,6 +458,43 @@ public class Socket extends FileDescriptor {
         setTrafficClass(fd, ipv6, trafficClass);
     }
 
+    public void setIntOpt(int level, int optname, int optvalue) throws IOException {
+        setIntOpt(fd, level, optname, optvalue);
+    }
+
+    public void setRawOpt(int level, int optname, ByteBuffer optvalue) throws IOException {
+        int limit = optvalue.limit();
+        if (optvalue.isDirect()) {
+            setRawOptAddress(fd, level, optname,
+                    Buffer.memoryAddress(optvalue) + optvalue.position(), optvalue.remaining());
+        } else if (optvalue.hasArray()) {
+            setRawOptArray(fd, level, optname,
+                    optvalue.array(), optvalue.arrayOffset() + optvalue.position(), optvalue.remaining());
+        } else {
+            byte[] bytes = new byte[optvalue.remaining()];
+            optvalue.duplicate().get(bytes);
+            setRawOptArray(fd, level, optname, bytes, 0, bytes.length);
+        }
+        optvalue.position(limit);
+    }
+
+    public int getIntOpt(int level, int optname) throws IOException {
+        return getIntOpt(fd, level, optname);
+    }
+
+    public void getRawOpt(int level, int optname, ByteBuffer out) throws IOException {
+        if (out.isDirect()) {
+            getRawOptAddress(fd, level, optname, Buffer.memoryAddress(out) + out.position() , out.remaining());
+        } else if (out.hasArray()) {
+            getRawOptArray(fd, level, optname, out.array(), out.position() + out.arrayOffset(), out.remaining());
+        } else {
+            byte[] outArray = new byte[out.remaining()];
+            getRawOptArray(fd, level, optname, outArray, 0, outArray.length);
+            out.put(outArray);
+        }
+        out.position(out.limit());
+    }
+
     public static boolean isIPv6Preferred() {
         return isIpv6Preferred;
     }
@@ -599,4 +636,15 @@ public class Socket extends FileDescriptor {
     private static native void setSoLinger(int fd, int soLinger) throws IOException;
     private static native void setBroadcast(int fd, int broadcast) throws IOException;
     private static native void setTrafficClass(int fd, boolean ipv6, int trafficClass) throws IOException;
+
+    private static native void setIntOpt(int fd, int level, int optname, int optvalue) throws IOException;
+    private static native void setRawOptArray(int fd, int level, int optname, byte[] optvalue, int offset, int length)
+            throws IOException;
+    private static native void setRawOptAddress(int fd, int level, int optname, long optvalueMemoryAddress, int length)
+            throws IOException;
+    private static native int getIntOpt(int fd, int level, int optname) throws IOException;
+    private static native void getRawOptArray(int fd, int level, int optname, byte[] out, int offset, int length)
+            throws IOException;
+    private static native void getRawOptAddress(int fd, int level, int optname, long outMemoryAddress, int length)
+            throws IOException;
 }


### PR DESCRIPTION
Motivation:

More and more socket options are added on every kernel / OS release. While we have "build-in" support for the most used there are situations when the user might want to specify something that we have not build-in.

Modifications:

- Add IntegerUnixChannelOption and RawUnixChannelOption which allows to set socket options that are not "build-in".
- Add unit tests

Result:

More flexibility for the user

Co-authored-by: Chris Vest <christianvest_hansen@apple.com>
