### PR TITLE
Don't expect buffers to be pre-zeroed

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PooledBufferAllocator.java
@@ -315,7 +315,7 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
         Drop<Buffer> drop = memory.drop();
         Buffer buffer = manager.recoverMemory(control, memory.memory(), drop);
         drop.attach(buffer);
-        return buffer.fill((byte) 0);
+        return buffer;
     }
 
     @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
@@ -504,9 +504,6 @@ public class BufferLifeCycleTest extends BufferTestSupport {
                     assertEquals(expected.readerOffset(), buf.readerOffset());
                     assertEquals(expected.writableBytes(), buf.writableBytes());
                     assertEquals(expected.writerOffset(), buf.writerOffset());
-                    byte[] bytes = new byte[8];
-                    buf.copyInto(0, bytes, 0, 8);
-                    assertThat(bytes).containsExactly(0, 0, 0, 0, 0, 0, 0, 0);
 
                     var tlr = ThreadLocalRandom.current();
                     for (int j = 0; j < tlr.nextInt(0, 8); j++) {


### PR DESCRIPTION
Motivation:
`ByteBuf` did not let people expect their unwritten area to be zeroed on allocation.
We can remove that overhead, since no code is relying on it anyway.

Modification:
The `PooledBufferAllocator` no longer zeroes buffers on allocation.
Fix the one test that was asserting buffers were zeroed.

Result:
Allocation with `PooledBufferAllocator` is now faster.
