### PR TITLE
Check if epoll_pwait2 is implemented

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -817,9 +817,12 @@ static jint netty_epoll_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix
         if (efd != -1) {
             struct timespec ts = { 0, 0 };
             struct epoll_event ev;
-            if (epoll_pwait2(efd, &ev, 1, &ts, NULL) != -1) {
-                epoll_pwait2_supported = 1;
-            }
+            do {
+                if (epoll_pwait2(efd, &ev, 1, &ts, NULL) != -1) {
+                    epoll_pwait2_supported = 1;
+                    break;
+                }
+            } while(errno == EINTR);
             close(efd);
         }
     }

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -816,7 +816,7 @@ static jint netty_epoll_native_JNI_OnLoad(JNIEnv* env, const char* packagePrefix
         int efd = epoll_create(1);
         if (efd != -1) {
             struct timespec ts = { 0, 0 };
-            struct epoll_event ev[1];
+            struct epoll_event ev;
             if (epoll_pwait2(efd, &ev, 1, &ts, NULL) != -1) {
                 epoll_pwait2_supported = 1;
             }


### PR DESCRIPTION
Motivation:

Its possible that while there is an epoll_pwait2(...) system call it is not implemented and so fail with ENOSYS.

Modifications:

Check if we can actually use epoll_pwait2(...) and it not fails due not implemented.

Result:

Fixes https://github.com/netty/netty/issues/12343