### PR TITLE
Fix data race bug in `PooledBufferAllocator`

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunk.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunk.java
@@ -566,24 +566,20 @@ final class PoolChunk implements PoolChunkMetric {
         private final PoolThreadCache threadCache;
         private final long handle;
         private final int maxLength;
-        private final int offset;
-        private final int size;
 
         private UntetheredChunkAllocation(
                 Object memory, PoolChunk chunk, PoolThreadCache threadCache,
                 long handle, int maxLength, int offset, int size) {
-            this.memory = memory;
+            this.memory = chunk.arena.manager.sliceMemory(memory, offset, size);
             this.chunk = chunk;
             this.threadCache = threadCache;
             this.handle = handle;
             this.maxLength = maxLength;
-            this.offset = offset;
-            this.size = size;
         }
 
         @Override
         public <Memory> Memory memory() {
-            return (Memory) chunk.arena.manager.sliceMemory(memory, offset, size);
+            return (Memory) memory;
         }
 
         @Override


### PR DESCRIPTION
Motivation:
When it comes to the `ByteBuffer` based Buffer implementation, the `MemoryManager.sliceMemory()` method works by mutating position and limit of the underlying `ByteBuffer` object, that in the case of `PoolChunk` is the shared memory field.
These mutations must be done under the protection of the locks in the pool, so the slicing must be done eagerly rather than lazily.

Modification:
Move the `sliceMemory()` call from the `memory()` accessor method to the constructor of `UntetheredChunkAllocation`.
The constructor is called under the protection of the locks inside the allocator, while the `memory()` accessor was not.

Result:
The `PooledBufferAllocator` should now be as thread-safe as it was intended to be.