### PR TITLE
Make the new Buffer API the default for transports

### DIFF
--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
@@ -150,8 +150,7 @@ public class WebSocketFrameAggregatorTest {
 
     private static byte[] toBytes(Buffer buf) {
         byte[] bytes = new byte[buf.readableBytes()];
-        buf.copyInto(buf.readerOffset(), bytes, 0, bytes.length);
-        buf.skipReadable(bytes.length);
+        buf.readBytes(bytes, 0, bytes.length);
         return bytes;
     }
 }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -642,7 +642,7 @@ public class Http2ConnectionRoundtripTest {
                         // Ensure we update the window size so we will try to write the rest of the frame while
                         // processing the flush.
                         http2Client.encoder().flowController().initialWindowSize(8);
-                        return ctx.newFailedFuture(new IllegalStateException());
+                        return ctx.newFailedFuture(new IllegalStateException("Exception for test"));
                     } catch (Http2Exception e) {
                         return ctx.newFailedFuture(e);
                     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -929,7 +929,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
                 ctx.close();
-                throw new Exception("exception");
+                throw new Exception("Exception for test");
             }
         });
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -144,6 +144,7 @@ public class StreamBufferingEncoderTest {
                 .when(ctx).newFailedFuture(any(Throwable.class));
 
         when(ctx.executor()).thenReturn(executor);
+        when(ctx.close()).thenReturn(newPromise().asFuture());
         when(channel.isActive()).thenReturn(false);
         when(channel.config()).thenReturn(config);
         when(channel.isWritable()).thenReturn(true);

--- a/example/src/main/java/io/netty5/example/http2/helloworld/client/HttpResponseHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/client/HttpResponseHandler.java
@@ -103,8 +103,7 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
             if (content.readableBytes() > 0) {
                 int contentLength = content.readableBytes();
                 byte[] arr = new byte[contentLength];
-                content.copyInto(content.readerOffset(), arr, 0, contentLength);
-                content.skipReadable(contentLength);
+                content.readBytes(arr, 0, contentLength);
                 System.out.println(new String(arr, 0, contentLength, CharsetUtil.UTF_8));
             }
 

--- a/handler/src/main/java/io/netty5/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/traffic/AbstractTrafficShapingHandler.java
@@ -18,6 +18,7 @@ package io.netty5.handler.traffic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufConvertible;
 import io.netty.buffer.ByteBufHolder;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandler;
@@ -646,6 +647,9 @@ public abstract class AbstractTrafficShapingHandler implements ChannelHandler {
      * @return size the size of the msg or {@code -1} if unknown.
      */
     protected long calculateSize(Object msg) {
+        if (msg instanceof Buffer) {
+            return ((Buffer) msg).readableBytes();
+        }
         if (msg instanceof ByteBufConvertible) {
             return ((ByteBufConvertible) msg).asByteBuf().readableBytes();
         }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
@@ -18,6 +18,7 @@ package io.netty5.resolver.dns;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelFactory;
@@ -27,11 +28,14 @@ import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.EventLoop;
 import io.netty5.channel.FixedRecvBufferAllocator;
+import io.netty5.channel.socket.BufferDatagramPacket;
 import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.handler.codec.CorruptedFrameException;
+import io.netty5.handler.codec.MessageToMessageDecoder;
+import io.netty5.handler.codec.MessageToMessageEncoder;
 import io.netty5.handler.codec.dns.DatagramDnsQueryEncoder;
 import io.netty5.handler.codec.dns.DatagramDnsResponse;
 import io.netty5.handler.codec.dns.DatagramDnsResponseDecoder;
@@ -77,6 +81,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static io.netty5.buffer.api.adaptor.ByteBufAdaptor.intoByteBuf;
+import static io.netty5.handler.adaptor.BufferConversionHandler.bufferToByteBuf;
 import static io.netty5.resolver.dns.DefaultDnsServerAddressStreamProvider.DNS_PORT;
 import static io.netty5.util.internal.ObjectUtil.checkPositive;
 import static java.util.Objects.requireNonNull;
@@ -203,6 +209,18 @@ public class DnsNameResolver extends InetNameResolver {
     };
     private static final DatagramDnsQueryEncoder DATAGRAM_ENCODER = new DatagramDnsQueryEncoder();
     private static final TcpDnsQueryEncoder TCP_ENCODER = new TcpDnsQueryEncoder();
+    private static final MessageToMessageDecoder<BufferDatagramPacket> CONVERTER = new MessageToMessageDecoder<BufferDatagramPacket>() {
+        @Override
+        protected void decode(ChannelHandlerContext ctx, BufferDatagramPacket msg) throws Exception {
+            ByteBuf content = intoByteBuf(msg.content());
+            ctx.fireChannelRead(new DatagramPacket(content, msg.recipient(), msg.sender()));
+        }
+
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    };
 
     final Promise<Channel> channelReadyPromise;
     final Channel ch;
@@ -452,13 +470,12 @@ public class DnsNameResolver extends InetNameResolver {
         Bootstrap b = new Bootstrap();
         b.group(executor());
         b.channelFactory(channelFactory);
-        b.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false); // todo DNS is not migrated yet
         channelReadyPromise = executor().newPromise();
         final DnsResponseHandler responseHandler = new DnsResponseHandler(channelReadyPromise);
         b.handler(new ChannelInitializer<DatagramChannel>() {
             @Override
             protected void initChannel(DatagramChannel ch) {
-                ch.pipeline().addLast(DATAGRAM_ENCODER, DATAGRAM_DECODER, responseHandler);
+                ch.pipeline().addLast(CONVERTER, DATAGRAM_ENCODER, DATAGRAM_DECODER, responseHandler);
                 ch.closeFuture().addListener(closeFuture -> {
                     resolveCache.clear();
                     cnameCache.clear();

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
@@ -209,7 +209,8 @@ public class DnsNameResolver extends InetNameResolver {
     };
     private static final DatagramDnsQueryEncoder DATAGRAM_ENCODER = new DatagramDnsQueryEncoder();
     private static final TcpDnsQueryEncoder TCP_ENCODER = new TcpDnsQueryEncoder();
-    private static final MessageToMessageDecoder<BufferDatagramPacket> CONVERTER = new MessageToMessageDecoder<BufferDatagramPacket>() {
+    private static final MessageToMessageDecoder<BufferDatagramPacket> CONVERTER =
+            new MessageToMessageDecoder<BufferDatagramPacket>() {
         @Override
         protected void decode(ChannelHandlerContext ctx, BufferDatagramPacket msg) throws Exception {
             ByteBuf content = intoByteBuf(msg.content());

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
@@ -452,6 +452,7 @@ public class DnsNameResolver extends InetNameResolver {
         Bootstrap b = new Bootstrap();
         b.group(executor());
         b.channelFactory(channelFactory);
+        b.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false); // todo DNS is not migrated yet
         channelReadyPromise = executor().newPromise();
         final DnsResponseHandler responseHandler = new DnsResponseHandler(channelReadyPromise);
         b.handler(new ChannelInitializer<DatagramChannel>() {

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
@@ -26,6 +26,7 @@ import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.ReflectiveChannelFactory;
 import io.netty5.channel.nio.NioHandler;
+import io.netty5.channel.socket.BufferDatagramPacket;
 import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.InternetProtocolFamily;
@@ -3061,10 +3062,10 @@ public class DnsNameResolverTest {
                 resolver.ch.pipeline().addFirst(new ChannelHandler() {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                        if (msg instanceof DatagramPacket) {
+                        if (msg instanceof BufferDatagramPacket) {
                             // Truncate the packet by 1 byte.
-                            DatagramPacket packet = (DatagramPacket) msg;
-                            packet.content().writerIndex(packet.content().writerIndex() - 1);
+                            BufferDatagramPacket packet = (BufferDatagramPacket) msg;
+                            packet.content().writerOffset(packet.content().writerOffset() - 1);
                         }
                         ctx.fireChannelRead(msg);
                     }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
@@ -3062,10 +3062,10 @@ public class DnsNameResolverTest {
                 resolver.ch.pipeline().addFirst(new ChannelHandler() {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                        if (msg instanceof BufferDatagramPacket) {
+                        if (msg instanceof DatagramPacket) {
                             // Truncate the packet by 1 byte.
-                            BufferDatagramPacket packet = (BufferDatagramPacket) msg;
-                            packet.content().writerOffset(packet.content().writerOffset() - 1);
+                            DatagramPacket packet = (DatagramPacket) msg;
+                            packet.content().writerIndex(packet.content().writerIndex() - 1);
                         }
                         ctx.fireChannelRead(msg);
                     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractComboTestsuiteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractComboTestsuiteTest.java
@@ -62,14 +62,6 @@ public abstract class AbstractComboTestsuiteTest<SB extends AbstractBootstrap<?,
 
     protected abstract void configure(SB sb, CB cb, ByteBufAllocator byteBufAllocator, BufferAllocator bufferAllocator);
 
-    public void enableNewBufferAPI(AbstractBootstrap<?, ?, ?> sb, Bootstrap cb) {
-        sb.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true);
-        if (sb instanceof ServerBootstrap) {
-            ((ServerBootstrap) sb).childOption(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true);
-        }
-        cb.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true);
-    }
-
     public void disableNewBufferAPI(AbstractBootstrap<?, ?, ?> sb, Bootstrap cb) {
         sb.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false);
         if (sb instanceof ServerBootstrap) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractComboTestsuiteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/AbstractComboTestsuiteTest.java
@@ -70,6 +70,14 @@ public abstract class AbstractComboTestsuiteTest<SB extends AbstractBootstrap<?,
         cb.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, true);
     }
 
+    public void disableNewBufferAPI(AbstractBootstrap<?, ?, ?> sb, Bootstrap cb) {
+        sb.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false);
+        if (sb instanceof ServerBootstrap) {
+            ((ServerBootstrap) sb).childOption(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false);
+        }
+        cb.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false);
+    }
+
     public interface Runner<SB extends AbstractBootstrap<?, ?, ?>, CB extends AbstractBootstrap<?, ?, ?>> {
         void run(SB sb, CB cb) throws Throwable;
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -54,6 +54,7 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
     }
 
     public void testSingleCompositeBufferWriteByteBuf(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        disableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {
@@ -254,6 +255,7 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
 
     public void testCompositeBufferPartialWriteDoesNotCorruptDataByteBuf(ServerBootstrap sb, Bootstrap cb)
             throws Throwable {
+        disableNewBufferAPI(sb, cb);
         // The scenario is the following:
         // Limit SO_SNDBUF so that a single buffer can be written, and part of a CompositeByteBuf at the same time.
         // We then write the single buffer, the CompositeByteBuf, and another single buffer and verify the data is not

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -152,7 +152,6 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
     }
 
     public void testSingleCompositeBufferWrite(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {
@@ -394,7 +393,6 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
     }
 
     public void testCompositeBufferPartialWriteDoesNotCorruptData(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         // The scenario is the following:
         // Limit SO_SNDBUF so that a single buffer can be written, and part of a CompositeByteBuf at the same time.
         // We then write the single buffer, the CompositeByteBuf, and another single buffer and verify the data is not

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -128,7 +128,6 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
     }
 
     public void testMulticast(Bootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         NetworkInterface iface = multicastNetworkInterface();
         assumeTrue(iface != null, "No NetworkInterface found that supports multicast and " +
                              socketInternetProtocalFamily());

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty5.testsuite.transport.socket;
 
-import io.netty5.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
+import io.netty5.bootstrap.Bootstrap;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
@@ -55,6 +55,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
     }
 
     public void testMulticastByteBuf(Bootstrap sb, Bootstrap cb) throws Throwable {
+        disableNewBufferAPI(sb, cb);
         NetworkInterface iface = multicastNetworkInterface();
         assumeTrue(iface != null, "No NetworkInterface found that supports multicast and " +
                              socketInternetProtocalFamily());
@@ -75,6 +76,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
 
         cb.option(ChannelOption.IP_MULTICAST_IF, iface);
         cb.option(ChannelOption.SO_REUSEADDR, true);
+        cb.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false);
 
         DatagramChannel sc = (DatagramChannel) sb.bind(newSocketAddress(iface)).get();
         assertEquals(iface, sc.config().getNetworkInterface());

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -324,7 +324,6 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     @SuppressWarnings("deprecation")
     private void testSimpleSend0(Bootstrap sb, Bootstrap cb, Buffer buf, boolean bindClient,
                                 final byte[] bytes, int count) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         Channel sc = null;
         Channel cc = null;
 
@@ -480,7 +479,6 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
     private void testSimpleSendWithConnect0(Bootstrap sb, Bootstrap cb, Buffer buf, final byte[] bytes, int count)
             throws Throwable {
-        enableNewBufferAPI(sb, cb);
         Channel sc = null;
         Channel cc = null;
         try (buf) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -112,7 +112,6 @@ public class SocketAutoReadTest extends AbstractSocketTest {
     }
 
     public void testAutoReadOffDuringReadOnlyReadsOne(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testAutoReadOffDuringReadOnlyReadsOne(true, sb, cb);
         testAutoReadOffDuringReadOnlyReadsOne(false, sb, cb);
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -62,7 +62,6 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
         final WriteHandler serverHandler;
         final WriteHandler clientHandler;
         if (useNewBufferAPI) {
-            enableNewBufferAPI(sb, cb);
             serverHandler = new BufferWriterHandler();
             clientHandler = new BufferWriterHandler();
         } else {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -24,7 +24,6 @@ import io.netty5.buffer.api.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -114,7 +113,6 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
     }
 
     public void testCancelWrite(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         final TestHandler sh = new TestHandler();
         final TestHandler ch = new TestHandler();
         final Buffer a = preferredAllocator().allocate(1).writeByte((byte) 'a');

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -49,6 +49,7 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
     }
 
     public void testCancelWriteByteBuf(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        disableNewBufferAPI(sb, cb);
         final TestHandler sh = new TestHandler();
         final TestHandler ch = new TestHandler();
         final ByteBuf a = Unpooled.buffer().writeByte('a');

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -135,7 +135,6 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
     }
 
     public void testConditionalWritability(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -42,6 +42,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
     }
 
     public void testConditionalWritabilityByteBuf(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        disableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
@@ -161,7 +161,6 @@ public class SocketConnectTest extends AbstractSocketTest {
     }
 
     public void testWriteWithFastOpenBeforeConnect(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         enableTcpFastOpen(sb, cb);
         sb.childOption(ChannelOption.AUTO_READ, true);
         cb.option(ChannelOption.AUTO_READ, true);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -140,7 +140,6 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
     }
 
     public void testAutoReadOffNoDataReadUntilReadCalled(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         final int sleepMs = 100;
@@ -293,7 +292,6 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
     }
 
     public void testAutoReadOnDataReadImmediately(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -44,6 +44,7 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
     }
 
     public void testAutoReadOffNoDataReadUntilReadCalledByteBuf(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        disableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         final int sleepMs = 100;
@@ -235,6 +236,7 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
     }
 
     public void testAutoReadOnDataReadImmediatelyByteBuf(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        disableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketEchoTest.java
@@ -73,7 +73,6 @@ public class SocketEchoTest extends AbstractSocketTest {
     }
 
     public void testSimpleEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testSimpleEcho0(sb, cb, true, true);
     }
 
@@ -84,7 +83,6 @@ public class SocketEchoTest extends AbstractSocketTest {
     }
 
     public void testSimpleEchoNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testSimpleEcho0(sb, cb, false, true);
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -81,7 +81,6 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
     }
 
     public void testReadPendingIsResetAfterEachRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
@@ -233,8 +233,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         @Override
         public void messageReceived(ChannelHandlerContext ctx, Buffer in) throws Exception {
             byte[] actual = new byte[in.readableBytes()];
-            in.copyInto(in.readerOffset(), actual, 0, actual.length);
-            in.skipReadable(actual.length);
+            in.readBytes(actual, 0, actual.length);
 
             int lastIdx = counter;
             for (int i = 0; i < actual.length; i ++) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -53,12 +53,10 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
     }
 
     public void testFixedLengthEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testFixedLengthEcho(sb, cb, true);
     }
 
     public void testFixedLengthEchoNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testFixedLengthEcho(sb, cb, false);
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -174,8 +174,8 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
     private void testGatheringWrite0(
             ServerBootstrap sb, Bootstrap cb, byte[] data, boolean composite, boolean autoRead, boolean newBufferAPI)
             throws Throwable {
-        if (newBufferAPI) {
-            enableNewBufferAPI(sb, cb);
+        if (!newBufferAPI) {
+            disableNewBufferAPI(sb, cb);
         }
         sb.childOption(ChannelOption.AUTO_READ, autoRead);
         cb.option(ChannelOption.AUTO_READ, autoRead);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -70,7 +70,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     private void testHalfClosureReceiveDataOnFinalWait2StateWhenSoLingerSet(
             ServerBootstrap sb, Bootstrap cb, boolean newBufferAPI)
             throws Throwable {
-        if (newBufferAPI) {
+        if (!newBufferAPI) {
+            disableNewBufferAPI(sb, cb);
         }
         Channel serverChannel = null;
         Channel clientChannel = null;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -71,7 +71,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             ServerBootstrap sb, Bootstrap cb, boolean newBufferAPI)
             throws Throwable {
         if (newBufferAPI) {
-            enableNewBufferAPI(sb, cb);
         }
         Channel serverChannel = null;
         Channel clientChannel = null;
@@ -222,7 +221,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     public void testAllDataReadAfterHalfClosure(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testAllDataReadAfterHalfClosure(true, sb, cb, true);
         testAllDataReadAfterHalfClosure(false, sb, cb, true);
     }
@@ -360,7 +358,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     public void testAutoCloseFalseDoesShutdownOutput(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testAutoCloseFalseDoesShutdownOutput(false, false, sb, cb, true);
         testAutoCloseFalseDoesShutdownOutput(false, true, sb, cb, true);
         testAutoCloseFalseDoesShutdownOutput(true, false, sb, cb, true);
@@ -596,7 +593,6 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
     }
 
     public void testAllDataReadClosure(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testAllDataReadClosure(true, false, sb, cb, true);
         testAllDataReadClosure(true, true, sb, cb, true);
         testAllDataReadClosure(false, false, sb, cb, true);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -61,7 +61,6 @@ public class SocketReadPendingTest extends AbstractSocketTest {
     public void testReadPendingIsResetAfterEachRead(ServerBootstrap sb, Bootstrap cb, boolean newBufferAPI)
             throws Throwable {
         if (newBufferAPI) {
-            enableNewBufferAPI(sb, cb);
         }
         Channel serverChannel = null;
         Channel clientChannel = null;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -60,7 +60,8 @@ public class SocketReadPendingTest extends AbstractSocketTest {
 
     public void testReadPendingIsResetAfterEachRead(ServerBootstrap sb, Bootstrap cb, boolean newBufferAPI)
             throws Throwable {
-        if (newBufferAPI) {
+        if (!newBufferAPI) {
+            disableNewBufferAPI(sb, cb);
         }
         Channel serverChannel = null;
         Channel clientChannel = null;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -16,8 +16,7 @@
 package io.netty5.testsuite.transport.socket;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -41,6 +40,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -67,7 +67,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             assertFalse(ch.isOutputShutdown());
 
             s = ss.accept();
-            ch.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 1 })).sync();
+            ch.writeAndFlush(onHeapAllocator().copyOf(new byte[] { 1 })).sync();
             assertEquals(1, s.getInputStream().read());
 
             assertTrue(h.ch.isOpen());
@@ -157,7 +157,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             s = ss.accept();
 
             byte[] expectedBytes = { 1, 2, 3, 4, 5, 6 };
-            Future<Void> writeFuture = ch.write(Unpooled.wrappedBuffer(expectedBytes));
+            Future<Void> writeFuture = ch.write(onHeapAllocator().copyOf(expectedBytes));
             h.assertWritability(false);
             ch.flush();
             writeFuture.sync();
@@ -182,7 +182,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
 
             try {
                 // If half-closed, the local endpoint shouldn't be able to write
-                ch.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{ 2 })).sync();
+                ch.writeAndFlush(onHeapAllocator().copyOf(new byte[]{ 2 })).sync();
                 fail();
             } catch (Throwable cause) {
                 checkThrowable(cause.getCause());
@@ -252,7 +252,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         }
     }
 
-    private static final class TestHandler extends SimpleChannelInboundHandler<ByteBuf> {
+    private static final class TestHandler extends SimpleChannelInboundHandler<Buffer> {
         volatile SocketChannel ch;
         final BlockingQueue<Byte> queue = new LinkedBlockingQueue<>();
         final BlockingDeque<Boolean> writabilityQueue = new LinkedBlockingDeque<>();
@@ -268,7 +268,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         }
 
         @Override
-        public void messageReceived(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
+        public void messageReceived(ChannelHandlerContext ctx, Buffer msg) throws Exception {
             queue.offer(msg.readByte());
         }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -151,7 +151,6 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
     public void testSslRenegotiationRejected(ServerBootstrap sb, Bootstrap cb, SslContext serverCtx,
                                              SslContext clientCtx, boolean delegate) throws Throwable {
         reset();
-        enableNewBufferAPI(sb, cb);
 
         final ExecutorService executorService = delegate ? Executors.newCachedThreadPool() : null;
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -17,7 +17,6 @@ package io.netty5.testsuite.transport.socket;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.Channel;
@@ -126,7 +125,6 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
 
     public void testSslGreeting(ServerBootstrap sb, Bootstrap cb, SslContext serverCtx,
                                 SslContext clientCtx, boolean delegate) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         final ServerHandler sh = new ServerHandler();
         final ClientHandler ch = new ClientHandler();
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -179,8 +179,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         @Override
         public void messageReceived(ChannelHandlerContext ctx, Buffer in) throws Exception {
             byte[] actual = new byte[in.readableBytes()];
-            in.copyInto(in.readerOffset(), actual, 0, actual.length);
-            in.skipReadable(in.readableBytes());
+            in.readBytes(actual, 0, actual.length);
             ctx.close();
         }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -17,7 +17,6 @@ package io.netty5.testsuite.transport.socket;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty5.buffer.api.Buffer;
@@ -90,7 +89,6 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
 
     public void testSslSessionReuse(ServerBootstrap sb, Bootstrap cb,
                                     SslContext serverCtx, SslContext clientCtx) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         final ReadAndDiscardHandler sh = new ReadAndDiscardHandler(true, true);
         final ReadAndDiscardHandler ch = new ReadAndDiscardHandler(false, true);
         final String[] protocols = { "TLSv1", "TLSv1.1", "TLSv1.2" };

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStartTlsTest.java
@@ -131,7 +131,6 @@ public class SocketStartTlsTest extends AbstractSocketTest {
 
     private void testStartTls(ServerBootstrap sb, Bootstrap cb,
                                      SslContext serverCtx, SslContext clientCtx, boolean autoRead) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         sb.childOption(ChannelOption.AUTO_READ, autoRead);
         cb.option(ChannelOption.AUTO_READ, autoRead);
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketStringEchoTest.java
@@ -64,7 +64,6 @@ public class SocketStringEchoTest extends AbstractSocketTest {
     }
 
     public void testStringEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testStringEcho(sb, cb, true);
     }
 
@@ -75,7 +74,6 @@ public class SocketStringEchoTest extends AbstractSocketTest {
     }
 
     public void testStringEchoNotAutoRead(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        enableNewBufferAPI(sb, cb);
         testStringEcho(sb, cb, false);
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -484,8 +484,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
             byte[] actual = new byte[in.readableBytes()];
             int nb = actual.length / messageSize;
             loggerServer.info("Step: " + step + " Read: " + nb + " blocks");
-            in.copyInto(in.readerOffset(), actual, 0, actual.length);
-            in.skipReadable(actual.length);
+            in.readBytes(actual, 0, actual.length);
             long timestamp = TrafficCounter.milliSecondFromNano();
             int isAutoRead = 0;
             int laststep = step;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -14,8 +14,8 @@ package io.netty5.testsuite.transport.socket;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
@@ -131,139 +131,139 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testNoTrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testNoTrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST NO TRAFFIC";
         currentTestRun = 0;
-        run(testInfo, this::testNoTrafficShapping);
+        run(testInfo, this::testNoTrafficShaping);
     }
 
-    public void testNoTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testNoTrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = null;
         int[] multipleMessage = { 1, 2, 1 };
         long[] minimalWaitBetween = null;
-        testTrafficShapping0(sb, cb, false, false, false, false, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, false, false, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testWriteTrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testWriteTrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST WRITE";
         currentTestRun = 0;
-        run(testInfo, this::testWriteTrafficShapping);
+        run(testInfo, this::testWriteTrafficShaping);
     }
 
-    public void testWriteTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testWriteTrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = null;
         int[] multipleMessage = { 1, 2, 1, 1 };
         long[] minimalWaitBetween = computeWaitWrite(multipleMessage);
-        testTrafficShapping0(sb, cb, false, false, true, false, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, false, true, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testReadTrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testReadTrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST READ";
         currentTestRun = 0;
-        run(testInfo, this::testReadTrafficShapping);
+        run(testInfo, this::testReadTrafficShaping);
     }
 
-    public void testReadTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testReadTrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = null;
         int[] multipleMessage = { 1, 2, 1, 1 };
         long[] minimalWaitBetween = computeWaitRead(multipleMessage);
-        testTrafficShapping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testWrite1TrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testWrite1TrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST WRITE";
         currentTestRun = 0;
-        run(testInfo, this::testWrite1TrafficShapping);
+        run(testInfo, this::testWrite1TrafficShaping);
     }
 
-    public void testWrite1TrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testWrite1TrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = null;
         int[] multipleMessage = { 1, 1, 1 };
         long[] minimalWaitBetween = computeWaitWrite(multipleMessage);
-        testTrafficShapping0(sb, cb, false, false, true, false, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, false, true, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testRead1TrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testRead1TrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST READ";
         currentTestRun = 0;
-        run(testInfo, this::testRead1TrafficShapping);
+        run(testInfo, this::testRead1TrafficShaping);
     }
 
-    public void testRead1TrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testRead1TrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = null;
         int[] multipleMessage = { 1, 1, 1 };
         long[] minimalWaitBetween = computeWaitRead(multipleMessage);
-        testTrafficShapping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testWriteGlobalTrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testWriteGlobalTrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST GLOBAL WRITE";
         currentTestRun = 0;
-        run(testInfo, this::testWriteGlobalTrafficShapping);
+        run(testInfo, this::testWriteGlobalTrafficShaping);
     }
 
-    public void testWriteGlobalTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testWriteGlobalTrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = null;
         int[] multipleMessage = { 1, 2, 1, 1 };
         long[] minimalWaitBetween = computeWaitWrite(multipleMessage);
-        testTrafficShapping0(sb, cb, false, false, true, true, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, false, true, true, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testReadGlobalTrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testReadGlobalTrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST GLOBAL READ";
         currentTestRun = 0;
-        run(testInfo, this::testReadGlobalTrafficShapping);
+        run(testInfo, this::testReadGlobalTrafficShaping);
     }
 
-    public void testReadGlobalTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testReadGlobalTrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = null;
         int[] multipleMessage = { 1, 2, 1, 1 };
         long[] minimalWaitBetween = computeWaitRead(multipleMessage);
-        testTrafficShapping0(sb, cb, false, true, false, true, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, true, false, true, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testAutoReadTrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testAutoReadTrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST AUTO READ";
         currentTestRun = 0;
-        run(testInfo, this::testAutoReadTrafficShapping);
+        run(testInfo, this::testAutoReadTrafficShaping);
     }
 
-    public void testAutoReadTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testAutoReadTrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = { 1, -1, -1, 1, -2, 0, 1, 0, -3, 0, 1, 2, 0 };
         int[] multipleMessage = new int[autoRead.length];
         Arrays.fill(multipleMessage, 1);
         long[] minimalWaitBetween = computeWaitAutoRead(autoRead);
-        testTrafficShapping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, true, false, false, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testAutoReadGlobalTrafficShapping(TestInfo testInfo) throws Throwable {
+    public void testAutoReadGlobalTrafficShaping(TestInfo testInfo) throws Throwable {
         currentTestName = "TEST AUTO READ GLOBAL";
         currentTestRun = 0;
-        run(testInfo, this::testAutoReadGlobalTrafficShapping);
+        run(testInfo, this::testAutoReadGlobalTrafficShaping);
     }
 
-    public void testAutoReadGlobalTrafficShapping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+    public void testAutoReadGlobalTrafficShaping(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         int[] autoRead = { 1, -1, -1, 1, -2, 0, 1, 0, -3, 0, 1, 2, 0 };
         int[] multipleMessage = new int[autoRead.length];
         Arrays.fill(multipleMessage, 1);
         long[] minimalWaitBetween = computeWaitAutoRead(autoRead);
-        testTrafficShapping0(sb, cb, false, true, false, true, autoRead, minimalWaitBetween, multipleMessage);
+        testTrafficShaping0(sb, cb, false, true, false, true, autoRead, minimalWaitBetween, multipleMessage);
     }
 
     /**
@@ -284,7 +284,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
      *            ensure correct testing)
      * @throws Throwable if something goes wrong, and the test fails.
      */
-    private static void testTrafficShapping0(
+    private static void testTrafficShaping0(
             ServerBootstrap sb, Bootstrap cb, final boolean additionalExecutor,
             final boolean limitRead, final boolean limitWrite, final boolean globalLimit, int[] autoRead,
             long[] minimalWaitBetween, int[] multipleMessage) throws Throwable {
@@ -392,7 +392,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
     }
 
-    private static class ClientHandler extends SimpleChannelInboundHandler<ByteBuf> {
+    private static class ClientHandler extends SimpleChannelInboundHandler<Buffer> {
         volatile Channel channel;
         final AtomicReference<Throwable> exception = new AtomicReference<>();
         volatile int step;
@@ -417,10 +417,10 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
 
         @Override
-        public void messageReceived(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+        public void messageReceived(ChannelHandlerContext ctx, Buffer in) throws Exception {
             long lastTimestamp = 0;
             loggerClient.debug("Step: " + step + " Read: " + in.readableBytes() / 8 + " blocks");
-            while (in.isReadable()) {
+            while (in.readableBytes() > 0) {
                 lastTimestamp = in.readLong();
                 multipleMessage[step]--;
             }
@@ -462,7 +462,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
     }
 
-    private static class ServerHandler extends SimpleChannelInboundHandler<ByteBuf> {
+    private static class ServerHandler extends SimpleChannelInboundHandler<Buffer> {
         private final int[] autoRead;
         private final int[] multipleMessage;
         volatile Channel channel;
@@ -480,11 +480,12 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
 
         @Override
-        public void messageReceived(final ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+        public void messageReceived(final ChannelHandlerContext ctx, Buffer in) throws Exception {
             byte[] actual = new byte[in.readableBytes()];
             int nb = actual.length / messageSize;
             loggerServer.info("Step: " + step + " Read: " + nb + " blocks");
-            in.readBytes(actual);
+            in.copyInto(in.readerOffset(), actual, 0, actual.length);
+            in.skipReadable(actual.length);
             long timestamp = TrafficCounter.milliSecondFromNano();
             int isAutoRead = 0;
             int laststep = step;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDatagramChannel.java
@@ -314,7 +314,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 // Check if sendmmsg(...) is supported which is only the case for GLIBC 2.14+
                 if (Native.IS_SUPPORTING_SENDMMSG && in.size() > 1 ||
                         // We only handle UDP_SEGMENT in sendmmsg.
-                        in.current() instanceof SegmentedDatagramPacket) {
+                        in.current() instanceof SegmentedDatagramPacket ||
+                        in.current() instanceof BufferSegmentedDatagramPacket) {
                     NativeDatagramPacketArray array = cleanDatagramPacketArray();
                     array.add(in, isConnected(), maxMessagesPerWrite);
                     int cnt = array.count();

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/IovArray.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/IovArray.java
@@ -207,10 +207,10 @@ public final class IovArray implements MessageProcessor, ReadableComponentProces
     }
 
     /**
-     * Returns the {@code memoryAddress} for the given {@code offset}.
+     * Returns the {@code memoryAddress} for the given {@code index}.
      */
-    public long memoryAddress(int offset) {
-        return memoryAddress + idx(offset);
+    public long memoryAddress(int index) {
+        return memoryAddress + idx(index);
     }
 
     /**

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelConfig.java
@@ -64,7 +64,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     private volatile ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
     private volatile BufferAllocator bufferAllocator = DefaultBufferAllocators.preferredAllocator();
     private volatile RecvBufferAllocator rcvBufAllocator;
-    private volatile boolean rcvBufAllocatorUseBuffer;
+    private volatile boolean rcvBufAllocatorUseBuffer = true;
     private volatile MessageSizeEstimator msgSizeEstimator = DEFAULT_MSG_SIZE_ESTIMATOR;
 
     private volatile int connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT;


### PR DESCRIPTION
Motivation:
We are transitioning to this new API, and this is a step in that direction.

Modification:
Change the default for ChannelOption.RCV_BUF_ALLOCATOR_USE_BUFFER to true, enabling the new API by default.
Explicitly disable it in tests that still rely on ByteBuf.

Result:
Buffer is now the default over ByteBuf.