### PR TITLE
Log specific exception to debug ParameterizedSslHandlerTest

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -47,6 +47,8 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ResourcesUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -636,6 +638,8 @@ public class ParameterizedSslHandlerTest {
     }
 
     private static final class ReentryWriteSslHandshakeHandler extends SimpleChannelInboundHandler<ByteBuf> {
+        private static final InternalLogger LOGGER =
+                InternalLoggerFactory.getInstance(ReentryWriteSslHandshakeHandler.class);
         private final String toWrite;
         private final StringBuilder readQueue;
         private final CountDownLatch doneLatch;
@@ -681,6 +685,7 @@ public class ParameterizedSslHandlerTest {
         }
 
         private void appendError(Throwable cause) {
+            LOGGER.error(new Exception("Caught possible write failure in ParameterizedSslHandlerTest.", cause));
             readQueue.append("failed to write '").append(toWrite).append("': ");
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
Motivation:
We have been seeing this test fail intermittently on Windows for some time.
The stack trace of the exception was supposed to be included in the test failure output, but we don't see it in practice.

Modification:
Add some logging to the test, so when it is about to fail, it will capture additional context in the log.

Result:
Hopefully we'll be able to debug this test in the future.