### PR TITLE
Enable debugging of asynchronous tasks in Intellij (#12316)

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>annotations-java5</artifactId>
       <scope>provided</scope>
     </dependency>
     <!-- Logging frameworks - completely optional -->

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -51,7 +51,11 @@
       <!-- Need compile scope to be taken into account by shade plugin -->
       <scope>compile</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- Logging frameworks - completely optional -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -19,6 +19,9 @@ import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import org.jetbrains.annotations.Async.Execute;
+import org.jetbrains.annotations.Async.Schedule;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -161,10 +164,14 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
      */
     protected static void safeExecute(Runnable task) {
         try {
-            task.run();
+            runTask(task);
         } catch (Throwable t) {
             logger.warn("A task raised an exception. Task: {}", task, t);
         }
+    }
+
+    protected static void runTask(@Execute Runnable task) {
+        task.run();
     }
 
     /**
@@ -177,7 +184,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
      * The default implementation just delegates to {@link #execute(Runnable)}.
      */
     @UnstableApi
-    public void lazyExecute(Runnable task) {
+    public void lazyExecute(@Schedule Runnable task) {
         execute(task);
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -184,7 +184,11 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
      * The default implementation just delegates to {@link #execute(Runnable)}.
      */
     @UnstableApi
-    public void lazyExecute(@Schedule Runnable task) {
+    public void lazyExecute(Runnable task) {
+        lazyExecute0(task);
+    }
+
+    private void lazyExecute0(@Schedule Runnable task) {
         execute(task);
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutor.java
@@ -63,7 +63,7 @@ public final class DefaultEventExecutor extends SingleThreadEventExecutor {
         for (;;) {
             Runnable task = takeTask();
             if (task != null) {
-                task.run();
+                runTask(task);
                 updateLastExecutionTime();
             }
 

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -20,6 +20,9 @@ import io.netty.util.internal.ThreadExecutorMap;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import org.jetbrains.annotations.Async.Execute;
+import org.jetbrains.annotations.Async.Schedule;
+
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Queue;
@@ -199,7 +202,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
     }
 
     @Override
-    public void execute(Runnable task) {
+    public void execute(@Schedule Runnable task) {
         addTask(ObjectUtil.checkNotNull(task, "task"));
         if (!inEventLoop()) {
             startThread();
@@ -237,7 +240,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
                 Runnable task = takeTask();
                 if (task != null) {
                     try {
-                        task.run();
+                        runTask(task);
                     } catch (Throwable t) {
                         logger.warn("Unexpected exception from the global event executor: ", t);
                     }

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -202,7 +202,11 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
     }
 
     @Override
-    public void execute(@Schedule Runnable task) {
+    public void execute(Runnable task) {
+        execute0(task);
+    }
+
+    private void execute0(@Schedule Runnable task) {
         addTask(ObjectUtil.checkNotNull(task, "task"));
         if (!inEventLoop()) {
             startThread();

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -20,7 +20,6 @@ import io.netty.util.internal.ThreadExecutorMap;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import org.jetbrains.annotations.Async.Execute;
 import org.jetbrains.annotations.Async.Schedule;
 
 import java.security.AccessController;

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -811,13 +811,21 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     @Override
-    public void execute(@Schedule Runnable task) {
+    public void execute(Runnable task) {
+        execute0(task);
+    }
+
+    @Override
+    public void lazyExecute(Runnable task) {
+        lazyExecute0(task);
+    }
+
+    private void execute0(@Schedule Runnable task) {
         ObjectUtil.checkNotNull(task, "task");
         execute(task, !(task instanceof LazyRunnable) && wakesUpForTask(task));
     }
 
-    @Override
-    public void lazyExecute(@Schedule Runnable task) {
+    private void lazyExecute0(@Schedule Runnable task) {
         execute(ObjectUtil.checkNotNull(task, "task"), false);
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.ThreadExecutorMap;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.Async.Schedule;
 
 import java.lang.Thread.State;
 import java.util.ArrayList;
@@ -598,7 +599,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
             shutdownHooks.clear();
             for (Runnable task: copy) {
                 try {
-                    task.run();
+                    runTask(task);
                 } catch (Throwable t) {
                     logger.warn("Shutdown hook raised an exception.", t);
                 } finally {
@@ -810,13 +811,13 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     @Override
-    public void execute(Runnable task) {
+    public void execute(@Schedule Runnable task) {
         ObjectUtil.checkNotNull(task, "task");
         execute(task, !(task instanceof LazyRunnable) && wakesUpForTask(task));
     }
 
     @Override
-    public void lazyExecute(Runnable task) {
+    public void lazyExecute(@Schedule Runnable task) {
         execute(ObjectUtil.checkNotNull(task, "task"), false);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -789,7 +789,7 @@
       <!-- Annotations for IDE integration and analysis -->
       <dependency>
         <groupId>org.jetbrains</groupId>
-        <artifactId>annotations</artifactId>
+        <artifactId>annotations-java5</artifactId>
         <version>23.0.0</version>
         <scope>provided</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -786,6 +786,14 @@
         <version>3.1.0</version>
       </dependency>
 
+      <!-- Annotations for IDE integration and analysis -->
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>23.0.0</version>
+        <scope>provided</scope>
+      </dependency>
+
       <dependency>
         <groupId>org.rxtx</groupId>
         <artifactId>rxtx</artifactId>

--- a/transport/src/main/java/io/netty/channel/DefaultEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventLoop.java
@@ -51,7 +51,7 @@ public class DefaultEventLoop extends SingleThreadEventLoop {
         for (;;) {
             Runnable task = takeTask();
             if (task != null) {
-                task.run();
+                runTask(task);
                 updateLastExecutionTime();
             }
 


### PR DESCRIPTION
Motivation:
Evented systems like Netty can be much harder to debug than sequential and blocking code.
Fortunately, with a few strategically placed hints, we can significantly improve the tooling support.

Modification:
Add a dependency on the JetBrains annotations, and use the `Schedule` and `Execute` annotations to tell the Intellij IDEA debugger how our event loops and executors handle asynchronous task execution.
Basically, we tell it where tasks are scheduled for asynchronous execution, and we tell it where this execution is picked up.

Result:
The Intellij IDEA debugger can then bridge the schedule and execute points, and present a unified, or spliced stack trace.
This way, we are able to see who scheduled what tasks, and why.
