### PR TITLE
Add bulk operations for ByteBuffer

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -418,10 +418,10 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
             writerOffset(woff + source.remaining());
             // Try to reduce bounce-checking by using long and int when possible.
             boolean needReverse = source.order() != ByteOrder.BIG_ENDIAN;
-            for (;length >= Long.BYTES; length -= Long.BYTES, woff += Long.BYTES) {
+            for (; length >= Long.BYTES; length -= Long.BYTES, woff += Long.BYTES) {
                 setLong(woff, needReverse ? Long.reverseBytes(source.getLong()) : source.getLong());
             }
-            for (;length >= Integer.BYTES; length -= Integer.BYTES, woff += Integer.BYTES) {
+            for (; length >= Integer.BYTES; length -= Integer.BYTES, woff += Integer.BYTES) {
                 setInt(woff, needReverse ? Integer.reverseBytes(source.getInt()) : source.getInt());
             }
             for (; length > 0; length--, woff++) {
@@ -430,7 +430,6 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
         }
         return this;
     }
-
 
     /**
      * Read from this buffer, into the destination {@link ByteBuffer}
@@ -452,10 +451,10 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
 
             // Try to reduce bounce-checking by using long and int when possible.
             boolean needReverse = destination.order() != ByteOrder.BIG_ENDIAN;
-            for (;length >= Long.BYTES; length -= Long.BYTES, roff += Long.BYTES) {
+            for (; length >= Long.BYTES; length -= Long.BYTES, roff += Long.BYTES) {
                 destination.putLong(needReverse ? Long.reverseBytes(getLong(roff)) : getLong(roff));
             }
-            for (;length >= Integer.BYTES; length -= Integer.BYTES, roff += Integer.BYTES) {
+            for (; length >= Integer.BYTES; length -= Integer.BYTES, roff += Integer.BYTES) {
                 destination.putInt(needReverse ? Integer.reverseBytes(getInt(roff)) : getInt(roff));
             }
             for (; length > 0; length--, roff++) {

--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -19,6 +19,7 @@ import io.netty5.buffer.api.internal.Statics;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.ScatteringByteChannel;
@@ -395,6 +396,71 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
         writerOffset(woff + length);
         for (int i = 0; i < length; i++) {
             setByte(woff + i, source[srcPos + i]);
+        }
+        return this;
+    }
+
+    /**
+     * Writes into this buffer from the source {@link ByteBuffer}.
+     * This updates the {@linkplain #writerOffset() write offset} of this buffer and also the position of
+     * the source {@link ByteBuffer}.
+     *
+     * @param source The {@link ByteBuffer} to read from.
+     * @return This buffer.
+     */
+    default Buffer writeBytes(ByteBuffer source) {
+        if (source.hasArray()) {
+            writeBytes(source.array(), source.arrayOffset() + source.position(), source.remaining());
+            source.position(source.limit());
+        } else {
+            int woff = writerOffset();
+            int length = source.remaining();
+            writerOffset(woff + source.remaining());
+            // Try to reduce bounce-checking by using long and int when possible.
+            boolean needReverse = source.order() != ByteOrder.BIG_ENDIAN;
+            for (;length >= Long.BYTES; length -= Long.BYTES, woff += Long.BYTES) {
+                setLong(woff, needReverse ? Long.reverseBytes(source.getLong()) : source.getLong());
+            }
+            for (;length >= Integer.BYTES; length -= Integer.BYTES, woff += Integer.BYTES) {
+                setInt(woff, needReverse ? Integer.reverseBytes(source.getInt()) : source.getInt());
+            }
+            for (; length > 0; length--, woff++) {
+                setByte(woff, source.get());
+            }
+        }
+        return this;
+    }
+
+
+    /**
+     * Read from this buffer, into the destination {@link ByteBuffer}
+     * This updates the {@linkplain #readerOffset() read offset} of this buffer and also the position of
+     * the destination {@link ByteBuffer}.
+     *
+     * @param destination The {@link ByteBuffer} to write into.
+     * @return This buffer.
+     */
+    default Buffer readBytes(ByteBuffer destination) {
+        if (destination.hasArray()) {
+            readBytes(destination.array(), destination.arrayOffset() + destination.position(),
+                    destination.remaining());
+            destination.position(destination.limit());
+        } else {
+            int roff = readerOffset();
+            int length = destination.remaining();
+            readerOffset(roff + destination.remaining());
+
+            // Try to reduce bounce-checking by using long and int when possible.
+            boolean needReverse = destination.order() != ByteOrder.BIG_ENDIAN;
+            for (;length >= Long.BYTES; length -= Long.BYTES, roff += Long.BYTES) {
+                destination.putLong(needReverse ? Long.reverseBytes(getLong(roff)) : getLong(roff));
+            }
+            for (;length >= Integer.BYTES; length -= Integer.BYTES, roff += Integer.BYTES) {
+                destination.putInt(needReverse ? Integer.reverseBytes(getInt(roff)) : getInt(roff));
+            }
+            for (; length > 0; length--, roff++) {
+                destination.put(getByte(roff));
+            }
         }
         return this;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -567,6 +567,18 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public Buffer writeBytes(ByteBuffer source) {
+        delegate.writeBytes(source);
+        return this;
+    }
+
+    @Override
+    public Buffer readBytes(ByteBuffer destination) {
+        delegate.readBytes(destination);
+        return this;
+    }
+
+    @Override
     public Send<Buffer> send() {
         return delegate.send();
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.buffer.api;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 /**
@@ -204,6 +205,16 @@ public interface CompositeBuffer extends Buffer {
     @Override
     default CompositeBuffer setBoolean(int woff, boolean value) {
         return (CompositeBuffer) Buffer.super.setBoolean(woff, value);
+    }
+
+    @Override
+    default CompositeBuffer writeBytes(ByteBuffer source) {
+        return (CompositeBuffer) Buffer.super.writeBytes(source);
+    }
+
+    @Override
+    default CompositeBuffer readBytes(ByteBuffer destination) {
+        return (CompositeBuffer) Buffer.super.readBytes(destination);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -843,7 +843,6 @@ public abstract class BufferTestSupport {
         return bs;
     }
 
-
     public static byte[] toByteArray(ByteBuffer buf) {
         byte[] bs = new byte[buf.remaining()];
         buf.duplicate().get(bs);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -843,6 +843,13 @@ public abstract class BufferTestSupport {
         return bs;
     }
 
+
+    public static byte[] toByteArray(ByteBuffer buf) {
+        byte[] bs = new byte[buf.remaining()];
+        buf.duplicate().get(bs);
+        return bs;
+    }
+
     public static void assertEquals(byte expected, byte actual) {
         if (expected != actual) {
             fail(String.format("expected: %1$s (0x%1$X) but was: %2$s (0x%2$X)", expected, actual));


### PR DESCRIPTION
Motivation:

We should provide bulk operations that either write a ByteBuffer or read into a ByteBuffer

Modifications:

- Add implementation
- Add unit tests

Result:

Expose bulk operations for ByteBuffer
