### PR TITLE
Don't use explicit types in diamond operator

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/BufferUtil.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferUtil.java
@@ -411,7 +411,7 @@ public final class BufferUtil {
 
     /* Separate class so that the expensive static initialisation is only done when needed */
     private static final class ThreadLocalDirectBufferHolder {
-        static final FastThreadLocal<Buffer> BUFFER = new FastThreadLocal<Buffer>() {
+        static final FastThreadLocal<Buffer> BUFFER = new FastThreadLocal<>() {
             @Override
             protected Buffer initialValue() throws Exception {
                 return DefaultBufferAllocators.offHeapAllocator().allocate(1024);

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -1001,7 +1001,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
 
     @Override
     public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
-        return new CompositeComponentIterator<T>((DefaultCompositeBuffer) acquire(), Buffer::forEachReadable);
+        return new CompositeComponentIterator<>((DefaultCompositeBuffer) acquire(), Buffer::forEachReadable);
     }
 
     @Override
@@ -1039,7 +1039,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     @Override
     public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
         checkWriteBounds(writerOffset(), writableBytes());
-        return new CompositeComponentIterator<T>((DefaultCompositeBuffer) acquire(), Buffer::forEachWritable);
+        return new CompositeComponentIterator<>((DefaultCompositeBuffer) acquire(), Buffer::forEachWritable);
     }
 
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors.">

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -135,7 +135,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     protected Owned<ByteBufBuffer> prepareSend() {
         final ByteBuf delegate = this.delegate;
         final int implicitCapacityLimit = this.implicitCapacityLimit;
-        return new Owned<ByteBufBuffer>() {
+        return new Owned<>() {
             @Override
             public ByteBufBuffer transferOwnership(Drop<ByteBufBuffer> drop) {
                 ByteBufBuffer buffer = new ByteBufBuffer(control, delegate, drop);
@@ -549,7 +549,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     @Override
     public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
         acquire();
-        return new ComponentIterator<T>() {
+        return new ComponentIterator<>() {
             ByteBuffer[] byteBuffers;
             int index;
 
@@ -629,7 +629,7 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
             close();
             throw bufferIsReadOnly(this);
         }
-        return new ComponentIterator<T>() {
+        return new ComponentIterator<>() {
             ByteBuffer[] byteBuffers;
             int index;
 

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -620,7 +620,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
 
     @Override
     public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
-        return new SingleComponentIterator<T>(acquire(), readableBytes() > 0? this : null);
+        return new SingleComponentIterator<>(acquire(), readableBytes() > 0 ? this : null);
     }
 
     @Override
@@ -644,7 +644,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     @Override
     public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
         checkWrite(writerOffset(), writableBytes(), false);
-        return new SingleComponentIterator<T>(acquire(), writableBytes() > 0? this : null);
+        return new SingleComponentIterator<>(acquire(), writableBytes() > 0 ? this : null);
     }
 
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors implementation.">
@@ -1119,7 +1119,7 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         int implicitCapacityLimit = this.implicitCapacityLimit;
         ByteBuffer base = this.base;
         ByteBuffer rmem = this.rmem;
-        return new Owned<NioBuffer>() {
+        return new Owned<>() {
             @Override
             public NioBuffer transferOwnership(Drop<NioBuffer> drop) {
                 NioBuffer copy = new NioBuffer(base, rmem, control, drop);

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/LifecycleTracer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/LifecycleTracer.java
@@ -208,7 +208,7 @@ public abstract class LifecycleTracer {
             Trace sendTrace = new Trace(TraceType.SEND);
             sendTrace.attachmentType = AttachmentType.RECEIVED_AT;
             addTrace(walk(sendTrace));
-            return new Owned<T>() {
+            return new Owned<>() {
                 @Override
                 public T transferOwnership(Drop<T> drop) {
                     sendTrace.attachment = walk(new Trace(TraceType.RECEIVE));

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/ResourceSupport.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/ResourceSupport.java
@@ -137,7 +137,7 @@ public abstract class ResourceSupport<I extends Resource<I>, T extends ResourceS
         }
         try {
             var owned = tracer.send(prepareSend());
-            return new SendFromOwned<I, T>(owned, drop, getClass());
+            return new SendFromOwned<>(owned, drop, getClass());
         } finally {
             acquires = -2; // Close without dropping. This also ignore future double-free attempts.
             makeInaccessible();

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/SizeClasses.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/SizeClasses.java
@@ -80,7 +80,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 abstract class SizeClasses implements SizeClassesMetric {
     private static final ConcurrentHashMap<SizeClassKey, SizeClassValue> CACHE =
-            new ConcurrentHashMap<SizeClassKey, SizeClassValue>();
+            new ConcurrentHashMap<>();
 
     static final int LOG2_QUANTUM = 4;
 

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -705,7 +705,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
 
     @Override
     public <T extends ReadableComponent & Next> ComponentIterator<T> forEachReadable() {
-        return new SingleComponentIterator<T>(acquire(), readableBytes() > 0? this : null);
+        return new SingleComponentIterator<>(acquire(), readableBytes() > 0 ? this : null);
     }
 
     @Override
@@ -729,7 +729,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     @Override
     public <T extends WritableComponent & Next> ComponentIterator<T> forEachWritable() {
         checkWrite(writerOffset(), writableBytes(), false);
-        return new SingleComponentIterator<T>(acquire(), writableBytes() > 0? this : null);
+        return new SingleComponentIterator<>(acquire(), writableBytes() > 0 ? this : null);
     }
 
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors implementation.">
@@ -1259,7 +1259,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         AllocatorControl control = this.control;
         long baseOffset = this.baseOffset;
         int rsize = this.rsize;
-        return new Owned<UnsafeBuffer>() {
+        return new Owned<>() {
             @Override
             public UnsafeBuffer transferOwnership(Drop<UnsafeBuffer> drop) {
                 UnsafeBuffer copy = new UnsafeBuffer(memory, baseOffset, rsize, control, drop);

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -44,7 +44,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
      * Creates a new decoder with the specified {@code recordDecoder}.
      */
     public DatagramDnsResponseDecoder(DnsRecordDecoder recordDecoder) {
-        responseDecoder = new DnsResponseDecoder<InetSocketAddress>(recordDecoder) {
+        responseDecoder = new DnsResponseDecoder<>(recordDecoder) {
             @Override
             protected DnsResponse newResponse(InetSocketAddress sender, InetSocketAddress recipient,
                                               int id, DnsOpCode opCode, DnsResponseCode responseCode) {

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/TcpDnsResponseDecoder.java
@@ -42,7 +42,7 @@ public final class TcpDnsResponseDecoder extends LengthFieldBasedFrameDecoderFor
         // See https://tools.ietf.org/html/rfc7766#section-8
         super(maxFrameLength, 0, 2, 0, 2);
 
-        this.responseDecoder = new DnsResponseDecoder<SocketAddress>(recordDecoder) {
+        this.responseDecoder = new DnsResponseDecoder<>(recordDecoder) {
             @Override
             protected DnsResponse newResponse(SocketAddress sender, SocketAddress recipient,
                                               int id, DnsOpCode opCode, DnsResponseCode responseCode) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpHeaders.java
@@ -280,7 +280,7 @@ public class DefaultHttpHeaders extends HttpHeaders {
     @Override
     public Iterator<String> valueStringIterator(CharSequence name) {
         final Iterator<CharSequence> itr = valueCharSequenceIterator(name);
-        return new Iterator<String>() {
+        return new Iterator<>() {
             @Override
             public boolean hasNext() {
                 return itr.hasNext();

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandler.java
@@ -61,7 +61,7 @@ public class WebSocketClientExtensionHandler implements ChannelHandler {
             HttpRequest request = (HttpRequest) msg;
             String headerValue = request.headers().getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
             List<WebSocketExtensionData> extraExtensions =
-              new ArrayList<WebSocketExtensionData>(extensionHandshakers.size());
+                    new ArrayList<>(extensionHandshakers.size());
             for (WebSocketClientExtensionHandshaker extensionHandshaker : extensionHandshakers) {
                 extraExtensions.add(extensionHandshaker.newRequestData());
             }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
@@ -93,7 +93,7 @@ public final class WebSocketExtensionUtil {
                 extraExtensions.add(userDefined);
             } else {
                 // merge with higher precedence to user defined parameters
-                Map<String, String> mergedParameters = new HashMap<String, String>(matchingExtra.parameters());
+                Map<String, String> mergedParameters = new HashMap<>(matchingExtra.parameters());
                 mergedParameters.putAll(userDefined.parameters());
                 extraExtensions.set(i, new WebSocketExtensionData(matchingExtra.name(), mergedParameters));
             }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -112,7 +112,7 @@ public class WebSocketServerExtensionHandler implements ChannelHandler {
                     if (validExtensions != null) {
                         String headerValue = headers.getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
                         List<WebSocketExtensionData> extraExtensions =
-                                new ArrayList<WebSocketExtensionData>(extensionHandshakers.size());
+                                new ArrayList<>(extensionHandshakers.size());
                         for (WebSocketServerExtension extension : validExtensions) {
                             extraExtensions.add(extension.newResponseData());
                         }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexCodec.java
@@ -86,7 +86,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
     private final ChannelHandler inboundStreamHandler;
     private final ChannelHandler upgradeStreamHandler;
     private final Queue<AbstractHttp2StreamChannel> readCompletePendingQueue =
-            new MaxCapacityQueue<AbstractHttp2StreamChannel>(new ArrayDeque<AbstractHttp2StreamChannel>(8),
+            new MaxCapacityQueue<>(new ArrayDeque<>(8),
                     // Choose 100 which is what is used most of the times as default.
                     Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS);
 

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexHandler.java
@@ -92,7 +92,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
     private final ChannelHandler inboundStreamHandler;
     private final ChannelHandler upgradeStreamHandler;
     private final Queue<AbstractHttp2StreamChannel> readCompletePendingQueue =
-            new MaxCapacityQueue<AbstractHttp2StreamChannel>(new ArrayDeque<AbstractHttp2StreamChannel>(8),
+            new MaxCapacityQueue<>(new ArrayDeque<>(8),
                     // Choose 100 which is what is used most of the times as default.
                     Http2CodecUtil.SMALLEST_MAX_CONCURRENT_STREAMS);
 

--- a/codec/src/main/java/io/netty5/handler/codec/CodecOutputList.java
+++ b/codec/src/main/java/io/netty5/handler/codec/CodecOutputList.java
@@ -33,7 +33,7 @@ final class CodecOutputList extends AbstractList<Object> implements RandomAccess
     };
 
     private static final FastThreadLocal<CodecOutputLists> CODEC_OUTPUT_LISTS_POOL =
-            new FastThreadLocal<CodecOutputLists>() {
+            new FastThreadLocal<>() {
                 @Override
                 protected CodecOutputLists initialValue() throws Exception {
                     // 16 CodecOutputList per Thread are cached.

--- a/codec/src/main/java/io/netty5/handler/codec/DateFormatter.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DateFormatter.java
@@ -71,7 +71,7 @@ public final class DateFormatter {
             new String[]{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
     private static final FastThreadLocal<DateFormatter> INSTANCES =
-            new FastThreadLocal<DateFormatter>() {
+            new FastThreadLocal<>() {
                 @Override
                 protected DateFormatter initialValue() {
                     return new DateFormatter();

--- a/codec/src/main/java/io/netty5/handler/codec/HeadersUtils.java
+++ b/codec/src/main/java/io/netty5/handler/codec/HeadersUtils.java
@@ -40,7 +40,7 @@ public final class HeadersUtils {
      */
     public static <K, V> List<String> getAllAsString(Headers<K, V, ?> headers, K name) {
         final List<V> allNames = headers.getAll(name);
-        return new AbstractList<String>() {
+        return new AbstractList<>() {
             @Override
             public String get(int index) {
                 V value = allNames.get(index);

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToMessageCodec.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToMessageCodec.java
@@ -54,7 +54,7 @@ import java.util.List;
  */
 public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends ChannelHandlerAdapter {
 
-    private final MessageToMessageEncoder<Object> encoder = new MessageToMessageEncoder<Object>() {
+    private final MessageToMessageEncoder<Object> encoder = new MessageToMessageEncoder<>() {
 
         @Override
         public boolean acceptOutboundMessage(Object msg) throws Exception {
@@ -68,7 +68,7 @@ public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends Cha
         }
     };
 
-    private final MessageToMessageDecoder<Object> decoder = new MessageToMessageDecoder<Object>() {
+    private final MessageToMessageDecoder<Object> decoder = new MessageToMessageDecoder<>() {
 
         @Override
         public boolean acceptInboundMessage(Object msg) throws Exception {

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ByteBufChecksum.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ByteBufChecksum.java
@@ -43,7 +43,7 @@ abstract class ByteBufChecksum implements Checksum {
             return (ByteBufChecksum) checksum;
         }
         if (checksum instanceof Adler32) {
-            return new OptimizedByteBufChecksum<Adler32>((Adler32) checksum) {
+            return new OptimizedByteBufChecksum<>((Adler32) checksum) {
                 @Override
                 public void update(ByteBuffer b) {
                     checksum.update(b);
@@ -51,7 +51,7 @@ abstract class ByteBufChecksum implements Checksum {
             };
         }
         if (checksum instanceof CRC32) {
-            return new OptimizedByteBufChecksum<CRC32>((CRC32) checksum) {
+            return new OptimizedByteBufChecksum<>((CRC32) checksum) {
                 @Override
                 public void update(ByteBuffer b) {
                     checksum.update(b);

--- a/common/src/main/java/io/netty5/util/AbstractReferenceCounted.java
+++ b/common/src/main/java/io/netty5/util/AbstractReferenceCounted.java
@@ -29,16 +29,17 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
             AtomicIntegerFieldUpdater.newUpdater(AbstractReferenceCounted.class, "refCnt");
 
     private static final ReferenceCountUpdater<AbstractReferenceCounted> updater =
-            new ReferenceCountUpdater<AbstractReferenceCounted>() {
-        @Override
-        protected AtomicIntegerFieldUpdater<AbstractReferenceCounted> updater() {
-            return AIF_UPDATER;
-        }
-        @Override
-        protected long unsafeOffset() {
-            return REFCNT_FIELD_OFFSET;
-        }
-    };
+            new ReferenceCountUpdater<>() {
+                @Override
+                protected AtomicIntegerFieldUpdater<AbstractReferenceCounted> updater() {
+                    return AIF_UPDATER;
+                }
+
+                @Override
+                protected long unsafeOffset() {
+                    return REFCNT_FIELD_OFFSET;
+                }
+            };
 
     // Value might not equal "real" reference count, all access should be via the updater
     @SuppressWarnings({"unused", "FieldMayBeFinal"})

--- a/common/src/main/java/io/netty5/util/AsciiString.java
+++ b/common/src/main/java/io/netty5/util/AsciiString.java
@@ -1368,30 +1368,30 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     public static final HashingStrategy<CharSequence> CASE_INSENSITIVE_HASHER =
-            new HashingStrategy<CharSequence>() {
-        @Override
-        public int hashCode(CharSequence o) {
-            return AsciiString.hashCode(o);
-        }
+            new HashingStrategy<>() {
+                @Override
+                public int hashCode(CharSequence o) {
+                    return AsciiString.hashCode(o);
+                }
 
-        @Override
-        public boolean equals(CharSequence a, CharSequence b) {
-            return AsciiString.contentEqualsIgnoreCase(a, b);
-        }
-    };
+                @Override
+                public boolean equals(CharSequence a, CharSequence b) {
+                    return AsciiString.contentEqualsIgnoreCase(a, b);
+                }
+            };
 
     public static final HashingStrategy<CharSequence> CASE_SENSITIVE_HASHER =
-            new HashingStrategy<CharSequence>() {
-        @Override
-        public int hashCode(CharSequence o) {
-            return AsciiString.hashCode(o);
-        }
+            new HashingStrategy<>() {
+                @Override
+                public int hashCode(CharSequence o) {
+                    return AsciiString.hashCode(o);
+                }
 
-        @Override
-        public boolean equals(CharSequence a, CharSequence b) {
-            return AsciiString.contentEquals(a, b);
-        }
-    };
+                @Override
+                public boolean equals(CharSequence a, CharSequence b) {
+                    return AsciiString.contentEquals(a, b);
+                }
+            };
 
     /**
      * Returns an {@link AsciiString} containing the given character sequence. If the given string is already a

--- a/common/src/main/java/io/netty5/util/AttributeKey.java
+++ b/common/src/main/java/io/netty5/util/AttributeKey.java
@@ -24,7 +24,7 @@ package io.netty5.util;
 @SuppressWarnings("UnusedDeclaration") // 'T' is used only at compile time
 public final class AttributeKey<T> extends AbstractConstant<AttributeKey<T>> {
 
-    private static final ConstantPool<AttributeKey<Object>> pool = new ConstantPool<AttributeKey<Object>>() {
+    private static final ConstantPool<AttributeKey<Object>> pool = new ConstantPool<>() {
         @Override
         protected AttributeKey<Object> newConstant(int id, String name) {
             return new AttributeKey<>(id, name);

--- a/common/src/main/java/io/netty5/util/DefaultAttributeMap.java
+++ b/common/src/main/java/io/netty5/util/DefaultAttributeMap.java
@@ -100,14 +100,14 @@ public class DefaultAttributeMap implements AttributeMap {
                 }
                 // let's try replace the removed attribute with a new one
                 if (newAttribute == null) {
-                    newAttribute = new DefaultAttribute<T>(this, key);
+                    newAttribute = new DefaultAttribute<>(this, key);
                 }
                 final int count = attributes.length;
                 newAttributes = Arrays.copyOf(attributes, count);
                 newAttributes[index] = newAttribute;
             } else {
                 if (newAttribute == null) {
-                    newAttribute = new DefaultAttribute<T>(this, key);
+                    newAttribute = new DefaultAttribute<>(this, key);
                 }
                 final int count = attributes.length;
                 newAttributes = new DefaultAttribute[count + 1];

--- a/common/src/main/java/io/netty5/util/DomainWildcardMappingBuilder.java
+++ b/common/src/main/java/io/netty5/util/DomainWildcardMappingBuilder.java
@@ -49,7 +49,7 @@ public class DomainWildcardMappingBuilder<V> {
      */
     public DomainWildcardMappingBuilder(int initialCapacity, V defaultValue) {
         this.defaultValue = requireNonNull(defaultValue, "defaultValue");
-        map = new LinkedHashMap<String, V>(initialCapacity);
+        map = new LinkedHashMap<>(initialCapacity);
     }
 
     /**
@@ -95,7 +95,7 @@ public class DomainWildcardMappingBuilder<V> {
      * @return new {@link Mapping} instance
      */
     public Mapping<String, V> build() {
-        return new ImmutableDomainWildcardMapping<V>(defaultValue, map);
+        return new ImmutableDomainWildcardMapping<>(defaultValue, map);
     }
 
     private static final class ImmutableDomainWildcardMapping<V> implements Mapping<String, V> {
@@ -108,7 +108,7 @@ public class DomainWildcardMappingBuilder<V> {
 
         ImmutableDomainWildcardMapping(V defaultValue, Map<String, V> map) {
             this.defaultValue = defaultValue;
-            this.map = new LinkedHashMap<String, V>(map);
+            this.map = new LinkedHashMap<>(map);
         }
 
         @Override

--- a/common/src/main/java/io/netty5/util/Recycler.java
+++ b/common/src/main/java/io/netty5/util/Recycler.java
@@ -38,7 +38,7 @@ import static java.lang.Math.min;
  */
 public abstract class Recycler<T> {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Recycler.class);
-    private static final Handle<?> NOOP_HANDLE = new Handle<Object>() {
+    private static final Handle<?> NOOP_HANDLE = new Handle<>() {
         @Override
         public void recycle(Object object) {
             // NOOP
@@ -263,7 +263,7 @@ public abstract class Recycler<T> {
         LocalPool(int maxCapacity, int ratioInterval, int chunkSize) {
             this.ratioInterval = ratioInterval;
             if (BLOCKING_POOL) {
-                pooledHandles = new BlockingMessageQueue<DefaultHandle<T>>(maxCapacity);
+                pooledHandles = new BlockingMessageQueue<>(maxCapacity);
             } else {
                 pooledHandles = (MessagePassingQueue<DefaultHandle<T>>) newMpscQueue(chunkSize, maxCapacity);
             }
@@ -320,7 +320,7 @@ public abstract class Recycler<T> {
             // We use ArrayDeque instead of ArrayBlockingQueue because ABQ allocates its max capacity up-front,
             // and these queues will usually have large capacities, in potentially great numbers (one per thread),
             // but often only have comparatively few items in them.
-            deque = new ArrayDeque<T>();
+            deque = new ArrayDeque<>();
         }
 
         @Override

--- a/common/src/main/java/io/netty5/util/Signal.java
+++ b/common/src/main/java/io/netty5/util/Signal.java
@@ -24,7 +24,7 @@ public final class Signal extends Error implements Constant<Signal> {
 
     private static final long serialVersionUID = -221145131122459977L;
 
-    private static final ConstantPool<Signal> pool = new ConstantPool<Signal>() {
+    private static final ConstantPool<Signal> pool = new ConstantPool<>() {
         @Override
         protected Signal newConstant(int id, String name) {
             return new Signal(id, name);

--- a/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/AbstractScheduledEventExecutor.java
@@ -237,7 +237,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (task instanceof RunnableScheduledFutureNode) {
             node = (RunnableScheduledFutureNode<V>) task;
         } else {
-            node = new DefaultRunnableScheduledFutureNode<V>(task);
+            node = new DefaultRunnableScheduledFutureNode<>(task);
         }
         scheduledTaskQueue().add(node);
     }
@@ -259,7 +259,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     protected static <V> RunnableScheduledFuture<V> newRunnableScheduledFuture(
             AbstractScheduledEventExecutor executor, Promise<V> promise, Callable<V> task,
             long deadlineNanos, long periodNanos) {
-        return new RunnableScheduledFutureAdapter<V>(executor, promise, task, deadlineNanos, periodNanos);
+        return new RunnableScheduledFutureAdapter<>(executor, promise, task, deadlineNanos, periodNanos);
     }
 
     /**

--- a/common/src/main/java/io/netty5/util/concurrent/DefaultFutureCompletionStage.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultFutureCompletionStage.java
@@ -360,7 +360,7 @@ final class DefaultFutureCompletionStage<V> implements FutureCompletionStage<V>,
         requireNonNull(fn, "fn");
 
         Promise<U> promise = executor().newPromise();
-        BiConsumer<V, Throwable> consumer = new AtomicBiConsumer<V, U>(promise) {
+        BiConsumer<V, Throwable> consumer = new AtomicBiConsumer<>(promise) {
             private static final long serialVersionUID = -8454630185124276599L;
 
             @Override
@@ -380,7 +380,7 @@ final class DefaultFutureCompletionStage<V> implements FutureCompletionStage<V>,
         requireNonNull(action, "action");
 
         Promise<Void> promise = executor().newPromise();
-        BiConsumer<V, Throwable> consumer = new AtomicBiConsumer<V, Void>(promise) {
+        BiConsumer<V, Throwable> consumer = new AtomicBiConsumer<>(promise) {
             private static final long serialVersionUID = -8429618092318150682L;
 
             @Override
@@ -401,7 +401,7 @@ final class DefaultFutureCompletionStage<V> implements FutureCompletionStage<V>,
         requireNonNull(action, "action");
 
         Promise<Void> promise = executor().newPromise();
-        BiConsumer<Object, Throwable> consumer = new AtomicBiConsumer<Object, Void>(promise) {
+        BiConsumer<Object, Throwable> consumer = new AtomicBiConsumer<>(promise) {
             private static final long serialVersionUID = 5994110691767731494L;
 
             @Override

--- a/common/src/main/java/io/netty5/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/GlobalEventExecutor.java
@@ -58,7 +58,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
         INSTANCE.scheduledTaskQueue().add(QUIET_PERIOD_TASK);
     }
 
-    private final BlockingQueue<Runnable> taskQueue = new LinkedBlockingQueue<Runnable>();
+    private final BlockingQueue<Runnable> taskQueue = new LinkedBlockingQueue<>();
 
     // because the GlobalEventExecutor is a singleton, tasks submitted to it can come from arbitrary threads and this
     // can trigger the creation of a thread from arbitrary thread groups; for this reason, the thread factory must not

--- a/common/src/main/java/io/netty5/util/concurrent/ImmediateEventExecutor.java
+++ b/common/src/main/java/io/netty5/util/concurrent/ImmediateEventExecutor.java
@@ -38,7 +38,7 @@ public final class ImmediateEventExecutor extends AbstractEventExecutor {
     /**
      * A Runnable will be queued if we are executing a Runnable. This is to prevent a {@link StackOverflowError}.
      */
-    private static final FastThreadLocal<Queue<Runnable>> DELAYED_RUNNABLES = new FastThreadLocal<Queue<Runnable>>() {
+    private static final FastThreadLocal<Queue<Runnable>> DELAYED_RUNNABLES = new FastThreadLocal<>() {
         @Override
         protected Queue<Runnable> initialValue() throws Exception {
             return new ArrayDeque<>();
@@ -47,7 +47,7 @@ public final class ImmediateEventExecutor extends AbstractEventExecutor {
     /**
      * Set to {@code true} if we are executing a runnable.
      */
-    private static final FastThreadLocal<Boolean> RUNNING = new FastThreadLocal<Boolean>() {
+    private static final FastThreadLocal<Boolean> RUNNING = new FastThreadLocal<>() {
         @Override
         protected Boolean initialValue() throws Exception {
             return false;

--- a/common/src/main/java/io/netty5/util/concurrent/NonStickyEventExecutorGroup.java
+++ b/common/src/main/java/io/netty5/util/concurrent/NonStickyEventExecutorGroup.java
@@ -101,7 +101,7 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
     @Override
     public Iterator<EventExecutor> iterator() {
         final Iterator<EventExecutor> itr = group.iterator();
-        return new Iterator<EventExecutor>() {
+        return new Iterator<>() {
             @Override
             public boolean hasNext() {
                 return itr.hasNext();

--- a/common/src/main/java/io/netty5/util/internal/ObjectPool.java
+++ b/common/src/main/java/io/netty5/util/internal/ObjectPool.java
@@ -66,19 +66,19 @@ public abstract class ObjectPool<T> {
      * that should be pooled.
      */
     public static <T> ObjectPool<T> newPool(final ObjectCreator<T> creator) {
-        return new RecyclerObjectPool<T>(Objects.requireNonNull(creator, "creator"));
+        return new RecyclerObjectPool<>(Objects.requireNonNull(creator, "creator"));
     }
 
     private static final class RecyclerObjectPool<T> extends ObjectPool<T> {
         private final Recycler<T> recycler;
 
         RecyclerObjectPool(final ObjectCreator<T> creator) {
-             recycler = new Recycler<T>() {
-                @Override
-                protected T newObject(Handle<T> handle) {
-                    return creator.newObject(handle);
-                }
-            };
+             recycler = new Recycler<>() {
+                 @Override
+                 protected T newObject(Handle<T> handle) {
+                     return creator.newObject(handle);
+                 }
+             };
         }
 
         @Override

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -187,8 +187,8 @@ public final class PlatformDependent {
         }
 
         final Set<String> allowedClassifiers = Collections.unmodifiableSet(
-                new HashSet<String>(Arrays.asList(ALLOWED_LINUX_OS_CLASSIFIERS)));
-        final Set<String> availableClassifiers = new LinkedHashSet<String>();
+                new HashSet<>(Arrays.asList(ALLOWED_LINUX_OS_CLASSIFIERS)));
+        final Set<String> availableClassifiers = new LinkedHashSet<>();
         for (final String osReleaseFileName : OS_RELEASE_FILES) {
             final File file = new File(osReleaseFileName);
             boolean found = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
@@ -297,7 +297,7 @@ final class PlatformDependent0 {
             LONG_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(long[].class);
             LONG_ARRAY_INDEX_SCALE = UNSAFE.arrayIndexScale(long[].class);
             final boolean unaligned;
-            Object maybeUnaligned = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            Object maybeUnaligned = AccessController.doPrivileged(new PrivilegedAction<>() {
                 @Override
                 public Object run() {
                     try {
@@ -329,7 +329,7 @@ final class PlatformDependent0 {
                         }
                         return unalignedMethod.invoke(null);
                     } catch (NoSuchMethodException | SecurityException
-                            | IllegalAccessException | ClassNotFoundException | InvocationTargetException e) {
+                             | IllegalAccessException | ClassNotFoundException | InvocationTargetException e) {
                         return e;
                     }
                 }
@@ -408,7 +408,7 @@ final class PlatformDependent0 {
         }
 
         if (javaVersion() > 9) {
-            ALIGN_SLICE = (Method) AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            ALIGN_SLICE = (Method) AccessController.doPrivileged(new PrivilegedAction<>() {
                 @Override
                 public Object run() {
                     try {

--- a/common/src/main/java/io/netty5/util/internal/ThreadExecutorMap.java
+++ b/common/src/main/java/io/netty5/util/internal/ThreadExecutorMap.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ThreadFactory;
  */
 public final class ThreadExecutorMap {
 
-    private static final FastThreadLocal<EventExecutor> mappings = new FastThreadLocal<EventExecutor>();
+    private static final FastThreadLocal<EventExecutor> mappings = new FastThreadLocal<>();
 
     private ThreadExecutorMap() { }
 

--- a/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty5/example/dns/tcp/TcpDnsServer.java
@@ -64,14 +64,14 @@ public final class TcpDnsServer {
                        new MultithreadEventLoopGroup(ioHandlerFactory))
                 .channel(NioServerSocketChannel.class)
                 .handler(new LoggingHandler(LogLevel.INFO))
-                .childHandler(new ChannelInitializer<Channel>() {
+                .childHandler(new ChannelInitializer<>() {
                     @Override
                     protected void initChannel(Channel ch) throws Exception {
                         ch.pipeline().addLast(new TcpDnsQueryDecoder(), new TcpDnsResponseEncoder(),
                                 new SimpleChannelInboundHandler<DnsQuery>() {
                                     @Override
                                     protected void messageReceived(ChannelHandlerContext ctx,
-                                                                DnsQuery msg) throws Exception {
+                                                                   DnsQuery msg) throws Exception {
                                         DnsQuestion question = msg.recordAt(DnsSection.QUESTION);
                                         System.out.println("Query domain: " + question);
 

--- a/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2ClientFrameInitializer.java
+++ b/example/src/main/java/io/netty5/example/http2/helloworld/frame/client/Http2ClientFrameInitializer.java
@@ -46,7 +46,7 @@ public final class Http2ClientFrameInitializer extends ChannelInitializer<Channe
             .initialSettings(Http2Settings.defaultSettings()) // this is the default, but shows it can be changed.
             .build();
         ch.pipeline().addLast(http2FrameCodec);
-        ch.pipeline().addLast(new Http2MultiplexHandler(new SimpleChannelInboundHandler<Object>() {
+        ch.pipeline().addLast(new Http2MultiplexHandler(new SimpleChannelInboundHandler<>() {
 
             @Override
             protected void messageReceived(ChannelHandlerContext ctx, Object msg) {

--- a/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
@@ -115,7 +115,7 @@ public class OcspClientExample {
     private static ChannelInitializer<Channel> newClientHandler(final ReferenceCountedOpenSslContext context,
             final String host, final Promise<FullHttpResponse> promise) {
 
-        return new ChannelInitializer<Channel>() {
+        return new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 SslHandler sslHandler = context.newHandler(ch.bufferAllocator());

--- a/example/src/main/java/io/netty5/example/ocsp/OcspServerExample.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspServerExample.java
@@ -142,14 +142,14 @@ public class OcspServerExample {
 
     private static ChannelInitializer<Channel> newServerHandler(final ReferenceCountedOpenSslContext context,
             final OCSPResp response) {
-        return new ChannelInitializer<Channel>() {
+        return new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 SslHandler sslHandler = context.newHandler(ch.bufferAllocator());
 
                 if (response != null) {
                     ReferenceCountedOpenSslEngine engine
-                        = (ReferenceCountedOpenSslEngine) sslHandler.engine();
+                            = (ReferenceCountedOpenSslEngine) sslHandler.engine();
 
                     engine.setOcspResponse(response.getEncoded());
                 }

--- a/example/src/main/java/io/netty5/example/proxy/HexDumpProxyFrontendHandler.java
+++ b/example/src/main/java/io/netty5/example/proxy/HexDumpProxyFrontendHandler.java
@@ -46,7 +46,7 @@ public class HexDumpProxyFrontendHandler implements ChannelHandler {
         Bootstrap b = new Bootstrap();
         b.group(inboundChannel.executor())
          .channel(ctx.channel().getClass())
-         .handler(new ChannelInitializer<Channel>() {
+         .handler(new ChannelInitializer<>() {
              @Override
              protected void initChannel(Channel ch) throws Exception {
                  outboundChannel = ch;

--- a/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslEngine.java
@@ -26,13 +26,13 @@ final class BouncyCastleAlpnSslEngine extends JdkAlpnSslEngine {
                      @SuppressWarnings("deprecation") JdkApplicationProtocolNegotiator applicationNegotiator,
                      boolean isServer) {
         super(engine, applicationNegotiator, isServer,
-                new BiConsumer<SSLEngine, AlpnSelector>() {
+                new BiConsumer<>() {
                     @Override
                     public void accept(SSLEngine e, AlpnSelector s) {
                         BouncyCastleAlpnSslUtils.setHandshakeApplicationProtocolSelector(e, s);
                     }
                 },
-                new BiConsumer<SSLEngine, List<String>>() {
+                new BiConsumer<>() {
                     @Override
                     public void accept(SSLEngine e, List<String> p) {
                         BouncyCastleAlpnSslUtils.setApplicationProtocols(e, p);

--- a/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslUtils.java
@@ -71,16 +71,16 @@ final class BouncyCastleAlpnSslUtils {
             final Class<?> testBCApplicationProtocolSelector = bcApplicationProtocolSelector;
 
             bcApplicationProtocolSelectorSelect = AccessController.doPrivileged(
-                    new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return testBCApplicationProtocolSelector.getMethod("select", Object.class, List.class);
-                }
-            });
+                    new PrivilegedExceptionAction<>() {
+                        @Override
+                        public Method run() throws Exception {
+                            return testBCApplicationProtocolSelector.getMethod("select", Object.class, List.class);
+                        }
+                    });
 
             SSLContext context = getSSLContext("BCJSSE");
             SSLEngine engine = context.createSSLEngine();
-            setParameters = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+            setParameters = AccessController.doPrivileged(new PrivilegedExceptionAction<>() {
                 @Override
                 public Method run() throws Exception {
                     return testBCSslEngine.getMethod("setParameters", testBCSslParameters);
@@ -88,7 +88,7 @@ final class BouncyCastleAlpnSslUtils {
             });
             setParameters.invoke(engine, bcSslParametersInstance);
 
-            setApplicationProtocols = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+            setApplicationProtocols = AccessController.doPrivileged(new PrivilegedExceptionAction<>() {
                 @Override
                 public Method run() throws Exception {
                     return testBCSslParameters.getMethod("setApplicationProtocols", String[].class);
@@ -96,7 +96,7 @@ final class BouncyCastleAlpnSslUtils {
             });
             setApplicationProtocols.invoke(bcSslParametersInstance, new Object[]{EmptyArrays.EMPTY_STRINGS});
 
-            getApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+            getApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<>() {
                 @Override
                 public Method run() throws Exception {
                     return testBCSslEngine.getMethod("getApplicationProtocol");
@@ -104,7 +104,7 @@ final class BouncyCastleAlpnSslUtils {
             });
             getApplicationProtocol.invoke(engine);
 
-            getHandshakeApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+            getHandshakeApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<>() {
                 @Override
                 public Method run() throws Exception {
                     return testBCSslEngine.getMethod("getHandshakeApplicationProtocol");
@@ -113,7 +113,7 @@ final class BouncyCastleAlpnSslUtils {
             getHandshakeApplicationProtocol.invoke(engine);
 
             setHandshakeApplicationProtocolSelector =
-                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                    AccessController.doPrivileged(new PrivilegedExceptionAction<>() {
                         @Override
                         public Method run() throws Exception {
                             return testBCSslEngine.getMethod("setBCHandshakeApplicationProtocolSelector",
@@ -122,7 +122,7 @@ final class BouncyCastleAlpnSslUtils {
                     });
 
             getHandshakeApplicationProtocolSelector =
-                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                    AccessController.doPrivileged(new PrivilegedExceptionAction<>() {
                         @Override
                         public Method run() throws Exception {
                             return testBCSslEngine.getMethod("getBCHandshakeApplicationProtocolSelector");
@@ -226,7 +226,7 @@ final class BouncyCastleAlpnSslUtils {
     static BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector(SSLEngine engine) {
         try {
             final Object selector = GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invoke(engine);
-            return new BiFunction<SSLEngine, List<String>, String>() {
+            return new BiFunction<>() {
 
                 @Override
                 public String apply(SSLEngine sslEngine, List<String> strings) {

--- a/handler/src/main/java/io/netty5/handler/ssl/GroupsConverter.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/GroupsConverter.java
@@ -28,7 +28,7 @@ final class GroupsConverter {
 
     static {
         // See https://tools.ietf.org/search/rfc4492#appendix-A and https://www.java.com/en/configure_crypto.html
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("secp224r1", "P-224");
         map.put("prime256v1", "P-256");
         map.put("secp256r1", "P-256");

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslEngine.java
@@ -99,13 +99,13 @@ class JdkAlpnSslEngine extends JdkSslEngine {
                      @SuppressWarnings("deprecation") JdkApplicationProtocolNegotiator applicationNegotiator,
                      boolean isServer) {
        this(engine, applicationNegotiator, isServer,
-               new BiConsumer<SSLEngine, AlpnSelector>() {
+               new BiConsumer<>() {
                    @Override
                    public void accept(SSLEngine e, AlpnSelector s) {
                        JdkAlpnSslUtils.setHandshakeApplicationProtocolSelector(e, s);
                    }
                },
-               new BiConsumer<SSLEngine, List<String>>() {
+               new BiConsumer<>() {
                    @Override
                    public void accept(SSLEngine e, List<String> p) {
                        JdkAlpnSslUtils.setApplicationProtocols(e, p);

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
@@ -305,10 +305,10 @@ public final class OpenSsl {
                     String groups = SystemPropertyUtil.get("jdk.tls.namedGroups", null);
                     if (groups != null) {
                         String[] nGroups = groups.split(",");
-                        Set<String> supportedNamedGroups = new LinkedHashSet<String>(nGroups.length);
-                        Set<String> supportedConvertedNamedGroups = new LinkedHashSet<String>(nGroups.length);
+                        Set<String> supportedNamedGroups = new LinkedHashSet<>(nGroups.length);
+                        Set<String> supportedConvertedNamedGroups = new LinkedHashSet<>(nGroups.length);
 
-                        Set<String> unsupportedNamedGroups = new LinkedHashSet<String>();
+                        Set<String> unsupportedNamedGroups = new LinkedHashSet<>();
                         for (String namedGroup : nGroups) {
                             String converted = GroupsConverter.toOpenSsl(namedGroup);
                             if (SSLContext.setCurvesList(sslCtx, converted)) {
@@ -431,7 +431,7 @@ public final class OpenSsl {
     static String checkTls13Ciphers(InternalLogger logger, String ciphers) {
         if (IS_BORINGSSL && !ciphers.isEmpty()) {
             assert EXTRA_SUPPORTED_TLS_1_3_CIPHERS.length > 0;
-            Set<String> boringsslTlsv13Ciphers = new HashSet<String>(EXTRA_SUPPORTED_TLS_1_3_CIPHERS.length);
+            Set<String> boringsslTlsv13Ciphers = new HashSet<>(EXTRA_SUPPORTED_TLS_1_3_CIPHERS.length);
             Collections.addAll(boringsslTlsv13Ciphers, EXTRA_SUPPORTED_TLS_1_3_CIPHERS);
             boolean ciphersNotMatch = false;
             for (String cipher: ciphers.split(":")) {

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslSessionCache.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslSessionCache.java
@@ -52,7 +52,7 @@ class OpenSslSessionCache implements SSLSessionCache {
     private final OpenSslEngineMap engineMap;
 
     private final Map<OpenSslSessionId, NativeSslSession> sessions =
-            new LinkedHashMap<OpenSslSessionId, NativeSslSession>() {
+            new LinkedHashMap<>() {
 
                 private static final long serialVersionUID = -7773696788135734448L;
 
@@ -255,7 +255,7 @@ class OpenSslSessionCache implements SSLSessionCache {
         synchronized (this) {
             sessionsArray = sessions.values().toArray(EMPTY_SESSIONS);
         }
-        List<OpenSslSessionId> ids = new ArrayList<OpenSslSessionId>(sessionsArray.length);
+        List<OpenSslSessionId> ids = new ArrayList<>(sessionsArray.length);
         for (OpenSslSession session: sessionsArray) {
             if (session.isValid()) {
                 ids.add(session.sessionId());

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslSessionContext.java
@@ -101,8 +101,9 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
 
     @Override
     public Enumeration<byte[]> getIds() {
-        return new Enumeration<byte[]>() {
+        return new Enumeration<>() {
             private final Iterator<OpenSslSessionId> ids = sessionCache.getIds().iterator();
+
             @Override
             public boolean hasMoreElements() {
                 return ids.hasNext();

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContextBuilder.java
@@ -206,7 +206,7 @@ public final class SslContextBuilder {
     private boolean startTls;
     private boolean enableOcsp;
     private String keyStoreType = KeyStore.getDefaultType();
-    private final Map<SslContextOption<?>, Object> options = new HashMap<SslContextOption<?>, Object>();
+    private final Map<SslContextOption<?>, Object> options = new HashMap<>();
 
     private SslContextBuilder(boolean forServer) {
         this.forServer = forServer;

--- a/handler/src/main/java/io/netty5/handler/ssl/SslContextOption.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslContextOption.java
@@ -30,10 +30,10 @@ import static java.util.Objects.requireNonNull;
  */
 public class SslContextOption<T> extends AbstractConstant<SslContextOption<T>> {
 
-    private static final ConstantPool<SslContextOption<Object>> pool = new ConstantPool<SslContextOption<Object>>() {
+    private static final ConstantPool<SslContextOption<Object>> pool = new ConstantPool<>() {
         @Override
         protected SslContextOption<Object> newConstant(int id, String name) {
-            return new SslContextOption<Object>(id, name);
+            return new SslContextOption<>(id, name);
         }
     };
 

--- a/handler/src/main/java/io/netty5/handler/ssl/util/FingerprintTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/FingerprintTrustManagerFactory.java
@@ -164,7 +164,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
         }
 
         int hashLength = md.getDigestLength();
-        List<byte[]> list = new ArrayList<byte[]>(fingerprints.length);
+        List<byte[]> list = new ArrayList<>(fingerprints.length);
         for (byte[] f: fingerprints) {
             if (f == null) {
                 break;
@@ -177,7 +177,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
             list.add(f.clone());
         }
 
-        this.tlmd = new FastThreadLocal<MessageDigest>() {
+        this.tlmd = new FastThreadLocal<>() {
 
             @Override
             protected MessageDigest initialValue() {

--- a/handler/src/main/java/io/netty5/handler/ssl/util/SimpleKeyManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/SimpleKeyManagerFactory.java
@@ -48,7 +48,7 @@ public abstract class SimpleKeyManagerFactory extends KeyManagerFactory {
      * To work around this issue, we use an ugly hack which uses a {@link FastThreadLocal }.
      */
     private static final FastThreadLocal<SimpleKeyManagerFactorySpi> CURRENT_SPI =
-            new FastThreadLocal<SimpleKeyManagerFactorySpi>() {
+            new FastThreadLocal<>() {
                 @Override
                 protected SimpleKeyManagerFactorySpi initialValue() {
                     return new SimpleKeyManagerFactorySpi();

--- a/handler/src/main/java/io/netty5/handler/ssl/util/SimpleTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/util/SimpleTrustManagerFactory.java
@@ -48,7 +48,7 @@ public abstract class SimpleTrustManagerFactory extends TrustManagerFactory {
      * To work around this issue, we use an ugly hack which uses a {@link ThreadLocal}.
      */
     private static final FastThreadLocal<SimpleTrustManagerFactorySpi> CURRENT_SPI =
-            new FastThreadLocal<SimpleTrustManagerFactorySpi>() {
+            new FastThreadLocal<>() {
                 @Override
                 protected SimpleTrustManagerFactorySpi initialValue() {
                     return new SimpleTrustManagerFactorySpi();

--- a/handler/src/main/java/io/netty5/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty5/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -622,25 +622,29 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      * @return the list of TrafficCounters that exists at the time of the call.
      */
     public Collection<TrafficCounter> channelTrafficCounters() {
-        return new AbstractCollection<TrafficCounter>() {
+        return new AbstractCollection<>() {
             @Override
             public Iterator<TrafficCounter> iterator() {
-                return new Iterator<TrafficCounter>() {
+                return new Iterator<>() {
                     final Iterator<PerChannel> iter = channelQueues.values().iterator();
+
                     @Override
                     public boolean hasNext() {
                         return iter.hasNext();
                     }
+
                     @Override
                     public TrafficCounter next() {
                         return iter.next().channelTrafficCounter;
                     }
+
                     @Override
                     public void remove() {
                         throw new UnsupportedOperationException();
                     }
                 };
             }
+
             @Override
             public int size() {
                 return channelQueues.size();

--- a/microbench/src/main/java/io/netty5/microbench/buffer/Utf8EncodingBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/buffer/Utf8EncodingBenchmark.java
@@ -87,10 +87,10 @@ public class Utf8EncodingBenchmark extends AbstractMicrobenchmark {
         InputStreamReader inStreamReader = null;
         BufferedReader buffReader = null;
         int maxExpectedSize = 0;
-        List<String> strings = new ArrayList<String>();
-        List<StringBuilder> stringBuilders = new ArrayList<StringBuilder>();
-        List<AnotherCharSequence> anotherCharSequenceList = new ArrayList<AnotherCharSequence>();
-        List<AsciiString> asciiStrings = new ArrayList<AsciiString>();
+        List<String> strings = new ArrayList<>();
+        List<StringBuilder> stringBuilders = new ArrayList<>();
+        List<AnotherCharSequence> anotherCharSequenceList = new ArrayList<>();
+        List<AsciiString> asciiStrings = new ArrayList<>();
         try {
             testTextStream = getClass().getResourceAsStream("/Utf8Samples.txt");
             inStreamReader = new InputStreamReader(testTextStream, "UTF-8");

--- a/microbench/src/main/java/io/netty5/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -57,7 +57,7 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
         serverChan = new ServerBootstrap()
             .channel(EpollServerSocketChannel.class)
             .group(group)
-            .childHandler(new ChannelInitializer<Channel>() {
+            .childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -76,12 +76,12 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
             .get();
     chan = new Bootstrap()
         .channel(EpollSocketChannel.class)
-        .handler(new ChannelInitializer<Channel>() {
+        .handler(new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) {
                 ch.pipeline().addLast(new ChannelHandler() {
 
-                private Promise<Void> lastWritePromise;
+                    private Promise<Void> lastWritePromise;
 
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {

--- a/microbench/src/main/java/io/netty5/microbench/concurrent/FastThreadLocalFastPathBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/concurrent/FastThreadLocalFastPathBenchmark.java
@@ -41,13 +41,13 @@ public class FastThreadLocalFastPathBenchmark extends AbstractMicrobenchmark {
     static {
         for (int i = 0; i < jdkThreadLocals.length; i ++) {
             final int num = rand.nextInt();
-            jdkThreadLocals[i] = new ThreadLocal<Integer>() {
+            jdkThreadLocals[i] = new ThreadLocal<>() {
                 @Override
                 protected Integer initialValue() {
                     return num;
                 }
             };
-            fastThreadLocals[i] = new FastThreadLocal<Integer>() {
+            fastThreadLocals[i] = new FastThreadLocal<>() {
                 @Override
                 protected Integer initialValue() {
                     return num;

--- a/microbench/src/main/java/io/netty5/microbench/concurrent/FastThreadLocalSlowPathBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/concurrent/FastThreadLocalSlowPathBenchmark.java
@@ -41,13 +41,13 @@ public class FastThreadLocalSlowPathBenchmark extends AbstractMicrobenchmark {
     static {
         for (int i = 0; i < jdkThreadLocals.length; i ++) {
             final int num = rand.nextInt();
-            jdkThreadLocals[i] = new ThreadLocal<Integer>() {
+            jdkThreadLocals[i] = new ThreadLocal<>() {
                 @Override
                 protected Integer initialValue() {
                     return num;
                 }
             };
-            fastThreadLocals[i] = new FastThreadLocal<Integer>() {
+            fastThreadLocals[i] = new FastThreadLocal<>() {
                 @Override
                 protected Integer initialValue() {
                     return num;

--- a/microbench/src/main/java/io/netty5/microbench/util/RecyclerBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/util/RecyclerBenchmark.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class RecyclerBenchmark extends AbstractMicrobenchmark {
-    private Recycler<DummyObject> recycler = new Recycler<DummyObject>() {
+    private Recycler<DummyObject> recycler = new Recycler<>() {
         @Override
         protected DummyObject newObject(Recycler.Handle<DummyObject> handle) {
             return new DummyObject(handle);
@@ -67,7 +67,7 @@ public class RecyclerBenchmark extends AbstractMicrobenchmark {
 
     @State(Scope.Benchmark)
     public static class ProducerConsumerState {
-        final ArrayBlockingQueue<DummyObject> queue = new ArrayBlockingQueue<DummyObject>(100);
+        final ArrayBlockingQueue<DummyObject> queue = new ArrayBlockingQueue<>(100);
     }
 
     // The allocation stats are the main thing interesting about this benchmark

--- a/microbench/src/main/java/io/netty5/microbench/util/ResourceLeakDetectorRecordBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/util/ResourceLeakDetectorRecordBenchmark.java
@@ -32,7 +32,7 @@ public class ResourceLeakDetectorRecordBenchmark extends AbstractMicrobenchmark 
     private int recordTimes;
     private ResourceLeakDetector.Level level;
 
-    ResourceLeakDetector<Object> detector = new ResourceLeakDetector<Object>(Object.class, 1) {
+    ResourceLeakDetector<Object> detector = new ResourceLeakDetector<>(Object.class, 1) {
         @Override
         protected void reportTracedLeak(String resourceType, String records) {
             // noop

--- a/microbench/src/main/java/io/netty5/util/DefaultAttributeMapBenchmark.java
+++ b/microbench/src/main/java/io/netty5/util/DefaultAttributeMapBenchmark.java
@@ -62,7 +62,7 @@ public class DefaultAttributeMapBenchmark extends AbstractMicrobenchmark {
         }
         attributes = new DefaultAttributeMap();
         keys = new AttributeKey[keyCount];
-        identityHashMap = new IdentityHashMap<AttributeKey<Integer>, Attribute<Integer>>(keyCount);
+        identityHashMap = new IdentityHashMap<>(keyCount);
         for (int i = 0; i < keyCount; i++) {
             final AttributeKey<Integer> key = AttributeKey.valueOf(Integer.toString(i));
             keys[i] = key;

--- a/resolver-dns-classes-macos/src/main/java/io/netty5/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
+++ b/resolver-dns-classes-macos/src/main/java/io/netty5/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
 
     private static final Comparator<DnsResolver> RESOLVER_COMPARATOR =
-            new Comparator<DnsResolver>() {
+            new Comparator<>() {
                 @Override
                 public int compare(DnsResolver r1, DnsResolver r2) {
                     // Note: order is descending (from higher to lower) so entries with lower search order override

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/Cache.java
@@ -50,7 +50,7 @@ abstract class Cache<E> {
     private static final AtomicReferenceFieldUpdater<Cache.Entries, FutureAndDelay> FUTURE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(Cache.Entries.class, FutureAndDelay.class, "expirationFuture");
 
-    private static final Future<?> CANCELLED_FUTURE = new Future<Object>() {
+    private static final Future<?> CANCELLED_FUTURE = new Future<>() {
         @Override
         public boolean cancel() {
             return false;

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultAuthoritativeDnsServerCache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultAuthoritativeDnsServerCache.java
@@ -34,7 +34,7 @@ public class DefaultAuthoritativeDnsServerCache implements AuthoritativeDnsServe
     private final int minTtl;
     private final int maxTtl;
     private final Comparator<InetSocketAddress> comparator;
-    private final Cache<InetSocketAddress> resolveCache = new Cache<InetSocketAddress>() {
+    private final Cache<InetSocketAddress> resolveCache = new Cache<>() {
         @Override
         protected boolean shouldReplaceAll(InetSocketAddress entry) {
             return false;

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultDnsCache.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class DefaultDnsCache implements DnsCache {
 
-    private final Cache<DefaultDnsCacheEntry> resolveCache = new Cache<DefaultDnsCacheEntry>() {
+    private final Cache<DefaultDnsCacheEntry> resolveCache = new Cache<>() {
 
         @Override
         protected boolean shouldReplaceAll(DefaultDnsCacheEntry entry) {

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultDnsCnameCache.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultDnsCnameCache.java
@@ -31,7 +31,7 @@ public final class DefaultDnsCnameCache implements DnsCnameCache {
     private final int minTtl;
     private final int maxTtl;
 
-    private final Cache<String> cache = new Cache<String>() {
+    private final Cache<String> cache = new Cache<>() {
         @Override
         protected boolean shouldReplaceAll(String entry) {
             // Only one 1:1 mapping is supported as specified in the RFC.

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsNameResolver.java
@@ -221,7 +221,7 @@ public class DnsNameResolver extends InetNameResolver {
     private final DnsCnameCache cnameCache;
 
     private final FastThreadLocal<DnsServerAddressStream> nameServerAddrStream =
-            new FastThreadLocal<DnsServerAddressStream>() {
+            new FastThreadLocal<>() {
                 @Override
                 protected DnsServerAddressStream initialValue() {
                     return dnsServerAddressStreamProvider.nameServerAddressStream("");
@@ -833,7 +833,7 @@ public class DnsNameResolver extends InetNameResolver {
         if (type == DnsRecordType.A || type == DnsRecordType.AAAA) {
             final List<InetAddress> hostsFileEntries = resolveHostsFileEntries(hostname);
             if (hostsFileEntries != null) {
-                List<DnsRecord> result = new ArrayList<DnsRecord>();
+                List<DnsRecord> result = new ArrayList<>();
                 for (InetAddress hostsFileEntry : hostsFileEntries) {
                     Buffer content = null;
                     if (hostsFileEntry instanceof Inet4Address) {

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
@@ -203,8 +203,9 @@ abstract class DnsResolveContext<T> {
             final int initialSearchDomainIdx = startWithoutSearchDomain ? 0 : 1;
 
             final Promise<List<T>> searchDomainPromise = parent.executor().newPromise();
-            searchDomainPromise.asFuture().addListener(new FutureListener<List<T>>() {
+            searchDomainPromise.asFuture().addListener(new FutureListener<>() {
                 private int searchDomainIdx = initialSearchDomainIdx;
+
                 @Override
                 public void operationComplete(Future<? extends List<T>> future) {
                     Throwable cause = future.cause();
@@ -688,7 +689,7 @@ abstract class DnsResolveContext<T> {
 
         @Override
         public Iterator<InetSocketAddress> iterator() {
-            return new Iterator<InetSocketAddress>() {
+            return new Iterator<>() {
                 private final DnsServerAddressStream stream = duplicate.duplicate();
                 private int i;
 

--- a/resolver/src/main/java/io/netty5/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty5/resolver/DefaultHostsFileEntriesResolver.java
@@ -124,7 +124,7 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
     }
 
     private static List<InetAddress> allAddresses(List<InetAddress> a, List<InetAddress> b) {
-        List<InetAddress> result = new ArrayList<InetAddress>(a.size() + (b == null ? 0 : b.size()));
+        List<InetAddress> result = new ArrayList<>(a.size() + (b == null ? 0 : b.size()));
         result.addAll(a);
         if (b != null) {
             result.addAll(b);

--- a/resolver/src/main/java/io/netty5/resolver/HostsFileEntriesProvider.java
+++ b/resolver/src/main/java/io/netty5/resolver/HostsFileEntriesProvider.java
@@ -132,8 +132,8 @@ public final class HostsFileEntriesProvider {
     private final Map<String, List<InetAddress>> ipv6Entries;
 
     HostsFileEntriesProvider(Map<String, List<InetAddress>> ipv4Entries, Map<String, List<InetAddress>> ipv6Entries) {
-        this.ipv4Entries = Collections.unmodifiableMap(new HashMap<String, List<InetAddress>>(ipv4Entries));
-        this.ipv6Entries = Collections.unmodifiableMap(new HashMap<String, List<InetAddress>>(ipv6Entries));
+        this.ipv4Entries = Collections.unmodifiableMap(new HashMap<>(ipv4Entries));
+        this.ipv6Entries = Collections.unmodifiableMap(new HashMap<>(ipv6Entries));
     }
 
     /**
@@ -209,8 +209,8 @@ public final class HostsFileEntriesProvider {
             requireNonNull(reader, "reader");
             BufferedReader buff = new BufferedReader(reader);
             try {
-                Map<String, List<InetAddress>> ipv4Entries = new HashMap<String, List<InetAddress>>();
-                Map<String, List<InetAddress>> ipv6Entries = new HashMap<String, List<InetAddress>>();
+                Map<String, List<InetAddress>> ipv4Entries = new HashMap<>();
+                Map<String, List<InetAddress>> ipv6Entries = new HashMap<>();
                 String line;
                 while ((line = buff.readLine()) != null) {
                     // remove comment
@@ -225,7 +225,7 @@ public final class HostsFileEntriesProvider {
                     }
 
                     // split
-                    List<String> lineParts = new ArrayList<String>();
+                    List<String> lineParts = new ArrayList<>();
                     for (String s : WHITESPACES.split(line)) {
                         if (!s.isEmpty()) {
                             lineParts.add(s);
@@ -254,13 +254,13 @@ public final class HostsFileEntriesProvider {
                         if (address instanceof Inet4Address) {
                             addresses = ipv4Entries.get(hostnameLower);
                             if (addresses == null) {
-                                addresses = new ArrayList<InetAddress>();
+                                addresses = new ArrayList<>();
                                 ipv4Entries.put(hostnameLower, addresses);
                             }
                         } else {
                             addresses = ipv6Entries.get(hostnameLower);
                             if (addresses == null) {
-                                addresses = new ArrayList<InetAddress>();
+                                addresses = new ArrayList<>();
                                 ipv6Entries.put(hostnameLower, addresses);
                             }
                         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -61,25 +61,25 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
         // Use a number which will typically not exceed /proc/sys/net/core/somaxconn (which is 128 on linux by default
         // often).
         int numChannels = 100;
-        final AtomicReference<Throwable> globalException = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> globalException = new AtomicReference<>();
         final AtomicInteger serverRemaining = new AtomicInteger(numChannels);
         final AtomicInteger clientRemaining = new AtomicInteger(numChannels);
         final Promise<Void> serverDonePromise = ImmediateEventExecutor.INSTANCE.newPromise();
         final Promise<Void> clientDonePromise = ImmediateEventExecutor.INSTANCE.newPromise();
 
-        sb.childHandler(new ChannelInitializer<Channel>() {
+        sb.childHandler(new ChannelInitializer<>() {
             @Override
             public void initChannel(Channel sch) {
                 ReuseFdHandler sh = new ReuseFdHandler(
-                    false,
-                    globalException,
-                    serverRemaining,
-                    serverDonePromise);
+                        false,
+                        globalException,
+                        serverRemaining,
+                        serverDonePromise);
                 sch.pipeline().addLast("handler", sh);
             }
         });
 
-        cb.handler(new ChannelInitializer<Channel>() {
+        cb.handler(new ChannelInitializer<>() {
             @Override
             public void initChannel(Channel sch) {
                 ReuseFdHandler ch = new ReuseFdHandler(
@@ -119,7 +119,7 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
         private final boolean client;
         volatile Channel channel;
         final AtomicReference<Throwable> globalException;
-        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        final AtomicReference<Throwable> exception = new AtomicReference<>();
         final StringBuilder received = new StringBuilder();
 
         ReuseFdHandler(

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketShutdownOutputByPeerTest.java
@@ -140,7 +140,7 @@ public abstract class AbstractSocketShutdownOutputByPeerTest<Socket> extends Abs
 
     private static class TestHandler extends SimpleChannelInboundHandler<Buffer> {
         volatile DuplexChannel ch;
-        final BlockingQueue<Byte> queue = new LinkedBlockingQueue<Byte>();
+        final BlockingQueue<Byte> queue = new LinkedBlockingQueue<>();
         final CountDownLatch halfClosure = new CountDownLatch(1);
         final CountDownLatch closure = new CountDownLatch(1);
         final AtomicInteger halfClosureCount = new AtomicInteger();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -196,7 +196,8 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
 
                           @Override
                           public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-                              // IOException is fine as it will also close the channel and may just be a connection reset.
+                              // IOException is fine as it will also close the channel
+                              // and may just be a connection reset.
                               if (!(cause instanceof IOException)) {
                                   clientReceived.set(cause);
                                   latch.countDown();
@@ -227,7 +228,8 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
 
                         @Override
                         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-                            // IOException is fine as it will also close the channel and may just be a connection reset.
+                            // IOException is fine as it will also close the channel
+                            // and may just be a connection reset.
                             if (!(cause instanceof IOException)) {
                                 closeAggregator();
                                 clientReceived.set(cause);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -58,7 +58,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
 
         MulticastTestHandler mhandler = new MulticastTestHandler();
 
-        sb.handler(new SimpleChannelInboundHandler<Object>() {
+        sb.handler(new SimpleChannelInboundHandler<>() {
             @Override
             public void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
                 // Nothing will be sent.

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -96,7 +96,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
     protected Channel setupServerChannel(Bootstrap sb, final byte[] bytes, final SocketAddress sender,
                                          final CountDownLatch latch, final AtomicReference<Throwable> errorRef,
                                          final boolean echo) throws Throwable {
-        sb.handler(new ChannelInitializer<Channel>() {
+        sb.handler(new ChannelInitializer<>() {
 
             @Override
             protected void initChannel(Channel ch) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastTest.java
@@ -158,7 +158,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
         Channel cc = null;
 
         try (buf) {
-            cb.handler(new SimpleChannelInboundHandler<Object>() {
+            cb.handler(new SimpleChannelInboundHandler<>() {
                 @Override
                 public void messageReceived(ChannelHandlerContext ctx, Object msgs) {
                     // Nothing will be sent.

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -72,7 +72,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
     @Test
     @Timeout(30)
     public void readMustBePendingUntilChannelIsActive(TestInfo info) throws Throwable {
-        run(info, new Runner<Bootstrap>() {
+        run(info, new Runner<>() {
             @Override
             public void run(Bootstrap bootstrap) throws Throwable {
                 SingleThreadEventLoop group = new SingleThreadEventLoop(

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -48,7 +48,7 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
             final int maxWriteChunkSize = 16 * 1024;
             final CountDownLatch latch = new CountDownLatch(1);
             sb.childOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024, 16 * 1024));
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -93,11 +93,12 @@ public class SocketConditionalWritabilityTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().get();
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new ChannelHandler() {
                         private int totalRead;
+
                         @Override
                         public void channelActive(ChannelHandlerContext ctx) {
                             ctx.writeAndFlush(ctx.bufferAllocator().allocate(1).writeByte((byte) 0));

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketDataReadInitialStateTest.java
@@ -57,7 +57,7 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
             final CountDownLatch clientReadLatch = new CountDownLatch(1);
             final AtomicReference<Channel> serverConnectedChannelRef = new AtomicReference<>();
 
-            sb.handler(new ChannelInitializer<Channel>() {
+            sb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -70,7 +70,7 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     serverConnectedChannelRef.set(ch);
@@ -85,10 +85,10 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
-                    ch.pipeline().addLast(new SimpleChannelInboundHandler<Object>() {
+                    ch.pipeline().addLast(new SimpleChannelInboundHandler<>() {
                         @Override
                         protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
                             clientReadLatch.countDown();
@@ -148,7 +148,7 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
             final CountDownLatch serverReadLatch = new CountDownLatch(1);
             final CountDownLatch clientReadLatch = new CountDownLatch(1);
 
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new SimpleChannelInboundHandler<Buffer>() {
@@ -161,10 +161,10 @@ public class SocketDataReadInitialStateTest extends AbstractSocketTest {
                 }
             });
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
-                    ch.pipeline().addLast(new SimpleChannelInboundHandler<Object>() {
+                    ch.pipeline().addLast(new SimpleChannelInboundHandler<>() {
                         @Override
                         protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
                             clientReadLatch.countDown();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFileRegionTest.java
@@ -139,7 +139,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
 
         out.close();
 
-        ChannelHandler ch = new SimpleChannelInboundHandler<Object>() {
+        ChannelHandler ch = new SimpleChannelInboundHandler<>() {
             @Override
             public void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
             }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -65,7 +65,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         final EchoHandler ch = new EchoHandler(autoRead);
 
         sb.childOption(ChannelOption.AUTO_READ, autoRead);
-        sb.childHandler(new ChannelInitializer<Channel>() {
+        sb.childHandler(new ChannelInitializer<>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
                 sch.pipeline().addLast("decoder", new FixedLengthFrameDecoder(1024));
@@ -74,7 +74,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         });
 
         cb.option(ChannelOption.AUTO_READ, autoRead);
-        cb.handler(new ChannelInitializer<Channel>() {
+        cb.handler(new ChannelInitializer<>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
                 sch.pipeline().addLast("decoder", new FixedLengthFrameDecoder(1024));

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -66,44 +66,44 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         final CountDownLatch waitHalfClosureDone = new CountDownLatch(1);
         try {
             sb.childOption(ChannelOption.SO_LINGER, 1)
-              .childHandler(new ChannelInitializer<Channel>() {
+              .childHandler(new ChannelInitializer<>() {
 
                   @Override
                   protected void initChannel(Channel ch) throws Exception {
                       ch.pipeline().addLast(new ChannelHandler() {
 
-                            @Override
-                            public void channelActive(final ChannelHandlerContext ctx) {
-                                SocketChannel channel = (SocketChannel) ctx.channel();
-                                channel.shutdownOutput();
-                            }
+                          @Override
+                          public void channelActive(final ChannelHandlerContext ctx) {
+                              SocketChannel channel = (SocketChannel) ctx.channel();
+                              channel.shutdownOutput();
+                          }
 
-                            @Override
-                            public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                                Resource.dispose(msg);
-                                waitHalfClosureDone.countDown();
-                            }
-                        });
+                          @Override
+                          public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                              Resource.dispose(msg);
+                              waitHalfClosureDone.countDown();
+                          }
+                      });
                   }
               });
 
             cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
-              .handler(new ChannelInitializer<Channel>() {
+              .handler(new ChannelInitializer<>() {
                   @Override
                   protected void initChannel(Channel ch) throws Exception {
                       ch.pipeline().addLast(new ChannelHandler() {
 
-                            @Override
-                            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-                                if (ChannelInputShutdownEvent.INSTANCE == evt) {
-                                    ctx.writeAndFlush(ctx.bufferAllocator().copyOf(new byte[16]));
-                                }
+                          @Override
+                          public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                              if (ChannelInputShutdownEvent.INSTANCE == evt) {
+                                  ctx.writeAndFlush(ctx.bufferAllocator().copyOf(new byte[16]));
+                              }
 
-                                if (ChannelInputShutdownReadComplete.INSTANCE == evt) {
-                                    ctx.close();
-                                }
-                            }
-                        });
+                              if (ChannelInputShutdownReadComplete.INSTANCE == evt) {
+                                  ctx.close();
+                              }
+                          }
+                      });
                   }
               });
 
@@ -132,7 +132,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
         try {
             cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
                     .option(ChannelOption.AUTO_READ, true);
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -152,7 +152,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             final AtomicInteger shutdownEventReceivedCounter = new AtomicInteger();
             final AtomicInteger shutdownReadCompleteEventReceivedCounter = new AtomicInteger();
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -212,7 +212,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
               .option(ChannelOption.AUTO_READ, autoRead)
               .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(numReadsPerReadLoop));
 
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -233,7 +233,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -329,14 +329,14 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                     expectedBytes, serverReadExpectedLatch, doneLatch, causeRef);
             final SimpleChannelInboundHandler<?> followerHandler = new AutoCloseFalseFollower(expectedBytes,
                     serverReadExpectedLatch, doneLatch, causeRef);
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
-                    ch.pipeline().addLast(clientIsLeader ? followerHandler :leaderHandler);
+                    ch.pipeline().addLast(clientIsLeader ? followerHandler : leaderHandler);
                 }
             });
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
                     ch.pipeline().addLast(clientIsLeader ? leaderHandler : followerHandler);
@@ -513,7 +513,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                     .option(ChannelOption.AUTO_READ, autoRead)
                     .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvBufferAllocator(numReadsPerReadLoop));
 
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -533,7 +533,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 }
             });
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
                     ch.pipeline().addLast(new ChannelHandler() {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketRstTest.java
@@ -56,14 +56,14 @@ public class SocketRstTest extends AbstractSocketTest {
         final CountDownLatch latch2 = new CountDownLatch(1);
         // SO_LINGER=0 means that we must send ONLY a RST when closing (not a FIN + RST).
         sb.childOption(ChannelOption.SO_LINGER, 0);
-        sb.childHandler(new ChannelInitializer<Channel>() {
+        sb.childHandler(new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 serverChannelRef.compareAndSet(null, ch);
                 latch.countDown();
             }
         });
-        cb.handler(new ChannelInitializer<Channel>() {
+        cb.handler(new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ch.pipeline().addLast(new ChannelHandler() {
@@ -110,14 +110,14 @@ public class SocketRstTest extends AbstractSocketTest {
         final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch latch2 = new CountDownLatch(1);
-        sb.childHandler(new ChannelInitializer<Channel>() {
+        sb.childHandler(new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 serverChannelRef.compareAndSet(null, ch);
                 latch.countDown();
             }
         });
-        cb.handler(new ChannelInitializer<Channel>() {
+        cb.handler(new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ch.pipeline().addLast(new ChannelHandler() {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -153,7 +153,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         final ExecutorService executorService = delegate ? Executors.newCachedThreadPool() : null;
 
         try {
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 public void initChannel(Channel sch) throws Exception {
                     serverChannel = sch;
@@ -165,7 +165,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
                 }
             });
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 public void initChannel(Channel sch) throws Exception {
                     clientChannel = sch;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslEchoTest.java
@@ -257,7 +257,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         sb.childOption(ChannelOption.AUTO_READ, autoRead);
         cb.option(ChannelOption.AUTO_READ, autoRead);
 
-        sb.childHandler(new ChannelInitializer<Channel>() {
+        sb.childHandler(new ChannelInitializer<>() {
             @Override
             public void initChannel(Channel sch) {
                 serverChannel = sch;
@@ -279,7 +279,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         });
 
         final CountDownLatch clientHandshakeEventLatch = new CountDownLatch(1);
-        cb.handler(new ChannelInitializer<Channel>() {
+        cb.handler(new ChannelInitializer<>() {
             @Override
             public void initChannel(Channel sch) {
                 clientChannel = sch;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -129,7 +129,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
 
         final ExecutorService executorService = delegate ? Executors.newCachedThreadPool() : null;
         try {
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 public void initChannel(Channel sch) throws Exception {
                     ChannelPipeline p = sch.pipeline();
@@ -139,7 +139,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
                 }
             });
 
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 public void initChannel(Channel sch) throws Exception {
                     ChannelPipeline p = sch.pipeline();

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketTestPermutation.java
@@ -72,7 +72,7 @@ public class SocketTestPermutation {
             for (BootstrapFactory<B> cbf: cbfs) {
                 final BootstrapFactory<A> sbf0 = sbf;
                 final BootstrapFactory<B> cbf0 = cbf;
-                list.add(new BootstrapComboFactory<A, B>() {
+                list.add(new BootstrapComboFactory<>() {
                     @Override
                     public A newServerInstance() {
                         return sbf0.newInstance();
@@ -119,7 +119,7 @@ public class SocketTestPermutation {
     public List<BootstrapComboFactory<Bootstrap, Bootstrap>> datagram(final InternetProtocolFamily family) {
         // Make the list of Bootstrap factories.
         List<BootstrapFactory<Bootstrap>> bfs = Collections.singletonList(
-                () -> new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
+                () -> new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<>() {
                     @Override
                     public Channel newChannel(EventLoop eventLoop) {
                         return new NioDatagramChannel(eventLoop, family);

--- a/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty5/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -73,7 +73,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             sb.childOption(ChannelOption.AUTO_READ, false);
             sb.childOption(ChannelOption.MAX_MESSAGES_PER_READ, 1);
             sb.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new TestHandler(bytesRead, extraReadRequested, latch));
@@ -132,7 +132,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             ServerBootstrap sb = new ServerBootstrap();
             sb.group(serverGroup);
             sb.channel(serverChannel());
-            sb.childHandler(new ChannelInitializer<Channel>() {
+            sb.childHandler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) {
                     ch.pipeline().addLast(new ChannelHandler() {
@@ -157,7 +157,7 @@ public abstract class DetectPeerCloseWithoutReadTest {
             cb.option(ChannelOption.AUTO_READ, false);
             cb.option(ChannelOption.MAX_MESSAGES_PER_READ, 1);
             cb.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvBufferAllocator(expectedBytes / 10));
-            cb.handler(new ChannelInitializer<Channel>() {
+            cb.handler(new ChannelInitializer<>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
                     ch.pipeline().addLast(new TestHandler(bytesRead, extraReadRequested, latch));

--- a/transport/src/main/java/io/netty5/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty5/bootstrap/AbstractBootstrap.java
@@ -355,7 +355,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
 
     static Map.Entry<ChannelOption<?>, Object>[] newOptionsArray(Map<ChannelOption<?>, Object> options) {
         synchronized (options) {
-            return new LinkedHashMap<ChannelOption<?>, Object>(options).entrySet().toArray(EMPTY_OPTION_ARRAY);
+            return new LinkedHashMap<>(options).entrySet().toArray(EMPTY_OPTION_ARRAY);
         }
     }
 

--- a/transport/src/main/java/io/netty5/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty5/bootstrap/ServerBootstrap.java
@@ -174,7 +174,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         final Entry<ChannelOption<?>, Object>[] currentChildOptions = newOptionsArray(childOptions);
         final Entry<AttributeKey<?>, Object>[] currentChildAttrs = newAttributesArray(childAttrs);
 
-        p.addLast(new ChannelInitializer<Channel>() {
+        p.addLast(new ChannelInitializer<>() {
             @Override
             public void initChannel(final Channel ch) {
                 final ChannelPipeline pipeline = ch.pipeline();

--- a/transport/src/main/java/io/netty5/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelHandlerMask.java
@@ -62,7 +62,7 @@ final class ChannelHandlerMask {
             MASK_CLOSE | MASK_REGISTER | MASK_DEREGISTER | MASK_READ | MASK_WRITE | MASK_FLUSH;
 
     private static final FastThreadLocal<Map<Class<? extends ChannelHandler>, Integer>> MASKS =
-            new FastThreadLocal<Map<Class<? extends ChannelHandler>, Integer>>() {
+            new FastThreadLocal<>() {
                 @Override
                 protected Map<Class<? extends ChannelHandler>, Integer> initialValue() {
                     return new WeakHashMap<>(32);

--- a/transport/src/main/java/io/netty5/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOption.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
 
-    private static final ConstantPool<ChannelOption<Object>> pool = new ConstantPool<ChannelOption<Object>>() {
+    private static final ConstantPool<ChannelOption<Object>> pool = new ConstantPool<>() {
         @Override
         protected ChannelOption<Object> newConstant(int id, String name) {
             return new ChannelOption<>(id, name);

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -56,12 +56,12 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     private static final ChannelHandler TAIL_HANDLER = new TailHandler();
 
     private static final FastThreadLocal<Map<Class<?>, String>> nameCaches =
-            new FastThreadLocal<Map<Class<?>, String>>() {
-        @Override
-        protected Map<Class<?>, String> initialValue() {
-            return new WeakHashMap<>();
-        }
-    };
+            new FastThreadLocal<>() {
+                @Override
+                protected Map<Class<?>, String> initialValue() {
+                    return new WeakHashMap<>();
+                }
+            };
 
     private static final AtomicReferenceFieldUpdater<DefaultChannelPipeline, MessageSizeEstimator.Handle> ESTIMATOR =
             AtomicReferenceFieldUpdater.newUpdater(

--- a/transport/src/main/java/io/netty5/channel/MultithreadEventLoopGroup.java
+++ b/transport/src/main/java/io/netty5/channel/MultithreadEventLoopGroup.java
@@ -274,7 +274,7 @@ public class MultithreadEventLoopGroup extends MultithreadEventExecutorGroup imp
 
     private static Object[] merge(IoHandlerFactory ioHandlerFactory,
                                   int maxTasksPerRun, Object... args) {
-        List<Object> argList = new ArrayList<Object>(2 + args.length);
+        List<Object> argList = new ArrayList<>(2 + args.length);
         argList.add(ioHandlerFactory);
         argList.add(maxTasksPerRun);
         Collections.addAll(argList, args);

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -206,11 +206,11 @@ public class EmbeddedChannel extends AbstractChannel {
     private void setup(boolean register, final ChannelHandler... handlers) {
         requireNonNull(handlers, "handlers");
         ChannelPipeline p = pipeline();
-        p.addLast(new ChannelInitializer<Channel>() {
+        p.addLast(new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline pipeline = ch.pipeline();
-                for (ChannelHandler h: handlers) {
+                for (ChannelHandler h : handlers) {
                     if (h == null) {
                         break;
                     }

--- a/transport/src/main/java/io/netty5/channel/local/LocalHandler.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalHandler.java
@@ -29,7 +29,7 @@ import java.util.concurrent.locks.LockSupport;
  * {@link IoHandler} implementation for {@link LocalChannel} and {@link LocalServerChannel}.
  */
 public final class LocalHandler implements IoHandler {
-    private final Set<LocalChannelUnsafe> registeredChannels = new HashSet<LocalChannelUnsafe>(64);
+    private final Set<LocalChannelUnsafe> registeredChannels = new HashSet<>(64);
     private volatile Thread executionThread;
 
     private LocalHandler() { }

--- a/transport/src/main/java/io/netty5/channel/nio/SelectedSelectionKeySet.java
+++ b/transport/src/main/java/io/netty5/channel/nio/SelectedSelectionKeySet.java
@@ -61,7 +61,7 @@ final class SelectedSelectionKeySet extends AbstractSet<SelectionKey> {
 
     @Override
     public Iterator<SelectionKey> iterator() {
-        return new Iterator<SelectionKey>() {
+        return new Iterator<>() {
             private int idx;
 
             @Override


### PR DESCRIPTION
Motivation:
We don't need unnecessary explicit type declarations in diamond operators in Java 8+. Since Netty5 is Java 11 based, we can get rid of them and make the code look clean,

Modification:
Removed explicit types and formatted code as per style.

Result:
Clean and more readable code.
