### PR TITLE
Add Buffer#transferFrom(java.nio.channels.FileChannel, long, int)

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -21,6 +21,7 @@ import io.netty5.buffer.api.internal.Statics;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.ScatteringByteChannel;
@@ -327,6 +328,24 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * @throws IOException If the write-operation on the channel failed for some reason.
      */
     int transferTo(WritableByteChannel channel, int length) throws IOException;
+
+    /**
+     * Read from the given channel starting from the given position and write to this buffer.
+     * The number of bytes actually read from the channel are returned, or -1 is returned if the channel has reached
+     * the end-of-stream.
+     * No more than the given {@code length} of bytes, or the number of {@linkplain #writableBytes() writable bytes},
+     * will be read from the channel, whichever is smaller.
+     * The channel's position is not modified.
+     * The {@linkplain #writerOffset() writer-offset} of this buffer will likewise be advanced by the number of bytes
+     * read.
+     *
+     * @param channel The channel to read from.
+     * @param position The file position.
+     * @param length The maximum number of bytes to read.
+     * @return The actual number of bytes read, possibly zero, or -1 if the end-of-stream has been reached.
+     * @throws IOException If the read-operation on the channel failed for some reason.
+     */
+    int transferFrom(FileChannel channel, long position, int length) throws IOException;
 
     /**
      * Read from the given channel and write to this buffer.

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -19,6 +19,7 @@ import io.netty5.buffer.api.ComponentIterator.Next;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
@@ -135,6 +136,11 @@ public class BufferStub implements Buffer {
     @Override
     public int transferTo(WritableByteChannel channel, int length) throws IOException {
         return delegate.transferTo(channel, length);
+    }
+
+    @Override
+    public int transferFrom(FileChannel channel, long position, int length) throws IOException {
+        return delegate.transferFrom(channel, position, length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -317,6 +317,9 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         if (length == 0) {
             return 0;
         }
+        if (!channel.isOpen()) {
+            throw new ClosedChannelException();
+        }
         int bytesRead = delegate.setBytes(writerOffset(), channel, position, length);
         if (bytesRead > 0) { // Don't skipWritable if bytesRead is 0 or -1
             skipWritable(bytesRead);

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -38,6 +38,7 @@ import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
@@ -297,6 +298,28 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         int bytesWritten = channel.write(readableBuffer().limit(length));
         skipReadable(bytesWritten);
         return bytesWritten;
+    }
+
+    @Override
+    public int transferFrom(FileChannel channel, long position, int length) throws IOException {
+        checkPositiveOrZero(position, "position");
+        checkPositiveOrZero(length, "length");
+        if (!isAccessible()) {
+            throw bufferIsClosed(this);
+        }
+        if (readOnly()) {
+            throw bufferIsReadOnly(this);
+        }
+        length = Math.min(writableBytes(), length);
+        if (length == 0) {
+            return 0;
+        }
+        checkSet(writerOffset(), length);
+        int bytesRead = channel.read(writableBuffer().limit(length), position);
+        if (bytesRead > 0) { // Don't skipWritable if bytesRead is 0 or -1
+            skipWritable(bytesRead);
+        }
+        return bytesRead;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

There are use cases when one needs to start reading from a given file position.

Modifications:

- Add Buffer#transferFrom(java.nio.channels.FileChannel, long, int)
- Add junit tests

Result:

One is able to start reading from a given file position.