### PR TITLE
Change skip* methods to return itself.

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -132,12 +132,13 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * Move the reader offset forward by the given delta.
      *
      * @param delta to accumulate.
+     * @return This buffer instance.
      * @throws IndexOutOfBoundsException if the new reader offset is greater than the current
      * {@link #writerOffset()}.
      * @throws IllegalArgumentException if the given delta is negative.
      * @throws BufferClosedException if this buffer is closed.
      */
-    void skipReadable(int delta);
+    Buffer skipReadable(int delta);
 
     /**
      * Set the reader offset. Make the next read happen from the given offset into the buffer.
@@ -161,12 +162,13 @@ public interface Buffer extends Resource<Buffer>, BufferAccessor {
      * Move the writer offset to ahead by the given delta.
      *
      * @param delta to accumulate.
+     * @return This buffer instance.
      * @throws IndexOutOfBoundsException if the new writer offset is greater than {@link #capacity()}.
      * @throws IllegalArgumentException if the given delta is negative.
      * @throws BufferClosedException if this buffer is closed.
      * @throws BufferReadOnlyException if this buffer is {@linkplain #readOnly() read-only}.
      */
-    void skipWritable(int delta);
+    Buffer skipWritable(int delta);
 
     /**
      * Set the writer offset. Make the next write happen at the given offset.

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -54,8 +54,9 @@ public class BufferStub implements Buffer {
     }
 
     @Override
-    public void skipReadable(int delta) {
+    public Buffer skipReadable(int delta) {
         delegate.skipReadable(delta);
+        return this;
     }
 
     @Override
@@ -70,8 +71,9 @@ public class BufferStub implements Buffer {
     }
 
     @Override
-    public void skipWritable(int delta) {
+    public Buffer skipWritable(int delta) {
         delegate.skipWritable(delta);
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
@@ -147,6 +147,12 @@ public interface CompositeBuffer extends Buffer {
     CompositeBuffer writerOffset(int offset);
 
     @Override
+    CompositeBuffer skipReadable(int delta);
+
+    @Override
+    CompositeBuffer skipWritable(int delta);
+
+    @Override
     CompositeBuffer fill(byte value);
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -352,15 +352,17 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
-    public void skipReadable(int delta) {
+    public CompositeBuffer skipReadable(int delta) {
         checkPositiveOrZero(delta, "delta");
         readerOffset(readerOffset() + delta);
+        return this;
     }
 
     @Override
-    public void skipWritable(int delta) {
+    public CompositeBuffer skipWritable(int delta) {
         checkPositiveOrZero(delta, "delta");
         writerOffset(writerOffset() + delta);
+        return this;
     }
 
     @Override
@@ -2129,10 +2131,11 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         }
 
         @Override
-        public void skipReadable(int byteCount) {
+        public ReadableComponent skipReadable(int byteCount) {
             ((ReadableComponent) currentComponent).skipReadable(byteCount);
             compositeBuffer.readerOffset(pastOffset + currentReadSkip + byteCount);
             currentReadSkip += byteCount; // This needs to be after the bounds-checks.
+            return this;
         }
 
         @Override
@@ -2171,10 +2174,11 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
         }
 
         @Override
-        public void skipWritable(int byteCount) {
+        public WritableComponent skipWritable(int byteCount) {
             ((WritableComponent) currentComponent).skipWritable(byteCount);
             compositeBuffer.writerOffset(pastOffset + currentWriteSkip + byteCount);
             currentWriteSkip += byteCount; // This needs to be after the bounds-checks.
+            return this;
         }
 
         @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/ReadableComponent.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/ReadableComponent.java
@@ -108,7 +108,8 @@ public interface ReadableComponent {
      * Move the read-offset to indicate that the given number of bytes were read from this component.
      *
      * @param byteCount The number of bytes read from this component.
+     * @return itself.
      * @see Buffer#skipReadable(int)
      */
-    void skipReadable(int byteCount);
+    ReadableComponent skipReadable(int byteCount);
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/WritableComponent.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/WritableComponent.java
@@ -83,7 +83,8 @@ public interface WritableComponent {
      * Move the write-offset to indicate that the given number of bytes were written to this component.
      *
      * @param byteCount The number of bytes written to this component.
+     * @return itself.
      * @see Buffer#skipWritable(int)
      */
-    void skipWritable(int byteCount);
+    WritableComponent skipWritable(int byteCount);
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/adaptor/ByteBufBuffer.java
@@ -160,9 +160,10 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     }
 
     @Override
-    public void skipReadable(int delta) {
+    public Buffer skipReadable(int delta) {
         checkPositiveOrZero(delta, "delta");
         delegate.readerIndex(delegate.readerIndex() + delta);
+        return this;
     }
 
     @Override
@@ -177,9 +178,10 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
     }
 
     @Override
-    public void skipWritable(int delta) {
+    public Buffer skipWritable(int delta) {
         checkPositiveOrZero(delta, "delta");
         delegate.writerIndex(delegate.writerIndex() + delta);
+        return this;
     }
 
     @Override
@@ -1331,10 +1333,11 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
 
         @Override
-        public void skipReadable(int byteCount) {
+        public ReadableComponent skipReadable(int byteCount) {
             buffer.skipReadable(byteCount);
             int delta = buffer.readerOffset() - startBufferReaderOffset;
             byteBuffer.position(startByteBufferPosition + delta);
+            return this;
         }
 
         @Override
@@ -1399,10 +1402,11 @@ public final class ByteBufBuffer extends ResourceSupport<Buffer, ByteBufBuffer> 
         }
 
         @Override
-        public void skipWritable(int byteCount) {
+        public WritableComponent skipWritable(int byteCount) {
             buffer.skipWritable(byteCount);
             int delta = buffer.writerOffset() - startBufferWriterOffset;
             byteBuffer.position(startByteBufferPosition + delta);
+            return this;
         }
 
         @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/bytebuffer/NioBuffer.java
@@ -140,15 +140,17 @@ final class NioBuffer extends AdaptableBuffer<NioBuffer>
     }
 
     @Override
-    public void skipReadable(int delta) {
+    public NioBuffer skipReadable(int delta) {
         checkPositiveOrZero(delta, "delta");
         readerOffset(readerOffset() + delta);
+        return this;
     }
 
     @Override
-    public void skipWritable(int delta) {
+    public NioBuffer skipWritable(int delta) {
         checkPositiveOrZero(delta, "delta");
         writerOffset(writerOffset() + delta);
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/UnsafeBuffer.java
@@ -148,15 +148,17 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     }
 
     @Override
-    public void skipReadable(int delta) {
+    public UnsafeBuffer skipReadable(int delta) {
         checkPositiveOrZero(delta, "delta");
         readerOffset(readerOffset() + delta);
+        return this;
     }
 
     @Override
-    public void skipWritable(int delta) {
+    public UnsafeBuffer skipWritable(int delta) {
         checkPositiveOrZero(delta, "delta");
         writerOffset(writerOffset() + delta);
+        return this;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We should return itself from the skip* methods to be more consistent and also allow method chaining

Modifications:

- Change Buffer.skip* methods to return Buffer
- Channge CompositeBuffer.skip* methods to return CompositeBuffer
- Change ReadableBufferComponent.skipReadable(...) to return ReadableBufferComponent
- Change WritableBufferComponent.skipWritable(...) to return WritableBufferComponent

Result:

More consistent API and be able to do method chaining
