### PR TITLE
Enable debugging of asynchronous tasks in Intellij

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -52,6 +52,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>${groupId}</groupId>
       <artifactId>netty-common</artifactId>
       <version>4.1.75.Final</version>

--- a/common/src/main/java/io/netty5/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/GlobalEventExecutor.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 import io.netty5.util.internal.ThreadExecutorMap;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Async.Execute;
+import org.jetbrains.annotations.Async.Schedule;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -199,7 +201,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
     }
 
     @Override
-    public void execute(Runnable task) {
+    public void execute(@Schedule Runnable task) {
         requireNonNull(task, "task");
 
         addTask(task);
@@ -236,7 +238,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
                 Runnable task = takeTask();
                 if (task != null) {
                     try {
-                        task.run();
+                        runTask(task);
                     } catch (Throwable t) {
                         logger.warn("Unexpected exception from the global event executor: ", t);
                     }
@@ -277,6 +279,10 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
                     // -> keep this thread alive to handle the newly added entries.
                 }
             }
+        }
+
+        private void runTask(@Execute Runnable task) {
+            task.run();
         }
     }
 }

--- a/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/SingleThreadEventExecutor.java
@@ -19,6 +19,8 @@ import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.ThreadExecutorMap;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Async.Execute;
+import org.jetbrains.annotations.Async.Schedule;
 
 import java.lang.Thread.State;
 import java.util.ArrayList;
@@ -321,7 +323,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
 
             do {
                 try {
-                    task.run();
+                    runTask(task);
                 } catch (Throwable t) {
                     logger.warn("A task raised an exception.", t);
                 }
@@ -330,6 +332,10 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
 
         updateLastExecutionTime();
         return true;
+    }
+
+    private void runTask(@Execute Runnable task) {
+        task.run();
     }
 
     /**
@@ -352,7 +358,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
                 }
 
                 try {
-                    task.run();
+                    runTask(task);
                 } catch (Throwable t) {
                     logger.warn("A task raised an exception.", t);
                 }
@@ -422,7 +428,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
         do {
             Runnable task = takeTask();
             if (task != null) {
-                task.run();
+                runTask(task);
                 updateLastExecutionTime();
             }
         } while (!confirmShutdown());
@@ -479,7 +485,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
             shutdownHooks.clear();
             for (Runnable task: copy) {
                 try {
-                    task.run();
+                    runTask(task);
                 } catch (Throwable t) {
                     logger.warn("Shutdown hook raised an exception.", t);
                 } finally {
@@ -650,7 +656,7 @@ public class SingleThreadEventExecutor extends AbstractScheduledEventExecutor im
     }
 
     @Override
-    public void execute(Runnable task) {
+    public void execute(@Schedule Runnable task) {
         requireNonNull(task, "task");
 
         boolean inEventLoop = inEventLoop();

--- a/pom.xml
+++ b/pom.xml
@@ -715,6 +715,14 @@
         <version>3.1.0</version>
       </dependency>
 
+      <!-- Annotations for IDE integration and analysis -->
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>23.0.0</version>
+        <scope>provided</scope>
+      </dependency>
+
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>servlet-api</artifactId>


### PR DESCRIPTION
Motivation:
Evented systems like Netty can be much harder to debug than sequential and blocking code.
Fortunately, with a few strategically placed hints, we can significantly improve the tooling support.

Modification:
Add a dependency on the JetBrains annotations, and use the `Schedule` and `Execute` annotations to tell the Intellij IDEA debugger how our event loops and executors handle asynchronous task execution.
Basically, we tell it where tasks are scheduled for asynchronous execution, and we tell it where this execution is picked up.

Result:
The Intellij IDEA debugger can then bridge the schedule and execute points, and present a unified, or spliced stack trace.
This way, we are able to see who scheduled what tasks, and why.

Before this change, the stack trace of a debugger break point looked like this:
<img width="744" alt="Screenshot 2022-04-19 at 13 54 13" src="https://user-images.githubusercontent.com/7993/164097870-27917bad-ac17-46b6-84f3-db9e095a3962.png">

Now, it looks like this, all the way back to the original test method in the JUnit test thread:
<img width="744" alt="Screenshot 2022-04-19 at 13 55 33" src="https://user-images.githubusercontent.com/7993/164098490-deb0c2d3-9e22-4199-b7b2-f6067612928e.png">
