### PR TITLE
Release our strong references to memory faster

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolArena.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolArena.java
@@ -450,6 +450,7 @@ class PoolArena extends SizeClasses implements PoolArenaMetric {
             PoolSubpage page = (PoolSubpage) SUBPAGE_ARRAY.getVolatile(smallSubpagePools, i);
             if (page != null) {
                 page.destroy();
+                SUBPAGE_ARRAY.setVolatile(smallSubpagePools, i, null);
             }
         }
         for (PoolChunkList list : new PoolChunkList[] {qInit, q000, q025, q050, q100}) {

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunkList.java
@@ -242,7 +242,10 @@ final class PoolChunkList implements PoolChunkListMetric {
         PoolChunk chunk = head;
         while (chunk != null) {
             chunk.destroy();
+            PoolChunk tmp = chunk;
             chunk = chunk.next;
+            tmp.next = null;
+            tmp.prev = null;
         }
         head = null;
     }


### PR DESCRIPTION
Motivation:
Now that PoolArenas are once again strongly referenced by the PoolThreadCache, it turns out long-lived threads can keep a lot of memory alive from closed pooled allocators.

Modification:
When the PooledBufferAllocator is closed, we go out of our way to null-out references to PoolChunks in the smallSubpagePools array, and in the PoolChunkLists.
Loosing the references to the closed PoolChunks allows the GC to collect the heap memory that might have been held alive by the PoolChunk.memory field.

Result:
We no longer accidentally hold on to memory we don't need.