### PR TITLE
Simplify redundant if-block

### DIFF
--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponse.java
@@ -202,14 +202,8 @@ public class DatagramDnsResponse extends DefaultDnsResponse
         }
 
         if (recipient() == null) {
-            if (that.recipient() != null) {
-                return false;
-            }
-        } else if (!recipient().equals(that.recipient())) {
-            return false;
-        }
-
-        return true;
+            return that.recipient() == null;
+        } else return recipient().equals(that.recipient());
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponse.java
@@ -203,7 +203,9 @@ public class DatagramDnsResponse extends DefaultDnsResponse
 
         if (recipient() == null) {
             return that.recipient() == null;
-        } else return recipient().equals(that.recipient());
+        } else {
+            return recipient().equals(that.recipient());
+        }
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpHeaders.java
@@ -1147,9 +1147,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
         int end;
         if (ignoreCase) {
             if ((end = AsciiString.indexOf(rawNext, ',', begin)) == -1) {
-                if (contentEqualsIgnoreCase(trim(rawNext), expected)) {
-                    return true;
-                }
+                return contentEqualsIgnoreCase(trim(rawNext), expected);
             } else {
                 do {
                     if (contentEqualsIgnoreCase(trim(rawNext.subSequence(begin, end)), expected)) {
@@ -1159,16 +1157,12 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
                 } while ((end = AsciiString.indexOf(rawNext, ',', begin)) != -1);
 
                 if (begin < rawNext.length()) {
-                    if (contentEqualsIgnoreCase(trim(rawNext.subSequence(begin, rawNext.length())), expected)) {
-                        return true;
-                    }
+                    return contentEqualsIgnoreCase(trim(rawNext.subSequence(begin, rawNext.length())), expected);
                 }
             }
         } else {
             if ((end = AsciiString.indexOf(rawNext, ',', begin)) == -1) {
-                if (contentEquals(trim(rawNext), expected)) {
-                    return true;
-                }
+                return contentEquals(trim(rawNext), expected);
             } else {
                 do {
                     if (contentEquals(trim(rawNext.subSequence(begin, end)), expected)) {
@@ -1178,9 +1172,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
                 } while ((end = AsciiString.indexOf(rawNext, ',', begin)) != -1);
 
                 if (begin < rawNext.length()) {
-                    if (contentEquals(trim(rawNext.subSequence(begin, rawNext.length())), expected)) {
-                        return true;
-                    }
+                    return contentEquals(trim(rawNext.subSequence(begin, rawNext.length())), expected);
                 }
             }
         }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/cookie/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/cookie/DefaultCookie.java
@@ -171,14 +171,10 @@ public class DefaultCookie implements Cookie {
         }
 
         if (domain() == null) {
-            if (that.domain() != null) {
-                return false;
-            }
+            return that.domain() == null;
         } else {
             return domain().equalsIgnoreCase(that.domain());
         }
-
-        return true;
     }
 
     @Override

--- a/codec/src/main/java/io/netty5/handler/codec/DateFormatter.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DateFormatter.java
@@ -403,10 +403,13 @@ public final class DateFormatter {
 
         if (year >= 70 && year <= 99) {
             year += 1900;
-        } else // invalid value
+        } else { // invalid value
             if (year >= 0 && year < 70) {
-            year += 2000;
-        } else return year >= 1601;
+                year += 2000;
+            } else {
+                return year >= 1601;
+            }
+        }
         return true;
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/DateFormatter.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DateFormatter.java
@@ -403,12 +403,10 @@ public final class DateFormatter {
 
         if (year >= 70 && year <= 99) {
             year += 1900;
-        } else if (year >= 0 && year < 70) {
+        } else // invalid value
+            if (year >= 0 && year < 70) {
             year += 2000;
-        } else if (year < 1601) {
-            // invalid value
-            return false;
-        }
+        } else return year >= 1601;
         return true;
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/DateFormatter.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DateFormatter.java
@@ -403,12 +403,11 @@ public final class DateFormatter {
 
         if (year >= 70 && year <= 99) {
             year += 1900;
-        } else { // invalid value
-            if (year >= 0 && year < 70) {
-                year += 2000;
-            } else {
-                return year >= 1601;
-            }
+        } else if (year >= 0 && year < 70) {
+            year += 2000;
+        } else if (year < 1601) {
+            // invalid value
+            return false;
         }
         return true;
     }

--- a/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
@@ -105,7 +105,9 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
         if (isStartMessage(in)) {
             aggregating = true;
             return true;
-        } else return aggregating && isContentMessage(in);
+        } else {
+            return aggregating && isContentMessage(in);
+        }
     }
 
     /**

--- a/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
@@ -105,11 +105,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
         if (isStartMessage(in)) {
             aggregating = true;
             return true;
-        } else if (aggregating && isContentMessage(in)) {
-            return true;
-        }
-
-        return false;
+        } else return aggregating && isContentMessage(in);
     }
 
     /**

--- a/handler/src/main/java/io/netty5/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty5/handler/timeout/IdleStateHandler.java
@@ -446,10 +446,7 @@ public class IdleStateHandler implements ChannelHandler {
                 long flushProgress = buf.currentProgress();
                 if (flushProgress != lastFlushProgress) {
                     lastFlushProgress = flushProgress;
-
-                    if (!first) {
-                        return true;
-                    }
+                    return !first;
                 }
             }
         }

--- a/microbench/src/main/java/io/netty5/microbenchmark/common/IsValidIpV6Benchmark.java
+++ b/microbench/src/main/java/io/netty5/microbenchmark/common/IsValidIpV6Benchmark.java
@@ -199,7 +199,9 @@ public class IsValidIpV6Benchmark extends AbstractMicrobenchmark {
                 // If we did not end in :: then this is invalid
                 return ipAddress.charAt(endOffset - 1) != ':' ||
                         ipAddress.charAt(endOffset - 2) == ':';
-            } else return numberOfColons != 8 || ipAddress.charAt(startOffset) == ':';
+            } else {
+                return numberOfColons != 8 || ipAddress.charAt(startOffset) == ':';
+            }
         }
     }
 

--- a/microbench/src/main/java/io/netty5/microbenchmark/common/IsValidIpV6Benchmark.java
+++ b/microbench/src/main/java/io/netty5/microbenchmark/common/IsValidIpV6Benchmark.java
@@ -184,10 +184,8 @@ public class IsValidIpV6Benchmark extends AbstractMicrobenchmark {
         // Check if we have an IPv4 ending
         if (numberOfPeriods > 0) {
             // There is a test case with 7 colons and valid ipv4 this should resolve it
-            if (numberOfPeriods != 3 ||
-                !(isValidIp4Word(word.toString()) && (numberOfColons < 7 || doubleColon))) {
-                return false;
-            }
+            return numberOfPeriods == 3 &&
+                    (isValidIp4Word(word.toString()) && (numberOfColons < 7 || doubleColon));
         } else {
             // If we're at then end and we haven't had 7 colons then there is a
             // problem unless we encountered a doubleColon
@@ -199,16 +197,10 @@ public class IsValidIpV6Benchmark extends AbstractMicrobenchmark {
                 // If we have an empty word at the end, it means we ended in either
                 // a : or a .
                 // If we did not end in :: then this is invalid
-                if (ipAddress.charAt(endOffset - 1) == ':' &&
-                    ipAddress.charAt(endOffset - 2) != ':') {
-                    return false;
-                }
-            } else if (numberOfColons == 8 && ipAddress.charAt(startOffset) != ':') {
-                return false;
-            }
+                return ipAddress.charAt(endOffset - 1) != ':' ||
+                        ipAddress.charAt(endOffset - 2) == ':';
+            } else return numberOfColons != 8 || ipAddress.charAt(startOffset) == ':';
         }
-
-        return true;
     }
 
     // Tests

--- a/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroup.java
@@ -174,11 +174,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
             }
         }
 
-        if (c == null) {
-            return false;
-        }
-
-        return true;
+        return c != null;
     }
 
     @Override


### PR DESCRIPTION
Motivation:
We can simplify redundant `if-blocks` to make the code look simpler.

Modification:
Replaced `if-block` with simpler `boolean` statements.

Result:
Simpler code
