### PR TITLE
Make it thread-safe to call MemoryManager#availableManagers

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/MemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/MemoryManager.java
@@ -88,7 +88,7 @@ public interface MemoryManager {
     }
 
     /**
-     * Get a lazy-loading stream of all available memory managers.
+     * Get a stream of all available memory managers.
      *
      * @return A stream of providers of memory managers instances.
      */

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -27,13 +27,9 @@ import io.netty5.buffer.api.pool.PooledBufferAllocator;
 import io.netty5.buffer.api.tests.Fixture.Properties;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
-import java.text.ParseException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;


### PR DESCRIPTION
Motivation:
It turns out ServiceLoader#stream is not thread-safe, so we cannot cache
the service loader directly.

Modification:
Create a lazily populated cache based on an immutable List, and protect
the ServiceLoader stream with a lock.
The returned stream now becomes eager, because the backing immutable
list is populated fully before streamed.
This is probably not a problem in practice, but theoretically, if
a provider throws exceptions from their static initialisers, it will now
prevent the stream from fully populating, and thus the cache from being
created.

Result:
We can now call MemoryManager#availableManagers in parallel.