### PR TITLE
Upgrade to `Brotli4j` 1.7.1 and use new `ByteBuf` API

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliDecoder.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
- * Uncompresses a {@link ByteBuf} encoded with the brotli format.
+ * Decompresses a {@link ByteBuf} encoded with the brotli format.
  *
  * See <a href="https://github.com/google/brotli">brotli</a>.
  */

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -16,8 +16,8 @@
 package io.netty.handler.codec.compression;
 
 import com.aayushatharva.brotli4j.encoder.Encoder;
+import com.aayushatharva.brotli4j.encoder.Encoders;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -75,15 +75,14 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
         }
 
         try {
-            byte[] uncompressed = ByteBufUtil.getBytes(msg, msg.readerIndex(), msg.readableBytes(), false);
-            byte[] compressed = Encoder.compress(uncompressed, parameters);
+            ByteBuf out;
             if (preferDirect) {
-                ByteBuf out = ctx.alloc().ioBuffer(compressed.length);
-                out.writeBytes(compressed);
-                return out;
+                out = ctx.alloc().ioBuffer();
             } else {
-                return Unpooled.wrappedBuffer(compressed);
+                out = Unpooled.buffer();
             }
+            Encoders.compress(msg, out, parameters);
+            return out;
         } catch (Exception e) {
             ReferenceCountUtil.release(msg);
             throw e;

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -79,7 +79,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
             if (preferDirect) {
                 out = ctx.alloc().ioBuffer();
             } else {
-                out = Unpooled.buffer();
+                out = ctx.alloc().buffer();
             }
             Encoders.compress(msg, out, parameters);
             return out;

--- a/pom.xml
+++ b/pom.xml
@@ -561,7 +561,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.6.0</brotli4j.version>
+    <brotli4j.version>1.7.0</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>

--- a/pom.xml
+++ b/pom.xml
@@ -561,7 +561,7 @@
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
-    <brotli4j.version>1.7.0</brotli4j.version>
+    <brotli4j.version>1.7.1</brotli4j.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>


### PR DESCRIPTION
Motivation:
`Brotli4j` v1.7.1 is released with the new `ByteBuf` API. It uses `ByteBuf` instead of `byte` array to minimize garbage creation and memory copy.

Modification:
Bumped to the `Brotli4j` to v1.7.1 and used new API for Encoder

Result:
New update and better performance
