### PR TITLE
Don't use unnecessary boxing

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -516,7 +516,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
                 char id = (char) payload.readUnsignedShort();
                 long value = payload.readUnsignedInt();
                 try {
-                    settings.put(id, Long.valueOf(value));
+                    settings.put(id, value);
                 } catch (IllegalArgumentException e) {
                     if (id == SETTINGS_INITIAL_WINDOW_SIZE) {
                         throw connectionError(FLOW_CONTROL_ERROR, e,

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2Settings.java
@@ -89,7 +89,7 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
      * @throws IllegalArgumentException if verification of the setting fails.
      */
     public Http2Settings headerTableSize(long value) {
-        put(SETTINGS_HEADER_TABLE_SIZE, Long.valueOf(value));
+        put(SETTINGS_HEADER_TABLE_SIZE, value);
         return this;
     }
 
@@ -125,7 +125,7 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
      * @throws IllegalArgumentException if verification of the setting fails.
      */
     public Http2Settings maxConcurrentStreams(long value) {
-        put(SETTINGS_MAX_CONCURRENT_STREAMS, Long.valueOf(value));
+        put(SETTINGS_MAX_CONCURRENT_STREAMS, value);
         return this;
     }
 
@@ -142,7 +142,7 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
      * @throws IllegalArgumentException if verification of the setting fails.
      */
     public Http2Settings initialWindowSize(int value) {
-        put(SETTINGS_INITIAL_WINDOW_SIZE, Long.valueOf(value));
+        put(SETTINGS_INITIAL_WINDOW_SIZE, (long) value);
         return this;
     }
 
@@ -159,7 +159,7 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
      * @throws IllegalArgumentException if verification of the setting fails.
      */
     public Http2Settings maxFrameSize(int value) {
-        put(SETTINGS_MAX_FRAME_SIZE, Long.valueOf(value));
+        put(SETTINGS_MAX_FRAME_SIZE, (long) value);
         return this;
     }
 
@@ -176,7 +176,7 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
      * @throws IllegalArgumentException if verification of the setting fails.
      */
     public Http2Settings maxHeaderListSize(long value) {
-        put(SETTINGS_MAX_HEADER_LIST_SIZE, Long.valueOf(value));
+        put(SETTINGS_MAX_HEADER_LIST_SIZE, value);
         return this;
     }
 

--- a/example/src/main/java/io/netty5/example/factorial/FactorialClientHandler.java
+++ b/example/src/main/java/io/netty5/example/factorial/FactorialClientHandler.java
@@ -83,7 +83,7 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
         // Do not send more than 4096 numbers.
         Future<Void> future = null;
         for (int i = 0; i < 4096 && next <= FactorialClient.COUNT; i++) {
-            future = ctx.write(Integer.valueOf(next));
+            future = ctx.write(next);
             next++;
         }
         if (next <= FactorialClient.COUNT) {


### PR DESCRIPTION
Motivation:
We should use primitive types wherever possible and avoid boxing for better performance.

Modification:
Removed unnecessary boxing

Result:
Efficient and faster code