### PR TITLE
Move methods for creating CompositeBuffer to BufferAllocator

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/BufferHolder.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferHolder.java
@@ -30,7 +30,7 @@ import static java.lang.invoke.MethodHandles.lookup;
  * The {@link BufferHolder} can only hold on to a single buffer, so objects and classes that need to hold on to multiple
  * buffers will have to do their implementation from scratch, though they can use the code of the {@link BufferHolder}
  * as inspiration. Alternatively, multiple buffers can be
- * {@linkplain CompositeBuffer#compose(BufferAllocator, Send[]) composed} into a single buffer, which can then be put
+ * {@linkplain BufferAllocator#compose(Iterable) composed} into a single buffer, which can then be put
  * in a buffer holder.
  * <p>
  * If you just want an object that is a reference to a buffer, then the {@link BufferRef} can be used for that purpose.

--- a/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
@@ -26,12 +26,12 @@ import java.nio.charset.Charset;
  * A composite buffer is constructed using one of the {@code compose} methods:
  * <ul>
  *     <li>
- *         {@link #compose(BufferAllocator, Send[])} creates a composite buffer from the buffers that are sent to it via
+ *         {@link BufferAllocator#compose(Iterable)} creates a composite buffer from the buffers that are sent to it via
  *         the passed in send objects. Since {@link Send#receive()} transfers ownership, the resulting composite buffer
  *         will have ownership, because it is guaranteed that there are no other references to its constituent buffers.
  *     </li>
  *     <li>
- *         {@link #compose(BufferAllocator)} creates an empty, zero capacity, composite buffer. Such empty buffers may
+ *         {@link BufferAllocator#compose()} creates an empty, zero capacity, composite buffer. Such empty buffers may
  *         change their {@linkplain #readOnly() read-only} states when they gain their first component.
  *     </li>
  * </ul>
@@ -73,26 +73,6 @@ import java.nio.charset.Charset;
 public interface CompositeBuffer extends Buffer {
 
     /**
-     * Compose the given sequence of sends of buffers and present them as a single buffer.
-     * <p>
-     * When a composite buffer is closed, all of its constituent component buffers are closed as well.
-     * <p>
-     * See the class documentation for more information on what is required of the given buffers for composition to be
-     * allowed.
-     *
-     * @param allocator The allocator for the composite buffer. This allocator will be used e.g. to service
-     * {@link #ensureWritable(int)} calls.
-     * @param sends The sent buffers to compose into a single buffer view.
-     * @return A buffer composed of, and backed by, the given buffers.
-     * @throws IllegalStateException if one of the sends have already been received. The remaining buffers and sends
-     * will be closed and discarded, respectively.
-     */
-    @SafeVarargs
-    static CompositeBuffer compose(BufferAllocator allocator, Send<Buffer>... sends) {
-        return DefaultCompositeBuffer.compose(allocator, sends);
-    }
-
-    /**
      * Create an empty composite buffer, that has no components. The buffer can be extended with components using either
      * {@link #ensureWritable(int)} or {@link #extendWith(Send)}.
      *
@@ -105,10 +85,10 @@ public interface CompositeBuffer extends Buffer {
     }
 
     /**
-     * Check if the given buffer is a {@linkplain #compose(BufferAllocator, Send...) composite} buffer or not.
+     * Check if the given buffer is a composite buffer or not.
      * @param composite The buffer to check.
-     * @return {@code true} if the given buffer was created with {@link #compose(BufferAllocator, Send...)},
-     * {@code false} otherwise.
+     * @return {@code true} if the given buffer was created with {@link BufferAllocator#compose()},
+     * {@link BufferAllocator#compose(Send)} or {@link BufferAllocator#compose(Iterable)}, {@code false} otherwise.
      */
     static boolean isComposite(Buffer composite) {
         return composite instanceof CompositeBuffer;
@@ -120,7 +100,7 @@ public interface CompositeBuffer extends Buffer {
      * the composite buffer was created.
      * The extension buffer is added to the end of this composite buffer, which is modified in-place.
      *
-     * @see #compose(BufferAllocator, Send...)
+     * @see BufferAllocator#compose(Send)
      * @param extension The buffer to extend the composite buffer with.
      * @return This composite buffer instance.
      */

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferAndChannelTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferAndChannelTest.java
@@ -19,7 +19,6 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferClosedException;
 import io.netty5.buffer.api.BufferReadOnlyException;
-import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -42,6 +41,7 @@ import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -482,10 +482,9 @@ public class BufferAndChannelTest extends BufferTestSupport {
         BufferAllocator allocator = DefaultBufferAllocators.onHeapAllocator();
         Path path = parentDir.resolve("transferTo");
         try (FileChannel channel = FileChannel.open(path, READ, WRITE, CREATE);
-             Buffer buf = CompositeBuffer.compose(
-                allocator,
-                allocator.allocate(4).writeInt(0x01020304).send(),
-                allocator.allocate(4).writeInt(0x05060708).send())) {
+             Buffer buf = allocator.compose(asList(
+                        allocator.allocate(4).writeInt(0x01020304).send(),
+                        allocator.allocate(4).writeInt(0x05060708).send()))) {
             WritableByteChannel channelWrapper = new WritableByteChannel() {
                 private boolean pastFirstCall;
 
@@ -526,10 +525,9 @@ public class BufferAndChannelTest extends BufferTestSupport {
         BufferAllocator allocator = DefaultBufferAllocators.onHeapAllocator();
         Path path = parentDir.resolve("transferFrom");
         try (FileChannel channel = FileChannel.open(path, READ, WRITE, CREATE);
-             Buffer buf = CompositeBuffer.compose(
-                allocator,
+             Buffer buf = allocator.compose(asList(
                 allocator.allocate(4).send(),
-                allocator.allocate(4).send())) {
+                allocator.allocate(4).send()))) {
             ByteBuffer byteBuffer = ByteBuffer.allocate(8).putLong(0x0102030405060708L).flip();
             assertThat(channel.write(byteBuffer)).isEqualTo(8);
             channel.position(0);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferBulkAccessTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
-import static io.netty5.buffer.api.CompositeBuffer.compose;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -93,7 +93,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return compose(a, bufFirst.send(), bufSecond.send());
+                    return a.compose(asList(bufFirst.send(), bufSecond.send()));
                 }
             });
         }
@@ -109,7 +109,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return compose(a, bufFirst.send(), bufSecond.send());
+                    return a.compose(asList(bufFirst.send(), bufSecond.send()));
                 }
             });
         }
@@ -125,7 +125,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return compose(a, bufFirst.send(), bufSecond.send());
+                    return a.compose(asList(bufFirst.send(), bufSecond.send()));
                 }
             });
         }
@@ -141,7 +141,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return compose(a, bufFirst.send(), bufSecond.send());
+                    return a.compose(asList(bufFirst.send(), bufSecond.send()));
                 }
             });
         }
@@ -157,7 +157,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return compose(a, bufFirst.send(), bufSecond.send()).writerOffset(size).copy();
+                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size).copy();
                 }
             });
         }
@@ -173,7 +173,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return compose(a, bufFirst.send(), bufSecond.send()).writerOffset(size).copy();
+                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size).copy();
                 }
             });
         }
@@ -189,7 +189,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return compose(a, bufFirst.send(), bufSecond.send()).writerOffset(size).copy();
+                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size).copy();
                 }
             });
         }
@@ -205,7 +205,7 @@ public class BufferBulkAccessTest extends BufferTestSupport {
                 int second = size - first;
                 try (var bufFirst = a.allocate(first);
                      var bufSecond = b.allocate(second)) {
-                    return compose(a, bufFirst.send(), bufSecond.send()).writerOffset(size).copy();
+                    return a.compose(asList(bufFirst.send(), bufSecond.send())).writerOffset(size).copy();
                 }
             });
         }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -76,8 +77,8 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             try (Buffer a = allocator.allocate(8);
                  Buffer b = allocator.allocate(8);
                  Buffer c = allocator.allocate(8);
-                 Buffer x = CompositeBuffer.compose(allocator, b.send(), c.send())) {
-                buf = CompositeBuffer.compose(allocator, a.send(), x.send());
+                 Buffer x = allocator.compose(asList(b.send(), c.send()))) {
+                buf = allocator.compose(asList(a.send(), x.send()));
             }
             assertThat(buf.countComponents()).isEqualTo(3);
             assertThat(buf.countReadableComponents()).isZero();
@@ -125,9 +126,9 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                 a.writeInt(1);
                 b.writeInt(2);
                 c.writeInt(3);
-                composite = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+                composite = allocator.compose(asList(a.send(), b.send(), c.send()));
             }
-            var list = new LinkedList<Integer>(List.of(1, 2, 3));
+            var list = new LinkedList<>(List.of(1, 2, 3));
             int count = composite.forEachReadable(0, (index, component) -> {
                 var buffer = component.readableBuffer();
                 int bufferValue = buffer.getInt();
@@ -161,7 +162,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                 a.writeInt(1);
                 b.writeInt(2);
                 c.writeInt(3);
-                composite = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+                composite = allocator.compose(asList(a.send(), b.send(), c.send()));
             }
             var list = new LinkedList<Integer>(List.of(1, 2, 3));
             int index = 0;
@@ -211,7 +212,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                 a.writeInt(1);
                 b.writeInt(2);
                 c.writeInt(3);
-                composite = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+                composite = allocator.compose(asList(a.send(), b.send(), c.send()));
             }
             int readPos = composite.readerOffset();
             int writePos = composite.writerOffset();
@@ -250,7 +251,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             try (Buffer a = allocator.allocate(4);
                  Buffer b = allocator.allocate(4);
                  Buffer c = allocator.allocate(4)) {
-                buf = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+                buf = allocator.compose(asList(a.send(), b.send(), c.send()));
             }
             int i = 1;
             while (buf.writableBytes() > 0) {
@@ -279,7 +280,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             try (Buffer a = allocator.allocate(4);
                  Buffer b = allocator.allocate(4);
                  Buffer c = allocator.allocate(4)) {
-                buf = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+                buf = allocator.compose(asList(a.send(), b.send(), c.send()));
             }
             int i = 1;
             while (buf.writableBytes() > 0) {
@@ -468,7 +469,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             try (Buffer a = allocator.allocate(8);
                  Buffer b = allocator.allocate(8);
                  Buffer c = allocator.allocate(8)) {
-                buf = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+                buf = allocator.compose(asList(a.send(), b.send(), c.send()));
             }
             buf.forEachWritable(0, (index, component) -> {
                 component.writableBuffer().putLong(0x0102030405060708L + 0x1010101010101010L * index);
@@ -488,7 +489,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
             try (Buffer a = allocator.allocate(8);
                  Buffer b = allocator.allocate(8);
                  Buffer c = allocator.allocate(8)) {
-                buf = CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+                buf = allocator.compose(asList(a.send(), b.send(), c.send()));
             }
             try (var iterator = buf.forEachWritable()) {
                 int index = 0;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEnsureWritableTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEnsureWritableTest.java
@@ -79,7 +79,7 @@ public class BufferEnsureWritableTest extends BufferTestSupport {
     @Test
     public void ensureWritableMustExpandCapacityOfEmptyCompositeBuffer() {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled();
-             Buffer buf = CompositeBuffer.compose(allocator)) {
+             Buffer buf = allocator.compose()) {
             assertThat(buf.writableBytes()).isEqualTo(0);
             buf.ensureWritable(8);
             assertThat(buf.writableBytes()).isGreaterThanOrEqualTo(8);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLifeCycleTest.java
@@ -757,7 +757,7 @@ public class BufferLifeCycleTest extends BufferTestSupport {
     @Test
     public void splitOnEmptyCompositeBuffer() {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled();
-             Buffer buf = CompositeBuffer.compose(allocator)) {
+             Buffer buf = allocator.compose()) {
             verifySplitEmptyCompositeBuffer(buf);
         }
     }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
@@ -92,7 +92,7 @@ public class BufferReadOnlyTest extends BufferTestSupport {
     @Test
     public void readOnlyBufferMustRemainReadOnlyAfterSendForEmptyCompositeBuffer() {
         try (BufferAllocator allocator = BufferAllocator.onHeapUnpooled();
-             Buffer buf = CompositeBuffer.compose(allocator)) {
+             Buffer buf = allocator.compose()) {
             buf.makeReadOnly();
             var send = buf.send();
             try (Buffer receive = send.receive()) {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -55,6 +55,8 @@ import static io.netty5.buffer.api.tests.Fixture.Properties.DIRECT;
 import static io.netty5.buffer.api.tests.Fixture.Properties.HEAP;
 import static io.netty5.buffer.api.tests.Fixture.Properties.POOLED;
 import static io.netty5.buffer.api.tests.Fixture.Properties.UNCLOSEABLE;
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -259,7 +261,7 @@ public abstract class BufferTestSupport {
                             int half = size / 2;
                             try (Buffer firstHalf = a.allocate(half);
                                  Buffer secondHalf = b.allocate(size - half)) {
-                                return CompositeBuffer.compose(a, firstHalf.send(), secondHalf.send());
+                                return a.compose(asList(firstHalf.send(), secondHalf.send()));
                             }
                         }
 
@@ -293,7 +295,7 @@ public abstract class BufferTestSupport {
                     try (Buffer a = allocator.allocate(part);
                          Buffer b = allocator.allocate(part);
                          Buffer c = allocator.allocate(size - part * 2)) {
-                        return CompositeBuffer.compose(allocator, a.send(), b.send(), c.send());
+                        return allocator.compose(asList(a.send(), b.send(), c.send()));
                     }
                 }
 
@@ -354,7 +356,7 @@ public abstract class BufferTestSupport {
                         if (size < 2) {
                             return allocator.allocate(size);
                         }
-                        var buf = CompositeBuffer.compose(allocator);
+                        var buf = allocator.compose();
                         buf.ensureWritable(size);
                         return buf;
                     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
@@ -210,7 +210,7 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
 
         HttpUtil.setTransferEncodingChunked(start, false);
 
-        final CompositeBuffer content = CompositeBuffer.compose(allocator);
+        final CompositeBuffer content = allocator.compose();
         FullHttpMessage<?> ret;
         if (start instanceof HttpRequest) {
             ret = new AggregatedFullHttpRequest((HttpRequest) start, content, null);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketFrameAggregator.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketFrameAggregator.java
@@ -101,12 +101,12 @@ public class WebSocketFrameAggregator
     @Override
     protected WebSocketFrame beginAggregation(BufferAllocator allocator, WebSocketFrame start) {
         if (start instanceof TextWebSocketFrame) {
-            final CompositeBuffer content = CompositeBuffer.compose(allocator, start.binaryData().send());
+            final CompositeBuffer content = allocator.compose(start.binaryData().send());
             return new TextWebSocketFrame(true, start.rsv(), content);
         }
 
         if (start instanceof BinaryWebSocketFrame) {
-            final CompositeBuffer content = CompositeBuffer.compose(allocator, start.binaryData().send());
+            final CompositeBuffer content = allocator.compose(start.binaryData().send());
             return new BinaryWebSocketFrame(true, start.rsv(), content);
         }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
@@ -124,7 +124,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
             decoder.writeInbound(intoByteBuf(FRAME_TAIL.get()));
         }
 
-        CompositeBuffer compositeDecompressedContent = CompositeBuffer.compose(ctx.bufferAllocator());
+        CompositeBuffer compositeDecompressedContent = ctx.bufferAllocator().compose();
         for (;;) {
             ByteBuf partUncompressedContent = decoder.readInbound();
             if (partUncompressedContent == null) {

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -209,7 +209,7 @@ public abstract class WebSocketClientHandshakerTest {
 
         byte[] bytes = "HTTP/1.1 101 Switching Protocols\r\n\r\n".getBytes(CharsetUtil.US_ASCII);
 
-        CompositeBuffer compositeBuffer = CompositeBuffer.compose(websocketChannel.bufferAllocator());
+        CompositeBuffer compositeBuffer = websocketChannel.bufferAllocator().compose();
         compositeBuffer.extendWith(websocketChannel.bufferAllocator().allocate(bytes.length).writeBytes(bytes).send());
         for (;;) {
             final Buffer buffer = websocketChannel.readOutbound();

--- a/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/ByteToMessageDecoderForBuffer.java
@@ -638,7 +638,7 @@ public abstract class ByteToMessageDecoderForBuffer extends ChannelHandlerAdapte
                 if (CompositeBuffer.isComposite(cumulation)) {
                     composite = (CompositeBuffer) cumulation;
                 } else {
-                    composite = CompositeBuffer.compose(alloc, cumulation.send());
+                    composite = alloc.compose(cumulation.send());
                 }
                 if (in.readOnly()) {
                     composite.extendWith(in.copy().send());

--- a/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderForBufferTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/ByteToMessageDecoderForBufferTest.java
@@ -41,7 +41,6 @@ import static io.netty5.buffer.api.BufferAllocator.offHeapPooled;
 import static io.netty5.buffer.api.BufferAllocator.offHeapUnpooled;
 import static io.netty5.buffer.api.BufferAllocator.onHeapPooled;
 import static io.netty5.buffer.api.BufferAllocator.onHeapUnpooled;
-import static io.netty5.buffer.api.CompositeBuffer.compose;
 import static io.netty5.handler.codec.ByteToMessageDecoderForBuffer.COMPOSITE_CUMULATOR;
 import static io.netty5.handler.codec.ByteToMessageDecoderForBuffer.MERGE_CUMULATOR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -461,7 +460,7 @@ public class ByteToMessageDecoderForBufferTest {
     public void releaseWhenCompositeCumulateThrows(BufferAllocator allocator) {
         this.allocator = allocator;
         Buffer buffer = newBufferWithRandomBytes(allocator);
-        try (CompositeBuffer cumulation = compose(allocator, buffer.send())) {
+        try (CompositeBuffer cumulation = allocator.compose(buffer.send())) {
             Buffer in = allocator.allocate(0);
             in.close(); // Cause the cumulator to throw.
 

--- a/codec/src/test/java/io/netty5/handler/codec/MessageAggregatorNewTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/MessageAggregatorNewTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static io.netty5.buffer.api.CompositeBuffer.compose;
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -105,7 +105,7 @@ public class MessageAggregatorNewTest {
 
         @Override
         protected CompositeBuffer beginAggregation(BufferAllocator allocator, Buffer start) {
-            return compose(allocator, start.copy().send());
+            return allocator.compose(start.copy().send());
         }
 
         @Override
@@ -137,8 +137,8 @@ public class MessageAggregatorNewTest {
             assertEquals(3, counter.value); // 2 reads issued from MockMessageAggregator
             // 1 read issued from EmbeddedChannel constructor
 
-            try (CompositeBuffer all = compose(allocator, first.copy().send(), chunk.copy().send(),
-                    last.copy().send());
+            try (CompositeBuffer all = allocator.compose(asList(first.copy().send(), chunk.copy().send(),
+                    last.copy().send()));
                  CompositeBuffer out = embedded.readInbound()) {
                 assertEquals(all, out);
                 assertTrue(all.isAccessible());

--- a/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
@@ -21,7 +21,6 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.buffer.api.Resource;
 import io.netty5.channel.Channel;
@@ -42,6 +41,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 
+import static java.util.Arrays.asList;
 import static java.util.Arrays.copyOfRange;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,9 +59,9 @@ class BufferConversionHandlerTest {
                                                   Unpooled.wrappedBuffer(copyOfRange(DATA, mid, len)));
         Buffer c = DefaultBufferAllocators.onHeapAllocator().copyOf(DATA);
         Buffer tmp = c.copy();
-        Buffer d = CompositeBuffer.compose(DefaultBufferAllocators.onHeapAllocator(),
+        Buffer d = DefaultBufferAllocators.onHeapAllocator().compose(asList(
                                            tmp.readSplit(mid).send(),
-                                           tmp.send());
+                                           tmp.send()));
         for (ByteBuf byteBuf : List.of(a, b)) {
             for (Buffer buffer : List.of(c, d)) {
                 builder.add(new TestData(byteBuf.copy(), buffer.copy()));

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -177,15 +177,13 @@ public class ParameterizedSslHandlerTest {
                                     if (evt instanceof SslHandshakeCompletionEvent) {
                                         SslHandshakeCompletionEvent sslEvt = (SslHandshakeCompletionEvent) evt;
                                         if (sslEvt.isSuccess()) {
-                                            @SuppressWarnings("unchecked")
-                                            Send<Buffer>[] components = new Send[numComponents];
+                                            List<Send<Buffer>> components = new ArrayList<>(numComponents);
                                             for (int i = 0; i < numComponents; ++i) {
                                                 Buffer buf = ctx.bufferAllocator().allocate(singleComponentSize);
                                                 buf.skipWritable(singleComponentSize);
-                                                components[i] = buf.send();
+                                                components.add(buf.send());
                                             }
-                                            CompositeBuffer content = CompositeBuffer.compose(
-                                                    ctx.bufferAllocator(), components);
+                                            CompositeBuffer content = ctx.bufferAllocator().compose(components);
                                             ctx.writeAndFlush(content).addListener(future -> {
                                                 writeCause = future.cause();
                                                 if (writeCause == null) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
@@ -420,10 +421,9 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                             ctx.write(contents.readSplit(soSndBuf - 100));
 
                             // Build and write CompositeByteBuf
-                            CompositeBuffer compositeBuffer = CompositeBuffer.compose(
-                                    ctx.bufferAllocator(),
+                            CompositeBuffer compositeBuffer = ctx.bufferAllocator().compose(asList(
                                     contents.readSplit(50).send(),
-                                    contents.readSplit(200).send());
+                                    contents.readSplit(200).send()));
                             ctx.write(compositeBuffer);
 
                             // Write a single buffer that is smaller than the second component of the
@@ -535,11 +535,10 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
     }
 
     private static Buffer newCompositeBuffer(BufferAllocator alloc) {
-        CompositeBuffer compositeBuffer = CompositeBuffer.compose(
-                alloc,
+        CompositeBuffer compositeBuffer = alloc.compose(asList(
                 alloc.allocate(4).writeInt(100).send(),
                 alloc.allocate(8).writeLong(123).send(),
-                alloc.allocate(8).writeLong(456).send());
+                alloc.allocate(8).writeLong(456).send()));
         assertEquals(EXPECTED_BYTES, compositeBuffer.readableBytes());
         return compositeBuffer;
     }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -122,11 +123,11 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     public void testSimpleSendCompositeDirectBuffer(Bootstrap sb, Bootstrap cb) throws Throwable {
         BufferAllocator alloc = DefaultBufferAllocators.offHeapAllocator();
         try (Buffer data = alloc.copyOf(BYTES)) {
-            CompositeBuffer buf = CompositeBuffer.compose(alloc, data.readSplit(2).send(), data.readSplit(2).send());
+            CompositeBuffer buf = alloc.compose(asList(data.readSplit(2).send(), data.readSplit(2).send()));
             testSimpleSend(sb, cb, buf, true, BYTES, 1);
         }
         try (Buffer data = alloc.copyOf(BYTES)) {
-            CompositeBuffer buf = CompositeBuffer.compose(alloc, data.readSplit(2).send(), data.readSplit(2).send());
+            CompositeBuffer buf = alloc.compose(asList(data.readSplit(2).send(), data.readSplit(2).send()));
             testSimpleSend(sb, cb, buf, true, BYTES, 4);
         }
     }
@@ -156,11 +157,11 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     public void testSimpleSendCompositeHeapBuffer(Bootstrap sb, Bootstrap cb) throws Throwable {
         BufferAllocator alloc = DefaultBufferAllocators.onHeapAllocator();
         try (Buffer data = alloc.copyOf(BYTES)) {
-            CompositeBuffer buf = CompositeBuffer.compose(alloc, data.readSplit(2).send(), data.readSplit(2).send());
+            CompositeBuffer buf = alloc.compose(asList(data.readSplit(2).send(), data.readSplit(2).send()));
             testSimpleSend(sb, cb, buf, true, BYTES, 1);
         }
         try (Buffer data = alloc.copyOf(BYTES)) {
-            CompositeBuffer buf = CompositeBuffer.compose(alloc, data.readSplit(2).send(), data.readSplit(2).send());
+            CompositeBuffer buf = alloc.compose(asList(data.readSplit(2).send(), data.readSplit(2).send()));
             testSimpleSend(sb, cb, buf, true, BYTES, 4);
         }
     }
@@ -190,16 +191,14 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     public void testSimpleSendCompositeMixedBuffer(Bootstrap sb, Bootstrap cb) throws Throwable {
         BufferAllocator offHeap = DefaultBufferAllocators.offHeapAllocator();
         BufferAllocator onHeap = DefaultBufferAllocators.onHeapAllocator();
-        CompositeBuffer buf = CompositeBuffer.compose(
-                offHeap,
+        CompositeBuffer buf = offHeap.compose(asList(
                 offHeap.allocate(2).writeBytes(BYTES, 0, 2).send(),
-                onHeap.allocate(2).writeBytes(BYTES, 0, 2).send());
+                onHeap.allocate(2).writeBytes(BYTES, 0, 2).send()));
         testSimpleSend(sb, cb, buf, true, BYTES, 1);
 
-        CompositeBuffer buf2 = CompositeBuffer.compose(
-                offHeap,
+        CompositeBuffer buf2 = offHeap.compose(asList(
                 offHeap.allocate(2).writeBytes(BYTES, 0, 2).send(),
-                onHeap.allocate(2).writeBytes(BYTES, 0, 2).send());
+                onHeap.allocate(2).writeBytes(BYTES, 0, 2).send()));
         testSimpleSend(sb, cb, buf2, true, BYTES, 4);
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -47,7 +47,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import static io.netty.buffer.Unpooled.compositeBuffer;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SocketGatheringWriteTest extends AbstractSocketTest {
@@ -197,10 +199,9 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
                     int length = Math.min(random.nextInt(1024 * 8), data.length - i);
                     if (composite && i % 2 == 0) {
                         int firstBufLength = length / 2;
-                        CompositeBuffer comp = CompositeBuffer.compose(
-                                alloc,
+                        CompositeBuffer comp = alloc.compose(asList(
                                 src.readSplit(firstBufLength).send(),
-                                src.readSplit(length - firstBufLength).send());
+                                src.readSplit(length - firstBufLength).send()));
                         cc.write(comp);
                     } else {
                         cc.write(src.readSplit(length));

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -331,7 +331,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             int length = Math.min(random.nextInt(1024 * 64), data.length - clientSendCounterVal);
             Buffer buf = dataBuffer.readSplit(length);
             if (useCompositeByteBuf) {
-                buf = CompositeBuffer.compose(bufferAllocator, buf.send());
+                buf = bufferAllocator.compose(buf.send());
             }
 
             Future<Void> future = clientChannel.writeAndFlush(buf);
@@ -572,7 +572,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
 
             Buffer buf = bufferAllocator.copyOf(actual);
             if (useCompositeByteBuf) {
-                buf = CompositeBuffer.compose(bufferAllocator, buf.send());
+                buf = bufferAllocator.compose(buf.send());
             }
             ctx.writeAndFlush(buf);
 

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.offHeapAllocator;
 import static java.util.Arrays.stream;
@@ -169,8 +170,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
                     components[i].fill((byte) 0);
                     components[i].skipWritable(segmentSize);
                 }
-                buffer = CompositeBuffer.compose(
-                        offHeapAllocator(), stream(components).map(Buffer::send).toArray(Send[]::new));
+                buffer = offHeapAllocator().compose(stream(components).map(Buffer::send).collect(Collectors.toList()));
             } else {
                 buffer = offHeapAllocator().allocate(bufferCapacity);
                 buffer.fill((byte) 0);

--- a/transport-native-unix-common/src/test/java/io/netty5/channel/unix/UnixChannelUtilTest.java
+++ b/transport-native-unix-common/src/test/java/io/netty5/channel/unix/UnixChannelUtilTest.java
@@ -138,7 +138,7 @@ public class UnixChannelUtilTest {
         }
 
         Collections.shuffle(buffers);
-        try (CompositeBuffer comp = CompositeBuffer.compose(offHeap, buffers.toArray(Send[]::new))) {
+        try (CompositeBuffer comp = offHeap.compose(buffers)) {
             assertEquals(expected, isBufferCopyNeededForWrite(comp, IOV_MAX), buffers.toString());
         }
     }

--- a/transport/src/main/java/io/netty5/channel/AbstractCoalescingBufferQueueForBuffer.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractCoalescingBufferQueueForBuffer.java
@@ -28,6 +28,7 @@ import java.util.ArrayDeque;
 
 import static io.netty5.util.ReferenceCountUtil.safeRelease;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
+import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
 @SuppressWarnings("unchecked")
@@ -289,7 +290,7 @@ public abstract class AbstractCoalescingBufferQueueForBuffer {
         // Create a composite buffer to accumulate this pair and potentially all the buffers
         // in the queue. Using +2 as we have already dequeued current and next.
         try (next) {
-            return CompositeBuffer.compose(alloc, cumulation.send(), next.send());
+            return alloc.compose(asList(cumulation.send(), next.send()));
         }
     }
 

--- a/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
@@ -20,7 +20,6 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.Send;
 import io.netty5.channel.ChannelOutboundBuffer.MessageProcessor;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
@@ -31,6 +30,7 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.netty.buffer.Unpooled.buffer;
@@ -218,9 +218,9 @@ public class ChannelOutboundBufferTest {
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
 
         Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
-        var sends = Stream.generate(() -> buf.copy().send()).limit(65).toArray(Send[]::new);
         @SuppressWarnings("unchecked")
-        CompositeBuffer comp = CompositeBuffer.compose(BufferAllocator.offHeapUnpooled(), sends);
+        var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
+        CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
 
         buffer.addMessage(comp, comp.readableBytes(), channel.newPromise());
 
@@ -279,9 +279,9 @@ public class ChannelOutboundBufferTest {
 
         Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
         assertEquals(4, buf.readableBytes());
-        var sends = Stream.generate(() -> buf.copy().send()).limit(65).toArray(Send[]::new);
         @SuppressWarnings("unchecked")
-        CompositeBuffer comp = CompositeBuffer.compose(BufferAllocator.offHeapUnpooled(), sends);
+        var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
+        CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
 
         assertEquals(65, comp.countComponents());
         buffer.addMessage(comp, comp.readableBytes(), channel.newPromise());


### PR DESCRIPTION
Motivation:

At the moment creation of CompositeBuffer is done via a static method. We should better add a method to the BufferAllocator for creation these buffers as this will allow users to easily decorate all type of buffers if needed.

Modifications:

- Move methods to BufferAllocator
- Adjust tests

Result:

More consistent API and possible to easily decorate