### PR TITLE
`UnsafeBuffer` should free its memory immediately upon deallocation

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/api/unsafe/FreeAddress.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/unsafe/FreeAddress.java
@@ -15,10 +15,12 @@
  */
 package io.netty5.buffer.api.unsafe;
 
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.util.internal.PlatformDependent;
 
-class FreeAddress implements Runnable {
+class FreeAddress implements Runnable, Drop<Buffer> {
     private final long address;
     private final int size;
 
@@ -31,5 +33,24 @@ class FreeAddress implements Runnable {
     public void run() {
         PlatformDependent.freeMemory(address);
         Statics.MEM_USAGE_NATIVE.add(-size);
+    }
+
+    @Override
+    public void drop(Buffer obj) {
+        run();
+    }
+
+    @Override
+    public Drop<Buffer> fork() {
+        throw new IllegalStateException(this + " cannot fork. Must be guarded by an ArcDrop.");
+    }
+
+    @Override
+    public void attach(Buffer obj) {
+    }
+
+    @Override
+    public String toString() {
+        return String.format("FreeAddress(0x%x, %s bytes)", address, size);
     }
 }


### PR DESCRIPTION
Motivation:
We have been relying on the GC for freeing the native memory backing `UnsafeBuffer`.
However, the GC might fall behind and cause us to run out of native memory.

Modification:
`UnsafeBuffer` now, by default, frees the native memory immediately upon deallocation.
A system property has been added so it's possible to switch back to the old behaviour, in case this causes bugs.

Result:
We are now much faster at returning unused native memory back to `malloc()`, or the OS.