### PR TITLE
Keep buffers alive for the duration of forEach calls

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -31,6 +31,7 @@ import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
 import io.netty5.buffer.api.internal.Statics;
 
 import java.io.IOException;
+import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
@@ -588,7 +589,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             return 0;
         }
         checkRead(readerOffset(), readableBytes);
-        return processor.process(initialIndex, this)? 1 : -1;
+        try {
+            return processor.process(initialIndex, this)? 1 : -1;
+        } finally {
+            Reference.reachabilityFence(this);
+        }
     }
 
     @Override
@@ -602,7 +607,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             return 0;
         }
         checkWrite(writerOffset(), writableBytes);
-        return processor.process(initialIndex, this)? 1 : -1;
+        try {
+            return processor.process(initialIndex, this)? 1 : -1;
+        } finally {
+            Reference.reachabilityFence(this);
+        }
     }
 
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors implementation.">

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -675,7 +675,11 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
             return 0;
         }
         checkRead(readerOffset(), readableBytes);
-        return processor.process(initialIndex, this)? 1 : -1;
+        try {
+            return processor.process(initialIndex, this)? 1 : -1;
+        } finally {
+            Reference.reachabilityFence(this);
+        }
     }
 
     @Override
@@ -689,7 +693,11 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
             return 0;
         }
         checkWrite(writerOffset(), writableBytes);
-        return processor.process(initialIndex, this)? 1 : -1;
+        try {
+            return processor.process(initialIndex, this)? 1 : -1;
+        } finally {
+            Reference.reachabilityFence(this);
+        }
     }
 
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors implementation.">


### PR DESCRIPTION
Motivation:
There was a theoretical issue where a Buffer instance could be garbage collected while the ByteBuffers from forEach components were still in use.
The issue exist because the Buffer instance itself is not necessarily used past the calls to acquiring ByteBuffers, and thus the compiler and GC can conspire to collect the Buffer instance, which in turn can lead the Cleaner to free the underlying memory that is still used by the ByteBuffer.

Modification:
Enclose the component processing in NioBuffer and UnsafeBuffer with try-finally clauses that adds a reachability fence to keep the buffers alive throughout the component processing.

Result:
Buffers can no longer be freed while component processing inside a forEach method is taking place.