### PR TITLE
Remove implicit buffer conversion from SslHandler

### DIFF
--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -344,7 +344,6 @@ public class Http2MultiplexTransportTest {
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(sslCtx.newHandler(ch.bufferAllocator()));
                     ch.pipeline().addLast(BufferConversionHandler.bufferToByteBuf());
-                    ch.pipeline().addLast(BufferConversionHandler.bufferToByteBuf());
                     ch.pipeline().addLast(new Http2FrameCodecBuilder(true).build());
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                 }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -24,6 +24,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.nio.NioHandler;
@@ -334,6 +335,7 @@ public class Http2MultiplexTransportTest {
                     .build();
 
             ServerBootstrap sb = new ServerBootstrap();
+            sb.childOption(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true);
             sb.group(eventLoopGroup);
             sb.channel(NioServerSocketChannel.class);
             sb.childHandler(new ChannelInitializer<Channel>() {
@@ -341,6 +343,7 @@ public class Http2MultiplexTransportTest {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(sslCtx.newHandler(ch.bufferAllocator()));
+                    ch.pipeline().addLast(BufferConversionHandler.bufferToByteBuf());
                     ch.pipeline().addLast(BufferConversionHandler.bufferToByteBuf());
                     ch.pipeline().addLast(new Http2FrameCodecBuilder(true).build());
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
@@ -369,12 +372,14 @@ public class Http2MultiplexTransportTest {
             final CountDownLatch latch = new CountDownLatch(2);
             final AtomicReference<AssertionError> errorRef = new AtomicReference<AssertionError>();
             Bootstrap bs = new Bootstrap();
+            bs.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true);
             bs.group(eventLoopGroup);
             bs.channel(NioSocketChannel.class);
             bs.handler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(clientCtx.newHandler(ch.bufferAllocator()));
+                    ch.pipeline().addLast(BufferConversionHandler.bufferToByteBuf());
                     ch.pipeline().addLast(new Http2FrameCodecBuilder(false).build());
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -473,12 +478,14 @@ public class Http2MultiplexTransportTest {
                     .build();
 
             ServerBootstrap sb = new ServerBootstrap();
+            sb.childOption(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true);
             sb.group(eventLoopGroup);
             sb.channel(NioServerSocketChannel.class);
             sb.childHandler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(serverCtx.newHandler(ch.bufferAllocator()));
+                    ch.pipeline().addLast(BufferConversionHandler.bufferToByteBuf());
                     ch.pipeline().addLast(new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
                         @Override
                         protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
@@ -518,12 +525,14 @@ public class Http2MultiplexTransportTest {
 
             final CountDownLatch latch = new CountDownLatch(1);
             Bootstrap bs = new Bootstrap();
+            bs.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true);
             bs.group(eventLoopGroup);
             bs.channel(NioSocketChannel.class);
             bs.handler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(clientCtx.newHandler(ch.bufferAllocator()));
+                    ch.pipeline().addLast(BufferConversionHandler.bufferToByteBuf());
                     ch.pipeline().addLast(new Http2FrameCodecBuilder(false).build());
                     ch.pipeline().addLast(new Http2MultiplexHandler(DISCARD_HANDLER));
                     ch.pipeline().addLast(new ChannelHandler() {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -22,6 +22,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.adaptor.BufferConversionHandler;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.http.DefaultFullHttpRequest;
 import io.netty5.handler.codec.http.DefaultFullHttpResponse;
@@ -440,7 +441,9 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         final Queue<Http2StreamFrame> frames = new ConcurrentLinkedQueue<>();
 
         final SslContext ctx = SslContextBuilder.forClient().sslProvider(SslProvider.JDK).build();
-        EmbeddedChannel ch = new EmbeddedChannel(ctx.newHandler(offHeapAllocator()),
+        EmbeddedChannel ch = new EmbeddedChannel(
+                ctx.newHandler(offHeapAllocator()),
+                BufferConversionHandler.bufferToByteBuf(),
                 new ChannelHandler() {
                     @Override
                     public Future<Void> write(ChannelHandlerContext ctx, Object msg) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -137,7 +137,6 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                                              TestInfo testInfo) throws Throwable {
         // BoringSSL does not support renegotiation intentionally.
         assumeFalse("BoringSSL".equals(OpenSsl.versionString()));
-        assumeTrue(OpenSsl.isAvailable());
         run(testInfo, (sb, cb) -> testSslRenegotiationRejected(sb, cb, serverCtx, clientCtx, delegate));
     }
 
@@ -152,6 +151,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
     public void testSslRenegotiationRejected(ServerBootstrap sb, Bootstrap cb, SslContext serverCtx,
                                              SslContext clientCtx, boolean delegate) throws Throwable {
         reset();
+        enableNewBufferAPI(sb, cb);
 
         final ExecutorService executorService = delegate ? Executors.newCachedThreadPool() : null;
 

--- a/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty5/util/internal/NettyBlockHoundIntegrationTest.java
@@ -21,6 +21,7 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.nio.NioHandler;
@@ -439,12 +440,14 @@ public class NettyBlockHoundIntegrationTest {
             sc = new ServerBootstrap()
                     .group(group)
                     .channel(NioServerSocketChannel.class)
+                    .childOption(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true)
                     .childHandler(serverSslHandler)
                     .bind(new InetSocketAddress(0)).get();
 
             Future<Channel> future = new Bootstrap()
                     .group(group)
                     .channel(NioSocketChannel.class)
+                    .option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true)
                     .handler(new ChannelInitializer<Channel>() {
                         @Override
                         protected void initChannel(Channel ch) {


### PR DESCRIPTION
Motivation:
This was transitional code to help the SslHandler port have fewer test failures in the initial PR.

Modification:
Remove the implicit buffer conversion, and fix the tests that started failing.

Result:
SslHandler is now a pure Buffer-based handler, and any required conversion must now be done explicitly elsewhere in the pipeline.

Posting as a draft to begin with, to have CI help me weed out the build failures.