### PR TITLE
Update to Maven 3.8.5

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip


### PR DESCRIPTION
Motivation:
We should keep our Maven Wrapper up-to-date

Modification:
Bumped Maven Wrapper to v3.8.5

Result:
Latest Maven release