### PR TITLE
CompositeBuffer.implicitCapacityLimit(...) should return CompositeBuffer

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
@@ -305,4 +305,7 @@ public interface CompositeBuffer extends Buffer {
 
     @Override
     CompositeBuffer setDouble(int woff, double value);
+
+    @Override
+    CompositeBuffer implicitCapacityLimit(int limit);
 }

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -400,7 +400,7 @@ final class DefaultCompositeBuffer extends ResourceSupport<Buffer, DefaultCompos
     }
 
     @Override
-    public Buffer implicitCapacityLimit(int limit) {
+    public CompositeBuffer implicitCapacityLimit(int limit) {
         checkImplicitCapacity(limit,  capacity());
         implicitCapacityLimit = limit;
         return this;


### PR DESCRIPTION
Motivation:

We did miss to override implicitCapacityLimit(...) and so return the wrong type.

Modifications:

Add missing override and change return type of impl

Result:

Return correct type
