### PR TITLE
Allow explicit choice of internet family

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -89,9 +89,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      * on the Operation Systems default which will be chosen.
      */
     public EpollDatagramChannel(InternetProtocolFamily family) {
-        this(family == null ?
-                newSocketDgram(Socket.isIPv6Preferred()) : newSocketDgram(family == InternetProtocolFamily.IPv6),
-                false);
+        this(newSocketDgram(family), false);
     }
 
     /**

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -17,6 +17,7 @@ package io.netty.channel.epoll;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.ServerSocketChannel;
 
 import java.io.IOException;
@@ -41,7 +42,11 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();
 
     public EpollServerSocketChannel() {
-        super(newSocketStream(), false);
+        this((InternetProtocolFamily) null);
+    }
+
+    public EpollServerSocketChannel(InternetProtocolFamily protocol) {
+        super(newSocketStream(protocol), false);
         config = new EpollServerSocketChannelConfig(this);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -47,6 +48,11 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
 
     public EpollSocketChannel() {
         super(newSocketStream(), false);
+        config = new EpollSocketChannelConfig(this);
+    }
+
+    public EpollSocketChannel(InternetProtocolFamily protocol) {
+        super(newSocketStream(protocol), false);
         config = new EpollSocketChannelConfig(this);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -331,12 +331,20 @@ public final class LinuxSocket extends Socket {
         return new LinuxSocket(newSocketStream0(ipv6));
     }
 
+    public static LinuxSocket newSocketStream(InternetProtocolFamily protocol) {
+        return new LinuxSocket(newSocketStream0(protocol));
+    }
+
     public static LinuxSocket newSocketStream() {
         return newSocketStream(isIPv6Preferred());
     }
 
     public static LinuxSocket newSocketDgram(boolean ipv6) {
         return new LinuxSocket(newSocketDgram0(ipv6));
+    }
+
+    public static LinuxSocket newSocketDgram(InternetProtocolFamily family) {
+        return new LinuxSocket(newSocketDgram0(family));
     }
 
     public static LinuxSocket newSocketDgram() {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -16,6 +16,7 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.DefaultFileRegion;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Socket;
@@ -196,8 +197,16 @@ final class BsdSocket extends Socket {
         return new BsdSocket(newSocketStream0());
     }
 
+    public static BsdSocket newSocketStream(InternetProtocolFamily protocol) {
+        return new BsdSocket(newSocketStream0(protocol));
+    }
+
     public static BsdSocket newSocketDgram() {
         return new BsdSocket(newSocketDgram0());
+    }
+
+    public static BsdSocket newSocketDgram(InternetProtocolFamily protocol) {
+        return new BsdSocket(newSocketDgram0(protocol));
     }
 
     public static BsdSocket newSocketDomain() {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -25,6 +25,7 @@ import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramChannelConfig;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.unix.DatagramSocketAddress;
 import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.IovArray;
@@ -58,6 +59,11 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
 
     public KQueueDatagramChannel() {
         super(null, newSocketDgram(), false);
+        config = new KQueueDatagramChannelConfig(this);
+    }
+
+    public KQueueDatagramChannel(InternetProtocolFamily protocol) {
+        super(null, newSocketDgram(protocol), false);
         config = new KQueueDatagramChannelConfig(this);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -18,6 +18,7 @@ package io.netty.channel.kqueue;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.unix.IovArray;
@@ -34,6 +35,11 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
 
     public KQueueSocketChannel() {
         super(null, BsdSocket.newSocketStream(), false);
+        config = new KQueueSocketChannelConfig(this);
+    }
+
+    public KQueueSocketChannel(InternetProtocolFamily protocol) {
+        super(null, BsdSocket.newSocketStream(protocol), false);
         config = new KQueueSocketChannelConfig(this);
     }
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -16,6 +16,7 @@
 package io.netty.channel.unix;
 
 import io.netty.channel.ChannelException;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 
@@ -499,6 +500,11 @@ public class Socket extends FileDescriptor {
         return isIpv6Preferred;
     }
 
+    public static boolean shouldUseIpv6(InternetProtocolFamily family) {
+        return family == null ? isIPv6Preferred() :
+                        family == InternetProtocolFamily.IPv6;
+    }
+
     private static native boolean isIPv6Preferred0(boolean ipv4Preferred);
 
     private static native boolean isIPv6(int fd);
@@ -534,6 +540,10 @@ public class Socket extends FileDescriptor {
         return newSocketStream0(isIPv6Preferred());
     }
 
+    protected static int newSocketStream0(InternetProtocolFamily protocol) {
+        return newSocketStream0(shouldUseIpv6(protocol));
+    }
+
     protected static int newSocketStream0(boolean ipv6) {
         int res = newSocketStreamFd(ipv6);
         if (res < 0) {
@@ -544,6 +554,10 @@ public class Socket extends FileDescriptor {
 
     protected static int newSocketDgram0() {
         return newSocketDgram0(isIPv6Preferred());
+    }
+
+    protected static int newSocketDgram0(InternetProtocolFamily family) {
+        return newSocketDgram0(shouldUseIpv6(family));
     }
 
     protected static int newSocketDgram0(boolean ipv6) {

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.util.internal.SocketUtils;
 import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.channel.socket.DefaultServerSocketChannelConfig;
@@ -29,7 +30,10 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.net.ProtocolFamily;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
 import java.nio.channels.SelectionKey;
@@ -51,7 +55,21 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NioServerSocketChannel.class);
 
-    private static ServerSocketChannel newSocket(SelectorProvider provider) {
+    private static final Method OPEN_SERVER_SOCKET_CHANNEL_WITH_FAMILY;
+
+    static {
+        Method found = null;
+        try {
+            found = SelectorProvider.class.getMethod(
+                            "openServerSocketChannel", ProtocolFamily.class);
+        } catch (Throwable e) {
+            logger.info("openServerSocketChannel(ProtocolFamily) not available, will use default method", e);
+        }
+        OPEN_SERVER_SOCKET_CHANNEL_WITH_FAMILY = found;
+    }
+
+    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
+    private static ServerSocketChannel newSocket(SelectorProvider provider, InternetProtocolFamily family) {
         try {
             /**
              *  Use the {@link SelectorProvider} to open {@link SocketChannel} and so remove condition in
@@ -59,6 +77,16 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
              *
              *  See <a href="https://github.com/netty/netty/issues/2308">#2308</a>.
              */
+            if (family != null && OPEN_SERVER_SOCKET_CHANNEL_WITH_FAMILY != null) {
+                try {
+                    return (ServerSocketChannel) OPEN_SERVER_SOCKET_CHANNEL_WITH_FAMILY.invoke(
+                                    provider, ProtocolFamilyConverter.convert(family));
+                } catch (InvocationTargetException e) {
+                    throw new IOException(e);
+                } catch (IllegalAccessException e) {
+                    throw new IOException(e);
+                }
+            }
             return provider.openServerSocketChannel();
         } catch (IOException e) {
             throw new ChannelException(
@@ -72,14 +100,21 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
      * Create a new instance
      */
     public NioServerSocketChannel() {
-        this(newSocket(DEFAULT_SELECTOR_PROVIDER));
+        this(DEFAULT_SELECTOR_PROVIDER);
     }
 
     /**
      * Create a new instance using the given {@link SelectorProvider}.
      */
     public NioServerSocketChannel(SelectorProvider provider) {
-        this(newSocket(provider));
+        this(provider, null);
+    }
+
+    /**
+     * Create a new instance using the given {@link SelectorProvider} and protocol family (supported only since JDK 15).
+     */
+    public NioServerSocketChannel(SelectorProvider provider, InternetProtocolFamily family) {
+        this(newSocket(provider, family));
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -28,6 +28,7 @@ import io.netty.channel.FileRegion;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioByteChannel;
 import io.netty.channel.socket.DefaultSocketChannelConfig;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -39,7 +40,10 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.net.ProtocolFamily;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -58,6 +62,19 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NioSocketChannel.class);
     private static final SelectorProvider DEFAULT_SELECTOR_PROVIDER = SelectorProvider.provider();
 
+    private static final Method OPEN_SOCKET_CHANNEL_WITH_FAMILY;
+
+    static {
+        Method found = null;
+        try {
+            found = SelectorProvider.class.getMethod(
+                            "openSocketChannel", ProtocolFamily.class);
+        } catch (Throwable e) {
+            logger.warn("openSocketChannel(ProtocolFamily) not available, will use default", e);
+        }
+        OPEN_SOCKET_CHANNEL_WITH_FAMILY = found;
+    }
+
     private static SocketChannel newSocket(SelectorProvider provider) {
         try {
             /**
@@ -66,6 +83,31 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
              *
              *  See <a href="https://github.com/netty/netty/issues/2308">#2308</a>.
              */
+            return provider.openSocketChannel();
+        } catch (IOException e) {
+            throw new ChannelException("Failed to open a socket.", e);
+        }
+    }
+
+    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
+    private static SocketChannel newSocket(SelectorProvider provider, InternetProtocolFamily family) {
+        try {
+            /**
+             *  Use the {@link SelectorProvider} to open {@link SocketChannel} and so remove condition in
+             *  {@link SelectorProvider#provider()} which is called by each SocketChannel.open() otherwise.
+             *
+             *  See <a href="https://github.com/netty/netty/issues/2308">#2308</a>.
+             */
+            if (family != null && OPEN_SOCKET_CHANNEL_WITH_FAMILY != null) {
+                try {
+                    return (SocketChannel) OPEN_SOCKET_CHANNEL_WITH_FAMILY.invoke(
+                                    provider, ProtocolFamilyConverter.convert(family));
+                } catch (InvocationTargetException e) {
+                    throw new IOException(e);
+                } catch (IllegalAccessException e) {
+                    throw new IOException(e);
+                }
+            }
             return provider.openSocketChannel();
         } catch (IOException e) {
             throw new ChannelException("Failed to open a socket.", e);
@@ -85,7 +127,14 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
      * Create a new instance using the given {@link SelectorProvider}.
      */
     public NioSocketChannel(SelectorProvider provider) {
-        this(newSocket(provider));
+        this(provider, null);
+    }
+
+    /**
+     * Create a new instance using the given {@link SelectorProvider} and protocol family (supported only since JDK 15).
+     */
+    public NioSocketChannel(SelectorProvider provider, InternetProtocolFamily family) {
+        this(newSocket(provider, family));
     }
 
     /**


### PR DESCRIPTION
Motivation:

Netty should be able to bind to specific protocol family only (IPv4, IPv6) if requested by the caller.

Modification:

Added `InternetProtocolFamily` to `SocketChannel` constructors.

Result:

Fixes #12269 
