### PR TITLE
Fix packagename for shading test

### DIFF
--- a/testsuite-shading/src/test/java/io/netty5/testsuite/shading/ShadingIT.java
+++ b/testsuite-shading/src/test/java/io/netty5/testsuite/shading/ShadingIT.java
@@ -43,7 +43,7 @@ public class ShadingIT {
         // Skip on windows.
         assumeFalse(PlatformDependent.isWindows());
 
-        String className = "io.netty.handler.ssl.OpenSsl";
+        String className = "io.netty5.handler.ssl.OpenSsl";
         testShading0(SHADING_PREFIX, className);
         testShading0(SHADING_PREFIX2, className);
     }


### PR DESCRIPTION
Motivation:

We did miss to update the packagename to io.netty5 and so the shading testsuite failed

Modifications:

Update packagename

Result:

Shading testsuite pass again