### PR TITLE
Correctly encode result even if no timeout is used

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -171,7 +171,8 @@ public final class Native {
                                 int timeoutSec, int timeoutNs, long millisThreshold) throws IOException {
         if (timeoutSec == 0 && timeoutNs == 0) {
             // Zero timeout => poll (aka return immediately)
-            return epollWait(epollFd, events, 0);
+            // We shift this to be consistent with what is done in epollWait0(...)
+            return (((long) epollWait(epollFd, events, 0)) << 32);
         }
         if (timeoutSec == Integer.MAX_VALUE) {
             // Max timeout => wait indefinitely: disarm timerfd first

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -172,7 +172,7 @@ public final class Native {
         if (timeoutSec == 0 && timeoutNs == 0) {
             // Zero timeout => poll (aka return immediately)
             // We shift this to be consistent with what is done in epollWait0(...)
-            return (((long) epollWait(epollFd, events, 0)) << 32);
+            return ((long) epollWait(epollFd, events, 0)) << 32;
         }
         if (timeoutSec == Integer.MAX_VALUE) {
             // Max timeout => wait indefinitely: disarm timerfd first

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -137,7 +137,6 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
         }
     }
 
-
     @Test
     public void testResultNoTimeoutCorrectlyEncoded() throws Throwable {
         final FileDescriptor epoll = Native.newEpollCreate();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -136,4 +136,50 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
             timerFd.close();
         }
     }
+
+
+    @Test
+    public void testResultNoTimeoutCorrectlyEncoded() throws Throwable {
+        final FileDescriptor epoll = Native.newEpollCreate();
+        final FileDescriptor eventFd = Native.newEventFd();
+        final FileDescriptor timerFd = Native.newTimerFd();
+        final EpollEventArray array = new EpollEventArray(1024);
+        try {
+            Native.epollCtlAdd(epoll.intValue(), eventFd.intValue(), Native.EPOLLIN | Native.EPOLLET);
+            final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
+            final Thread t = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        for (;;) {
+                            long ready = Native.epollWait(epoll, array, timerFd, 0, 0, 10);
+                            if (ready > 0) {
+                                assertEquals(1, Native.epollReady(ready));
+                                assertEquals(eventFd.intValue(), array.fd(0));
+                                return;
+                            }
+                            Thread.sleep(100);
+                        }
+                    } catch (IOException e) {
+                        causeRef.set(e);
+                    } catch (InterruptedException ignore) {
+                        // ignore
+                    }
+                }
+            });
+            t.start();
+            Native.eventFdWrite(eventFd.intValue(), 1);
+
+            t.join();
+            Throwable cause = causeRef.get();
+            if (cause != null) {
+                throw cause;
+            }
+        } finally {
+            array.free();
+            epoll.close();
+            eventFd.close();
+            timerFd.close();
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

86004b7303621784f7ec8850323d9a707f17f9f8 did introduce a change to reduc the syscalls but missed to correctly encode the result in the case of no timeout used.

Modifications:

Correctly shift the result

Result:

Correctly behaviour even when no timeout is used. Fixes https://github.com/netty/netty/issues/12280