### PR TITLE
Update transport-native-epoll compile flags

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -34,8 +34,9 @@
     <unix.common.lib.dir>${project.build.directory}/unix-common-lib</unix.common.lib.dir>
     <unix.common.lib.unpacked.dir>${unix.common.lib.dir}/META-INF/native/lib</unix.common.lib.unpacked.dir>
     <unix.common.include.unpacked.dir>${unix.common.lib.dir}/META-INF/native/include</unix.common.include.unpacked.dir>
-    <jni.compiler.args.cflags>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
-    <jni.compiler.args.ldflags>LDFLAGS=-L${unix.common.lib.unpacked.dir} -Wl,--no-as-needed -lrt -ldl -Wl,--whole-archive -l${unix.common.lib.name} -Wl,--no-whole-archive</jni.compiler.args.ldflags>
+    <jni.compiler.args.cflags>CFLAGS=-O2 -pipe -Werror -fno-omit-frame-pointer -Wunused-variable -fvisibility=hidden -D_FORTIFY_SOURCE=2 -ffunction-sections -fdata-sections -I${unix.common.include.unpacked.dir}</jni.compiler.args.cflags>
+    <jni.compiler.args.ldflags>LDFLAGS=-Wl,-z,relro -Wl,-z,now -Wl,--as-needed -Wl,--gc-sections -L${unix.common.lib.unpacked.dir}</jni.compiler.args.ldflags>
+    <jni.compiler.args.libs>LIBS=-Wl,--whole-archive -l${unix.common.lib.name} -Wl,--no-whole-archive -ldl</jni.compiler.args.libs>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <skipTests>true</skipTests>
     <japicmp.skip>true</japicmp.skip>
@@ -157,6 +158,7 @@
                   <platform>.</platform>
                   <configureArgs>
                     <arg>${jni.compiler.args.ldflags}</arg>
+                    <arg>${jni.compiler.args.libs}</arg>
                     <arg>${jni.compiler.args.cflags}</arg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                   </configureArgs>
@@ -306,6 +308,7 @@
                   <platform>.</platform>
                   <configureArgs>
                     <arg>${jni.compiler.args.ldflags}</arg>
+                    <arg>${jni.compiler.args.libs}</arg>
                     <arg>${jni.compiler.args.cflags}</arg>
                     <configureArg>--libdir=${project.build.directory}/native-build/target/lib</configureArg>
                     <configureArg>--host=aarch64-linux-gnu</configureArg>


### PR DESCRIPTION
Motivation:

Loading of the native epoll transport might segfault the JVM if musl is used and no glibc-compat is installed:

Modifications:

- Move libraries to LIBS where they should be, avoiding need for
  -Wl,--no-as-needed.
- Use -O2 instead of -O3; there are no tight loops so -O3 just increases
  code size for no benefit.
- Add -pipe for faster compilation.
- Add -D_FORTIFY_SOURCE=2 and -Wl,-z,relro for security.
- Add -Wl,-z,now for security and to improve musl
  compatibility. musl does not implement __strdup and __strndup which
  old glibc aliases strdup and strndup to, but OpenJDK loads libraries
  with RTLD_LAZY, so this is not discovered until too late. See
  https://github.com/grpc/grpc-java/issues/8751#issuecomment-1086963256
  for more information.
- Add -ffunction-sections -fdata-sections -Wl,--gc-sections to reduce
  output size and avoid linking librt when not really needed (only used
  for kqueue)

Result:
"Fixes" #11701 by making the native library load fail.