### PR TITLE
Change some lamdas to named classes

### DIFF
--- a/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty5/util/concurrent/DefaultPromise.java
@@ -472,10 +472,23 @@ public class DefaultPromise<V> implements Promise<V>, Future<V> {
     }
 
     private void notifyListeners() {
-        safeExecute(executor(), this::notifyListenersNow);
+        safeExecute(executor(), new NotifyListeners(this));
     }
 
-    @SuppressWarnings("unchecked")
+    private static final class NotifyListeners implements Runnable {
+        private final DefaultPromise<?> promise;
+
+        private NotifyListeners(DefaultPromise<?> promise) {
+            this.promise = promise;
+        }
+
+        @Override
+        public void run() {
+            promise.notifyListenersNow();
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "MethodOnlyUsedFromInnerClass" })
     private void notifyListenersNow() {
         Object listeners;
         synchronized (this) {


### PR DESCRIPTION
Motivation:
When debugging, it is difficult to tell where a lambda object is coming from and what it does.

Modification:
Change a few common lamdas to named classes, so they are easily identified when debugging.

Result:
Easier debugging.
