### PR TITLE
Remove useless 'null' check from `NetUtilInitializations#determineLoopback`

### DIFF
--- a/common/src/main/java/io/netty5/util/NetUtilInitializations.java
+++ b/common/src/main/java/io/netty5/util/NetUtilInitializations.java
@@ -71,13 +71,11 @@ final class NetUtilInitializations {
         List<NetworkInterface> ifaces = new ArrayList<>();
         try {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            if (interfaces != null) {
-                while (interfaces.hasMoreElements()) {
-                    NetworkInterface iface = interfaces.nextElement();
-                    // Use the interface with proper INET addresses only.
-                    if (SocketUtils.addressesFromNetworkInterface(iface).hasMoreElements()) {
-                        ifaces.add(iface);
-                    }
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                // Use the interface with proper INET addresses only.
+                if (SocketUtils.addressesFromNetworkInterface(iface).hasMoreElements()) {
+                    ifaces.add(iface);
                 }
             }
         } catch (SocketException e) {


### PR DESCRIPTION
Motivation:
There is a null check for the `NetworkInterface.getNetworkInterfaces()`. However, it can never be null because it always returns an element if there is at least 1 present. If there is no element then it'll throw an `SocketException`

Modification:
Removed useless null check

Result:
No need for a null check and simpler code.