### PR TITLE
Remove unnecessary semi-colon from `BrotliDecompressor#State` enum

### DIFF
--- a/codec/src/main/java/io/netty5/handler/codec/compression/BrotliDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/BrotliDecompressor.java
@@ -45,7 +45,7 @@ public final class BrotliDecompressor implements Decompressor {
         PROCESSING,
         FINISHED,
         CLOSED
-    };
+    }
 
     private State state = State.PROCESSING;
 


### PR DESCRIPTION
Motivation:
We don't need a semi-colon at the end of `enum`.

Modification:
Removed unnecessary semi-colon

Result:
Clean code