### PR TITLE
Add API for external Buffer component iteration

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.buffer.api;
 
+import io.netty5.buffer.api.ComponentIterator.Next;
 import io.netty5.buffer.api.internal.Statics;
 
 import java.io.IOException;
@@ -1010,6 +1011,32 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * In any case, the number of components processed may be less than {@link #countComponents()}.
      */
     <E extends Exception> int forEachReadable(int initialIndex, ReadableComponentProcessor<E> processor) throws E;
+
+    /**
+     * Create a {@linkplain ComponentIterator component iterator} for all readable components in this buffer.
+     * <p>
+     * Unlike the {@link #forEachReadable(int, ReadableComponentProcessor)} method, this API permits <em>external</em>
+     * iteration of the components, while at the same time protecting the life-cycle of the buffer.
+     * <p>
+     * The typical code pattern for using this API looks like the following:
+     * <pre>{@code
+     *      try (var iteration = buffer.forEachReadable()) {
+     *          for (var c = iteration.first(); c != null; c = c.next()) {
+     *              ByteBuffer componentBuffer = c.readableBuffer();
+     *              // ...
+     *          }
+     *      }
+     * }</pre>
+     * Note the use of the {@code var} keyword for local variables, which are required for correctly expressing the
+     * generic types used in the iteration.
+     * Following this code pattern will ensure that the components, and their parent buffer, will be correctly
+     * life-cycled.
+     *
+     * @return A component iterator of {@linkplain ReadableComponent readable components}.
+     * @param <T> An intersection type that presents both the {@link ReadableComponent} interface,
+     *          <em>and</em> the ability to progress the iteration via the {@link Next#next()} method.
+     */
+    <T extends ReadableComponent & ComponentIterator.Next> ComponentIterator<T> forEachReadable();
 
     /**
      * Process all writable components of this buffer, and return the number of components processed.

--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -991,8 +991,9 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * <p>
      * The {@link ByteBuffer} instances obtained from the component, share lifetime with that internal component.
      * This means they can be accessed as long as the internal memory store remain unchanged. Methods that may cause
-     * such changes are {@link #split(int)}, {@link #split()}, {@link #compact()}, {@link #ensureWritable(int)},
-     * {@link #ensureWritable(int, int, boolean)}, and {@link #send()}.
+     * such changes are {@link #split(int)}, {@link #split()}, {@link #readSplit(int)}, {@link #writeSplit(int)},
+     * {@link #compact()}, {@link #ensureWritable(int)}, {@link #ensureWritable(int, int, boolean)},
+     * and {@link #send()}.
      * <p>
      * The best way to ensure this doesn't cause any trouble, is to use the buffers directly as part of the iteration.
      * <p>
@@ -1031,6 +1032,23 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * generic types used in the iteration.
      * Following this code pattern will ensure that the components, and their parent buffer, will be correctly
      * life-cycled.
+     * <p>
+     * <strong>Note</strong> that the {@link ReadableComponent} instances exposed by the iterator could be reused for
+     * multiple calls, so the data must be extracted from the component in the context of the iteration.
+     * <p>
+     * The {@link ByteBuffer} instances obtained from the component, share lifetime with that internal component.
+     * This means they can be accessed as long as the internal memory store remain unchanged. Methods that may cause
+     * such changes are {@link #split(int)}, {@link #split()}, {@link #readSplit(int)}, {@link #writeSplit(int)},
+     * {@link #compact()}, {@link #ensureWritable(int)}, {@link #ensureWritable(int, int, boolean)},
+     * and {@link #send()}.
+     * <p>
+     * The best way to ensure this doesn't cause any trouble, is to use the buffers directly as part of the iteration.
+     * <p>
+     * <strong>Note</strong> that the arrays, memory addresses, and byte buffers exposed as components by this method,
+     * should not be used for changing the buffer contents. Doing so may cause undefined behaviour.
+     * <p>
+     * Changes to position and limit of the byte buffers exposed via the processed components, are not reflected back to
+     * this buffer instance.
      *
      * @return A component iterator of {@linkplain ReadableComponent readable components}.
      * @param <T> An intersection type that presents both the {@link ReadableComponent} interface,
@@ -1059,8 +1077,9 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * <p>
      * The {@link ByteBuffer} instances obtained from the component, share lifetime with that internal component.
      * This means they can be accessed as long as the internal memory store remain unchanged. Methods that may cause
-     * such changes are {@link #split(int)}, {@link #split()}, {@link #compact()}, {@link #ensureWritable(int)},
-     * {@link #ensureWritable(int, int, boolean)}, and {@link #send()}.
+     * such changes are {@link #split(int)}, {@link #split()}, {@link #readSplit(int)}, {@link #writeSplit(int)},
+     * {@link #compact()}, {@link #ensureWritable(int)}, {@link #ensureWritable(int, int, boolean)},
+     * and {@link #send()}.
      * <p>
      * The best way to ensure this doesn't cause any trouble, is to use the buffers directly as part of the iteration.
      * <p>
@@ -1076,6 +1095,50 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * In any case, the number of components processed may be less than {@link #countComponents()}.
      */
     <E extends Exception> int forEachWritable(int initialIndex, WritableComponentProcessor<E> processor) throws E;
+
+    /**
+     * Create a {@linkplain ComponentIterator component iterator} for all writable components in this buffer.
+     * <p>
+     * Unlike the {@link #forEachWritable(int, WritableComponentProcessor)} method, this API permits <em>external</em>
+     * iteration of the components, while at the same time protecting the life-cycle of the buffer.
+     * <p>
+     * The typical code pattern for using this API looks like the following:
+     * <pre>{@code
+     *      try (var iteration = buffer.forEachWritable()) {
+     *          for (var c = iteration.first(); c != null; c = c.next()) {
+     *              ByteBuffer componentBuffer = c.writableBuffer();
+     *              // ...
+     *          }
+     *      }
+     * }</pre>
+     * Note the use of the {@code var} keyword for local variables, which are required for correctly expressing the
+     * generic types used in the iteration.
+     * Following this code pattern will ensure that the components, and their parent buffer, will be correctly
+     * life-cycled.
+     * <p>
+     * <strong>Note</strong> that the {@link WritableComponent} instances exposed by the iterator could be reused for
+     * multiple calls, so the data must be extracted from the component in the context of the iteration.
+     * <p>
+     * The {@link ByteBuffer} instances obtained from the component, share lifetime with that internal component.
+     * This means they can be accessed as long as the internal memory store remain unchanged. Methods that may cause
+     * such changes are {@link #split(int)}, {@link #split()}, {@link #readSplit(int)}, {@link #writeSplit(int)},
+     * {@link #compact()}, {@link #ensureWritable(int)}, {@link #ensureWritable(int, int, boolean)},
+     * and {@link #send()}.
+     * <p>
+     * The best way to ensure this doesn't cause any trouble, is to use the buffers directly as part of the iteration.
+     * <p>
+     * <strong>Note</strong> that the arrays, memory addresses, and byte buffers exposed as components by this method,
+     * should not be used for changing the buffer contents beyond the respective array offset and length,
+     * or buffer position and limit. Doing so may cause undefined behaviour.
+     * <p>
+     * Changes to position and limit of the byte buffers exposed via the processed components, are not reflected back to
+     * this buffer instance.
+     *
+     * @return A component iterator of {@linkplain ReadableComponent readable components}.
+     * @param <T> An intersection type that presents both the {@link ReadableComponent} interface,
+     *          <em>and</em> the ability to progress the iteration via the {@link Next#next()} method.
+     */
+    <T extends WritableComponent & ComponentIterator.Next> ComponentIterator<T> forEachWritable();
 
     /**
      * Decodes this buffer's readable bytes into a string with the specified {@linkplain Charset}.

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -256,6 +256,11 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
+        return delegate.forEachWritable();
+    }
+
+    @Override
     public byte readByte() {
         return delegate.readByte();
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -15,6 +15,8 @@
  */
 package io.netty5.buffer.api;
 
+import io.netty5.buffer.api.ComponentIterator.Next;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
@@ -240,6 +242,11 @@ public class BufferStub implements Buffer {
     public <E extends Exception> int forEachReadable(int initialIndex,
                                                      ReadableComponentProcessor<E> processor) throws E {
         return delegate.forEachReadable(initialIndex, processor);
+    }
+
+    @Override
+    public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
+        return delegate.forEachReadable();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/ComponentIterator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/ComponentIterator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.api;
+
+import io.netty5.buffer.api.ComponentIterator.Next;
+
+public interface ComponentIterator<T extends Next> extends AutoCloseable {
+    T first();
+
+    @Override
+    void close();
+
+    interface Next {
+        <N extends Next> N next();
+    }
+}

--- a/buffer/src/main/java/io/netty5/buffer/api/ComponentIterator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/ComponentIterator.java
@@ -16,14 +16,62 @@
 package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.ComponentIterator.Next;
+import io.netty5.util.SafeCloseable;
 
-public interface ComponentIterator<T extends Next> extends AutoCloseable {
+/**
+ * A facade for iterating the readable or writable components of a {@link Buffer}.
+ *
+ * <strong>Note:</strong> the {@linkplain ComponentIterator iterator object} must be
+ * {@linkplain ComponentIterator#close() closed} after use.
+ * The easiest way to ensure this, is to use a try-with-resources clause.
+ * <p>
+ * The typical code pattern for using this API looks like the following:
+ * <pre>{@code
+ *      try (var iteration = buffer.forEachReadable()) {
+ *          for (var c = iteration.first(); c != null; c = c.next()) {
+ *              ByteBuffer componentBuffer = c.readableBuffer();
+ *              // ...
+ *          }
+ *      }
+ * }</pre>
+ * Note the use of the {@code var} keyword for local variables, which are required for correctly expressing the
+ * generic types used in the iteration.
+ * Following this code pattern will ensure that the components, and their parent buffer, will be correctly
+ * life-cycled.
+ *
+ * @param <T> A type that implements {@link Next}, and either {@link ReadableComponent} or {@link WritableComponent}.
+ * @see Buffer#forEachReadable()
+ * @see Buffer#forEachWritable()
+ */
+public interface ComponentIterator<T extends Next> extends SafeCloseable {
+    /**
+     * Get the first component of the iteration, or {@code null} if there are no components.
+     * <p>
+     * The object returned will implement both {@link Next}, and one of the {@link ReadableComponent} or
+     * {@link WritableComponent} interfaces.
+     *
+     * @return The first component of the iteration, or {@code null} if there are no components.
+     */
     T first();
 
-    @Override
-    void close();
-
+    /**
+     * This interface exposes external iteration on components.
+     */
     interface Next {
+        /**
+         * Get the next component of the iteration, or {@code null} if there are no more components.
+         * <p>
+         * The returned object, if any, will be of the same type as this object, and would typically be assigned to the
+         * same variable.
+         * <p>
+         * Iteration is only valid while the {@link ComponentIterator} is open.
+         * Calling this method after the associated component iterator has been
+         * {@linkplain ComponentIterator#close() closed} may result in undefined behaviour.
+         *
+         * @return The next component in the iteration, or {@code null} if there are no more components.
+         * @param <N> A type that implements {@link Next}, and one of the {@link ReadableComponent} or
+         * {@link WritableComponent} interfaces.
+         */
         <N extends Next> N next();
     }
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -25,6 +25,8 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferClosedException;
 import io.netty5.buffer.api.BufferReadOnlyException;
 import io.netty5.buffer.api.ByteCursor;
+import io.netty5.buffer.api.ComponentIterator;
+import io.netty5.buffer.api.ComponentIterator.Next;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.Owned;
 import io.netty5.buffer.api.ReadableComponent;
@@ -542,6 +544,11 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
             }
         }
         return byteBuffers.length;
+    }
+
+    @Override
+    public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
+        return null; // TODO not yet implemented
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -530,7 +530,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
         if (delegate.nioBufferCount() == 1) {
             ByteBuffer byteBuffer = delegate.nioBuffer(readerOffset(), readableBytes);
-            if (processor.process(initialIndex, new ReadableBufferComponent(byteBuffer, this))) {
+            if (processor.process(initialIndex, new ReadableBufferComponent(byteBuffer, this, null))) {
                 return 1;
             } else {
                 return -1;
@@ -538,7 +538,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
         ByteBuffer[] byteBuffers = delegate.nioBuffers(readerOffset(), readableBytes);
         for (int i = 0; i < byteBuffers.length; i++) {
-            ReadableBufferComponent component = new ReadableBufferComponent(byteBuffers[i], this);
+            ReadableBufferComponent component = new ReadableBufferComponent(byteBuffers[i], this, null);
             if (!processor.process(initialIndex + i, component)) {
                 return -(i + 1);
             }
@@ -548,7 +548,47 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
-        return null; // TODO not yet implemented
+        acquire();
+        return new ComponentIterator<T>() {
+            ByteBuffer[] byteBuffers;
+            int index;
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public T first() {
+                int readableBytes = readableBytes();
+                if (readableBytes == 0) {
+                    return null;
+                }
+                if (delegate.nioBufferCount() == 1) {
+                    ByteBuffer byteBuffer = delegate.nioBuffer(readerOffset(), readableBytes);
+                    return (T) new ReadableBufferComponent(byteBuffer, ByteBufBuffer.this, this::noNext);
+                }
+                byteBuffers = delegate.nioBuffers(readerOffset(), readableBytes);
+                return getNext();
+            }
+
+            private <N extends Next> N noNext() {
+                return null;
+            }
+
+            @SuppressWarnings("unchecked")
+            private <N extends Next> N getNext() {
+                if (index >= byteBuffers.length) {
+                    return null;
+                }
+                ByteBuffer byteBuffer = byteBuffers[index];
+                index++;
+                return (N) new ReadableBufferComponent(byteBuffer, ByteBufBuffer.this, this::getNext);
+            }
+
+            @Override
+            public void close() {
+                byteBuffers = null;
+                index = 0;
+                ByteBufBuffer.this.close();
+            }
+        };
     }
 
     @Override
@@ -566,7 +606,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
         if (delegate.nioBufferCount() == 1) {
             ByteBuffer byteBuffer = delegate.nioBuffer(writerOffset(), writableBytes);
-            if (processor.process(initialIndex, new WritableBufferComponent(byteBuffer, this))) {
+            if (processor.process(initialIndex, new WritableBufferComponent(byteBuffer, this, null))) {
                 return 1;
             } else {
                 return -1;
@@ -574,12 +614,61 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
         ByteBuffer[] byteBuffers = delegate.nioBuffers(writerOffset(), writableBytes);
         for (int i = 0; i < byteBuffers.length; i++) {
-            WritableBufferComponent component = new WritableBufferComponent(byteBuffers[i], this);
+            WritableBufferComponent component = new WritableBufferComponent(byteBuffers[i], this, null);
             if (!processor.process(initialIndex + i, component)) {
                 return -(i + 1);
             }
         }
         return byteBuffers.length;
+    }
+
+    @Override
+    public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
+        acquire();
+        if (readOnly()) {
+            close();
+            throw bufferIsReadOnly(this);
+        }
+        return new ComponentIterator<T>() {
+            ByteBuffer[] byteBuffers;
+            int index;
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public T first() {
+                int writableBytes = writableBytes();
+                if (writableBytes == 0) {
+                    return null;
+                }
+                if (delegate.nioBufferCount() == 1) {
+                    ByteBuffer byteBuffer = delegate.nioBuffer(writerOffset(), writableBytes);
+                    return (T) new WritableBufferComponent(byteBuffer, ByteBufBuffer.this, this::noNext);
+                }
+                byteBuffers = delegate.nioBuffers(readerOffset(), writableBytes);
+                return getNext();
+            }
+
+            private <N extends Next> N noNext() {
+                return null;
+            }
+
+            @SuppressWarnings("unchecked")
+            private <N extends Next> N getNext() {
+                if (index >= byteBuffers.length) {
+                    return null;
+                }
+                ByteBuffer byteBuffer = byteBuffers[index];
+                index++;
+                return (N) new WritableBufferComponent(byteBuffer, ByteBufBuffer.this, this::getNext);
+            }
+
+            @Override
+            public void close() {
+                byteBuffers = null;
+                index = 0;
+                ByteBufBuffer.this.close();
+            }
+        };
     }
 
     @Override
@@ -1163,15 +1252,18 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
     }
 
-    private static final class ReadableBufferComponent implements ReadableComponent, NotReadOnlyReadableComponent {
+    private static final class ReadableBufferComponent
+            implements ReadableComponent, NotReadOnlyReadableComponent, Next {
         private final ByteBuffer byteBuffer;
         private final Buffer buffer;
         private final int startByteBufferPosition;
         private final int startBufferReaderOffset;
+        private final Next next;
 
-        ReadableBufferComponent(ByteBuffer byteBuffer, Buffer buffer) {
+        ReadableBufferComponent(ByteBuffer byteBuffer, Buffer buffer, Next next) {
             this.byteBuffer = byteBuffer;
             this.buffer = buffer;
+            this.next = next;
             startByteBufferPosition = byteBuffer.position();
             startBufferReaderOffset = buffer.readerOffset();
         }
@@ -1227,17 +1319,24 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         public ByteBuffer mutableReadableBuffer() {
             return byteBuffer;
         }
+
+        @Override
+        public <N extends Next> N next() {
+            return next.next();
+        }
     }
 
-    private static final class WritableBufferComponent implements WritableComponent {
+    private static final class WritableBufferComponent implements WritableComponent, Next {
         private final ByteBuffer byteBuffer;
         private final Buffer buffer;
+        private final Next next;
         private final int startByteBufferPosition;
         private final int startBufferWriterOffset;
 
-        WritableBufferComponent(ByteBuffer byteBuffer, Buffer buffer) {
+        WritableBufferComponent(ByteBuffer byteBuffer, Buffer buffer, Next next) {
             this.byteBuffer = byteBuffer;
             this.buffer = buffer;
+            this.next = next;
             startByteBufferPosition = byteBuffer.position();
             startBufferWriterOffset = buffer.writerOffset();
         }
@@ -1282,6 +1381,11 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
             buffer.skipWritable(byteCount);
             int delta = buffer.writerOffset() - startBufferWriterOffset;
             byteBuffer.position(startByteBufferPosition + delta);
+        }
+
+        @Override
+        public <N extends Next> N next() {
+            return next.next();
         }
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -643,7 +643,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     @Override
     public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
-        checkWrite(writerOffset(), writableBytes());
+        checkWrite(writerOffset(), writableBytes(), false);
         return new SingleComponentIterator<T>(acquire(), writableBytes() > 0? this : null);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -20,6 +20,8 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferReadOnlyException;
 import io.netty5.buffer.api.ByteCursor;
+import io.netty5.buffer.api.ComponentIterator;
+import io.netty5.buffer.api.ComponentIterator.Next;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.Owned;
 import io.netty5.buffer.api.ReadableComponent;
@@ -28,6 +30,7 @@ import io.netty5.buffer.api.WritableComponent;
 import io.netty5.buffer.api.WritableComponentProcessor;
 import io.netty5.buffer.api.internal.AdaptableBuffer;
 import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
+import io.netty5.buffer.api.internal.SingleComponentIterator;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.util.internal.PlatformDependent;
 
@@ -52,7 +55,7 @@ import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
 
 final class NioBuffer extends AdaptableBuffer<NioBuffer>
-        implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent {
+        implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent, ComponentIterator.Next {
     private static final ByteBuffer CLOSED_BUFFER = ByteBuffer.allocate(0);
 
     private ByteBuffer base;
@@ -590,6 +593,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     public ByteBuffer writableBuffer() {
         return bbslice(wmem, writerOffset(), writableBytes());
     }
+
+    @Override
+    public <N extends Next> N next() {
+        return null; // There is no "next" component in our external-iteration of components.
+    }
     // </editor-fold>
 
     @Override
@@ -608,6 +616,11 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         } finally {
             Reference.reachabilityFence(this);
         }
+    }
+
+    @Override
+    public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
+        return new SingleComponentIterator<T>(acquire());
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -620,7 +620,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     @Override
     public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
-        return new SingleComponentIterator<T>(acquire());
+        return new SingleComponentIterator<T>(acquire(), readableBytes() > 0? this : null);
     }
 
     @Override
@@ -639,6 +639,12 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         } finally {
             Reference.reachabilityFence(this);
         }
+    }
+
+    @Override
+    public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
+        checkWrite(writerOffset(), writableBytes());
+        return new SingleComponentIterator<T>(acquire(), writableBytes() > 0? this : null);
     }
 
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors implementation.">

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/SingleComponentIterator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/SingleComponentIterator.java
@@ -22,10 +22,12 @@ import io.netty5.buffer.api.Resource;
 import java.lang.ref.Reference;
 
 public final class SingleComponentIterator<T extends Next> implements ComponentIterator<T> {
+    private final Resource<?> lifecycle;
     private final T singleComponent;
 
     @SuppressWarnings("unchecked")
-    public SingleComponentIterator(Object singleComponent) {
+    public SingleComponentIterator(Resource<?> lifecycle, Object singleComponent) {
+        this.lifecycle = lifecycle;
         this.singleComponent = (T) singleComponent;
     }
 
@@ -36,7 +38,7 @@ public final class SingleComponentIterator<T extends Next> implements ComponentI
 
     @Override
     public void close() {
-        ((Resource<?>) singleComponent).close();
-        Reference.reachabilityFence(singleComponent);
+        lifecycle.close();
+        Reference.reachabilityFence(lifecycle);
     }
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/SingleComponentIterator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/SingleComponentIterator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.buffer.api.internal;
+
+import io.netty5.buffer.api.ComponentIterator;
+import io.netty5.buffer.api.ComponentIterator.Next;
+import io.netty5.buffer.api.Resource;
+
+import java.lang.ref.Reference;
+
+public final class SingleComponentIterator<T extends Next> implements ComponentIterator<T> {
+    private final T singleComponent;
+
+    @SuppressWarnings("unchecked")
+    public SingleComponentIterator(Object singleComponent) {
+        this.singleComponent = (T) singleComponent;
+    }
+
+    @Override
+    public T first() {
+        return singleComponent;
+    }
+
+    @Override
+    public void close() {
+        ((Resource<?>) singleComponent).close();
+        Reference.reachabilityFence(singleComponent);
+    }
+}

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/SingleComponentIterator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/SingleComponentIterator.java
@@ -21,13 +21,16 @@ import io.netty5.buffer.api.Resource;
 
 import java.lang.ref.Reference;
 
+import static java.util.Objects.requireNonNull;
+
 public final class SingleComponentIterator<T extends Next> implements ComponentIterator<T> {
     private final Resource<?> lifecycle;
     private final T singleComponent;
 
     @SuppressWarnings("unchecked")
     public SingleComponentIterator(Resource<?> lifecycle, Object singleComponent) {
-        this.lifecycle = lifecycle;
+        this.lifecycle = requireNonNull(lifecycle, "lifecycle");
+        // The singleComponent may be null if there is nothing to iterate.
         this.singleComponent = (T) singleComponent;
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -728,7 +728,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
     @Override
     public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
-        checkWrite(writerOffset(), writableBytes());
+        checkWrite(writerOffset(), writableBytes(), false);
         return new SingleComponentIterator<T>(acquire(), writableBytes() > 0? this : null);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -705,7 +705,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
     @Override
     public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
-        return new SingleComponentIterator<T>(acquire());
+        return new SingleComponentIterator<T>(acquire(), readableBytes() > 0? this : null);
     }
 
     @Override
@@ -724,6 +724,12 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         } finally {
             Reference.reachabilityFence(this);
         }
+    }
+
+    @Override
+    public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
+        checkWrite(writerOffset(), writableBytes());
+        return new SingleComponentIterator<T>(acquire(), writableBytes() > 0? this : null);
     }
 
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors implementation.">

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -20,6 +20,8 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferReadOnlyException;
 import io.netty5.buffer.api.ByteCursor;
+import io.netty5.buffer.api.ComponentIterator;
+import io.netty5.buffer.api.ComponentIterator.Next;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.Owned;
 import io.netty5.buffer.api.ReadableComponent;
@@ -28,6 +30,7 @@ import io.netty5.buffer.api.WritableComponent;
 import io.netty5.buffer.api.WritableComponentProcessor;
 import io.netty5.buffer.api.internal.AdaptableBuffer;
 import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
+import io.netty5.buffer.api.internal.SingleComponentIterator;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.util.internal.PlatformDependent;
 
@@ -50,7 +53,7 @@ import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
 
 final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
-        implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent {
+        implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent, ComponentIterator.Next {
     private static final int CLOSED_SIZE = -1;
     private static final boolean ACCESS_UNALIGNED = PlatformDependent.isUnaligned();
     private static final boolean FLIP_BYTES = ByteOrder.BIG_ENDIAN != ByteOrder.nativeOrder();
@@ -675,6 +678,11 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         }
         return buf;
     }
+
+    @Override
+    public <N extends Next> N next() {
+        return null; // There is no "next" component in our external-iteration of components.
+    }
     // </editor-fold>
 
     @Override
@@ -693,6 +701,11 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         } finally {
             Reference.reachabilityFence(this);
         }
+    }
+
+    @Override
+    public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
+        return new SingleComponentIterator<T>(acquire());
     }
 
     @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.nio.ByteOrder.BIG_ENDIAN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -115,7 +116,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
     }
 
     @Test
-    public void forEachReadableMustVisitAllReadableConstituentBuffersInOrder() {
+    public void internalForEachReadableMustVisitAllReadableConstituentBuffersInOrder() {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
             Buffer composite;
             try (Buffer a = allocator.allocate(4);
@@ -146,6 +147,45 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                 return true;
             });
             assertEquals(3, count);
+            assertThat(list).isEmpty();
+        }
+    }
+
+    @Test
+    public void externalForEachReadableMustVisitAllReadableConstituentBuffersInOrder() {
+        try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
+            Buffer composite;
+            try (Buffer a = allocator.allocate(4);
+                 Buffer b = allocator.allocate(4);
+                 Buffer c = allocator.allocate(4)) {
+                a.writeInt(1);
+                b.writeInt(2);
+                c.writeInt(3);
+                composite = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+            }
+            var list = new LinkedList<Integer>(List.of(1, 2, 3));
+            int index = 0;
+            try (var iterator = composite.forEachReadable()) {
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    var buffer = component.readableBuffer();
+                    int bufferValue = buffer.getInt();
+                    int expectedValue = list.pollFirst().intValue();
+                    assertEquals(expectedValue, bufferValue);
+                    assertEquals(bufferValue, index + 1);
+                    assertThrows(ReadOnlyBufferException.class, () -> buffer.put(0, (byte) 0xFF));
+                    var writableBuffer = Statics.tryGetWritableBufferFromReadableComponent(component);
+                    if (writableBuffer != null) {
+                        int pos = writableBuffer.position();
+                        bufferValue = writableBuffer.getInt();
+                        assertEquals(expectedValue, bufferValue);
+                        assertEquals(bufferValue, index + 1);
+                        writableBuffer.put(pos, (byte) 0xFF);
+                        assertEquals((byte) 0xFF, writableBuffer.get(pos));
+                    }
+                    index++;
+                }
+            }
+            assertEquals(3, index);
             assertThat(list).isEmpty();
         }
     }
@@ -198,12 +238,13 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             buf.writeLong(0);
             buf.close();
             assertThrows(BufferClosedException.class, () -> buf.forEachReadable(0, (component, index) -> true));
+            assertThrows(BufferClosedException.class, () -> buf.forEachReadable());
         }
     }
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachReadableMustAllowCollectingBuffersInArray(Fixture fixture) {
+    public void internalForEachReadableMustAllowCollectingBuffersInArray(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator()) {
             Buffer buf;
             try (Buffer a = allocator.allocate(4);
@@ -232,7 +273,103 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachReadableMustExposeByteCursors(Fixture fixture) {
+    public void externalForEachReadableMustAllowCollectingBuffersInArray(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator()) {
+            Buffer buf;
+            try (Buffer a = allocator.allocate(4);
+                 Buffer b = allocator.allocate(4);
+                 Buffer c = allocator.allocate(4)) {
+                buf = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+            }
+            int i = 1;
+            while (buf.writableBytes() > 0) {
+                buf.writeByte((byte) i++);
+            }
+            ByteBuffer[] buffers = new ByteBuffer[buf.countReadableComponents()];
+            try (var iterator = buf.forEachReadable()) {
+                int index = 0;
+                for (var component = iterator.first(); component != null; component = component.next())  {
+                    buffers[index] = component.readableBuffer();
+                    index++;
+                }
+                System.out.println("buffers[2].get(0) = " + buffers[2].get(0));
+            }
+            System.out.println("buffers[2].get(0) = " + buffers[2].get(0));
+            i = 1;
+            assertThat(buffers.length).isGreaterThanOrEqualTo(1);
+            for (ByteBuffer buffer : buffers) {
+                while (buffer.hasRemaining()) {
+                    assertEquals((byte) i++, buffer.get());
+                }
+            }
+            buf.close();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void internalForEachReadableMustExposeByteCursors(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(20)) {
+            buf.writeLong(0x0102030405060708L);
+            buf.writeLong(0x1112131415161718L);
+            assertEquals(0x01020304, buf.readInt());
+            try (Buffer actualData = allocator.allocate(buf.readableBytes());
+                 Buffer expectedData = allocator.allocate(12)) {
+                expectedData.writeInt(0x05060708);
+                expectedData.writeInt(0x11121314);
+                expectedData.writeInt(0x15161718);
+
+                buf.forEachReadable(0, (i, component) -> {
+                    ByteCursor forward = component.openCursor();
+                    while (forward.readByte()) {
+                        actualData.writeByte(forward.getByte());
+                    }
+                    return true;
+                });
+
+                assertEquals(expectedData.readableBytes(), actualData.readableBytes());
+                while (expectedData.readableBytes() > 0) {
+                    assertEquals(expectedData.readByte(), actualData.readByte());
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void externalForEachReadableMustExposeByteCursors(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(20)) {
+            buf.writeLong(0x0102030405060708L);
+            buf.writeLong(0x1112131415161718L);
+            assertEquals(0x01020304, buf.readInt());
+            try (Buffer actualData = allocator.allocate(buf.readableBytes());
+                 Buffer expectedData = allocator.allocate(12)) {
+                expectedData.writeInt(0x05060708);
+                expectedData.writeInt(0x11121314);
+                expectedData.writeInt(0x15161718);
+
+                try (var iterator = buf.forEachReadable()) {
+                    for (var component = iterator.first(); component != null; component = component.next()) {
+                        ByteCursor forward = component.openCursor();
+                        while (forward.readByte()) {
+                            actualData.writeByte(forward.getByte());
+                        }
+                    }
+                }
+
+                assertEquals(expectedData.readableBytes(), actualData.readableBytes());
+                while (expectedData.readableBytes() > 0) {
+                    assertEquals(expectedData.readByte(), actualData.readByte());
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void internalForEachReadableMustExposeByteCursorsPartial(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(32)) {
             buf.writeLong(0x0102030405060708L);
@@ -262,7 +399,38 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachReadableMustReturnZeroWhenNotReadable(Fixture fixture) {
+    public void externalForEachReadableMustExposeByteCursorsPartial(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(32)) {
+            buf.writeLong(0x0102030405060708L);
+            buf.writeLong(0x1112131415161718L);
+            assertEquals(0x01020304, buf.readInt());
+            try (Buffer actualData = allocator.allocate(buf.readableBytes());
+                 Buffer expectedData = allocator.allocate(12)) {
+                expectedData.writeInt(0x05060708);
+                expectedData.writeInt(0x11121314);
+                expectedData.writeInt(0x15161718);
+
+                try (var iterator = buf.forEachReadable()) {
+                    for (var component = iterator.first(); component != null; component = component.next()) {
+                        ByteCursor forward = component.openCursor();
+                        while (forward.readByte()) {
+                            actualData.writeByte(forward.getByte());
+                        }
+                    }
+                }
+
+                assertEquals(expectedData.readableBytes(), actualData.readableBytes());
+                while (expectedData.readableBytes() > 0) {
+                    assertEquals(expectedData.readByte(), actualData.readByte());
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void internalForEachReadableMustReturnZeroWhenNotReadable(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(0)) {
             int count = buf.forEachReadable(0, (index, component) -> {
@@ -270,6 +438,17 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                 return true;
             });
             assertEquals(0, count);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void externalForEachReadableMustReturnNullFirstWhenNotReadable(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(0)) {
+            try (var iterator = buf.forEachReadable()) {
+                assertThat(iterator.first()).isNull();
+            }
         }
     }
 
@@ -283,7 +462,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
     }
 
     @Test
-    public void forEachWritableMustVisitAllWritableConstituentBuffersInOrder() {
+    public void internalForEachWritableMustVisitAllWritableConstituentBuffersInOrder() {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
             Buffer buf;
             try (Buffer a = allocator.allocate(8);
@@ -295,6 +474,29 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                 component.writableBuffer().putLong(0x0102030405060708L + 0x1010101010101010L * index);
                 return true;
             });
+            buf.writerOffset(3 * 8);
+            assertEquals(0x0102030405060708L, buf.readLong());
+            assertEquals(0x1112131415161718L, buf.readLong());
+            assertEquals(0x2122232425262728L, buf.readLong());
+        }
+    }
+
+    @Test
+    public void externalForEachWritableMustVisitAllWritableConstituentBuffersInOrder() {
+        try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled()) {
+            Buffer buf;
+            try (Buffer a = allocator.allocate(8);
+                 Buffer b = allocator.allocate(8);
+                 Buffer c = allocator.allocate(8)) {
+                buf = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+            }
+            try (var iterator = buf.forEachWritable()) {
+                int index = 0;
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    component.writableBuffer().putLong(0x0102030405060708L + 0x1010101010101010L * index);
+                    index++;
+                }
+            }
             buf.writerOffset(3 * 8);
             assertEquals(0x0102030405060708L, buf.readLong());
             assertEquals(0x1112131415161718L, buf.readLong());
@@ -314,7 +516,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachWritableMustStopIterationWhenProcessorRetursFalse(Fixture fixture) {
+    public void forEachWritableMustStopIterationWhenProcessorReturnsFalse(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             AtomicInteger counter = new AtomicInteger();
@@ -328,13 +530,13 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachWritableChangesMadeToByteBufferComponentMustBeReflectedInBuffer(Fixture fixture) {
+    public void internalForEachWritableChangesMadeToByteBufferComponentMustBeReflectedInBuffer(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(9)) {
             buf.writeByte((byte) 0xFF);
             AtomicInteger writtenCounter = new AtomicInteger();
             buf.forEachWritable(0, (index, component) -> {
-                var buffer = component.writableBuffer();
+                ByteBuffer buffer = component.writableBuffer();
                 while (buffer.hasRemaining()) {
                     buffer.put((byte) writtenCounter.incrementAndGet());
                 }
@@ -348,7 +550,28 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachWritableMustReturnZeroWhenNotWritable(Fixture fixture) {
+    public void externalForEachWritableChangesMadeToByteBufferComponentMustBeReflectedInBuffer(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(9)) {
+            buf.writeByte((byte) 0xFF);
+            AtomicInteger writtenCounter = new AtomicInteger();
+            try (var iterator = buf.forEachWritable()) {
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    ByteBuffer buffer = component.writableBuffer();
+                    while (buffer.hasRemaining()) {
+                        buffer.put((byte) writtenCounter.incrementAndGet());
+                    }
+                }
+            }
+            buf.writerOffset(9);
+            assertEquals((byte) 0xFF, buf.readByte());
+            assertEquals(0x0102030405060708L, buf.readLong());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void internalForEachWritableMustReturnZeroWhenNotWritable(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(0)) {
             int count = buf.forEachWritable(0, (index, component) -> {
@@ -361,12 +584,23 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void changesMadeToByteBufferComponentsShouldBeReflectedInBuffer(Fixture fixture) {
+    public void externalForEachWritableMustReturnZeroWhenNotWritable(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(0)) {
+            try (var iterator = buf.forEachWritable()) {
+                assertThat(iterator.first()).isNull();
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void changesMadeToByteBufferComponentsInInternalIterationShouldBeReflectedInBuffer(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             AtomicInteger counter = new AtomicInteger();
             buf.forEachWritable(0, (index, component) -> {
-                var buffer = component.writableBuffer();
+                ByteBuffer buffer = component.writableBuffer();
                 while (buffer.hasRemaining()) {
                     buffer.put((byte) counter.incrementAndGet());
                 }
@@ -381,11 +615,33 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
+    public void changesMadeToByteBufferComponentsInExternalIterationShouldBeReflectedInBuffer(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            AtomicInteger counter = new AtomicInteger();
+            try (var iterator = buf.forEachWritable()) {
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    ByteBuffer buffer = component.writableBuffer();
+                    while (buffer.hasRemaining()) {
+                        buffer.put((byte) counter.incrementAndGet());
+                    }
+                }
+            }
+            buf.writerOffset(buf.capacity());
+            for (int i = 0; i < 8; i++) {
+                assertEquals((byte) i + 1, buf.getByte(i));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
     public void forEachWritableOnClosedBufferMustThrow(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator()) {
             Buffer buf = allocator.allocate(8);
             buf.close();
             assertThrows(BufferClosedException.class, () -> buf.forEachWritable(0, (index, component) -> true));
+            assertThrows(BufferClosedException.class, () -> buf.forEachWritable());
         }
     }
 
@@ -395,12 +651,13 @@ public class BufferComponentIterationTest extends BufferTestSupport {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8).makeReadOnly()) {
             assertThrows(BufferReadOnlyException.class, () -> buf.forEachWritable(0, (index, component) -> true));
+            assertThrows(BufferReadOnlyException.class, () -> buf.forEachWritable());
         }
     }
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachWritableMustAllowCollectingBuffersInArray(Fixture fixture) {
+    public void internalForEachWritableMustAllowCollectingBuffersInArray(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
             ByteBuffer[] buffers = new ByteBuffer[buf.countWritableComponents()];
@@ -425,7 +682,35 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachReadableMustBeAbleToIncrementReaderOffset(Fixture fixture) {
+    public void externalForEachWritableMustAllowCollectingBuffersInArray(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8)) {
+            ByteBuffer[] buffers = new ByteBuffer[buf.countWritableComponents()];
+            try (var iterator = buf.forEachWritable()) {
+                int index = 0;
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    buffers[index] = component.writableBuffer();
+                    index++;
+                }
+            }
+            assertThat(buffers.length).isGreaterThanOrEqualTo(1);
+            int i = 1;
+            for (ByteBuffer buffer : buffers) {
+                while (buffer.hasRemaining()) {
+                    buffer.put((byte) i++);
+                }
+            }
+            buf.writerOffset(buf.capacity());
+            i = 1;
+            while (buf.readableBytes() > 0) {
+                assertEquals((byte) i++, buf.readByte());
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void internalForEachReadableMustBeAbleToIncrementReaderOffset(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8);
              Buffer target = allocator.allocate(5)) {
@@ -453,11 +738,40 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
-    public void forEachWritableMustBeAbleToIncrementWriterOffset(Fixture fixture) {
+    public void externalForEachReadableMustBeAbleToIncrementReaderOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8);
+             Buffer target = allocator.allocate(5)) {
+            buf.writeLong(0x0102030405060708L);
+            try (var iterator = buf.forEachReadable()) {
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    while (target.writableBytes() > 0 && component.readableBytes() > 0) {
+                        ByteBuffer byteBuffer = component.readableBuffer();
+                        byte value = byteBuffer.get();
+                        byteBuffer.clear();
+                        target.writeByte(value);
+                        var cmp = component; // Capture for lambda.
+                        assertThrows(IndexOutOfBoundsException.class, () -> cmp.skipReadable(9));
+                        component.skipReadable(0);
+                        component.skipReadable(1);
+                    }
+                }
+            }
+            assertThat(buf.readerOffset()).isEqualTo(5);
+            assertThat(buf.readableBytes()).isEqualTo(3);
+            assertThat(target.readableBytes()).isEqualTo(5);
+            assertThat(target).isEqualTo(allocator.copyOf(new byte[] {0x01, 0x02, 0x03, 0x04, 0x05}));
+            assertThat(buf).isEqualTo(allocator.copyOf(new byte[] {0x06, 0x07, 0x08}));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void internalForEachWritableMustBeAbleToIncrementWriterOffset(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8).writeLong(0x0102030405060708L);
              Buffer target = buf.copy()) {
-            buf.writerOffset(0); // Prime the buffer with data, but leave the write offset at zero.
+            buf.writerOffset(0); // Prime the buffer with data, but leave the write-offset at zero.
             int components = buf.forEachWritable(0, (index, component) -> {
                 while (component.writableBytes() > 0) {
                     ByteBuffer byteBuffer = component.writableBuffer();
@@ -480,6 +794,34 @@ public class BufferComponentIterationTest extends BufferTestSupport {
 
     @ParameterizedTest
     @MethodSource("allocators")
+    public void externalForEachWritableMustBeAbleToIncrementWriterOffset(Fixture fixture) {
+        try (BufferAllocator allocator = fixture.createAllocator();
+             Buffer buf = allocator.allocate(8).writeLong(0x0102030405060708L);
+             Buffer target = buf.copy()) {
+            buf.writerOffset(0); // Prime the buffer with data, but leave the write-offset at zero.
+            try (var iterator = buf.forEachWritable()) {
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    while (component.writableBytes() > 0) {
+                        ByteBuffer byteBuffer = component.writableBuffer();
+                        byte value = byteBuffer.get();
+                        byteBuffer.clear();
+                        assertThat(value).isEqualTo(target.readByte());
+                        var cmp = component; // Capture for lambda.
+                        assertThrows(IndexOutOfBoundsException.class, () -> cmp.skipWritable(9));
+                        component.skipWritable(0);
+                        component.skipWritable(1);
+                    }
+                }
+            }
+            assertThat(buf.writerOffset()).isEqualTo(8);
+            assertThat(target.readerOffset()).isEqualTo(8);
+            target.readerOffset(0);
+            assertThat(buf).isEqualTo(target);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
     public void negativeSkipReadableOnReadableComponentMustThrow(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
              Buffer buf = allocator.allocate(8)) {
@@ -489,6 +831,13 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                 assertThrows(IllegalArgumentException.class, () -> component.skipReadable(-1));
                 return true;
             });
+
+            try (var iterator = buf.forEachReadable()) {
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    var cmp = component; // Capture for lambda.
+                    assertThrows(IllegalArgumentException.class, () -> cmp.skipReadable(-1));
+                }
+            }
         }
     }
 
@@ -501,6 +850,153 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                 assertThrows(IllegalArgumentException.class, () -> component.skipWritable(-1));
                 return true;
             });
+
+            try (var iterator = buf.forEachWritable()) {
+                for (var component = iterator.first(); component != null; component = component.next()) {
+                    var cmp = component; // Capture for lambda.
+                    assertThrows(IllegalArgumentException.class, () -> cmp.skipWritable(-1));
+                }
+            }
+        }
+    }
+
+    public static void verifyForEachReadableSingleComponent(Fixture fixture, Buffer buf) {
+        buf.forEachReadable(0, (index, component) -> {
+            ByteBuffer buffer = component.readableBuffer();
+            assertThat(buffer.position()).isZero();
+            assertThat(buffer.limit()).isEqualTo(8);
+            assertThat(buffer.capacity()).isEqualTo(8);
+            assertEquals(0x0102030405060708L, buffer.getLong());
+
+            if (fixture.isDirect()) {
+                assertThat(component.readableNativeAddress()).isNotZero();
+            } else {
+                assertThat(component.readableNativeAddress()).isZero();
+            }
+
+            if (component.hasReadableArray()) {
+                byte[] array = component.readableArray();
+                byte[] arrayCopy = new byte[component.readableArrayLength()];
+                System.arraycopy(array, component.readableArrayOffset(), arrayCopy, 0, arrayCopy.length);
+                if (buffer.order() == BIG_ENDIAN) {
+                    assertThat(arrayCopy).containsExactly(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08);
+                } else {
+                    assertThat(arrayCopy).containsExactly(0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01);
+                }
+            }
+
+            assertThrows(ReadOnlyBufferException.class, () -> buffer.put(0, (byte) 0xFF));
+            return true;
+        });
+
+        try (var iterator = buf.forEachReadable()) {
+            for (var component = iterator.first(); component != null; component = component.next()) {
+                ByteBuffer buffer = component.readableBuffer();
+                assertThat(buffer.position()).isZero();
+                assertThat(buffer.limit()).isEqualTo(8);
+                assertThat(buffer.capacity()).isEqualTo(8);
+                assertEquals(0x0102030405060708L, buffer.getLong());
+
+                if (fixture.isDirect()) {
+                    assertThat(component.readableNativeAddress()).isNotZero();
+                } else {
+                    assertThat(component.readableNativeAddress()).isZero();
+                }
+
+                if (component.hasReadableArray()) {
+                    byte[] array = component.readableArray();
+                    byte[] arrayCopy = new byte[component.readableArrayLength()];
+                    System.arraycopy(array, component.readableArrayOffset(), arrayCopy, 0, arrayCopy.length);
+                    if (buffer.order() == BIG_ENDIAN) {
+                        assertThat(arrayCopy).containsExactly(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08);
+                    } else {
+                        assertThat(arrayCopy).containsExactly(0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01);
+                    }
+                }
+
+                assertThrows(ReadOnlyBufferException.class, () -> buffer.put(0, (byte) 0xFF));
+            }
+        }
+    }
+
+    public static void verifyForEachWritableSingleComponent(Fixture fixture, Buffer buf) {
+        int roff = buf.readerOffset();
+        int woff = buf.writerOffset();
+        buf.fill((byte) 0);
+        buf.forEachWritable(0, (index, component) -> {
+            ByteBuffer buffer = component.writableBuffer();
+            assertThat(buffer.position()).isZero();
+            assertThat(buffer.limit()).isEqualTo(8);
+            assertThat(buffer.capacity()).isEqualTo(8);
+            buffer.putLong(0x0102030405060708L);
+            buffer.flip();
+            assertEquals(0x0102030405060708L, buffer.getLong());
+            buf.writerOffset(8);
+            assertEquals(0x0102030405060708L, buf.getLong(0));
+
+            if (fixture.isDirect()) {
+                assertThat(component.writableNativeAddress()).isNotZero();
+            } else {
+                assertThat(component.writableNativeAddress()).isZero();
+            }
+
+            buf.writerOffset(0);
+            if (component.hasWritableArray()) {
+                byte[] array = component.writableArray();
+                int offset = component.writableArrayOffset();
+                byte[] arrayCopy = new byte[component.writableArrayLength()];
+                System.arraycopy(array, offset, arrayCopy, 0, arrayCopy.length);
+                if (buffer.order() == BIG_ENDIAN) {
+                    assertThat(arrayCopy).containsExactly(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08);
+                } else {
+                    assertThat(arrayCopy).containsExactly(0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01);
+                }
+            }
+
+            buffer.put(0, (byte) 0xFF);
+            assertEquals((byte) 0xFF, buffer.get(0));
+            assertEquals((byte) 0xFF, buf.getByte(0));
+            return true;
+        });
+
+        buf.resetOffsets().writerOffset(woff).readerOffset(roff);
+
+        buf.fill((byte) 0);
+        try (var iterator = buf.forEachWritable()) {
+            for (var component = iterator.first(); component != null; component = component.next()) {
+                ByteBuffer buffer = component.writableBuffer();
+                assertThat(buffer.position()).isZero();
+                assertThat(buffer.limit()).isEqualTo(8);
+                assertThat(buffer.capacity()).isEqualTo(8);
+                buffer.putLong(0x0102030405060708L);
+                buffer.flip();
+                assertEquals(0x0102030405060708L, buffer.getLong());
+                buf.writerOffset(8);
+                assertEquals(0x0102030405060708L, buf.getLong(0));
+
+                if (fixture.isDirect()) {
+                    assertThat(component.writableNativeAddress()).isNotZero();
+                } else {
+                    assertThat(component.writableNativeAddress()).isZero();
+                }
+
+                buf.writerOffset(0);
+                if (component.hasWritableArray()) {
+                    byte[] array = component.writableArray();
+                    int offset = component.writableArrayOffset();
+                    byte[] arrayCopy = new byte[component.writableArrayLength()];
+                    System.arraycopy(array, offset, arrayCopy, 0, arrayCopy.length);
+                    if (buffer.order() == BIG_ENDIAN) {
+                        assertThat(arrayCopy).containsExactly(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08);
+                    } else {
+                        assertThat(arrayCopy).containsExactly(0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01);
+                    }
+                }
+
+                buffer.put(0, (byte) 0xFF);
+                assertEquals((byte) 0xFF, buffer.get(0));
+                assertEquals((byte) 0xFF, buf.getByte(0));
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:
Accessing the internal ByteBuffer instances, or the native addresses, with the `Buffer.forEachReadable/Writable` methods have turned out to be rather troublesome.
The trouble specifically comes from the API being designed around _internal_ iteration.
While internal iteration is excellent at masking whether a buffer is composite or not, the loss of local mutable context (because of the use of lambdas) makes it rather combersome to use.

Modification:
This adds an API based on external iteration of the components.
There are a number of requirements pulling on this API and causing it to look the way it does.
First, we really want to ensure that the parent `Buffer` instance is strongly referenced and live throughout the entire iteration.
With internal iteration, we can place a `reachabilityFence` after the iteration.
With external iteration, we instead rely on the `ComponentIterator` being `AutoCloseable` and place a reachability fence in the close method.
Second, we wish to prevent the components from leaking beyond the iteration.
This isn't entirely possible to prevent, for either internal or external iteration.
The use of intersection types discourages assigning the iterator or the components to fields, though they don't prevent it.
It does, however, prevent correctly typed local variables from existing beyond their intended scope.

Result:
We have a API for external buffer component iteration.