### PR TITLE
Bump Log4j2 to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,7 +551,7 @@
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
-    <log4j2.version>2.17.1</log4j2.version>
+    <log4j2.version>2.17.2</log4j2.version>
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <junit.version>5.7.0</junit.version>
     <skipTests>false</skipTests>


### PR DESCRIPTION
Motivation:
We should always use up-to-date `log4j2`

Modification:
Updated Log4j2 2.17.1 to 2.17.2

Result:
Up-to-date Log4j2
