### PR TITLE
Use `StandardCharsets#UTF_8` Charset

### DIFF
--- a/common/src/main/java/io/netty5/util/internal/ResourcesUtil.java
+++ b/common/src/main/java/io/netty5/util/internal/ResourcesUtil.java
@@ -17,6 +17,7 @@ package io.netty5.util.internal;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A utility class that provides various common operations and constants
@@ -32,11 +33,7 @@ public final class ResourcesUtil {
      * @return The file named {@code fileName} associated with {@link Class} {@code resourceClass} .
      */
     public static File getFile(Class resourceClass, String fileName) {
-        try {
-            return new File(URLDecoder.decode(resourceClass.getResource(fileName).getFile(), "UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            return new File(resourceClass.getResource(fileName).getFile());
-        }
+        return new File(URLDecoder.decode(resourceClass.getResource(fileName).getFile(), StandardCharsets.UTF_8));
     }
 
     private ResourcesUtil() { }

--- a/example/src/main/java/io/netty5/example/http2/file/Http2StaticFileServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http2/file/Http2StaticFileServerHandler.java
@@ -40,6 +40,7 @@ import java.io.FileNotFoundException;
 import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -207,7 +208,7 @@ public class Http2StaticFileServerHandler implements ChannelHandler {
 
     private static String sanitizeUri(String uri) throws UnsupportedEncodingException {
         // Decode the path.
-        uri = URLDecoder.decode(uri, "UTF-8");
+        uri = URLDecoder.decode(uri, StandardCharsets.UTF_8);
 
         if (uri.isEmpty() || uri.charAt(0) != '/') {
             return null;

--- a/microbench/src/main/java/io/netty5/microbench/buffer/Utf8EncodingBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/Utf8EncodingBenchmark.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -267,7 +268,7 @@ public class Utf8EncodingBenchmark extends AbstractMicrobenchmark {
         int countBytes = 0;
         for (String string : strings) {
             buffer.writerIndex(0);
-            final byte[] bytes = string.getBytes("UTF-8");
+            final byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
             buffer.writeBytes(bytes);
             countBytes += buffer.writerIndex();
         }


### PR DESCRIPTION
Motivation:
We should use `StandardCharsets#UTF_8` instance instead of `"UTF-8"` Charset,

Modification:
Changed 'UTF-8' to 'StandardCharsets#UTF_8' Charset

Result:
Subtle Charset