### PR TITLE
HTTP2: flush preface / settings frames when channel become active (#1…

### DIFF
--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -82,6 +82,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
     private Http2FrameListener frameListener;
     private long gracefulShutdownTimeoutMillis = Http2CodecUtil.DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS;
     private boolean decoupleCloseAndGoAway;
+    private boolean flushPreface = true;
 
     // The property that will prohibit connection() and codec() if set by server(),
     // because this property is used only when this builder creates an Http2Connection.
@@ -484,6 +485,36 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
      */
     protected boolean decoupleCloseAndGoAway() {
         return decoupleCloseAndGoAway;
+    }
+
+    /**
+     * Determine if the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-3.5">Preface</a>
+     * should be automatically flushed when the {@link Channel} becomes active or not.
+     * <p>
+     * Client may choose to opt-out from this automatic behavior and manage flush manually if it's ready to send
+     * request frames immediately after the preface. It may help to avoid unnecessary latency.
+     *
+     * @param flushPreface {@code true} to automatically flush, {@code false otherwise}.
+     * @return {@code this}.
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-3.5">HTTP/2 Connection Preface</a>
+     */
+    protected B flushPreface(boolean flushPreface) {
+        this.flushPreface = flushPreface;
+        return self();
+    }
+
+    /**
+     * Determine if the <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-3.5">Preface</a>
+     * should be automatically flushed when the {@link Channel} becomes active or not.
+     * <p>
+     * Client may choose to opt-out from this automatic behavior and manage flush manually if it's ready to send
+     * request frames immediately after the preface. It may help to avoid unnecessary latency.
+     *
+     * @return {@code true} if automatically flushed.
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-3.5">HTTP/2 Connection Preface</a>
+     */
+    protected boolean flushPreface() {
+        return flushPreface;
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerBuilder.java
@@ -104,6 +104,11 @@ public final class Http2ConnectionHandlerBuilder
     }
 
     @Override
+    public Http2ConnectionHandlerBuilder flushPreface(boolean flushPreface) {
+        return super.flushPreface(flushPreface);
+    }
+
+    @Override
     public Http2ConnectionHandler build() {
         return super.build();
     }
@@ -111,6 +116,6 @@ public final class Http2ConnectionHandlerBuilder
     @Override
     protected Http2ConnectionHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                            Http2Settings initialSettings) {
-        return new Http2ConnectionHandler(decoder, encoder, initialSettings, decoupleCloseAndGoAway());
+        return new Http2ConnectionHandler(decoder, encoder, initialSettings, decoupleCloseAndGoAway(), flushPreface());
     }
 }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
@@ -163,8 +163,8 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
             new IntObjectHashMap<>(8);
 
     Http2FrameCodec(Http2ConnectionEncoder encoder, Http2ConnectionDecoder decoder, Http2Settings initialSettings,
-                    boolean decoupleCloseAndGoAway) {
-        super(decoder, encoder, initialSettings, decoupleCloseAndGoAway);
+                    boolean decoupleCloseAndGoAway, boolean flushPreface) {
+        super(decoder, encoder, initialSettings, decoupleCloseAndGoAway, flushPreface);
 
         decoder.frameListener(new FrameListener());
         connection().addListener(new ConnectionListener());

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodecBuilder.java
@@ -180,6 +180,11 @@ public class Http2FrameCodecBuilder extends
     }
 
     @Override
+    public Http2FrameCodecBuilder flushPreface(boolean flushPreface) {
+        return super.flushPreface(flushPreface);
+    }
+
+    @Override
     public int decoderEnforceMaxConsecutiveEmptyDataFrames() {
         return super.decoderEnforceMaxConsecutiveEmptyDataFrames();
     }
@@ -226,7 +231,8 @@ public class Http2FrameCodecBuilder extends
     @Override
     protected Http2FrameCodec build(
             Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder, Http2Settings initialSettings) {
-        Http2FrameCodec codec = new Http2FrameCodec(encoder, decoder, initialSettings, decoupleCloseAndGoAway());
+        Http2FrameCodec codec = new Http2FrameCodec(encoder, decoder, initialSettings,
+                decoupleCloseAndGoAway(), flushPreface());
         codec.gracefulShutdownTimeoutMillis(gracefulShutdownTimeoutMillis());
         return codec;
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexCodec.java
@@ -100,8 +100,8 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                         Http2ConnectionDecoder decoder,
                         Http2Settings initialSettings,
                         ChannelHandler inboundStreamHandler,
-                        ChannelHandler upgradeStreamHandler, boolean decoupleCloseAndGoAway) {
-        super(encoder, decoder, initialSettings, decoupleCloseAndGoAway);
+                        ChannelHandler upgradeStreamHandler, boolean decoupleCloseAndGoAway, boolean flushPreface) {
+        super(encoder, decoder, initialSettings, decoupleCloseAndGoAway, flushPreface);
         this.inboundStreamHandler = inboundStreamHandler;
         this.upgradeStreamHandler = upgradeStreamHandler;
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -197,6 +197,11 @@ public class Http2MultiplexCodecBuilder
     }
 
     @Override
+    public Http2MultiplexCodecBuilder flushPreface(boolean flushPreface) {
+        return super.flushPreface(flushPreface);
+    }
+
+    @Override
     public int decoderEnforceMaxConsecutiveEmptyDataFrames() {
         return super.decoderEnforceMaxConsecutiveEmptyDataFrames();
     }
@@ -243,7 +248,7 @@ public class Http2MultiplexCodecBuilder
     protected Http2MultiplexCodec build(
             Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder, Http2Settings initialSettings) {
         Http2MultiplexCodec codec = new Http2MultiplexCodec(encoder, decoder, initialSettings, childHandler,
-                upgradeStreamHandler, decoupleCloseAndGoAway());
+                upgradeStreamHandler, decoupleCloseAndGoAway(), flushPreface());
         codec.gracefulShutdownTimeoutMillis(gracefulShutdownTimeoutMillis());
         return codec;
     }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -64,6 +64,15 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
         this.httpScheme = httpScheme;
     }
 
+    protected HttpToHttp2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                           Http2Settings initialSettings, boolean validateHeaders,
+                                           boolean decoupleCloseAndGoAway, boolean flushPreface,
+                                           HttpScheme httpScheme) {
+        super(decoder, encoder, initialSettings, decoupleCloseAndGoAway, flushPreface);
+        this.validateHeaders = validateHeaders;
+        this.httpScheme = httpScheme;
+    }
+
     /**
      * Get the next stream id either from the {@link HttpHeaders} object or HTTP/2 codec
      *

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
@@ -93,6 +93,11 @@ public final class HttpToHttp2ConnectionHandlerBuilder extends
         return super.decoupleCloseAndGoAway(decoupleCloseAndGoAway);
     }
 
+    @Override
+    public HttpToHttp2ConnectionHandlerBuilder flushPreface(boolean flushPreface) {
+        return super.flushPreface(flushPreface);
+    }
+
     /**
      * Add {@code scheme} in {@link Http2Headers} if not already present.
      *
@@ -113,6 +118,6 @@ public final class HttpToHttp2ConnectionHandlerBuilder extends
     protected HttpToHttp2ConnectionHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                                  Http2Settings initialSettings) {
         return new HttpToHttp2ConnectionHandler(decoder, encoder, initialSettings, isValidateHeaders(),
-                decoupleCloseAndGoAway(), httpScheme);
+                decoupleCloseAndGoAway(), flushPreface(), httpScheme);
     }
 }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -244,7 +244,7 @@ public class Http2ConnectionRoundtripTest {
         }).when(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(5), eq(headers),
                 anyInt(), anyShort(), anyBoolean(), eq(0), eq(true));
 
-        bootstrapEnv(1, 2, 1, 0, 0);
+        bootstrapEnv(1, 2, 2, 0, 0);
 
         // Set the maxHeaderListSize to 100 so we may be able to write some headers, but not all. We want to verify
         // that we don't corrupt state if some can be written but not all.
@@ -410,7 +410,7 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void headersUsingHigherValuedStreamIdPreventsUsingLowerStreamId() throws Exception {
-        bootstrapEnv(1, 1, 1, 0);
+        bootstrapEnv(1, 1, 2, 0);
 
         final Http2Headers headers = dummyHeaders();
         runInChannel(clientChannel, () -> {
@@ -632,7 +632,7 @@ public class Http2ConnectionRoundtripTest {
     @Test
     public void writeFailureFlowControllerRemoveFrame()
             throws Exception {
-        bootstrapEnv(1, 1, 2, 1);
+        bootstrapEnv(1, 1, 3, 1);
 
         final Promise<Void> dataPromise = newPromise();
         final Promise<Void> assertPromise = newPromise();
@@ -720,7 +720,7 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void noMoreStreamIdsShouldSendGoAway() throws Exception {
-        bootstrapEnv(1, 1, 3, 1, 1);
+        bootstrapEnv(1, 1, 4, 1, 1);
 
         // Don't wait for the server to close streams
         setClientGracefulShutdownTime(0);
@@ -902,7 +902,7 @@ public class Http2ConnectionRoundtripTest {
                 any(ByteBuf.class), eq(0), anyBoolean());
         try {
             // Initialize the data latch based on the number of bytes expected.
-            bootstrapEnv(length, 1, 2, 1);
+            bootstrapEnv(length, 1, 3, 1);
 
             // Create the stream and send all of the data at once.
             runInChannel(clientChannel, () -> {
@@ -979,7 +979,7 @@ public class Http2ConnectionRoundtripTest {
         }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), anyInt(),
                 any(ByteBuf.class), anyInt(), anyBoolean());
         try {
-            bootstrapEnv(numStreams * length, 1, numStreams * 4, numStreams);
+            bootstrapEnv(numStreams * length, 1, numStreams * 4 + 1, numStreams);
             runInChannel(clientChannel, () -> {
                 int upperLimit = 3 + 2 * numStreams;
                 for (int streamId = 3; streamId < upperLimit; streamId += 2) {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -218,7 +218,7 @@ public class Http2FrameCodecTest {
         Http2Connection conn = new DefaultHttp2Connection(true);
         Http2ConnectionEncoder enc = new DefaultHttp2ConnectionEncoder(conn, new DefaultHttp2FrameWriter());
         Http2ConnectionDecoder dec = new DefaultHttp2ConnectionDecoder(conn, enc, new DefaultHttp2FrameReader());
-        Http2FrameCodec codec = new Http2FrameCodec(enc, dec, new Http2Settings(), false);
+        Http2FrameCodec codec = new Http2FrameCodec(enc, dec, new Http2Settings(), false, true);
         EmbeddedChannel em = new EmbeddedChannel(codec);
 
         AtomicReference<Http2Exception> errorRef = new AtomicReference<>();


### PR DESCRIPTION
…2349)

Motivation:

We need to manually flush the channel when it becomes active and we wrote the preface / settigns frame as otherwise the remote peer might never see it.

Modifications:

- Flush after writing preface / settings
- Adjust unit test to verify the new behaviour
- Adjust unit tests to complete mocking everything before the connection is actually established

Result:

Fixes https://github.com/netty/netty/issues/12089

Co-authored-by: Maksym Ostroverkhov <m.ostroverkhov@gmail.com>
