### PR TITLE
Fix a bug where Netty fails to load a shaded native library (#12358)

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,7 +29,11 @@ services:
 
   build:
     <<: *common
-    command: /bin/bash -cl "./mvnw -B -ntp clean install -Dio.netty5.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora"
+    command: '/bin/bash -cl "
+      ./mvnw -B -ntp clean install -Dio.netty5.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora &&
+      cd testsuite-shading &&
+      ../mvnw -B -ntp integration-test failsafe:verify -Dtcnative.classifier=linux-x86_64-fedora
+    "'
 
   deploy:
     <<: *common

--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.5.Final</version>
+        <version>0.0.6.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -34,7 +34,9 @@
     <classesShadedDir>${project.build.directory}/classes-shaded</classesShadedDir>
     <classesShadedNativeDir>${classesShadedDir}/META-INF/native</classesShadedNativeDir>
     <shadingPrefix>shaded</shadingPrefix>
-    <shadingPrefix2>shaded2</shadingPrefix2>
+    <shadingPrefix2>shaded_2</shadingPrefix2>
+    <mangledShadingPrefix>shaded</mangledShadingPrefix>
+    <mangledShadingPrefix2>shaded_12</mangledShadingPrefix2>
     <skipShadingTestsuite>true</skipShadingTestsuite>
     <shadedPackagePrefix>io.netty5.</shadedPackagePrefix>
     <japicmp.skip>true</japicmp.skip>
@@ -137,12 +139,12 @@
                     <include name="shaded2.jar" />
                   </fileset>
                 </unzip>
-                <copy file="${classesShadedNativeDir}/lib${nativeTransportLib}" tofile="${classesShadedNativeDir}/lib${shadingPrefix}_${nativeTransportLib}" />
-                <copy file="${classesShadedNativeDir}/lib${nativeTransportLib}" tofile="${classesShadedNativeDir}/lib${shadingPrefix2}_${nativeTransportLib}" />
+                <copy file="${classesShadedNativeDir}/lib${nativeTransportLib}" tofile="${classesShadedNativeDir}/lib${mangledShadingPrefix}_${nativeTransportLib}" />
+                <copy file="${classesShadedNativeDir}/lib${nativeTransportLib}" tofile="${classesShadedNativeDir}/lib${mangledShadingPrefix2}_${nativeTransportLib}" />
                 <delete file="${classesShadedNativeDir}/lib${nativeTransportLib}" />
 
-                <copy file="${classesShadedNativeDir}/lib${nativeTcnativeLib}" tofile="${classesShadedNativeDir}/lib${shadingPrefix}_${nativeTcnativeLib}" />
-                <copy file="${classesShadedNativeDir}/lib${nativeTcnativeLib}" tofile="${classesShadedNativeDir}/lib${shadingPrefix2}_${nativeTcnativeLib}" />
+                <copy file="${classesShadedNativeDir}/lib${nativeTcnativeLib}" tofile="${classesShadedNativeDir}/lib${mangledShadingPrefix}_${nativeTcnativeLib}" />
+                <copy file="${classesShadedNativeDir}/lib${nativeTcnativeLib}" tofile="${classesShadedNativeDir}/lib${mangledShadingPrefix2}_${nativeTcnativeLib}" />
                 <delete file="${classesShadedNativeDir}/lib${nativeTcnativeLib}" />
 
                 <delete file="${project.build.directory}/shaded1.jar" />


### PR DESCRIPTION
Related: https://github.com/netty/netty-jni-util/pull/13

Motivation:

Netty can't load a shaded native library because `netty-jni-util` has a
bug that appends an extra `/` when attmpting JNI `FindClass`. For
example, `parsePackagePrefix()` returns `shaded//` instead of `shaded/`,
leading to a bad attempt to load `shaded//io/netty/...`.

Netty also doesn't handle the case where a shaded package name contains
an underscore (`_`), such as `my_shaded_deps.io.netty.*`, because it
simply replaces `.` with `_` and vice versa. JNI specification defines
a mangling rule to avoid this issue:

- https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#resolving_native_method_names

Modifications:

- Replace `_` into `_1` so that `parsePackagePrefix()` in
  `netty-jni-utils.c` can get the correct package name later.
- Update the `docker-compose.yaml` so that the integration tests in
  `testsuite-shading` are always run as a part of CI, so we don't have
  a regression in the future.

Result:

- A user can use a functionality that requires a native library even if
  they shaded Netty *and* the shaded package name contains an underscore
  (`_`).