### PR TITLE
Use `StandardCharsets#UTF_8` Charset

### DIFF
--- a/common/src/main/java/io/netty5/util/NetUtilInitializations.java
+++ b/common/src/main/java/io/netty5/util/NetUtilInitializations.java
@@ -71,13 +71,11 @@ final class NetUtilInitializations {
         List<NetworkInterface> ifaces = new ArrayList<>();
         try {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            if (interfaces != null) {
-                while (interfaces.hasMoreElements()) {
-                    NetworkInterface iface = interfaces.nextElement();
-                    // Use the interface with proper INET addresses only.
-                    if (SocketUtils.addressesFromNetworkInterface(iface).hasMoreElements()) {
-                        ifaces.add(iface);
-                    }
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                // Use the interface with proper INET addresses only.
+                if (SocketUtils.addressesFromNetworkInterface(iface).hasMoreElements()) {
+                    ifaces.add(iface);
                 }
             }
         } catch (SocketException e) {


### PR DESCRIPTION
Motivation:
We should use `StandardCharsets#UTF_8` instance instead of `"UTF-8"` Charset,

Modification:
Changed 'UTF-8' to 'StandardCharsets#UTF_8' Charset

Result:
Subtle Charset