### PR TITLE
Fix test isolation failure in `ByteBufAdaptorTest`

### DIFF
--- a/buffer/src/test/java/io/netty5/buffer/api/tests/adaptor/ByteBufAdaptorTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/adaptor/ByteBufAdaptorTest.java
@@ -31,36 +31,29 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public abstract class ByteBufAdaptorTest extends AbstractByteBufTest {
-    static ByteBufAllocatorAdaptor alloc;
-
-    static void setUpAllocator(String name) {
+    static ByteBufAllocatorAdaptor setUpAllocator(String name) {
         Optional<MemoryManager> managers = MemoryManager.lookupImplementation(name);
         assumeTrue(managers.isPresent(), () -> "Memory implementation '" + name + "' not found.");
         BufferAllocator onheap = MemoryManager.using(managers.get(), BufferAllocator::onHeapPooled);
         BufferAllocator offheap = MemoryManager.using(managers.get(), BufferAllocator::onHeapPooled);
-        alloc = new ByteBufAllocatorAdaptor(onheap, offheap);
+        return new ByteBufAllocatorAdaptor(onheap, offheap);
     }
 
-    @AfterAll
-    public static void tearDownAllocator() throws Exception {
-        if (alloc != null) {
-            alloc.close();
-        }
-    }
+    protected abstract ByteBufAllocatorAdaptor alloc();
 
     @Override
     protected ByteBuf newBuffer(int capacity, int maxCapacity) {
-        return alloc.buffer(capacity, maxCapacity);
+        return alloc().buffer(capacity, maxCapacity);
     }
 
     @Test
     public void byteBufOfFromOnHeapBufferMustMirrorContentsOfBuffer() {
-        byteBufOfFromBufferMustMirrorContentsOfBuffer(alloc.getOnHeap());
+        byteBufOfFromBufferMustMirrorContentsOfBuffer(alloc().getOnHeap());
     }
 
     @Test
     public void byteBufOfFromOffHeapBufferMustMirrorContentsOfBuffer() {
-        byteBufOfFromBufferMustMirrorContentsOfBuffer(alloc.getOffHeap());
+        byteBufOfFromBufferMustMirrorContentsOfBuffer(alloc().getOffHeap());
     }
 
     private static void byteBufOfFromBufferMustMirrorContentsOfBuffer(BufferAllocator allocator) {

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/adaptor/NioByteBufAdaptorTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/adaptor/NioByteBufAdaptorTest.java
@@ -15,11 +15,27 @@
  */
 package io.netty5.buffer.api.tests.adaptor;
 
+import io.netty5.buffer.api.adaptor.ByteBufAllocatorAdaptor;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
 public class NioByteBufAdaptorTest extends ByteBufAdaptorTest {
+    static ByteBufAllocatorAdaptor alloc;
+
     @BeforeAll
     public static void setUpAllocator() {
-        setUpAllocator("ByteBuffer");
+        alloc = setUpAllocator("ByteBuffer");
+    }
+
+    @AfterAll
+    public static void tearDownAllocator() throws Exception {
+        if (alloc != null) {
+            alloc.close();
+        }
+    }
+
+    @Override
+    protected ByteBufAllocatorAdaptor alloc() {
+        return alloc;
     }
 }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/adaptor/UnsafeByteBufAdaptorTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/adaptor/UnsafeByteBufAdaptorTest.java
@@ -15,11 +15,27 @@
  */
 package io.netty5.buffer.api.tests.adaptor;
 
+import io.netty5.buffer.api.adaptor.ByteBufAllocatorAdaptor;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
 public class UnsafeByteBufAdaptorTest extends ByteBufAdaptorTest {
+    static ByteBufAllocatorAdaptor alloc;
+
     @BeforeAll
     public static void setUpAllocator() {
-        setUpAllocator("Unsafe");
+        alloc = setUpAllocator("Unsafe");
+    }
+
+    @AfterAll
+    public static void tearDownAllocator() throws Exception {
+        if (alloc != null) {
+            alloc.close();
+        }
+    }
+
+    @Override
+    protected ByteBufAllocatorAdaptor alloc() {
+        return alloc;
     }
 }


### PR DESCRIPTION
Motivation:
We now run most buffer tests in parallel.
That means we can no longer have mutable static fields in super-classes, that are shared between multiple sub-classes.

Modification:
Push the static `alloc` allocator field in `ByteBufAdaptorTest` down to sub-classes, so they no longer share the same field.

Result:
No more test failures from one test running faster than the other, and closing the allocator to cause failure in the other.
This also means the tests are now using the allocator, with the memory manager, that they intended.