### PR TITLE
Ensure ByteBufBuffer#transferFrom starts writing from writerOffset

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -310,7 +310,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
         if (channel instanceof ScatteringByteChannel) {
             ScatteringByteChannel scatteringByteChannel = (ScatteringByteChannel) channel;
-            int bytesRead = delegate.setBytes(readerOffset(), scatteringByteChannel, length);
+            int bytesRead = delegate.setBytes(writerOffset(), scatteringByteChannel, length);
             if (bytesRead > 0) {
                 skipWritable(bytesRead);
             }


### PR DESCRIPTION
Motivation:

`ByteBufBuffer#transferFrom` uses `readerOffset` when transfers data from a channel to the buffer,
this causes data to be overwritten.

Modification:

- Ensure `ByteBufBuffer#transferFrom` starts writing from `writerOffset`
- Add junit test

Result:

The channel's data is transferred correctly.