### PR TITLE
Allow explicit choice of internet family

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -98,9 +98,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      * on the Operation Systems default which will be chosen.
      */
     public EpollDatagramChannel(EventLoop eventLoop, InternetProtocolFamily family) {
-        this(eventLoop, family == null ?
-            newSocketDgram(Socket.isIPv6Preferred()) :
-            newSocketDgram(family == InternetProtocolFamily.IPv6),
+        this(eventLoop, newSocketDgram(family),
         false);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollServerSocketChannel.java
@@ -18,6 +18,7 @@ package io.netty5.channel.epoll;
 import io.netty5.channel.Channel;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.socket.ServerSocketChannel;
 
 import java.io.IOException;
@@ -42,7 +43,12 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();
 
     public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
-        super(eventLoop, childEventLoopGroup, newSocketStream(), false);
+        this(eventLoop, childEventLoopGroup, (InternetProtocolFamily) null);
+    }
+
+    public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                    InternetProtocolFamily protocolFamily) {
+        super(eventLoop, childEventLoopGroup, newSocketStream(protocolFamily), false);
         config = new EpollServerSocketChannelConfig(this);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollSocketChannel.java
@@ -22,6 +22,7 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.EventLoop;
+import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.util.concurrent.GlobalEventExecutor;
@@ -49,7 +50,11 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
     private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();
 
     public EpollSocketChannel(EventLoop eventLoop) {
-        super(eventLoop, newSocketStream(), false);
+        this(eventLoop, null);
+    }
+
+    public EpollSocketChannel(EventLoop eventLoop, InternetProtocolFamily protocolFamily) {
+        super(eventLoop, newSocketStream(protocolFamily), false);
         config = new EpollSocketChannelConfig(this);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/LinuxSocket.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/LinuxSocket.java
@@ -328,12 +328,20 @@ public final class LinuxSocket extends Socket {
         return new LinuxSocket(newSocketStream0(ipv6));
     }
 
+    public static LinuxSocket newSocketStream(InternetProtocolFamily protocol) {
+        return new LinuxSocket(newSocketStream0(protocol));
+    }
+
     public static LinuxSocket newSocketStream() {
         return newSocketStream(isIPv6Preferred());
     }
 
     public static LinuxSocket newSocketDgram(boolean ipv6) {
         return new LinuxSocket(newSocketDgram0(ipv6));
+    }
+
+    public static LinuxSocket newSocketDgram(InternetProtocolFamily family) {
+        return new LinuxSocket(newSocketDgram0(family));
     }
 
     public static LinuxSocket newSocketDgram() {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/BsdSocket.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/BsdSocket.java
@@ -16,6 +16,8 @@
 package io.netty5.channel.kqueue;
 
 import io.netty5.channel.DefaultFileRegion;
+import io.netty5.channel.socket.InternetProtocolFamily;
+
 import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.PeerCredentials;
 import io.netty5.channel.unix.Socket;
@@ -196,8 +198,16 @@ final class BsdSocket extends Socket {
         return new BsdSocket(newSocketStream0());
     }
 
+    public static BsdSocket newSocketStream(InternetProtocolFamily protocol) {
+        return new BsdSocket(newSocketStream0(protocol));
+    }
+
     public static BsdSocket newSocketDgram() {
         return new BsdSocket(newSocketDgram0());
+    }
+
+    public static BsdSocket newSocketDgram(InternetProtocolFamily protocol) {
+        return new BsdSocket(newSocketDgram0(protocol));
     }
 
     public static BsdSocket newSocketDomain() {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -28,6 +28,7 @@ import io.netty5.channel.socket.BufferDatagramPacket;
 import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.DatagramChannelConfig;
 import io.netty5.channel.socket.DatagramPacket;
+import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.unix.DatagramSocketAddress;
 import io.netty5.channel.unix.Errors;
 import io.netty5.channel.unix.IovArray;
@@ -64,7 +65,11 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     private final KQueueDatagramChannelConfig config;
 
     public KQueueDatagramChannel(EventLoop eventLoop) {
-        super(null, eventLoop, newSocketDgram(), false);
+        this(eventLoop, null);
+    }
+
+    public KQueueDatagramChannel(EventLoop eventLoop, InternetProtocolFamily protocolFamily) {
+        super(null, eventLoop, newSocketDgram(protocolFamily), false);
         config = new KQueueDatagramChannelConfig(this);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelOutboundBuffer;
 import io.netty5.channel.EventLoop;
+import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.socket.ServerSocketChannel;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.unix.IovArray;
@@ -34,7 +35,11 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
     private final KQueueSocketChannelConfig config;
 
     public KQueueSocketChannel(EventLoop eventLoop) {
-        super(null, eventLoop, BsdSocket.newSocketStream(), false);
+        this(eventLoop, null);
+    }
+
+    public KQueueSocketChannel(EventLoop eventLoop, InternetProtocolFamily protocol) {
+        super(null, eventLoop, BsdSocket.newSocketStream(protocol), false);
         config = new KQueueSocketChannelConfig(this);
     }
 

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/Socket.java
@@ -16,6 +16,7 @@
 package io.netty5.channel.unix;
 
 import io.netty5.channel.ChannelException;
+import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
@@ -499,6 +500,11 @@ public class Socket extends FileDescriptor {
         return isIpv6Preferred;
     }
 
+    public static boolean shouldUseIpv6(InternetProtocolFamily family) {
+        return family == null ? isIPv6Preferred() :
+                        family == InternetProtocolFamily.IPv6;
+    }
+
     private static native boolean isIPv6Preferred0(boolean ipv4Preferred);
 
     private static native boolean isIPv6(int fd);
@@ -534,6 +540,10 @@ public class Socket extends FileDescriptor {
         return newSocketStream0(isIPv6Preferred());
     }
 
+    protected static int newSocketStream0(InternetProtocolFamily protocol) {
+        return newSocketStream0(shouldUseIpv6(protocol));
+    }
+
     protected static int newSocketStream0(boolean ipv6) {
         int res = newSocketStreamFd(ipv6);
         if (res < 0) {
@@ -544,6 +554,10 @@ public class Socket extends FileDescriptor {
 
     protected static int newSocketDgram0() {
         return newSocketDgram0(isIPv6Preferred());
+    }
+
+    protected static int newSocketDgram0(InternetProtocolFamily family) {
+        return newSocketDgram0(shouldUseIpv6(family));
     }
 
     protected static int newSocketDgram0(boolean ipv6) {


### PR DESCRIPTION
Motivation:

Netty should be able to bind to specific protocol family only (IPv4, IPv6) if requested by the caller.

Modification:

Added `InternetProtocolFamily` to `SocketChannel` constructors.

Result:

Fixes #12269
