### PR TITLE
Fix compression integration testing with direct buffers

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -154,7 +154,7 @@ public abstract class AbstractIntegrationTest {
     protected void testIdentity(final byte[] data, boolean heapBuffer) {
         initChannels();
         final ByteBuf in = heapBuffer? Unpooled.wrappedBuffer(data) :
-                Unpooled.directBuffer(data.length).setBytes(0, data);
+                Unpooled.directBuffer(data.length).writeBytes(data);
         final CompositeByteBuf compressed = Unpooled.compositeBuffer();
         final CompositeByteBuf decompressed = Unpooled.compositeBuffer();
 


### PR DESCRIPTION
Motivation:

We did not correctly increase the writerIndex when testing with direct buffers so the test did not test anything

Modifications:

Replace setBytes(...) with writeBytes(...)

Result:

Test with direct buffers are done correctly