### PR TITLE
Remove `null` check from `NetUtil#sysctlGetInt`

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -236,9 +236,10 @@ public final class NetUtil {
                 br.close();
             }
         } finally {
-            if (process != null) {
-                process.destroy();
-            }
+            // No need of 'null' check because we're initializing
+            // the Process instance in first line. Any exception
+            // raised will directly lead to throwable.
+            process.destroy();
         }
     }
 


### PR DESCRIPTION
Motivation:
There is a `null` check for the `Process` instance. However, it can never be `null` because it is being initialized at the first line and if there is an exception during initialization then we will throw the exception directly.

Modification:
Removed useless `null` check

Result:
No need for a `null` check and simpler code.
