### PR TITLE
Fix bug where write accesses to read-only buffers would sometimes modify write offset

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -1429,7 +1429,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     private void checkWriteBounds(int index, int size) {
-        if (index < 0 || capacity < index + size) {
+        if (index < 0 || capacity < index + size || readOnly) {
             throw indexOutOfBounds(index, true);
         }
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -613,6 +613,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeByte(byte value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Byte.BYTES);
             delegate.writeByte(value);
@@ -634,6 +637,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeUnsignedByte(int value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Byte.BYTES);
             delegate.writeByte((byte) (value & 0xFF));
@@ -673,6 +679,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeChar(char value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Character.BYTES);
             delegate.writeChar(value);
@@ -731,6 +740,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeShort(short value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Short.BYTES);
             delegate.writeShort(value);
@@ -753,6 +765,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeUnsignedShort(int value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Short.BYTES);
             delegate.writeShort((short) (value & 0xFFFF));
@@ -811,6 +826,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeMedium(int value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(3);
             delegate.writeMedium(value);
@@ -833,6 +851,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeUnsignedMedium(int value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(3);
             delegate.writeMedium(value);
@@ -891,6 +912,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeInt(int value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Integer.BYTES);
             delegate.writeInt(value);
@@ -913,6 +937,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeUnsignedInt(long value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Integer.BYTES);
             delegate.writeInt((int) (value & 0xFFFFFFFFL));
@@ -953,6 +980,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeFloat(float value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Float.BYTES);
             delegate.writeFloat(value);
@@ -993,6 +1023,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeLong(long value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             checkWrite(Long.BYTES);
             delegate.writeLong(value);
@@ -1033,6 +1066,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
 
     @Override
     public Buffer writeDouble(double value) {
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
         try {
             int size = Double.BYTES;
             checkWrite(size);

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
@@ -155,6 +155,32 @@ public class BufferReadOnlyTest extends BufferTestSupport {
              Buffer buf = allocator.allocate(8).makeReadOnly()) {
             assertThrows(BufferReadOnlyException.class, () -> buf.writerOffset(0));
             assertThrows(BufferReadOnlyException.class, () -> buf.writerOffset(4));
+
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeByte((byte) 0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeShort((short) 0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeChar((char) 0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeMedium(0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeInt(0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeFloat(0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeLong(0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeDouble(0));
+            assertEquals(0, buf.writerOffset());
+
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeUnsignedByte(0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeUnsignedShort(0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeUnsignedMedium(0));
+            assertEquals(0, buf.writerOffset());
+            assertThrows(BufferReadOnlyException.class, () -> buf.writeUnsignedInt(0));
+            assertEquals(0, buf.writerOffset());
         }
     }
 


### PR DESCRIPTION
Motivation:
Read-only buffers must not only reject modifications to their contents, but also to their write offsets.

Modification:
Move the read-only checks earlier in DefaultCompositeBuffer and ByteBufBuffer implementations, so the exception is thrown _before_ any changes to the write-offset.

Result:
Read-only buffers have more consistent behaviour.