### PR TITLE
Reduce CPU pressure around BufferLeakDetectionTest

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLeakDetectionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLeakDetectionTest.java
@@ -23,6 +23,7 @@ import io.netty5.buffer.api.Send;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -47,6 +48,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("StringOperationCanBeSimplified")
+@Isolated
 public class BufferLeakDetectionTest extends BufferTestSupport {
     @ParameterizedTest
     @MethodSource("allocators")


### PR DESCRIPTION
Motivation:
Running buffer tests in parallel reduces the CPU resources available to each individual test, causing tests that rely on timeliness to suffer as a result.

Modification:
Run the BufferLeakDetectionTest in isolation from other tests.
This test demands a lot of CPU resources on its own, as it stresses the JVM garbage collector.
It also expects many tasks to complete within 20 seconds, which may not be feasible on CI, if all the other buffer tests are running.

Result:
Hopefully this will let it complete in time, and make it pass as often as before.
