### PR TITLE
Allow `BufferHolder` to hide behind an interface

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/BufferHolder.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferHolder.java
@@ -39,7 +39,7 @@ import static java.lang.invoke.MethodHandles.lookup;
  *
  * @param <T> The concrete {@link BufferHolder} type.
  */
-public abstract class BufferHolder<T extends BufferHolder<T>> implements Resource<T> {
+public abstract class BufferHolder<T extends Resource<T>> implements Resource<T> {
     private static final VarHandle BUF = Statics.findVarHandle(lookup(), BufferHolder.class, "buf", Buffer.class);
     private Buffer buf;
 

--- a/buffer/src/test/java/io/netty5/buffer/api/BufferHolderTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/BufferHolderTest.java
@@ -35,6 +35,29 @@ class BufferHolderTest {
         }
     }
 
+    @Test
+    public void bufferHolderInterface() {
+        Buffer buf = onHeapUnpooled().allocate(0);
+        try (Example first = new DefaultExample(buf)) {
+            Example second = first.send().receive();
+            second.close();
+        }
+    }
+
+    private interface Example extends Resource<Example> {
+    }
+
+    private final class DefaultExample extends BufferHolder<Example> implements Example {
+        protected DefaultExample(Buffer buf) {
+            super(buf);
+        }
+
+        @Override
+        protected Example receive(Buffer buf) {
+            return new DefaultExample(buf);
+        }
+    }
+
     @SuppressWarnings({ "SimplifiableJUnitAssertion", "rawtypes", "EqualsBetweenInconvertibleTypes" })
     @Test
     public void testDifferentClassesAreNotEqual() {


### PR DESCRIPTION
Motivation:
`BufferHolder` may be used to implement `Resource` but these implementations might themselves hide behind interfaces that extend `Resource`.

Modification:
`BufferHolder` no longer requires that the exposed interface extend `BufferHolder` - only `Resource` is required.

Result:
`BufferHolder` implementations can now hide behind interfaces.