### PR TITLE
Add a SensitiveBufferAllocator

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/SensitiveBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/SensitiveBufferAllocator.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.api;
+
+import io.netty5.buffer.api.internal.ArcDrop;
+import io.netty5.buffer.api.internal.CleanerDrop;
+
+import java.nio.ByteBuffer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * This {@link BufferAllocator} is for allocating {@linkplain StandardAllocationTypes#OFF_HEAP off-heap}
+ * {@link Buffer}s that may contain sensitive information, which should be erased from memory (overwritten) when the
+ * buffer is closed.
+ * <p>
+ * The features and behaviours of this allocator are otherwise exactly the same as
+ * {@link BufferAllocator#offHeapUnpooled()}.
+ * <p>
+ * Of particular note, the byte arrays passed to {@link BufferAllocator#copyOf(byte[])}
+ * and {@link BufferAllocator#constBufferSupplier(byte[])}, and the {@linkplain ByteBuffer buffer} passed to
+ * {@link BufferAllocator#copyOf(ByteBuffer)} are <strong>not</strong> cleared by this allocator.
+ * These copies of the sensitive data must be cleared separately!
+ * Ideally these methods should not be used for sensitive data in the first place, and the sensitive data should
+ * instead be directly written to, or created in, a sensitive buffer.
+ * <p>
+ * This allocator is stateless, and the {@link #close()} method has no effect.
+ */
+public final class SensitiveBufferAllocator implements BufferAllocator {
+    private static final BufferAllocator INSTANCE = new SensitiveBufferAllocator();
+    private static final AllocatorControl CONTROL = () -> INSTANCE;
+    private static final Function<Drop<Buffer>, Drop<Buffer>> DECORATOR = SensitiveBufferAllocator::decorate;
+
+    /**
+     * Get the sensitive off-heap buffer allocator instance.
+     *
+     * @return The allocator.
+     */
+    public static BufferAllocator sensitiveOffHeapAllocator() {
+        return INSTANCE;
+    }
+
+    private SensitiveBufferAllocator() {
+    }
+
+    @Override
+    public boolean isPooling() {
+        return false;
+    }
+
+    @Override
+    public AllocationType getAllocationType() {
+        return StandardAllocationTypes.OFF_HEAP;
+    }
+
+    @Override
+    public Buffer allocate(int size) {
+        MemoryManager manager = MemoryManager.instance();
+        return manager.allocateShared(CONTROL, size, DECORATOR, getAllocationType());
+    }
+
+    private static Drop<Buffer> decorate(Drop<Buffer> base) {
+        MemoryManager manager = MemoryManager.instance();
+        return CleanerDrop.wrap(ArcDrop.wrap(new ZeroingDrop(manager, base)), manager);
+    }
+
+    @Override
+    public Supplier<Buffer> constBufferSupplier(byte[] bytes) {
+        Buffer origin = copyOf(bytes).makeReadOnly();
+        return () -> origin.copy(origin.readerOffset(), origin.readableBytes(), true);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private static final class ZeroingDrop implements Drop<Buffer> {
+        private final MemoryManager manager;
+        private final Drop<Buffer> base;
+
+        ZeroingDrop(MemoryManager manager, Drop<Buffer> base) {
+            this.manager = manager;
+            this.base = base;
+        }
+
+        @Override
+        public void drop(Buffer obj) {
+            // The given buffer object might only be a small piece of the original buffer, due to split() calls.
+            // We go through the memory recovery process in order to get back the full memory allocation.
+            Object memory = manager.unwrapRecoverableMemory(obj);
+            try (Buffer buffer = manager.recoverMemory(CONTROL, memory, base)) {
+                buffer.fill((byte) 0);
+            }
+        }
+
+        @Override
+        public Drop<Buffer> fork() {
+            // ZeroingDrop should be guarded by an ArcDrop, because we can only zero after we're sure
+            // there is no more structural sharing of the memory!
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void attach(Buffer obj) {
+            base.attach(obj);
+        }
+
+        @Override
+        public String toString() {
+            return "ZeroingDrop(" + base + ')';
+        }
+    }
+}

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufMemoryManager.java
@@ -24,6 +24,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
 import io.netty5.buffer.api.StandardAllocationTypes;
+import io.netty5.buffer.api.internal.ArcDrop;
 import io.netty5.buffer.api.internal.WrappingAllocation;
 
 import java.util.function.Function;
@@ -74,7 +75,7 @@ public final class ByteBufMemoryManager implements MemoryManager {
     }
 
     private static Drop<Buffer> drop() {
-        return convert(ByteBufBuffer.ByteBufDrop.INSTANCE);
+        return ArcDrop.wrap(convert(ByteBufBuffer.ByteBufDrop.INSTANCE));
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
@@ -86,12 +86,8 @@ public interface Statics {
         }
     }
 
-    static <T extends Buffer> Drop<T> standardDropWrap(Drop<T> drop, MemoryManager manager) {
-        return CleanerDrop.wrap(ArcDrop.wrap(drop), manager);
-    }
-
     static Function<Drop<Buffer>, Drop<Buffer>> standardDrop(MemoryManager manager) {
-        return drop -> standardDropWrap(drop, manager);
+        return drop -> CleanerDrop.wrap(drop, manager);
     }
 
     static VarHandle findVarHandle(Lookup lookup, Class<?> recv, String name, Class<?> type) {

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunk.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunk.java
@@ -28,8 +28,6 @@ import io.netty5.util.internal.LongPriorityQueue;
 
 import java.util.PriorityQueue;
 
-import static io.netty5.buffer.api.internal.Statics.standardDropWrap;
-
 /**
  * Description of algorithm for PageRun/PoolSubpage allocation from PoolChunk
  *
@@ -590,8 +588,8 @@ final class PoolChunk implements PoolChunkMetric {
 
         @Override
         public <BufferType extends Buffer> Drop<BufferType> drop() {
-            var pooledDrop = new PooledDrop(chunk, threadCache, handle, maxLength);
-            return (Drop<BufferType>) standardDropWrap(pooledDrop, chunk.arena.manager);
+            var pooledDrop = ArcDrop.wrap(new PooledDrop(chunk, threadCache, handle, maxLength));
+            return (Drop<BufferType>) CleanerDrop.wrap(pooledDrop, chunk.arena.manager);
         }
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
@@ -812,7 +812,7 @@ public class BufferLifeCycleTest extends BufferTestSupport {
     }
 
     @ParameterizedTest
-    @MethodSource("allocators")
+    @MethodSource("closeableAllocators")
     public void allocatingOnClosedAllocatorMustThrow(Fixture fixture) {
         BufferAllocator allocator = fixture.createAllocator();
         Supplier<Buffer> supplier = allocator.constBufferSupplier(new byte[8]);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -203,7 +203,7 @@ public abstract class BufferTestSupport {
         // Add 2-way composite buffers of all combinations.
         for (Fixture first : initFixtures) {
             for (Fixture second : initFixtures) {
-                Properties[] properties;
+                final Properties[] properties;
                 if (first.isUncloseable() || second.isUncloseable()) {
                     properties = new Properties[] { COMPOSITE, UNCLOSEABLE };
                 } else {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/Fixture.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/Fixture.java
@@ -66,10 +66,15 @@ public final class Fixture implements Supplier<BufferAllocator> {
         return properties.contains(Properties.POOLED);
     }
 
+    public boolean isUncloseable() {
+        return properties.contains(Properties.UNCLOSEABLE);
+    }
+
     public enum Properties {
         HEAP,
         DIRECT,
         COMPOSITE,
-        POOLED
+        POOLED,
+        UNCLOSEABLE
     }
 }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.api.tests;
+
+import io.netty5.buffer.api.AllocationType;
+import io.netty5.buffer.api.AllocatorControl;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.Drop;
+import io.netty5.buffer.api.MemoryManager;
+import io.netty5.buffer.api.Send;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static io.netty5.buffer.api.SensitiveBufferAllocator.sensitiveOffHeapAllocator;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SensitiveBufferTest {
+    @Test
+    public void sensitiveBufferMustZeroMemoryOnClose() {
+        MemoryManager baseMemoryManager = MemoryManager.instance();
+        StubManager stubManager = new StubManager(baseMemoryManager);
+        try (Buffer buffer = MemoryManager.using(stubManager, () -> sensitiveOffHeapAllocator().allocate(8))) {
+            buffer.writeLong(0x0102030405060708L);
+        }
+        assertEquals(8, stubManager.getBytesCleared());
+    }
+
+    @Test
+    public void sensitiveReadOnlyBufferMustZeroMemoryOnClose() {
+        MemoryManager baseMemoryManager = MemoryManager.instance();
+        StubManager stubManager = new StubManager(baseMemoryManager);
+        try (Buffer buffer = MemoryManager.using(stubManager, () -> sensitiveOffHeapAllocator().allocate(8))) {
+            buffer.writeLong(0x0102030405060708L);
+            // We must be able to zero the sensitive memory even if the buffer becomes read-only!
+            buffer.makeReadOnly();
+        }
+        assertEquals(8, stubManager.getBytesCleared());
+    }
+
+    @Test
+    public void closingSplitPartMustNotZeroBytesUntilAllPartsAreClosed() {
+        MemoryManager baseMemoryManager = MemoryManager.instance();
+        StubManager stubManager = new StubManager(baseMemoryManager);
+        try (Buffer buffer = MemoryManager.using(stubManager, () -> sensitiveOffHeapAllocator().allocate(8))) {
+            buffer.writeLong(0x0102030405060708L);
+            Buffer split = buffer.readSplit(4);
+            split.close();
+            // The four bytes from the split part we closed must not be zeroed because the drop has insufficient
+            // information about the structural sharing.
+            assertEquals(0, stubManager.getBytesCleared());
+        }
+        assertEquals(8, stubManager.getBytesCleared());
+    }
+
+    @Test
+    public void closingReadOnlySplitPartMustNotZeroBytesUntilAllPartsAreClosed() {
+        MemoryManager baseMemoryManager = MemoryManager.instance();
+        StubManager stubManager = new StubManager(baseMemoryManager);
+        try (Buffer buffer = MemoryManager.using(stubManager, () -> sensitiveOffHeapAllocator().allocate(8))) {
+            buffer.writeLong(0x0102030405060708L);
+            Buffer split = buffer.readSplit(4);
+            split.makeReadOnly();
+            split.close();
+            // The four bytes from the split part we closed must not be zeroed because the drop has insufficient
+            // information about the structural sharing.
+            assertEquals(0, stubManager.getBytesCleared());
+            buffer.makeReadOnly();
+        }
+        assertEquals(8, stubManager.getBytesCleared());
+    }
+
+    @Test
+    public void closingBuffersWithComplicatedStructuralSharingMustNotZeroBytesUntilAllPartsAreClosed() {
+        MemoryManager baseMemoryManager = MemoryManager.instance();
+        StubManager stubManager = new StubManager(baseMemoryManager);
+        try (Buffer buffer = MemoryManager.using(stubManager, () -> sensitiveOffHeapAllocator().allocate(8))) {
+            buffer.writeLong(0x0102030405060708L).makeReadOnly();
+            try (Buffer split = buffer.readSplit(4)) {
+                assertTrue(split.readOnly());
+                split.copy(0, 4, true).close();
+            }
+            final Send<Buffer> send;
+            try (Buffer copy = buffer.copy(0, 4, true)) {
+                send = buffer.send();
+                copy.readSplit(2).close();
+            }
+            assertEquals(0, stubManager.getBytesCleared());
+            send.close();
+            assertEquals(8, stubManager.getBytesCleared());
+        }
+    }
+
+    private static class StubManager implements MemoryManager {
+        private final MemoryManager baseMemoryManager;
+        private final AtomicInteger bytesCleared = new AtomicInteger();
+
+        StubManager(MemoryManager baseMemoryManager) {
+            this.baseMemoryManager = baseMemoryManager;
+        }
+
+        @Override
+        public Buffer allocateShared(AllocatorControl control, long size,
+                                     Function<Drop<Buffer>, Drop<Buffer>> dropDecorator,
+                                     AllocationType allocationType) {
+            return baseMemoryManager.allocateShared(
+                    control,
+                    size,
+                    drop -> dropDecorator.apply(new CheckingDrop(bytesCleared, drop)),
+                    allocationType);
+        }
+
+        @Override
+        public Buffer allocateConstChild(Buffer readOnlyConstParent) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object unwrapRecoverableMemory(Buffer buf) {
+            return baseMemoryManager.unwrapRecoverableMemory(buf);
+        }
+
+        @Override
+        public Buffer recoverMemory(AllocatorControl control, Object recoverableMemory, Drop<Buffer> drop) {
+            return baseMemoryManager.recoverMemory(control, recoverableMemory, drop);
+        }
+
+        @Override
+        public Object sliceMemory(Object memory, int offset, int length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String implementationName() {
+            throw new UnsupportedOperationException();
+        }
+
+        public int getBytesCleared() {
+            return bytesCleared.get();
+        }
+
+        private static final class CheckingDrop implements Drop<Buffer> {
+            private final AtomicInteger bytesCleared;
+            private final Drop<Buffer> delegate;
+
+            CheckingDrop(AtomicInteger bytesCleared, Drop<Buffer> delegate) {
+                this.bytesCleared = bytesCleared;
+                this.delegate = delegate;
+            }
+
+            @Override
+            public void drop(Buffer obj) {
+                int capacity = obj.capacity();
+                for (int i = 0; i < capacity; i++) {
+                    assertEquals((byte) 0, obj.getByte(i));
+                }
+                bytesCleared.addAndGet(capacity);
+                delegate.drop(obj);
+            }
+
+            @Override
+            public Drop<Buffer> fork() {
+                // CheckingDrop should be guarded by an ArcDrop.
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void attach(Buffer obj) {
+                delegate.attach(obj);
+            }
+
+            @Override
+            public String toString() {
+                return "CheckingDrop(" + delegate + ')';
+            }
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
@@ -106,7 +106,7 @@ public class SensitiveBufferTest {
         }
     }
 
-    private static class StubManager implements MemoryManager {
+    private static final class StubManager implements MemoryManager {
         private final MemoryManager baseMemoryManager;
         private final AtomicInteger bytesCleared = new AtomicInteger();
 


### PR DESCRIPTION
Motivation:
We have use cases in PemPrivateKey and sensitive PemValue objects, for buffers that can zero out themselves when closed.
Users may have use cases for sensitive buffers as well.

Modification:
Add a SensitiveBufferAllocator that functions similarly to the unpooled off-heap allocator, except the buffers are equipped with a drop implementation that zero out the memory of the buffer when it is deallocated.
The sensitive buffers otherwise behave exactly the same as any other off-heap buffer.
The allocator is not pooling because we don't anticipate a high allocation rate for sensitive buffers.
The sensitive buffers only come in an off-heap variant, since a GC may freely produce copies of any on-heap memory, eliminating our control of the lifetime of the data.
In the process of adding this, some unnecessary usages of ArcDrop have also been removed to aid testing, and incidentally also reduces overhead.

Result:
It is possible to reliably allocate buffers that zero out their memory when deallocated, thus reducing (but not eliminating) the window for memory scraping attacks.
