### PR TITLE
Use `String#repeat` instead of manually appending `String`

### DIFF
--- a/microbench/src/main/java/io/netty5/handler/codec/http/QueryStringEncoderBenchmark.java
+++ b/microbench/src/main/java/io/netty5/handler/codec/http/QueryStringEncoderBenchmark.java
@@ -86,10 +86,6 @@ public class QueryStringEncoderBenchmark extends AbstractMicrobenchmark {
     }
 
     private static String repeat(String s, int num) {
-        StringBuilder sb = new StringBuilder(num * s.length());
-        for (int i = 0; i < num; i++) {
-            sb.append(s);
-        }
-        return sb.toString();
+        return s.repeat(Math.max(0, num));
     }
 }

--- a/microbench/src/main/java/io/netty5/microbench/buffer/BufferUtilBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/BufferUtilBenchmark.java
@@ -33,8 +33,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 @Warmup(iterations = 5)
 @Measurement(iterations = 10)
-public class
-BufferUtilBenchmark extends AbstractMicrobenchmark {
+public class BufferUtilBenchmark extends AbstractMicrobenchmark {
 
     @Param({ "true", "false" })
     private boolean direct;
@@ -58,9 +57,7 @@ BufferUtilBenchmark extends AbstractMicrobenchmark {
         buffer = direct? Unpooled.directBuffer(maxBytes) : Unpooled.buffer(maxBytes);
         wrapped = Unpooled.unreleasableBuffer(direct? Unpooled.directBuffer(maxBytes) : Unpooled.buffer(maxBytes));
         asciiSequence = new StringBuilder(length);
-        for (int i = 0; i < length; i++) {
-            asciiSequence.append('a');
-        }
+        asciiSequence.append("a".repeat(Math.max(0, length)));
         ascii = asciiSequence.toString();
 
         // Generate some mixed UTF-8 String for benchmark

--- a/microbench/src/main/java/io/netty5/microbench/buffer/SlicedByteBufBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/SlicedByteBufBenchmark.java
@@ -48,11 +48,7 @@ public class SlicedByteBufBenchmark extends AbstractMicrobenchmark {
             throw new IllegalStateException();
         }
 
-        StringBuilder asciiSequence = new StringBuilder(128);
-        for (int i = 0; i < 128; i++) {
-            asciiSequence.append('a');
-        }
-        ascii = asciiSequence.toString();
+        ascii = "a".repeat(128);
     }
 
     @TearDown


### PR DESCRIPTION
Motivation:
Java 11 provides a method to repeat the String character several times. So we can move from the `StringBuilder` based technique to the `String#repeat` method.

Modification:
Changed `StringBuilder` method to `String#repeat`

Result:
Simple API for repeating code.
