### PR TITLE
AbstractReferenceCountedByteBuf can save using a volatile set on constructor

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -18,7 +18,6 @@ package io.netty.buffer;
 
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReferenceCountUpdater;
 
 /**
@@ -48,12 +47,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
 
     protected AbstractReferenceCountedByteBuf(int maxCapacity) {
         super(maxCapacity);
-        if (!PlatformDependent.hasUnsafe()) {
-            refCnt = updater.initialValue();
-        } else {
-            PlatformDependent.putInt(this, REFCNT_FIELD_OFFSET, updater.initialValue());
-            PlatformDependent.storeFence();
-        }
+        updater.setInitialValue(this);
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -504,12 +504,8 @@ public final class PlatformDependent {
         return PlatformDependent0.getInt(object, fieldOffset);
     }
 
-    public static void putInt(Object object, long fieldOffset, int value) {
-        PlatformDependent0.putInt(object, fieldOffset, value);
-    }
-
-    public static void storeFence() {
-        PlatformDependent0.storeFence();
+    static void safeConstructPutInt(Object object, long fieldOffset, int value) {
+        PlatformDependent0.safeConstructPutInt(object, fieldOffset, value);
     }
 
     public static int getIntVolatile(long address) {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -504,6 +504,14 @@ public final class PlatformDependent {
         return PlatformDependent0.getInt(object, fieldOffset);
     }
 
+    public static void putInt(Object object, long fieldOffset, int value) {
+        PlatformDependent0.putInt(object, fieldOffset, value);
+    }
+
+    public static void storeFence() {
+        PlatformDependent0.storeFence();
+    }
+
     public static int getIntVolatile(long address) {
         return PlatformDependent0.getIntVolatile(address);
     }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -49,6 +49,7 @@ final class PlatformDependent0 {
     private static final Method ALIGN_SLICE;
     private static final int JAVA_VERSION = javaVersion0();
     private static final boolean IS_ANDROID = isAndroid0();
+    private static final boolean STORE_FENCE_AVAILABLE;
 
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE;
     private static final Object INTERNAL_UNSAFE;
@@ -81,7 +82,7 @@ final class PlatformDependent0 {
         Throwable unsafeUnavailabilityCause = null;
         Unsafe unsafe;
         Object internalUnsafe = null;
-
+        boolean storeFenceAvailable = false;
         if ((unsafeUnavailabilityCause = EXPLICIT_NO_UNSAFE_CAUSE) != null) {
             direct = null;
             addressField = null;
@@ -170,6 +171,38 @@ final class PlatformDependent0 {
                 }
             }
 
+            // ensure Unsafe::storeFence to be available: jdk < 8 shouldn't have it
+            if (unsafe != null) {
+                final Unsafe finalUnsafe = unsafe;
+                final Object maybeException = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                    @Override
+                    public Object run() {
+                        try {
+                            finalUnsafe.getClass().getDeclaredMethod("storeFence");
+                            return null;
+                        } catch (NoSuchMethodException e) {
+                            return e;
+                        } catch (SecurityException e) {
+                            return e;
+                        }
+                    }
+                });
+
+                if (maybeException == null) {
+                    logger.debug("sun.misc.Unsafe.storeFence: available");
+                    storeFenceAvailable = true;
+                } else {
+                    storeFenceAvailable = false;
+                    // Unsafe.storeFence unavailable.
+                    if (logger.isTraceEnabled()) {
+                        logger.debug("sun.misc.Unsafe.storeFence: unavailable", (Throwable) maybeException);
+                    } else {
+                        logger.debug("sun.misc.Unsafe.storeFence: unavailable: {}",
+                                     ((Throwable) maybeException).getMessage());
+                    }
+                }
+            }
+
             if (unsafe != null) {
                 final Unsafe finalUnsafe = unsafe;
 
@@ -239,6 +272,7 @@ final class PlatformDependent0 {
             UNALIGNED = false;
             DIRECT_BUFFER_CONSTRUCTOR = null;
             ALLOCATE_ARRAY_METHOD = null;
+            STORE_FENCE_AVAILABLE = false;
         } else {
             Constructor<?> directBufferConstructor;
             long address = -1;
@@ -424,6 +458,7 @@ final class PlatformDependent0 {
                 logger.debug("jdk.internal.misc.Unsafe.allocateUninitializedArray(int): unavailable prior to Java9");
             }
             ALLOCATE_ARRAY_METHOD = allocateArrayMethod;
+            STORE_FENCE_AVAILABLE = storeFenceAvailable;
         }
 
         if (javaVersion() > 9) {
@@ -575,12 +610,13 @@ final class PlatformDependent0 {
         return UNSAFE.getInt(object, fieldOffset);
     }
 
-    static void putInt(Object object, long fieldOffset, int value) {
-        UNSAFE.putInt(object, fieldOffset, value);
-    }
-
-    static void storeFence() {
-        UNSAFE.storeFence();
+    static void safeConstructPutInt(Object object, long fieldOffset, int value) {
+        if (STORE_FENCE_AVAILABLE) {
+            UNSAFE.putInt(object, fieldOffset, value);
+            UNSAFE.storeFence();
+        } else {
+            UNSAFE.putIntVolatile(object, fieldOffset, value);
+        }
     }
 
     private static long getLong(Object object, long fieldOffset) {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -575,6 +575,14 @@ final class PlatformDependent0 {
         return UNSAFE.getInt(object, fieldOffset);
     }
 
+    static void putInt(Object object, long fieldOffset, int value) {
+        UNSAFE.putInt(object, fieldOffset, value);
+    }
+
+    static void storeFence() {
+        UNSAFE.storeFence();
+    }
+
     private static long getLong(Object object, long fieldOffset) {
         return UNSAFE.getLong(object, fieldOffset);
     }

--- a/common/src/main/java/io/netty/util/internal/ReferenceCountUpdater.java
+++ b/common/src/main/java/io/netty/util/internal/ReferenceCountUpdater.java
@@ -59,6 +59,15 @@ public abstract class ReferenceCountUpdater<T extends ReferenceCounted> {
         return 2;
     }
 
+    public void setInitialValue(T instance) {
+        final long offset = unsafeOffset();
+        if (offset == -1) {
+            updater().set(instance, initialValue());
+        } else {
+            PlatformDependent.safeConstructPutInt(instance, offset, initialValue());
+        }
+    }
+
     private static int realRefCnt(int rawCnt) {
         return rawCnt != 2 && rawCnt != 4 && (rawCnt & 1) != 0 ? 0 : rawCnt >>> 1;
     }

--- a/microbench/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBufBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBufBenchmark.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.GroupThreads;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -55,6 +56,17 @@ public class AbstractReferenceCountedByteBufBenchmark extends AbstractMicrobench
         buf.retain();
         Blackhole.consumeCPU(delay);
         return buf.release();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public boolean createUseAndRelease(Blackhole useBuffer) {
+        ByteBuf unpooled = Unpooled.buffer(1);
+        useBuffer.consume(unpooled);
+        Blackhole.consumeCPU(delay);
+        return unpooled.release();
     }
 
     @Benchmark


### PR DESCRIPTION
Motivation:

AbstractReferenceCountedByteBuf can be made faster by ensure proper safe initialization vs volatile set on construction

Modification:

Using Unsafe and plain store instead of volatile set

Result:

Faster AbstractReferenceCountedByteBuf allocation