### PR TITLE
Port length field decoder and prepender to `Buffer` API

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBuffer.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.channel.ChannelHandlerContext;
+
+import java.nio.ByteOrder;
+
+import static io.netty5.util.internal.ObjectUtil.*;
+import static java.util.Objects.*;
+
+/**
+ * A decoder that splits the received {@link Buffer}s dynamically by the
+ * value of the length field in the message.  It is particularly useful when you
+ * decode a binary message which has an integer header field that represents the
+ * length of the message body or the whole message.
+ * <p>
+ * {@link LengthFieldBasedFrameDecoderForBuffer} has many configuration parameters so
+ * that it can decode any message with a length field, which is often seen in
+ * proprietary client-server protocols. Here are some example that will give
+ * you the basic idea on which option does what.
+ *
+ * <h3>2 bytes length field at offset 0, do not strip header</h3>
+ * <p>
+ * The value of the length field in this example is <tt>12 (0x0C)</tt> which
+ * represents the length of "HELLO, WORLD".  By default, the decoder assumes
+ * that the length field represents the number of the bytes that follows the
+ * length field.  Therefore, it can be decoded with the simplistic parameter
+ * combination.
+ * <pre>
+ * <b>lengthFieldOffset</b>   = <b>0</b>
+ * <b>lengthFieldLength</b>   = <b>2</b>
+ * lengthAdjustment    = 0
+ * initialBytesToStrip = 0 (= do not strip header)
+ *
+ * BEFORE DECODE (14 bytes)         AFTER DECODE (14 bytes)
+ * +--------+----------------+      +--------+----------------+
+ * | Length | Actual Content |----->| Length | Actual Content |
+ * | 0x000C | "HELLO, WORLD" |      | 0x000C | "HELLO, WORLD" |
+ * +--------+----------------+      +--------+----------------+
+ * </pre>
+ *
+ * <h3>2 bytes length field at offset 0, strip header</h3>
+ * <p>
+ * Because we can get the length of the content by calling
+ * {@link Buffer#readableBytes()}, you might want to strip the length
+ * field by specifying <tt>initialBytesToStrip</tt>.  In this example, we
+ * specified <tt>2</tt>, that is same with the length of the length field, to
+ * strip the first two bytes.
+ * <pre>
+ * lengthFieldOffset   = 0
+ * lengthFieldLength   = 2
+ * lengthAdjustment    = 0
+ * <b>initialBytesToStrip</b> = <b>2</b> (= the length of the Length field)
+ *
+ * BEFORE DECODE (14 bytes)         AFTER DECODE (12 bytes)
+ * +--------+----------------+      +----------------+
+ * | Length | Actual Content |----->| Actual Content |
+ * | 0x000C | "HELLO, WORLD" |      | "HELLO, WORLD" |
+ * +--------+----------------+      +----------------+
+ * </pre>
+ *
+ * <h3>2 bytes length field at offset 0, do not strip header, the length field
+ * represents the length of the whole message</h3>
+ * <p>
+ * In most cases, the length field represents the length of the message body
+ * only, as shown in the previous examples.  However, in some protocols, the
+ * length field represents the length of the whole message, including the
+ * message header.  In such a case, we specify a non-zero
+ * <tt>lengthAdjustment</tt>.  Because the length value in this example message
+ * is always greater than the body length by <tt>2</tt>, we specify <tt>-2</tt>
+ * as <tt>lengthAdjustment</tt> for compensation.
+ * <pre>
+ * lengthFieldOffset   =  0
+ * lengthFieldLength   =  2
+ * <b>lengthAdjustment</b>    = <b>-2</b> (= the length of the Length field)
+ * initialBytesToStrip =  0
+ *
+ * BEFORE DECODE (14 bytes)         AFTER DECODE (14 bytes)
+ * +--------+----------------+      +--------+----------------+
+ * | Length | Actual Content |----->| Length | Actual Content |
+ * | 0x000E | "HELLO, WORLD" |      | 0x000E | "HELLO, WORLD" |
+ * +--------+----------------+      +--------+----------------+
+ * </pre>
+ *
+ * <h3>3 bytes length field at the end of 5 bytes header, do not strip header</h3>
+ * <p>
+ * The following message is a simple variation of the first example.  An extra
+ * header value is prepended to the message.  <tt>lengthAdjustment</tt> is zero
+ * again because the decoder always takes the length of the prepended data into
+ * account during frame length calculation.
+ * <pre>
+ * <b>lengthFieldOffset</b>   = <b>2</b> (= the length of Header 1)
+ * <b>lengthFieldLength</b>   = <b>3</b>
+ * lengthAdjustment    = 0
+ * initialBytesToStrip = 0
+ *
+ * BEFORE DECODE (17 bytes)                      AFTER DECODE (17 bytes)
+ * +----------+----------+----------------+      +----------+----------+----------------+
+ * | Header 1 |  Length  | Actual Content |----->| Header 1 |  Length  | Actual Content |
+ * |  0xCAFE  | 0x00000C | "HELLO, WORLD" |      |  0xCAFE  | 0x00000C | "HELLO, WORLD" |
+ * +----------+----------+----------------+      +----------+----------+----------------+
+ * </pre>
+ *
+ * <h3>3 bytes length field at the beginning of 5 bytes header, do not strip header</h3>
+ * <p>
+ * This is an advanced example that shows the case where there is an extra
+ * header between the length field and the message body.  You have to specify a
+ * positive <tt>lengthAdjustment</tt> so that the decoder counts the extra
+ * header into the frame length calculation.
+ * <pre>
+ * lengthFieldOffset   = 0
+ * lengthFieldLength   = 3
+ * <b>lengthAdjustment</b>    = <b>2</b> (= the length of Header 1)
+ * initialBytesToStrip = 0
+ *
+ * BEFORE DECODE (17 bytes)                      AFTER DECODE (17 bytes)
+ * +----------+----------+----------------+      +----------+----------+----------------+
+ * |  Length  | Header 1 | Actual Content |----->|  Length  | Header 1 | Actual Content |
+ * | 0x00000C |  0xCAFE  | "HELLO, WORLD" |      | 0x00000C |  0xCAFE  | "HELLO, WORLD" |
+ * +----------+----------+----------------+      +----------+----------+----------------+
+ * </pre>
+ *
+ * <h3>2 bytes length field at offset 1 in the middle of 4 bytes header,
+ * strip the first header field and the length field</h3>
+ * <p>
+ * This is a combination of all the examples above.  There are the prepended
+ * header before the length field and the extra header after the length field.
+ * The prepended header affects the <tt>lengthFieldOffset</tt> and the extra
+ * header affects the <tt>lengthAdjustment</tt>.  We also specified a non-zero
+ * <tt>initialBytesToStrip</tt> to strip the length field and the prepended
+ * header from the frame.  If you don't want to strip the prepended header, you
+ * could specify <tt>0</tt> for <tt>initialBytesToSkip</tt>.
+ * <pre>
+ * lengthFieldOffset   = 1 (= the length of HDR1)
+ * lengthFieldLength   = 2
+ * <b>lengthAdjustment</b>    = <b>1</b> (= the length of HDR2)
+ * <b>initialBytesToStrip</b> = <b>3</b> (= the length of HDR1 + LEN)
+ *
+ * BEFORE DECODE (16 bytes)                       AFTER DECODE (13 bytes)
+ * +------+--------+------+----------------+      +------+----------------+
+ * | HDR1 | Length | HDR2 | Actual Content |----->| HDR2 | Actual Content |
+ * | 0xCA | 0x000C | 0xFE | "HELLO, WORLD" |      | 0xFE | "HELLO, WORLD" |
+ * +------+--------+------+----------------+      +------+----------------+
+ * </pre>
+ *
+ * <h3>2 bytes length field at offset 1 in the middle of 4 bytes header,
+ * strip the first header field and the length field, the length field
+ * represents the length of the whole message</h3>
+ * <p>
+ * Let's give another twist to the previous example.  The only difference from
+ * the previous example is that the length field represents the length of the
+ * whole message instead of the message body, just like the third example.
+ * We have to count the length of HDR1 and Length into <tt>lengthAdjustment</tt>.
+ * Please note that we don't need to take the length of HDR2 into account
+ * because the length field already includes the whole header length.
+ * <pre>
+ * lengthFieldOffset   =  1
+ * lengthFieldLength   =  2
+ * <b>lengthAdjustment</b>    = <b>-3</b> (= the length of HDR1 + LEN, negative)
+ * <b>initialBytesToStrip</b> = <b> 3</b>
+ *
+ * BEFORE DECODE (16 bytes)                       AFTER DECODE (13 bytes)
+ * +------+--------+------+----------------+      +------+----------------+
+ * | HDR1 | Length | HDR2 | Actual Content |----->| HDR2 | Actual Content |
+ * | 0xCA | 0x0010 | 0xFE | "HELLO, WORLD" |      | 0xFE | "HELLO, WORLD" |
+ * +------+--------+------+----------------+      +------+----------------+
+ * </pre>
+ *
+ * @see LengthFieldPrepender
+ */
+public class LengthFieldBasedFrameDecoderForBuffer extends ByteToMessageDecoderForBuffer {
+
+    private final ByteOrder byteOrder;
+    private final int maxFrameLength;
+    private final int lengthFieldOffset;
+    private final int lengthFieldLength;
+    private final int lengthFieldEndOffset;
+    private final int lengthAdjustment;
+    private final int initialBytesToStrip;
+    private final boolean failFast;
+
+    private long tooLongFrameLength;
+    private long bytesToDiscard;
+    private int currentFrameLength = -1;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength    the maximum length of the frame.  If the length of the frame is
+     *                          greater than this value, {@link TooLongFrameException} will be
+     *                          thrown.
+     * @param lengthFieldOffset the offset of the length field
+     * @param lengthFieldLength the length of the length field
+     */
+    public LengthFieldBasedFrameDecoderForBuffer(int maxFrameLength, int lengthFieldOffset, int lengthFieldLength) {
+        this(maxFrameLength, lengthFieldOffset, lengthFieldLength, 0, 0);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength      the maximum length of the frame.  If the length of the frame is
+     *                            greater than this value, {@link TooLongFrameException} will be
+     *                            thrown.
+     * @param lengthFieldOffset   the offset of the length field
+     * @param lengthFieldLength   the length of the length field
+     * @param lengthAdjustment    the compensation value to add to the value of the length field
+     * @param initialBytesToStrip the number of first bytes to strip out from the decoded frame
+     */
+    public LengthFieldBasedFrameDecoderForBuffer(
+            int maxFrameLength, int lengthFieldOffset, int lengthFieldLength,
+            int lengthAdjustment, int initialBytesToStrip) {
+        this(maxFrameLength,
+             lengthFieldOffset, lengthFieldLength, lengthAdjustment,
+             initialBytesToStrip, true);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength      the maximum length of the frame.  If the length of the frame is
+     *                            greater than this value, {@link TooLongFrameException} will be
+     *                            thrown.
+     * @param lengthFieldOffset   the offset of the length field
+     * @param lengthFieldLength   the length of the length field
+     * @param lengthAdjustment    the compensation value to add to the value of the length field
+     * @param initialBytesToStrip the number of first bytes to strip out from the decoded frame
+     * @param failFast            If <tt>true</tt>, a {@link TooLongFrameException} is thrown as
+     *                            soon as the decoder notices the length of the frame will exceed
+     *                            <tt>maxFrameLength</tt> regardless of whether the entire frame
+     *                            has been read.  If <tt>false</tt>, a {@link TooLongFrameException}
+     *                            is thrown after the entire frame that exceeds <tt>maxFrameLength</tt>
+     *                            has been read.
+     */
+    public LengthFieldBasedFrameDecoderForBuffer(
+            int maxFrameLength, int lengthFieldOffset, int lengthFieldLength,
+            int lengthAdjustment, int initialBytesToStrip, boolean failFast) {
+        this(ByteOrder.BIG_ENDIAN, maxFrameLength, lengthFieldOffset, lengthFieldLength,
+             lengthAdjustment, initialBytesToStrip, failFast);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param byteOrder           the {@link ByteOrder} of the length field
+     * @param maxFrameLength      the maximum length of the frame.  If the length of the frame is
+     *                            greater than this value, {@link TooLongFrameException} will be
+     *                            thrown.
+     * @param lengthFieldOffset   the offset of the length field
+     * @param lengthFieldLength   the length of the length field
+     * @param lengthAdjustment    the compensation value to add to the value of the length field
+     * @param initialBytesToStrip the number of first bytes to strip out from the decoded frame
+     * @param failFast            If <tt>true</tt>, a {@link TooLongFrameException} is thrown as
+     *                            soon as the decoder notices the length of the frame will exceed
+     *                            <tt>maxFrameLength</tt> regardless of whether the entire frame
+     *                            has been read.  If <tt>false</tt>, a {@link TooLongFrameException}
+     *                            is thrown after the entire frame that exceeds <tt>maxFrameLength</tt>
+     *                            has been read.
+     */
+    public LengthFieldBasedFrameDecoderForBuffer(
+            ByteOrder byteOrder, int maxFrameLength, int lengthFieldOffset, int lengthFieldLength,
+            int lengthAdjustment, int initialBytesToStrip, boolean failFast) {
+        requireNonNull(byteOrder, "byteOrder");
+        checkPositive(maxFrameLength, "maxFrameLength");
+        checkPositiveOrZero(lengthFieldOffset, "lengthFieldOffset");
+        checkPositiveOrZero(initialBytesToStrip, "initialBytesToStrip");
+
+        if (lengthFieldOffset > maxFrameLength - lengthFieldLength) {
+            throw new IllegalArgumentException(
+                    "maxFrameLength (" + maxFrameLength + ") " +
+                    "must be equal to or greater than " +
+                    "lengthFieldOffset (" + lengthFieldOffset + ") + " +
+                    "lengthFieldLength (" + lengthFieldLength + ").");
+        }
+
+        this.byteOrder = byteOrder;
+        this.maxFrameLength = maxFrameLength;
+        this.lengthFieldOffset = lengthFieldOffset;
+        this.lengthFieldLength = lengthFieldLength;
+        this.lengthAdjustment = lengthAdjustment;
+        lengthFieldEndOffset = lengthFieldOffset + lengthFieldLength;
+        this.initialBytesToStrip = initialBytesToStrip;
+        this.failFast = failFast;
+    }
+
+    @Override
+    protected final void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
+        final Object decoded = decode0(ctx, in);
+        if (decoded != null) {
+            ctx.fireChannelRead(decoded);
+        }
+    }
+
+    private void discardTooLongFrame(Buffer in) {
+        final int bytesToDiscardNow = (int) Math.min(bytesToDiscard, in.readableBytes());
+        in.skipReadable(bytesToDiscardNow);
+
+        bytesToDiscard -= bytesToDiscardNow;
+
+        failOnLengthExceededIfNecessary(false);
+    }
+
+    private static void failOnNegativeLengthField(Buffer buffer, long frameLength, int lengthFieldEndOffset) {
+        buffer.skipReadable(lengthFieldEndOffset);
+        throw new CorruptedFrameException("negative pre-adjustment length field: " + frameLength);
+    }
+
+    private static void failOnFrameLengthLessThanLengthFieldEndOffset(
+            Buffer buffer, long frameLength, int lengthFieldEndOffset) {
+        buffer.skipReadable(lengthFieldEndOffset);
+        throw new CorruptedFrameException(
+                "Adjusted frame length (" + frameLength + ") is less " +
+                "than lengthFieldEndOffset: " + lengthFieldEndOffset);
+    }
+
+    private void handleFrameLengthExceeded(Buffer buffer, long frameLength) {
+        final long discard = frameLength - buffer.readableBytes();
+        tooLongFrameLength = frameLength;
+
+        if (discard < 0) {
+            // buffer contains more bytes then the frameLength so we can discard all now
+            buffer.skipReadable((int) frameLength);
+        } else {
+            // Enter the discard mode and discard everything received so far.
+            bytesToDiscard = discard;
+            buffer.skipReadable(buffer.readableBytes());
+        }
+        failOnLengthExceededIfNecessary(true);
+    }
+
+    private static void failOnFrameLengthLessThanInitialBytesToStrip(
+            Buffer buffer, int frameLength, int initialBytesToStrip) {
+        buffer.skipReadable(frameLength);
+        throw new CorruptedFrameException(
+                "Adjusted frame length (" + frameLength + ") is less " +
+                "than initialBytesToStrip: " + initialBytesToStrip);
+    }
+
+    /**
+     * Create a frame out of the {@link Buffer} and return it.
+     *
+     * @param ctx    the {@link ChannelHandlerContext} which this {@link ByteToMessageDecoder} belongs to
+     * @param buffer the {@link Buffer} from which to read data
+     * @return the {@link Buffer} which represent the frame or {@code null} if no frame could be created.
+     */
+    protected Object decode0(ChannelHandlerContext ctx, Buffer buffer) throws Exception {
+        if (currentFrameLength == -1) { // new frame
+            if (bytesToDiscard > 0) {
+                discardTooLongFrame(buffer);
+            }
+
+            if (buffer.readableBytes() < lengthFieldEndOffset) {
+                return null;
+            }
+
+            final int actualLengthFieldOffset = buffer.readerOffset() + lengthFieldOffset;
+            long frameLength = getUnadjustedFrameLength(buffer, actualLengthFieldOffset, lengthFieldLength);
+
+            if (frameLength < 0) {
+                failOnNegativeLengthField(buffer, frameLength, lengthFieldEndOffset);
+            }
+
+            frameLength += lengthAdjustment + lengthFieldEndOffset;
+
+            if (frameLength < lengthFieldEndOffset) {
+                failOnFrameLengthLessThanLengthFieldEndOffset(buffer, frameLength, lengthFieldEndOffset);
+            }
+
+            if (frameLength > maxFrameLength) {
+                handleFrameLengthExceeded(buffer, frameLength);
+                return null;
+            }
+
+            // never overflows because it's less than maxFrameLength
+            currentFrameLength = (int) frameLength;
+        }
+
+        if (buffer.readableBytes() < currentFrameLength) { // frameLengthInt exist, just check buf
+            return null;
+        }
+
+        if (initialBytesToStrip > currentFrameLength) {
+            failOnFrameLengthLessThanInitialBytesToStrip(buffer, currentFrameLength, initialBytesToStrip);
+        }
+
+        buffer.skipReadable(initialBytesToStrip);
+
+        // extract frame
+        final Buffer frame = extractFrame(ctx, buffer, currentFrameLength - initialBytesToStrip);
+        currentFrameLength = -1; // start processing the next frame
+        return frame;
+    }
+
+    /**
+     * Decodes the specified region of the buffer into an unadjusted frame length.  The default implementation is
+     * capable of decoding the specified region into an unsigned 8/16/24/32/64 bit integer.  Override this method to
+     * decode the length field encoded differently.  Note that this method must not modify the state of the specified
+     * buffer (e.g. {@code readerOffset}, {@code writerOffset}, and the content of the buffer.)
+     *
+     * @throws DecoderException if failed to decode the specified region
+     */
+    protected long getUnadjustedFrameLength(Buffer buffer, int offset, int length) {
+        final long frameLength;
+
+        switch (length) {
+        case 1:
+            frameLength = buffer.getUnsignedByte(offset);
+            break;
+        case 2:
+            frameLength = buffer.getUnsignedShort(offset);
+            break;
+        case 3:
+            frameLength = buffer.getUnsignedMedium(offset);
+            break;
+        case 4:
+            frameLength = buffer.getUnsignedInt(offset);
+            break;
+        case 8:
+            frameLength = buffer.getLong(offset);
+            break;
+        default:
+            throw new DecoderException(
+                    "unsupported lengthFieldLength: " + lengthFieldLength + " (expected: 1, 2, 3, 4, or 8)");
+        }
+
+        return byteOrder == ByteOrder.LITTLE_ENDIAN? Long.reverseBytes(frameLength) : frameLength;
+    }
+
+    private void failOnLengthExceededIfNecessary(boolean firstDetectionOfTooLongFrame) {
+        if (bytesToDiscard == 0) {
+            // Reset to the initial state and tell the handlers that
+            // the frame was too large.
+            final long tooLongFrameLength = this.tooLongFrameLength;
+            this.tooLongFrameLength = 0;
+
+            if (!failFast || firstDetectionOfTooLongFrame) {
+                failOnLengthExceeded(tooLongFrameLength);
+            }
+        } else {
+            // Keep discarding and notify handlers if necessary.
+            if (failFast && firstDetectionOfTooLongFrame) {
+                failOnLengthExceeded(tooLongFrameLength);
+            }
+        }
+    }
+
+    private void failOnLengthExceeded(long frameLength) {
+        if (frameLength > 0) {
+            throw new TooLongFrameException(
+                    "Adjusted frame length exceeds " + maxFrameLength + ": " + frameLength + " - discarded");
+        } else {
+            throw new TooLongFrameException("Adjusted frame length exceeds " + maxFrameLength + " - discarding");
+        }
+    }
+
+    /**
+     * Extract the sub-region of the specified buffer.  This method must modify the state of the buffer to continue
+     * after the frame (e.g. by splitting the buffer or by increasing {@code readerOffset}).
+     */
+    protected Buffer extractFrame(@SuppressWarnings("unused") ChannelHandlerContext ctx, Buffer buffer, int length) {
+        return buffer.readSplit(length);
+    }
+
+}

--- a/codec/src/main/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBuffer.java
@@ -20,8 +20,9 @@ import io.netty5.channel.ChannelHandlerContext;
 
 import java.nio.ByteOrder;
 
-import static io.netty5.util.internal.ObjectUtil.*;
-import static java.util.Objects.*;
+import static io.netty5.util.internal.ObjectUtil.checkPositive;
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A decoder that splits the received {@link Buffer}s dynamically by the

--- a/codec/src/main/java/io/netty5/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LengthFieldPrepender.java
@@ -15,16 +15,15 @@
  */
 package io.netty5.handler.codec;
 
-import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
-import static java.util.Objects.requireNonNull;
-
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 
 import java.nio.ByteOrder;
 import java.util.List;
 
+import static io.netty5.util.internal.ObjectUtil.*;
+import static java.util.Objects.*;
 
 /**
  * An encoder that prepends the length of the message.  The length value is
@@ -53,7 +52,7 @@ import java.util.List;
  * </pre>
  */
 @Sharable
-public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
+public class LengthFieldPrepender extends MessageToMessageEncoder<Buffer> {
 
     private final ByteOrder byteOrder;
     private final int lengthFieldLength;
@@ -64,10 +63,7 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
      * Creates a new instance.
      *
      * @param lengthFieldLength the length of the prepended length field.
-     *                          Only 1, 2, 3, 4, and 8 are allowed.
-     *
-     * @throws IllegalArgumentException
-     *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
+     *                          Only 1, 2, 3, 4, and 8 are supported by default.
      */
     public LengthFieldPrepender(int lengthFieldLength) {
         this(lengthFieldLength, false);
@@ -76,15 +72,11 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
     /**
      * Creates a new instance.
      *
-     * @param lengthFieldLength the length of the prepended length field.
-     *                          Only 1, 2, 3, 4, and 8 are allowed.
-     * @param lengthIncludesLengthFieldLength
-     *                          if {@code true}, the length of the prepended
-     *                          length field is added to the value of the
-     *                          prepended length field.
-     *
-     * @throws IllegalArgumentException
-     *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
+     * @param lengthFieldLength               the length of the prepended length field.
+     *                                        Only 1, 2, 3, 4, and 8 are supported by default.
+     * @param lengthIncludesLengthFieldLength if {@code true}, the length of the prepended
+     *                                        length field is added to the value of the
+     *                                        prepended length field.
      */
     public LengthFieldPrepender(int lengthFieldLength, boolean lengthIncludesLengthFieldLength) {
         this(lengthFieldLength, 0, lengthIncludesLengthFieldLength);
@@ -94,12 +86,9 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
      * Creates a new instance.
      *
      * @param lengthFieldLength the length of the prepended length field.
-     *                          Only 1, 2, 3, 4, and 8 are allowed.
+     *                          Only 1, 2, 3, 4, and 8 are supported by default.
      * @param lengthAdjustment  the compensation value to add to the value
      *                          of the length field
-     *
-     * @throws IllegalArgumentException
-     *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
      */
     public LengthFieldPrepender(int lengthFieldLength, int lengthAdjustment) {
         this(lengthFieldLength, lengthAdjustment, false);
@@ -108,17 +97,13 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
     /**
      * Creates a new instance.
      *
-     * @param lengthFieldLength the length of the prepended length field.
-     *                          Only 1, 2, 3, 4, and 8 are allowed.
-     * @param lengthAdjustment  the compensation value to add to the value
-     *                          of the length field
-     * @param lengthIncludesLengthFieldLength
-     *                          if {@code true}, the length of the prepended
-     *                          length field is added to the value of the
-     *                          prepended length field.
-     *
-     * @throws IllegalArgumentException
-     *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
+     * @param lengthFieldLength               the length of the prepended length field.
+     *                                        Only 1, 2, 3, 4, and 8 are supported by default.
+     * @param lengthAdjustment                the compensation value to add to the value
+     *                                        of the length field
+     * @param lengthIncludesLengthFieldLength if {@code true}, the length of the prepended
+     *                                        length field is added to the value of the
+     *                                        prepended length field.
      */
     public LengthFieldPrepender(int lengthFieldLength, int lengthAdjustment, boolean lengthIncludesLengthFieldLength) {
         this(ByteOrder.BIG_ENDIAN, lengthFieldLength, lengthAdjustment, lengthIncludesLengthFieldLength);
@@ -127,29 +112,18 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
     /**
      * Creates a new instance.
      *
-     * @param byteOrder         the {@link ByteOrder} of the length field
-     * @param lengthFieldLength the length of the prepended length field.
-     *                          Only 1, 2, 3, 4, and 8 are allowed.
-     * @param lengthAdjustment  the compensation value to add to the value
-     *                          of the length field
-     * @param lengthIncludesLengthFieldLength
-     *                          if {@code true}, the length of the prepended
-     *                          length field is added to the value of the
-     *                          prepended length field.
-     *
-     * @throws IllegalArgumentException
-     *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
+     * @param byteOrder                       the {@link ByteOrder} of the length field
+     * @param lengthFieldLength               the length of the prepended length field.
+     *                                        Only 1, 2, 3, 4, and 8 are supported by default.
+     * @param lengthAdjustment                the compensation value to add to the value
+     *                                        of the length field
+     * @param lengthIncludesLengthFieldLength if {@code true}, the length of the prepended
+     *                                        length field is added to the value of the
+     *                                        prepended length field.
      */
     public LengthFieldPrepender(
             ByteOrder byteOrder, int lengthFieldLength,
             int lengthAdjustment, boolean lengthIncludesLengthFieldLength) {
-        if (lengthFieldLength != 1 && lengthFieldLength != 2 &&
-            lengthFieldLength != 3 && lengthFieldLength != 4 &&
-            lengthFieldLength != 8) {
-            throw new IllegalArgumentException(
-                    "lengthFieldLength must be either 1, 2, 3, 4, or 8: " +
-                    lengthFieldLength);
-        }
         requireNonNull(byteOrder, "byteOrder");
 
         this.byteOrder = byteOrder;
@@ -159,45 +133,63 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
-        int length = msg.readableBytes() + lengthAdjustment;
+    protected void encode(ChannelHandlerContext ctx, Buffer buffer, List<Object> out) throws Exception {
+        int length = buffer.readableBytes() + lengthAdjustment;
         if (lengthIncludesLengthFieldLength) {
             length += lengthFieldLength;
         }
 
         checkPositiveOrZero(length, "length");
 
+        out.add(getLengthFieldBuffer(ctx, length, lengthFieldLength, byteOrder));
+        out.add(buffer.split());
+    }
+
+    /**
+     * Encodes the length into a buffer which will be prepended as the length field.  The default implementation is
+     * capable of encoding the length into an 8/16/24/32/64 bit integer.  Override this method to encode the length
+     * field differently.
+     *
+     * @param ctx the {@link ChannelHandlerContext} which this {@link LengthFieldPrepender} belongs to
+     * @param length the length which should be encoded in the length field
+     * @param lengthFieldLength the length of the prepended length field
+     * @param byteOrder the {@link ByteOrder} of the length field
+     * @return A buffer containing the encoded length
+     * @throws EncoderException if failed to encode the length
+     */
+    protected Buffer getLengthFieldBuffer(
+            ChannelHandlerContext ctx, int length, int lengthFieldLength, ByteOrder byteOrder) {
+        final boolean reverseBytes = byteOrder == ByteOrder.LITTLE_ENDIAN;
+
         switch (lengthFieldLength) {
         case 1:
             if (length >= 256) {
-                throw new IllegalArgumentException(
-                        "length does not fit into a byte: " + length);
+                throw new IllegalArgumentException("length does not fit into a byte: " + length);
             }
-            out.add(ctx.alloc().buffer(1).order(byteOrder).writeByte((byte) length));
-            break;
+            return ctx.bufferAllocator().allocate(lengthFieldLength).writeByte((byte) length);
         case 2:
             if (length >= 65536) {
-                throw new IllegalArgumentException(
-                        "length does not fit into a short integer: " + length);
+                throw new IllegalArgumentException("length does not fit into a short integer: " + length);
             }
-            out.add(ctx.alloc().buffer(2).order(byteOrder).writeShort((short) length));
-            break;
+            return ctx.bufferAllocator().allocate(lengthFieldLength)
+                      .writeShort(reverseBytes ? Short.reverseBytes((short) length) : (short) length);
         case 3:
             if (length >= 16777216) {
-                throw new IllegalArgumentException(
-                        "length does not fit into a medium integer: " + length);
+                throw new IllegalArgumentException("length does not fit into a medium integer: " + length);
             }
-            out.add(ctx.alloc().buffer(3).order(byteOrder).writeMedium(length));
-            break;
+
+            return ctx.bufferAllocator().allocate(lengthFieldLength)
+                      .writeMedium(reverseBytes ? Integer.reverseBytes(length) >> Byte.SIZE : length);
         case 4:
-            out.add(ctx.alloc().buffer(4).order(byteOrder).writeInt(length));
-            break;
+            return ctx.bufferAllocator().allocate(lengthFieldLength)
+                      .writeInt(reverseBytes ? Integer.reverseBytes(length) : length);
         case 8:
-            out.add(ctx.alloc().buffer(8).order(byteOrder).writeLong(length));
-            break;
+            return ctx.bufferAllocator().allocate(lengthFieldLength)
+                      .writeLong(reverseBytes ? Long.reverseBytes(length) : length);
         default:
-            throw new Error("should not reach here");
+            throw new EncoderException(
+                    "unsupported lengthFieldLength: " + lengthFieldLength + " (expected: 1, 2, 3, 4, or 8)");
         }
-        out.add(msg.retain());
     }
+
 }

--- a/codec/src/main/java/io/netty5/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LengthFieldPrepender.java
@@ -22,8 +22,8 @@ import io.netty5.channel.ChannelHandlerContext;
 import java.nio.ByteOrder;
 import java.util.List;
 
-import static io.netty5.util.internal.ObjectUtil.*;
-import static java.util.Objects.*;
+import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+import static java.util.Objects.requireNonNull;
 
 /**
  * An encoder that prepends the length of the message.  The length value is

--- a/codec/src/test/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBufferTest.java
@@ -29,12 +29,7 @@ public class LengthFieldBasedFrameDecoderForBufferTest {
         final EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoderForBuffer(16, 0, 4));
         final Buffer buffer = prepareTestBuffer(channel.bufferAllocator());
 
-        try {
-            channel.writeInbound(buffer);
-            fail();
-        } catch (TooLongFrameException e) {
-            // expected
-        }
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(buffer));
         assertTrue(channel.finish());
 
         try (final Buffer readBuffer = channel.readInbound()) {
@@ -52,12 +47,7 @@ public class LengthFieldBasedFrameDecoderForBufferTest {
         final EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoderForBuffer(16, 0, 4));
         final Buffer buffer = prepareTestBuffer(channel.bufferAllocator());
 
-        try {
-            channel.writeInbound(buffer.readSplit(14));
-            fail();
-        } catch (TooLongFrameException e) {
-            // expected
-        }
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(buffer.readSplit(14)));
         assertTrue(channel.writeInbound(buffer));
         assertTrue(channel.finish());
 

--- a/codec/src/test/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBufferTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LengthFieldBasedFrameDecoderForBufferTest {
+
+    @Test
+    public void testDiscardTooLongFrame1() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoderForBuffer(16, 0, 4));
+        final Buffer buffer = prepareTestBuffer(channel.bufferAllocator());
+
+        try {
+            channel.writeInbound(buffer);
+            fail();
+        } catch (TooLongFrameException e) {
+            // expected
+        }
+        assertTrue(channel.finish());
+
+        try (final Buffer readBuffer = channel.readInbound()) {
+            assertEquals(5, readBuffer.readableBytes());
+            assertEquals(1, readBuffer.readInt());
+            assertEquals(50, readBuffer.readByte());
+        }
+
+        assertNull(channel.readInbound());
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testDiscardTooLongFrame2() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoderForBuffer(16, 0, 4));
+        final Buffer buffer = prepareTestBuffer(channel.bufferAllocator());
+
+        try {
+            channel.writeInbound(buffer.readSplit(14));
+            fail();
+        } catch (TooLongFrameException e) {
+            // expected
+        }
+        assertTrue(channel.writeInbound(buffer));
+        assertTrue(channel.finish());
+
+        try (final Buffer readBuffer = channel.readInbound()) {
+            assertEquals(5, readBuffer.readableBytes());
+            assertEquals(1, readBuffer.readInt());
+            assertEquals(50, readBuffer.readByte());
+        }
+
+        assertNull(channel.readInbound());
+        assertFalse(channel.finish());
+    }
+
+    private static Buffer prepareTestBuffer(BufferAllocator allocator) {
+        final Buffer buffer = allocator.allocate(41);
+        buffer.writeInt(32);
+        for (byte i = 0; i < 32; i++) {
+            buffer.writeByte(i);
+        }
+        buffer.writeInt(1);
+        buffer.writeByte((byte) 50);
+        return buffer;
+    }
+
+}

--- a/codec/src/test/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBufferTest.java
@@ -20,7 +20,11 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LengthFieldBasedFrameDecoderForBufferTest {
 

--- a/codec/src/test/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBufferTest.java
@@ -36,7 +36,7 @@ public class LengthFieldBasedFrameDecoderForBufferTest {
         assertThrows(TooLongFrameException.class, () -> channel.writeInbound(buffer));
         assertTrue(channel.finish());
 
-        try (final Buffer readBuffer = channel.readInbound()) {
+        try (Buffer readBuffer = channel.readInbound()) {
             assertEquals(5, readBuffer.readableBytes());
             assertEquals(1, readBuffer.readInt());
             assertEquals(50, readBuffer.readByte());
@@ -55,7 +55,7 @@ public class LengthFieldBasedFrameDecoderForBufferTest {
         assertTrue(channel.writeInbound(buffer));
         assertTrue(channel.finish());
 
-        try (final Buffer readBuffer = channel.readInbound()) {
+        try (Buffer readBuffer = channel.readInbound()) {
             assertEquals(5, readBuffer.readableBytes());
             assertEquals(1, readBuffer.readInt());
             assertEquals(50, readBuffer.readByte());

--- a/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldBasedFrameDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldBasedFrameDecoderForBufferTest.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.frame;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.LengthFieldBasedFrameDecoderForBuffer;
 import io.netty5.handler.codec.TooLongFrameException;
 import io.netty5.util.CharsetUtil;
@@ -33,12 +32,9 @@ public class LengthFieldBasedFrameDecoderForBufferTest {
 
         for (int i = 0; i < 2; i++) {
             assertFalse(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 2 })));
-            try {
-                assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0 })));
-                fail(DecoderException.class.getSimpleName() + " must be raised.");
-            } catch (TooLongFrameException e) {
-                // Expected
-            }
+            assertThrows(TooLongFrameException.class, () -> {
+                channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0 }));
+            });
 
             assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 1, 'A' })));
 
@@ -54,12 +50,9 @@ public class LengthFieldBasedFrameDecoderForBufferTest {
                 new LengthFieldBasedFrameDecoderForBuffer(5, 0, 4, 0, 4));
 
         for (int i = 0; i < 2; i++) {
-            try {
-                assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 2 })));
-                fail(DecoderException.class.getSimpleName() + " must be raised.");
-            } catch (TooLongFrameException e) {
-                // Expected
-            }
+            assertThrows(TooLongFrameException.class, () -> {
+                channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 2 }));
+            });
 
             assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 0, 0, 1, 'A' })));
 

--- a/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldBasedFrameDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldBasedFrameDecoderForBufferTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.frame;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.codec.DecoderException;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoderForBuffer;
+import io.netty5.handler.codec.TooLongFrameException;
+import io.netty5.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LengthFieldBasedFrameDecoderForBufferTest {
+    @Test
+    public void testFailSlowTooLongFrameRecovery() throws Exception {
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                new LengthFieldBasedFrameDecoderForBuffer(5, 0, 4, 0, 4, false));
+
+        for (int i = 0; i < 2; i++) {
+            assertFalse(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 2 })));
+            try {
+                assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0 })));
+                fail(DecoderException.class.getSimpleName() + " must be raised.");
+            } catch (TooLongFrameException e) {
+                // Expected
+            }
+
+            assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 1, 'A' })));
+
+            try (Buffer buffer = channel.readInbound()) {
+                assertEquals("A", buffer.toString(CharsetUtil.ISO_8859_1));
+            }
+        }
+    }
+
+    @Test
+    public void testFailFastTooLongFrameRecovery() throws Exception {
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                new LengthFieldBasedFrameDecoderForBuffer(5, 0, 4, 0, 4));
+
+        for (int i = 0; i < 2; i++) {
+            try {
+                assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 2 })));
+                fail(DecoderException.class.getSimpleName() + " must be raised.");
+            } catch (TooLongFrameException e) {
+                // Expected
+            }
+
+            assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(new byte[] { 0, 0, 0, 0, 0, 1, 'A' })));
+
+            try (Buffer buffer = channel.readInbound()) {
+                assertEquals("A", buffer.toString(CharsetUtil.ISO_8859_1));
+            }
+        }
+    }
+}

--- a/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldBasedFrameDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldBasedFrameDecoderForBufferTest.java
@@ -22,7 +22,10 @@ import io.netty5.handler.codec.TooLongFrameException;
 import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LengthFieldBasedFrameDecoderForBufferTest {
     @Test

--- a/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldPrependerTest.java
@@ -25,7 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LengthFieldPrependerTest {
 

--- a/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/frame/LengthFieldPrependerTest.java
@@ -15,102 +15,97 @@
  */
 package io.netty5.handler.codec.frame;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.LengthFieldPrepender;
-import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static io.netty.buffer.Unpooled.*;
 import java.nio.ByteOrder;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LengthFieldPrependerTest {
 
-    private ByteBuf msg;
+    private Buffer message;
 
     @BeforeEach
     public void setUp() throws Exception {
-        msg = copiedBuffer("A", CharsetUtil.ISO_8859_1);
+        message = DefaultBufferAllocators.onHeapAllocator().copyOf(new byte[] {50});
     }
 
     @Test
     public void testPrependLength() throws Exception {
-        final EmbeddedChannel ch = new EmbeddedChannel(new LengthFieldPrepender(4));
-        ch.writeOutbound(msg);
-        ByteBuf buf = ch.readOutbound();
-        assertEquals(4, buf.readableBytes());
-        assertEquals(msg.readableBytes(), buf.readInt());
-        buf.release();
+        final EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldPrepender(4));
+        assertTrue(channel.writeOutbound(message.copy()));
 
-        buf = ch.readOutbound();
-        assertSame(buf, msg);
-        buf.release();
-    }
+        try (Buffer buffer = channel.readOutbound()) {
+            assertEquals(4, buffer.readableBytes());
+            assertEquals(message.readableBytes(), buffer.readInt());
+        }
 
-    @Test
-    public void testPrependLengthIncludesLengthFieldLength() throws Exception {
-        final EmbeddedChannel ch = new EmbeddedChannel(new LengthFieldPrepender(4, true));
-        ch.writeOutbound(msg);
-        ByteBuf buf = ch.readOutbound();
-        assertEquals(4, buf.readableBytes());
-        assertEquals(5, buf.readInt());
-        buf.release();
-
-        buf = ch.readOutbound();
-        assertSame(buf, msg);
-        buf.release();
-    }
-
-    @Test
-    public void testPrependAdjustedLength() throws Exception {
-        final EmbeddedChannel ch = new EmbeddedChannel(new LengthFieldPrepender(4, -1));
-        ch.writeOutbound(msg);
-        ByteBuf buf = ch.readOutbound();
-        assertEquals(4, buf.readableBytes());
-        assertEquals(msg.readableBytes() - 1, buf.readInt());
-        buf.release();
-
-        buf = ch.readOutbound();
-        assertSame(buf, msg);
-        buf.release();
-    }
-
-    @Test
-    public void testAdjustedLengthLessThanZero() throws Exception {
-        final EmbeddedChannel ch = new EmbeddedChannel(new LengthFieldPrepender(4, -2));
-        try {
-            ch.writeOutbound(msg);
-            fail(EncoderException.class.getSimpleName() + " must be raised.");
-        } catch (EncoderException e) {
-            // Expected
+        try (Buffer buffer = channel.readOutbound()) {
+            assertEquals(message, buffer);
         }
     }
 
     @Test
-    public void testPrependLengthInLittleEndian() throws Exception {
-        final EmbeddedChannel ch = new EmbeddedChannel(new LengthFieldPrepender(ByteOrder.LITTLE_ENDIAN, 4, 0, false));
-        ch.writeOutbound(msg);
-        ByteBuf buf = ch.readOutbound();
-        assertEquals(4, buf.readableBytes());
-        byte[] writtenBytes = new byte[buf.readableBytes()];
-        buf.getBytes(0, writtenBytes);
-        assertEquals(1, writtenBytes[0]);
-        assertEquals(0, writtenBytes[1]);
-        assertEquals(0, writtenBytes[2]);
-        assertEquals(0, writtenBytes[3]);
-        buf.release();
+    public void testPrependLengthIncludesLengthFieldLength() throws Exception {
+        final EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldPrepender(4, true));
+        assertTrue(channel.writeOutbound(message.copy()));
 
-        buf = ch.readOutbound();
-        assertSame(buf, msg);
-        buf.release();
-        assertFalse(ch.finish(), "The channel must have been completely read");
+        try (Buffer buffer = channel.readOutbound()) {
+            assertEquals(4, buffer.readableBytes());
+            assertEquals(message.readableBytes() + 4, buffer.readInt());
+        }
+
+        try (Buffer buffer = channel.readOutbound()) {
+            assertEquals(message, buffer);
+        }
+    }
+
+    @Test
+    public void testPrependAdjustedLength() throws Exception {
+        final EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldPrepender(4, -1));
+        assertTrue(channel.writeOutbound(message.copy()));
+
+        try (Buffer buffer = channel.readOutbound()) {
+            assertEquals(4, buffer.readableBytes());
+            assertEquals(message.readableBytes() - 1, buffer.readInt());
+        }
+
+        try (Buffer buffer = channel.readOutbound()) {
+            assertEquals(message, buffer);
+        }
+    }
+
+    @Test
+    public void testAdjustedLengthLessThanZero() throws Exception {
+        final EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldPrepender(4, -2));
+        assertThrows(EncoderException.class, () -> channel.writeOutbound(message.copy()));
+    }
+
+    @Test
+    public void testPrependLengthInLittleEndian() throws Exception {
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                new LengthFieldPrepender(ByteOrder.LITTLE_ENDIAN, 4, 0, false));
+        assertTrue(channel.writeOutbound(message.copy()));
+
+        try (Buffer buffer = channel.readOutbound()) {
+            assertEquals(4, buffer.readableBytes());
+            assertEquals(1, buffer.readByte());
+            assertEquals(0, buffer.readByte());
+            assertEquals(0, buffer.readByte());
+            assertEquals(0, buffer.readByte());
+        }
+
+        try (Buffer buffer = channel.readOutbound()) {
+            assertEquals(message, buffer);
+        }
+
+        assertFalse(channel.finish(), "The channel must have been completely read");
     }
 
 }


### PR DESCRIPTION
Motivation:
Allow creation of pipelines only with `Buffer` API

Modification:
- Add a version of `LengthFieldBasedFrameDecoder` which uses `Buffer` API. I've added it into separate class similar to `ByteToMessageDecoderForBuffer` so it doesn't break codec implementations still using `ByteBuf`.
- Port `LengthFieldPrepender` to `Buffer` API
- Extract creation of length field buffer into overwritable method (similar to it's counterpart in `LengthFieldBasedFrameDecoder`)
- Adjust affected tests

Result:
- `LengthFieldBasedFrameDecoderForBuffer` is now available. 
- `LengthFieldPrepender` now uses `Buffer` API and has a customizable method for encoding the length field.