### PR TITLE
optimize

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BlockCompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BlockCompressor.java
@@ -115,6 +115,7 @@ final class Bzip2BlockCompressor {
             for (int j = 0, k = i << 4; j < HUFFMAN_SYMBOL_RANGE_SIZE; j++, k++) {
                 if (blockValuesPresent[k]) {
                     condensedInUse[i] = true;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Motivation:

There is no need to finish inner loop when condensedInUse[i] setting as true.

Result:

Small optimization
