### PR TITLE
Make maven module build order more clear on Windows

### DIFF
--- a/testsuite-native/pom.xml
+++ b/testsuite-native/pom.xml
@@ -38,6 +38,24 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport-classes-epoll</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-transport-classes-kqueue</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty5-resolver-dns-classes-macos</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
@@ -54,6 +72,7 @@
       <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
+
   <profiles>
     <profile>
       <id>skipTests</id>
@@ -65,33 +84,6 @@
       <properties>
         <skipNativeTestsuite>true</skipNativeTestsuite>
       </properties>
-    </profile>
-
-    <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty5-transport-native-epoll</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty5-transport-native-kqueue</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty5-resolver-dns-native-macos</artifactId>
-          <version>${project.version}</version>
-          <scope>compile</scope>
-        </dependency>
-      </dependencies>
     </profile>
 
     <profile>


### PR DESCRIPTION
Motivation:
On Windows, some Maven versions on might not identify that `netty-testsuite-native` needs to have the classes for our native modules compiled first.
This can make the build fail with a compilation error saying that e.g. the epoll or kqueue packages can't be found.

Modification:
The `netty-testsuite-native` now unconditionally depends on the classes of the native modules.
Then relies on the profiles for pulling in the native dependencies, like before.

Result:
Clean whole-project builds on Windows should no longer have any problems with compiling `netty-testsuite-native`.

If there is no issue then describe the changes introduced by this PR.
