### PR TITLE
Automatically use boringssl-static when compiling on Mac M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,14 +390,14 @@
     </profile>
 
     <profile>
-      <id>boringssl-osx-arch64</id>
+      <id>boringssl-mac-aarch64</id>
       <activation>
         <os>
           <!--
-           Automatically active on osx with aarch64 as we only release static boringssl version of
+           Automatically active on mac with aarch64 as we only release static boringssl version of
            netty-tcnative for it.
          -->
-          <family>osx</family>
+          <family>mac</family>
           <arch>aarch64</arch>
         </os>
       </activation>


### PR DESCRIPTION
Motivation:

As we only publish netty-tcnative-boringssl-static for Mac M1 we need to ensure we activate the correct profile.

Modifications:

Replace incorrect family value (osx) with correct one (mac)

Result:

Be able to compile on Mac M1 without the need to specify the profile manually.
Fixes https://github.com/netty/netty/issues/12251
