### PR TITLE
Fix compilation on Mac OS

### DIFF
--- a/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
@@ -36,7 +36,7 @@ static jclass dnsResolverClass = NULL;
 static jclass byteArrayClass = NULL;
 static jclass stringClass = NULL;
 static jmethodID dnsResolverMethodId = NULL;
-static char* staticPackagePrefix = NULL;
+static char const* staticPackagePrefix = NULL;
 
 // JNI Registered Methods Begin
 
@@ -164,7 +164,7 @@ static void netty_resolver_dns_native_macos_JNI_OnUnLoad(JNIEnv* env) {
 
 // IMPORTANT: If you add any NETTY_JNI_UTIL_LOAD_CLASS or NETTY_JNI_UTIL_FIND_CLASS calls you also need to update
 //            MacOSDnsServerAddressStreamProvider to reflect that.
-static jint netty_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
+static jint netty_resolver_dns_native_macos_JNI_OnLoad(JNIEnv* env, char const* packagePrefix) {
     int ret = JNI_ERR;
     int providerRegistered = 0;
     char* nettyClassName = NULL;


### PR DESCRIPTION
Motivation:
My compiler require that the const-ness of the package prefix is preserved.

Modification:
Make the `staticPackagePrefix` variable `const`.
The `const` qualifier here means that the value pointed to is unassignable.
However, we are still allowed to assign to the pointer (the pointer itself isn't `const`), which is why the rest of the code does not complain about this change.

Result:
No more native compilation errors on MacOS.

This is a back port of #12323