### PR TITLE
Fix typo in Blockhound integration

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -135,7 +135,7 @@ class Hidden {
                     "parse");
 
             builder.allowBlockingCallsInside(
-                    "io.netty.util.NetUil$SoMaxConnAction",
+                    "io.netty.util.NetUtil$SoMaxConnAction",
                     "run");
 
             builder.nonBlockingThreadPredicate(new Function<Predicate<Thread>, Predicate<Thread>>() {


### PR DESCRIPTION
Motivation:
We have a typo in the list of places where Blockhound should allow blocking calls.
This caused Blockhound to sometimes flag NetUtil as making blocking calls, instead of allowing them.

Modification:
Fix the typo in the allow-list to match the NetUtil class.

Result:
Fixes #12411