### PR TITLE
Don't call strdup on packagePrefix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.3.Final</version>
+        <version>0.0.4.Final-SNAPSHOT</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.4.Final-SNAPSHOT</version>
+        <version>0.0.4.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>

--- a/resolver-dns-native-macos/src/main/c/netty5_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty5_resolver_dns_macos.c
@@ -191,9 +191,7 @@ static jint netty5_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, const char*
     NETTY_JNI_UTIL_LOAD_CLASS(env, byteArrayClass, "[B", done);
     NETTY_JNI_UTIL_LOAD_CLASS(env, stringClass, "java/lang/String", done);
 
-    if (packagePrefix != NULL) {
-        staticPackagePrefix = strdup(packagePrefix);
-    }
+    staticPackagePrefix = packagePrefix;
 
     ret = NETTY_JNI_UTIL_JNI_VERSION;
 done:

--- a/transport-native-epoll/src/main/c/netty5_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty5_epoll_native.c
@@ -761,9 +761,7 @@ static jint netty5_epoll_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefi
 
     ret = NETTY_JNI_UTIL_JNI_VERSION;
 
-    if (packagePrefix != NULL) {
-        staticPackagePrefix = strdup(packagePrefix);
-    }
+    staticPackagePrefix = packagePrefix;
 done:
 
     netty_jni_util_free_dynamic_methods_table(dynamicMethods, fixed_method_table_size, dynamicMethodsTableSize());

--- a/transport-native-kqueue/src/main/c/netty5_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty5_kqueue_native.c
@@ -404,9 +404,7 @@ static jint netty5_kqueue_native_JNI_OnLoad(JNIEnv* env, const char* packagePref
         goto error;
     }
 
-    if (packagePrefix != NULL) {
-        staticPackagePrefix = strdup(packagePrefix);
-    }
+    staticPackagePrefix = packagePrefix;
     return NETTY_JNI_UTIL_JNI_VERSION;
 error:
    if (staticallyRegistered == 1) {

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -298,7 +298,7 @@
                       <env key="LIB_DIR" value="${nativeLibOnlyDir}" />
                       <env key="OBJ_DIR" value="${nativeObjsOnlyDir}" />
                       <env key="JNI_PLATFORM" value="${jni.platform}" />
-                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden" />
+                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -std=gnu99" />
                       <env key="LDFLAGS" value="-Wl,--no-as-needed -lrt" />
                       <env key="LIB_NAME" value="${nativeLibName}" />
                     </exec>
@@ -368,7 +368,7 @@
                       <env key="LIB_DIR" value="${nativeLibOnlyDir}" />
                       <env key="OBJ_DIR" value="${nativeObjsOnlyDir}" />
                       <env key="JNI_PLATFORM" value="${jni.platform}" />
-                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden" />
+                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -std=gnu99" />
                       <env key="LDFLAGS" value="-Wl,--no-as-needed -lrt" />
                       <env key="LIB_NAME" value="${nativeLibName}" />
                     </exec>
@@ -442,7 +442,7 @@
                       <env key="LIB_DIR" value="${nativeLibOnlyDir}" />
                       <env key="OBJ_DIR" value="${nativeObjsOnlyDir}" />
                       <env key="JNI_PLATFORM" value="${jni.platform}" />
-                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden" />
+                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -std=gnu99" />
                       <env key="LDFLAGS" value="-Wl,--no-as-needed -lrt" />
                       <env key="LIB_NAME" value="${nativeLibName}" />
                     </exec>
@@ -516,7 +516,7 @@
                       <env key="LIB_DIR" value="${nativeLibOnlyDir}" />
                       <env key="OBJ_DIR" value="${nativeObjsOnlyDir}" />
                       <env key="JNI_PLATFORM" value="${jni.platform}" />
-                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden" />
+                      <env key="CFLAGS" value="-O3 -Werror -Wno-attributes -fPIC -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -std=gnu99" />
                       <env key="LDFLAGS" value="-Wl,--no-as-needed -lrt" />
                       <env key="LIB_NAME" value="${nativeLibName}" />
                     </exec>


### PR DESCRIPTION
Improves musl compatibility and slightly improves efficiency.

Requires https://github.com/netty/netty-jni-util/pull/8.

Together with netty-jni-util#8, fixes #11701.