### PR TITLE
Make `Buffer.write*` methods automatically grow capacity

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -223,6 +223,27 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     boolean isDirect();
 
     /**
+     * Set an upper limit to the implicit capacity growth. Buffer {@code write*} methods may implicitly grow the buffer
+     * capacity instead of throwing a bounds check exception. The implicit capacity limit restricts this growth so the
+     * buffer capacity does not automatically grow beyond the given limit. When the limit is reached, and there is no
+     * more writable space left, then the {@code write*} methods will start throwing exceptions.
+     * <p>
+     * The default limit is the maximum buffer size.
+     * <p>
+     * The limit is carried through {@link #send()} calls, but the buffer instances returned from the various
+     * {@code split} and {@code copy} methods will have the default limit set.
+     * <p>
+     * The limit is not impacted by calls to {@code split} methods on this buffer. In other words, even though
+     * {@code split} methods reduce the capacity of this buffer, the set limit, if any, remains the same.
+     *
+     * @param limit The maximum size this buffers capacity will implicitly grow to via {@code write*} methods.
+     * @return This buffer instance.
+     * @throws IndexOutOfBoundsException if the limit is negative, greater than the maximum buffer size, or if the
+     *                                   {@linkplain #capacity() capacity} is already greater than the given limit.
+     */
+    Buffer implicitCapacityLimit(int limit);
+
+    /**
      * Copies the given length of data from this buffer into the given destination array, beginning at the given source
      * position in this buffer, and the given destination position in the destination array.
      * <p>

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAccessor.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAccessor.java
@@ -18,8 +18,7 @@ package io.netty5.buffer.api;
 /**
  * This interface is just the primitive data accessor methods that {@link Buffer} exposes.
  * It can be useful if you only need the data access methods, and perhaps wish to decorate or modify their behaviour.
- * Usually, you'd use the {@link Buffer} interface directly, since this lets you properly control the buffer reference
- * count.
+ * Usually, you'd use the {@link Buffer} interface directly, since this lets you properly control the buffer life cycle.
  */
 public interface BufferAccessor {
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors interface.">
@@ -63,7 +62,8 @@ public interface BufferAccessor {
      *
      * @param value The boolean value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Byte#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Byte#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     default Buffer writeBoolean(boolean value) {
         return writeByte((byte) (value ? 1 :0));
@@ -143,7 +143,8 @@ public interface BufferAccessor {
      *
      * @param value The byte value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Byte#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Byte#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeByte(byte value);
 
@@ -168,7 +169,8 @@ public interface BufferAccessor {
      *
      * @param value The int value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Byte#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Byte#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeUnsignedByte(int value);
 
@@ -217,7 +219,8 @@ public interface BufferAccessor {
      *
      * @param value The char value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than 2.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than 2,
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeChar(char value);
 
@@ -290,7 +293,8 @@ public interface BufferAccessor {
      *
      * @param value The short value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Short#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Short#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeShort(short value);
 
@@ -315,7 +319,8 @@ public interface BufferAccessor {
      *
      * @param value The int value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Short#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Short#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeUnsignedShort(int value);
 
@@ -388,7 +393,8 @@ public interface BufferAccessor {
      *
      * @param value The int value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than 3.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than 3,
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeMedium(int value);
 
@@ -413,7 +419,8 @@ public interface BufferAccessor {
      *
      * @param value The int value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than 3.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than 3,
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeUnsignedMedium(int value);
 
@@ -486,7 +493,8 @@ public interface BufferAccessor {
      *
      * @param value The int value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Integer#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Integer#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeInt(int value);
 
@@ -511,7 +519,8 @@ public interface BufferAccessor {
      *
      * @param value The long value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Integer#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Integer#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeUnsignedInt(long value);
 
@@ -560,7 +569,8 @@ public interface BufferAccessor {
      *
      * @param value The float value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Float#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Float#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeFloat(float value);
 
@@ -609,7 +619,8 @@ public interface BufferAccessor {
      *
      * @param value The long value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Long#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Long#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeLong(long value);
 
@@ -658,7 +669,8 @@ public interface BufferAccessor {
      *
      * @param value The double value to write.
      * @return This Buffer.
-     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Double#BYTES}.
+     * @throws IndexOutOfBoundsException If {@link Buffer#writableBytes} is less than {@link Double#BYTES},
+     * and the {@linkplain Buffer#capacity() buffer capacity} cannot be automatically increased.
      */
     Buffer writeDouble(double value);
 

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -110,6 +110,12 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public Buffer implicitCapacityLimit(int limit) {
+        delegate.implicitCapacityLimit(limit);
+        return this;
+    }
+
+    @Override
     public void copyInto(int srcPos, byte[] dest, int destPos, int length) {
         delegate.copyInto(srcPos, dest, destPos, length);
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
 import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
+import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
@@ -389,15 +390,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
 
     @Override
     public Buffer implicitCapacityLimit(int limit) {
-        if (limit < capacity()) {
-            throw new IndexOutOfBoundsException(
-                    "Implicit capacity limit (" + limit + ") cannot be less than capacity (" + capacity() + ')');
-        }
-        if (limit > MAX_BUFFER_SIZE) {
-            throw new IndexOutOfBoundsException(
-                    "Implicit capacity limit (" + limit +
-                    ") cannot be greater than max buffer size (" + MAX_BUFFER_SIZE + ')');
-        }
+        checkImplicitCapacity(limit,  capacity());
         implicitCapacityLimit = limit;
         return this;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -1386,6 +1386,9 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     private BufferAccessor prepWrite(int size) {
+        if (writableBytes() < size) {
+            ensureWritable(size, bufs.length == 0? 128 : capacity() / bufs.length, false);
+        }
         var buf = prepWrite(woff, size);
         woff += size;
         return buf;

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -1386,7 +1386,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     private BufferAccessor prepWrite(int size) {
-        if (writableBytes() < size) {
+        if (writableBytes() < size && isOwned()) {
             ensureWritable(size, bufs.length == 0? 128 : capacity() / bufs.length, false);
         }
         var buf = prepWrite(woff, size);

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -397,7 +397,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         delegate.ensureWritable(growBy, true);
         if (writableBytes() < size) {
             // The ensureWritable call is not guaranteed to work, in which case we'll have to re-allocate ourselves.
-            int newSize = readableBytes() + writableBytes() + growBy;
+            int newSize = capacity() + growBy;
             Statics.assertValidBufferSize(newSize);
             ByteBufBuffer buffer = (ByteBufBuffer) control.getAllocator().allocate(newSize);
 

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -592,6 +592,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeByte(byte value) {
         try {
+            ensureWritable(Byte.BYTES, 1, false);
             delegate.writeByte(value);
             return this;
         } catch (RuntimeException e) {
@@ -612,6 +613,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeUnsignedByte(int value) {
         try {
+            ensureWritable(Byte.BYTES, 1, false);
             delegate.writeByte((byte) (value & 0xFF));
             return this;
         } catch (RuntimeException e) {
@@ -650,7 +652,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeChar(char value) {
         try {
-            delegate.getChar(writerOffset()); // Force a bounds check
+            ensureWritable(Character.BYTES, 1, false);
             delegate.writeChar(value);
             return this;
         } catch (RuntimeException e) {
@@ -708,7 +710,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeShort(short value) {
         try {
-            delegate.getShort(writerOffset()); // Force a bounds check
+            ensureWritable(Short.BYTES, 1, false);
             delegate.writeShort(value);
             return this;
         } catch (RuntimeException e) {
@@ -730,7 +732,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeUnsignedShort(int value) {
         try {
-            delegate.getShort(writerOffset()); // Force a bounds check
+            ensureWritable(Short.BYTES, 1, false);
             delegate.writeShort((short) (value & 0xFFFF));
             return this;
         } catch (RuntimeException e) {
@@ -788,7 +790,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeMedium(int value) {
         try {
-            delegate.getMedium(writerOffset()); // Force a bounds check
+            ensureWritable(3, 1, false);
             delegate.writeMedium(value);
             return this;
         } catch (RuntimeException e) {
@@ -810,7 +812,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeUnsignedMedium(int value) {
         try {
-            delegate.getMedium(writerOffset()); // Force a bounds check
+            ensureWritable(3, 1, false);
             delegate.writeMedium(value);
             return this;
         } catch (RuntimeException e) {
@@ -868,7 +870,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeInt(int value) {
         try {
-            delegate.getInt(writerOffset()); // Force a bounds check
+            ensureWritable(Integer.BYTES, 1, false);
             delegate.writeInt(value);
             return this;
         } catch (RuntimeException e) {
@@ -890,7 +892,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeUnsignedInt(long value) {
         try {
-            delegate.getInt(writerOffset()); // Force a bounds check
+            ensureWritable(Integer.BYTES, 1, false);
             delegate.writeInt((int) (value & 0xFFFFFFFFL));
             return this;
         } catch (RuntimeException e) {
@@ -930,7 +932,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeFloat(float value) {
         try {
-            delegate.getFloat(writerOffset()); // Force a bounds check
+            ensureWritable(Float.BYTES, 1, false);
             delegate.writeFloat(value);
             return this;
         } catch (RuntimeException e) {
@@ -970,7 +972,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeLong(long value) {
         try {
-            delegate.getLong(writerOffset()); // Force a bounds check
+            ensureWritable(Long.BYTES, 1, false);
             delegate.writeLong(value);
             return this;
         } catch (RuntimeException e) {
@@ -1010,7 +1012,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeDouble(double value) {
         try {
-            delegate.getDouble(writerOffset()); // Force a bounds check
+            ensureWritable(Double.BYTES, 1, false);
             delegate.writeDouble(value);
             return this;
         } catch (RuntimeException e) {

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -50,6 +50,7 @@ import java.util.function.Supplier;
 import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
 import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
+import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressOfDirectByteBuffer;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
@@ -233,15 +234,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer implicitCapacityLimit(int limit) {
-        if (limit < capacity()) {
-            throw new IndexOutOfBoundsException(
-                    "Implicit capacity limit (" + limit + ") cannot be less than capacity (" + capacity() + ')');
-        }
-        if (limit > MAX_BUFFER_SIZE) {
-            throw new IndexOutOfBoundsException(
-                    "Implicit capacity limit (" + limit +
-                    ") cannot be greater than max buffer size (" + MAX_BUFFER_SIZE + ')');
-        }
+        checkImplicitCapacity(limit,  capacity());
         implicitCapacityLimit = limit;
         return this;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -592,7 +592,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeByte(byte value) {
         try {
-            ensureWritable(Byte.BYTES, 1, false);
+            checkWrite(Byte.BYTES);
             delegate.writeByte(value);
             return this;
         } catch (RuntimeException e) {
@@ -613,7 +613,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeUnsignedByte(int value) {
         try {
-            ensureWritable(Byte.BYTES, 1, false);
+            checkWrite(Byte.BYTES);
             delegate.writeByte((byte) (value & 0xFF));
             return this;
         } catch (RuntimeException e) {
@@ -652,7 +652,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeChar(char value) {
         try {
-            ensureWritable(Character.BYTES, 1, false);
+            checkWrite(Character.BYTES);
             delegate.writeChar(value);
             return this;
         } catch (RuntimeException e) {
@@ -710,7 +710,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeShort(short value) {
         try {
-            ensureWritable(Short.BYTES, 1, false);
+            checkWrite(Short.BYTES);
             delegate.writeShort(value);
             return this;
         } catch (RuntimeException e) {
@@ -732,7 +732,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeUnsignedShort(int value) {
         try {
-            ensureWritable(Short.BYTES, 1, false);
+            checkWrite(Short.BYTES);
             delegate.writeShort((short) (value & 0xFFFF));
             return this;
         } catch (RuntimeException e) {
@@ -790,7 +790,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeMedium(int value) {
         try {
-            ensureWritable(3, 1, false);
+            checkWrite(3);
             delegate.writeMedium(value);
             return this;
         } catch (RuntimeException e) {
@@ -812,7 +812,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeUnsignedMedium(int value) {
         try {
-            ensureWritable(3, 1, false);
+            checkWrite(3);
             delegate.writeMedium(value);
             return this;
         } catch (RuntimeException e) {
@@ -870,7 +870,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeInt(int value) {
         try {
-            ensureWritable(Integer.BYTES, 1, false);
+            checkWrite(Integer.BYTES);
             delegate.writeInt(value);
             return this;
         } catch (RuntimeException e) {
@@ -892,7 +892,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeUnsignedInt(long value) {
         try {
-            ensureWritable(Integer.BYTES, 1, false);
+            checkWrite(Integer.BYTES);
             delegate.writeInt((int) (value & 0xFFFFFFFFL));
             return this;
         } catch (RuntimeException e) {
@@ -932,7 +932,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeFloat(float value) {
         try {
-            ensureWritable(Float.BYTES, 1, false);
+            checkWrite(Float.BYTES);
             delegate.writeFloat(value);
             return this;
         } catch (RuntimeException e) {
@@ -972,7 +972,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeLong(long value) {
         try {
-            ensureWritable(Long.BYTES, 1, false);
+            checkWrite(Long.BYTES);
             delegate.writeLong(value);
             return this;
         } catch (RuntimeException e) {
@@ -1012,11 +1012,20 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public Buffer writeDouble(double value) {
         try {
-            ensureWritable(Double.BYTES, 1, false);
+            int size = Double.BYTES;
+            checkWrite(size);
             delegate.writeDouble(value);
             return this;
         } catch (RuntimeException e) {
             throw accessException(e, true);
+        }
+    }
+
+    private void checkWrite(int size) {
+        if (writableBytes() < size && isOwned()) {
+            ensureWritable(size, 1, false);
+        } else {
+            delegate.getByte(writerOffset() + size - 1); // Force bounds check
         }
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -440,6 +440,15 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer copy(int offset, int length, boolean readOnly) {
+        if (readOnly && readOnly()) {
+            ByteBufBuffer copy = newConstChild();
+            if (offset > 0 || length < capacity()) {
+                copy.delegate = delegate.slice(offset, length);
+            }
+            copy.readerOffset(0);
+            copy.delegate.writerIndex(length);
+            return copy;
+        }
         Buffer copy = control.getAllocator().allocate(length);
         try {
             copyInto(offset, copy, 0, length);
@@ -1073,7 +1082,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         return Statics.hashCode(this);
     }
 
-    Buffer newConstChild() {
+    ByteBufBuffer newConstChild() {
         assert readOnly();
         var drop = unsafeGetDrop().fork();
         var child = new ByteBufBuffer(control, delegate.duplicate(), drop);

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -384,7 +384,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         if (readOnly()) {
             throw bufferIsReadOnly(this);
         }
-        if (writableBytes() > size) {
+        if (writableBytes() >= size) {
             return this;
         }
         if (allowCompaction) {

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufMemoryManager.java
@@ -50,12 +50,11 @@ public final class ByteBufMemoryManager implements MemoryManager {
                                  AllocationType allocationType) {
         int capacity = Math.toIntExact(size);
         if (allocationType == StandardAllocationTypes.OFF_HEAP) {
-            ByteBuf byteBuf = unpooledDirectAllocator.directBuffer(capacity, capacity);
-            byteBuf.setZero(0, capacity);
+            ByteBuf byteBuf = unpooledDirectAllocator.directBuffer(capacity, Math.max(capacity, 131072 /* 128k */));
             return ByteBufBuffer.wrap(byteBuf, control, convert(dropDecorator.apply(drop())));
         }
         if (allocationType == StandardAllocationTypes.ON_HEAP) {
-            ByteBuf byteBuf = Unpooled.wrappedBuffer(new byte[capacity]);
+            ByteBuf byteBuf = Unpooled.buffer(capacity, Math.max(capacity, 131072 /* 128k */));
             byteBuf.setIndex(0, 0);
             return ByteBufBuffer.wrap(byteBuf, control, convert(dropDecorator.apply(drop())));
         }

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufMemoryManager.java
@@ -50,11 +50,17 @@ public final class ByteBufMemoryManager implements MemoryManager {
                                  AllocationType allocationType) {
         int capacity = Math.toIntExact(size);
         if (allocationType == StandardAllocationTypes.OFF_HEAP) {
-            ByteBuf byteBuf = unpooledDirectAllocator.directBuffer(capacity, Math.max(capacity, 131072 /* 128k */));
+            ByteBuf byteBuf = unpooledDirectAllocator.directBuffer(capacity, capacity);
+            if (byteBuf.capacity() != capacity) {
+                byteBuf = byteBuf.slice(0, capacity);
+            }
             return ByteBufBuffer.wrap(byteBuf, control, convert(dropDecorator.apply(drop())));
         }
         if (allocationType == StandardAllocationTypes.ON_HEAP) {
-            ByteBuf byteBuf = Unpooled.buffer(capacity, Math.max(capacity, 131072 /* 128k */));
+            ByteBuf byteBuf = Unpooled.buffer(capacity, capacity);
+            if (byteBuf.capacity() != capacity) {
+                byteBuf = byteBuf.slice(0, capacity);
+            }
             byteBuf.setIndex(0, 0);
             return ByteBufBuffer.wrap(byteBuf, control, convert(dropDecorator.apply(drop())));
         }

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -1161,7 +1161,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
             throw bufferIsReadOnly(this);
         }
         int capacity = capacity();
-        if (mayExpand && index > 0 && index <= capacity && capacity < 131072 /* 128k */) {
+        if (mayExpand && index > 0 && index <= capacity && capacity < 131072 /* 128k */ && isOwned()) {
             int minimumGrowth = PlatformDependent.roundToPowerOfTwo(capacity * 2) - capacity; // Grow into power-of-two.
             ensureWritable(size, minimumGrowth, false);
             checkSet(index, size); // Verify writing is now possible, without recursing.

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -45,6 +45,7 @@ import static io.netty5.buffer.api.internal.Statics.bbput;
 import static io.netty5.buffer.api.internal.Statics.bbslice;
 import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
+import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -200,15 +201,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     @Override
     public Buffer implicitCapacityLimit(int limit) {
-        if (limit < capacity()) {
-            throw new IndexOutOfBoundsException(
-                    "Implicit capacity limit (" + limit + ") cannot be less than capacity (" + capacity() + ')');
-        }
-        if (limit > MAX_BUFFER_SIZE) {
-            throw new IndexOutOfBoundsException(
-                    "Implicit capacity limit (" + limit +
-                    ") cannot be greater than max buffer size (" + MAX_BUFFER_SIZE + ')');
-        }
+        checkImplicitCapacity(limit,  capacity());
         implicitCapacityLimit = limit;
         return this;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -1123,13 +1123,13 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     private void checkWrite(int index, int size, boolean mayExpand) {
         if (index < roff | wmem.capacity() < index + size) {
-            writeAccessCheckException(index, size, mayExpand);
+            handleWriteAccessBoundsFailure(index, size, mayExpand);
         }
     }
 
     private void checkSet(int index, int size) {
         if (index < 0 | wmem.capacity() < index + size) {
-            writeAccessCheckException(index, size, false);
+            handleWriteAccessBoundsFailure(index, size, false);
         }
     }
 
@@ -1153,7 +1153,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         return outOfBounds(index, size);
     }
 
-    private void writeAccessCheckException(int index, int size, boolean mayExpand) {
+    private void handleWriteAccessBoundsFailure(int index, int size, boolean mayExpand) {
         if (rmem == CLOSED_BUFFER) {
             throw bufferIsClosed(this);
         }
@@ -1171,7 +1171,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     }
 
     private IndexOutOfBoundsException outOfBounds(int index, int size) {
-        throw new IndexOutOfBoundsException(
+        return new IndexOutOfBoundsException(
                 "Access at index " + index + " of size " + size + " is out of bounds: " +
                 "[read 0 to " + woff + ", write 0 to " + rmem.capacity() + "].");
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
@@ -63,6 +63,11 @@ public interface Statics {
     };
     MethodHandle BB_SLICE_OFFSETS = getByteBufferSliceOffsetsMethodHandle();
     MethodHandle BB_PUT_OFFSETS = getByteBufferPutOffsetsMethodHandle();
+    /**
+     * The maximum buffer size we support is the maximum array length generally supported by JVMs,
+     * because on-heap buffers will be backed by byte-arrays.
+     */
+    int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
 
     static MethodHandle getByteBufferSliceOffsetsMethodHandle() {
         try {
@@ -114,11 +119,9 @@ public interface Statics {
         if (size < 0) {
             throw new IllegalArgumentException("Buffer size must not be negative, but was " + size + '.');
         }
-        // We use max array size because on-heap buffers will be backed by byte-arrays.
-        int maxArraySize = Integer.MAX_VALUE - 8;
-        if (size > maxArraySize) {
+        if (size > MAX_BUFFER_SIZE) {
             throw new IllegalArgumentException(
-                    "Buffer size cannot be greater than " + maxArraySize + ", but was " + size + '.');
+                    "Buffer size cannot be greater than " + MAX_BUFFER_SIZE + ", but was " + size + '.');
         }
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/Statics.java
@@ -125,6 +125,19 @@ public interface Statics {
         }
     }
 
+    static void checkImplicitCapacity(int implicitCapacity, int currentCapacity) {
+        if (implicitCapacity < currentCapacity) {
+            throw new IndexOutOfBoundsException(
+                    "Implicit capacity limit (" + implicitCapacity +
+                    ") cannot be less than capacity (" + currentCapacity + ')');
+        }
+        if (implicitCapacity > MAX_BUFFER_SIZE) {
+            throw new IndexOutOfBoundsException(
+                    "Implicit capacity limit (" + implicitCapacity +
+                    ") cannot be greater than max buffer size (" + MAX_BUFFER_SIZE + ')');
+        }
+    }
+
     static void checkLength(int length) {
         if (length < 0) {
             throw new IllegalArgumentException("The length cannot be negative: " + length + '.');

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -43,6 +43,7 @@ import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
 import static io.netty5.buffer.api.internal.Statics.bbslice;
 import static io.netty5.buffer.api.internal.Statics.bufferIsClosed;
 import static io.netty5.buffer.api.internal.Statics.bufferIsReadOnly;
+import static io.netty5.buffer.api.internal.Statics.checkImplicitCapacity;
 import static io.netty5.buffer.api.internal.Statics.checkLength;
 import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -191,15 +192,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
     @Override
     public Buffer implicitCapacityLimit(int limit) {
-        if (limit < capacity()) {
-            throw new IndexOutOfBoundsException(
-                    "Implicit capacity limit (" + limit + ") cannot be less than capacity (" + capacity() + ')');
-        }
-        if (limit > MAX_BUFFER_SIZE) {
-            throw new IndexOutOfBoundsException(
-                    "Implicit capacity limit (" + limit +
-                    ") cannot be greater than max buffer size (" + MAX_BUFFER_SIZE + ')');
-        }
+        checkImplicitCapacity(limit,  capacity());
         implicitCapacityLimit = limit;
         return this;
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -1263,13 +1263,13 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
     private void checkWrite(int index, int size, boolean mayExpand) {
         if (index < roff | wsize < index + size) {
-            writeAccessCheckException(index, size, mayExpand);
+            handleWriteAccessBoundsFailure(index, size, mayExpand);
         }
     }
 
     private void checkSet(int index, int size) {
         if (index < 0 | wsize < index + size) {
-            writeAccessCheckException(index, size, false);
+            handleWriteAccessBoundsFailure(index, size, false);
         }
     }
 
@@ -1280,7 +1280,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         return outOfBounds(index, size);
     }
 
-    private void writeAccessCheckException(int index, int size, boolean mayExpand) {
+    private void handleWriteAccessBoundsFailure(int index, int size, boolean mayExpand) {
         if (rsize == CLOSED_SIZE) {
             throw attachTrace(bufferIsClosed(this));
         }

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -1288,7 +1288,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
             throw bufferIsReadOnly(this);
         }
         int capacity = capacity();
-        if (mayExpand && index > 0 && index <= capacity && capacity < 131072 /* 128k */) {
+        if (mayExpand && index > 0 && index <= capacity && capacity < 131072 /* 128k */ && isOwned()) {
             int minimumGrowth = PlatformDependent.roundToPowerOfTwo(capacity * 2) - capacity; // Grow into power-of-two.
             ensureWritable(size, minimumGrowth, false);
             checkSet(index, size); // Verify writing is now possible, without recursing.

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCharSequenceTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCharSequenceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BufferCharSequenceTest extends BufferTestSupport {
 
@@ -56,6 +57,17 @@ public class BufferCharSequenceTest extends BufferTestSupport {
             Assertions.assertEquals(data.toString(), new String(read, US_ASCII));
             assertEquals(data.length(), buf.writerOffset());
             assertEquals(data.length(), buf.readerOffset());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writeCharSequenceMustExpandCapacityIfBufferIsTooSmall(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(4)) {
+            String string = "Hello World";
+            buffer.writeCharSequence(string, US_ASCII);
+            assertThat(buffer.capacity()).isGreaterThanOrEqualTo(string.length());
         }
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCopyAllocateTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCopyAllocateTest.java
@@ -60,7 +60,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
                 assertFalse(buffer.readOnly());
                 buffer.ensureWritable(Long.BYTES, 1, true);
                 buffer.writeLong(0x0102030405060708L);
-                assertThat(buffer.capacity()).isEqualTo(array.length + Long.BYTES);
+                assertThat(buffer.capacity()).isGreaterThanOrEqualTo(array.length + Long.BYTES);
                 assertThat(buffer.readableBytes()).isEqualTo(array.length + Long.BYTES);
                 for (int i = 0; i < array.length; i++) {
                     byte b = array[i];
@@ -94,7 +94,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
             assertThat(buffer.capacity()).isZero();
             assertTrue(buffer.isAccessible());
             buffer.ensureWritable(4);
-            assertThat(buffer.capacity()).isEqualTo(4);
+            assertThat(buffer.capacity()).isGreaterThanOrEqualTo(4);
         }
     }
 
@@ -139,7 +139,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
                 assertFalse(buffer.readOnly());
                 buffer.ensureWritable(Long.BYTES, 1, true);
                 buffer.writeLong(0x0102030405060708L);
-                assertThat(buffer.capacity()).isEqualTo(byteBuffer.capacity() + Long.BYTES);
+                assertThat(buffer.capacity()).isGreaterThanOrEqualTo(byteBuffer.capacity() + Long.BYTES);
                 assertThat(buffer.readableBytes()).isEqualTo(byteBuffer.capacity() + Long.BYTES);
                 while (byteBuffer.hasRemaining()) {
                     byte b = byteBuffer.get();
@@ -173,7 +173,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
             assertThat(buffer.capacity()).isZero();
             assertTrue(buffer.isAccessible());
             buffer.ensureWritable(4);
-            assertThat(buffer.capacity()).isEqualTo(4);
+            assertThat(buffer.capacity()).isGreaterThanOrEqualTo(4);
         }
     }
 
@@ -185,7 +185,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
             assertThat(buffer.capacity()).isZero();
             assertTrue(buffer.isAccessible());
             buffer.ensureWritable(4);
-            assertThat(buffer.capacity()).isEqualTo(4);
+            assertThat(buffer.capacity()).isGreaterThanOrEqualTo(4);
         }
     }
 
@@ -237,7 +237,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
                 assertFalse(buffer.readOnly());
                 buffer.ensureWritable(Long.BYTES, 1, true);
                 buffer.writeLong(0x0102030405060708L);
-                assertThat(buffer.capacity()).isEqualTo(byteBuffer.capacity() + Long.BYTES);
+                assertThat(buffer.capacity()).isGreaterThanOrEqualTo(byteBuffer.capacity() + Long.BYTES);
                 assertThat(buffer.readableBytes()).isEqualTo(byteBuffer.capacity() + Long.BYTES);
                 while (byteBuffer.hasRemaining()) {
                     byte b = byteBuffer.get();
@@ -274,7 +274,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
             assertThat(buffer.capacity()).isZero();
             assertTrue(buffer.isAccessible());
             buffer.ensureWritable(4);
-            assertThat(buffer.capacity()).isEqualTo(4);
+            assertThat(buffer.capacity()).isGreaterThanOrEqualTo(4);
         }
     }
 
@@ -286,7 +286,7 @@ public class BufferCopyAllocateTest extends BufferTestSupport {
             assertThat(buffer.capacity()).isZero();
             assertTrue(buffer.isAccessible());
             buffer.ensureWritable(4);
-            assertThat(buffer.capacity()).isEqualTo(4);
+            assertThat(buffer.capacity()).isGreaterThanOrEqualTo(4);
         }
     }
 }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEnsureWritableTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEnsureWritableTest.java
@@ -50,8 +50,9 @@ public class BufferEnsureWritableTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             buf.ensureWritable(8);
+            assertEquals(8, buf.capacity());
             buf.writeLong(1);
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeByte((byte) 1));
+            assertEquals(8, buf.capacity());
         }
     }
 
@@ -141,7 +142,7 @@ public class BufferEnsureWritableTest extends BufferTestSupport {
             assertThat(buf.capacity()).isEqualTo(16);
             buf.writeByte((byte) 1);
             buf.ensureWritable(16, 32, true); // Now we DO need to allocate, because we can't compact.
-            assertThat(buf.capacity()).isEqualTo(16 /* existing capacity */ + 32 /* minimum growth */);
+            assertThat(buf.capacity()).isGreaterThanOrEqualTo(16 /* existing capacity */ + 32 /* minimum growth */);
         }
     }
 }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferImplicitCapacityTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferImplicitCapacityTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.api.tests;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static io.netty5.buffer.api.internal.Statics.MAX_BUFFER_SIZE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BufferImplicitCapacityTest extends BufferTestSupport {
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void implicitLimitMustBeWithinBounds(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(8)) {
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.implicitCapacityLimit(0));
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.implicitCapacityLimit(buffer.capacity() - 1));
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.implicitCapacityLimit(-1));
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.implicitCapacityLimit(MAX_BUFFER_SIZE + 1));
+            buffer.implicitCapacityLimit(MAX_BUFFER_SIZE);
+            buffer.implicitCapacityLimit(buffer.capacity());
+            buffer.writeLong(0x0102030405060708L);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeByte((byte) 1));
+            assertEquals(8, buffer.capacity());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void bufferFromCopyMustHaveResetImplicitCapacityLimit(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(8)) {
+            buffer.writeLong(0x0102030405060708L);
+            buffer.implicitCapacityLimit(buffer.capacity());
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeByte((byte) 1));
+            try (Buffer copy = buffer.copy()) {
+                assertEquals(8, copy.readableBytes());
+                copy.writeByte((byte) 2); // No more implicit limit
+            }
+            try (Buffer copy = buffer.copy(0, 8)) {
+                assertEquals(8, copy.readableBytes());
+                copy.writeByte((byte) 2); // No more implicit limit
+            }
+            try (Buffer copy = buffer.copy(1, 6)) {
+                assertEquals(6, copy.readableBytes());
+                copy.writeByte((byte) 3); // No more implicit limit
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void bufferFromSplitMustHaveResetImplicitCapacityLimit(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(32)) {
+            buffer.implicitCapacityLimit(32);
+            try (Buffer split = buffer.split()) {
+                split.writeLong(0).writeLong(0).writeLong(0).writeLong(0); // 32 bytes written.
+                split.writeByte((byte) 0); // 33rd byte, mustn't fail.
+            }
+            assertEquals(32, buffer.capacity());
+            try (Buffer split = buffer.split(2)) {
+                split.writeLong(0).writeLong(0).writeLong(0).writeLong(0); // 32 bytes written.
+                split.writeByte((byte) 0); // 33rd byte, mustn't fail.
+            }
+            assertEquals(30, buffer.capacity());
+            buffer.writeInt(42).readInt();
+            try (Buffer split = buffer.readSplit(4)) {
+                split.writeLong(0).writeLong(0).writeLong(0).writeLong(0); // 32 bytes written.
+                split.writeByte((byte) 0); // 33rd byte, mustn't fail.
+            }
+            assertEquals(22, buffer.capacity());
+            buffer.writeLong(0);
+            try (Buffer split = buffer.writeSplit(8)) {
+                split.writeLong(0).writeLong(0).writeLong(0).writeLong(0); // 32 bytes written.
+                split.writeByte((byte) 0); // 33rd byte, mustn't fail.
+            }
+            assertEquals(6, buffer.capacity());
+            buffer.writeLong(0).writeLong(0).writeLong(0).writeLong(0); // 32 bytes written.
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeByte((byte) 0)); // 33rd byte, at limit.
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void splitDoesNotReduceImplicitCapacityLimit(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(8)) {
+            buffer.implicitCapacityLimit(8);
+            buffer.writeLong(0x0102030405060708L);
+            buffer.split().close();
+            assertEquals(0, buffer.capacity());
+            buffer.writeLong(0x0102030405060708L);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeByte((byte) 1));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void sendMustPreserveImplicitCapacityLimit(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(8)) {
+            buffer.writeLong(0x0102030405060708L);
+            try (Buffer sent = buffer.implicitCapacityLimit(8).send().receive()) {
+                assertThrows(IndexOutOfBoundsException.class, () -> sent.writeByte((byte) 0));
+                assertEquals(0x0102030405060708L, sent.readLong());
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void ensureWritableCanGrowBeyondImplicitCapacityLimit(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buffer = allocator.allocate(8).implicitCapacityLimit(8)) {
+            buffer.writeLong(0x0102030405060708L);
+            buffer.ensureWritable(8);
+            buffer.writeLong(0x0102030405060708L);
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeByte((byte) 1));
+            buffer.readByte();
+            buffer.compact(); // Now we have room and don't need to expand capacity implicitly.
+            buffer.writeByte((byte) 1);
+            // And now there's no more room.
+            assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeByte((byte) 1));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void writesMustThrowIfSizeWouldGoBeyondImplicitCapacityLimit(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator()) {
+            // Short
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(1)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeShort((short) 0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(2)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeShort((short) 0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(1)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeUnsignedShort(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(2)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeUnsignedShort(0));
+                buffer.writeByte((byte) 0);
+            }
+
+            // Char
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(1)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeChar('0'));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(2)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeChar('0'));
+                buffer.writeByte((byte) 0);
+            }
+
+            // Medium
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(2)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeMedium(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(3)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeMedium(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(2)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeUnsignedMedium(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(3)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeUnsignedMedium(0));
+                buffer.writeByte((byte) 0);
+            }
+
+            // Int
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(3)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeInt(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(4)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeInt(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(3)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeUnsignedInt(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(4)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeUnsignedInt(0));
+                buffer.writeByte((byte) 0);
+            }
+
+            // Float
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(3)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeFloat(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(4)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeFloat(0));
+                buffer.writeByte((byte) 0);
+            }
+
+            // Long
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(7)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeLong(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(8)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeLong(0));
+                buffer.writeByte((byte) 0);
+            }
+
+            // Double
+            try (Buffer buffer = allocator.allocate(0).implicitCapacityLimit(7)) {
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeDouble(0));
+                buffer.writeByte((byte) 0);
+            }
+            try (Buffer buffer = allocator.allocate(1).implicitCapacityLimit(8)) {
+                buffer.writeByte((byte) 0);
+                assertThrows(IndexOutOfBoundsException.class, () -> buffer.writeDouble(0));
+                buffer.writeByte((byte) 0);
+            }
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferPrimitiveRelativeAccessorsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferPrimitiveRelativeAccessorsTest.java
@@ -20,6 +20,7 @@ import io.netty5.buffer.api.BufferAllocator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -195,16 +196,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfByteMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfByteMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(8);
             byte value = 0x01;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeByte(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeByte(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(8);
+            assertEquals(value, buf.readByte());
         }
     }
 
@@ -229,16 +230,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfUnsignedByteMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfUnsignedByteMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(8);
             int value = 0x01;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeUnsignedByte(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeUnsignedByte(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(8);
+            assertEquals(value, buf.readUnsignedByte());
         }
     }
 
@@ -330,16 +331,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfCharMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfCharMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(7);
             char value = 0x0102;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeChar(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeChar(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(7);
+            assertEquals(value, buf.readChar());
         }
     }
 
@@ -498,16 +499,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfShortMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfShortMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(7);
             short value = 0x0102;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeShort(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeShort(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(7);
+            assertEquals(value, buf.readShort());
         }
     }
 
@@ -532,16 +533,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfUnsignedShortMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfUnsignedShortMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(7);
             int value = 0x0102;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeUnsignedShort(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeUnsignedShort(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(7);
+            assertEquals(value, buf.readUnsignedShort());
         }
     }
 
@@ -700,16 +701,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfMediumMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfMediumMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(6);
             int value = 0x010203;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeMedium(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeMedium(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(6);
+            assertEquals(value, buf.readMedium());
         }
     }
 
@@ -734,16 +735,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfUnsignedMediumMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfUnsignedMediumMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(6);
             int value = 0x010203;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeUnsignedMedium(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeUnsignedMedium(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(6);
+            assertEquals(value, buf.readMedium());
         }
     }
 
@@ -902,16 +903,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfIntMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfIntMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(5);
             int value = 0x01020304;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeInt(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeInt(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(5);
+            assertEquals(value, buf.readInt());
         }
     }
 
@@ -936,16 +937,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfUnsignedIntMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfUnsignedIntMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(5);
             long value = 0x01020304;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeUnsignedInt(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeUnsignedInt(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(5);
+            assertEquals(value, buf.readUnsignedInt());
         }
     }
 
@@ -1037,16 +1038,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfFloatMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfFloatMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(5);
             float value = Float.intBitsToFloat(0x01020304);
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeFloat(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeFloat(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(5);
+            assertEquals(value, buf.readFloat());
         }
     }
 
@@ -1138,16 +1139,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfLongMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfLongMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(1);
             long value = 0x0102030405060708L;
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeLong(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeLong(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(1);
+            assertEquals(value, buf.readLong());
         }
     }
 
@@ -1239,16 +1240,16 @@ public class BufferPrimitiveRelativeAccessorsTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    void relativeWriteOfDoubleMustBoundsCheckWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
+    void relativeWriteOfDoubleMustExpandCapacityWhenWriteOffsetAndSizeIsBeyondCapacity(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             assertEquals(Long.BYTES, buf.capacity());
             buf.writerOffset(1);
             double value = Double.longBitsToDouble(0x0102030405060708L);
-            assertThrows(IndexOutOfBoundsException.class, () -> buf.writeDouble(value));
-            buf.writerOffset(Long.BYTES);
-            // Verify contents are unchanged.
-            assertEquals(0, buf.readLong());
+            buf.writeDouble(value);
+            assertThat(buf.capacity()).isGreaterThan(Long.BYTES);
+            buf.readerOffset(1);
+            assertEquals(value, buf.readDouble());
         }
     }
 

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -232,8 +232,8 @@ public abstract class BufferTestSupport {
 
         @Override
         public Supplier<Buffer> constBufferSupplier(byte[] bytes) {
-            byte[] array = bytes.clone();
-            return () -> delegate.copyOf(array).makeReadOnly();
+            Buffer parent = delegate.copyOf(bytes).makeReadOnly();
+            return () -> parent.copy(0, parent.readableBytes(), true);
         }
 
         @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -68,7 +68,15 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class BufferTestSupport {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(BufferTestSupport.class);
-    public static ExecutorService executor;
+    public static ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = Executors.defaultThreadFactory().newThread(r);
+            thread.setName("BufferTest-" + thread.getName());
+            thread.setDaemon(true); // Do not prevent shut down of test runner.
+            return thread;
+        }
+    });
 
     private static final Memoize<Fixture[]> INITIAL_COMBINATIONS = new Memoize<>(
             () -> initialFixturesForEachImplementation().toArray(Fixture[]::new));
@@ -136,6 +144,7 @@ public abstract class BufferTestSupport {
     static List<Fixture> initialAllocators() {
         return List.of(
                 new Fixture("heap", BufferAllocator::onHeapUnpooled, HEAP),
+                new Fixture("copyOf", () -> new CopyOfAllocator(BufferAllocator.onHeapUnpooled()), HEAP),
                 new Fixture("direct", BufferAllocator::offHeapUnpooled, DIRECT),
                 new Fixture("sensitive", SensitiveBufferAllocator::sensitiveOffHeapAllocator, DIRECT, UNCLOSEABLE),
                 new Fixture("pooledHeap", BufferAllocator::onHeapPooled, POOLED, HEAP),
@@ -193,6 +202,43 @@ public abstract class BufferTestSupport {
         public Supplier<Buffer> constBufferSupplier(byte[] bytes) {
             Buffer base = allocate(bytes.length).writeBytes(bytes).makeReadOnly();
             return () -> base; // Technically off-spec.
+        }
+    }
+
+    private static final class CopyOfAllocator extends TestAllocator {
+        private final BufferAllocator delegate;
+
+        private CopyOfAllocator(BufferAllocator delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean isPooling() {
+            return delegate.isPooling();
+        }
+
+        @Override
+        public AllocationType getAllocationType() {
+            return delegate.getAllocationType();
+        }
+
+        @Override
+        public Buffer allocate(int size) {
+            if (size < 0) {
+                throw new IllegalArgumentException();
+            }
+            return delegate.copyOf(new byte[size]).writerOffset(0);
+        }
+
+        @Override
+        public Supplier<Buffer> constBufferSupplier(byte[] bytes) {
+            byte[] array = bytes.clone();
+            return () -> delegate.copyOf(array).makeReadOnly();
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
         }
     }
 
@@ -372,24 +418,6 @@ public abstract class BufferTestSupport {
             };
         }, f.getProperties()));
         return builder.build();
-    }
-
-    @BeforeAll
-    static void startExecutor() throws IOException, ParseException {
-        executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = Executors.defaultThreadFactory().newThread(r);
-                thread.setName("BufferTest-" + thread.getName());
-                thread.setDaemon(true); // Do not prevent shut down of test runner.
-                return thread;
-            }
-        });
-    }
-
-    @AfterAll
-    static void stopExecutor() throws IOException {
-        executor.shutdown();
     }
 
     static void writeRandomBytes(Buffer buf, int length) {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferWriteBytesCombinationsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferWriteBytesCombinationsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferWriteBytesCombinationsTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferWriteBytesCombinationsTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Motivation:
Depending on the format, it can be hard to allocate correctly sized buffers up-front.
In these cases, it is quite convenient if the primitive write methods automatically expand the buffer until some threshold.

Modification:
Add logic to the bounds checking to automatically expand buffers when used by a primitive write method.

Result:
Buffers are now more convenient to use for writing, when the amount of data cannot be easily determined a priori.