### PR TITLE
Run the netty-buffer tests in parallel

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCleanerTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCleanerTest.java
@@ -17,6 +17,7 @@ package io.netty5.buffer.api.tests;
 
 import io.netty5.buffer.api.MemoryManager;
 import io.netty5.buffer.api.internal.Statics;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -30,6 +31,7 @@ import static io.netty5.buffer.api.MemoryManager.using;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@Isolated // Cannot run in parallel with any other tests because we access Statics.MEM_USAGE_NATIVE.
 public class BufferCleanerTest extends BufferTestSupport {
     @SuppressWarnings("unused")
     private static volatile int sink;

--- a/buffer/src/test/resources/junit-platform.properties
+++ b/buffer/src/test/resources/junit-platform.properties
@@ -1,0 +1,17 @@
+# Copyright 2022 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
Motivation:
We have a lot of test cases to go through, due to the number of combinations and buffer states explored by the parameterised tests.

Modification:
Tell the JUnit 5 runner platform to run the buffer tests in parallel, per class.
Within each class, the tests will run sequentially.
This preserves the existing setup/tear-down behaviour.
The BufferCleanerTest is an exception, due to how it accesses Statics.MEM_USAGE_NATIVE, so it runs in isolation, when no other tests are running.

Result:
Faster build.

~This PR may randomly fail, until #12356 is merged and we can rebase on top of it.~
Rebased.