### PR TITLE
Don't use ByteBufConvertible when not necessary

### DIFF
--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
@@ -200,6 +200,9 @@ public final class ChannelOutboundBuffer {
     }
 
     private static long total(Object msg) {
+        if (msg instanceof Buffer) {
+            return ((Buffer) msg).readableBytes();
+        }
         if (msg instanceof ByteBufConvertible) {
             return ((ByteBufConvertible) msg).asByteBuf().readableBytes();
         }

--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
@@ -203,14 +203,14 @@ public final class ChannelOutboundBuffer {
         if (msg instanceof Buffer) {
             return ((Buffer) msg).readableBytes();
         }
-        if (msg instanceof ByteBufConvertible) {
-            return ((ByteBufConvertible) msg).asByteBuf().readableBytes();
-        }
         if (msg instanceof FileRegion) {
             return ((FileRegion) msg).count();
         }
         if (msg instanceof ByteBufHolder) {
             return ((ByteBufHolder) msg).content().readableBytes();
+        }
+        if (msg instanceof ByteBufConvertible) {
+            return ((ByteBufConvertible) msg).asByteBuf().readableBytes();
         }
         return -1;
     }


### PR DESCRIPTION
Motivation:

While doing a performance test using latest netty5 (from main branch, and java 11), I have observed a performance issue in the ChannelOutboundBuffer.total method.

I'm using new Buffer API.

So, when the _msg_ parameter passed to _io.netty5.buffer.api.internal.ChannelOutboundBuffer.total(Object msg)_  is  an instance of the new **Buffer** type (_io.netty5.buffer.api.bytebuffer.NioBuffer_ in my case), then the following method call takes around 31% of CPU

```
    private static long total(Object msg) {
        if (msg instanceof ByteBufConvertible) {
            return ((ByteBufConvertible) msg).asByteBuf().readableBytes();
        }
        if (msg instanceof FileRegion) {
            return ((FileRegion) msg).count();
        }
        if (msg instanceof ByteBufHolder) {
            return ((ByteBufHolder) msg).content().readableBytes();
        }
        return -1;
    }

```
Here, since the NioBuffer implements the ByteBufConvertible interface, then the asByteBuf() convertion method is called and it takes a lot of CPU. Please check [asyncprofiler trace](https://github.com/netty/netty/files/8471572/cpu-buffer.html.gz).

Modification:

Test if the passed parameter is an instance of a Buffer:

```
    private static long total(Object msg) {
        if (msg instanceof Buffer) {
            return ((Buffer) msg).readableBytes();
        }
        if (msg instanceof ByteBufConvertible) {
            return ((ByteBufConvertible) msg).asByteBuf().readableBytes();
        }
        if (msg instanceof FileRegion) {
            return ((FileRegion) msg).count();
        }
        if (msg instanceof ByteBufHolder) {
            return ((ByteBufHolder) msg).content().readableBytes();
        }
        return -1;
    }

```

Result:

there is no more performance issue after applying the above patch.