### PR TITLE
Add a BufferAllocator.copyOf(String, Charset)

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/BufferUtil.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferUtil.java
@@ -131,7 +131,7 @@ public final class BufferUtil {
      * result.
      */
     public static Buffer writeAscii(BufferAllocator alloc, CharSequence seq) {
-        return alloc.copyOf(seq.toString().getBytes(StandardCharsets.US_ASCII));
+        return alloc.copyOf(seq.toString(), StandardCharsets.US_ASCII);
     }
 
     /**

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
@@ -20,6 +20,7 @@ import io.netty5.buffer.api.pool.PooledBufferAllocator;
 import io.netty5.util.SafeCloseable;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.function.Supplier;
 
@@ -209,6 +210,24 @@ public interface BufferAllocator extends SafeCloseable {
      * @throws IllegalStateException if this allocator has been {@linkplain #close() closed}.
      */
     default Buffer copyOf(byte[] bytes) {
+        return allocate(bytes.length).writeBytes(bytes);
+    }
+
+    /**
+     * Allocate a {@link Buffer} with the same size and contents of the given {@link String},
+     * when interpreted as a sequence of bytes with the given {@link Charset}.
+     * This may throw an {@link OutOfMemoryError} if there is not enough free memory available to allocate a
+     * {@link Buffer} of the requested size.
+     * <p>
+     * The allocated buffer will use big endian byte order.
+     *
+     * @param str The {@link String} that determines the size and contents of the new buffer.
+     * @param charset The {@link Charset} that determines how to turn the string into a sequence of bytes.
+     * @return The newly allocated {@link Buffer}.
+     * @throws IllegalStateException if this allocator has been {@linkplain #close() closed}.
+     */
+    default Buffer copyOf(String str, Charset charset) {
+        byte[] bytes = str.getBytes(charset);
         return allocate(bytes.length).writeBytes(bytes);
     }
 

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/LifecycleTracer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/LifecycleTracer.java
@@ -16,7 +16,6 @@
 package io.netty5.buffer.api.internal;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.LeakInfo;
 import io.netty5.buffer.api.LeakInfo.TracePoint;
 import io.netty5.buffer.api.Owned;

--- a/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunk.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/pool/PoolChunk.java
@@ -17,7 +17,6 @@ package io.netty5.buffer.api.pool;
 
 import io.netty5.buffer.api.AllocatorControl;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
 import io.netty5.buffer.api.internal.ArcDrop;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferComponentIterationTest.java
@@ -20,7 +20,6 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferClosedException;
 import io.netty5.buffer.api.BufferReadOnlyException;
 import io.netty5.buffer.api.ByteCursor;
-import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.internal.Statics;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEnsureWritableTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferEnsureWritableTest.java
@@ -17,7 +17,6 @@ package io.netty5.buffer.api.tests;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.CompositeBuffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
@@ -18,7 +18,6 @@ package io.netty5.buffer.api.tests;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferReadOnlyException;
-import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.Send;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import org.junit.jupiter.api.Assertions;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSearchTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSearchTest.java
@@ -269,27 +269,27 @@ public class BufferSearchTest extends BufferTestSupport {
     @MethodSource("allocators")
     public void bytesBeforeMatchingBufferNeedles(Fixture fixture) {
         try (BufferAllocator allocator = fixture.createAllocator();
-            Buffer haystack = allocator.copyOf("abc123".getBytes(StandardCharsets.UTF_8))) {
+            Buffer haystack = allocator.copyOf("abc123", StandardCharsets.UTF_8)) {
 
-            try (Buffer needle = allocator.copyOf("a".getBytes(StandardCharsets.UTF_8))) {
+            try (Buffer needle = allocator.copyOf("a", StandardCharsets.UTF_8)) {
                 assertEquals(0, haystack.bytesBefore(needle));
             }
-            try (Buffer needle = allocator.copyOf("bc".getBytes(StandardCharsets.UTF_8))) {
+            try (Buffer needle = allocator.copyOf("bc", StandardCharsets.UTF_8)) {
                 assertEquals(1, haystack.bytesBefore(needle));
             }
-            try (Buffer needle = allocator.copyOf("c".getBytes(StandardCharsets.UTF_8))) {
+            try (Buffer needle = allocator.copyOf("c", StandardCharsets.UTF_8)) {
                 assertEquals(2, haystack.bytesBefore(needle));
             }
-            try (Buffer needle = allocator.copyOf("abc12".getBytes(StandardCharsets.UTF_8))) {
+            try (Buffer needle = allocator.copyOf("abc12", StandardCharsets.UTF_8)) {
                 assertEquals(0, haystack.bytesBefore(needle));
             }
-            try (Buffer needle = allocator.copyOf("abcdef".getBytes(StandardCharsets.UTF_8))) {
+            try (Buffer needle = allocator.copyOf("abcdef", StandardCharsets.UTF_8)) {
                 assertEquals(-1, haystack.bytesBefore(needle));
             }
-            try (Buffer needle = allocator.copyOf("abc12x".getBytes(StandardCharsets.UTF_8))) {
+            try (Buffer needle = allocator.copyOf("abc12x", StandardCharsets.UTF_8)) {
                 assertEquals(-1, haystack.bytesBefore(needle));
             }
-            try (Buffer needle = allocator.copyOf("abc123def".getBytes(StandardCharsets.UTF_8))) {
+            try (Buffer needle = allocator.copyOf("abc123def", StandardCharsets.UTF_8)) {
                 assertEquals(-1, haystack.bytesBefore(needle));
             }
         }

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferTestSupport.java
@@ -55,7 +55,6 @@ import static io.netty5.buffer.api.tests.Fixture.Properties.DIRECT;
 import static io.netty5.buffer.api.tests.Fixture.Properties.HEAP;
 import static io.netty5.buffer.api.tests.Fixture.Properties.POOLED;
 import static io.netty5.buffer.api.tests.Fixture.Properties.UNCLOSEABLE;
-import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/adaptor/ByteBufAdaptorTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/adaptor/ByteBufAdaptorTest.java
@@ -21,7 +21,6 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.MemoryManager;
 import io.netty5.buffer.api.adaptor.ByteBufAdaptor;
 import io.netty5.buffer.api.adaptor.ByteBufAllocatorAdaptor;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/TextWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/TextWebSocketFrame.java
@@ -17,7 +17,8 @@ package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.CharsetUtil;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Web Socket text frame.
@@ -62,7 +63,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
         if (text == null || text.isEmpty()) {
             return allocator.allocate(0);
         } else {
-            return allocator.copyOf(text.getBytes(CharsetUtil.UTF_8));
+            return allocator.copyOf(text, UTF_8);
         }
     }
 
@@ -84,7 +85,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
      * Returns the text data in this frame.
      */
     public String text() {
-        return binaryData().toString(CharsetUtil.UTF_8);
+        return binaryData().toString(UTF_8);
     }
 
     @Override

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -39,10 +39,12 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
 import static io.netty5.util.ReferenceCountUtil.release;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -117,8 +119,7 @@ public class HttpClientCodecTest {
         }
 
         assertNull(ch.readInbound());
-        final byte[] responseBytes = INCOMPLETE_CHUNKED_RESPONSE.getBytes(ISO_8859_1);
-        ch.writeInbound(ch.bufferAllocator().copyOf(responseBytes));
+        ch.writeInbound(ch.bufferAllocator().copyOf(INCOMPLETE_CHUNKED_RESPONSE, ISO_8859_1));
         assertThat(ch.readInbound(), instanceOf(HttpResponse.class));
         ((HttpContent<?>) ch.readInbound()).close(); // Chunk 'first'
         ((HttpContent<?>) ch.readInbound()).close(); // Chunk 'second'
@@ -153,15 +154,14 @@ public class HttpClientCodecTest {
                               and the client should still handle this.
                               See RFC 7230, 3.3.3: https://tools.ietf.org/html/rfc7230#section-3.3.3.
                              */
-                            final byte[] bytes = ("HTTP/1.0 200 OK\r\n" +
+                            final String reply = "HTTP/1.0 200 OK\r\n" +
                                     "Date: Fri, 31 Dec 1999 23:59:59 GMT\r\n" +
-                                    "Content-Type: text/html\r\n\r\n").getBytes(CharsetUtil.ISO_8859_1);
-                            sChannel.writeAndFlush(ch.bufferAllocator().copyOf(bytes))
+                                    "Content-Type: text/html\r\n\r\n";
+                            sChannel.writeAndFlush(ch.bufferAllocator().copyOf(reply, ISO_8859_1))
                                     .addListener(future -> {
                                         assertTrue(future.isSuccess());
-                                        final byte[] bytes1 = "<html><body>hello half closed!</body></html>\r\n"
-                                                .getBytes(CharsetUtil.ISO_8859_1);
-                                        sChannel.writeAndFlush(ch.bufferAllocator().copyOf(bytes1))
+                                        final String reply2 = "<html><body>hello half closed!</body></html>\r\n";
+                                        sChannel.writeAndFlush(ch.bufferAllocator().copyOf(reply2, ISO_8859_1))
                                                 .addListener(future1 -> {
                                                     assertTrue(future1.isSuccess());
                                                     sChannel.shutdownOutput();
@@ -246,8 +246,7 @@ public class HttpClientCodecTest {
         assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod, "http://localhost/",
                         ch.bufferAllocator().allocate(0))),
                 "Channel outbound write failed.");
-        final byte[] responseBytes = response.getBytes(ISO_8859_1);
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(responseBytes)),
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(response, ISO_8859_1)),
                 "Channel inbound write failed.");
 
         for (;;) {
@@ -300,16 +299,14 @@ public class HttpClientCodecTest {
         request.headers().set(HttpHeaderNames.UPGRADE, "TLS/1.2");
         assertTrue(ch.writeOutbound(request), "Channel outbound write failed.");
 
-        final byte[] bytes = SWITCHING_PROTOCOLS_RESPONSE.getBytes(ISO_8859_1);
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(bytes)),
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(SWITCHING_PROTOCOLS_RESPONSE, ISO_8859_1)),
                 "Channel inbound write failed.");
         Object switchingProtocolsResponse = ch.readInbound();
         assertNotNull(switchingProtocolsResponse, "No response received");
         assertThat("Response was not decoded", switchingProtocolsResponse, instanceOf(FullHttpResponse.class));
         ((FullHttpResponse) switchingProtocolsResponse).close();
 
-        final byte[] bytes2 = SWITCHING_PROTOCOLS_RESPONSE.getBytes(ISO_8859_1);
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(bytes2)),
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(SWITCHING_PROTOCOLS_RESPONSE, ISO_8859_1)),
                 "Channel inbound write failed");
         Object finalResponse = ch.readInbound();
         assertNotNull(finalResponse, "No response received");
@@ -320,14 +317,13 @@ public class HttpClientCodecTest {
 
     @Test
     public void testWebSocketResponse() {
-        byte[] data = ("HTTP/1.1 101 Switching Protocols\r\n" +
-                       "Upgrade: websocket\r\n" +
-                       "Connection: Upgrade\r\n" +
-                       "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo= \r\n" +
-                       "Sec-WebSocket-Protocol: chat\r\n\r\n")
-                .getBytes(CharsetUtil.US_ASCII);
+        String data = "HTTP/1.1 101 Switching Protocols\r\n" +
+                      "Upgrade: websocket\r\n" +
+                      "Connection: Upgrade\r\n" +
+                      "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo= \r\n" +
+                      "Sec-WebSocket-Protocol: chat\r\n\r\n";
         EmbeddedChannel ch = new EmbeddedChannel(new HttpClientCodec());
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data, US_ASCII)));
 
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
@@ -344,12 +340,12 @@ public class HttpClientCodecTest {
 
     @Test
     public void testWebDavResponse() {
-        byte[] data = ("HTTP/1.1 102 Processing\r\n" +
-                       "Status-URI: Status-URI:http://status.com; 404\r\n" +
-                       "\r\n" +
-                       "1234567812345678").getBytes();
+        String data = "HTTP/1.1 102 Processing\r\n" +
+                      "Status-URI: Status-URI:http://status.com; 404\r\n" +
+                      "\r\n" +
+                      "1234567812345678";
         EmbeddedChannel ch = new EmbeddedChannel(new HttpClientCodec());
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data, US_ASCII)));
 
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
@@ -364,19 +360,19 @@ public class HttpClientCodecTest {
 
     @Test
     public void testInformationalResponseKeepsPairsInSync() {
-        byte[] data = ("HTTP/1.1 102 Processing\r\n" +
+        String data = "HTTP/1.1 102 Processing\r\n" +
                 "Status-URI: Status-URI:http://status.com; 404\r\n" +
-                "\r\n").getBytes();
-        byte[] data2 = ("HTTP/1.1 200 OK\r\n" +
+                "\r\n";
+        String data2 = "HTTP/1.1 200 OK\r\n" +
                 "Content-Length: 8\r\n" +
                 "\r\n" +
-                "12345678").getBytes();
+                "12345678";
         EmbeddedChannel ch = new EmbeddedChannel(new HttpClientCodec());
         assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.HEAD, "/",
                 ch.bufferAllocator().allocate(0))));
         ((Buffer) ch.readOutbound()).close();
         assertNull(ch.readOutbound());
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data, US_ASCII)));
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
         assertThat(res.status(), is(HttpResponseStatus.PROCESSING));
@@ -390,7 +386,7 @@ public class HttpClientCodecTest {
                 ch.bufferAllocator().allocate(0))));
         ((Buffer) ch.readOutbound()).close();
         assertNull(ch.readOutbound());
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data2)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(data2, US_ASCII)));
 
         res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
@@ -416,9 +412,8 @@ public class HttpClientCodecTest {
                 ch.bufferAllocator().allocate(0));
         assertTrue(ch.writeOutbound(request));
 
-        final byte[] responseBytes = response.getBytes(UTF_8);
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(responseBytes)));
-        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(responseBytes)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(response, UTF_8)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf(response, UTF_8)));
         FullHttpResponse resp = ch.readInbound();
         assertTrue(resp.decoderResult().isSuccess());
         resp.close();

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -32,14 +32,12 @@ import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.handler.codec.CodecException;
 import io.netty5.handler.codec.PrematureChannelClosureException;
-import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 import io.netty5.util.concurrent.Future;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
 import static io.netty5.util.ReferenceCountUtil.release;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
@@ -30,6 +30,7 @@ import io.netty5.handler.codec.compression.Compressor;
 import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
@@ -382,8 +383,7 @@ public class HttpContentEncoderTest {
         HttpResponse res = new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.METHOD_NOT_ALLOWED);
         res.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
         ch.writeOutbound(res);
-        final byte[] contentBytes = content.getBytes(CharsetUtil.UTF_8);
-        ch.writeOutbound(new DefaultHttpContent(preferredAllocator().copyOf(contentBytes)));
+        ch.writeOutbound(new DefaultHttpContent(preferredAllocator().copyOf(content, StandardCharsets.UTF_8)));
         ch.writeOutbound(new EmptyLastHttpContent(preferredAllocator()));
 
         assertEncodedResponse(ch);

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpObjectAggregatorTest.java
@@ -20,12 +20,10 @@ import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.DecoderResultProvider;
 import io.netty5.util.AsciiString;
-import io.netty5.util.CharsetUtil;
 import io.netty5.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
-import java.nio.charset.StandardCharsets;
 
 import static io.netty5.buffer.api.CompositeBuffer.isComposite;
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpRequestDecoderTest.java
@@ -388,9 +388,9 @@ public class HttpRequestDecoderTest {
     private void testHeaderNameStartsWithControlChar(int controlChar) {
         Buffer requestBuffer = preferredAllocator().allocate(256);
         requestBuffer.writeCharSequence("GET /some/path HTTP/1.1\r\n" +
-                "Host: netty.io\r\n", CharsetUtil.US_ASCII);
+                "Host: netty.io\r\n", US_ASCII);
         requestBuffer.writeByte((byte) controlChar);
-        requestBuffer.writeCharSequence("Transfer-Encoding: chunked\r\n\r\n", CharsetUtil.US_ASCII);
+        requestBuffer.writeCharSequence("Transfer-Encoding: chunked\r\n\r\n", US_ASCII);
         testInvalidHeaders0(requestBuffer);
     }
 
@@ -422,10 +422,10 @@ public class HttpRequestDecoderTest {
     private void testHeaderNameEndsWithControlChar(int controlChar) {
         Buffer requestBuffer = preferredAllocator().allocate(256);
         requestBuffer.writeCharSequence("GET /some/path HTTP/1.1\r\n" +
-                "Host: netty.io\r\n", CharsetUtil.US_ASCII);
-        requestBuffer.writeCharSequence("Transfer-Encoding", CharsetUtil.US_ASCII);
+                "Host: netty.io\r\n", US_ASCII);
+        requestBuffer.writeCharSequence("Transfer-Encoding", US_ASCII);
         requestBuffer.writeByte((byte) controlChar);
-        requestBuffer.writeCharSequence(": chunked\r\n\r\n", CharsetUtil.US_ASCII);
+        requestBuffer.writeCharSequence(": chunked\r\n\r\n", US_ASCII);
         testInvalidHeaders0(requestBuffer);
     }
 
@@ -552,12 +552,12 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testHttpMessageDecoderResult() {
-        byte[] requestStr = ("PUT /some/path HTTP/1.1\r\n" +
+        String requestStr = "PUT /some/path HTTP/1.1\r\n" +
                 "Content-Length: 11\r\n" +
                 "Connection: close\r\n\r\n" +
-                "Lorem ipsum").getBytes(US_ASCII);
+                "Lorem ipsum";
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
-        assertTrue(channel.writeInbound(channel.bufferAllocator().allocate(requestStr.length).writeBytes(requestStr)));
+        assertTrue(channel.writeInbound(channel.bufferAllocator().copyOf(requestStr, US_ASCII)));
         HttpRequest request = channel.readInbound();
         assertTrue(request.decoderResult().isSuccess());
         assertThat(request.decoderResult(), instanceOf(HttpMessageDecoderResult.class));
@@ -570,9 +570,8 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
-    private static void testInvalidHeaders0(String requestStr) {
-        byte[] request = requestStr.getBytes(US_ASCII);
-        testInvalidHeaders0(preferredAllocator().copyOf(request));
+    private static void testInvalidHeaders0(String request) {
+        testInvalidHeaders0(preferredAllocator().copyOf(request, US_ASCII));
     }
 
     private static void testInvalidHeaders0(Buffer requestBuffer) {

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerCodecTest.java
@@ -160,8 +160,7 @@ public class HttpServerCodecTest {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
 
         // Send the request headers.
-        final byte[] data = "HEAD / HTTP/1.1\r\n\r\n".getBytes(StandardCharsets.UTF_8);
-        assertTrue(ch.writeInbound(ch.bufferAllocator().allocate(data.length).writeBytes(data)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf("HEAD / HTTP/1.1\r\n\r\n", StandardCharsets.UTF_8)));
 
         HttpRequest request = ch.readInbound();
         assertEquals(HttpMethod.HEAD, request.method());
@@ -184,6 +183,6 @@ public class HttpServerCodecTest {
     }
 
     private static Buffer prepareDataChunk(BufferAllocator allocator, int size) {
-        return allocator.copyOf("a".repeat(Math.max(0, size)).getBytes(StandardCharsets.UTF_8));
+        return allocator.copyOf("a".repeat(Math.max(0, size)), StandardCharsets.UTF_8);
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
@@ -44,7 +44,7 @@ public class WebSocketProtocolHandlerTest {
     @Test
     public void testPingFrame() {
         String message = "Hello, world";
-        Buffer pingData = preferredAllocator().copyOf(message.getBytes(UTF_8));
+        Buffer pingData = preferredAllocator().copyOf(message, UTF_8);
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler() { });
 
         PingWebSocketFrame inputMessage = new PingWebSocketFrame(pingData);
@@ -73,10 +73,10 @@ public class WebSocketProtocolHandlerTest {
 
         // When
         assertFalse(channel.writeInbound(
-                new PingWebSocketFrame(preferredAllocator().copyOf(text1.getBytes(UTF_8))),
+                new PingWebSocketFrame(preferredAllocator().copyOf(text1, UTF_8)),
                 new TextWebSocketFrame(preferredAllocator(), text2),
                 new TextWebSocketFrame(preferredAllocator(), text3),
-                new PingWebSocketFrame(preferredAllocator().copyOf(text4.getBytes(UTF_8))
+                new PingWebSocketFrame(preferredAllocator().copyOf(text4, UTF_8)
                 )));
 
         // Then - no messages were handled or propagated

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -172,7 +172,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
 
         String requestString = "GET / HTTP/1.1\r\n" +
                          "Host: example.com\r\n\r\n";
-        Buffer inbound = onHeapAllocator().copyOf(requestString.getBytes(CharsetUtil.US_ASCII));
+        Buffer inbound = onHeapAllocator().copyOf(requestString, CharsetUtil.US_ASCII);
 
         assertTrue(channel.writeInbound(inbound));
 
@@ -245,7 +245,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
     private void validateClearTextUpgrade(String upgradeString) {
         setUpServerChannel();
 
-        Buffer upgrade = onHeapAllocator().copyOf(upgradeString.getBytes(CharsetUtil.US_ASCII));
+        Buffer upgrade = onHeapAllocator().copyOf(upgradeString, CharsetUtil.US_ASCII);
 
         assertFalse(channel.writeInbound(upgrade));
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -48,7 +48,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Constructor;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -48,6 +48,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Constructor;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -911,10 +912,10 @@ public class Http2FrameCodecTest {
         // Check if we could make it accessible which may fail on java9.
         Assumptions.assumeTrue(ReflectionUtil.trySetAccessible(constructor, true) == null);
 
-        byte[] longString = new String(new char[70000]).replace("\0", "*").getBytes(UTF_8);
+        String longString = new String(new char[70000]).replace("\0", "*");
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.GET, "/",
-                preferredAllocator().copyOf(longString));
+                preferredAllocator().copyOf(longString, UTF_8));
 
         HttpServerUpgradeHandler.UpgradeEvent upgradeEvent = constructor.newInstance(
             "HTTP/2", request);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -357,7 +357,7 @@ public class HttpToHttp2ConnectionHandlerTest {
     public void testInvalidStreamId() throws Exception {
         bootstrapEnv(2, 1, 0);
         final FullHttpRequest request = new DefaultFullHttpRequest(
-                HTTP_1_1, POST, "/foo", preferredAllocator().copyOf("foobar".getBytes(UTF_8)));
+                HTTP_1_1, POST, "/foo", preferredAllocator().copyOf("foobar", UTF_8));
         final HttpHeaders httpHeaders = request.headers();
         httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), -1);
         httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
@@ -384,7 +384,7 @@ public class HttpToHttp2ConnectionHandlerTest {
         bootstrapEnv(3, 1, 0);
         final FullHttpRequest request = new DefaultFullHttpRequest(
                 HTTP_1_1, POST, "http://your_user-name123@www.example.org:5555/example",
-                preferredAllocator().copyOf(text.getBytes(UTF_8)));
+                preferredAllocator().copyOf(text, UTF_8));
         final HttpHeaders httpHeaders = request.headers();
         httpHeaders.set(HttpHeaderNames.HOST, "www.example-origin.org:5555");
         httpHeaders.add(of("foo"), of("goo"));
@@ -422,7 +422,7 @@ public class HttpToHttp2ConnectionHandlerTest {
         bootstrapEnv(4, 1, 1);
         final FullHttpRequest request = new DefaultFullHttpRequest(
                 HTTP_1_1, POST, "http://your_user-name123@www.example.org:5555/example",
-                preferredAllocator().copyOf(text.getBytes(UTF_8)));
+                preferredAllocator().copyOf(text, UTF_8));
         final HttpHeaders httpHeaders = request.headers();
         httpHeaders.set(HttpHeaderNames.HOST, "www.example.org:5555");
         httpHeaders.add(of("foo"), of("goo"));
@@ -482,9 +482,9 @@ public class HttpToHttp2ConnectionHandlerTest {
                         .add(new AsciiString("foo2"), new AsciiString("goo2"));
 
         final DefaultHttpContent httpContent = new DefaultHttpContent(
-                preferredAllocator().copyOf(text.getBytes(UTF_8)));
+                preferredAllocator().copyOf(text, UTF_8));
         final LastHttpContent<?> lastHttpContent = new DefaultLastHttpContent(
-                preferredAllocator().copyOf(text2.getBytes(StandardCharsets.UTF_8)));
+                preferredAllocator().copyOf(text2, UTF_8));
 
         lastHttpContent.trailingHeaders().add(of("trailing"), of("bar"));
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -47,7 +47,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/TestChannelInitializer.java
@@ -16,8 +16,6 @@
 
 package io.netty5.handler.codec.http2;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.Channel;

--- a/codec/src/main/java/io/netty5/handler/codec/string/StringEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/string/StringEncoder.java
@@ -74,6 +74,6 @@ public class StringEncoder extends MessageToMessageEncoder<CharSequence> {
             return;
         }
 
-        out.add(ctx.bufferAllocator().copyOf(msg.toString().getBytes(charset)));
+        out.add(ctx.bufferAllocator().copyOf(msg.toString(), charset));
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/DatagramPacketDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/DatagramPacketDecoderTest.java
@@ -53,7 +53,7 @@ public class DatagramPacketDecoderTest {
     public void testDecode() {
         InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
         InetSocketAddress sender = SocketUtils.socketAddress("127.0.0.1", 20000);
-        Buffer content = DefaultBufferAllocators.preferredAllocator().copyOf("netty".getBytes(CharsetUtil.UTF_8));
+        Buffer content = DefaultBufferAllocators.preferredAllocator().copyOf("netty", CharsetUtil.UTF_8);
         assertTrue(channel.writeInbound(new DatagramPacket(content, recipient, sender)));
         assertEquals("netty", channel.readInbound());
     }

--- a/codec/src/test/java/io/netty5/handler/codec/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/DelimiterBasedFrameDecoderTest.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.codec;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,7 @@ public class DelimiterBasedFrameDecoderTest {
     public void testMultipleLinesStrippedDelimiters() {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, true,
                 Delimiters.lineDelimiter()));
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "TestLine\r\ng\r\n", Charset.defaultCharset()));
+        ch.writeInbound(ch.bufferAllocator().copyOf("TestLine\r\ng\r\n", Charset.defaultCharset()));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("TestLine", buf.toString(Charset.defaultCharset()));
@@ -53,9 +52,9 @@ public class DelimiterBasedFrameDecoderTest {
     public void testIncompleteLinesStrippedDelimiters() {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, true,
                 Delimiters.lineDelimiter()));
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "Test", Charset.defaultCharset()));
+        ch.writeInbound(ch.bufferAllocator().copyOf("Test", Charset.defaultCharset()));
         assertNull(ch.readInbound());
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "Line\r\ng\r\n", Charset.defaultCharset()));
+        ch.writeInbound(ch.bufferAllocator().copyOf("Line\r\ng\r\n", Charset.defaultCharset()));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("TestLine", buf.toString(Charset.defaultCharset()));
@@ -73,7 +72,7 @@ public class DelimiterBasedFrameDecoderTest {
     public void testMultipleLines() {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, false,
                 Delimiters.lineDelimiter()));
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "TestLine\r\ng\r\n", Charset.defaultCharset()));
+        ch.writeInbound(ch.bufferAllocator().copyOf("TestLine\r\ng\r\n", Charset.defaultCharset()));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("TestLine\r\n", buf.toString(Charset.defaultCharset()));
@@ -91,9 +90,9 @@ public class DelimiterBasedFrameDecoderTest {
     public void testIncompleteLines() {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, false,
                 Delimiters.lineDelimiter()));
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "Test", Charset.defaultCharset()));
+        ch.writeInbound(ch.bufferAllocator().copyOf("Test", Charset.defaultCharset()));
         assertNull(ch.readInbound());
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "Line\r\ng\r\n", Charset.defaultCharset()));
+        ch.writeInbound(ch.bufferAllocator().copyOf("Line\r\ng\r\n", Charset.defaultCharset()));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("TestLine\r\n", buf.toString(Charset.defaultCharset()));
@@ -112,7 +111,7 @@ public class DelimiterBasedFrameDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new DelimiterBasedFrameDecoder(8192, true, Delimiters.lineDelimiter()));
 
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "first\r\nsecond\nthird", CharsetUtil.US_ASCII));
+        ch.writeInbound(ch.bufferAllocator().copyOf("first\r\nsecond\nthird", CharsetUtil.US_ASCII));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("first", buf.toString(CharsetUtil.US_ASCII));
@@ -145,7 +144,4 @@ public class DelimiterBasedFrameDecoderTest {
         assertFalse(delimiter.isAccessible());
     }
 
-    private static Buffer copiedBuffer(BufferAllocator allocator, String str, Charset charset) {
-        return allocator.copyOf(str.getBytes(charset));
-    }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/LineBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/LineBasedFrameDecoderTest.java
@@ -16,12 +16,9 @@
 package io.netty5.handler.codec;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
-
-import java.nio.charset.Charset;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -37,7 +34,7 @@ public class LineBasedFrameDecoderTest {
     public void testDecodeWithStrip() {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(8192, true, false));
 
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "first\r\nsecond\nthird", CharsetUtil.US_ASCII));
+        ch.writeInbound(ch.bufferAllocator().copyOf("first\r\nsecond\nthird", CharsetUtil.US_ASCII));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("first", buf.toString(CharsetUtil.US_ASCII));
@@ -55,7 +52,7 @@ public class LineBasedFrameDecoderTest {
     public void testDecodeWithoutStrip() {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(8192, false, false));
 
-        ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "first\r\nsecond\nthird", CharsetUtil.US_ASCII));
+        ch.writeInbound(ch.bufferAllocator().copyOf("first\r\nsecond\nthird", CharsetUtil.US_ASCII));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("first\r\n", buf.toString(CharsetUtil.US_ASCII));
@@ -75,14 +72,14 @@ public class LineBasedFrameDecoderTest {
 
         try {
             ch.writeInbound(
-                    copiedBuffer(ch.bufferAllocator(), "12345678901234567890\r\nfirst\nsecond", CharsetUtil.US_ASCII));
+                    ch.bufferAllocator().copyOf("12345678901234567890\r\nfirst\nsecond", CharsetUtil.US_ASCII));
             fail();
         } catch (Exception e) {
             assertThat(e, is(instanceOf(TooLongFrameException.class)));
         }
 
         try (Buffer buf = ch.readInbound();
-             Buffer buf2 = copiedBuffer(ch.bufferAllocator(), "first\n", CharsetUtil.US_ASCII)) {
+             Buffer buf2 = ch.bufferAllocator().copyOf("first\n", CharsetUtil.US_ASCII)) {
             assertThat(buf, is(buf2));
         }
 
@@ -93,16 +90,16 @@ public class LineBasedFrameDecoderTest {
     public void testTooLongLine2() {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(16, false, false));
 
-        assertFalse(ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "12345678901234567", CharsetUtil.US_ASCII)));
+        assertFalse(ch.writeInbound(ch.bufferAllocator().copyOf("12345678901234567", CharsetUtil.US_ASCII)));
         try {
-            ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "890\r\nfirst\r\n", CharsetUtil.US_ASCII));
+            ch.writeInbound(ch.bufferAllocator().copyOf("890\r\nfirst\r\n", CharsetUtil.US_ASCII));
             fail();
         } catch (Exception e) {
             assertThat(e, is(instanceOf(TooLongFrameException.class)));
         }
 
         try (Buffer buf = ch.readInbound();
-             Buffer buf2 = copiedBuffer(ch.bufferAllocator(), "first\r\n", CharsetUtil.US_ASCII)) {
+             Buffer buf2 = ch.bufferAllocator().copyOf("first\r\n", CharsetUtil.US_ASCII)) {
             assertThat(buf, is(buf2));
         }
 
@@ -114,18 +111,18 @@ public class LineBasedFrameDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(16, false, true));
 
         try {
-            ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "12345678901234567", CharsetUtil.US_ASCII));
+            ch.writeInbound(ch.bufferAllocator().copyOf("12345678901234567", CharsetUtil.US_ASCII));
             fail();
         } catch (Exception e) {
             assertThat(e, is(instanceOf(TooLongFrameException.class)));
         }
 
-        assertThat(ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "890", CharsetUtil.US_ASCII)), is(false));
+        assertThat(ch.writeInbound(ch.bufferAllocator().copyOf("890", CharsetUtil.US_ASCII)), is(false));
         assertThat(ch.writeInbound(
-                copiedBuffer(ch.bufferAllocator(), "123\r\nfirst\r\n", CharsetUtil.US_ASCII)), is(true));
+                ch.bufferAllocator().copyOf("123\r\nfirst\r\n", CharsetUtil.US_ASCII)), is(true));
 
         try (Buffer buf = ch.readInbound();
-             Buffer buf2 = copiedBuffer(ch.bufferAllocator(), "first\r\n", CharsetUtil.US_ASCII)) {
+             Buffer buf2 = ch.bufferAllocator().copyOf("first\r\n", CharsetUtil.US_ASCII)) {
             assertThat(buf, is(buf2));
         }
 
@@ -136,7 +133,7 @@ public class LineBasedFrameDecoderTest {
     public void testDecodeSplitsCorrectly() {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(8192, false, false));
 
-        assertTrue(ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "line\r\n.\r\n", CharsetUtil.US_ASCII)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf("line\r\n.\r\n", CharsetUtil.US_ASCII)));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("line\r\n", buf.toString(CharsetUtil.US_ASCII));
@@ -153,13 +150,13 @@ public class LineBasedFrameDecoderTest {
     public void testFragmentedDecode() {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(8192, false, false));
 
-        assertFalse(ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "huu", CharsetUtil.US_ASCII)));
+        assertFalse(ch.writeInbound(ch.bufferAllocator().copyOf("huu", CharsetUtil.US_ASCII)));
         assertNull(ch.readInbound());
 
-        assertFalse(ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "haa\r", CharsetUtil.US_ASCII)));
+        assertFalse(ch.writeInbound(ch.bufferAllocator().copyOf("haa\r", CharsetUtil.US_ASCII)));
         assertNull(ch.readInbound());
 
-        assertTrue(ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "\nhuuhaa\r\n", CharsetUtil.US_ASCII)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf("\nhuuhaa\r\n", CharsetUtil.US_ASCII)));
         try (Buffer buf = ch.readInbound()) {
             assertEquals("huuhaa\r\n", buf.toString(CharsetUtil.US_ASCII));
         }
@@ -175,7 +172,7 @@ public class LineBasedFrameDecoderTest {
     public void testEmptyLine() {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(8192, true, false));
 
-        assertTrue(ch.writeInbound(copiedBuffer(ch.bufferAllocator(), "\nabcna\r\n", CharsetUtil.US_ASCII)));
+        assertTrue(ch.writeInbound(ch.bufferAllocator().copyOf("\nabcna\r\n", CharsetUtil.US_ASCII)));
 
         try (Buffer buf = ch.readInbound()) {
             assertEquals("", buf.toString(CharsetUtil.US_ASCII));
@@ -208,9 +205,5 @@ public class LineBasedFrameDecoderTest {
         }
 
         assertFalse(ch.finish());
-    }
-
-    private static Buffer copiedBuffer(BufferAllocator allocator, String str, Charset charset) {
-        return allocator.copyOf(str.getBytes(charset));
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/base64/Base64Test.java
+++ b/codec/src/test/java/io/netty5/handler/codec/base64/Base64Test.java
@@ -168,6 +168,6 @@ public class Base64Test {
     }
 
     private static Buffer copiedBuffer(String str, Charset charset) {
-        return onHeapAllocator().copyOf(str.getBytes(charset));
+        return onHeapAllocator().copyOf(str, charset);
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/string/StringDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/string/StringDecoderTest.java
@@ -19,9 +19,8 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -32,7 +31,7 @@ public class StringDecoderTest {
     @Test
     public void testDecode() {
         String msg = "abc123";
-        Buffer buffer = preferredAllocator().copyOf(msg.getBytes(StandardCharsets.UTF_8));
+        Buffer buffer = preferredAllocator().copyOf(msg, UTF_8);
         EmbeddedChannel channel = new EmbeddedChannel(new StringDecoder());
         assertTrue(channel.writeInbound(buffer));
         String result = channel.readInbound();

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServerHandler.java
@@ -37,6 +37,7 @@ import io.netty5.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty5.handler.codec.http.cookie.ServerCookieEncoder;
 import io.netty5.util.CharsetUtil;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -151,10 +152,9 @@ public class HttpSnoopServerHandler extends SimpleChannelInboundHandler<Object> 
         // Decide whether to close the connection or not.
         boolean keepAlive = HttpUtil.isKeepAlive(request);
         // Build the response object.
-        final byte[] bytes = buf.toString().getBytes(UTF_8);
         FullHttpResponse response = new DefaultFullHttpResponse(
                 HTTP_1_1, currentObj.decoderResult().isSuccess()? OK : BAD_REQUEST,
-                ctx.bufferAllocator().copyOf(bytes));
+                ctx.bufferAllocator().copyOf(buf.toString(), UTF_8));
 
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
 

--- a/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServerHandler.java
+++ b/example/src/main/java/io/netty5/example/http/snoop/HttpSnoopServerHandler.java
@@ -37,7 +37,6 @@ import io.netty5.handler.codec.http.cookie.ServerCookieDecoder;
 import io.netty5.handler.codec.http.cookie.ServerCookieEncoder;
 import io.netty5.util.CharsetUtil;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServerBenchmarkPage.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServerBenchmarkPage.java
@@ -18,8 +18,6 @@ package io.netty5.example.http.websocketx.benchmarkserver;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 
-import java.nio.charset.StandardCharsets;
-
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**

--- a/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServerBenchmarkPage.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/benchmarkserver/WebSocketServerBenchmarkPage.java
@@ -18,6 +18,8 @@ package io.netty5.example.http.websocketx.benchmarkserver;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 
+import java.nio.charset.StandardCharsets;
+
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
@@ -28,7 +30,7 @@ public final class WebSocketServerBenchmarkPage {
     private static final String NEWLINE = "\r\n";
 
     public static Buffer getContent(BufferAllocator allocator, String webSocketLocation) {
-        final byte[] content = ("<html><head><title>Web Socket Performance Test</title></head>" + NEWLINE +
+        final String content = "<html><head><title>Web Socket Performance Test</title></head>" + NEWLINE +
                 "<body>" + NEWLINE +
                 "<h2>WebSocket Performance Test</h2>" + NEWLINE +
                 "<label>Connection Status:</label>" + NEWLINE +
@@ -182,8 +184,8 @@ public final class WebSocketServerBenchmarkPage {
                 "}" + NEWLINE +
                 "</script>" + NEWLINE +
                 "</body>" + NEWLINE +
-                "</html>" + NEWLINE).getBytes(US_ASCII);
-        return allocator.copyOf(content);
+                "</html>" + NEWLINE;
+        return allocator.copyOf(content, US_ASCII);
     }
 
     private WebSocketServerBenchmarkPage() {

--- a/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketServerIndexPage.java
+++ b/example/src/main/java/io/netty5/example/http/websocketx/server/WebSocketServerIndexPage.java
@@ -18,7 +18,7 @@ package io.netty5.example.http.websocketx.server;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Generates the demo HTML page which is served at http://localhost:8080/
@@ -28,7 +28,7 @@ public final class WebSocketServerIndexPage {
     private static final String NEWLINE = "\r\n";
 
     public static Buffer getContent(BufferAllocator allocator, String webSocketLocation) {
-        final byte[] content = ("<html><head><title>Web Socket Test</title></head>" + NEWLINE +
+        final String content = "<html><head><title>Web Socket Test</title></head>" + NEWLINE +
                 "<body>" + NEWLINE +
                 "<script type=\"text/javascript\">" + NEWLINE +
                 "var socket;" + NEWLINE +
@@ -70,8 +70,8 @@ public final class WebSocketServerIndexPage {
                 "<textarea id=\"responseText\" style=\"width:500px;height:300px;\"></textarea>" + NEWLINE +
                 "</form>" + NEWLINE +
                 "</body>" + NEWLINE +
-                "</html>" + NEWLINE).getBytes(StandardCharsets.US_ASCII);
-        return allocator.copyOf(content);
+                "</html>" + NEWLINE;
+        return allocator.copyOf(content, US_ASCII);
     }
 
     private WebSocketServerIndexPage() {

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
@@ -25,8 +25,9 @@ import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.nio.NioHandler;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.nio.NioDatagramChannel;
-import io.netty5.util.CharsetUtil;
 import io.netty5.util.internal.SocketUtils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * A UDP broadcast client that asks for a quote of the moment (QOTM) to {@link QuoteOfTheMomentServer}.
@@ -51,7 +52,7 @@ public final class QuoteOfTheMomentClient {
             Channel ch = b.bind(0).get();
 
             // Broadcast the QOTM request to port 8080.
-            Buffer message = DefaultBufferAllocators.preferredAllocator().copyOf("QOTM?".getBytes(CharsetUtil.UTF_8));
+            Buffer message = DefaultBufferAllocators.preferredAllocator().copyOf("QOTM?", UTF_8);
             ch.writeAndFlush(new DatagramPacket(message, SocketUtils.socketAddress("255.255.255.255", PORT))).sync();
 
             // QuoteOfTheMomentClientHandler will close the DatagramChannel when a

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServerHandler.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentServerHandler.java
@@ -19,9 +19,10 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.channel.socket.DatagramPacket;
-import io.netty5.util.CharsetUtil;
 
 import java.util.Random;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class QuoteOfTheMomentServerHandler extends SimpleChannelInboundHandler<DatagramPacket> {
 
@@ -46,8 +47,8 @@ public class QuoteOfTheMomentServerHandler extends SimpleChannelInboundHandler<D
     @Override
     public void messageReceived(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
         System.err.println(packet);
-        if ("QOTM?".equals(packet.content().toString(CharsetUtil.UTF_8))) {
-            Buffer message = ctx.bufferAllocator().copyOf(("QOTM: " + nextQuote()).getBytes(CharsetUtil.UTF_8));
+        if ("QOTM?".equals(packet.content().toString(UTF_8))) {
+            Buffer message = ctx.bufferAllocator().copyOf("QOTM: " + nextQuote(), UTF_8);
             ctx.write(new DatagramPacket(message, packet.sender()));
         }
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslEngine.java
@@ -17,7 +17,6 @@ package io.netty5.handler.ssl;
 
 import javax.net.ssl.SSLEngine;
 import java.util.List;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 final class BouncyCastleAlpnSslEngine extends JdkAlpnSslEngine {

--- a/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/BouncyCastleAlpnSslUtils.java
@@ -23,7 +23,6 @@ import io.netty5.util.internal.logging.InternalLoggerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
-import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.security.AccessController;

--- a/handler/src/main/java/io/netty5/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemReader.java
@@ -17,7 +17,6 @@ package io.netty5.handler.ssl;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.handler.codec.base64.Base64;
-import io.netty5.util.CharsetUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -37,6 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Reads a PEM file and converts it into a list of DERs so that they are imported into a {@link KeyStore} easily.
@@ -82,7 +82,7 @@ final class PemReader {
         Matcher m = CERT_PATTERN.matcher(content);
         int start = 0;
         while (m.find(start)) {
-            try (Buffer base64 = onHeapAllocator().copyOf(m.group(1).getBytes(CharsetUtil.US_ASCII))) {
+            try (Buffer base64 = onHeapAllocator().copyOf(m.group(1), US_ASCII)) {
                 Buffer der = Base64.decode(base64);
                 certs.add(der);
             }
@@ -124,7 +124,7 @@ final class PemReader {
                     " (see https://netty.io/wiki/sslcontextbuilder-and-private-key.html for more information)");
         }
 
-        try (Buffer base64 = onHeapAllocator().copyOf(m.group(1).getBytes(CharsetUtil.US_ASCII))) {
+        try (Buffer base64 = onHeapAllocator().copyOf(m.group(1), US_ASCII)) {
             return Base64.decode(base64);
         }
     }
@@ -140,7 +140,7 @@ final class PemReader {
                 }
                 out.write(buf, 0, ret);
             }
-            return out.toString(CharsetUtil.US_ASCII.name());
+            return out.toString(US_ASCII.name());
         } finally {
             safeClose(out);
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/OptionalSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OptionalSslHandlerTest.java
@@ -28,6 +28,7 @@ import org.mockito.MockitoAnnotations;
 import java.nio.charset.StandardCharsets;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -55,7 +56,7 @@ public class OptionalSslHandlerTest {
     @Test
     public void handlerRemoved() throws Exception {
         OptionalSslHandler handler = new OptionalSslHandler(sslContext);
-        try (Buffer payload = onHeapAllocator().copyOf("plaintext".getBytes(StandardCharsets.UTF_8))) {
+        try (Buffer payload = onHeapAllocator().copyOf("plaintext", UTF_8)) {
             handler.decode(context, payload);
             verify(pipeline).remove(handler);
         }
@@ -75,7 +76,7 @@ public class OptionalSslHandlerTest {
                 return HANDLER_NAME;
             }
         };
-        try (Buffer payload = onHeapAllocator().copyOf("plaintext".getBytes(StandardCharsets.UTF_8))) {
+        try (Buffer payload = onHeapAllocator().copyOf("plaintext", UTF_8)) {
             handler.decode(context, payload);
             verify(pipeline).replace(handler, HANDLER_NAME, nonSslHandler);
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/OptionalSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OptionalSslHandlerTest.java
@@ -25,8 +25,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import java.nio.charset.StandardCharsets;
-
 import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Mockito.verify;

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -1159,10 +1159,10 @@ public abstract class SSLEngineTest {
     }
 
     protected void runTest(String expectedApplicationProtocol) throws Exception {
-        try (Buffer clientMessage = onHeapAllocator().copyOf("I am a client".getBytes(UTF_8))) {
+        try (Buffer clientMessage = onHeapAllocator().copyOf("I am a client", UTF_8)) {
             writeAndVerifyReceived(clientMessage, clientChannel, serverLatch, serverReceiver);
         }
-        try (Buffer serverMessage = onHeapAllocator().copyOf("I am a server".getBytes(UTF_8))) {
+        try (Buffer serverMessage = onHeapAllocator().copyOf("I am a server", UTF_8)) {
             writeAndVerifyReceived(serverMessage, serverConnectedChannel, clientLatch, clientReceiver);
         }
         verifyApplicationLevelProtocol(clientChannel, expectedApplicationProtocol);

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -553,7 +553,7 @@ public class SniHandlerTest {
                                    sslContext.newEngine(offHeapAllocator(), sniHost, -1)))
                            .connect(address).get();
 
-                    cc.writeAndFlush(cc.bufferAllocator().copyOf("Hello, World!".getBytes(UTF_8)))
+                    cc.writeAndFlush(cc.bufferAllocator().copyOf("Hello, World!", UTF_8))
                             .syncUninterruptibly();
 
                     // Notice how the server's SslContext refCnt is 2 as it is incremented when the SSLEngine is created

--- a/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
@@ -191,7 +191,7 @@ public class OcspTest {
         ChannelHandler serverHandler = new ChannelHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                ctx.writeAndFlush(ctx.bufferAllocator().copyOf("Hello, World!".getBytes(UTF_8)));
+                ctx.writeAndFlush(ctx.bufferAllocator().copyOf("Hello, World!", UTF_8));
                 ctx.fireChannelActive();
             }
         };
@@ -284,7 +284,7 @@ public class OcspTest {
         ChannelHandler serverHandler = new ChannelHandler() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                ctx.writeAndFlush(ctx.bufferAllocator().copyOf("Hello, World!".getBytes(UTF_8)));
+                ctx.writeAndFlush(ctx.bufferAllocator().copyOf("Hello, World!", UTF_8));
                 ctx.fireChannelActive();
             }
         };

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -137,7 +137,7 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
         public void channelActive(ChannelHandlerContext ctx) {
             channel = ctx.channel();
             if (client) {
-                ctx.writeAndFlush(preferredAllocator().copyOf(EXPECTED_PAYLOAD.getBytes(US_ASCII)));
+                ctx.writeAndFlush(preferredAllocator().copyOf(EXPECTED_PAYLOAD, US_ASCII));
             }
         }
 
@@ -151,7 +151,7 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
                 if (client) {
                     ctx.close();
                 } else {
-                    ctx.writeAndFlush(preferredAllocator().copyOf(EXPECTED_PAYLOAD.getBytes(US_ASCII)));
+                    ctx.writeAndFlush(preferredAllocator().copyOf(EXPECTED_PAYLOAD, US_ASCII));
                 }
             }
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectTest.java
@@ -170,7 +170,7 @@ public class SocketConnectTest extends AbstractSocketTest {
     }
 
     private static Object writeAsciiBuffer(Channel sc, String seq) {
-        return DefaultBufferAllocators.preferredAllocator().copyOf(seq.getBytes(US_ASCII));
+        return DefaultBufferAllocators.preferredAllocator().copyOf(seq, US_ASCII);
     }
 
     protected void enableTcpFastOpen(ServerBootstrap sb, Bootstrap cb) {

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
-import java.io.IOException;
 import java.net.ConnectException;
 import java.net.Socket;
 import java.util.concurrent.ExecutionException;

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDatagramUnicastTest.java
@@ -17,8 +17,6 @@ package io.netty5.channel.epoll;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.Send;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramPathTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollDomainDatagramPathTest.java
@@ -53,7 +53,7 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
                                       .bind(EpollSocketTestPermutation.newDomainSocketAddress()).get();
                 ch.writeAndFlush(new DomainDatagramPacket(
-                        ch.bufferAllocator().copyOf("test".getBytes(CharsetUtil.US_ASCII)),
+                        ch.bufferAllocator().copyOf("test", CharsetUtil.US_ASCII),
                         EpollSocketTestPermutation.newDomainSocketAddress())).sync();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramPathTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueDomainDatagramPathTest.java
@@ -21,13 +21,13 @@ import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.unix.DomainDatagramPacket;
 import io.netty5.testsuite.transport.TestsuitePermutation;
 import io.netty5.testsuite.transport.socket.AbstractClientSocketTest;
-import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.FileNotFoundException;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -53,7 +53,7 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
                 Channel ch = bootstrap.handler(new ChannelHandlerAdapter() { })
                                       .bind(KQueueSocketTestPermutation.newSocketAddress()).get();
                 ch.writeAndFlush(new DomainDatagramPacket(
-                        ch.bufferAllocator().copyOf("test".getBytes(CharsetUtil.US_ASCII)),
+                        ch.bufferAllocator().copyOf("test", US_ASCII),
                         KQueueSocketTestPermutation.newSocketAddress())).sync();
                 fail("Expected FileNotFoundException");
             } catch (Exception e) {

--- a/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueRcvAllocatorOverrideSocketSslEchoTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty5/channel/kqueue/KQueueRcvAllocatorOverrideSocketSslEchoTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.channel.kqueue;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.BufferAllocator;

--- a/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty5/channel/ChannelOutboundBufferTest.java
@@ -112,7 +112,7 @@ public class ChannelOutboundBufferTest {
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
         assertEquals(0, buffer.nioBufferCount());
 
-        Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
         buffer.addMessage(buf, buf.readableBytes(), channel.newPromise());
         assertEquals(0, buffer.nioBufferCount(), "Should still be 0 as not flushed yet");
         buffer.addFlush();
@@ -161,7 +161,7 @@ public class ChannelOutboundBufferTest {
 
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
 
-        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
         for (int i = 0; i < 64; i++) {
             buffer.addMessage(buf.copy(), buf.readableBytes(), channel.newPromise());
         }
@@ -217,7 +217,7 @@ public class ChannelOutboundBufferTest {
 
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
 
-        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
         @SuppressWarnings("unchecked")
         var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
         CompositeBuffer comp = BufferAllocator.offHeapUnpooled().compose(sends);
@@ -277,7 +277,7 @@ public class ChannelOutboundBufferTest {
 
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
 
-        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        Buffer buf = BufferAllocator.offHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
         assertEquals(4, buf.readableBytes());
         @SuppressWarnings("unchecked")
         var sends = Stream.generate(() -> buf.copy().send()).limit(65).collect(Collectors.toList());
@@ -324,7 +324,7 @@ public class ChannelOutboundBufferTest {
     public void removeBytes() {
         TestChannel channel = new TestChannel();
         ChannelOutboundBuffer buffer = new ChannelOutboundBuffer(channel);
-        Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1".getBytes(CharsetUtil.US_ASCII));
+        Buffer buf = BufferAllocator.onHeapUnpooled().copyOf("buf1", CharsetUtil.US_ASCII);
         int size = buf.readableBytes();
         buffer.addMessage(buf, size, channel.newPromise());
         buffer.addFlush();

--- a/transport/src/test/java/io/netty5/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty5/channel/CoalescingBufferQueueTest.java
@@ -60,8 +60,8 @@ public class CoalescingBufferQueueTest {
         };
         emptyPromise = newPromise();
 
-        cat = BufferAllocator.offHeapUnpooled().copyOf("cat".getBytes(CharsetUtil.US_ASCII));
-        mouse = BufferAllocator.offHeapUnpooled().copyOf("mouse".getBytes(CharsetUtil.US_ASCII));
+        cat = BufferAllocator.offHeapUnpooled().copyOf("cat", CharsetUtil.US_ASCII);
+        mouse = BufferAllocator.offHeapUnpooled().copyOf("mouse", CharsetUtil.US_ASCII);
     }
 
     @AfterEach
@@ -77,7 +77,7 @@ public class CoalescingBufferQueueTest {
         assertQueueSize(8, false);
         Promise<Void> aggregatePromise = newPromise();
         assertEquals("catmous", dequeue(7, aggregatePromise));
-        Buffer remainder = BufferAllocator.offHeapUnpooled().copyOf("mous".getBytes(CharsetUtil.US_ASCII));
+        Buffer remainder = BufferAllocator.offHeapUnpooled().copyOf("mous", CharsetUtil.US_ASCII);
         writeQueue.addFirst(remainder, aggregatePromise);
         Promise<Void> aggregatePromise2 = newPromise();
         assertEquals("mouse", dequeue(5, aggregatePromise2));


### PR DESCRIPTION
Motivation:
It is somewhat common to allocate a Buffer from a String and a Charset.

Modification:
Add a convenience method that converts the string to bytes, and allocates a buffer for those bytes, in one go.
In certain cases, we can also optimise a bit, and use the byte array we get from String as the backing memory of the Buffer.
Many usages sites have also been updated to take advantage of this new API.

Result:
Cleaner code.