### PR TITLE
Implement Buffer.bytesBefore(Buffer)

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -525,6 +525,22 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
     int bytesBefore(byte needle);
 
     /**
+     * Get the number of {@linkplain #readableBytes() readable bytes}, until the given {@code needle} is found in this
+     * buffer.
+     * The found offset will be the offset into this buffer, relative to its {@linkplain #readerOffset() reader-offset},
+     * of the first byte of a sequence that matches all readable bytes in the given {@code needle} buffer.
+     * If the needle is not found, {@code -1} is returned.
+     * <p>
+     * This method does not modify the {@linkplain #readerOffset() reader-offset} or the
+     * {@linkplain #writerOffset() write-offset}.
+     *
+     * @param needle The buffer value to search for.
+     * @return The offset, relative to the current {@link #readerOffset()}, of the found value, or {@code -1} if none
+     * was found.
+     */
+    int bytesBefore(Buffer needle);
+
+    /**
      * Opens a cursor to iterate the readable bytes of this buffer. The {@linkplain #readerOffset() reader offset} and
      * {@linkplain #writerOffset() writer offset} are not modified by the cursor.
      * <p>

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -166,6 +166,11 @@ public class BufferStub implements Buffer {
     }
 
     @Override
+    public int bytesBefore(Buffer needle) {
+        return delegate.bytesBefore(needle);
+    }
+
+    @Override
     public ByteCursor openCursor() {
         return delegate.openCursor();
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -621,6 +621,11 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
+    public int bytesBefore(Buffer needle) {
+        return Statics.bytesBefore(this, null, needle, null);
+    }
+
+    @Override
     public ByteCursor openCursor() {
         return openCursor(readerOffset(), readableBytes());
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -346,6 +346,11 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     }
 
     @Override
+    public int bytesBefore(Buffer needle) {
+        return Statics.bytesBefore(this, null, needle, null);
+    }
+
+    @Override
     public ByteCursor openCursor() {
         return openCursor(readerOffset(), readableBytes());
     }

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -32,6 +32,7 @@ import io.netty5.buffer.api.internal.AdaptableBuffer;
 import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
 import io.netty5.buffer.api.internal.SingleComponentIterator;
 import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.Statics.UncheckedLoadByte;
 
 import java.io.IOException;
 import java.lang.ref.Reference;
@@ -355,6 +356,20 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
         }
 
         return -1;
+    }
+
+    @Override
+    public int bytesBefore(Buffer needle) {
+        UncheckedLoadByte uncheckedLoadByte = NioBuffer::uncheckedLoadByte;
+        return Statics.bytesBefore(this, uncheckedLoadByte,
+                                   needle, needle instanceof NioBuffer ? uncheckedLoadByte : null);
+    }
+
+    /**
+     * Used by {@link #bytesBefore(Buffer)}.
+     */
+    private static byte uncheckedLoadByte(Buffer buffer, int offset) {
+        return ((NioBuffer) buffer).rmem.get(offset);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -32,7 +32,10 @@ import io.netty5.buffer.api.internal.AdaptableBuffer;
 import io.netty5.buffer.api.internal.NotReadOnlyReadableComponent;
 import io.netty5.buffer.api.internal.SingleComponentIterator;
 import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.Statics.UncheckedLoadByte;
 import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.UnsafeAccess;
+import sun.misc.Unsafe;
 
 import java.io.IOException;
 import java.lang.ref.Reference;
@@ -52,11 +55,13 @@ import static io.netty5.buffer.api.internal.Statics.nativeAddressWithOffset;
 import static io.netty5.util.internal.ObjectUtil.checkPositiveOrZero;
 import static io.netty5.util.internal.PlatformDependent.roundToPowerOfTwo;
 
+@UnsafeAccess
 final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         implements ReadableComponent, WritableComponent, NotReadOnlyReadableComponent, ComponentIterator.Next {
     private static final int CLOSED_SIZE = -1;
     private static final boolean ACCESS_UNALIGNED = PlatformDependent.isUnaligned();
     private static final boolean FLIP_BYTES = ByteOrder.BIG_ENDIAN != ByteOrder.nativeOrder();
+    private static final Unsafe UNSAFE = (Unsafe) PlatformDependent.unwrapUnsafeOrNull();
     private UnsafeMemory memory; // The memory liveness; monitored by Cleaner.
     private Object base; // On-heap address reference object, or null for off-heap.
     private long baseOffset; // Offset of this buffer into the memory.
@@ -399,6 +404,25 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
         } finally {
             Reference.reachabilityFence(memory);
         }
+    }
+
+    @Override
+    public int bytesBefore(Buffer needle) {
+        try {
+            UncheckedLoadByte uncheckedLoadByte = UnsafeBuffer::uncheckedLoadByte;
+            return Statics.bytesBefore(this, uncheckedLoadByte,
+                                       needle, needle instanceof UnsafeBuffer ? uncheckedLoadByte : null);
+        } finally {
+            Reference.reachabilityFence(memory);
+        }
+    }
+
+    /**
+     * Used by {@link #bytesBefore(Buffer)}.
+     */
+    private static byte uncheckedLoadByte(Buffer buffer, int offset) {
+        UnsafeBuffer unsafeBuffer = (UnsafeBuffer) buffer;
+        return UNSAFE.getByte(unsafeBuffer.base, unsafeBuffer.address + offset);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferAllocateTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferAllocateTest.java
@@ -17,11 +17,13 @@ package io.netty5.buffer.api.tests;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Isolated
 public class BufferAllocateTest extends BufferTestSupport {
 
     @ParameterizedTest

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.StackWalker.Option;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -1017,6 +1018,17 @@ public final class PlatformDependent {
      */
     public static <C> Deque<C> newConcurrentDeque() {
         return new ConcurrentLinkedDeque<>();
+    }
+
+    public static Object unwrapUnsafeOrNull() {
+        if (!hasUnsafe()) {
+            return null;
+        }
+        Class<?> callerClass = StackWalker.getInstance(Set.of(Option.RETAIN_CLASS_REFERENCE), 1).getCallerClass();
+        if (!callerClass.isAnnotationPresent(io.netty5.util.internal.UnsafeAccess.class)) {
+            return null;
+        }
+        return PlatformDependent0.UNSAFE;
     }
 
     private static boolean isWindows0() {

--- a/common/src/main/java/io/netty5/util/internal/UnsafeAccess.java
+++ b/common/src/main/java/io/netty5/util/internal/UnsafeAccess.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.util.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for internal Netty classes that gives them permission to directly access the
+ * {@code Unsafe} instance, if available.
+ */
+@UnstableApi
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface UnsafeAccess {
+}

--- a/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmark.java
@@ -57,11 +57,9 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
     public AbstractMicrobenchmark(boolean disableAssertions, boolean disableHarnessExecutor) {
         final String[] customArgs;
         if (disableHarnessExecutor) {
-            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m",
-                    "-XX:BiasedLockingStartupDelay=0"};
+            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m"};
         } else {
             customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m",
-                    "-XX:BiasedLockingStartupDelay=0",
                     "-Djmh.executor=CUSTOM",
                     "-Djmh.executor.class=io.netty5.microbench.util.AbstractMicrobenchmark$HarnessExecutor"};
         }
@@ -85,6 +83,12 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
         if (getForks() >= 0) {
             runnerOptions.forks(getForks());
         }
+        // Async Profiler.
+//        runnerOptions.addProfiler(org.openjdk.jmh.profile.AsyncProfiler.class,
+//                                  "output=flamegraph;libPath=/<path>/async-profiler/build/libasyncProfiler.dylib");
+
+        // Assembly profiler on Mac OS.
+//        runnerOptions.addProfiler("dtraceasm");
 
         return runnerOptions;
     }


### PR DESCRIPTION
Motivation:
It is useful to have an efficient sub-string search on buffer, as some important protocols (e.g. HTTP/1, HTTP/2) use multi-byte delimiters.

Modification:
Port over the ByteBufUtil.indexOf implementation of the Two-Way sub-string search algorithm.
Make some additional tweaks to improve performance a bit, e.g. avoid bounds checking, reduce stack height and method size to help inlining.
Also add more testing of this feature, and update the BufferBytesBeforeBenchmark to include it.

Result:
Buffer now has efficient sub-string searching.