### PR TITLE
Make insureWritable(int) double capacity by default

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -566,7 +566,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * If this buffer does not already have the necessary space, then it will be expanded using the
      * {@link BufferAllocator} the buffer was created with.
      * This method is the same as calling {@link #ensureWritable(int, int, boolean)} where {@code allowCompaction} is
-     * {@code false}.
+     * {@code true}.
      *
      * @param size The requested number of bytes of space that should be available for writing.
      * @return This buffer instance.
@@ -575,7 +575,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @throws BufferReadOnlyException if this buffer is {@linkplain #readOnly() read-only}.
      */
     default Buffer ensureWritable(int size) {
-        ensureWritable(size, 1, true);
+        ensureWritable(size, capacity(), true);
         return this;
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCopyAllocateTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCopyAllocateTest.java
@@ -58,7 +58,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
             ThreadLocalRandom.current().nextBytes(array);
             try (Buffer buffer = allocator.copyOf(array)) {
                 assertFalse(buffer.readOnly());
-                buffer.ensureWritable(Long.BYTES);
+                buffer.ensureWritable(Long.BYTES, 1, true);
                 buffer.writeLong(0x0102030405060708L);
                 assertThat(buffer.capacity()).isEqualTo(array.length + Long.BYTES);
                 assertThat(buffer.readableBytes()).isEqualTo(array.length + Long.BYTES);
@@ -137,7 +137,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
             ThreadLocalRandom.current().nextBytes(byteBuffer.array());
             try (Buffer buffer = allocator.copyOf(byteBuffer)) {
                 assertFalse(buffer.readOnly());
-                buffer.ensureWritable(Long.BYTES);
+                buffer.ensureWritable(Long.BYTES, 1, true);
                 buffer.writeLong(0x0102030405060708L);
                 assertThat(buffer.capacity()).isEqualTo(byteBuffer.capacity() + Long.BYTES);
                 assertThat(buffer.readableBytes()).isEqualTo(byteBuffer.capacity() + Long.BYTES);
@@ -235,7 +235,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
 
             try (Buffer buffer = allocator.copyOf(byteBuffer)) {
                 assertFalse(buffer.readOnly());
-                buffer.ensureWritable(Long.BYTES);
+                buffer.ensureWritable(Long.BYTES, 1, true);
                 buffer.writeLong(0x0102030405060708L);
                 assertThat(buffer.capacity()).isEqualTo(byteBuffer.capacity() + Long.BYTES);
                 assertThat(buffer.readableBytes()).isEqualTo(byteBuffer.capacity() + Long.BYTES);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -284,7 +284,7 @@ public abstract class BufferTestSupport {
                             return allocator.allocate(size);
                         }
                         var buf = allocator.allocate(size - 1);
-                        buf.ensureWritable(size);
+                        buf.ensureWritable(size, 1, true);
                         return buf;
                     }
 


### PR DESCRIPTION
Motivation:
This method might naively be called often, e.g. once per some small element where many are added in a loop.
Such loops, if they increase the capacity every time, would have very poor performance with n-squared copying overhead.

Modification:
The `ensureWritable(int)` method now doubles the capacity of the buffer by default, which amortises the copying cost, in case it gets called frequently.

Result:
The `ensureWritable(int)` now performs better in situations where it gets called often with small values.
