### PR TITLE
NioBuffer::copyInto array fast path

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -218,6 +218,14 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             throw new IllegalArgumentException("The srcPos + length is beyond the end of the buffer: " +
                     "srcPos = " + srcPos + ", length = " + length + '.');
         }
+        if (dest.hasArray() && hasReadableArray()) {
+            final byte[] srcArray = rmem.array();
+            final int srcStart = rmem.arrayOffset() + srcPos;
+            final byte[] dstArray = dest.array();
+            final int dstStart = dest.arrayOffset() + destPos;
+            System.arraycopy(srcArray, srcStart, dstArray, dstStart, length);
+            return;
+        }
         dest = dest.duplicate().clear();
         bbput(dest, destPos, rmem, srcPos, length);
     }


### PR DESCRIPTION
Motivation:

NioBuffer::copyInto create intermediate slice/duplicates to perform a copy

Modification:

Uses System::arrayCopy if possible to use an idiomatic intrinsic, always present regardless the JDK version used and save potential garbage to be created.

Result:

Less garbage and faster array copy