### PR TITLE
Fix the default chunk size to 4MiB

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -85,7 +85,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             validateAndCalculateChunkSize(DEFAULT_PAGE_SIZE, defaultMaxOrder);
         } catch (Throwable t) {
             maxOrderFallbackCause = t;
-            defaultMaxOrder = 11;
+            defaultMaxOrder = 9;
         }
         DEFAULT_MAX_ORDER = defaultMaxOrder;
 


### PR DESCRIPTION
Motivation:

Since the defaultMaxOrder equals 9, fix the try catch block with setting defaultMaxOrder with 9, to meet the requirement of default 4 MiB chunk size

Modification:

modify the try catch block cope with defaultMaxOrder to 9