### PR TITLE
Add utility methods to reverse byte order for non-standard types

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty5/buffer/ByteBufUtil.java
@@ -51,6 +51,42 @@ public final class ByteBufUtil {
     }
 
     /**
+     * Reverses the byte order (endianness) of an unsigned short
+     * @param value the number with original byte order
+     * @return the number with reversed byte order
+     */
+    public static int reverseUnsignedShort(int value) {
+        return Integer.reverseBytes(value) >>> Short.SIZE;
+    }
+
+    /**
+     * Reverses the byte order (endianness) of a medium
+     * @param value the number with original byte order
+     * @return the number with reversed byte order
+     */
+    public static int reverseMedium(int value) {
+        return Integer.reverseBytes(value) >> Byte.SIZE;
+    }
+
+    /**
+     * Reverses the byte order (endianness) of an unsigned medium
+     * @param value the number with original byte order
+     * @return the number with reversed byte order
+     */
+    public static int reverseUnsignedMedium(int value) {
+        return Integer.reverseBytes(value) >>> Byte.SIZE;
+    }
+
+    /**
+     * Reverses the byte order (endianness) of an unsigned integer
+     * @param value the number with original byte order
+     * @return the number with reversed byte order
+     */
+    public static long reverseUnsignedInt(long value) {
+        return Long.reverseBytes(value) >>> Integer.SIZE;
+    }
+
+    /**
      * Returns a <a href="https://en.wikipedia.org/wiki/Hex_dump">hex dump</a>
      * of the specified buffer's readable bytes.
      */

--- a/buffer/src/test/java/io/netty5/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/ByteBufUtilTest.java
@@ -5,7 +5,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/buffer/src/test/java/io/netty5/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/ByteBufUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty5.buffer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ByteBufUtilTest {
+
+    @Test
+    void testReverseUnsignedShort() {
+        assertEquals(0x00FF00, ByteBufUtil.reverseUnsignedShort(0x0000FF));
+        assertEquals(0x0000FF, ByteBufUtil.reverseUnsignedShort(0x00FF00));
+    }
+
+    @Test
+    void testReverseMedium() {
+        assertEquals(0xFFFF0000, ByteBufUtil.reverseMedium(0x000000FF));
+        assertEquals(0x000000FF, ByteBufUtil.reverseMedium(0xFFFF0000));
+    }
+
+    @Test
+    void testReverseUnsignedMedium() {
+        assertEquals(0xFF0000, ByteBufUtil.reverseUnsignedMedium(0x0000FF));
+        assertEquals(0x0000FF, ByteBufUtil.reverseUnsignedMedium(0xFF0000));
+    }
+
+    @Test
+    void testReverseUnsignedInt() {
+        assertEquals(0xFF000000L, ByteBufUtil.reverseUnsignedInt(0x000000FFL));
+        assertEquals(0x000000FFL, ByteBufUtil.reverseUnsignedInt(0xFF000000L));
+    }
+
+}

--- a/codec/src/main/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LengthFieldBasedFrameDecoderForBuffer.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.handler.codec;
 
+import io.netty5.buffer.ByteBufUtil;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 
@@ -423,13 +424,13 @@ public class LengthFieldBasedFrameDecoderForBuffer extends ByteToMessageDecoderF
             return buffer.getUnsignedByte(offset);
         case 2:
             final int shortLength = buffer.getUnsignedShort(offset);
-            return reverseBytes? Integer.reverseBytes(shortLength) >>> Short.SIZE : shortLength;
+            return reverseBytes? ByteBufUtil.reverseUnsignedShort(shortLength) : shortLength;
         case 3:
             final int mediumLength = buffer.getUnsignedMedium(offset);
-            return reverseBytes? Integer.reverseBytes(mediumLength) >>> Byte.SIZE : mediumLength;
+            return reverseBytes? ByteBufUtil.reverseUnsignedMedium(mediumLength) : mediumLength;
         case 4:
             final long intLength = buffer.getUnsignedInt(offset);
-            return reverseBytes? Long.reverseBytes(intLength) >>> Integer.SIZE : intLength;
+            return reverseBytes? ByteBufUtil.reverseUnsignedInt(intLength) : intLength;
         case 8:
             final long longLength = buffer.getLong(offset);
             return reverseBytes? Long.reverseBytes(longLength) : longLength;

--- a/codec/src/main/java/io/netty5/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty5/handler/codec/LengthFieldPrepender.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.handler.codec;
 
+import io.netty5.buffer.ByteBufUtil;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
@@ -177,9 +178,8 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<Buffer> {
             if (length >= 16777216) {
                 throw new IllegalArgumentException("length does not fit into a medium integer: " + length);
             }
-
             return ctx.bufferAllocator().allocate(lengthFieldLength)
-                      .writeMedium(reverseBytes ? Integer.reverseBytes(length) >> Byte.SIZE : length);
+                      .writeMedium(reverseBytes ? ByteBufUtil.reverseMedium(length) : length);
         case 4:
             return ctx.bufferAllocator().allocate(lengthFieldLength)
                       .writeInt(reverseBytes ? Integer.reverseBytes(length) : length);


### PR DESCRIPTION
Motivation:
The new `Buffer` API doesn't provide methods to read or write little-endian values. Instead the documentation suggestions to use standard java methods like `Integer.reverseBytes`. However netty also provides read and write methods for non-standard types like unsigned numbers and mediums, which have no methods to reverse the byte order.

Modification:
- Add `reverse*` methods to `ByteBufUtil`
- Add tests for new methods
- Use new methods in places where reversing the byte order was done manually before

Result:
`reverse*` methods are available for non-standard number types