### PR TITLE
ArcDrop doesn't need a volatile set on instance creation

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/internal/ArcDrop.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/ArcDrop.java
@@ -36,7 +36,6 @@ public final class ArcDrop<T> implements Drop<T> {
 
     public ArcDrop(Drop<T> delegate) {
         this.delegate = delegate;
-        count = 1;
     }
 
     public static <X> Drop<X> wrap(Drop<X> drop) {
@@ -72,7 +71,7 @@ public final class ArcDrop<T> implements Drop<T> {
             n = c - 1;
             checkValidState(c);
         } while (!COUNT.compareAndSet(this, c, n));
-        if (n == 0) {
+        if (n == -1) {
             delegate.drop(obj);
         }
     }
@@ -105,7 +104,7 @@ public final class ArcDrop<T> implements Drop<T> {
     }
 
     private static void checkValidState(int count) {
-        if (count == 0) {
+        if (count == -1) {
             throw new IllegalStateException("Underlying resources have already been freed.");
         }
     }


### PR DESCRIPTION
Motivation:

ArcDrop is using a volatile set to initialize its internal field, but that's costy and unnecessary

Modification:

Changing the logic to just use the default initial value

Result:

Faster ArcDrop allocation