### PR TITLE
Remove ORIGIN header from ws opening handshake v13, clean up code

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -40,7 +40,6 @@ import io.netty5.util.concurrent.Promise;
 
 import java.net.URI;
 import java.nio.channels.ClosedChannelException;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
@@ -51,8 +50,6 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class WebSocketClientHandshaker {
 
-    private static final String HTTP_SCHEME_PREFIX = HttpScheme.HTTP + "://";
-    private static final String HTTPS_SCHEME_PREFIX = HttpScheme.HTTPS + "://";
     protected static final int DEFAULT_FORCE_CLOSE_TIMEOUT_MILLIS = 10000;
 
     private final URI uri;
@@ -547,32 +544,5 @@ public abstract class WebSocketClientHandshaker {
         // if the port is not standard (80/443) its needed to add the port to the header.
         // See https://tools.ietf.org/html/rfc6454#section-6.2
         return NetUtil.toSocketAddressString(host, port);
-    }
-
-    static CharSequence websocketOriginValue(URI wsURL) {
-        String scheme = wsURL.getScheme();
-        final String schemePrefix;
-        int port = wsURL.getPort();
-        final int defaultPort;
-        if (WebSocketScheme.WSS.name().contentEquals(scheme)
-            || HttpScheme.HTTPS.name().contentEquals(scheme)
-            || (scheme == null && port == WebSocketScheme.WSS.port())) {
-
-            schemePrefix = HTTPS_SCHEME_PREFIX;
-            defaultPort = WebSocketScheme.WSS.port();
-        } else {
-            schemePrefix = HTTP_SCHEME_PREFIX;
-            defaultPort = WebSocketScheme.WS.port();
-        }
-
-        // Convert uri-host to lower case (by RFC 6454, chapter 4 "Origin of a URI")
-        String host = wsURL.getHost().toLowerCase(Locale.US);
-
-        if (port != defaultPort && port != -1) {
-            // if the port is not standard (80/443) its needed to add the port to the header.
-            // See https://tools.ietf.org/html/rfc6454#section-6.2
-            return schemePrefix + NetUtil.toSocketAddressString(host, port);
-        }
-        return schemePrefix + host;
     }
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -31,8 +31,8 @@ import java.net.URI;
 
 /**
  * <p>
- * Performs client side opening and closing handshakes for web socket specification version <a
- * href="https://datatracker.ietf.org/doc/html/rfc6455">websocketprotocol-v13</a>
+ * Performs client side opening and closing handshakes for web socket specification version
+ * <a href="https://datatracker.ietf.org/doc/html/rfc6455">websocketprotocol-v13</a>
  * </p>
  */
 public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
@@ -198,7 +198,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
             headers.set(HttpHeaderNames.HOST, websocketHostValue(wsURL));
         }
 
-        var nonce = createNonce();
+        String nonce = createNonce();
         headers.set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, nonce);
@@ -232,12 +232,12 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      */
     @Override
     protected void verify(FullHttpResponse response) {
-        var status = response.status();
+        HttpResponseStatus status = response.status();
         if (!HttpResponseStatus.SWITCHING_PROTOCOLS.equals(status)) {
             throw new WebSocketClientHandshakeException("Invalid handshake response status: " + status, response);
         }
 
-        var headers = response.headers();
+        HttpHeaders headers = response.headers();
         CharSequence upgrade = headers.get(HttpHeaderNames.UPGRADE);
         if (!HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(upgrade)) {
             throw new WebSocketClientHandshakeException("Invalid handshake response upgrade: " + upgrade, response);
@@ -248,13 +248,13 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
                     + headers.get(HttpHeaderNames.CONNECTION), response);
         }
 
-        var accept = headers.get(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT);
+        String accept = headers.get(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT);
         if (accept == null) {
             throw new WebSocketClientHandshakeException("Invalid handshake response sec-websocket-accept: null",
                                                         response);
         }
 
-        var expectedAccept = WebSocketUtil.calculateV13Accept(sentNonce);
+        String expectedAccept = WebSocketUtil.calculateV13Accept(sentNonce);
         if (!expectedAccept.equals(accept.trim())) {
             throw new WebSocketClientHandshakeException("Invalid handshake response sec-websocket-accept: " + accept +
                                                         ", expected: " + expectedAccept, response);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -25,30 +25,23 @@ import io.netty5.handler.codec.http.HttpHeaders;
 import io.netty5.handler.codec.http.HttpMethod;
 import io.netty5.handler.codec.http.HttpResponseStatus;
 import io.netty5.handler.codec.http.HttpVersion;
-import io.netty5.util.CharsetUtil;
-import io.netty5.util.internal.logging.InternalLogger;
-import io.netty5.util.internal.logging.InternalLoggerFactory;
+import io.netty5.util.internal.StringUtil;
 
 import java.net.URI;
 
 /**
  * <p>
  * Performs client side opening and closing handshakes for web socket specification version <a
- * href="https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17" >draft-ietf-hybi-thewebsocketprotocol-
- * 17</a>
+ * href="https://datatracker.ietf.org/doc/html/rfc6455">websocketprotocol-v13</a>
  * </p>
  */
 public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
 
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(WebSocketClientHandshaker13.class);
-
-    public static final String MAGIC_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-
-    private String expectedChallengeResponseString;
-
     private final boolean allowExtensions;
     private final boolean performMasking;
     private final boolean allowMaskMismatch;
+
+    private volatile String sentNonce;
 
     /**
      * Creates a new instance.
@@ -56,8 +49,6 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * @param webSocketURL
      *            URL for web socket communications. e.g "ws://myhost.com/mypath". Subsequent web socket frames will be
      *            sent to this URL.
-     * @param version
-     *            Version of web socket specification to use to connect to the server
      * @param subprotocol
      *            Sub protocol request sent to the server.
      * @param allowExtensions
@@ -67,9 +58,9 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * @param maxFramePayloadLength
      *            Maximum length of a frame's payload
      */
-    public WebSocketClientHandshaker13(URI webSocketURL, WebSocketVersion version, String subprotocol,
+    public WebSocketClientHandshaker13(URI webSocketURL, String subprotocol,
                                        boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength) {
-        this(webSocketURL, version, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength,
+        this(webSocketURL, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength,
                 true, false);
     }
 
@@ -79,8 +70,6 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * @param webSocketURL
      *            URL for web socket communications. e.g "ws://myhost.com/mypath". Subsequent web socket frames will be
      *            sent to this URL.
-     * @param version
-     *            Version of web socket specification to use to connect to the server
      * @param subprotocol
      *            Sub protocol request sent to the server.
      * @param allowExtensions
@@ -97,10 +86,10 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      *            When set to true, frames which are not masked properly according to the standard will still be
      *            accepted.
      */
-    public WebSocketClientHandshaker13(URI webSocketURL, WebSocketVersion version, String subprotocol,
+    public WebSocketClientHandshaker13(URI webSocketURL, String subprotocol,
             boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength,
             boolean performMasking, boolean allowMaskMismatch) {
-        this(webSocketURL, version, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength,
+        this(webSocketURL, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength,
                 performMasking, allowMaskMismatch, DEFAULT_FORCE_CLOSE_TIMEOUT_MILLIS);
     }
 
@@ -110,8 +99,6 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * @param webSocketURL
      *            URL for web socket communications. e.g "ws://myhost.com/mypath". Subsequent web socket frames will be
      *            sent to this URL.
-     * @param version
-     *            Version of web socket specification to use to connect to the server
      * @param subprotocol
      *            Sub protocol request sent to the server.
      * @param allowExtensions
@@ -130,11 +117,11 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * @param forceCloseTimeoutMillis
      *            Close the connection if it was not closed by the server after timeout specified.
      */
-    public WebSocketClientHandshaker13(URI webSocketURL, WebSocketVersion version, String subprotocol,
+    public WebSocketClientHandshaker13(URI webSocketURL, String subprotocol,
                                        boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength,
                                        boolean performMasking, boolean allowMaskMismatch,
                                        long forceCloseTimeoutMillis) {
-        this(webSocketURL, version, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength, performMasking,
+        this(webSocketURL, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength, performMasking,
                 allowMaskMismatch, forceCloseTimeoutMillis, false);
     }
 
@@ -144,8 +131,6 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * @param webSocketURL
      *            URL for web socket communications. e.g "ws://myhost.com/mypath". Subsequent web socket frames will be
      *            sent to this URL.
-     * @param version
-     *            Version of web socket specification to use to connect to the server
      * @param subprotocol
      *            Sub protocol request sent to the server.
      * @param allowExtensions
@@ -167,12 +152,12 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      *            Use an absolute url for the Upgrade request, typically when connecting through an HTTP proxy over
      *            clear HTTP
      */
-    WebSocketClientHandshaker13(URI webSocketURL, WebSocketVersion version, String subprotocol,
+    WebSocketClientHandshaker13(URI webSocketURL, String subprotocol,
                                 boolean allowExtensions, HttpHeaders customHeaders, int maxFramePayloadLength,
                                 boolean performMasking, boolean allowMaskMismatch,
                                 long forceCloseTimeoutMillis, boolean absoluteUpgradeUrl) {
-        super(webSocketURL, version, subprotocol, customHeaders, maxFramePayloadLength, forceCloseTimeoutMillis,
-                absoluteUpgradeUrl);
+        super(webSocketURL, WebSocketVersion.V13, subprotocol, customHeaders, maxFramePayloadLength,
+              forceCloseTimeoutMillis, absoluteUpgradeUrl);
         this.allowExtensions = allowExtensions;
         this.performMasking = performMasking;
         this.allowMaskMismatch = allowMaskMismatch;
@@ -190,7 +175,6 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      * Upgrade: websocket
      * Connection: Upgrade
      * Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
-     * Origin: http://example.com
      * Sec-WebSocket-Protocol: chat, superchat
      * Sec-WebSocket-Version: 13
      * </pre>
@@ -199,22 +183,6 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
     @Override
     protected FullHttpRequest newHandshakeRequest(BufferAllocator allocator) {
         URI wsURL = uri();
-
-        // Get 16 bit nonce and base 64 encode it
-        byte[] nonce = WebSocketUtil.randomBytes(16);
-        String key = WebSocketUtil.base64(nonce);
-
-        String acceptSeed = key + MAGIC_GUID;
-        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
-        expectedChallengeResponseString = WebSocketUtil.base64(sha1);
-
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "WebSocket version 13 client handshake key: {}, expected response: {}",
-                    key, expectedChallengeResponseString);
-        }
-
-        // Format request
         FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, upgradeUrl(wsURL),
                 allocator.allocate(0));
         HttpHeaders headers = request.headers();
@@ -223,24 +191,21 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
             headers.add(customHeaders);
             if (!headers.contains(HttpHeaderNames.HOST)) {
                 // Only add HOST header if customHeaders did not contain it.
-                //
-                // See https://github.com/netty/netty/issues/10101
+                // See https://github.com/netty/netty/issues/10101.
                 headers.set(HttpHeaderNames.HOST, websocketHostValue(wsURL));
             }
         } else {
             headers.set(HttpHeaderNames.HOST, websocketHostValue(wsURL));
         }
 
+        var nonce = createNonce();
         headers.set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
-               .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, key);
+               .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, nonce);
 
-        if (!headers.contains(HttpHeaderNames.ORIGIN)) {
-            headers.set(HttpHeaderNames.ORIGIN, websocketOriginValue(wsURL));
-        }
-
+        sentNonce = nonce;
         String expectedSubprotocol = expectedSubprotocol();
-        if (expectedSubprotocol != null && !expectedSubprotocol.isEmpty()) {
+        if (!StringUtil.isNullOrEmpty(expectedSubprotocol)) {
             headers.set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, expectedSubprotocol);
         }
 
@@ -267,12 +232,12 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      */
     @Override
     protected void verify(FullHttpResponse response) {
-        HttpResponseStatus status = response.status();
+        var status = response.status();
         if (!HttpResponseStatus.SWITCHING_PROTOCOLS.equals(status)) {
-            throw new WebSocketClientHandshakeException("Invalid handshake response getStatus: " + status, response);
+            throw new WebSocketClientHandshakeException("Invalid handshake response status: " + status, response);
         }
 
-        HttpHeaders headers = response.headers();
+        var headers = response.headers();
         CharSequence upgrade = headers.get(HttpHeaderNames.UPGRADE);
         if (!HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(upgrade)) {
             throw new WebSocketClientHandshakeException("Invalid handshake response upgrade: " + upgrade, response);
@@ -283,10 +248,16 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
                     + headers.get(HttpHeaderNames.CONNECTION), response);
         }
 
-        CharSequence accept = headers.get(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT);
-        if (accept == null || !accept.equals(expectedChallengeResponseString)) {
-            throw new WebSocketClientHandshakeException(String.format(
-                    "Invalid challenge. Actual: %s. Expected: %s", accept, expectedChallengeResponseString), response);
+        var accept = headers.get(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT);
+        if (accept == null) {
+            throw new WebSocketClientHandshakeException("Invalid handshake response sec-websocket-accept: null",
+                                                        response);
+        }
+
+        var expectedAccept = WebSocketUtil.calculateV13Accept(sentNonce);
+        if (!expectedAccept.equals(accept.trim())) {
+            throw new WebSocketClientHandshakeException("Invalid handshake response sec-websocket-accept: " + accept +
+                                                        ", expected: " + expectedAccept, response);
         }
     }
 
@@ -306,4 +277,12 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         return this;
     }
 
+    /**
+     * Creates a nonce consisting of a randomly selected 16-byte value
+     * that has been base64-encoded.
+     */
+    private static String createNonce() {
+        var nonce = WebSocketUtil.randomBytes(16);
+        return WebSocketUtil.base64(nonce);
+    }
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerFactory.java
@@ -144,7 +144,7 @@ public final class WebSocketClientHandshakerFactory {
             boolean performMasking, boolean allowMaskMismatch, long forceCloseTimeoutMillis) {
         if (version == V13) {
             return new WebSocketClientHandshaker13(
-                    webSocketURL, V13, subprotocol, allowExtensions, customHeaders,
+                    webSocketURL, subprotocol, allowExtensions, customHeaders,
                     maxFramePayloadLength, performMasking, allowMaskMismatch, forceCloseTimeoutMillis);
         }
 
@@ -187,7 +187,7 @@ public final class WebSocketClientHandshakerFactory {
         boolean performMasking, boolean allowMaskMismatch, long forceCloseTimeoutMillis, boolean absoluteUpgradeUrl) {
         if (version == V13) {
             return new WebSocketClientHandshaker13(
-                webSocketURL, V13, subprotocol, allowExtensions, customHeaders,
+                webSocketURL, subprotocol, allowExtensions, customHeaders,
                 maxFramePayloadLength, performMasking, allowMaskMismatch, forceCloseTimeoutMillis, absoluteUpgradeUrl);
         }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -23,9 +23,8 @@ import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.handler.codec.http.HttpHeaders;
 import io.netty5.handler.codec.http.HttpResponseStatus;
-import io.netty5.util.CharsetUtil;
 
-import static io.netty5.handler.codec.http.HttpVersion.*;
+import static io.netty5.handler.codec.http.HttpVersion.HTTP_1_1;
 
 /**
  * <p>
@@ -34,8 +33,6 @@ import static io.netty5.handler.codec.http.HttpVersion.*;
  * </p>
  */
 public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
-
-    public static final String WEBSOCKET_13_ACCEPT_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
     /**
      * Constructor specifying the destination web socket location
@@ -136,7 +133,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
     @Override
     protected FullHttpResponse newHandshakeResponse(BufferAllocator allocator, FullHttpRequest req,
                                                     HttpHeaders headers) {
-        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        String key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
         if (key == null) {
             throw new WebSocketServerHandshakeException("not a WebSocket request: missing key", req);
         }
@@ -147,14 +144,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
             res.headers().add(headers);
         }
 
-        String acceptSeed = key + WEBSOCKET_13_ACCEPT_GUID;
-        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
-        String accept = WebSocketUtil.base64(sha1);
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("WebSocket version 13 server handshake key: {}, response: {}", key, accept);
-        }
-
+        String accept = WebSocketUtil.calculateV13Accept(key);
         res.headers().set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                      .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                      .set(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT, accept);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketUtil.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.handler.codec.http.websocketx;
 
+import io.netty5.util.CharsetUtil;
 import io.netty5.util.concurrent.FastThreadLocal;
 
 import java.security.MessageDigest;
@@ -23,67 +24,68 @@ import java.util.Base64;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * A utility class mainly for use by web sockets
+ * A utility class mainly for use by web sockets.
  */
 final class WebSocketUtil {
 
-    private static final FastThreadLocal<MessageDigest> SHA1 = new FastThreadLocal<MessageDigest>() {
+    private static final String V13_ACCEPT_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+    private static final FastThreadLocal<MessageDigest> SHA1 = new FastThreadLocal<>() {
         @Override
         protected MessageDigest initialValue() throws Exception {
             try {
-                //Try to get a MessageDigest that uses SHA1
-                //Suppress a warning about weak hash algorithm
-                //since it's defined in draft-ietf-hybi-thewebsocketprotocol-00
-                return MessageDigest.getInstance("SHA1"); // lgtm [java/weak-cryptographic-algorithm]
+                // Try to get a MessageDigest that uses SHA1.
+                // Suppress a warning about weak hash algorithm
+                // since it's defined in https://datatracker.ietf.org/doc/html/rfc6455#section-10.8.
+                return MessageDigest.getInstance("SHA-1"); // lgtm [java/weak-cryptographic-algorithm]
             } catch (NoSuchAlgorithmException e) {
-                //This shouldn't happen! How old is the computer?
-                throw new InternalError("SHA-1 not supported on this platform - Outdated?");
+                // This shouldn't happen! How old is the computer ?
+                throw new InternalError("SHA-1 not supported on this platform - Outdated ?");
             }
         }
     };
 
     /**
-     * Performs a SHA-1 hash on the specified data
+     * Performs a SHA-1 hash on the specified data.
      *
      * @param data The data to hash
-     * @return The hashed data
+     * @return the hashed data
      */
     static byte[] sha1(byte[] data) {
-        // TODO(normanmaurer): Create sha1 method that not need MessageDigest.
-        return digest(SHA1, data);
-    }
-
-    private static byte[] digest(FastThreadLocal<MessageDigest> digestFastThreadLocal, byte[] data) {
-        MessageDigest digest = digestFastThreadLocal.get();
-        digest.reset();
-        return digest.digest(data);
+        var sha1Digest = SHA1.get();
+        sha1Digest.reset();
+        return sha1Digest.digest(data);
     }
 
     /**
-     * Performs base64 encoding on the specified data
+     * Performs base64 encoding on the specified data.
      *
      * @param data The data to encode
-     * @return An encoded string containing the data
+     * @return an encoded string containing the data
      */
     static String base64(byte[] data) {
         return Base64.getEncoder().encodeToString(data);
     }
+
     /**
-     * Creates an arbitrary number of random bytes
+     * Creates an arbitrary number of random bytes.
      *
      * @param size the number of random bytes to create
-     * @return An array of random bytes
+     * @return an array of random bytes
      */
     static byte[] randomBytes(int size) {
-        byte[] bytes = new byte[size];
+        var bytes = new byte[size];
         ThreadLocalRandom.current().nextBytes(bytes);
         return bytes;
     }
 
-    /**
-     * A private constructor to ensure that instances of this class cannot be made
-     */
+    static String calculateV13Accept(String nonce) {
+        var concat = nonce + V13_ACCEPT_GUID;
+        var sha1 = WebSocketUtil.sha1(concat.getBytes(CharsetUtil.US_ASCII));
+        return WebSocketUtil.base64(sha1);
+    }
+
     private WebSocketUtil() {
-        // Unused
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketUtil.java
@@ -52,7 +52,7 @@ final class WebSocketUtil {
      * @return the hashed data
      */
     static byte[] sha1(byte[] data) {
-        var sha1Digest = SHA1.get();
+        MessageDigest sha1Digest = SHA1.get();
         sha1Digest.reset();
         return sha1Digest.digest(data);
     }
@@ -80,12 +80,11 @@ final class WebSocketUtil {
     }
 
     static String calculateV13Accept(String nonce) {
-        var concat = nonce + V13_ACCEPT_GUID;
-        var sha1 = WebSocketUtil.sha1(concat.getBytes(CharsetUtil.US_ASCII));
+        String concat = nonce + V13_ACCEPT_GUID;
+        byte[] sha1 = WebSocketUtil.sha1(concat.getBytes(CharsetUtil.US_ASCII));
         return WebSocketUtil.base64(sha1);
     }
 
     private WebSocketUtil() {
-        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker13Test.java
@@ -15,24 +15,30 @@
  */
 package io.netty5.handler.codec.http.websocketx;
 
+import io.netty5.handler.codec.http.DefaultFullHttpResponse;
+import io.netty5.handler.codec.http.FullHttpResponse;
 import io.netty5.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.HttpHeaderValues;
 import io.netty5.handler.codec.http.HttpHeaders;
+import io.netty5.handler.codec.http.HttpResponseStatus;
+import io.netty5.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class WebSocketClientHandshaker13Test extends WebSocketClientHandshakerTest {
 
     @Override
     protected WebSocketClientHandshaker newHandshaker(URI uri, String subprotocol, HttpHeaders headers,
                                                       boolean absoluteUpgradeUrl) {
-        return new WebSocketClientHandshaker13(uri, WebSocketVersion.V13, subprotocol, false, headers,
-          1024, true, true, 10000,
-          absoluteUpgradeUrl);
-    }
-
-    @Override
-    protected CharSequence getOriginHeaderName() {
-        return HttpHeaderNames.ORIGIN;
+        return new WebSocketClientHandshaker13(uri, subprotocol, false, headers,
+                                               1024, true, true, 10000,
+                                               absoluteUpgradeUrl);
     }
 
     @Override
@@ -43,11 +49,99 @@ public class WebSocketClientHandshaker13Test extends WebSocketClientHandshakerTe
     @Override
     protected CharSequence[] getHandshakeRequiredHeaderNames() {
         return new CharSequence[] {
+                HttpHeaderNames.HOST,
                 HttpHeaderNames.UPGRADE,
                 HttpHeaderNames.CONNECTION,
                 HttpHeaderNames.SEC_WEBSOCKET_KEY,
-                HttpHeaderNames.HOST,
                 HttpHeaderNames.SEC_WEBSOCKET_VERSION,
         };
+    }
+
+    @Test
+    void testWebSocketClientInvalidUpgrade() {
+        var handshaker = newHandshaker(URI.create("ws://localhost:9999/ws"), null,
+                                       null, false);
+        var response = websocketUpgradeResponse();
+        response.headers().remove(HttpHeaderNames.UPGRADE);
+
+        final WebSocketClientHandshakeException exception;
+        try (response) {
+            exception = assertThrows(WebSocketClientHandshakeException.class,
+                                     () -> handshaker.finishHandshake(null, response));
+        }
+
+        assertEquals("Invalid handshake response upgrade: null", exception.getMessage());
+        assertNotNull(exception.response());
+        assertEquals(response.headers(), exception.response().headers());
+    }
+
+    @Test
+    void testWebSocketClientInvalidConnection() {
+        var handshaker = newHandshaker(URI.create("ws://localhost:9999/ws"), null,
+                                       null, false);
+        var response = websocketUpgradeResponse();
+        response.headers().set(HttpHeaderNames.CONNECTION, "Close");
+
+        final WebSocketClientHandshakeException exception;
+        try (response) {
+            exception = assertThrows(WebSocketClientHandshakeException.class,
+                                     () -> handshaker.finishHandshake(null, response));
+        }
+
+        assertEquals("Invalid handshake response connection: Close", exception.getMessage());
+        assertNotNull(exception.response());
+        assertEquals(response.headers(), exception.response().headers());
+    }
+
+    @Test
+    void testWebSocketClientInvalidNullAccept() {
+        var handshaker = newHandshaker(URI.create("ws://localhost:9999/ws"), null,
+                                       null, false);
+        var response = websocketUpgradeResponse();
+
+        final WebSocketClientHandshakeException exception;
+        try (response) {
+            exception = assertThrows(WebSocketClientHandshakeException.class,
+                                     () -> handshaker.finishHandshake(null, response));
+        }
+
+        assertEquals("Invalid handshake response sec-websocket-accept: null", exception.getMessage());
+        assertNotNull(exception.response());
+        assertEquals(response.headers(), exception.response().headers());
+    }
+
+    @Test
+    void testWebSocketClientInvalidExpectedAccept() {
+        var handshaker = newHandshaker(URI.create("ws://localhost:9999/ws"), null,
+                                       null, false);
+        final String sentNonce;
+        try (var request = handshaker.newHandshakeRequest(preferredAllocator())) {
+            sentNonce = request.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        }
+
+        var fakeAccept = WebSocketUtil.base64(WebSocketUtil.randomBytes(16));
+        var response = websocketUpgradeResponse();
+        response.headers().set(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT, fakeAccept);
+
+        final WebSocketClientHandshakeException exception;
+        try (response) {
+            exception = assertThrows(WebSocketClientHandshakeException.class,
+                                     () -> handshaker.finishHandshake(null, response));
+        }
+
+        var expectedAccept = WebSocketUtil.calculateV13Accept(sentNonce);
+        assertEquals("Invalid handshake response sec-websocket-accept: " + fakeAccept + ", expected: "
+                     + expectedAccept, exception.getMessage());
+        assertNotNull(exception.response());
+        assertEquals(response.headers(), exception.response().headers());
+    }
+
+    private static FullHttpResponse websocketUpgradeResponse() {
+        var response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS, preferredAllocator().allocate(0));
+        response.headers()
+                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
+                .set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET);
+        return response;
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshaker13Test.java
@@ -119,7 +119,7 @@ public class WebSocketClientHandshaker13Test extends WebSocketClientHandshakerTe
             sentNonce = request.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
         }
 
-        var fakeAccept = WebSocketUtil.base64(WebSocketUtil.randomBytes(16));
+        String fakeAccept = WebSocketUtil.base64(WebSocketUtil.randomBytes(16));
         var response = websocketUpgradeResponse();
         response.headers().set(HttpHeaderNames.SEC_WEBSOCKET_ACCEPT, fakeAccept);
 
@@ -129,7 +129,7 @@ public class WebSocketClientHandshaker13Test extends WebSocketClientHandshakerTe
                                      () -> handshaker.finishHandshake(null, response));
         }
 
-        var expectedAccept = WebSocketUtil.calculateV13Accept(sentNonce);
+        String expectedAccept = WebSocketUtil.calculateV13Accept(sentNonce);
         assertEquals("Invalid handshake response sec-websocket-accept: " + fakeAccept + ", expected: "
                      + expectedAccept, exception.getMessage());
         assertNotNull(exception.response());

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -311,10 +311,10 @@ public abstract class WebSocketClientHandshakerTest {
 
     @Test
     void testSetOriginFromCustomHeaders() {
-        HttpHeaders customHeaders = new DefaultHttpHeaders().set(HttpHeaderNames.ORIGIN, "http://example.com");
-        WebSocketClientHandshaker handshaker = newHandshaker(URI.create("ws://server.example.com/chat"), null,
+        var customHeaders = new DefaultHttpHeaders().set(HttpHeaderNames.ORIGIN, "http://example.com");
+        var handshaker = newHandshaker(URI.create("ws://server.example.com/chat"), null,
                                                              customHeaders, false);
-        try (FullHttpRequest request = handshaker.newHandshakeRequest(preferredAllocator())) {
+        try (var request = handshaker.newHandshakeRequest(preferredAllocator())) {
             assertEquals("http://example.com", request.headers().get(HttpHeaderNames.ORIGIN));
         }
     }
@@ -341,8 +341,8 @@ public abstract class WebSocketClientHandshakerTest {
     }
 
     private void testHostHeader(String uri, String expected) {
-        WebSocketClientHandshaker handshaker = newHandshaker(URI.create(uri));
-        try (FullHttpRequest request = handshaker.newHandshakeRequest(preferredAllocator())) {
+        var handshaker = newHandshaker(URI.create(uri));
+        try (var request = handshaker.newHandshakeRequest(preferredAllocator())) {
             assertEquals(expected, request.headers().get(HttpHeaderNames.HOST));
         }
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -119,7 +119,7 @@ public class WebSocketHandshakeHandOverTest {
         assertTrue(serverReceivedHandshake);
         assertNotNull(serverHandshakeComplete);
         assertEquals("/test", serverHandshakeComplete.requestUri());
-        assertEquals(8, serverHandshakeComplete.requestHeaders().size());
+        assertEquals(7, serverHandshakeComplete.requestHeaders().size());
         assertEquals("test-proto-2", serverHandshakeComplete.selectedSubprotocol());
 
         // Transfer the handshake response and the websocket message to the client

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketUtilTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketUtilTest.java
@@ -16,30 +16,49 @@
 package io.netty5.handler.codec.http.websocketx;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class WebSocketUtilTest {
 
-    // how many times do we want to run each random variable checker
-    private static final int NUM_ITERATIONS = 1000;
-
-    private static void assertRandomWithinBoundaries(int min, int max) {
-        int r = ThreadLocalRandom.current().nextInt(min, max + 1);
-        assertTrue(min <= r && r <= max);
+    @ParameterizedTest
+    @ValueSource(ints = {2, 4, 8, 16, 24, 48, 64, 128 })
+    void testRandomBytes(int size) {
+        var random1 = WebSocketUtil.randomBytes(size);
+        var random2 = WebSocketUtil.randomBytes(size);
+        assertEquals(size, random1.length);
+        assertEquals(size, random2.length);
+        assertFalse(Arrays.equals(random1, random2));
     }
 
     @Test
-    public void testRandomNumberGenerator() {
-        int iteration = 0;
-        while (++iteration < NUM_ITERATIONS) {
-            assertRandomWithinBoundaries(0, 1);
-            assertRandomWithinBoundaries(0, 1);
-            assertRandomWithinBoundaries(-1, 1);
-            assertRandomWithinBoundaries(-1, 0);
-        }
+    void testBase64() {
+        var random = WebSocketUtil.randomBytes(8);
+        String expected = Base64.getEncoder().encodeToString(random);
+        assertEquals(expected, WebSocketUtil.base64(random));
     }
 
+    @Test
+    void testCalculateV13Accept() throws Exception {
+        var random = new byte[16];
+        ThreadLocalRandom.current().nextBytes(random);
+        var nonce = Base64.getEncoder().encodeToString(random);
+
+        var concat = nonce + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+        var sha1Digest = MessageDigest.getInstance("SHA-1");
+        var sha1 = sha1Digest.digest(concat.getBytes(StandardCharsets.US_ASCII));
+        var expectedAccept = Base64.getEncoder().encodeToString(sha1);
+
+        assertEquals(expectedAccept, WebSocketUtil.calculateV13Accept(nonce));
+    }
 }
+

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketUtilTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketUtilTest.java
@@ -51,14 +51,13 @@ public class WebSocketUtilTest {
     void testCalculateV13Accept() throws Exception {
         var random = new byte[16];
         ThreadLocalRandom.current().nextBytes(random);
-        var nonce = Base64.getEncoder().encodeToString(random);
+        String nonce = Base64.getEncoder().encodeToString(random);
 
-        var concat = nonce + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
-        var sha1Digest = MessageDigest.getInstance("SHA-1");
-        var sha1 = sha1Digest.digest(concat.getBytes(StandardCharsets.US_ASCII));
-        var expectedAccept = Base64.getEncoder().encodeToString(sha1);
+        String concat = nonce + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+        MessageDigest sha1Digest = MessageDigest.getInstance("SHA-1");
+        byte[] sha1 = sha1Digest.digest(concat.getBytes(StandardCharsets.US_ASCII));
+        String expectedAccept = Base64.getEncoder().encodeToString(sha1);
 
         assertEquals(expectedAccept, WebSocketUtil.calculateV13Accept(nonce));
     }
 }
-


### PR DESCRIPTION
Motivation:

In Netty 5 we only left the latest 13 version of websocket, so we can clean up the code a bit.

Modification:

- Remove `origin` header from handshake request, it can be set with `customHeaders`, see #9673
- Calculate expected value of `sec-websocket-accept` only when we received a response
- Remove unused code
- Add more tests for clientHandshaker13

Result:
Removed not used code and fixed wrong behaviour with origin header #9673.
