### PR TITLE
Migrate DNS to Buffer

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty5/buffer/ByteBufUtil.java
@@ -16,11 +16,10 @@
 package io.netty5.buffer;
 
 import io.netty.buffer.ByteBuf;
-import io.netty5.util.internal.MathUtil;
-import io.netty5.util.internal.PlatformDependent;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.util.AsciiString;
+import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
@@ -145,18 +144,8 @@ public final class ByteBufUtil {
      * The copy will start at {@code start} and copy {@code length} bytes.
      */
     public static byte[] getBytes(Buffer buf, int start, int length) {
-        return getBytes(buf, start, length, true);
-    }
-
-    /**
-     * Return an array of the underlying storage from {@code buf} into a byte array.
-     * The copy will start at {@code start} and copy {@code length} bytes.
-     * If {@code copy} is true a copy will be made of the memory.
-     * If {@code copy} is false the underlying storage will be shared, if possible.
-     */
-    public static byte[] getBytes(Buffer buf, int start, int length, boolean copy) {
         int capacity = buf.capacity();
-        if (MathUtil.isOutOfBounds(start, length, capacity)) {
+        if (isOutOfBounds(start, length, capacity)) {
             throw new IndexOutOfBoundsException("expected: " + "0 <= start(" + start + ") <= start + length(" + length
                                                 + ") <= " + "buf.capacity(" + capacity + ')');
         }
@@ -249,7 +238,7 @@ public final class ByteBufUtil {
             for (i = 0; i < HEXDUMP_ROWPREFIXES.length; i++) {
                 StringBuilder buf = new StringBuilder(12);
                 buf.append(NEWLINE);
-                buf.append(Long.toHexString(i << 4 & 0xFFFFFFFFL | 0x100000000L));
+                buf.append(Long.toHexString(i << 4L & 0xFFFFFFFFL | 0x100000000L));
                 buf.setCharAt(buf.length() - 9, '|');
                 buf.append('|');
                 HEXDUMP_ROWPREFIXES[i] = buf.toString();

--- a/buffer/src/main/java/io/netty5/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty5/buffer/ByteBufUtil.java
@@ -16,6 +16,8 @@
 package io.netty5.buffer;
 
 import io.netty.buffer.ByteBuf;
+import io.netty5.util.internal.MathUtil;
+import io.netty5.util.internal.PlatformDependent;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.util.AsciiString;
@@ -128,6 +130,40 @@ public final class ByteBufUtil {
      */
     public static Buffer writeAscii(BufferAllocator alloc, CharSequence seq) {
         return alloc.copyOf(seq.toString().getBytes(StandardCharsets.US_ASCII));
+    }
+
+    /**
+     * Create a copy of the underlying storage from {@code buf} into a byte array.
+     * The copy will start at {@link Buffer#readerOffset()} and copy {@link Buffer#readableBytes()} bytes.
+     */
+    public static byte[] getBytes(Buffer buf) {
+        return getBytes(buf,  buf.readerOffset(), buf.readableBytes());
+    }
+
+    /**
+     * Create a copy of the underlying storage from {@code buf} into a byte array.
+     * The copy will start at {@code start} and copy {@code length} bytes.
+     */
+    public static byte[] getBytes(Buffer buf, int start, int length) {
+        return getBytes(buf, start, length, true);
+    }
+
+    /**
+     * Return an array of the underlying storage from {@code buf} into a byte array.
+     * The copy will start at {@code start} and copy {@code length} bytes.
+     * If {@code copy} is true a copy will be made of the memory.
+     * If {@code copy} is false the underlying storage will be shared, if possible.
+     */
+    public static byte[] getBytes(Buffer buf, int start, int length, boolean copy) {
+        int capacity = buf.capacity();
+        if (MathUtil.isOutOfBounds(start, length, capacity)) {
+            throw new IndexOutOfBoundsException("expected: " + "0 <= start(" + start + ") <= start + length(" + length
+                                                + ") <= " + "buf.capacity(" + capacity + ')');
+        }
+
+        byte[] bytes = PlatformDependent.allocateUninitializedArray(length);
+        buf.copyInto(start, bytes, 0, length);
+        return bytes;
     }
 
     /**

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsMessage.java
@@ -401,14 +401,10 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
         }
 
         if (this instanceof DnsQuery) {
-            if (!(that instanceof DnsQuery)) {
-                return false;
-            }
-        } else if (that instanceof DnsQuery) {
-            return false;
+            return that instanceof DnsQuery;
+        } else {
+            return !(that instanceof DnsQuery);
         }
-
-        return true;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQuery.java
@@ -168,14 +168,10 @@ public class DatagramDnsQuery extends DefaultDnsQuery
         }
 
         if (recipient() == null) {
-            if (that.recipient() != null) {
-                return false;
-            }
-        } else if (!recipient().equals(that.recipient())) {
-            return false;
+            return that.recipient() == null;
+        } else {
+            return recipient().equals(that.recipient());
         }
-
-        return true;
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -17,19 +17,18 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.channel.socket.DatagramPacket;
+import io.netty5.channel.socket.BufferDatagramPacket;
 import io.netty5.handler.codec.MessageToMessageDecoder;
 import io.netty5.util.internal.UnstableApi;
-
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Decodes a {@link DatagramPacket} into a {@link DatagramDnsQuery}.
+ * Decodes a {@link BufferDatagramPacket} into a {@link DatagramDnsQuery}.
  */
 @UnstableApi
 @ChannelHandler.Sharable
-public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPacket> {
+public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<BufferDatagramPacket> {
 
     private final DnsRecordDecoder recordDecoder;
 
@@ -48,7 +47,7 @@ public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPac
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, BufferDatagramPacket packet) throws Exception {
         DnsQuery query = DnsMessageUtil.decodeDnsQuery(recordDecoder, packet.content(),
                 new DnsMessageUtil.DnsQueryFactory() {
             @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -48,8 +48,8 @@ public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<BufferDatag
 
     @Override
     protected void decode(ChannelHandlerContext ctx, BufferDatagramPacket packet) throws Exception {
-        DnsQuery query = DnsMessageUtil.decodeDnsQuery(recordDecoder, packet.content(),
-                new DnsMessageUtil.DnsQueryFactory() {
+        DnsQuery query = DnsMessageUtil.decodeDnsQuery(recordDecoder, ctx.bufferAllocator(), packet.content(),
+                                                       new DnsMessageUtil.DnsQueryFactory() {
             @Override
             public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
                 return new DatagramDnsQuery(packet.sender(), packet.recipient(), id, dnsOpCode);

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -65,6 +65,6 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<BufferDa
     }
 
     protected DnsResponse decodeResponse(ChannelHandlerContext ctx, BufferDatagramPacket packet) throws Exception {
-        return responseDecoder.decode(packet.sender(), packet.recipient(), packet.content());
+        return responseDecoder.decode(packet.sender(), packet.recipient(), ctx.bufferAllocator(), packet.content());
     }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.channel.socket.DatagramPacket;
+import io.netty5.channel.socket.BufferDatagramPacket;
 import io.netty5.handler.codec.CorruptedFrameException;
 import io.netty5.handler.codec.MessageToMessageDecoder;
 import io.netty5.util.internal.UnstableApi;
@@ -25,11 +25,11 @@ import io.netty5.util.internal.UnstableApi;
 import java.net.InetSocketAddress;
 
 /**
- * Decodes a {@link DatagramPacket} into a {@link DatagramDnsResponse}.
+ * Decodes a {@link BufferDatagramPacket} into a {@link DatagramDnsResponse}.
  */
 @UnstableApi
 @ChannelHandler.Sharable
-public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<DatagramPacket> {
+public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<BufferDatagramPacket> {
 
     private final DnsResponseDecoder<InetSocketAddress> responseDecoder;
 
@@ -44,7 +44,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
      * Creates a new decoder with the specified {@code recordDecoder}.
      */
     public DatagramDnsResponseDecoder(DnsRecordDecoder recordDecoder) {
-        this.responseDecoder = new DnsResponseDecoder<InetSocketAddress>(recordDecoder) {
+        responseDecoder = new DnsResponseDecoder<InetSocketAddress>(recordDecoder) {
             @Override
             protected DnsResponse newResponse(InetSocketAddress sender, InetSocketAddress recipient,
                                               int id, DnsOpCode opCode, DnsResponseCode responseCode) {
@@ -54,7 +54,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, BufferDatagramPacket packet) throws Exception {
         final DnsResponse response;
         try {
             response = decodeResponse(ctx, packet);
@@ -64,7 +64,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
         ctx.fireChannelRead(response);
     }
 
-    protected DnsResponse decodeResponse(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
+    protected DnsResponse decodeResponse(ChannelHandlerContext ctx, BufferDatagramPacket packet) throws Exception {
         return responseDecoder.decode(packet.sender(), packet.recipient(), packet.content());
     }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseEncoder.java
@@ -15,11 +15,11 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.channel.socket.DatagramPacket;
+import io.netty5.channel.socket.BufferDatagramPacket;
 import io.netty5.handler.codec.MessageToMessageEncoder;
 import io.netty5.util.internal.UnstableApi;
 
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Encodes a {@link DatagramDnsResponse} (or an {@link AddressedEnvelope} of {@link DnsResponse}} into a
- * {@link DatagramPacket}.
+ * {@link BufferDatagramPacket}.
  */
 @UnstableApi
 @ChannelHandler.Sharable
@@ -59,20 +59,20 @@ public class DatagramDnsResponseEncoder
 
         final InetSocketAddress recipient = in.recipient();
         final DnsResponse response = in.content();
-        final ByteBuf buf = allocateBuffer(ctx, in);
+        final Buffer buf = allocateBuffer(ctx, in);
 
         DnsMessageUtil.encodeDnsResponse(recordEncoder, response, buf);
 
-        out.add(new DatagramPacket(buf, recipient, null));
+        out.add(new BufferDatagramPacket(buf, recipient, null));
     }
 
     /**
-     * Allocate a {@link ByteBuf} which will be used for constructing a datagram packet.
-     * Sub-classes may override this method to return a {@link ByteBuf} with a perfect matching initial capacity.
+     * Allocate a {@link Buffer} which will be used for constructing a datagram packet.
+     * Sub-classes may override this method to return a {@link Buffer} with a perfect matching initial capacity.
      */
-    protected ByteBuf allocateBuffer(
+    protected Buffer allocateBuffer(
         ChannelHandlerContext ctx,
         @SuppressWarnings("unused") AddressedEnvelope<DnsResponse, InetSocketAddress> msg) throws Exception {
-        return ctx.alloc().ioBuffer(1024);
+        return ctx.bufferAllocator().allocate(1024);
     }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.internal.UnstableApi;
 
 /**
@@ -34,7 +34,7 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
     protected DefaultDnsRecordDecoder() { }
 
     @Override
-    public final DnsQuestion decodeQuestion(ByteBuf in) throws Exception {
+    public final DnsQuestion decodeQuestion(Buffer in) throws Exception {
         String name = decodeName(in);
         DnsRecordType type = DnsRecordType.valueOf(in.readUnsignedShort());
         int qClass = in.readUnsignedShort();
@@ -42,14 +42,14 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
     }
 
     @Override
-    public final <T extends DnsRecord> T decodeRecord(ByteBuf in) throws Exception {
-        final int startOffset = in.readerIndex();
+    public final <T extends DnsRecord> T decodeRecord(Buffer in) throws Exception {
+        final int startOffset = in.readerOffset();
         final String name = decodeName(in);
 
-        final int endOffset = in.writerIndex();
-        if (endOffset - in.readerIndex() < 10) {
+        final int endOffset = in.writerOffset();
+        if (endOffset - in.readerOffset() < 10) {
             // Not enough data
-            in.readerIndex(startOffset);
+            in.readerOffset(startOffset);
             return null;
         }
 
@@ -57,28 +57,28 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
         final int aClass = in.readUnsignedShort();
         final long ttl = in.readUnsignedInt();
         final int length = in.readUnsignedShort();
-        final int offset = in.readerIndex();
+        final int offset = in.readerOffset();
 
         if (endOffset - offset < length) {
             // Not enough data
-            in.readerIndex(startOffset);
+            in.readerOffset(startOffset);
             return null;
         }
 
         @SuppressWarnings("unchecked")
         T record = (T) decodeRecord(name, type, aClass, ttl, in, offset, length);
-        in.readerIndex(offset + length);
+        in.readerOffset(offset + length);
         return record;
     }
 
     /**
-     * Decodes a record from the information decoded so far by {@link #decodeRecord(ByteBuf)}.
+     * Decodes a record from the information decoded so far by {@link #decodeRecord(Buffer)}.
      *
      * @param name the domain name of the record
      * @param type the type of the record
      * @param dnsClass the class of the record
      * @param timeToLive the TTL of the record
-     * @param in the {@link ByteBuf} that contains the RDATA
+     * @param in the {@link Buffer} that contains the RDATA
      * @param offset the start offset of the RDATA in {@code in}
      * @param length the length of the RDATA
      *
@@ -86,23 +86,29 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
      */
     protected DnsRecord decodeRecord(
             String name, DnsRecordType type, int dnsClass, long timeToLive,
-            ByteBuf in, int offset, int length) throws Exception {
+            Buffer in, int offset, int length) throws Exception {
 
         // DNS message compression means that domain names may contain "pointers" to other positions in the packet
         // to build a full message. This means the indexes are meaningful and we need the ability to reference the
         // indexes un-obstructed, and thus we cannot use a slice here.
         // See https://www.ietf.org/rfc/rfc1035 [4.1.4. Message compression]
-        if (type == DnsRecordType.PTR) {
-            return new DefaultDnsPtrRecord(
-                    name, dnsClass, timeToLive, decodeName0(in.duplicate().setIndex(offset, offset + length)));
+        int roff = in.readerOffset();
+        int woff = in.writerOffset();
+        in.resetOffsets().writerOffset(offset + length).readerOffset(offset);
+        try {
+            if (type == DnsRecordType.PTR) {
+                return new DefaultDnsPtrRecord(
+                        name, dnsClass, timeToLive, decodeName0(in));
+            }
+            if (type == DnsRecordType.CNAME || type == DnsRecordType.NS) {
+                return new DefaultDnsRawRecord(name, type, dnsClass, timeToLive,
+                                               DnsCodecUtil.decompressDomainName(in));
+            }
+            return new DefaultDnsRawRecord(
+                    name, type, dnsClass, timeToLive, in.copy());
+        } finally {
+            in.resetOffsets().writerOffset(woff).readerOffset(roff);
         }
-        if (type == DnsRecordType.CNAME || type == DnsRecordType.NS) {
-            return new DefaultDnsRawRecord(name, type, dnsClass, timeToLive,
-                                           DnsCodecUtil.decompressDomainName(
-                                                   in.duplicate().setIndex(offset, offset + length)));
-        }
-        return new DefaultDnsRawRecord(
-                name, type, dnsClass, timeToLive, in.retainedDuplicate().setIndex(offset, offset + length));
     }
 
     /**
@@ -113,7 +119,7 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
      * @param in the byte buffer containing the DNS packet
      * @return the domain name for an entry
      */
-    protected String decodeName0(ByteBuf in) {
+    protected String decodeName0(Buffer in) {
         return decodeName(in);
     }
 
@@ -125,7 +131,7 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
      * @param in the byte buffer containing the DNS packet
      * @return the domain name for an entry
      */
-    public static String decodeName(ByteBuf in) {
+    public static String decodeName(Buffer in) {
         return DnsCodecUtil.decodeDomainName(in);
     }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsCodecUtil.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsCodecUtil.java
@@ -102,9 +102,7 @@ final class DnsCodecUtil {
                 if (in.readableBytes() < len) {
                     throw new CorruptedFrameException("truncated label in a name");
                 }
-                byte[] nameBytes = new byte[len];
-                in.readBytes(nameBytes, 0, len);
-                name.append(new String(nameBytes, CharsetUtil.UTF_8)).append('.');
+                name.append(in.readCharSequence(len, StandardCharsets.UTF_8)).append('.');
             } else { // len == 0
                 break;
             }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsCodecUtil.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsCodecUtil.java
@@ -128,9 +128,8 @@ final class DnsCodecUtil {
      * @param compression compressed data
      * @return decompressed data
      */
-    static Buffer decompressDomainName(Buffer compression) {
+    static Buffer decompressDomainName(BufferAllocator allocator, Buffer compression) {
         String domainName = decodeDomainName(compression);
-        BufferAllocator allocator = compression.isDirect()? offHeapAllocator() : onHeapAllocator();
         Buffer result = allocator.allocate(domainName.length() << 1);
         encodeDomainName(domainName, result);
         return result;

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsMessageUtil.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsMessageUtil.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.handler.codec.CorruptedFrameException;
 import io.netty5.util.internal.StringUtil;
@@ -179,7 +179,7 @@ final class DnsMessageUtil {
         }
     }
 
-    static DnsQuery decodeDnsQuery(DnsRecordDecoder decoder, ByteBuf buf, DnsQueryFactory supplier) throws Exception {
+    static DnsQuery decodeDnsQuery(DnsRecordDecoder decoder, Buffer buf, DnsQueryFactory supplier) throws Exception {
         DnsQuery query = newQuery(buf, supplier);
         boolean success = false;
         try {
@@ -200,7 +200,7 @@ final class DnsMessageUtil {
         }
     }
 
-    private static DnsQuery newQuery(ByteBuf buf, DnsQueryFactory supplier) {
+    private static DnsQuery newQuery(Buffer buf, DnsQueryFactory supplier) {
         int id = buf.readUnsignedShort();
         int flags = buf.readUnsignedShort();
         if (flags >> 15 == 1) {
@@ -214,14 +214,14 @@ final class DnsMessageUtil {
     }
 
     private static void decodeQuestions(DnsRecordDecoder decoder,
-                                        DnsQuery query, ByteBuf buf, int questionCount) throws Exception {
+                                        DnsQuery query, Buffer buf, int questionCount) throws Exception {
         for (int i = questionCount; i > 0; --i) {
             query.addRecord(DnsSection.QUESTION, decoder.decodeQuestion(buf));
         }
     }
 
     private static void decodeRecords(DnsRecordDecoder decoder,
-                                      DnsQuery query, DnsSection section, ByteBuf buf, int count) throws Exception {
+                                      DnsQuery query, DnsSection section, Buffer buf, int count) throws Exception {
         for (int i = count; i > 0; --i) {
             DnsRecord r = decoder.decodeRecord(buf);
             if (r == null) {
@@ -231,7 +231,7 @@ final class DnsMessageUtil {
         }
     }
 
-    static void encodeDnsResponse(DnsRecordEncoder encoder, DnsResponse response, ByteBuf buf) throws Exception {
+    static void encodeDnsResponse(DnsRecordEncoder encoder, DnsResponse response, Buffer buf) throws Exception {
         boolean success = false;
         try {
             encodeHeader(response, buf);
@@ -242,7 +242,7 @@ final class DnsMessageUtil {
             success = true;
         } finally {
             if (!success) {
-                buf.release();
+                buf.close();
             }
         }
     }
@@ -253,8 +253,8 @@ final class DnsMessageUtil {
      * @param response the response header being encoded
      * @param buf      the buffer the encoded data should be written to
      */
-    private static void encodeHeader(DnsResponse response, ByteBuf buf) {
-        buf.writeShort(response.id());
+    private static void encodeHeader(DnsResponse response, Buffer buf) {
+        buf.writeShort((short) response.id());
         int flags = 32768;
         flags |= (response.opCode().byteValue() & 0xFF) << 11;
         if (response.isAuthoritativeAnswer()) {
@@ -271,22 +271,22 @@ final class DnsMessageUtil {
         }
         flags |= response.z() << 4;
         flags |= response.code().intValue();
-        buf.writeShort(flags);
-        buf.writeShort(response.count(DnsSection.QUESTION));
-        buf.writeShort(response.count(DnsSection.ANSWER));
-        buf.writeShort(response.count(DnsSection.AUTHORITY));
-        buf.writeShort(response.count(DnsSection.ADDITIONAL));
+        buf.writeShort((short) flags);
+        buf.writeShort((short) response.count(DnsSection.QUESTION));
+        buf.writeShort((short) response.count(DnsSection.ANSWER));
+        buf.writeShort((short) response.count(DnsSection.AUTHORITY));
+        buf.writeShort((short) response.count(DnsSection.ADDITIONAL));
     }
 
-    private static void encodeQuestions(DnsRecordEncoder encoder, DnsResponse response, ByteBuf buf) throws Exception {
+    private static void encodeQuestions(DnsRecordEncoder encoder, DnsResponse response, Buffer buf) throws Exception {
         int count = response.count(DnsSection.QUESTION);
         for (int i = 0; i < count; ++i) {
-            encoder.encodeQuestion(response.<DnsQuestion>recordAt(DnsSection.QUESTION, i), buf);
+            encoder.encodeQuestion(response.recordAt(DnsSection.QUESTION, i), buf);
         }
     }
 
     private static void encodeRecords(DnsRecordEncoder encoder,
-                                      DnsResponse response, DnsSection section, ByteBuf buf) throws Exception {
+                                      DnsResponse response, DnsSection section, Buffer buf) throws Exception {
         int count = response.count(section);
         for (int i = 0; i < count; ++i) {
             encoder.encodeRecord(response.recordAt(section, i), buf);

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsMessageUtil.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsMessageUtil.java
@@ -16,6 +16,7 @@
 package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.handler.codec.CorruptedFrameException;
 import io.netty5.util.internal.StringUtil;
@@ -179,7 +180,9 @@ final class DnsMessageUtil {
         }
     }
 
-    static DnsQuery decodeDnsQuery(DnsRecordDecoder decoder, Buffer buf, DnsQueryFactory supplier) throws Exception {
+    static DnsQuery decodeDnsQuery(DnsRecordDecoder decoder,
+                                   BufferAllocator allocator, Buffer buf,
+                                   DnsQueryFactory supplier) throws Exception {
         DnsQuery query = newQuery(buf, supplier);
         boolean success = false;
         try {
@@ -188,9 +191,9 @@ final class DnsMessageUtil {
             int authorityRecordCount = buf.readUnsignedShort();
             int additionalRecordCount = buf.readUnsignedShort();
             decodeQuestions(decoder, query, buf, questionCount);
-            decodeRecords(decoder, query, DnsSection.ANSWER, buf, answerCount);
-            decodeRecords(decoder, query, DnsSection.AUTHORITY, buf, authorityRecordCount);
-            decodeRecords(decoder, query, DnsSection.ADDITIONAL, buf, additionalRecordCount);
+            decodeRecords(decoder, query, DnsSection.ANSWER, allocator, buf, answerCount);
+            decodeRecords(decoder, query, DnsSection.AUTHORITY, allocator, buf, authorityRecordCount);
+            decodeRecords(decoder, query, DnsSection.ADDITIONAL, allocator, buf, additionalRecordCount);
             success = true;
             return query;
         } finally {
@@ -221,9 +224,11 @@ final class DnsMessageUtil {
     }
 
     private static void decodeRecords(DnsRecordDecoder decoder,
-                                      DnsQuery query, DnsSection section, Buffer buf, int count) throws Exception {
+                                      DnsQuery query, DnsSection section,
+                                      BufferAllocator allocator, Buffer buf,
+                                      int count) throws Exception {
         for (int i = count; i > 0; --i) {
-            DnsRecord r = decoder.decodeRecord(buf);
+            DnsRecord r = decoder.decodeRecord(allocator, buf);
             if (r == null) {
                 break;
             }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRawRecord.java
@@ -17,33 +17,16 @@ package io.netty5.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.Resource;
 import io.netty5.util.internal.UnstableApi;
 
 /**
  * A generic {@link DnsRecord} that contains an undecoded {@code RDATA}.
  */
 @UnstableApi
-public interface DnsRawRecord extends DnsRecord, ByteBufHolder {
-    @Override
-    DnsRawRecord copy();
-
-    @Override
-    DnsRawRecord duplicate();
-
-    @Override
-    DnsRawRecord retainedDuplicate();
-
-    @Override
-    DnsRawRecord replace(ByteBuf content);
-
-    @Override
-    DnsRawRecord retain();
-
-    @Override
-    DnsRawRecord retain(int increment);
-
-    @Override
-    DnsRawRecord touch();
+public interface DnsRawRecord extends DnsRecord, Resource<DnsRawRecord> {
+    Buffer content();
 
     @Override
     DnsRawRecord touch(Object hint);

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRawRecord.java
@@ -15,8 +15,6 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufHolder;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.Resource;
 import io.netty5.util.internal.UnstableApi;
@@ -26,6 +24,13 @@ import io.netty5.util.internal.UnstableApi;
  */
 @UnstableApi
 public interface DnsRawRecord extends DnsRecord, Resource<DnsRawRecord> {
+    /**
+     * Get a reference to the {@link Buffer} backing this raw DNS record.
+     * Care must be taken with the returned buffer, as changes to the buffer offsets or its contents will reflect on
+     * the raw DNS record contents.
+     *
+     * @return The {@link Buffer} instance backing this raw DNS record.
+     */
     Buffer content();
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecordDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.internal.UnstableApi;
 
 /**
@@ -33,7 +33,7 @@ public interface DnsRecordDecoder {
      *
      * @param in the input buffer which contains a DNS question at its reader index
      */
-    DnsQuestion decodeQuestion(ByteBuf in) throws Exception;
+    DnsQuestion decodeQuestion(Buffer in) throws Exception;
 
     /**
      * Decodes a DNS record into its object representation.
@@ -42,5 +42,5 @@ public interface DnsRecordDecoder {
      *
      * @return the decoded record, or {@code null} if there are not enough data in the input buffer
      */
-    <T extends DnsRecord> T decodeRecord(ByteBuf in) throws Exception;
+    <T extends DnsRecord> T decodeRecord(Buffer in) throws Exception;
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecordDecoder.java
@@ -16,6 +16,7 @@
 package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.util.internal.UnstableApi;
 
 /**
@@ -38,9 +39,9 @@ public interface DnsRecordDecoder {
     /**
      * Decodes a DNS record into its object representation.
      *
-     * @param in the input buffer which contains a DNS record at its reader index
-     *
+     * @param allocator
+     * @param in        the input buffer which contains a DNS record at its reader index
      * @return the decoded record, or {@code null} if there are not enough data in the input buffer
      */
-    <T extends DnsRecord> T decodeRecord(Buffer in) throws Exception;
+    <T extends DnsRecord> T decodeRecord(BufferAllocator allocator, Buffer in) throws Exception;
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecordEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.internal.UnstableApi;
 
 /**
@@ -33,12 +33,12 @@ public interface DnsRecordEncoder {
      *
      * @param out the output buffer where the encoded question will be written to
      */
-    void encodeQuestion(DnsQuestion question, ByteBuf out) throws Exception;
+    void encodeQuestion(DnsQuestion question, Buffer out) throws Exception;
 
     /**
      * Encodes a {@link DnsRecord}.
      *
      * @param out the output buffer where the encoded record will be written to
      */
-    void encodeRecord(DnsRecord record, ByteBuf out) throws Exception;
+    void encodeRecord(DnsRecord record, Buffer out) throws Exception;
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsResponseDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.handler.codec.CorruptedFrameException;
 
 import java.net.SocketAddress;
@@ -32,7 +32,7 @@ abstract class DnsResponseDecoder<A extends SocketAddress> {
         this.recordDecoder = Objects.requireNonNull(recordDecoder, "recordDecoder");
     }
 
-    final DnsResponse decode(A sender, A recipient, ByteBuf buffer) throws Exception {
+    final DnsResponse decode(A sender, A recipient, Buffer buffer) throws Exception {
         final int id = buffer.readUnsignedShort();
 
         final int flags = buffer.readUnsignedShort();
@@ -82,14 +82,14 @@ abstract class DnsResponseDecoder<A extends SocketAddress> {
     protected abstract DnsResponse newResponse(A sender, A recipient, int id,
                                                DnsOpCode opCode, DnsResponseCode responseCode) throws Exception;
 
-    private void decodeQuestions(DnsResponse response, ByteBuf buf, int questionCount) throws Exception {
+    private void decodeQuestions(DnsResponse response, Buffer buf, int questionCount) throws Exception {
         for (int i = questionCount; i > 0; i --) {
             response.addRecord(DnsSection.QUESTION, recordDecoder.decodeQuestion(buf));
         }
     }
 
     private boolean decodeRecords(
-            DnsResponse response, DnsSection section, ByteBuf buf, int count) throws Exception {
+            DnsResponse response, DnsSection section, Buffer buf, int count) throws Exception {
         for (int i = count; i > 0; i --) {
             final DnsRecord r = recordDecoder.decodeRecord(buf);
             if (r == null) {

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -15,14 +15,15 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
-import static java.util.Objects.requireNonNull;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoderForBuffer;
 import io.netty5.util.internal.UnstableApi;
 
+import static java.util.Objects.requireNonNull;
+
 @UnstableApi
-public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
+public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoderForBuffer {
     private final DnsRecordDecoder decoder;
 
     /**
@@ -41,13 +42,13 @@ public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
     }
 
     @Override
-    protected Object decode0(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
-        ByteBuf frame = (ByteBuf) super.decode0(ctx, in);
+    protected Object decode0(ChannelHandlerContext ctx, Buffer in) throws Exception {
+        Buffer frame = (Buffer) super.decode0(ctx, in);
         if (frame == null) {
             return null;
         }
 
-        return DnsMessageUtil.decodeDnsQuery(decoder, frame.slice(), new DnsMessageUtil.DnsQueryFactory() {
+        return DnsMessageUtil.decodeDnsQuery(decoder, frame.split(), new DnsMessageUtil.DnsQueryFactory() {
             @Override
             public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
                 return new DefaultDnsQuery(id, dnsOpCode);

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsQueryDecoder.java
@@ -48,7 +48,8 @@ public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoderForBuf
             return null;
         }
 
-        return DnsMessageUtil.decodeDnsQuery(decoder, frame.split(), new DnsMessageUtil.DnsQueryFactory() {
+        return DnsMessageUtil.decodeDnsQuery(decoder, ctx.bufferAllocator(), frame.split(),
+                                             new DnsMessageUtil.DnsQueryFactory() {
             @Override
             public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
                 return new DefaultDnsQuery(id, dnsOpCode);

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseDecoder.java
@@ -60,9 +60,4 @@ public final class TcpDnsResponseDecoder extends LengthFieldBasedFrameDecoderFor
             return responseDecoder.decode(ctx.channel().remoteAddress(), ctx.channel().localAddress(), frame.split());
         }
     }
-
-//    @Override
-//    protected Buffer extractFrame(ChannelHandlerContext ctx, Buffer buffer, int length) {
-//        return buffer.copy(buffer.readerOffset(), length);
-//    }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseDecoder.java
@@ -57,7 +57,9 @@ public final class TcpDnsResponseDecoder extends LengthFieldBasedFrameDecoderFor
             if (frame == null) {
                 return null;
             }
-            return responseDecoder.decode(ctx.channel().remoteAddress(), ctx.channel().localAddress(), frame.split());
+            SocketAddress sender = ctx.channel().remoteAddress();
+            SocketAddress recipient = ctx.channel().localAddress();
+            return responseDecoder.decode(sender, recipient, ctx.bufferAllocator(), frame.split());
         }
     }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseDecoder.java
@@ -15,15 +15,15 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty5.handler.codec.LengthFieldBasedFrameDecoderForBuffer;
 import io.netty5.util.internal.UnstableApi;
 
 import java.net.SocketAddress;
 
 @UnstableApi
-public final class TcpDnsResponseDecoder extends LengthFieldBasedFrameDecoder {
+public final class TcpDnsResponseDecoder extends LengthFieldBasedFrameDecoderForBuffer {
 
     private final DnsResponseDecoder<SocketAddress> responseDecoder;
 
@@ -52,21 +52,17 @@ public final class TcpDnsResponseDecoder extends LengthFieldBasedFrameDecoder {
     }
 
     @Override
-    protected Object decode0(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
-        ByteBuf frame = (ByteBuf) super.decode0(ctx, in);
-        if (frame == null) {
-            return null;
-        }
-
-        try {
-            return responseDecoder.decode(ctx.channel().remoteAddress(), ctx.channel().localAddress(), frame.slice());
-        } finally {
-            frame.release();
+    protected Object decode0(ChannelHandlerContext ctx, Buffer in) throws Exception {
+        try (Buffer frame = (Buffer) super.decode0(ctx, in)) {
+            if (frame == null) {
+                return null;
+            }
+            return responseDecoder.decode(ctx.channel().remoteAddress(), ctx.channel().localAddress(), frame.split());
         }
     }
 
-    @Override
-    protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
-        return buffer.copy(index, length);
-    }
+//    @Override
+//    protected Buffer extractFrame(ChannelHandlerContext ctx, Buffer buffer, int length) {
+//        return buffer.copy(buffer.readerOffset(), length);
+//    }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -15,14 +15,15 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToMessageEncoder;
-import static java.util.Objects.requireNonNull;
 import io.netty5.util.internal.UnstableApi;
 
 import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 @UnstableApi
 @ChannelHandler.Sharable
@@ -45,11 +46,11 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
 
     @Override
     protected void encode(ChannelHandlerContext ctx, DnsResponse response, List<Object> out) throws Exception {
-        ByteBuf buf = ctx.alloc().ioBuffer(1024);
+        Buffer buf = ctx.bufferAllocator().allocate(1024);
 
-        buf.writerIndex(buf.writerIndex() + 2);
+        buf.skipWritable(2);
         DnsMessageUtil.encodeDnsResponse(encoder, response, buf);
-        buf.setShort(0, buf.readableBytes() - 2);
+        buf.setShort(0, (short) (buf.readableBytes() - 2));
 
         out.add(buf);
     }

--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/DefaultDnsRecordDecoderTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/DefaultDnsRecordDecoderTest.java
@@ -15,11 +15,11 @@
  */
 package io.netty5.handler.codec.dns;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.Resource;
 import org.junit.jupiter.api.Test;
 
+import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -27,14 +27,14 @@ public class DefaultDnsRecordDecoderTest {
 
     @Test
     public void testDecodeName() {
-        testDecodeName("netty.io.", Unpooled.wrappedBuffer(new byte[] {
+        testDecodeName("netty.io.", onHeapAllocator().copyOf(new byte[] {
                 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0
         }));
     }
 
     @Test
     public void testDecodeNameWithoutTerminator() {
-        testDecodeName("netty.io.", Unpooled.wrappedBuffer(new byte[] {
+        testDecodeName("netty.io.", onHeapAllocator().copyOf(new byte[] {
                 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o'
         }));
     }
@@ -42,94 +42,85 @@ public class DefaultDnsRecordDecoderTest {
     @Test
     public void testDecodeNameWithExtraTerminator() {
         // Should not be decoded as 'netty.io..'
-        testDecodeName("netty.io.", Unpooled.wrappedBuffer(new byte[] {
+        testDecodeName("netty.io.", onHeapAllocator().copyOf(new byte[] {
                 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0, 0
         }));
     }
 
     @Test
     public void testDecodeEmptyName() {
-        testDecodeName(".", Unpooled.buffer().writeByte(0));
+        testDecodeName(".", onHeapAllocator().allocate(1).writeByte((byte) 0));
     }
 
     @Test
     public void testDecodeEmptyNameFromEmptyBuffer() {
-        testDecodeName(".", Unpooled.EMPTY_BUFFER);
+        testDecodeName(".", onHeapAllocator().allocate(0));
     }
 
     @Test
     public void testDecodeEmptyNameFromExtraZeroes() {
-        testDecodeName(".", Unpooled.wrappedBuffer(new byte[] { 0, 0 }));
+        testDecodeName(".", onHeapAllocator().copyOf(new byte[] { 0, 0 }));
     }
 
-    private static void testDecodeName(String expected, ByteBuf buffer) {
+    private static void testDecodeName(String expected, Buffer buffer) {
         try {
             DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
             assertEquals(expected, decoder.decodeName0(buffer));
         } finally {
-            buffer.release();
+            buffer.close();
         }
     }
 
     @Test
     public void testDecodePtrRecord() throws Exception {
         DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
-        ByteBuf buffer = Unpooled.buffer().writeByte(0);
-        int readerIndex = buffer.readerIndex();
-        int writerIndex = buffer.writerIndex();
-        try {
+        try (Buffer buffer = onHeapAllocator().allocate(1).writeByte((byte) 0)) {
+            int readerOffset = buffer.readerOffset();
+            int writerOffset = buffer.writerOffset();
             DnsPtrRecord record = (DnsPtrRecord) decoder.decodeRecord(
                     "netty.io", DnsRecordType.PTR, DnsRecord.CLASS_IN, 60, buffer, 0, 1);
             assertEquals("netty.io.", record.name());
             assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
             assertEquals(60, record.timeToLive());
             assertEquals(DnsRecordType.PTR, record.type());
-            assertEquals(readerIndex, buffer.readerIndex());
-            assertEquals(writerIndex, buffer.writerIndex());
-        } finally {
-            buffer.release();
+            assertEquals(readerOffset, buffer.readerOffset());
+            assertEquals(writerOffset, buffer.writerOffset());
         }
     }
 
     @Test
-    public void testdecompressCompressPointer() {
+    public void testDecompressCompressPointer() {
         byte[] compressionPointer = {
                 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0,
                 (byte) 0xC0, 0
         };
-        ByteBuf buffer = Unpooled.wrappedBuffer(compressionPointer);
-        ByteBuf uncompressed = null;
-        try {
-            uncompressed = DnsCodecUtil.decompressDomainName(buffer.duplicate().setIndex(10, 12));
-            assertEquals(0, ByteBufUtil.compare(buffer.duplicate().setIndex(0, 10), uncompressed));
+        Buffer uncompressed = null;
+        try (Buffer buffer = onHeapAllocator().copyOf(compressionPointer)) {
+            buffer.writerOffset(12).readerOffset(10);
+            uncompressed = DnsCodecUtil.decompressDomainName(buffer);
+            buffer.readerOffset(0).writerOffset(10);
+            assertEquals(buffer, uncompressed);
         } finally {
-            buffer.release();
-            if (uncompressed != null) {
-                uncompressed.release();
-            }
+            Resource.dispose(uncompressed);
         }
     }
 
     @Test
-    public void testdecompressNestedCompressionPointer() {
+    public void testDecompressNestedCompressionPointer() {
         byte[] nestedCompressionPointer = {
                 6, 'g', 'i', 't', 'h', 'u', 'b', 2, 'i', 'o', 0, // github.io
                 5, 'n', 'e', 't', 't', 'y', (byte) 0xC0, 0, // netty.github.io
                 (byte) 0xC0, 11, // netty.github.io
         };
-        ByteBuf buffer = Unpooled.wrappedBuffer(nestedCompressionPointer);
-        ByteBuf uncompressed = null;
-        try {
-            uncompressed = DnsCodecUtil.decompressDomainName(buffer.duplicate().setIndex(19, 21));
-            assertEquals(0, ByteBufUtil.compare(
-                    Unpooled.wrappedBuffer(new byte[] {
-                            5, 'n', 'e', 't', 't', 'y', 6, 'g', 'i', 't', 'h', 'u', 'b', 2, 'i', 'o', 0
-                    }), uncompressed));
+        Buffer uncompressed = null;
+        try (Buffer buffer = onHeapAllocator().copyOf(nestedCompressionPointer).readerOffset(19).writerOffset(21);
+             Buffer expected = onHeapAllocator().copyOf(new byte[] {
+                     5, 'n', 'e', 't', 't', 'y', 6, 'g', 'i', 't', 'h', 'u', 'b', 2, 'i', 'o', 0
+             })) {
+            uncompressed = DnsCodecUtil.decompressDomainName(buffer);
+            assertEquals(expected, uncompressed);
         } finally {
-            buffer.release();
-            if (uncompressed != null) {
-                uncompressed.release();
-            }
+            Resource.dispose(uncompressed);
         }
     }
 
@@ -140,29 +131,24 @@ public class DefaultDnsRecordDecoderTest {
                 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0,
                 (byte) 0xC0, 0
         };
-        ByteBuf buffer = Unpooled.wrappedBuffer(compressionPointer);
         DefaultDnsRawRecord cnameRecord = null;
         DefaultDnsRawRecord nsRecord = null;
-        try {
+        try (Buffer buffer = onHeapAllocator().copyOf(compressionPointer)) {
             cnameRecord = (DefaultDnsRawRecord) decoder.decodeRecord(
                     "netty.github.io", DnsRecordType.CNAME, DnsRecord.CLASS_IN, 60, buffer, 10, 2);
-            assertEquals(0, ByteBufUtil.compare(buffer.duplicate().setIndex(0, 10), cnameRecord.content()),
+            buffer.writerOffset(10).readerOffset(0);
+            assertEquals(buffer, cnameRecord.content(),
                 "The rdata of CNAME-type record should be decompressed in advance");
             assertEquals("netty.io.", DnsCodecUtil.decodeDomainName(cnameRecord.content()));
             nsRecord = (DefaultDnsRawRecord) decoder.decodeRecord(
                     "netty.github.io", DnsRecordType.NS, DnsRecord.CLASS_IN, 60, buffer, 10, 2);
-            assertEquals(0, ByteBufUtil.compare(buffer.duplicate().setIndex(0, 10), nsRecord.content()),
+            buffer.writerOffset(10).readerOffset(0);
+            assertEquals(buffer, nsRecord.content(),
                         "The rdata of NS-type record should be decompressed in advance");
             assertEquals("netty.io.", DnsCodecUtil.decodeDomainName(nsRecord.content()));
         } finally {
-            buffer.release();
-            if (cnameRecord != null) {
-                cnameRecord.release();
-            }
-
-            if (nsRecord != null) {
-                nsRecord.release();
-            }
+            Resource.dispose(cnameRecord);
+            Resource.dispose(nsRecord);
         }
     }
 
@@ -178,14 +164,15 @@ public class DefaultDnsRecordDecoderTest {
         DefaultDnsRawRecord rawPlainRecord = null;
         DefaultDnsRawRecord rawUncompressedRecord = null;
         DefaultDnsRawRecord rawUncompressedIndexedRecord = null;
-        ByteBuf buffer = Unpooled.wrappedBuffer(rfcExample);
-        try {
+        try (Buffer buffer = onHeapAllocator().copyOf(rfcExample)) {
             // First lets test that our utility function can correctly handle index references and decompression.
-            String plainName = DefaultDnsRecordDecoder.decodeName(buffer.duplicate());
+            String plainName = DefaultDnsRecordDecoder.decodeName(buffer);
             assertEquals("F.ISI.ARPA.", plainName);
-            String uncompressedPlainName = DefaultDnsRecordDecoder.decodeName(buffer.duplicate().setIndex(16, 20));
+            buffer.writerOffset(20).readerOffset(16);
+            String uncompressedPlainName = DefaultDnsRecordDecoder.decodeName(buffer);
             assertEquals(plainName, uncompressedPlainName);
-            String uncompressedIndexedName = DefaultDnsRecordDecoder.decodeName(buffer.duplicate().setIndex(12, 20));
+            buffer.writerOffset(20).readerOffset(12);
+            String uncompressedIndexedName = DefaultDnsRecordDecoder.decodeName(buffer);
             assertEquals("FOO." + plainName, uncompressedIndexedName);
 
             // Now lets make sure out object parsing produces the same results for non PTR type (just use CNAME).
@@ -221,36 +208,26 @@ public class DefaultDnsRecordDecoderTest {
             assertEquals(uncompressedIndexedName, ptrRecord.name());
             assertEquals(uncompressedIndexedName, ptrRecord.hostname());
         } finally {
-            if (rawPlainRecord != null) {
-                rawPlainRecord.release();
-            }
-            if (rawUncompressedRecord != null) {
-                rawUncompressedRecord.release();
-            }
-            if (rawUncompressedIndexedRecord != null) {
-                rawUncompressedIndexedRecord.release();
-            }
-            buffer.release();
+            Resource.dispose(rawPlainRecord);
+            Resource.dispose(rawUncompressedRecord);
+            Resource.dispose(rawUncompressedIndexedRecord);
         }
     }
 
     @Test
     public void testTruncatedPacket() throws Exception {
-        ByteBuf buffer = Unpooled.buffer();
-        buffer.writeByte(0);
-        buffer.writeShort(DnsRecordType.A.intValue());
-        buffer.writeShort(1);
-        buffer.writeInt(32);
+        try (Buffer buffer = onHeapAllocator().allocate(64)) {
+            buffer.writeByte((byte) 0);
+            buffer.writeShort((short) DnsRecordType.A.intValue());
+            buffer.writeShort((short) 1);
+            buffer.writeInt(32);
 
-        // Write a truncated last value.
-        buffer.writeByte(0);
-        DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
-        try {
-            int readerIndex = buffer.readerIndex();
+            // Write a truncated last value.
+            buffer.writeByte((byte) 0);
+            DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
+            int readerOffset = buffer.readerOffset();
             assertNull(decoder.decodeRecord(buffer));
-            assertEquals(readerIndex, buffer.readerIndex());
-        } finally {
-            buffer.release();
+            assertEquals(readerOffset, buffer.readerOffset());
         }
     }
 }

--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/TcpDnsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
+import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -62,7 +63,7 @@ public class TcpDnsTest {
         DnsResponse readResponse = channel.readInbound();
         assertThat(readResponse.recordAt(DnsSection.QUESTION), is((DnsRecord) question));
         DnsRawRecord record = new DefaultDnsRawRecord(question.name(),
-                DnsRecordType.A, TTL, Unpooled.wrappedBuffer(QUERY_RESULT));
+                DnsRecordType.A, TTL, onHeapAllocator().copyOf(QUERY_RESULT));
         assertThat(readResponse.recordAt(DnsSection.ANSWER), is((DnsRecord) record));
         assertThat(readResponse.<DnsRawRecord>recordAt(DnsSection.ANSWER).content(), is(record.content()));
         ReferenceCountUtil.release(readResponse);
@@ -77,7 +78,7 @@ public class TcpDnsTest {
 
         for (byte[] address : addresses) {
             DefaultDnsRawRecord queryAnswer = new DefaultDnsRawRecord(question.name(),
-                    DnsRecordType.A, TTL, Unpooled.wrappedBuffer(address));
+                    DnsRecordType.A, TTL, onHeapAllocator().copyOf(address));
             response.addRecord(DnsSection.ANSWER, queryAnswer);
         }
         return response;

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToMessageEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToMessageEncoder.java
@@ -99,8 +99,7 @@ public abstract class MessageToMessageEncoder<I> extends ChannelHandlerAdapter {
                                 StringUtil.simpleClassName(this) + " must produce at least one message.");
                     }
                 } finally {
-                    final int sizeMinusOne = out.size() - 1;
-                    if (sizeMinusOne == 0) {
+                    if (out.size() == 1) {
                         ctx.write(out.getUnsafe(0)).cascadeTo(promise);
                     } else {
                         writePromiseCombiner(ctx, out, promise);

--- a/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
+++ b/example/src/main/java/io/netty5/example/dns/dot/DoTClient.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.example.dns.dot;
 
-import io.netty.buffer.ByteBufUtil;
+import io.netty5.buffer.ByteBufUtil;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsClient.java
@@ -16,7 +16,7 @@
 package io.netty5.example.dns.tcp;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBufUtil;
+import io.netty5.buffer.ByteBufUtil;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
@@ -17,8 +17,7 @@ package io.netty5.example.dns.tcp;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.ByteBufUtil;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
@@ -77,10 +76,11 @@ public final class TcpDnsServer {
                                         System.out.println("Query domain: " + question);
 
                                         //always return 192.168.1.1
-                                        ctx.writeAndFlush(newResponse(msg, question, 600, QUERY_RESULT));
+                                        ctx.writeAndFlush(newResponse(ctx, msg, question, 600, QUERY_RESULT));
                                     }
 
-                                    private DefaultDnsResponse newResponse(DnsQuery query,
+                                    private DefaultDnsResponse newResponse(ChannelHandlerContext ctx,
+                                                                           DnsQuery query,
                                                                            DnsQuestion question,
                                                                            long ttl, byte[]... addresses) {
                                         DefaultDnsResponse response = new DefaultDnsResponse(query.id());
@@ -89,7 +89,7 @@ public final class TcpDnsServer {
                                         for (byte[] address : addresses) {
                                             DefaultDnsRawRecord queryAnswer = new DefaultDnsRawRecord(
                                                     question.name(),
-                                                    DnsRecordType.A, ttl, Unpooled.wrappedBuffer(address));
+                                                    DnsRecordType.A, ttl, ctx.bufferAllocator().copyOf(address));
                                             response.addRecord(DnsSection.ANSWER, queryAnswer);
                                         }
                                         return response;

--- a/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
+++ b/example/src/main/java/io/netty5/example/dns/udp/DnsClient.java
@@ -16,7 +16,7 @@
 package io.netty5.example.dns.udp;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBufUtil;
+import io.netty5.buffer.ByteBufUtil;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsAddressDecoder.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsAddressDecoder.java
@@ -15,14 +15,13 @@
  */
 package io.netty5.resolver.dns;
 
+import io.netty5.buffer.api.Buffer;
+import io.netty5.handler.codec.dns.DnsRawRecord;
+import io.netty5.handler.codec.dns.DnsRecord;
+
 import java.net.IDN;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufHolder;
-import io.netty5.handler.codec.dns.DnsRawRecord;
-import io.netty5.handler.codec.dns.DnsRecord;
 
 /**
  * Decodes an {@link InetAddress} from an A or AAAA {@link DnsRawRecord}.
@@ -46,14 +45,14 @@ final class DnsAddressDecoder {
         if (!(record instanceof DnsRawRecord)) {
             return null;
         }
-        final ByteBuf content = ((ByteBufHolder) record).content();
+        final Buffer content = ((DnsRawRecord) record).content();
         final int contentLen = content.readableBytes();
         if (contentLen != INADDRSZ4 && contentLen != INADDRSZ6) {
             return null;
         }
 
         final byte[] addrBytes = new byte[contentLen];
-        content.getBytes(content.readerIndex(), addrBytes);
+        content.copyInto(content.readerOffset(), addrBytes, 0, addrBytes.length);
 
         try {
             return InetAddress.getByAddress(decodeIdn ? IDN.toUnicode(name) : name, addrBytes);

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
@@ -16,8 +16,6 @@
 package io.netty5.resolver.dns;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.Channel;
@@ -30,12 +28,9 @@ import io.netty5.channel.EventLoop;
 import io.netty5.channel.FixedRecvBufferAllocator;
 import io.netty5.channel.socket.BufferDatagramPacket;
 import io.netty5.channel.socket.DatagramChannel;
-import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.InternetProtocolFamily;
 import io.netty5.channel.socket.SocketChannel;
 import io.netty5.handler.codec.CorruptedFrameException;
-import io.netty5.handler.codec.MessageToMessageDecoder;
-import io.netty5.handler.codec.MessageToMessageEncoder;
 import io.netty5.handler.codec.dns.DatagramDnsQueryEncoder;
 import io.netty5.handler.codec.dns.DatagramDnsResponse;
 import io.netty5.handler.codec.dns.DatagramDnsResponseDecoder;
@@ -81,8 +76,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static io.netty5.buffer.api.adaptor.ByteBufAdaptor.intoByteBuf;
-import static io.netty5.handler.adaptor.BufferConversionHandler.bufferToByteBuf;
+import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
 import static io.netty5.resolver.dns.DefaultDnsServerAddressStreamProvider.DNS_PORT;
 import static io.netty5.util.internal.ObjectUtil.checkPositive;
 import static java.util.Objects.requireNonNull;
@@ -190,9 +184,9 @@ public class DnsNameResolver extends InetNameResolver {
 
     private static final DatagramDnsResponseDecoder DATAGRAM_DECODER = new DatagramDnsResponseDecoder() {
         @Override
-        protected DnsResponse decodeResponse(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
+        protected DnsResponse decodeResponse(ChannelHandlerContext ctx, BufferDatagramPacket packet) throws Exception {
             DnsResponse response = super.decodeResponse(ctx, packet);
-            if (packet.content().isReadable()) {
+            if (packet.content().readableBytes() > 0) {
                 // If there is still something to read we did stop parsing because of a truncated message.
                 // This can happen if we enabled EDNS0 but our MTU is not big enough to handle all the
                 // data.
@@ -458,7 +452,6 @@ public class DnsNameResolver extends InetNameResolver {
         Bootstrap b = new Bootstrap();
         b.group(executor());
         b.channelFactory(channelFactory);
-        b.option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false);
         channelReadyPromise = executor().newPromise();
         final DnsResponseHandler responseHandler = new DnsResponseHandler(channelReadyPromise);
         b.handler(new ChannelInitializer<DatagramChannel>() {
@@ -843,14 +836,14 @@ public class DnsNameResolver extends InetNameResolver {
             if (hostsFileEntries != null) {
                 List<DnsRecord> result = new ArrayList<DnsRecord>();
                 for (InetAddress hostsFileEntry : hostsFileEntries) {
-                    ByteBuf content = null;
+                    Buffer content = null;
                     if (hostsFileEntry instanceof Inet4Address) {
                         if (type == DnsRecordType.A) {
-                            content = Unpooled.wrappedBuffer(hostsFileEntry.getAddress());
+                            content = onHeapAllocator().copyOf(hostsFileEntry.getAddress());
                         }
                     } else if (hostsFileEntry instanceof Inet6Address) {
                         if (type == DnsRecordType.AAAA) {
-                            content = Unpooled.wrappedBuffer(hostsFileEntry.getAddress());
+                            content = onHeapAllocator().copyOf(hostsFileEntry.getAddress());
                         }
                     }
                     if (content != null) {
@@ -1278,7 +1271,6 @@ public class DnsNameResolver extends InetNameResolver {
             bs.option(ChannelOption.SO_REUSEADDR, true)
             .group(executor())
             .channelFactory(socketChannelFactory)
-            .option(ChannelOption.RCVBUF_ALLOCATOR_USE_BUFFER, false)
             .handler(TCP_ENCODER);
             bs.connect(res.sender()).addListener(future -> {
                 if (future.isFailed()) {

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
@@ -76,7 +76,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
 import static io.netty5.resolver.dns.DefaultDnsServerAddressStreamProvider.DNS_PORT;
 import static io.netty5.util.internal.ObjectUtil.checkPositive;
 import static java.util.Objects.requireNonNull;
@@ -839,11 +838,11 @@ public class DnsNameResolver extends InetNameResolver {
                     Buffer content = null;
                     if (hostsFileEntry instanceof Inet4Address) {
                         if (type == DnsRecordType.A) {
-                            content = onHeapAllocator().copyOf(hostsFileEntry.getAddress());
+                            content = ch.bufferAllocator().copyOf(hostsFileEntry.getAddress());
                         }
                     } else if (hostsFileEntry instanceof Inet6Address) {
                         if (type == DnsRecordType.AAAA) {
-                            content = onHeapAllocator().copyOf(hostsFileEntry.getAddress());
+                            content = ch.bufferAllocator().copyOf(hostsFileEntry.getAddress());
                         }
                     }
                     if (content != null) {

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
@@ -16,8 +16,7 @@
 
 package io.netty5.resolver.dns;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufHolder;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.EventLoop;
 import io.netty5.handler.codec.CorruptedFrameException;
@@ -899,7 +898,7 @@ abstract class DnsResolveContext<T> {
                 continue;
             }
 
-            final ByteBuf recordContent = ((ByteBufHolder) r).content();
+            final Buffer recordContent = ((DnsRawRecord) r).content();
             final String domainName = decodeDomainName(recordContent);
             if (domainName == null) {
                 continue;
@@ -1033,15 +1032,15 @@ abstract class DnsResolveContext<T> {
         promise.tryFailure(unknownHostException);
     }
 
-    static String decodeDomainName(ByteBuf in) {
-        int readerIndex = in.readerIndex();
+    static String decodeDomainName(Buffer in) {
+        int readerIndex = in.readerOffset();
         try {
             return DefaultDnsRecordDecoder.decodeName(in);
         } catch (CorruptedFrameException e) {
             // In this case we just return null.
             return null;
         } finally {
-            in.readerIndex(readerIndex);
+            in.readerOffset(readerIndex);
         }
     }
 
@@ -1182,7 +1181,7 @@ abstract class DnsResolveContext<T> {
                 return;
             }
 
-            final ByteBuf recordContent = ((ByteBufHolder) r).content();
+            final Buffer recordContent = ((DnsRawRecord) r).content();
             final String domainName = decodeDomainName(recordContent);
             if (domainName == null) {
                 // Could not be parsed, ignore.


### PR DESCRIPTION
Motivation:
We wish to migrate to the new `Buffer` API and remove `ByteBuf`.
To that end, we will have to migrate our DNS implementation to the new API.

Modification:
Change all usages of `ByteBuf` to `Buffer` in the DNS code, and change usages of `DatagramPacket` to `BufferDatagramPacket`.

Result:
Our DNS codec and resolver implementation now use the `Buffer` API.

Currently draft, since some DNS APIs are relying on `ReferenceCounted` and maybe we don't want to do that.