### PR TITLE
Finish mocking before using the mocks

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -148,7 +148,6 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void inflightFrameAfterStreamResetShouldNotMakeConnectionUnusable() throws Exception {
-        bootstrapEnv(1, 1, 2, 1);
         final CountDownLatch latch = new CountDownLatch(1);
         doAnswer(new Answer<Void>() {
             @Override
@@ -174,6 +173,8 @@ public class Http2ConnectionRoundtripTest {
             }
         }).when(clientListener).onHeadersRead(any(ChannelHandlerContext.class), eq(5), any(Http2Headers.class),
                 anyInt(), anyShort(), anyBoolean(), anyInt(), anyBoolean());
+
+        bootstrapEnv(1, 1, 2, 1);
 
         // Create a single stream by sending a HEADERS frame to the server.
         final short weight = 16;
@@ -233,8 +234,6 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void encodeViolatesMaxHeaderListSizeCanStillUseConnection() throws Exception {
-        bootstrapEnv(1, 2, 1, 0, 0);
-
         final CountDownLatch serverSettingsAckLatch1 = new CountDownLatch(2);
         final CountDownLatch serverSettingsAckLatch2 = new CountDownLatch(3);
         final CountDownLatch clientSettingsLatch1 = new CountDownLatch(3);
@@ -272,6 +271,8 @@ public class Http2ConnectionRoundtripTest {
             }
         }).when(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(5), eq(headers),
                 anyInt(), anyShort(), anyBoolean(), eq(0), eq(true));
+
+        bootstrapEnv(1, 2, 1, 0, 0);
 
         // Set the maxHeaderListSize to 100 so we may be able to write some headers, but not all. We want to verify
         // that we don't corrupt state if some can be written but not all.
@@ -364,8 +365,6 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void testSettingsAckIsSentBeforeUsingFlowControl() throws Exception {
-        bootstrapEnv(1, 1, 1, 1);
-
         final CountDownLatch serverSettingsAckLatch1 = new CountDownLatch(1);
         final CountDownLatch serverSettingsAckLatch2 = new CountDownLatch(2);
         final CountDownLatch serverDataLatch = new CountDownLatch(1);
@@ -394,6 +393,8 @@ public class Http2ConnectionRoundtripTest {
             }
         }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3),
                 any(ByteBuf.class), eq(0), anyBoolean());
+
+        bootstrapEnv(1, 1, 1, 1);
 
         final Http2Headers headers = dummyHeaders();
 
@@ -519,8 +520,6 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void headersWriteForPeerStreamWhichWasResetShouldNotGoAway() throws Exception {
-        bootstrapEnv(1, 1, 1, 0);
-
         final CountDownLatch serverGotRstLatch = new CountDownLatch(1);
         final CountDownLatch serverWriteHeadersLatch = new CountDownLatch(1);
         final AtomicReference<Throwable> serverWriteHeadersCauseRef = new AtomicReference<Throwable>();
@@ -535,6 +534,8 @@ public class Http2ConnectionRoundtripTest {
                 return null;
             }
         }).when(serverListener).onRstStreamRead(any(ChannelHandlerContext.class), eq(streamId), anyLong());
+
+        bootstrapEnv(1, 1, 1, 0);
 
         final Http2Headers headers = dummyHeaders();
         runInChannel(clientChannel, new Http2Runnable() {
@@ -867,12 +868,6 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void createStreamAfterReceiveGoAwayShouldNotSendGoAway() throws Exception {
-        bootstrapEnv(1, 1, 2, 1, 1);
-
-        // We want both sides to do graceful shutdown during the test.
-        setClientGracefulShutdownTime(10000);
-        setServerGracefulShutdownTime(10000);
-
         final CountDownLatch clientGoAwayLatch = new CountDownLatch(1);
         doAnswer(new Answer<Void>() {
             @Override
@@ -881,6 +876,12 @@ public class Http2ConnectionRoundtripTest {
                 return null;
             }
         }).when(clientListener).onGoAwayRead(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class));
+
+        bootstrapEnv(1, 1, 2, 1, 1);
+
+        // We want both sides to do graceful shutdown during the test.
+        setClientGracefulShutdownTime(10000);
+        setServerGracefulShutdownTime(10000);
 
         // Create a single stream by sending a HEADERS frame to the server.
         final Http2Headers headers = dummyHeaders();
@@ -950,12 +951,6 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void listenerIsNotifiedOfGoawayBeforeStreamsAreRemovedFromTheConnection() throws Exception {
-        bootstrapEnv(1, 1, 2, 1, 1);
-
-        // We want both sides to do graceful shutdown during the test.
-        setClientGracefulShutdownTime(10000);
-        setServerGracefulShutdownTime(10000);
-
         final AtomicReference<Http2Stream.State> clientStream3State = new AtomicReference<Http2Stream.State>();
         final CountDownLatch clientGoAwayLatch = new CountDownLatch(1);
         doAnswer(new Answer<Void>() {
@@ -966,6 +961,12 @@ public class Http2ConnectionRoundtripTest {
                 return null;
             }
         }).when(clientListener).onGoAwayRead(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class));
+
+        bootstrapEnv(1, 1, 2, 1, 1);
+
+        // We want both sides to do graceful shutdown during the test.
+        setClientGracefulShutdownTime(10000);
+        setServerGracefulShutdownTime(10000);
 
         // Create a single stream by sending a HEADERS frame to the server.
         final Http2Headers headers = dummyHeaders();


### PR DESCRIPTION
Motivation:

We should ensure we finish the mocking before we bootstrap the servers as otherwise it might fail

Modifications:

Finish setup mocks before bootstrap

Result:

No more mocking failures