### PR TITLE
Fix bug in read-only buffer copy

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -184,6 +184,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             }
             copy.roff = 0;
             copy.woff = length;
+            return copy;
         }
         Buffer copy = control.getAllocator().allocate(length);
         try {

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -196,6 +196,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
             copy.rsize = length;
             copy.roff = 0;
             copy.woff = length;
+            return copy;
         }
         Buffer copy = control.getAllocator().allocate(length);
         try {


### PR DESCRIPTION
Motivation:
When a read-only copy of a read-only buffer was requested, we would rely on the infrastructure for const buffers to create structurally shared buffers and avoid actually copying.
Unfortunately, we forgot to return this structurally shared buffer copy in the `NioBuffer` and `UnsafeBuffer` implementations, and instead fell through to the traditional copying code.
The effect of this is that we leaked the structurally shared copy, and also did the work of actually copying the buffer.

Modification:
Return the structurally sharing copy - if we make one - from the copy methods of `NioBuffer` and `UnsafeBuffer`.

Result:
No leak, and intended optimisation actually realised.