### PR TITLE
Add method to get read-only Buffer copy without offsets

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -676,7 +676,7 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     /**
      * Returns a copy of the given region of this buffer.
      * Modifying the content of the returned buffer will not affect this buffers contents.
-     * The two buffers will  maintain separate offsets.
+     * The two buffers will maintain separate offsets.
      * This method does not modify {@link #readerOffset()} or {@link #writerOffset()} of this buffer.
      * <p>
      * The copy is created with a {@linkplain #writerOffset() write offset} equal to the length of the copy,
@@ -699,9 +699,36 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     }
 
     /**
+     * Returns a copy of this buffer's readable bytes, with the given read-only setting.
+     * Modifying the content of the returned buffer will not affect this buffers contents.
+     * The two buffers will maintain separate offsets.
+     * This method does not modify {@link #readerOffset()} or {@link #writerOffset()} of this buffer.
+     * <p>
+     * The copy is created with a {@linkplain #writerOffset() write offset} equal to the length of the copy,
+     * so that the entire contents of the copy is ready to be read.
+     * <p>
+     * The returned buffer will be read-only if, and only if, the {@code readOnly} argument is {@code true}, and it
+     * will not be read-only if the argument is {@code false}.
+     * This is the case regardless of the {@linkplain #readOnly() read-only state} of this buffer.
+     * <p>
+     * If this buffer is read-only, and a read-only copy is requested, then implementations <em>may</em> use structural
+     * sharing and have both buffers backed by the same underlying memory.
+     *
+     * @param readOnly The desired {@link #readOnly()} state of the returned buffer.
+     * @return A new buffer instance, with independent {@link #readerOffset()} and {@link #writerOffset()},
+     * that contains a copy of the given region of this buffer.
+     * @throws IllegalArgumentException if the {@code offset} or {@code length} reaches outside the bounds of the
+     * buffer.
+     * @throws BufferClosedException if this buffer is closed.
+     */
+    default Buffer copy(boolean readOnly) {
+        return copy(readerOffset(), readableBytes(), readOnly);
+    }
+
+    /**
      * Returns a copy of the given region of this buffer.
      * Modifying the content of the returned buffer will not affect this buffers contents.
-     * The two buffers will  maintain separate offsets.
+     * The two buffers will maintain separate offsets.
      * This method does not modify {@link #readerOffset()} or {@link #writerOffset()} of this buffer.
      * <p>
      * The copy is created with a {@linkplain #writerOffset() write offset} equal to the length of the copy,

--- a/buffer/src/main/java/io/netty5/buffer/api/SensitiveBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/SensitiveBufferAllocator.java
@@ -80,7 +80,7 @@ public final class SensitiveBufferAllocator implements BufferAllocator {
     @Override
     public Supplier<Buffer> constBufferSupplier(byte[] bytes) {
         Buffer origin = copyOf(bytes).makeReadOnly();
-        return () -> origin.copy(origin.readerOffset(), origin.readableBytes(), true);
+        return () -> origin.copy(true);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -230,7 +230,7 @@ public abstract class BufferTestSupport {
         @Override
         public Supplier<Buffer> constBufferSupplier(byte[] bytes) {
             Buffer parent = delegate.copyOf(bytes).makeReadOnly();
-            return () -> parent.copy(0, parent.readableBytes(), true);
+            return () -> parent.copy(true);
         }
 
         @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
@@ -93,10 +93,10 @@ public class SensitiveBufferTest {
             buffer.writeLong(0x0102030405060708L).makeReadOnly();
             try (Buffer split = buffer.readSplit(4)) {
                 assertTrue(split.readOnly());
-                split.copy(0, 4, true).close();
+                split.copy(true).close();
             }
             final Send<Buffer> send;
-            try (Buffer copy = buffer.copy(0, 4, true)) {
+            try (Buffer copy = buffer.copy(true)) {
                 send = buffer.send();
                 copy.readSplit(2).close();
             }

--- a/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/DelimiterBasedFrameDecoder.java
@@ -130,7 +130,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoderForBuffer {
                 for (int i = 0; i < delimiters.length; i++) {
                     Buffer d = delimiters[i];
                     validateDelimiter(d);
-                    this.delimiters[i] = d.copy(d.readerOffset(), d.readableBytes(), true);
+                    this.delimiters[i] = d.copy(true);
                 }
             } catch (IllegalArgumentException e) {
                 re = e;

--- a/handler/src/main/java/io/netty5/handler/ssl/PemPrivateKey.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemPrivateKey.java
@@ -128,7 +128,7 @@ public final class PemPrivateKey extends BufferHolder<PemPrivateKey> implements 
     @Override
     public PemPrivateKey copy() {
         Buffer buffer = getBuffer();
-        return new PemPrivateKey(buffer.copy(buffer.readerOffset(), buffer.readableBytes(), true));
+        return new PemPrivateKey(buffer.copy(true));
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/PemValue.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemValue.java
@@ -46,7 +46,7 @@ class PemValue extends BufferHolder<PemValue> implements PemEncoded {
     @Override
     public PemValue copy() {
         Buffer buffer = getBuffer();
-        return new PemValue(buffer.copy(buffer.readerOffset(), buffer.readableBytes(), true));
+        return new PemValue(buffer.copy(true));
     }
 
     @Override

--- a/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
@@ -190,7 +190,7 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
 
     @Override
     public PemX509Certificate copy() {
-        return new PemX509Certificate(content.copy(content.readerOffset(), content.readableBytes(), true));
+        return new PemX509Certificate(content.copy(true));
     }
 
     @Override

--- a/microbench/src/main/java/io/netty5/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -129,7 +129,7 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public Object pingPong() throws Exception {
-        return chan.pipeline().writeAndFlush(abyte.copy(0, 1, true)).sync();
+        return chan.pipeline().writeAndFlush(abyte.copy(true)).sync();
     }
 
     @Benchmark

--- a/microbench/src/main/java/io/netty5/microbench/handler/ssl/AbstractSslHandlerThroughputBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/handler/ssl/AbstractSslHandlerThroughputBenchmark.java
@@ -92,7 +92,7 @@ public abstract class AbstractSslHandlerThroughputBenchmark extends AbstractSslH
         clientCtx.releaseCumulation();
 
         for (int i = 0; i < numWrites; ++i) {
-            Buffer copy = wrapSrcBuffer.copy(wrapSrcBuffer.readerOffset(), wrapSrcBuffer.readableBytes(), true);
+            Buffer copy = wrapSrcBuffer.copy(true);
             clientSslHandler.write(clientCtx, copy);
         }
         clientSslHandler.flush(clientCtx);


### PR DESCRIPTION
Motivation:
It seems to be the common case that when we want a read-only copy of a buffer, we want a copy of the readable byte range.

Modification:
Add a method specifically for this use case, where we can request a read-only copy, without having to specify the readable byte range explicitly.
Also update every relevant usage site.

Result:
Cleaner code, and easier access to the structural-sharing copy optimisation.