### PR TITLE
Use `try-with-resources` for `AutoCloseable` implementations

### DIFF
--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -194,11 +194,9 @@ public final class PlatformDependent {
             boolean found = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                 try {
                     if (file.exists()) {
-                        BufferedReader reader = null;
-                        try {
-                            reader = new BufferedReader(
-                                    new InputStreamReader(
-                                            new FileInputStream(file), CharsetUtil.UTF_8));
+                        try (BufferedReader reader = new BufferedReader(
+                                new InputStreamReader(
+                                        new FileInputStream(file), CharsetUtil.UTF_8))) {
 
                             String line;
                             while ((line = reader.readLine()) != null) {
@@ -216,14 +214,6 @@ public final class PlatformDependent {
                             logger.debug("Unable to read {}", osReleaseFileName, e);
                         } catch (IOException e) {
                             logger.debug("Error while reading content of {}", osReleaseFileName, e);
-                        } finally {
-                            if (reader != null) {
-                                try {
-                                    reader.close();
-                                } catch (IOException ignored) {
-                                    // Ignore
-                                }
-                            }
                         }
                         // specification states we should only fall back if /etc/os-release does not exist
                         return true;

--- a/example/src/main/java/io/netty5/example/ocsp/OcspServerExample.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspServerExample.java
@@ -164,16 +164,14 @@ public class OcspServerExample {
 
     private static X509Certificate[] parseCertificates(Class<?> clazz, String name) throws Exception {
         InputStream in = clazz.getResourceAsStream(name);
-        if (in == null) {
-            throw new FileNotFoundException("clazz=" + clazz + ", name=" + name);
-        }
 
-        try {
+        try (in) {
+            if (in == null) {
+                throw new FileNotFoundException("clazz=" + clazz + ", name=" + name);
+            }
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, CharsetUtil.US_ASCII))) {
                 return parseCertificates(reader);
             }
-        } finally {
-            in.close();
         }
     }
 
@@ -184,20 +182,17 @@ public class OcspServerExample {
 
         List<X509Certificate> dst = new ArrayList<>();
 
-        PEMParser parser = new PEMParser(reader);
-        try {
-          X509CertificateHolder holder = null;
+        try (PEMParser parser = new PEMParser(reader)) {
+            X509CertificateHolder holder;
 
-          while ((holder = (X509CertificateHolder) parser.readObject()) != null) {
-            X509Certificate certificate = converter.getCertificate(holder);
-            if (certificate == null) {
-              continue;
+            while ((holder = (X509CertificateHolder) parser.readObject()) != null) {
+                X509Certificate certificate = converter.getCertificate(holder);
+                if (certificate == null) {
+                    continue;
+                }
+
+                dst.add(certificate);
             }
-
-            dst.add(certificate);
-          }
-        } finally {
-            parser.close();
         }
 
         return dst.toArray(new X509Certificate[0]);

--- a/example/src/main/java/io/netty5/example/ocsp/OcspServerExample.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspServerExample.java
@@ -163,9 +163,7 @@ public class OcspServerExample {
     }
 
     private static X509Certificate[] parseCertificates(Class<?> clazz, String name) throws Exception {
-        InputStream in = clazz.getResourceAsStream(name);
-
-        try (in) {
+        try (InputStream in = clazz.getResourceAsStream(name)) {
             if (in == null) {
                 throw new FileNotFoundException("clazz=" + clazz + ", name=" + name);
             }

--- a/example/src/main/java/io/netty5/example/ocsp/OcspUtils.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspUtils.java
@@ -149,8 +149,7 @@ public final class OcspUtils {
                         contentLength = Integer.MAX_VALUE;
                     }
 
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    try (baos) {
+                    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
                         byte[] buffer = new byte[8192];
                         int length;
 
@@ -161,8 +160,8 @@ public final class OcspUtils {
                                 break;
                             }
                         }
+                        return new OCSPResp(baos.toByteArray());
                     }
-                    return new OCSPResp(baos.toByteArray());
                 }
             }
         } finally {

--- a/example/src/main/java/io/netty5/example/ocsp/OcspUtils.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspUtils.java
@@ -150,9 +150,9 @@ public final class OcspUtils {
                     }
 
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    try {
+                    try (baos) {
                         byte[] buffer = new byte[8192];
-                        int length = -1;
+                        int length;
 
                         while ((length = in.read(buffer)) != -1) {
                             baos.write(buffer, 0, length);
@@ -161,8 +161,6 @@ public final class OcspUtils {
                                 break;
                             }
                         }
-                    } finally {
-                        baos.close();
                     }
                     return new OCSPResp(baos.toByteArray());
                 }

--- a/resolver/src/main/java/io/netty5/resolver/HostsFileEntriesProvider.java
+++ b/resolver/src/main/java/io/netty5/resolver/HostsFileEntriesProvider.java
@@ -189,15 +189,12 @@ public final class HostsFileEntriesProvider {
             }
             if (file.exists() && file.isFile()) {
                 for (Charset charset : charsets) {
-                    BufferedReader reader = new BufferedReader(
-                            new InputStreamReader(new FileInputStream(file), charset));
-                    try {
+                    try (BufferedReader reader = new BufferedReader(
+                            new InputStreamReader(new FileInputStream(file), charset))) {
                         HostsFileEntriesProvider entries = parse(reader);
                         if (entries != HostsFileEntriesProvider.EMPTY) {
                             return entries;
                         }
-                    } finally {
-                        reader.close();
                     }
                 }
             }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -203,8 +203,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
                 while (addresses.hasMoreElements()) {
                     InetAddress address = addresses.nextElement();
                     if (socketInternetProtocalFamily().addressType().isAssignableFrom(address.getClass())) {
-                        MulticastSocket socket = new MulticastSocket(newAnySocketAddress());
-                        try (socket) {
+                        try (MulticastSocket socket = new MulticastSocket(newAnySocketAddress())) {
                             socket.setReuseAddress(true);
                             socket.setNetworkInterface(iface);
                             socket.send(new java.net.DatagramPacket(new byte[]{1, 2, 3, 4}, 4,

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -204,16 +204,14 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
                     InetAddress address = addresses.nextElement();
                     if (socketInternetProtocalFamily().addressType().isAssignableFrom(address.getClass())) {
                         MulticastSocket socket = new MulticastSocket(newAnySocketAddress());
-                        socket.setReuseAddress(true);
-                        socket.setNetworkInterface(iface);
-                        try {
-                            socket.send(new java.net.DatagramPacket(new byte[] { 1, 2, 3, 4 }, 4,
-                                                                    new InetSocketAddress(groupAddress(), 12345)));
+                        try (socket) {
+                            socket.setReuseAddress(true);
+                            socket.setNetworkInterface(iface);
+                            socket.send(new java.net.DatagramPacket(new byte[]{1, 2, 3, 4}, 4,
+                                    new InetSocketAddress(groupAddress(), 12345)));
                             return iface;
                         } catch (IOException ignore) {
                             // Try the next interface
-                        } finally {
-                            socket.close();
                         }
                     }
                 }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -105,21 +105,15 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         // Check if the test can be executed or should be skipped because of no network/internet connection
         // See https://github.com/netty/netty/issues/1474
         boolean badHostTimedOut = true;
-        Socket socket = new Socket();
-        try {
+        try (Socket socket = new Socket()) {
             SocketUtils.connect(socket, SocketUtils.socketAddress(BAD_HOST, BAD_PORT), 10);
         } catch (ConnectException e) {
             badHostTimedOut = false;
             // is thrown for no route to host when using Socket connect
         } catch (Exception e) {
             // ignore
-        } finally {
-            try {
-                socket.close();
-            } catch (IOException e) {
-                // ignore
-            }
         }
+        // ignore
 
         assumeTrue(badHostTimedOut, "The connection attempt to " + BAD_HOST + " does not time out.");
 


### PR DESCRIPTION
Motivation:
We can use `try-with-resources` to avoid manually closing resources. It makes the code look good.

Modification:
Replaced `try-finally` with `try-with-resources`

Result:
Clean code
