### PR TITLE
Use if-else instead of switch case in `MacAddressUtil#bestAvailableMac`

### DIFF
--- a/common/src/main/java/io/netty5/util/internal/MacAddressUtil.java
+++ b/common/src/main/java/io/netty5/util/internal/MacAddressUtil.java
@@ -115,17 +115,16 @@ public final class MacAddressUtil {
             return null;
         }
 
-        switch (bestMacAddr.length) {
-            case EUI48_MAC_ADDRESS_LENGTH: // EUI-48 - convert to EUI-64
-                byte[] newAddr = new byte[EUI64_MAC_ADDRESS_LENGTH];
-                System.arraycopy(bestMacAddr, 0, newAddr, 0, 3);
-                newAddr[3] = (byte) 0xFF;
-                newAddr[4] = (byte) 0xFE;
-                System.arraycopy(bestMacAddr, 3, newAddr, 5, 3);
-                bestMacAddr = newAddr;
-                break;
-            default: // Unknown
-                bestMacAddr = Arrays.copyOf(bestMacAddr, EUI64_MAC_ADDRESS_LENGTH);
+        // Unknown
+        if (bestMacAddr.length == EUI48_MAC_ADDRESS_LENGTH) { // EUI-48 - convert to EUI-64
+            byte[] newAddr = new byte[EUI64_MAC_ADDRESS_LENGTH];
+            System.arraycopy(bestMacAddr, 0, newAddr, 0, 3);
+            newAddr[3] = (byte) 0xFF;
+            newAddr[4] = (byte) 0xFE;
+            System.arraycopy(bestMacAddr, 3, newAddr, 5, 3);
+            bestMacAddr = newAddr;
+        } else {
+            bestMacAddr = Arrays.copyOf(bestMacAddr, EUI64_MAC_ADDRESS_LENGTH);
         }
 
         return bestMacAddr;

--- a/common/src/main/java/io/netty5/util/internal/MacAddressUtil.java
+++ b/common/src/main/java/io/netty5/util/internal/MacAddressUtil.java
@@ -115,7 +115,6 @@ public final class MacAddressUtil {
             return null;
         }
 
-        // Unknown
         if (bestMacAddr.length == EUI48_MAC_ADDRESS_LENGTH) { // EUI-48 - convert to EUI-64
             byte[] newAddr = new byte[EUI64_MAC_ADDRESS_LENGTH];
             System.arraycopy(bestMacAddr, 0, newAddr, 0, 3);
@@ -124,6 +123,7 @@ public final class MacAddressUtil {
             System.arraycopy(bestMacAddr, 3, newAddr, 5, 3);
             bestMacAddr = newAddr;
         } else {
+            // Unknown
             bestMacAddr = Arrays.copyOf(bestMacAddr, EUI64_MAC_ADDRESS_LENGTH);
         }
 


### PR DESCRIPTION
Motivation:
`switch` cases are efficient when there are quite a few branches compared to `if-else`. Since we are only using 1 case, it's best to use the `if-else` condition.

Modification:
Changed `switch` to `if-else`

Result:
Efficient code
