### PR TITLE
Remove some println() calls from the buffer tests

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
@@ -293,9 +293,7 @@ public class BufferComponentIterationTest extends BufferTestSupport {
                     buffers[index] = component.readableBuffer();
                     index++;
                 }
-                System.out.println("buffers[2].get(0) = " + buffers[2].get(0));
             }
-            System.out.println("buffers[2].get(0) = " + buffers[2].get(0));
             i = 1;
             assertThat(buffers.length).isGreaterThanOrEqualTo(1);
             for (ByteBuffer buffer : buffers) {


### PR DESCRIPTION
Motivation:
These look like debugging left-overs.

Modification:
Remove println() calls from test code.

Result:
Less noisy build log.
