### PR TITLE
Migrate Compression API to new Buffer API

### DIFF
--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
@@ -141,6 +141,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
                 // We also can't compose buffers that will have writer-offset gaps.
                 // Trim off the excess with split.
                 bufferList.add(partUncompressedContent.split().send());
+                partUncompressedContent.close();
             } else {
                 bufferList.add(partUncompressedContent.send());
             }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
@@ -153,6 +153,7 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
                 // We also can't compose buffers that will have writer-offset gaps.
                 // Trim off the excess with split.
                 bufferList.add(partCompressedContent.split().send());
+                partCompressedContent.close();
             } else {
                 bufferList.add(partCompressedContent.send());
             }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
@@ -15,9 +15,9 @@
  */
 package io.netty5.handler.codec.http.websocketx.extensions.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.CompositeByteBuf;
 import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.CompositeBuffer;
+import io.netty5.buffer.api.Send;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CodecException;
@@ -30,13 +30,12 @@ import io.netty5.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionEncoder;
 import io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
-import static io.netty5.buffer.api.adaptor.ByteBufAdaptor.extractOrCopy;
-import static io.netty5.buffer.api.adaptor.ByteBufAdaptor.intoByteBuf;
 import static io.netty5.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.FRAME_TAIL_LENGTH;
 
 /**
@@ -95,13 +94,13 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
 
     @Override
     protected void encode(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
-        final ByteBuf compressedContent;
+        final Buffer compressedContent;
         if (msg.binaryData().readableBytes() > 0) {
             compressedContent = compressContent(ctx, msg);
         } else if (msg.isFinalFragment()) {
             // Set empty DEFLATE block manually for unknown buffer size
             // https://tools.ietf.org/html/rfc7692#section-7.2.3.6
-            compressedContent = intoByteBuf(EMPTY_DEFLATE_BLOCK.get());
+            compressedContent = EMPTY_DEFLATE_BLOCK.get();
         } else {
             msg.close();
             throw new CodecException("cannot compress content buffer");
@@ -109,16 +108,13 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
 
         final WebSocketFrame outMsg;
         if (msg instanceof TextWebSocketFrame) {
-            outMsg = new TextWebSocketFrame(msg.isFinalFragment(), rsv(msg),
-                    extractOrCopy(ctx.bufferAllocator(), compressedContent));
+            outMsg = new TextWebSocketFrame(msg.isFinalFragment(), rsv(msg), compressedContent);
         } else if (msg instanceof BinaryWebSocketFrame) {
-            outMsg = new BinaryWebSocketFrame(msg.isFinalFragment(), rsv(msg),
-                    extractOrCopy(ctx.bufferAllocator(), compressedContent));
+            outMsg = new BinaryWebSocketFrame(msg.isFinalFragment(), rsv(msg), compressedContent);
         } else if (msg instanceof ContinuationWebSocketFrame) {
-            outMsg = new ContinuationWebSocketFrame(msg.isFinalFragment(), rsv(msg),
-                    extractOrCopy(ctx.bufferAllocator(), compressedContent));
+            outMsg = new ContinuationWebSocketFrame(msg.isFinalFragment(), rsv(msg), compressedContent);
         } else {
-            compressedContent.release();
+            compressedContent.close();
             throw new CodecException("unexpected frame type: " + msg.getClass().getName());
         }
 
@@ -131,29 +127,38 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
         super.handlerRemoved(ctx);
     }
 
-    private ByteBuf compressContent(ChannelHandlerContext ctx, WebSocketFrame msg) {
+    private Buffer compressContent(ChannelHandlerContext ctx, WebSocketFrame msg) {
         if (encoder == null) {
             encoder = new EmbeddedChannel(ZlibCodecFactory.newZlibEncoder(
                     ZlibWrapper.NONE, compressionLevel, windowSize, 8));
         }
 
-        encoder.writeOutbound(intoByteBuf(msg.binaryData()));
+        encoder.writeOutbound(msg.binaryData());
 
-        CompositeByteBuf fullCompressedContent = ctx.alloc().compositeBuffer();
+        List<Send<Buffer>> bufferList = new ArrayList<>();
         for (;;) {
-            ByteBuf partCompressedContent = encoder.readOutbound();
+            Buffer partCompressedContent = encoder.readOutbound();
             if (partCompressedContent == null) {
                 break;
             }
-            if (!partCompressedContent.isReadable()) {
-                partCompressedContent.release();
+            if (partCompressedContent.readableBytes() == 0) {
+                partCompressedContent.close();
                 continue;
             }
-            fullCompressedContent.addComponent(true, partCompressedContent);
+            if (partCompressedContent.readerOffset() != 0) {
+                // We can't compose buffers that will have reader-offset gaps.
+                partCompressedContent.readSplit(0).close(); // Trim off already-read bytes at the beginning.
+            }
+            if (partCompressedContent.writableBytes() > 0) {
+                // We also can't compose buffers that will have writer-offset gaps.
+                // Trim off the excess with split.
+                bufferList.add(partCompressedContent.split().send());
+            } else {
+                bufferList.add(partCompressedContent.send());
+            }
         }
 
-        if (fullCompressedContent.numComponents() <= 0) {
-            fullCompressedContent.release();
+        if (bufferList.isEmpty()) {
             throw new CodecException("cannot read compressed buffer");
         }
 
@@ -161,10 +166,11 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
             cleanup();
         }
 
-        ByteBuf compressedContent;
+        Buffer compressedContent;
+        CompositeBuffer fullCompressedContent = ctx.bufferAllocator().compose(bufferList);
         if (removeFrameTail(msg)) {
             int realLength = fullCompressedContent.readableBytes() - FRAME_TAIL_LENGTH;
-            compressedContent = fullCompressedContent.slice(0, realLength);
+            compressedContent = fullCompressedContent.readerOffset(0).writerOffset(realLength);
         } else {
             compressedContent = fullCompressedContent;
         }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 import static io.netty5.buffer.api.adaptor.ByteBufAdaptor.intoByteBuf;
-import static io.netty5.handler.adaptor.BufferConversionHandler.bufferToByteBuf;
 import static io.netty5.handler.adaptor.BufferConversionHandler.byteBufToBuffer;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -788,7 +787,7 @@ public class HttpContentDecoderTest {
 
     private static byte[] gzDecompress(byte[] input) {
         ChannelHandler decoder = ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP);
-        EmbeddedChannel channel = new EmbeddedChannel(decoder, byteBufToBuffer());
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
         assertTrue(channel.writeInbound(channel.bufferAllocator().allocate(input.length).writeBytes(input)));
         assertTrue(channel.finish()); // close the channel to indicate end-of-data
 
@@ -844,9 +843,9 @@ public class HttpContentDecoderTest {
 
     private static byte[] gzCompress(byte[] input) {
         ChannelHandler encoder = ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP);
-        EmbeddedChannel channel = new EmbeddedChannel(bufferToByteBuf(), encoder);
-        assertTrue(channel.writeOutbound(intoByteBuf(channel.bufferAllocator()
-                .allocate(input.length).writeBytes(input))));
+        EmbeddedChannel channel = new EmbeddedChannel(encoder);
+        assertTrue(channel.writeOutbound(channel.bufferAllocator()
+                .allocate(input.length).writeBytes(input)));
         assertTrue(channel.finish());  // close the channel to indicate end-of-data
 
         int outputSize = 0;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
@@ -16,9 +16,8 @@
 
 package io.netty5.handler.codec.http;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
@@ -656,11 +655,11 @@ public class HttpContentDecoderTest {
             @Override
             protected Decompressor newContentDecoder(String contentEncoding) {
                 return new Decompressor() {
-                    private ByteBuf input;
+                    private Buffer input;
                     @Override
-                    public ByteBuf decompress(ByteBuf input, ByteBufAllocator allocator) throws DecompressionException {
-                        if (input.isReadable()) {
-                            final ByteBuf slice = input.readRetainedSlice(input.readableBytes());
+                    public Buffer decompress(Buffer input, BufferAllocator allocator) throws DecompressionException {
+                        if (input.readableBytes() > 0) {
+                            final Buffer slice = input.readSplit(input.readableBytes());
                             this.input = input;
                             return slice;
                         }
@@ -680,7 +679,7 @@ public class HttpContentDecoderTest {
                     @Override
                     public void close() {
                         if (input != null) {
-                            input.release();
+                            input.close();
                         }
                         throw new DecoderException();
                     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentDecoderTest.java
@@ -659,7 +659,7 @@ public class HttpContentDecoderTest {
                     @Override
                     public Buffer decompress(Buffer input, BufferAllocator allocator) throws DecompressionException {
                         if (input.readableBytes() > 0) {
-                            final Buffer slice = input.readSplit(input.readableBytes());
+                            final Buffer slice = input.split();
                             this.input = input;
                             return slice;
                         }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
@@ -57,8 +57,7 @@ public class HttpContentEncoderTest {
                 private boolean finished;
                 @Override
                 public Buffer compress(Buffer input, BufferAllocator allocator) throws CompressionException {
-                    Buffer out = allocator.allocate(256);
-                    out.writeBytes(String.valueOf(input.readableBytes()).getBytes(CharsetUtil.US_ASCII));
+                    Buffer out = allocator.copyOf(String.valueOf(input.readableBytes()), CharsetUtil.US_ASCII);
                     input.skipReadable(input.readableBytes());
                     return out;
                 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
@@ -16,9 +16,8 @@
 
 package io.netty5.handler.codec.http;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
@@ -57,17 +56,17 @@ public class HttpContentEncoderTest {
             return new Result("test", new Compressor() {
                 private boolean finished;
                 @Override
-                public ByteBuf compress(ByteBuf input, ByteBufAllocator allocator) throws CompressionException {
-                    ByteBuf out = allocator.buffer();
+                public Buffer compress(Buffer input, BufferAllocator allocator) throws CompressionException {
+                    Buffer out = allocator.allocate(256);
                     out.writeBytes(String.valueOf(input.readableBytes()).getBytes(CharsetUtil.US_ASCII));
-                    input.skipBytes(input.readableBytes());
+                    input.skipReadable(input.readableBytes());
                     return out;
                 }
 
                 @Override
-                public ByteBuf finish(ByteBufAllocator allocator) {
+                public Buffer finish(BufferAllocator allocator) {
                     finished = true;
-                    return Unpooled.EMPTY_BUFFER;
+                    return allocator.allocate(0);
                 }
 
                 @Override
@@ -438,17 +437,17 @@ public class HttpContentEncoderTest {
             @Override
             protected Result beginEncode(HttpResponse httpResponse, String acceptEncoding) {
                 return new Result("myencoding", new Compressor() {
-                    private ByteBuf input;
+                    private Buffer input;
 
                     @Override
-                    public ByteBuf compress(ByteBuf input, ByteBufAllocator allocator) throws CompressionException {
+                    public Buffer compress(Buffer input, BufferAllocator allocator) throws CompressionException {
                         this.input = input;
-                        return input.retainedSlice();
+                        return input.copy();
                     }
 
                     @Override
-                    public ByteBuf finish(ByteBufAllocator allocator) {
-                        return Unpooled.EMPTY_BUFFER;
+                    public Buffer finish(BufferAllocator allocator) {
+                        return allocator.allocate(0);
                     }
 
                     @Override
@@ -464,7 +463,7 @@ public class HttpContentEncoderTest {
                     @Override
                     public void close() {
                         if (input != null) {
-                            input.release();
+                            input.close();
                         }
                         throw new EncoderException();
                     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoderTest.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static io.netty5.handler.adaptor.BufferConversionHandler.bufferToByteBuf;
-import static io.netty5.handler.adaptor.BufferConversionHandler.byteBufToBuffer;
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtension.RSV1;
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtension.RSV3;
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.ALWAYS_SKIP;
@@ -42,9 +40,7 @@ public class PerFrameDeflateDecoderTest {
     @Test
     public void testCompressedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
-                bufferToByteBuf(),
-                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
 
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false));
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static io.netty5.handler.adaptor.BufferConversionHandler.bufferToByteBuf;
-import static io.netty5.handler.adaptor.BufferConversionHandler.byteBufToBuffer;
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtension.RSV1;
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtension.RSV3;
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.ALWAYS_SKIP;
@@ -51,9 +49,7 @@ public class PerMessageDeflateDecoderTest {
     @Test
     public void testCompressedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
-                bufferToByteBuf(),
-                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
 
         // initialize
@@ -113,9 +109,7 @@ public class PerMessageDeflateDecoderTest {
     @Test
     public void testFragmentedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
-                bufferToByteBuf(),
-                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
 
         // initialize
@@ -169,9 +163,7 @@ public class PerMessageDeflateDecoderTest {
     @Test
     public void testMultiCompressedPayloadWithinFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
-                bufferToByteBuf(),
-                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
 
         // initialize
@@ -244,9 +236,7 @@ public class PerMessageDeflateDecoderTest {
         WebSocketExtensionFilter selectivityDecompressionFilter =
                 frame -> frame instanceof TextWebSocketFrame && frame.binaryData().readableBytes() < 100;
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
-                bufferToByteBuf(),
-                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
                 new PerMessageDeflateDecoder(false, selectivityDecompressionFilter));
 
@@ -287,9 +277,7 @@ public class PerMessageDeflateDecoderTest {
         WebSocketExtensionFilter selectivityDecompressionFilter = frame -> frame.binaryData().readableBytes() < 100;
 
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
-                bufferToByteBuf(),
-                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
                 new PerMessageDeflateDecoder(false, selectivityDecompressionFilter));
 
@@ -352,9 +340,7 @@ public class PerMessageDeflateDecoderTest {
                          "62667963626b687a726d676e646263776e67797264706d6c6863626577616967706a78636a72697464756e627" +
                          "977616f79736475676f76736f7178746a7a7479626c64636b6b6778637768746c62";
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
-                bufferToByteBuf(),
-                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false));
 
         Buffer originPayload = encoderChannel.bufferAllocator().copyOf(ByteBufUtil.decodeHexDump(hexDump));

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Random;
 
-import static io.netty5.handler.adaptor.BufferConversionHandler.byteBufToBuffer;
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.ALWAYS_SKIP;
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.NEVER_SKIP;
 import static io.netty5.handler.codec.http.websocketx.extensions.compression.DeflateEncoder.EMPTY_DEFLATE_BLOCK;
@@ -51,8 +50,7 @@ public class PerMessageDeflateEncoderTest {
     public void testCompressedFrame() {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
 
         // initialize
         byte[] payload = new byte[300];
@@ -112,8 +110,7 @@ public class PerMessageDeflateEncoderTest {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 new PerMessageDeflateEncoder(9, 15, false, NEVER_SKIP));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
 
         // initialize
         byte[] payload1 = new byte[100];
@@ -203,8 +200,7 @@ public class PerMessageDeflateEncoderTest {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 new PerMessageDeflateEncoder(9, 15, false, selectivityCompressionFilter));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
-                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE),
-                byteBufToBuffer());
+                ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE));
 
         String textPayload = "not compressed payload";
         byte[] binaryPayload = new byte[101];

--- a/codec/src/main/java/io/netty5/handler/codec/compression/BrotliDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/BrotliDecompressor.java
@@ -88,9 +88,7 @@ public final class BrotliDecompressor implements Decompressor {
     private Buffer pull(BufferAllocator alloc) {
         ByteBuffer nativeBuffer = decoder.pull();
         // nativeBuffer actually wraps brotli's internal buffer so we need to copy its content
-        Buffer copy = alloc.allocate(nativeBuffer.remaining());
-        copy.writeBytes(nativeBuffer);
-        return copy;
+        return alloc.copyOf(nativeBuffer);
     }
 
     private static int readBytes(Buffer in, ByteBuffer dest) {

--- a/codec/src/main/java/io/netty5/handler/codec/compression/BufferChecksum.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/BufferChecksum.java
@@ -25,11 +25,11 @@ import static java.util.Objects.requireNonNull;
 /**
  * {@link Checksum} implementation which can directly act on a {@link Buffer}.
  */
-class ByteBufChecksum implements Checksum {
+class BufferChecksum implements Checksum {
 
     private final Checksum checksum;
 
-    ByteBufChecksum(Checksum checksum) {
+    BufferChecksum(Checksum checksum) {
         this.checksum = requireNonNull(checksum);
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2BitReader.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2BitReader.java
@@ -15,12 +15,12 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 /**
  * An bit reader that allows the reading of single bit booleans, bit strings of
  * arbitrary length (up to 32 bits), and bit aligned 32-bit integers. A single byte
- * at a time is read from the {@link ByteBuf} when more bits are required.
+ * at a time is read from the {@link Buffer} when more bits are required.
  */
 class Bzip2BitReader {
     /**
@@ -29,9 +29,9 @@ class Bzip2BitReader {
     private static final int MAX_COUNT_OF_READABLE_BYTES = Integer.MAX_VALUE >>> 3;
 
     /**
-     * The {@link ByteBuf} from which to read data.
+     * The {@link Buffer} from which to read data.
      */
-    private ByteBuf in;
+    private Buffer in;
 
     /**
      * A buffer of bits read from the input stream that have not yet been returned.
@@ -44,14 +44,14 @@ class Bzip2BitReader {
     private int bitCount;
 
     /**
-     * Set the {@link ByteBuf} from which to read data.
+     * Set the {@link Buffer} from which to read data.
      */
-    void setByteBuf(ByteBuf in) {
+    void setBuffer(Buffer in) {
         this.in = in;
     }
 
     /**
-     * Reads up to 32 bits from the {@link ByteBuf}.
+     * Reads up to 32 bits from the {@link Buffer}.
      * @param count The number of bits to read (maximum {@code 32} as a size of {@code int})
      * @return The bits requested, right-aligned within the integer
      */
@@ -98,7 +98,7 @@ class Bzip2BitReader {
     }
 
     /**
-     * Reads a single bit from the {@link ByteBuf}.
+     * Reads a single bit from the {@link Buffer}.
      * @return {@code true} if the bit read was {@code 1}, otherwise {@code false}
      */
     boolean readBoolean() {
@@ -114,7 +114,7 @@ class Bzip2BitReader {
     }
 
     /**
-     * Refill the {@link ByteBuf} by one byte.
+     * Refill the {@link Buffer} by one byte.
      */
     void refill() {
         int readData = in.readUnsignedByte();
@@ -127,7 +127,7 @@ class Bzip2BitReader {
      * @return {@code true} if one bit is available for reading, otherwise {@code false}
      */
     boolean isReadable() {
-        return bitCount > 0 || in.isReadable();
+        return bitCount > 0 || in.readableBytes() > 0;
     }
 
     /**

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2BitWriter.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2BitWriter.java
@@ -15,12 +15,12 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 /**
  * A bit writer that allows the writing of single bit booleans, unary numbers, bit strings
  * of arbitrary length (up to 32 bits), and bit aligned 32-bit integers. A single byte at a
- * time is written to the {@link ByteBuf} when sufficient bits have been accumulated.
+ * time is written to the {@link Buffer} when sufficient bits have been accumulated.
  */
 final class Bzip2BitWriter {
     /**
@@ -34,11 +34,11 @@ final class Bzip2BitWriter {
     private int bitCount;
 
     /**
-     * Writes up to 32 bits to the output {@link ByteBuf}.
+     * Writes up to 32 bits to the output {@link Buffer}.
      * @param count The number of bits to write (maximum {@code 32} as a size of {@code int})
      * @param value The bits to write
      */
-    void writeBits(ByteBuf out, final int count, final long value) {
+    void writeBits(Buffer out, final int count, final long value) {
         if (count < 0 || count > 32) {
             throw new IllegalArgumentException("count: " + count + " (expected: 0-32)");
         }
@@ -56,10 +56,10 @@ final class Bzip2BitWriter {
     }
 
     /**
-     * Writes a single bit to the output {@link ByteBuf}.
+     * Writes a single bit to the output {@link Buffer}.
      * @param value The bit to write
      */
-    void writeBoolean(ByteBuf out, final boolean value) {
+    void writeBoolean(Buffer out, final boolean value) {
         int bitCount = this.bitCount + 1;
         long bitBuffer = this.bitBuffer | (value ? 1L << 64 - bitCount : 0L);
 
@@ -73,11 +73,11 @@ final class Bzip2BitWriter {
     }
 
     /**
-     * Writes a zero-terminated unary number to the output {@link ByteBuf}.
+     * Writes a zero-terminated unary number to the output {@link Buffer}.
      * Example of the output for value = 6: {@code 1111110}
      * @param value The number of {@code 1} to write
      */
-    void writeUnary(ByteBuf out, int value) {
+    void writeUnary(Buffer out, int value) {
         if (value < 0) {
             throw new IllegalArgumentException("value: " + value + " (expected 0 or more)");
         }
@@ -88,18 +88,18 @@ final class Bzip2BitWriter {
     }
 
     /**
-     * Writes an integer as 32 bits to the output {@link ByteBuf}.
+     * Writes an integer as 32 bits to the output {@link Buffer}.
      * @param value The integer to write
      */
-    void writeInt(ByteBuf out, final int value) {
+    void writeInt(Buffer out, final int value) {
         writeBits(out, 32, value);
     }
 
     /**
-     * Writes any remaining bits to the output {@link ByteBuf},
+     * Writes any remaining bits to the output {@link Buffer},
      * zero padding to a whole byte as required.
      */
-    void flush(ByteBuf out) {
+    void flush(Buffer out) {
         final int bitCount = this.bitCount;
 
         if (bitCount > 0) {
@@ -107,9 +107,9 @@ final class Bzip2BitWriter {
             final int shiftToRight = 64 - bitCount;
 
             if (bitCount <= 8) {
-                out.writeByte((int) (bitBuffer >>> shiftToRight << 8 - bitCount));
+                out.writeByte((byte) (bitBuffer >>> shiftToRight << 8 - bitCount));
             } else if (bitCount <= 16) {
-                out.writeShort((int) (bitBuffer >>> shiftToRight << 16 - bitCount));
+                out.writeShort((short) (bitBuffer >>> shiftToRight << 16 - bitCount));
             } else if (bitCount <= 24) {
                 out.writeMedium((int) (bitBuffer >>> shiftToRight << 24 - bitCount));
             } else {

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2HuffmanStageEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Bzip2HuffmanStageEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
 import java.util.Arrays;
 
@@ -299,7 +299,7 @@ final class Bzip2HuffmanStageEncoder {
     /**
      * Write out the selector list and Huffman tables.
      */
-    private void writeSelectorsAndHuffmanTables(ByteBuf out) {
+    private void writeSelectorsAndHuffmanTables(Buffer out) {
         final Bzip2BitWriter writer = this.writer;
         final byte[] selectors = this.selectors;
         final int totalSelectors = selectors.length;
@@ -338,7 +338,7 @@ final class Bzip2HuffmanStageEncoder {
     /**
      * Writes out the encoded block data.
      */
-    private void writeBlockData(ByteBuf out) {
+    private void writeBlockData(Buffer out) {
         final Bzip2BitWriter writer = this.writer;
         final int[][] huffmanMergedCodeSymbols = this.huffmanMergedCodeSymbols;
         final byte[] selectors = this.selectors;
@@ -359,7 +359,7 @@ final class Bzip2HuffmanStageEncoder {
     /**
      * Encodes and writes the block data.
      */
-    void encode(ByteBuf out) {
+    void encode(Buffer out) {
         // Create optimised selector list and Huffman tables
         generateHuffmanOptimisationSeeds();
         for (int i = 3; i >= 0; i--) {

--- a/codec/src/main/java/io/netty5/handler/codec/compression/CompressionUtil.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/CompressionUtil.java
@@ -22,7 +22,7 @@ final class CompressionUtil {
 
     private CompressionUtil() { }
 
-    static void checkChecksum(ByteBufChecksum checksum, Buffer uncompressed, int currentChecksum) {
+    static void checkChecksum(BufferChecksum checksum, Buffer uncompressed, int currentChecksum) {
         checksum.reset();
         checksum.update(uncompressed,
                 uncompressed.readerOffset(), uncompressed.readableBytes());

--- a/codec/src/main/java/io/netty5/handler/codec/compression/CompressionUtil.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/CompressionUtil.java
@@ -15,18 +15,17 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 
-import java.nio.ByteBuffer;
 
 final class CompressionUtil {
 
     private CompressionUtil() { }
 
-    static void checkChecksum(ByteBufChecksum checksum, ByteBuf uncompressed, int currentChecksum) {
+    static void checkChecksum(ByteBufChecksum checksum, Buffer uncompressed, int currentChecksum) {
         checksum.reset();
         checksum.update(uncompressed,
-                uncompressed.readerIndex(), uncompressed.readableBytes());
+                uncompressed.readerOffset(), uncompressed.readableBytes());
 
         final int checksumResult = (int) checksum.getValue();
         if (checksumResult != currentChecksum) {
@@ -34,15 +33,5 @@ final class CompressionUtil {
                     "stream corrupted: mismatching checksum: %d (expected: %d)",
                     checksumResult, currentChecksum));
         }
-    }
-
-    static ByteBuffer safeNioBuffer(ByteBuf buffer) {
-        return buffer.nioBufferCount() == 1 ? buffer.internalNioBuffer(buffer.readerIndex(), buffer.readableBytes())
-                : buffer.nioBuffer();
-    }
-
-    static ByteBuffer safeNioBuffer(ByteBuf buffer, int index, int length) {
-        return buffer.nioBufferCount() == 1 ? buffer.internalNioBuffer(index, length)
-                : buffer.nioBuffer(index, length);
     }
 }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Compressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Compressor.java
@@ -15,46 +15,46 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 
 /**
  * Compressor that takes care of compress some input.
  */
 public interface Compressor extends AutoCloseable {
     /**
-     * This method will read from the input {@link ByteBuf} and compress into a new {@link ByteBuf} that will be
-     * allocated (if needed) from the {@link ByteBufAllocator}. This method is expected to consume all data from the
+     * This method will read from the input {@link Buffer} and compress into a new {@link Buffer} that will be
+     * allocated (if needed) from the {@link BufferAllocator}. This method is expected to consume all data from the
      * input but <strong>not</strong> take ownership. The caller is responsible to release the input buffer after
      * this method returns.
      *
-     * @param input         the {@link ByteBuf} that contains the data to be compressed.
-     * @param allocator     the {@link ByteBufAllocator} that is used to allocate a new buffer (if needed) to write the
+     * @param input         the {@link Buffer} that contains the data to be compressed.
+     * @param allocator     the {@link BufferAllocator} that is used to allocate a new buffer (if needed) to write the
      *                      compressed bytes too.
-     * @return              the {@link ByteBuf} that contains the compressed data. The caller of this method takes
+     * @return              the {@link Buffer} that contains the compressed data. The caller of this method takes
      *                      ownership of the buffer. The return value will <strong>never</strong> be {@code null}.
      * @throws CompressionException   thrown if an compression error was encountered or the compressor was closed
      * already.
      */
-    ByteBuf compress(ByteBuf input, ByteBufAllocator allocator) throws CompressionException;
+    Buffer compress(Buffer input, BufferAllocator allocator) throws CompressionException;
 
     /**
-     * By calling this method we signal that the compression stream is marked as finish. The returned {@link ByteBuf}
+     * By calling this method we signal that the compression stream is marked as finish. The returned {@link Buffer}
      * might contain a "trailer" which marks the end of the stream.
      *
-     * @return  the {@link ByteBuf} which represent the end of the compression stream, which might be empty if the
+     * @return  the {@link Buffer} which represent the end of the compression stream, which might be empty if the
      *          compressor don't need a trailer to signal the end. The caller of this method takes
      *          ownership of the buffer. The return value will <strong>never</strong> be {@code null}.
-     * @throws CompressionException   thrown if an compression error was encountered or the compressor was closed
+     * @throws CompressionException   thrown if a compression error was encountered or the compressor was closed
      * already.
      */
-    ByteBuf finish(ByteBufAllocator allocator) throws CompressionException;
+    Buffer finish(BufferAllocator allocator) throws CompressionException;
 
     /**
      * Returns {@code} true if the compressor was finished or closed. This might happen because someone explicit called
-     * {@link #finish(ByteBufAllocator)} / {@link #close()} or the compressor implementation did decide to close itself
+     * {@link #finish(BufferAllocator)} / {@link #close()} or the compressor implementation did decide to close itself
      * due a compression error which can't be recovered. After {@link #isFinished()} returns {@code true} the
-     * {@link #compress(ByteBuf, ByteBufAllocator)} method will just return an empty buffer without consuming anything
+     * {@link #compress(Buffer, BufferAllocator)} method will just return an empty buffer without consuming anything
      * from its input buffer.
      *
      * @return  {@code true }if the compressor was marked as finished, {@code false} otherwise.
@@ -70,8 +70,8 @@ public interface Compressor extends AutoCloseable {
 
     /**#
      * Close the compressor. After this method was called {@link #isFinished()}
-     * will return {@code true} as well and it is not allowed to call {@link #compress(ByteBuf, ByteBufAllocator)} or
-     * {@link #finish(ByteBufAllocator)} anymore
+     * will return {@code true} as well and it is not allowed to call {@link #compress(Buffer, BufferAllocator)} or
+     * {@link #finish(BufferAllocator)} anymore
 -     */
     @Override
     void close();

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Crc32c.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Crc32c.java
@@ -25,7 +25,7 @@ import java.util.zip.Checksum;
  * The implementation of this class has been sourced from the Appendix of RFC 3309,
  * but with masking due to Java not being able to support unsigned types.
  */
-class Crc32c extends ByteBufChecksum {
+class Crc32c extends BufferChecksum {
     private static final int[] CRC_TABLE = {
             0x00000000, 0xF26B8303, 0xE13B70F7, 0x1350F3F4,
             0xC79A971F, 0x35F1141C, 0x26A1E7E8, 0xD4CA64EB,

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Crc32c.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Crc32c.java
@@ -15,6 +15,8 @@
  */
 package io.netty5.handler.codec.compression;
 
+import java.util.zip.Checksum;
+
 /**
  * Implements CRC32-C as defined in:
  * "Optimization of Cyclic Redundancy-CHeck Codes with 24 and 32 Parity Bits",
@@ -94,29 +96,33 @@ class Crc32c extends ByteBufChecksum {
     private static final long LONG_MASK = 0xFFFFFFFFL;
     private static final int BYTE_MASK = 0xFF;
 
-    private int crc = ~0;
+    Crc32c() {
+        super(new Checksum() {
+            private int crc = ~0;
 
-    @Override
-    public void update(int b) {
-        crc = crc32c(crc, b);
-    }
+            @Override
+            public void update(int b) {
+                crc = crc32c(crc, b);
+            }
 
-    @Override
-    public void update(byte[] buffer, int offset, int length) {
-        int end = offset + length;
-        for (int i = offset; i < end; i++) {
-            update(buffer[i]);
-        }
-    }
+            @Override
+            public void update(byte[] b, int off, int len) {
+                int end = off + len;
+                for (int i = off; i < end; i++) {
+                    update(b[i]);
+                }
+            }
 
-    @Override
-    public long getValue() {
-        return (crc ^ LONG_MASK) & LONG_MASK;
-    }
+            @Override
+            public long getValue() {
+                return (crc ^ LONG_MASK) & LONG_MASK;
+            }
 
-    @Override
-    public void reset() {
-        crc = ~0;
+            @Override
+            public void reset() {
+                crc = ~0;
+            }
+        });
     }
 
     private static int crc32c(int crc, int b) {

--- a/codec/src/main/java/io/netty5/handler/codec/compression/DecompressionHandler.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/DecompressionHandler.java
@@ -16,8 +16,10 @@
 package io.netty5.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -25,7 +27,7 @@ import java.util.function.Supplier;
 /**
  * {@link ByteToMessageDecoder} that uses a {@link Decompressor} for decompressing incoming {@link ByteBuf}s.
  */
-public final class DecompressionHandler extends ByteToMessageDecoder {
+public final class DecompressionHandler extends ByteToMessageDecoderForBuffer {
 
     private final Supplier<? extends Decompressor> decompressorSupplier;
     private final boolean discardBytesAfterFinished;
@@ -60,25 +62,25 @@ public final class DecompressionHandler extends ByteToMessageDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         if (decompressor == null) {
-            ctx.fireChannelRead(in.readRetainedSlice(in.readableBytes()));
+            ctx.fireChannelRead(in.readSplit(in.readableBytes()));
             return;
         }
         while (!decompressor.isFinished()) {
-            int idx = in.readerIndex();
-            ByteBuf decompressed = decompressor.decompress(in, ctx.alloc());
+            int idx = in.readerOffset();
+            Buffer decompressed = decompressor.decompress(in, ctx.bufferAllocator());
             if (decompressed != null) {
                 ctx.fireChannelRead(decompressed);
-            } else if (idx == in.readerIndex()) {
+            } else if (idx == in.readerOffset()) {
                 return;
             }
         }
         assert decompressor.isFinished();
         if (discardBytesAfterFinished) {
-            in.skipBytes(in.readableBytes());
+            in.skipReadable(in.readableBytes());
         } else {
-            ctx.fireChannelRead(in.readRetainedSlice(in.readableBytes()));
+            ctx.fireChannelRead(in.readSplit(in.readableBytes()));
         }
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/compression/DecompressionHandler.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/DecompressionHandler.java
@@ -64,7 +64,7 @@ public final class DecompressionHandler extends ByteToMessageDecoderForBuffer {
     @Override
     protected void decode(ChannelHandlerContext ctx, Buffer in) throws Exception {
         if (decompressor == null) {
-            ctx.fireChannelRead(in.readSplit(in.readableBytes()));
+            ctx.fireChannelRead(in.split());
             return;
         }
         while (!decompressor.isFinished()) {
@@ -80,7 +80,7 @@ public final class DecompressionHandler extends ByteToMessageDecoderForBuffer {
         if (discardBytesAfterFinished) {
             in.skipReadable(in.readableBytes());
         } else {
-            ctx.fireChannelRead(in.readSplit(in.readableBytes()));
+            ctx.fireChannelRead(in.split());
         }
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Decompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Decompressor.java
@@ -15,17 +15,17 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 
 /**
  * Decompressor that takes care of decompress some input.
  */
 public interface Decompressor extends AutoCloseable {
     /**
-     * This method will read from the input {@link ByteBuf} and decompress into a new {@link ByteBuf} that will be
-     * allocated (if needed) from the {@link ByteBufAllocator}. If there is not enough readable data in the
-     * {@link ByteBuf} to process it will return {@code null}.
+     * This method will read from the input {@link Buffer} and decompress into a new {@link Buffer} that will be
+     * allocated (if needed) from the {@link BufferAllocator}. If there is not enough readable data in the
+     * {@link Buffer} to process it will return {@code null}.
      *
      * This method should be called in a loop as long:
      *
@@ -36,17 +36,17 @@ public interface Decompressor extends AutoCloseable {
      * </li>
      * Otherwise this method should be called again once there is more data in the input buffer.
      *
-     * @param input         the {@link ByteBuf} that contains the data to be decompressed.
-     * @param allocator     the {@link ByteBufAllocator} that is used to allocate a new buffer (if needed) to write the
+     * @param input         the {@link Buffer} that contains the data to be decompressed.
+     * @param allocator     the {@link BufferAllocator} that is used to allocate a new buffer (if needed) to write the
      *                      decompressed bytes too.
-     * @return              the {@link ByteBuf} that contains the decompressed data. The caller of this method takes
+     * @return              the {@link Buffer} that contains the decompressed data. The caller of this method takes
      *                      ownership of the buffer. The return value will be {@code null} if there is not enough data
      *                      readable in the input to make any progress. In this case the user should call it again once
      *                      there is more data ready to be consumed.
      * @throws DecompressionException   thrown if an decompression error was encountered or the decompressor was closed
      *                                  before.
      */
-    ByteBuf decompress(ByteBuf input, ByteBufAllocator allocator) throws DecompressionException;
+    Buffer decompress(Buffer input, BufferAllocator allocator) throws DecompressionException;
 
     /**
      * Returns {@code} true if the decompressor was finish. This might be because the decompressor was explicitly closed
@@ -65,7 +65,7 @@ public interface Decompressor extends AutoCloseable {
 
     /**
      * Close the decompressor. After this method was called {@link #isFinished()}
-     * will return {@code true} as well and it is not allowed to call {@link #decompress(ByteBuf, ByteBufAllocator)}
+     * will return {@code true} as well and it is not allowed to call {@link #decompress(Buffer, BufferAllocator)}
      * anymore.
      */
     @Override

--- a/codec/src/main/java/io/netty5/handler/codec/compression/FastLzCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/FastLzCompressor.java
@@ -15,9 +15,8 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 
 import java.util.function.Supplier;
 import java.util.zip.Adler32;
@@ -38,7 +37,7 @@ import static io.netty5.handler.codec.compression.FastLz.OPTIONS_OFFSET;
 import static io.netty5.handler.codec.compression.FastLz.calculateOutputBufferLength;
 
 /**
- * Compresses a {@link ByteBuf} using the FastLZ algorithm.
+ * Compresses a {@link Buffer} using the FastLZ algorithm.
  *
  * See <a href="https://github.com/netty/netty/issues/2750">FastLZ format</a>.
  */
@@ -74,7 +73,7 @@ public final class FastLzCompressor implements Compressor {
      */
     private FastLzCompressor(int level, Checksum checksum) {
         this.level = level;
-        this.checksum = checksum == null ? null : ByteBufChecksum.wrapChecksum(checksum);
+        this.checksum = checksum == null ? null : new ByteBufChecksum(checksum);
     }
 
     /**
@@ -135,12 +134,12 @@ public final class FastLzCompressor implements Compressor {
     }
 
     @Override
-    public ByteBuf compress(ByteBuf in, ByteBufAllocator allocator) throws CompressionException {
+    public Buffer compress(Buffer in, BufferAllocator allocator) throws CompressionException {
         switch (state) {
             case CLOSED:
                 throw new CompressionException("Compressor closed");
             case FINISHED:
-                return Unpooled.EMPTY_BUFFER;
+                return allocator.allocate(0);
             case PROCESSING:
                 return compressData(in, allocator);
             default:
@@ -148,17 +147,19 @@ public final class FastLzCompressor implements Compressor {
         }
     }
 
-    private ByteBuf compressData(ByteBuf in, ByteBufAllocator allocator) {
+    private Buffer compressData(Buffer in, BufferAllocator allocator) {
         final ByteBufChecksum checksum = this.checksum;
-        ByteBuf out = allocator.buffer();
+        // TODO: Is this a good size ?
+        Buffer out = allocator.allocate(in.readableBytes() / 2);
         for (;;) {
-            if (!in.isReadable()) {
+            if (in.readableBytes() == 0) {
                 return out;
             }
-            final int idx = in.readerIndex();
+            final int idx = in.readerOffset();
             final int length = Math.min(in.readableBytes(), MAX_CHUNK_LENGTH);
 
-            final int outputIdx = out.writerIndex();
+            final int outputIdx = out.writerOffset();
+            out.ensureWritable(4);
             out.setMedium(outputIdx, MAGIC_NUMBER);
             int outputOffset = outputIdx + CHECKSUM_OFFSET + (checksum != null ? 4 : 0);
 
@@ -175,7 +176,7 @@ public final class FastLzCompressor implements Compressor {
                     checksum.update(in, idx, length);
                     out.setInt(outputIdx + CHECKSUM_OFFSET, (int) checksum.getValue());
                 }
-                out.setBytes(outputPtr, in, idx, length);
+                in.copyInto(idx, out, outputPtr, length);
                 chunkLength = length;
             } else {
                 // try to compress
@@ -188,39 +189,41 @@ public final class FastLzCompressor implements Compressor {
                 final int maxOutputLength = calculateOutputBufferLength(length);
                 out.ensureWritable(outputOffset + 4 + maxOutputLength);
                 final int outputPtr = outputOffset + 4;
+
                 final int compressedLength =
-                        FastLz.compress(in, in.readerIndex(), length, out, outputPtr, level);
+                        FastLz.compress(in, in.readerOffset(), length, out, outputPtr, level);
 
                 if (compressedLength < length) {
                     blockType = BLOCK_TYPE_COMPRESSED;
                     chunkLength = compressedLength;
 
-                    out.setShort(outputOffset, chunkLength);
+                    out.setShort(outputOffset, (short) chunkLength);
                     outputOffset += 2;
                 } else {
                     blockType = BLOCK_TYPE_NON_COMPRESSED;
-                    out.setBytes(outputOffset + 2, in, idx, length);
+                    in.copyInto(idx, out, outputOffset + 2, length);
+
                     chunkLength = length;
                 }
             }
-            out.setShort(outputOffset, length);
+            out.setShort(outputOffset, (short) length);
 
             out.setByte(outputIdx + OPTIONS_OFFSET,
-                    blockType | (checksum != null ? BLOCK_WITH_CHECKSUM : BLOCK_WITHOUT_CHECKSUM));
-            out.writerIndex(outputOffset + 2 + chunkLength);
-            in.skipBytes(length);
+                    (byte) (blockType | (checksum != null ? BLOCK_WITH_CHECKSUM : BLOCK_WITHOUT_CHECKSUM)));
+            out.writerOffset(outputOffset + 2 + chunkLength);
+            in.skipReadable(length);
         }
     }
 
     @Override
-    public ByteBuf finish(ByteBufAllocator allocator) {
+    public Buffer finish(BufferAllocator allocator) {
         switch (state) {
             case CLOSED:
                 throw new CompressionException("Compressor closed");
             case FINISHED:
             case PROCESSING:
                 state = State.FINISHED;
-                return Unpooled.EMPTY_BUFFER;
+                return allocator.allocate(0);
             default:
                 throw new IllegalStateException();
         }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/FastLzCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/FastLzCompressor.java
@@ -50,7 +50,7 @@ public final class FastLzCompressor implements Compressor {
     /**
      * Underlying checksum calculator in use.
      */
-    private final ByteBufChecksum checksum;
+    private final BufferChecksum checksum;
 
     private enum State {
         PROCESSING,
@@ -73,7 +73,7 @@ public final class FastLzCompressor implements Compressor {
      */
     private FastLzCompressor(int level, Checksum checksum) {
         this.level = level;
-        this.checksum = checksum == null ? null : new ByteBufChecksum(checksum);
+        this.checksum = checksum == null ? null : new BufferChecksum(checksum);
     }
 
     /**
@@ -148,9 +148,9 @@ public final class FastLzCompressor implements Compressor {
     }
 
     private Buffer compressData(Buffer in, BufferAllocator allocator) {
-        final ByteBufChecksum checksum = this.checksum;
-        // TODO: Is this a good size ?
-        Buffer out = allocator.allocate(in.readableBytes() / 2);
+        final BufferChecksum checksum = this.checksum;
+        // for text compression it can at max half the size, lets try to keep a bit of head-room.
+        Buffer out = allocator.allocate((int) ((double) in.readableBytes() / 1.5));
         for (;;) {
             if (in.readableBytes() == 0) {
                 return out;

--- a/codec/src/main/java/io/netty5/handler/codec/compression/FastLzDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/FastLzDecompressor.java
@@ -49,7 +49,7 @@ public final class FastLzDecompressor implements Decompressor {
     /**
      * Underlying checksum calculator in use.
      */
-    private final ByteBufChecksum checksum;
+    private final BufferChecksum checksum;
 
     /**
      * Length of current received chunk of data.
@@ -78,7 +78,7 @@ public final class FastLzDecompressor implements Decompressor {
     private int currentChecksum;
 
     private FastLzDecompressor(Checksum checksum) {
-        this.checksum = checksum == null ? null : new ByteBufChecksum(checksum);
+        this.checksum = checksum == null ? null : new BufferChecksum(checksum);
     }
 
     /**
@@ -178,7 +178,7 @@ public final class FastLzDecompressor implements Decompressor {
                         output = in.readSplit(chunkLength);
                     }
 
-                    final ByteBufChecksum checksum = this.checksum;
+                    final BufferChecksum checksum = this.checksum;
                     if (hasChecksum && checksum != null) {
                         checksum.reset();
                         checksum.update(output, output.readerOffset(), output.readableBytes());

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Compressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Compressor.java
@@ -72,7 +72,7 @@ public final class Lz4Compressor implements Compressor {
     /**
      * Underlying checksum calculator in use.
      */
-    private final ByteBufChecksum checksum;
+    private final BufferChecksum checksum;
 
     /**
      * Compression level of current LZ4 encoder (depends on {@link #blockSize}).
@@ -160,7 +160,7 @@ public final class Lz4Compressor implements Compressor {
                           Checksum checksum, int maxEncodeSize) {
         compressor = highCompressor ? factory.highCompressor() : factory.fastCompressor();
         this.checksum = checksum == null ? null : checksum instanceof Lz4XXHash32 ? (Lz4XXHash32) checksum :
-                new ByteBufChecksum(checksum);
+                new BufferChecksum(checksum);
 
         compressionLevel = compressionLevel(blockSize);
         this.blockSize = blockSize;

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Compressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Compressor.java
@@ -16,9 +16,8 @@
 
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.util.internal.ObjectUtil;
 import net.jpountz.lz4.LZ4Compressor;
@@ -45,7 +44,7 @@ import static io.netty5.handler.codec.compression.Lz4Constants.TOKEN_OFFSET;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Compresses a {@link ByteBuf} using the LZ4 format.
+ * Compresses a {@link Buffer} using the LZ4 format.
  *
  * See original <a href="https://github.com/Cyan4973/lz4">LZ4 Github project</a>
  * and <a href="https://fastcompression.blogspot.ru/2011/05/lz4-explained.html">LZ4 block format</a>
@@ -160,7 +159,8 @@ public final class Lz4Compressor implements Compressor {
     private Lz4Compressor(LZ4Factory factory, boolean highCompressor, int blockSize,
                           Checksum checksum, int maxEncodeSize) {
         compressor = highCompressor ? factory.highCompressor() : factory.fastCompressor();
-        this.checksum = ByteBufChecksum.wrapChecksum(checksum);
+        this.checksum = checksum == null ? null : checksum instanceof Lz4XXHash32 ? (Lz4XXHash32) checksum :
+                new ByteBufChecksum(checksum);
 
         compressionLevel = compressionLevel(blockSize);
         this.blockSize = blockSize;
@@ -180,7 +180,7 @@ public final class Lz4Compressor implements Compressor {
         return compressionLevel;
     }
 
-    private ByteBuf allocateBuffer(ByteBufAllocator allocator, ByteBuf msg) {
+    private Buffer allocateBuffer(BufferAllocator allocator, Buffer msg) {
         int targetBufSize = 0;
         int remaining = msg.readableBytes();
 
@@ -204,30 +204,30 @@ public final class Lz4Compressor implements Compressor {
                                                      "allowable size (%d bytes)", targetBufSize, maxEncodeSize));
         }
 
-        return allocator.buffer(targetBufSize);
+        return allocator.allocate(targetBufSize);
     }
 
     @Override
-    public ByteBuf compress(ByteBuf input, ByteBufAllocator allocator) throws CompressionException {
+    public Buffer compress(Buffer input, BufferAllocator allocator) throws CompressionException {
         switch (state) {
             case CLOSED:
                 throw new CompressionException("Compressor closed");
             case FINISHED:
-                return Unpooled.EMPTY_BUFFER;
+                return allocator.allocate(0);
             case PROCESSING:
-                if (!input.isReadable()) {
-                    return Unpooled.EMPTY_BUFFER;
+                if (input.readableBytes() == 0) {
+                    return allocator.allocate(0);
                 }
 
-                ByteBuf out = allocateBuffer(allocator, input);
+                Buffer out = allocateBuffer(allocator, input);
                 try {
                     // We need to compress as long as we have input to read as we are limited by the blockSize that
                     // is used.
-                    while (input.isReadable()) {
+                    while (input.readableBytes() > 0) {
                         compressData(input, out);
                     }
                 } catch (Throwable cause) {
-                    out.release();
+                    out.close();
                     throw cause;
                 }
                 return out;
@@ -237,7 +237,7 @@ public final class Lz4Compressor implements Compressor {
     }
 
     @Override
-    public ByteBuf finish(ByteBufAllocator allocator) {
+    public Buffer finish(BufferAllocator allocator) {
         switch (state) {
             case CLOSED:
                 throw new CompressionException("Compressor closed");
@@ -245,16 +245,16 @@ public final class Lz4Compressor implements Compressor {
             case PROCESSING:
                 state = State.FINISHED;
 
-                final ByteBuf footer = allocator.buffer(HEADER_LENGTH);
+                final Buffer footer = allocator.allocate(HEADER_LENGTH);
                 footer.ensureWritable(HEADER_LENGTH);
-                final int idx = footer.writerIndex();
+                final int idx = footer.writerOffset();
                 footer.setLong(idx, MAGIC_NUMBER);
                 footer.setByte(idx + TOKEN_OFFSET, (byte) (BLOCK_TYPE_NON_COMPRESSED | compressionLevel));
                 footer.setInt(idx + COMPRESSED_LENGTH_OFFSET, 0);
                 footer.setInt(idx + DECOMPRESSED_LENGTH_OFFSET, 0);
                 footer.setInt(idx + CHECKSUM_OFFSET, 0);
 
-                footer.writerIndex(idx + HEADER_LENGTH);
+                footer.skipWritable(HEADER_LENGTH);
                 return footer;
             default:
                 throw new IllegalStateException();
@@ -280,8 +280,8 @@ public final class Lz4Compressor implements Compressor {
      *
      * Encodes the input buffer into {@link #blockSize} chunks in the output buffer.
      */
-    private void compressData(ByteBuf in, ByteBuf out) {
-        int inReaderIndex = in.readerIndex();
+    private void compressData(Buffer in, Buffer out) {
+        int inReaderIndex = in.readerOffset();
         int flushableBytes = Math.min(in.readableBytes(), blockSize);
         assert flushableBytes > 0;
         checksum.reset();
@@ -290,33 +290,55 @@ public final class Lz4Compressor implements Compressor {
 
         final int bufSize = compressor.maxCompressedLength(flushableBytes) + HEADER_LENGTH;
         out.ensureWritable(bufSize);
-        final int idx = out.writerIndex();
-        int compressedLength;
+        final int idx = out.writerOffset();
+        int compressedLength = 0;
         try {
-            ByteBuffer outNioBuffer = out.internalNioBuffer(idx + HEADER_LENGTH, out.writableBytes() - HEADER_LENGTH);
-            int pos = outNioBuffer.position();
-            // We always want to start at position 0 as we take care of reusing the buffer in the encode(...) loop.
-            compressor.compress(in.internalNioBuffer(inReaderIndex, flushableBytes), outNioBuffer);
-            compressedLength = outNioBuffer.position() - pos;
+            out.skipWritable(HEADER_LENGTH);
+            assert out.countWritableComponents() == 1;
+            int readable = flushableBytes;
+
+            try (var writableIteration = out.forEachWritable()) {
+                var writableComponent = writableIteration.first();
+                try (var readableIteration = in.forEachReadable()) {
+                    for (var readableComponent = readableIteration.first();
+                         readableComponent != null; readableComponent = readableComponent.next()) {
+                        ByteBuffer outNioBuffer = writableComponent.writableBuffer();
+                        int pos = outNioBuffer.position();
+                        ByteBuffer inNioBuffer = readableComponent.readableBuffer();
+                        if (inNioBuffer.remaining() > readable) {
+                            inNioBuffer.limit(inNioBuffer.position() + readable);
+                            compressor.compress(inNioBuffer, outNioBuffer);
+                            compressedLength += outNioBuffer.position() - pos;
+                            break;
+                        } else {
+                            readable -= inNioBuffer.remaining();
+                            compressor.compress(inNioBuffer, outNioBuffer);
+                            compressedLength += outNioBuffer.position() - pos;
+                        }
+                    }
+                }
+            }
         } catch (LZ4Exception e) {
             throw new CompressionException(e);
+        } finally {
+            out.writerOffset(idx);
         }
         final int blockType;
         if (compressedLength >= flushableBytes) {
             blockType = BLOCK_TYPE_NON_COMPRESSED;
             compressedLength = flushableBytes;
-            out.setBytes(idx + HEADER_LENGTH, in, inReaderIndex, flushableBytes);
+            in.copyInto(inReaderIndex, out, idx + HEADER_LENGTH, flushableBytes);
         } else {
             blockType = BLOCK_TYPE_COMPRESSED;
         }
 
         out.setLong(idx, MAGIC_NUMBER);
         out.setByte(idx + TOKEN_OFFSET, (byte) (blockType | compressionLevel));
-        out.setIntLE(idx + COMPRESSED_LENGTH_OFFSET, compressedLength);
-        out.setIntLE(idx + DECOMPRESSED_LENGTH_OFFSET, flushableBytes);
-        out.setIntLE(idx + CHECKSUM_OFFSET, check);
-        out.writerIndex(idx + HEADER_LENGTH + compressedLength);
+        out.setInt(idx + COMPRESSED_LENGTH_OFFSET, Integer.reverseBytes(compressedLength));
+        out.setInt(idx + DECOMPRESSED_LENGTH_OFFSET, Integer.reverseBytes(flushableBytes));
+        out.setInt(idx + CHECKSUM_OFFSET, Integer.reverseBytes(check));
+        out.writerOffset(idx + HEADER_LENGTH + compressedLength);
 
-        in.readerIndex(inReaderIndex + flushableBytes);
+        in.readerOffset(inReaderIndex + flushableBytes);
     }
 }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Decompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Lz4Decompressor.java
@@ -71,7 +71,7 @@ public final class Lz4Decompressor implements Decompressor {
     /**
      * Underlying checksum calculator in use.
      */
-    private ByteBufChecksum checksum;
+    private BufferChecksum checksum;
 
     /**
      * Type of current block.
@@ -105,7 +105,7 @@ public final class Lz4Decompressor implements Decompressor {
     private Lz4Decompressor(LZ4Factory factory, Checksum checksum) {
         decompressor = factory.fastDecompressor();
         this.checksum = checksum == null ? null : checksum instanceof Lz4XXHash32 ? (Lz4XXHash32) checksum :
-                new ByteBufChecksum(checksum);
+                new BufferChecksum(checksum);
     }
 
     /**
@@ -178,6 +178,7 @@ public final class Lz4Decompressor implements Decompressor {
             }
         }
     }
+
     @Override
     public Buffer decompress(Buffer in, BufferAllocator allocator) throws DecompressionException {
         try {
@@ -250,7 +251,7 @@ public final class Lz4Decompressor implements Decompressor {
                         return null;
                     }
 
-                    final ByteBufChecksum checksum = this.checksum;
+                    final BufferChecksum checksum = this.checksum;
                     Buffer uncompressed = null;
 
                     try {

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Lz4XXHash32.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Lz4XXHash32.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.zip.Checksum;
 
 /**
- * A special-purpose {@link ByteBufChecksum} implementation for use with
+ * A special-purpose {@link BufferChecksum} implementation for use with
  * {@link Lz4Compressor} and {@link Lz4Decompressor}.
  *
  * {@link StreamingXXHash32#asChecksum()} has a particularly nasty implementation
@@ -46,7 +46,7 @@ import java.util.zip.Checksum;
  * {@link Lz4Compressor} and {@link Lz4Decompressor}:
  * {@code reset()}, followed by one {@code update()}, followed by {@code getValue()}.
  */
-public final class Lz4XXHash32 extends ByteBufChecksum {
+public final class Lz4XXHash32 extends BufferChecksum {
 
     private static final XXHash32 XXHASH32 = XXHashFactory.fastestInstance().hash32();
 

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Snappy.java
@@ -499,8 +499,7 @@ public final class Snappy {
     private static void copyRegion(Buffer out, int initialIndex, int offset, int length) {
         out.readerOffset(initialIndex - offset);
         out.copyInto(out.readerOffset(), out, out.writerOffset(), length);
-        out.skipReadable(length);
-        out.skipWritable(length);
+        out.skipWritable(length).skipReadable(length);
     }
 
     /**

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Snappy.java
@@ -16,6 +16,8 @@
 package io.netty5.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.BufferUtil;
+import io.netty5.buffer.api.Buffer;
 
 /**
  * Uncompresses an input {@link ByteBuf} encoded with Snappy compression into an
@@ -55,19 +57,19 @@ public final class Snappy {
         written = 0;
     }
 
-    public void encode(final ByteBuf in, final ByteBuf out, final int length) {
+    public void encode(final Buffer in, final Buffer out, final int length) {
         // Write the preamble length to the output buffer
         for (int i = 0;; i ++) {
             int b = length >>> i * 7;
             if ((b & 0xFFFFFF80) != 0) {
-                out.writeByte(b & 0x7f | 0x80);
+                out.writeByte((byte) (b & 0x7f | 0x80));
             } else {
-                out.writeByte(b);
+                out.writeByte((byte) b);
                 break;
             }
         }
 
-        int inIndex = in.readerIndex();
+        int inIndex = in.readerOffset();
         final int baseIndex = inIndex;
 
         final short[] table = getHashTable(length);
@@ -110,7 +112,7 @@ public final class Snappy {
                     inIndex += matched;
                     int offset = base - candidate;
                     encodeCopy(out, offset, matched);
-                    in.readerIndex(in.readerIndex() + matched);
+                    in.readerOffset(in.readerOffset() + matched);
                     insertTail = inIndex - 1;
                     nextEmit = inIndex;
                     if (inIndex >= length - 4) {
@@ -146,7 +148,7 @@ public final class Snappy {
      *     within the range of our hash table size
      * @return A 32-bit hash of 4 bytes located at index
      */
-    private static int hash(ByteBuf in, int index, int shift) {
+    private static int hash(Buffer in, int index, int shift) {
         return in.getInt(index) * 0x1e35a7bd >>> shift;
     }
 
@@ -175,7 +177,7 @@ public final class Snappy {
      * @param maxIndex The length of our input buffer
      * @return The number of bytes for which our candidate copy is a repeat of
      */
-    private static int findMatchingLength(ByteBuf in, int minIndex, int inIndex, int maxIndex) {
+    private static int findMatchingLength(Buffer in, int minIndex, int inIndex, int maxIndex) {
         int matched = 0;
 
         while (inIndex <= maxIndex - 4 &&
@@ -219,29 +221,32 @@ public final class Snappy {
      * @param out The output buffer to copy to
      * @param length The length of the literal to copy
      */
-    static void encodeLiteral(ByteBuf in, ByteBuf out, int length) {
+    static void encodeLiteral(Buffer in, Buffer out, int length) {
         if (length < 61) {
-            out.writeByte(length - 1 << 2);
+            out.writeByte((byte) (length - 1 << 2));
         } else {
             int bitLength = bitsToEncode(length - 1);
             int bytesToEncode = 1 + bitLength / 8;
-            out.writeByte(59 + bytesToEncode << 2);
+            out.writeByte((byte) (59 + bytesToEncode << 2));
             for (int i = 0; i < bytesToEncode; i++) {
-                out.writeByte(length - 1 >> i * 8 & 0x0ff);
+                out.writeByte((byte) (length - 1 >> i * 8 & 0x0ff));
             }
         }
 
-        out.writeBytes(in, length);
+        out.ensureWritable(length);
+        in.copyInto(in.readerOffset(), out, out.writerOffset(), length);
+        in.skipReadable(length);
+        out.skipWritable(length);
     }
 
-    private static void encodeCopyWithOffset(ByteBuf out, int offset, int length) {
+    private static void encodeCopyWithOffset(Buffer out, int offset, int length) {
         if (length < 12 && offset < 2048) {
-            out.writeByte(COPY_1_BYTE_OFFSET | length - 4 << 2 | offset >> 8 << 5);
-            out.writeByte(offset & 0x0ff);
+            out.writeByte((byte) (COPY_1_BYTE_OFFSET | length - 4 << 2 | offset >> 8 << 5));
+            out.writeByte((byte) (offset & 0x0ff));
         } else {
-            out.writeByte(COPY_2_BYTE_OFFSET | length - 1 << 2);
-            out.writeByte(offset & 0x0ff);
-            out.writeByte(offset >> 8 & 0x0ff);
+            out.writeByte((byte) (COPY_2_BYTE_OFFSET | length - 1 << 2));
+            out.writeByte((byte) (offset & 0x0ff));
+            out.writeByte((byte) (offset >> 8 & 0x0ff));
         }
     }
 
@@ -252,7 +257,7 @@ public final class Snappy {
      * @param offset The offset at which the original instance lies
      * @param length The length of the original instance
      */
-    private static void encodeCopy(ByteBuf out, int offset, int length) {
+    private static void encodeCopy(Buffer out, int offset, int length) {
         while (length >= 68) {
             encodeCopyWithOffset(out, offset, 64);
             length -= 64;
@@ -266,8 +271,8 @@ public final class Snappy {
         encodeCopyWithOffset(out, offset, length);
     }
 
-    public void decode(ByteBuf in, ByteBuf out) {
-        while (in.isReadable()) {
+    public void decode(Buffer in, Buffer out) {
+        while (in.readableBytes() > 0) {
             switch (state) {
             case READING_PREAMBLE:
                 int uncompressedLength = readPreamble(in);
@@ -283,7 +288,7 @@ public final class Snappy {
                 state = State.READING_TAG;
                 // fall through
             case READING_TAG:
-                if (!in.isReadable()) {
+                if (in.readableBytes() == 0) {
                     return;
                 }
                 tag = in.readByte();
@@ -355,10 +360,10 @@ public final class Snappy {
      * @return The calculated length based on the input buffer, or 0 if
      *   no preamble is able to be calculated
      */
-    private static int readPreamble(ByteBuf in) {
+    private static int readPreamble(Buffer in) {
         int length = 0;
         int byteIndex = 0;
-        while (in.isReadable()) {
+        while (in.readableBytes() > 0) {
             int current = in.readUnsignedByte();
             length |= (current & 0x7f) << byteIndex++ * 7;
             if ((current & 0x80) == 0) {
@@ -382,13 +387,13 @@ public final class Snappy {
      * @return The calculated length based on the input buffer, or 0 if
      *   no preamble is able to be calculated
      */
-    int getPreamble(ByteBuf in) {
+    int getPreamble(Buffer in) {
         if (state == State.READING_PREAMBLE) {
-            int readerIndex = in.readerIndex();
+            int readerIndex = in.readerOffset();
             try {
                 return readPreamble(in);
             } finally {
-                in.readerIndex(readerIndex);
+                in.readerOffset(readerIndex);
             }
         }
         return 0;
@@ -405,12 +410,12 @@ public final class Snappy {
      * @param out The output buffer to write the literal to
      * @return The number of bytes appended to the output buffer, or -1 to indicate "try again later"
      */
-    static int decodeLiteral(byte tag, ByteBuf in, ByteBuf out) {
-        int readerIndex = in.readerIndex();
+    static int decodeLiteral(byte tag, Buffer in, Buffer out) {
+        int readerIndex = in.readerOffset();
         int length;
         switch(tag >> 2 & 0x3F) {
         case 60:
-            if (!in.isReadable()) {
+            if (in.readableBytes() == 0) {
                 return NOT_ENOUGH_INPUT;
             }
             length = in.readUnsignedByte();
@@ -419,19 +424,19 @@ public final class Snappy {
             if (in.readableBytes() < 2) {
                 return NOT_ENOUGH_INPUT;
             }
-            length = in.readUnsignedShortLE();
+            length = BufferUtil.reverseUnsignedShort(in.readUnsignedShort());
             break;
         case 62:
             if (in.readableBytes() < 3) {
                 return NOT_ENOUGH_INPUT;
             }
-            length = in.readUnsignedMediumLE();
+            length = BufferUtil.reverseUnsignedMedium(in.readUnsignedMedium());
             break;
         case 63:
             if (in.readableBytes() < 4) {
                 return NOT_ENOUGH_INPUT;
             }
-            length = in.readIntLE();
+            length = Integer.reverseBytes(in.readInt());
             break;
         default:
             length = tag >> 2 & 0x3F;
@@ -439,11 +444,14 @@ public final class Snappy {
         length += 1;
 
         if (in.readableBytes() < length) {
-            in.readerIndex(readerIndex);
+            in.readerOffset(readerIndex);
             return NOT_ENOUGH_INPUT;
         }
 
-        out.writeBytes(in, length);
+        out.ensureWritable(length);
+        in.copyInto(in.readerOffset(), out, out.writerOffset(), length);
+        in.skipReadable(length);
+        out.skipWritable(length);
         return length;
     }
 
@@ -460,35 +468,39 @@ public final class Snappy {
      *     "try again later"
      * @throws DecompressionException If the read offset is invalid
      */
-    private static int decodeCopyWith1ByteOffset(byte tag, ByteBuf in, ByteBuf out, int writtenSoFar) {
-        if (!in.isReadable()) {
+    private static int decodeCopyWith1ByteOffset(byte tag, Buffer in, Buffer out, int writtenSoFar) {
+        if (in.readableBytes() == 0) {
             return NOT_ENOUGH_INPUT;
         }
 
-        int initialIndex = out.writerIndex();
+        int initialIndex = out.writerOffset();
         int length = 4 + ((tag & 0x01c) >> 2);
         int offset = (tag & 0x0e0) << 8 >> 5 | in.readUnsignedByte();
 
         validateOffset(offset, writtenSoFar);
 
-        int readerIndex = out.readerIndex();
+        int readerIndex = out.readerOffset();
         if (offset < length) {
             int copies = length / offset;
             for (; copies > 0; copies--) {
-                out.readerIndex(initialIndex - offset);
-                out.readBytes(out, offset);
+                copyRegion(out, initialIndex, offset, offset);
             }
             if (length % offset != 0) {
-                out.readerIndex(initialIndex - offset);
-                out.readBytes(out, length % offset);
+                copyRegion(out, initialIndex, offset, length % offset);
             }
         } else {
-            out.readerIndex(initialIndex - offset);
-            out.readBytes(out, length);
+            copyRegion(out, initialIndex, offset, length);
         }
-        out.readerIndex(readerIndex);
+        out.readerOffset(readerIndex);
 
         return length;
+    }
+
+    private static void copyRegion(Buffer out, int initialIndex, int offset, int length) {
+        out.readerOffset(initialIndex - offset);
+        out.copyInto(out.readerOffset(), out, out.writerOffset(), length);
+        out.skipReadable(length);
+        out.skipWritable(length);
     }
 
     /**
@@ -504,33 +516,30 @@ public final class Snappy {
      * @return The number of bytes appended to the output buffer, or -1 to indicate
      *     "try again later"
      */
-    private static int decodeCopyWith2ByteOffset(byte tag, ByteBuf in, ByteBuf out, int writtenSoFar) {
+    private static int decodeCopyWith2ByteOffset(byte tag, Buffer in, Buffer out, int writtenSoFar) {
         if (in.readableBytes() < 2) {
             return NOT_ENOUGH_INPUT;
         }
 
-        int initialIndex = out.writerIndex();
+        int initialIndex = out.writerOffset();
         int length = 1 + (tag >> 2 & 0x03f);
-        int offset = in.readUnsignedShortLE();
+        int offset = BufferUtil.reverseUnsignedShort(in.readUnsignedShort());
 
         validateOffset(offset, writtenSoFar);
 
-        int readerIndex = out.readerIndex();
+        int readerIndex = out.readerOffset();
         if (offset < length) {
             int copies = length / offset;
             for (; copies > 0; copies--) {
-                out.readerIndex(initialIndex - offset);
-                out.readBytes(out, offset);
+                copyRegion(out, initialIndex, offset, offset);
             }
             if (length % offset != 0) {
-                out.readerIndex(initialIndex - offset);
-                out.readBytes(out, length % offset);
+                copyRegion(out, initialIndex, offset, length % offset);
             }
         } else {
-            out.readerIndex(initialIndex - offset);
-            out.readBytes(out, length);
+            copyRegion(out, initialIndex, offset, length);
         }
-        out.readerIndex(readerIndex);
+        out.readerOffset(readerIndex);
 
         return length;
     }
@@ -548,33 +557,30 @@ public final class Snappy {
      *     "try again later"
      * @throws DecompressionException If the read offset is invalid
      */
-    private static int decodeCopyWith4ByteOffset(byte tag, ByteBuf in, ByteBuf out, int writtenSoFar) {
+    private static int decodeCopyWith4ByteOffset(byte tag, Buffer in, Buffer out, int writtenSoFar) {
         if (in.readableBytes() < 4) {
             return NOT_ENOUGH_INPUT;
         }
 
-        int initialIndex = out.writerIndex();
+        int initialIndex = out.writerOffset();
         int length = 1 + (tag >> 2 & 0x03F);
-        int offset = in.readIntLE();
+        int offset = Integer.reverseBytes(in.readInt());
 
         validateOffset(offset, writtenSoFar);
 
-        int readerIndex = out.readerIndex();
+        int readerIndex = out.readerOffset();
         if (offset < length) {
             int copies = length / offset;
             for (; copies > 0; copies--) {
-                out.readerIndex(initialIndex - offset);
-                out.readBytes(out, offset);
+                copyRegion(out, initialIndex, offset, offset);
             }
             if (length % offset != 0) {
-                out.readerIndex(initialIndex - offset);
-                out.readBytes(out, length % offset);
+                copyRegion(out, initialIndex, offset, length % offset);
             }
         } else {
-            out.readerIndex(initialIndex - offset);
-            out.readBytes(out, length);
+            copyRegion(out, initialIndex, offset, length);
         }
-        out.readerIndex(readerIndex);
+        out.readerOffset(readerIndex);
 
         return length;
     }
@@ -609,8 +615,8 @@ public final class Snappy {
      *
      * @param data The input data to calculate the CRC32C checksum of
      */
-    static int calculateChecksum(ByteBuf data) {
-        return calculateChecksum(data, data.readerIndex(), data.readableBytes());
+    static int calculateChecksum(Buffer data) {
+        return calculateChecksum(data, data.readerOffset(), data.readableBytes());
     }
 
     /**
@@ -619,7 +625,7 @@ public final class Snappy {
      *
      * @param data The input data to calculate the CRC32C checksum of
      */
-    static int calculateChecksum(ByteBuf data, int offset, int length) {
+    static int calculateChecksum(Buffer data, int offset, int length) {
         Crc32c crc32 = new Crc32c();
         try {
             crc32.update(data, offset, length);
@@ -638,8 +644,8 @@ public final class Snappy {
      * @param data The input data to calculate the CRC32C checksum of
      * @throws DecompressionException If the calculated and supplied checksums do not match
      */
-    static void validateChecksum(int expectedChecksum, ByteBuf data) {
-        validateChecksum(expectedChecksum, data, data.readerIndex(), data.readableBytes());
+    static void validateChecksum(int expectedChecksum, Buffer data) {
+        validateChecksum(expectedChecksum, data, data.readerOffset(), data.readableBytes());
     }
 
     /**
@@ -651,7 +657,7 @@ public final class Snappy {
      * @param data The input data to calculate the CRC32C checksum of
      * @throws DecompressionException If the calculated and supplied checksums do not match
      */
-    static void validateChecksum(int expectedChecksum, ByteBuf data, int offset, int length) {
+    static void validateChecksum(int expectedChecksum, Buffer data, int offset, int length) {
         final int actualChecksum = calculateChecksum(data, offset, length);
         if (actualChecksum != expectedChecksum) {
             throw new DecompressionException(

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
@@ -266,7 +266,7 @@ public final class ZlibCompressor implements Compressor {
                         footer.writeByte((byte) crcValue);
                         footer.writeByte((byte) (crcValue >>> 8));
                         footer.writeByte((byte) (crcValue >>> 16));
-                        footer.writeByte((byte) ((crcValue >>> 24)));
+                        footer.writeByte((byte) (crcValue >>> 24));
                         footer.writeByte((byte) uncBytes);
                         footer.writeByte((byte) (uncBytes >>> 8));
                         footer.writeByte((byte) (uncBytes >>> 16));

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
@@ -195,7 +195,8 @@ public final class ZlibCompressor implements Compressor {
         Buffer out = allocator.allocate(sizeEstimate);
 
         try (var readableIteration = uncompressed.forEachReadable()) {
-            for (var readableComponent = readableIteration.first(); readableComponent != null; readableComponent = readableComponent.next()) {
+            for (var readableComponent = readableIteration.first();
+                 readableComponent != null; readableComponent = readableComponent.next()) {
                 compressData(readableComponent.readableBuffer(), out);
             }
         }
@@ -302,11 +303,13 @@ public final class ZlibCompressor implements Compressor {
 
     private void deflate(Buffer out) {
         try (var writableIteration = out.forEachWritable()) {
-            for (var writableComponent = writableIteration.first(); writableComponent != null; writableComponent = writableComponent.next()) {
+            for (var writableComponent = writableIteration.first();
+                 writableComponent != null; writableComponent = writableComponent.next()) {
                 if (writableComponent.hasWritableArray()) {
                     for (;;) {
                         int numBytes = deflater.deflate(
-                                writableComponent.writableArray(), writableComponent.writableArrayOffset(),  writableComponent.writableBytes(), Deflater.SYNC_FLUSH);
+                                writableComponent.writableArray(), writableComponent.writableArrayOffset(),
+                                writableComponent.writableBytes(), Deflater.SYNC_FLUSH);
                         if (numBytes <= 0) {
                             break;
                         }
@@ -323,6 +326,5 @@ public final class ZlibCompressor implements Compressor {
                 }
             }
         }
-
     }
 }

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibCompressor.java
@@ -199,8 +199,6 @@ public final class ZlibCompressor implements Compressor {
             for (var readableComponent = readableIteration.first();
                  readableComponent != null; readableComponent = readableComponent.next()) {
                 compressData(readableComponent.readableBuffer(), out);
-                // TODO: Is this needed ?
-                readableComponent.skipReadable(readableComponent.readableBytes());
             }
         }
         return out;

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
@@ -295,10 +295,9 @@ public final class ZlibDecompressor implements Decompressor {
                             readFooter = true;
                         }
                         break;
-                    } else {
-                        decompressed = prepareDecompressBuffer(allocator, decompressed, inflater.getRemaining() << 1);
                     }
                 }
+                decompressed = prepareDecompressBuffer(allocator, decompressed, inflater.getRemaining() << 1);
             }
 
             int remaining = inflater.getRemaining();
@@ -552,21 +551,14 @@ public final class ZlibDecompressor implements Decompressor {
             return buf;
         }
 
-        // TODO: Fix me
-        /*
-        // this always expands the buffer if possible, even if the expansion is less than preferredSize
-        // we throw the exception only if the buffer could not be expanded at all
-        // this means that one final attempt to deserialize will always be made with the buffer at maxAllocation
-        if (buffer.ensureWritable(preferredSize, true) == 1) {
-            // buffer must be consumed so subclasses don't add it to output
-            // we therefore duplicate it when calling decompressionBufferExhausted() to guarantee non-interference
-            // but wait until after to consume it so the subclass can tell how much output is really in the buffer
-            decompressionBufferExhausted(buffer.duplicate());
+        // TODO:
+        buffer.ensureWritable(preferredSize);
+        if (buffer.writableBytes() < preferredSize) {
+            decompressionBufferExhausted(buffer);
             buffer.skipReadable(buffer.readableBytes());
             throw new DecompressionException(
-                    "Decompression buffer has reached maximum size: " + buffer.maxCapacity());
+                    "Decompression buffer has reached maximum size: " + buffer.capacity());
         }
-        */
         return buffer;
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
@@ -301,7 +301,8 @@ public final class ZlibDecompressor implements Decompressor {
                 }
             }
 
-            in.skipReadable(readableBytes - inflater.getRemaining());
+            int remaining = inflater.getRemaining();
+            in.skipReadable(readableBytes - remaining);
 
             if (readFooter) {
                 gzipState = GzipState.FOOTER_START;

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
@@ -41,7 +41,7 @@ public final class ZlibDecompressor implements Decompressor {
     private final byte[] dictionary;
 
     // GZIP related
-    private final ByteBufChecksum crc;
+    private final BufferChecksum crc;
     private final boolean decompressConcatenated;
 
     /**
@@ -76,7 +76,7 @@ public final class ZlibDecompressor implements Decompressor {
         switch (wrapper) {
             case GZIP:
                 inflater = new Inflater(true);
-                crc = new ByteBufChecksum(new CRC32());
+                crc = new BufferChecksum(new CRC32());
                 break;
             case NONE:
                 inflater = new Inflater(true);

--- a/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/ZlibDecompressor.java
@@ -15,9 +15,8 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 
 import java.nio.ByteBuffer;
 import java.util.function.Supplier;
@@ -29,7 +28,7 @@ import java.util.zip.Inflater;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Decompress a {@link ByteBuf} using the inflate algorithm.
+ * Decompress a {@link Buffer} using the inflate algorithm.
  */
 public final class ZlibDecompressor implements Decompressor {
     private static final int FHCRC = 0x02;
@@ -77,7 +76,7 @@ public final class ZlibDecompressor implements Decompressor {
         switch (wrapper) {
             case GZIP:
                 inflater = new Inflater(true);
-                crc = ByteBufChecksum.wrapChecksum(new CRC32());
+                crc = new ByteBufChecksum(new CRC32());
                 break;
             case NONE:
                 inflater = new Inflater(true);
@@ -113,7 +112,7 @@ public final class ZlibDecompressor implements Decompressor {
      *
      * @param maxAllocation
      *          Maximum size of the decompression buffer. Must be &gt;= 0.
-     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
+     *          If zero, maximum size is decided by the {@link BufferAllocator}.
      * @return the factory.
      */
     public static Supplier<ZlibDecompressor> newFactory(int maxAllocation) {
@@ -138,7 +137,7 @@ public final class ZlibDecompressor implements Decompressor {
      *
      * @param maxAllocation
      *          Maximum size of the decompression buffer. Must be &gt;= 0.
-     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
+     *          If zero, maximum size is decided by the {@link BufferAllocator}.
      * @return the factory.
      */
     public static Supplier<ZlibDecompressor> newFactory(byte[] dictionary, int maxAllocation) {
@@ -163,7 +162,7 @@ public final class ZlibDecompressor implements Decompressor {
      *
      * @param maxAllocation
      *          Maximum size of the decompression buffer. Must be &gt;= 0.
-     *          If zero, maximum size is decided by the {@link ByteBufAllocator}.
+     *          If zero, maximum size is decided by the {@link BufferAllocator}.
      * @return the factory.
      */
     public static Supplier<ZlibDecompressor> newFactory(ZlibWrapper wrapper, int maxAllocation) {
@@ -194,12 +193,12 @@ public final class ZlibDecompressor implements Decompressor {
     }
 
     @Override
-    public ByteBuf decompress(ByteBuf in, ByteBufAllocator allocator) throws DecompressionException {
+    public Buffer decompress(Buffer in, BufferAllocator allocator) throws DecompressionException {
         if (closed) {
             throw new DecompressionException("Decompressor closed");
         }
         if (finished) {
-            return Unpooled.EMPTY_BUFFER;
+            return allocator.allocate(0);
         }
 
         int readableBytes = in.readableBytes();
@@ -213,7 +212,7 @@ public final class ZlibDecompressor implements Decompressor {
                 return null;
             }
 
-            boolean nowrap = !looksLikeZlib(in.getShort(in.readerIndex()));
+            boolean nowrap = !looksLikeZlib(in.getShort(in.readerOffset()));
             inflater = new Inflater(nowrap);
             decideZlibOrNone = false;
         }
@@ -241,83 +240,90 @@ public final class ZlibDecompressor implements Decompressor {
         }
 
         if (inflater.needsInput()) {
-            if (in.hasArray()) {
-                inflater.setInput(in.array(), in.arrayOffset() + in.readerIndex(), readableBytes);
-            } else {
-                if (in.nioBufferCount() == 1) {
-                    inflater.setInput(in.internalNioBuffer(in.readerIndex(), readableBytes));
+            try (var readableIteration = in.forEachReadable()) {
+                var readableComponent = readableIteration.first();
+                if (readableComponent.hasReadableArray()) {
+                    inflater.setInput(readableComponent.readableArray(),
+                            readableComponent.readableArrayOffset(), readableComponent.readableBytes());
                 } else {
-                    inflater.setInput(in.nioBuffer(in.readerIndex(), readableBytes));
+                    inflater.setInput(readableComponent.readableBuffer());
                 }
             }
         }
 
-        ByteBuf decompressed = prepareDecompressBuffer(allocator, null, inflater.getRemaining() << 1);
+        Buffer decompressed = prepareDecompressBuffer(allocator, null, inflater.getRemaining() << 1);
         try {
             boolean readFooter = false;
             while (!inflater.needsInput()) {
-                int writerIndex = decompressed.writerIndex();
-                int writable = decompressed.writableBytes();
-                int outputLength;
-                if (decompressed.hasArray()) {
-                    byte[] outArray = decompressed.array();
-                    int outIndex = decompressed.arrayOffset() + writerIndex;
-                    outputLength = inflater.inflate(outArray, outIndex, writable);
-                } else if (decompressed.nioBufferCount() == 1) {
-                    ByteBuffer buffer = decompressed.internalNioBuffer(writerIndex, writable);
-                    outputLength = inflater.inflate(buffer);
-                } else {
+                int writableComponents = decompressed.countWritableComponents();
+                if (writableComponents == 0) {
+                    break;
+                } else if (writableComponents > 1) {
                     throw new IllegalStateException(
                             "Decompress buffer must have array or exactly 1 NIO buffer: " + decompressed);
                 }
-                if (outputLength > 0) {
-                    decompressed.writerIndex(writerIndex + outputLength);
-                    if (crc != null) {
-                        crc.update(decompressed, writerIndex, outputLength);
-                    }
-                } else  if (inflater.needsDictionary()) {
-                    if (dictionary == null) {
-                        throw new DecompressionException(
-                                "decompression failure, unable to set dictionary as non was specified");
-                    }
-                    inflater.setDictionary(dictionary);
-                }
-
-                if (inflater.finished()) {
-                    if (crc == null) {
-                        finished = true; // Do not decode anymore.
+                try (var writableIteration = decompressed.forEachWritable()) {
+                    var writableComponent = writableIteration.first();
+                    int writerIndex = decompressed.writerOffset();
+                    int writable = decompressed.writableBytes();
+                    int outputLength;
+                    if (writableComponent.hasWritableArray()) {
+                        byte[] outArray = writableComponent.writableArray();
+                        int outIndex = writableComponent.writableArrayOffset();
+                        outputLength = inflater.inflate(outArray, outIndex, writable);
                     } else {
-                        readFooter = true;
+                        ByteBuffer buffer = writableComponent.writableBuffer();
+                        outputLength = inflater.inflate(buffer);
                     }
-                    break;
-                } else {
-                    decompressed = prepareDecompressBuffer(allocator, decompressed, inflater.getRemaining() << 1);
+                    if (outputLength > 0) {
+                        writableComponent.skipWritable(outputLength);
+                        if (crc != null) {
+                            crc.update(decompressed, writerIndex, outputLength);
+                        }
+                    } else if (inflater.needsDictionary()) {
+                        if (dictionary == null) {
+                            throw new DecompressionException(
+                                    "decompression failure, unable to set dictionary as non was specified");
+                        }
+                        inflater.setDictionary(dictionary);
+                    }
+
+                    if (inflater.finished()) {
+                        if (crc == null) {
+                            finished = true; // Do not decode anymore.
+                        } else {
+                            readFooter = true;
+                        }
+                        break;
+                    } else {
+                        decompressed = prepareDecompressBuffer(allocator, decompressed, inflater.getRemaining() << 1);
+                    }
                 }
             }
 
-            in.skipBytes(readableBytes - inflater.getRemaining());
+            in.skipReadable(readableBytes - inflater.getRemaining());
 
             if (readFooter) {
                 gzipState = GzipState.FOOTER_START;
                 handleGzipFooter(in);
             }
 
-            if (decompressed.isReadable()) {
+            if (decompressed.readableBytes() > 0) {
                 return decompressed;
             } else {
-                decompressed.release();
+                decompressed.close();
                 return null;
             }
         } catch (DataFormatException e) {
-            decompressed.release();
+            decompressed.close();
             throw new DecompressionException("decompression failure", e);
         } catch (Throwable cause) {
-            decompressed.release();
+            decompressed.close();
             throw cause;
         }
     }
 
-    private boolean handleGzipFooter(ByteBuf in) {
+    private boolean handleGzipFooter(Buffer in) {
         if (readGZIPFooter(in)) {
             finished = !decompressConcatenated;
 
@@ -331,7 +337,7 @@ public final class ZlibDecompressor implements Decompressor {
         return false;
     }
 
-    private boolean readGZIPHeader(ByteBuf in) {
+    private boolean readGZIPHeader(Buffer in) {
         switch (gzipState) {
             case HEADER_START:
                 if (in.readableBytes() < 10) {
@@ -363,8 +369,8 @@ public final class ZlibDecompressor implements Decompressor {
                 }
 
                 // mtime (int)
-                crc.update(in, in.readerIndex(), 4);
-                in.skipBytes(4);
+                crc.update(in, in.readerOffset(), 4);
+                in.skipReadable(4);
 
                 crc.update(in.readUnsignedByte()); // extra flags
                 crc.update(in.readUnsignedByte()); // operating system
@@ -390,8 +396,8 @@ public final class ZlibDecompressor implements Decompressor {
                     if (in.readableBytes() < xlen) {
                         return false;
                     }
-                    crc.update(in, in.readerIndex(), xlen);
-                    in.skipBytes(xlen);
+                    crc.update(in, in.readerOffset(), xlen);
+                    in.skipReadable(xlen);
                 }
                 gzipState = GzipState.SKIP_FNAME;
                 // fall through
@@ -430,10 +436,10 @@ public final class ZlibDecompressor implements Decompressor {
      * @return  {@code true} if the operation is complete and we can move to the next state, {@code false} if
      * we need to retry again once we have more readable bytes.
      */
-    private boolean skipIfNeeded(ByteBuf in, int flagMask) {
+    private boolean skipIfNeeded(Buffer in, int flagMask) {
         if ((flags & flagMask) != 0) {
             for (;;) {
-                if (!in.isReadable()) {
+                if (in.readableBytes() == 0) {
                     // We didnt find the end yet, need to retry again once more data is readable
                     return false;
                 }
@@ -453,9 +459,9 @@ public final class ZlibDecompressor implements Decompressor {
      *
      * @param   in the input.
      * @return  {@code true} if the footer could be read, {@code false} if the read could not be performed as
-     *          the input {@link ByteBuf} doesn't have enough readable bytes (8 bytes).
+     *          the input {@link Buffer} doesn't have enough readable bytes (8 bytes).
      */
-    private boolean readGZIPFooter(ByteBuf in) {
+    private boolean readGZIPFooter(Buffer in) {
         if (in.readableBytes() < 8) {
             return false;
         }
@@ -481,9 +487,9 @@ public final class ZlibDecompressor implements Decompressor {
      *
      * @param   in the input.
      * @return  {@code true} if verification could be performed, {@code false} if verification could not be
-     * performed as the input {@link ByteBuf} doesn't have enough readable bytes (4 bytes).
+     * performed as the input {@link Buffer} doesn't have enough readable bytes (4 bytes).
      */
-    private boolean verifyCrc(ByteBuf in) {
+    private boolean verifyCrc(Buffer in) {
         if (in.readableBytes() < 4) {
             return false;
         }
@@ -499,7 +505,7 @@ public final class ZlibDecompressor implements Decompressor {
         return true;
     }
 
-    private boolean verifyCrc16(ByteBuf in) {
+    private boolean verifyCrc16(Buffer in) {
         if (in.readableBytes() < 2) {
             return false;
         }
@@ -532,17 +538,21 @@ public final class ZlibDecompressor implements Decompressor {
 
     /**
      * Allocate or expand the decompression buffer, without exceeding the maximum allocation.
-     * Calls {@link #decompressionBufferExhausted(ByteBuf)} if the buffer is full and cannot be expanded further.
+     * Calls {@link #decompressionBufferExhausted(Buffer)} if the buffer is full and cannot be expanded further.
      */
-    protected ByteBuf prepareDecompressBuffer(ByteBufAllocator allocator, ByteBuf buffer, int preferredSize) {
+    protected Buffer prepareDecompressBuffer(BufferAllocator allocator, Buffer buffer, int preferredSize) {
         if (buffer == null) {
             if (maxAllocation == 0) {
-                return allocator.buffer(preferredSize);
+                return allocator.allocate(preferredSize);
             }
 
-            return allocator.buffer(Math.min(preferredSize, maxAllocation), maxAllocation);
+            Buffer buf = allocator.allocate(Math.min(preferredSize, maxAllocation));
+            buf.implicitCapacityLimit(maxAllocation);
+            return buf;
         }
 
+        // TODO: Fix me
+        /*
         // this always expands the buffer if possible, even if the expansion is less than preferredSize
         // we throw the exception only if the buffer could not be expanded at all
         // this means that one final attempt to deserialize will always be made with the buffer at maxAllocation
@@ -551,15 +561,15 @@ public final class ZlibDecompressor implements Decompressor {
             // we therefore duplicate it when calling decompressionBufferExhausted() to guarantee non-interference
             // but wait until after to consume it so the subclass can tell how much output is really in the buffer
             decompressionBufferExhausted(buffer.duplicate());
-            buffer.skipBytes(buffer.readableBytes());
+            buffer.skipReadable(buffer.readableBytes());
             throw new DecompressionException(
                     "Decompression buffer has reached maximum size: " + buffer.maxCapacity());
         }
-
+        */
         return buffer;
     }
 
-    protected void decompressionBufferExhausted(ByteBuf buffer) {
+    protected void decompressionBufferExhausted(Buffer buffer) {
         finished = true;
     }
 

--- a/codec/src/test/java/io/netty5/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/AbstractIntegrationTest.java
@@ -160,7 +160,7 @@ public abstract class AbstractIntegrationTest {
                 }
             }
         } finally {
-            //closeChannels();
+            closeChannels();
         }
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/BufferChecksumTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/BufferChecksumTest.java
@@ -29,7 +29,7 @@ import java.util.zip.Checksum;
 import static io.netty5.handler.codec.compression.Lz4Constants.DEFAULT_SEED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ByteBufChecksumTest {
+public class BufferChecksumTest {
 
     private static final byte[] BYTE_ARRAY = new byte[1024];
 
@@ -55,24 +55,24 @@ public class ByteBufChecksumTest {
             // all variations of xxHash32: slow and naive, optimised, wrapped optimised;
             // the last two should be literally identical, but it's best to guard against
             // an accidental regression in ByteBufChecksum#wrapChecksum(Checksum)
-            testUpdate(xxHash32(DEFAULT_SEED), new ByteBufChecksum(xxHash32(DEFAULT_SEED)), buf);
+            testUpdate(xxHash32(DEFAULT_SEED), new BufferChecksum(xxHash32(DEFAULT_SEED)), buf);
             testUpdate(xxHash32(DEFAULT_SEED), new Lz4XXHash32(DEFAULT_SEED), buf);
-            testUpdate(xxHash32(DEFAULT_SEED), new ByteBufChecksum(new Lz4XXHash32(DEFAULT_SEED)), buf);
+            testUpdate(xxHash32(DEFAULT_SEED), new BufferChecksum(new Lz4XXHash32(DEFAULT_SEED)), buf);
 
             // CRC32 and Adler32, special-cased to use ReflectiveByteBufChecksum
-            testUpdate(new CRC32(), new ByteBufChecksum(new CRC32()), buf);
-            testUpdate(new Adler32(), new ByteBufChecksum(new Adler32()), buf);
+            testUpdate(new CRC32(), new BufferChecksum(new CRC32()), buf);
+            testUpdate(new Adler32(), new BufferChecksum(new Adler32()), buf);
         }
     }
 
-    private static void testUpdate(Checksum checksum, ByteBufChecksum wrapped, Buffer buf) {
+    private static void testUpdate(Checksum checksum, BufferChecksum wrapped, Buffer buf) {
         testUpdate(checksum, wrapped, buf, 0, BYTE_ARRAY.length);
         testUpdate(checksum, wrapped, buf, 0, BYTE_ARRAY.length - 1);
         testUpdate(checksum, wrapped, buf, 1, BYTE_ARRAY.length - 1);
         testUpdate(checksum, wrapped, buf, 1, BYTE_ARRAY.length - 2);
     }
 
-    private static void testUpdate(Checksum checksum, ByteBufChecksum wrapped, Buffer buf, int off, int len) {
+    private static void testUpdate(Checksum checksum, BufferChecksum wrapped, Buffer buf, int off, int len) {
         checksum.reset();
         wrapped.reset();
 

--- a/codec/src/test/java/io/netty5/handler/codec/compression/ByteBufChecksumTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/ByteBufChecksumTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import net.jpountz.xxhash.XXHashFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,41 +40,39 @@ public class ByteBufChecksumTest {
 
     @Test
     public void testHeapByteBufUpdate() {
-        testUpdate(Unpooled.wrappedBuffer(BYTE_ARRAY));
+        testUpdate(BufferAllocator.onHeapUnpooled().copyOf(BYTE_ARRAY));
     }
 
     @Test
     public void testDirectByteBufUpdate() {
-        ByteBuf buf = Unpooled.directBuffer(BYTE_ARRAY.length);
+        Buffer buf = BufferAllocator.offHeapUnpooled().allocate(BYTE_ARRAY.length);
         buf.writeBytes(BYTE_ARRAY);
         testUpdate(buf);
     }
 
-    private static void testUpdate(ByteBuf buf) {
-        try {
+    private static void testUpdate(Buffer buf) {
+        try (buf) {
             // all variations of xxHash32: slow and naive, optimised, wrapped optimised;
             // the last two should be literally identical, but it's best to guard against
             // an accidental regression in ByteBufChecksum#wrapChecksum(Checksum)
-            testUpdate(xxHash32(DEFAULT_SEED), ByteBufChecksum.wrapChecksum(xxHash32(DEFAULT_SEED)), buf);
+            testUpdate(xxHash32(DEFAULT_SEED), new ByteBufChecksum(xxHash32(DEFAULT_SEED)), buf);
             testUpdate(xxHash32(DEFAULT_SEED), new Lz4XXHash32(DEFAULT_SEED), buf);
-            testUpdate(xxHash32(DEFAULT_SEED), ByteBufChecksum.wrapChecksum(new Lz4XXHash32(DEFAULT_SEED)), buf);
+            testUpdate(xxHash32(DEFAULT_SEED), new ByteBufChecksum(new Lz4XXHash32(DEFAULT_SEED)), buf);
 
             // CRC32 and Adler32, special-cased to use ReflectiveByteBufChecksum
-            testUpdate(new CRC32(), ByteBufChecksum.wrapChecksum(new CRC32()), buf);
-            testUpdate(new Adler32(), ByteBufChecksum.wrapChecksum(new Adler32()), buf);
-        } finally {
-            buf.release();
+            testUpdate(new CRC32(), new ByteBufChecksum(new CRC32()), buf);
+            testUpdate(new Adler32(), new ByteBufChecksum(new Adler32()), buf);
         }
     }
 
-    private static void testUpdate(Checksum checksum, ByteBufChecksum wrapped, ByteBuf buf) {
+    private static void testUpdate(Checksum checksum, ByteBufChecksum wrapped, Buffer buf) {
         testUpdate(checksum, wrapped, buf, 0, BYTE_ARRAY.length);
         testUpdate(checksum, wrapped, buf, 0, BYTE_ARRAY.length - 1);
         testUpdate(checksum, wrapped, buf, 1, BYTE_ARRAY.length - 1);
         testUpdate(checksum, wrapped, buf, 1, BYTE_ARRAY.length - 2);
     }
 
-    private static void testUpdate(Checksum checksum, ByteBufChecksum wrapped, ByteBuf buf, int off, int len) {
+    private static void testUpdate(Checksum checksum, ByteBufChecksum wrapped, Buffer buf, int off, int len) {
         checksum.reset();
         wrapped.reset();
 

--- a/codec/src/test/java/io/netty5/handler/codec/compression/Bzip2EncoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/Bzip2EncoderTest.java
@@ -15,9 +15,8 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufInputStream;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.BufferInputStream;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 
@@ -34,8 +33,8 @@ public class Bzip2EncoderTest extends AbstractEncoderTest {
     }
 
     @Override
-    protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
-        InputStream is = new ByteBufInputStream(compressed, true);
+    protected Buffer decompress(Buffer compressed, int originalLength) throws Exception {
+        InputStream is = new BufferInputStream(compressed.send());
         BZip2CompressorInputStream bzip2Is = null;
         byte[] decompressed = new byte[originalLength];
         try {
@@ -58,6 +57,6 @@ public class Bzip2EncoderTest extends AbstractEncoderTest {
             }
         }
 
-        return Unpooled.wrappedBuffer(decompressed);
+        return channel.bufferAllocator().copyOf(decompressed);
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,8 +18,11 @@ package io.netty5.handler.codec.compression;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
+import io.netty5.buffer.api.Send;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -55,7 +58,7 @@ final class CompressionTestUtils {
     }
 
     static CompositeBuffer compose(BufferAllocator allocator, Supplier<Buffer> supplier) {
-        CompositeBuffer compositeBuffer = allocator.compose();
+        List<Send<Buffer>> bufferList = new ArrayList<>();
         for (;;) {
             try (Buffer msg = supplier.get()) {
                 if (msg == null) {
@@ -68,13 +71,13 @@ final class CompressionTestUtils {
                 if (msg.writableBytes() > 0) {
                     // We also can't compose buffers that will have writer-offset gaps.
                     // Trim off the excess with split.
-                    compositeBuffer.extendWith(msg.split().send());
+                    bufferList.add(msg.split().send());
                 } else {
-                    compositeBuffer.extendWith(msg.send());
+                    bufferList.add(msg.send());
                 }
             }
         }
-        return compositeBuffer;
+        return allocator.compose(bufferList);
     }
 
     private CompressionTestUtils() { }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.handler.codec.compression;
+
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.buffer.api.CompositeBuffer;
+import io.netty5.channel.embedded.EmbeddedChannel;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class CompressionTestUtils {
+
+    static void assertDecodeInputThrows(EmbeddedChannel channel, byte[] bytes,
+                                        Class<? extends Exception> exceptionClass) {
+        Buffer in = channel.bufferAllocator().copyOf(bytes);
+        assertThrows(exceptionClass, () -> channel.writeInbound(in));
+    }
+
+    static void assertDecodeInput(EmbeddedChannel channel, byte[] input, byte[] expected) {
+        Buffer in = BufferAllocator.onHeapUnpooled().copyOf(input);
+        assertTrue(channel.writeInbound(in));
+        assertInbound(channel, expected);
+    }
+
+    static void assertInbound(EmbeddedChannel channel, byte[] expected) {
+        try (Buffer expectedBuffer = channel.bufferAllocator().copyOf(expected);
+             Buffer actual = channel.readInbound()) {
+            assertEquals(expectedBuffer, actual);
+        }
+    }
+
+    static void assertOutbound(EmbeddedChannel channel, byte[] expected) {
+        try (Buffer expectedBuffer = channel.bufferAllocator().copyOf(expected);
+             Buffer actual = channel.readOutbound()) {
+            assertEquals(expectedBuffer, actual);
+        }
+    }
+
+    static CompositeBuffer compose(BufferAllocator allocator, Supplier<Buffer> supplier) {
+        CompositeBuffer compositeBuffer = allocator.compose();
+        for (;;) {
+            try (Buffer msg = supplier.get()) {
+                if (msg == null) {
+                    break;
+                }
+                if (msg.readerOffset() != 0) {
+                    // We can't compose buffers that will have reader-offset gaps.
+                    msg.readSplit(0).close(); // Trim off already-read bytes at the beginning.
+                }
+                if (msg.writableBytes() > 0) {
+                    // We also can't compose buffers that will have writer-offset gaps.
+                    // Trim off the excess with split.
+                    compositeBuffer.extendWith(msg.split().send());
+                } else {
+                    compositeBuffer.extendWith(msg.send());
+                }
+            }
+        }
+        return compositeBuffer;
+    }
+
+    private CompressionTestUtils() { }
+}

--- a/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
@@ -72,6 +72,7 @@ final class CompressionTestUtils {
                     // We also can't compose buffers that will have writer-offset gaps.
                     // Trim off the excess with split.
                     bufferList.add(msg.split().send());
+                    msg.close();
                 } else {
                     bufferList.add(msg.send());
                 }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
@@ -72,7 +72,6 @@ final class CompressionTestUtils {
                     // We also can't compose buffers that will have writer-offset gaps.
                     // Trim off the excess with split.
                     bufferList.add(msg.split().send());
-                    msg.close();
                 } else {
                     bufferList.add(msg.send());
                 }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -15,10 +15,9 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufInputStream;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.BufferInputStream;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import net.jpountz.lz4.LZ4BlockInputStream;
@@ -37,15 +36,15 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     private ChannelHandlerContext ctx;
 
     /**
-     * A {@link ByteBuf} for mocking purposes, largely because it's difficult to allocate to huge buffers.
+     * A {@link Buffer} for mocking purposes, largely because it's difficult to allocate to huge buffers.
      */
     @Mock
-    private ByteBuf buffer;
+    private Buffer buffer;
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
+        when(ctx.bufferAllocator()).thenReturn(BufferAllocator.onHeapUnpooled());
     }
 
     @Override
@@ -54,8 +53,8 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     }
 
     @Override
-    protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
-        InputStream is = new ByteBufInputStream(compressed, true);
+    protected Buffer decompress(Buffer compressed, int originalLength) throws Exception {
+        InputStream is = new BufferInputStream(compressed.send());
         LZ4BlockInputStream lz4Is = null;
         byte[] decompressed = new byte[originalLength];
         try {
@@ -78,6 +77,6 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
             }
         }
 
-        return Unpooled.wrappedBuffer(decompressed);
+        return channel.bufferAllocator().copyOf(decompressed);
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/LzfDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/LzfDecoderTest.java
@@ -16,8 +16,8 @@
 package io.netty5.handler.codec.compression;
 
 import com.ning.compress.lzf.LZFEncoder;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
@@ -38,20 +38,20 @@ public class LzfDecoderTest extends AbstractDecoderTest {
 
     @Test
     public void testUnexpectedBlockIdentifier() {
-        ByteBuf in = Unpooled.buffer();
-        in.writeShort(0x1234);  //random value
-        in.writeByte(BLOCK_TYPE_NON_COMPRESSED);
-        in.writeShort(0);
+        Buffer in = channel.bufferAllocator().allocate(8);
+        in.writeShort((short) 0x1234);  //random value
+        in.writeByte((byte) BLOCK_TYPE_NON_COMPRESSED);
+        in.writeShort((short) 0);
 
         assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected block identifier");
     }
 
     @Test
     public void testUnknownTypeOfChunk() {
-        ByteBuf in = Unpooled.buffer();
+        Buffer in = channel.bufferAllocator().allocate(8);
         in.writeByte(BYTE_Z);
         in.writeByte(BYTE_V);
-        in.writeByte(0xFF);   //random value
+        in.writeByte((byte) 0xFF);   //random value
         in.writeInt(0);
 
         assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unknown type of chunk");

--- a/codec/src/test/java/io/netty5/handler/codec/compression/LzfEncoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/LzfEncoderTest.java
@@ -18,6 +18,7 @@ package io.netty5.handler.codec.compression;
 import com.ning.compress.lzf.LZFDecoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
 public class LzfEncoderTest extends AbstractEncoderTest {
@@ -28,12 +29,13 @@ public class LzfEncoderTest extends AbstractEncoderTest {
     }
 
     @Override
-    protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
-        byte[] compressedArray = new byte[compressed.readableBytes()];
-        compressed.readBytes(compressedArray);
-        compressed.release();
+    protected Buffer decompress(Buffer compressed, int originalLength) throws Exception {
+        try (compressed) {
+            byte[] compressedArray = new byte[compressed.readableBytes()];
+            compressed.readBytes(compressedArray, 0, compressedArray.length);
 
-        byte[] decompressed = LZFDecoder.decode(compressedArray);
-        return Unpooled.wrappedBuffer(decompressed);
+            byte[] decompressed = LZFDecoder.decode(compressedArray);
+            return channel.bufferAllocator().copyOf(decompressed);
+        }
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -15,18 +15,15 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SnappyFrameDecoderTest {
     private EmbeddedChannel channel;
@@ -43,61 +40,49 @@ public class SnappyFrameDecoderTest {
 
     @Test
     public void testReservedUnskippableChunkTypeCausesError() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            0x03, 0x01, 0x00, 0x00, 0x00
-        });
-
-        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
+        CompressionTestUtils.assertDecodeInputThrows(channel, new byte[] {
+                0x03, 0x01, 0x00, 0x00, 0x00
+        }, DecompressionException.class);
     }
 
     @Test
     public void testInvalidStreamIdentifierLength() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            -0x80, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
-        });
-
-        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
+        CompressionTestUtils.assertDecodeInputThrows(channel, new byte[] {
+                -0x80, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
+        }, DecompressionException.class);
     }
 
     @Test
     public void testInvalidStreamIdentifierValue() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            (byte) 0xff, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
-        });
-
-        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
+        CompressionTestUtils.assertDecodeInputThrows(channel, new byte[] {
+                (byte) 0xff, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
+        }, DecompressionException.class);
     }
 
     @Test
     public void testReservedSkippableBeforeStreamIdentifier() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            -0x7f, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
-        });
-
-        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
+        CompressionTestUtils.assertDecodeInputThrows(channel, new byte[] {
+                -0x7f, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
+        }, DecompressionException.class);
     }
 
     @Test
     public void testUncompressedDataBeforeStreamIdentifier() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            0x01, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
-        });
-
-        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
+        CompressionTestUtils.assertDecodeInputThrows(channel, new byte[] {
+                0x01, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
+        }, DecompressionException.class);
     }
 
     @Test
     public void testCompressedDataBeforeStreamIdentifier() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            0x00, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
-        });
-
-        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
+        CompressionTestUtils.assertDecodeInputThrows(channel, new byte[] {
+                0x00, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
+        }, DecompressionException.class);
     }
 
     @Test
     public void testReservedSkippableSkipsInput() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
+        Buffer in = BufferAllocator.onHeapUnpooled().copyOf(new byte[] {
            (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
            -0x7f, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
@@ -105,45 +90,30 @@ public class SnappyFrameDecoderTest {
         assertFalse(channel.writeInbound(in));
         assertNull(channel.readInbound());
 
-        assertFalse(in.isReadable());
+        assertFalse(in.readableBytes() > 0);
     }
 
     @Test
     public void testUncompressedDataAppendsToOut() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-           (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
-            0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
-        });
-
-        assertTrue(channel.writeInbound(in));
-
-        ByteBuf expected = Unpooled.wrappedBuffer(new byte[] { 'n', 'e', 't', 't', 'y' });
-        ByteBuf actual = channel.readInbound();
-        assertEquals(expected, actual);
-
-        expected.release();
-        actual.release();
+        CompressionTestUtils.assertDecodeInput(channel,
+                new byte[] {
+                        (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
+                        0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
+                },
+                new byte[] { 'n', 'e', 't', 't', 'y' });
     }
 
     @Test
     public void testCompressedDataDecodesAndAppendsToOut() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-           (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
-            0x00, 0x0B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                  0x05, // preamble length
-                  0x04 << 2, // literal tag + length
-                  0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
-        });
-
-        assertTrue(channel.writeInbound(in));
-
-        ByteBuf expected = Unpooled.wrappedBuffer(new byte[] { 'n', 'e', 't', 't', 'y' });
-        ByteBuf actual = channel.readInbound();
-
-        assertEquals(expected, actual);
-
-        expected.release();
-        actual.release();
+        CompressionTestUtils.assertDecodeInput(channel,
+                new byte[] {
+                        (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
+                        0x00, 0x0B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        0x05, // preamble length
+                        0x04 << 2, // literal tag + length
+                        0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
+                },
+                new byte[] { 'n', 'e', 't', 't', 'y' });
     }
 
     // The following two tests differ in only the checksum provided for the literal
@@ -154,12 +124,10 @@ public class SnappyFrameDecoderTest {
         EmbeddedChannel channel = new EmbeddedChannel(new DecompressionHandler(SnappyDecompressor.newFactory(true)));
         try {
             // checksum here is presented as 0
-            ByteBuf in = Unpooled.wrappedBuffer(new byte[]{
+            CompressionTestUtils.assertDecodeInputThrows(channel, new byte[] {
                     (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
                     0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
-            });
-
-            assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
+            }, DecompressionException.class);
         } finally {
             channel.finishAndReleaseAll();
         }
@@ -169,19 +137,13 @@ public class SnappyFrameDecoderTest {
     public void testInvalidChecksumDoesNotThrowException() {
         EmbeddedChannel channel = new EmbeddedChannel(new DecompressionHandler(SnappyDecompressor.newFactory(true)));
         try {
-            // checksum here is presented as a282986f (little endian)
-            ByteBuf in = Unpooled.wrappedBuffer(new byte[]{
-                    (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
-                    0x01, 0x09, 0x00, 0x00, 0x6f, -0x68, 0x2e, -0x47, 'n', 'e', 't', 't', 'y'
-            });
-
-            assertTrue(channel.writeInbound(in));
-            ByteBuf expected = Unpooled.wrappedBuffer(new byte[] { 'n', 'e', 't', 't', 'y' });
-            ByteBuf actual = channel.readInbound();
-            assertEquals(expected, actual);
-
-            expected.release();
-            actual.release();
+            CompressionTestUtils.assertDecodeInput(channel,
+                    new byte[] {
+                            // checksum here is presented as a282986f (little endian)
+                            (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
+                            0x01, 0x09, 0x00, 0x00, 0x6f, -0x68, 0x2e, -0x47, 'n', 'e', 't', 't', 'y'
+                    },
+                    new byte[] { 'n', 'e', 't', 't', 'y' });
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/SnappyTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/SnappyTest.java
@@ -15,13 +15,14 @@
  */
 package io.netty5.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty5.util.CharsetUtil;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
 
 import static io.netty5.handler.codec.compression.Snappy.calculateChecksum;
 import static io.netty5.handler.codec.compression.Snappy.decodeLiteral;
@@ -39,304 +40,269 @@ public class SnappyTest {
         snappy.reset();
     }
 
-    @Test
-    public void testDecodeLiteral() throws Exception {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            0x05, // preamble length
-            0x04 << 2, // literal tag + length
-            0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
-        });
-        ByteBuf out = Unpooled.buffer(5);
-        snappy.decode(in, out);
+    private static void assertBufferContent(byte[] expected, Buffer actual, String msg) {
+        try (Buffer expectedBuffer =  BufferAllocator.offHeapUnpooled().copyOf(expected)) {
+            assertEquals(expectedBuffer, actual, msg);
+        }
+    }
 
-        // "netty"
-        ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
-            0x6e, 0x65, 0x74, 0x74, 0x79
-        });
-        assertEquals(expected, out, "Literal was not decoded correctly");
+    private void assertDecode(byte[] inBytes, byte[] expected, String msg) {
+        try (Buffer in = BufferAllocator.offHeapUnpooled().copyOf(inBytes);
+             Buffer out = BufferAllocator.offHeapUnpooled().allocate(5)) {
+            snappy.decode(in, out);
+            // "netty"
+            assertBufferContent(expected, out, msg);
+        }
+    }
 
-        in.release();
-        out.release();
-        expected.release();
+    private void assertDecodeThrows(byte[] inBytes) {
+        try (Buffer in = BufferAllocator.offHeapUnpooled().copyOf(inBytes);
+             Buffer out = BufferAllocator.offHeapUnpooled().allocate(5)) {
+            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
+        }
     }
 
     @Test
-    public void testDecodeCopyWith1ByteOffset() throws Exception {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            0x0a, // preamble length
-            0x04 << 2, // literal tag + length
-            0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
-            0x01 << 2 | 0x01, // copy with 1-byte offset + length
-            0x05 // offset
-        });
-        ByteBuf out = Unpooled.buffer(10);
-        snappy.decode(in, out);
+    public void testDecodeLiteral() {
+        assertDecode(new byte[]{
+                0x05, // preamble length
+                0x04 << 2, // literal tag + length
+                0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
+        }, new byte[] {
+                0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
+        }, "Literal was not decoded correctly");
+    }
 
-        // "nettynetty" - we saved a whole byte :)
-        ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
-            0x6e, 0x65, 0x74, 0x74, 0x79, 0x6e, 0x65, 0x74, 0x74, 0x79
-        });
-        assertEquals(expected, out, "Copy was not decoded correctly");
+    @Test
+    public void testDecodeCopyWith1ByteOffset() {
+        assertDecode(new byte[]{
+                0x0a, // preamble length
+                0x04 << 2, // literal tag + length
+                0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
+                0x01 << 2 | 0x01, // copy with 1-byte offset + length
+                0x05 // offset
+        }, new byte[] {
+                0x6e, 0x65, 0x74, 0x74, 0x79, 0x6e, 0x65, 0x74, 0x74, 0x79 // "nettynetty" - we saved a whole byte :)
 
-        in.release();
-        out.release();
-        expected.release();
+        }, "Copy was not decoded correctly");
     }
 
     @Test
     public void testDecodeCopyWithTinyOffset() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
+        assertDecodeThrows(new byte[] {
             0x0b, // preamble length
             0x04 << 2, // literal tag + length
             0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
             0x05 << 2 | 0x01, // copy with 1-byte offset + length
             0x00 // INVALID offset (< 1)
         });
-        ByteBuf out = Unpooled.buffer(10);
-        try {
-            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
-        } finally {
-            in.release();
-            out.release();
-        }
     }
 
     @Test
     public void testDecodeCopyWithOffsetBeforeChunk() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            0x0a, // preamble length
-            0x04 << 2, // literal tag + length
-            0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
-            0x05 << 2 | 0x01, // copy with 1-byte offset + length
-            0x0b // INVALID offset (greater than chunk size)
+        assertDecodeThrows(new byte[] {
+                0x0a, // preamble length
+                0x04 << 2, // literal tag + length
+                0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
+                0x05 << 2 | 0x01, // copy with 1-byte offset + length
+                0x0b // INVALID offset (greater than chunk size)
         });
-        ByteBuf out = Unpooled.buffer(10);
-        try {
-            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
-        } finally {
-            in.release();
-            out.release();
-        }
     }
 
     @Test
     public void testDecodeWithOverlyLongPreamble() {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            -0x80, -0x80, -0x80, -0x80, 0x7f, // preamble length
-            0x04 << 2, // literal tag + length
-            0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
+        assertDecodeThrows(new byte[] {
+                -0x80, -0x80, -0x80, -0x80, 0x7f, // preamble length
+                0x04 << 2, // literal tag + length
+                0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
         });
-        ByteBuf out = Unpooled.buffer(10);
-        try {
-            assertThrows(DecompressionException.class, () -> snappy.decode(in, out));
-        } finally {
-            in.release();
-            out.release();
+    }
+
+    @Test
+    public void encodeShortTextIsLiteral() {
+        try (Buffer in =  BufferAllocator.onHeapUnpooled().copyOf(new byte[] {
+                0x6e, 0x65, 0x74, 0x74, 0x79
+        }); Buffer out = BufferAllocator.onHeapUnpooled().allocate(7);
+        Buffer expected = BufferAllocator.onHeapUnpooled().copyOf(new byte[] {
+                0x05, // preamble length
+                0x04 << 2, // literal tag + length
+                0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
+        })) {
+            snappy.encode(in, out, 5);
+            assertEquals(expected, out, "Encoded literal was invalid");
         }
     }
 
     @Test
-    public void encodeShortTextIsLiteral() throws Exception {
-        ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            0x6e, 0x65, 0x74, 0x74, 0x79
-        });
-        ByteBuf out = Unpooled.buffer(7);
-        snappy.encode(in, out, 5);
-
-        ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
-            0x05, // preamble length
-            0x04 << 2, // literal tag + length
-            0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
-        });
-        assertEquals(expected, out, "Encoded literal was invalid");
-
-        in.release();
-        out.release();
-        expected.release();
-    }
-
-    @Test
-    public void encodeAndDecodeLongTextUsesCopy() throws Exception {
+    public void encodeAndDecodeLongTextUsesCopy() {
         String srcStr = "Netty has been designed carefully with the experiences " +
                    "earned from the implementation of a lot of protocols " +
                    "such as FTP, SMTP, HTTP, and various binary and " +
                    "text-based legacy protocols";
-        ByteBuf in = Unpooled.wrappedBuffer(srcStr.getBytes("US-ASCII"));
-        ByteBuf out = Unpooled.buffer(180);
-        snappy.encode(in, out, in.readableBytes());
-
         // The only compressibility in the above are the words:
         // "the ", "rotocols", " of ", "TP, " and "and ". So this is a literal,
         // followed by a copy followed by another literal, followed by another copy...
-        ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
-            -0x49, 0x01, // preamble length
-            -0x10, 0x42, // literal tag + length
+        byte[] expectedBytes = new byte[] {
+                -0x49, 0x01, // preamble length
+                -0x10, 0x42, // literal tag + length
 
-            // Literal
-            0x4e, 0x65, 0x74, 0x74, 0x79, 0x20, 0x68, 0x61, 0x73, 0x20,
-            0x62, 0x65, 0x65, 0x6e, 0x20, 0x64, 0x65, 0x73, 0x69, 0x67,
-            0x6e, 0x65, 0x64, 0x20, 0x63, 0x61, 0x72, 0x65, 0x66, 0x75,
-            0x6c, 0x6c, 0x79, 0x20, 0x77, 0x69, 0x74, 0x68, 0x20, 0x74,
-            0x68, 0x65, 0x20, 0x65, 0x78, 0x70, 0x65, 0x72, 0x69, 0x65,
-            0x6e, 0x63, 0x65, 0x73, 0x20, 0x65, 0x61, 0x72, 0x6e, 0x65,
-            0x64, 0x20, 0x66, 0x72, 0x6f, 0x6d, 0x20,
+                // Literal
+                0x4e, 0x65, 0x74, 0x74, 0x79, 0x20, 0x68, 0x61, 0x73, 0x20,
+                0x62, 0x65, 0x65, 0x6e, 0x20, 0x64, 0x65, 0x73, 0x69, 0x67,
+                0x6e, 0x65, 0x64, 0x20, 0x63, 0x61, 0x72, 0x65, 0x66, 0x75,
+                0x6c, 0x6c, 0x79, 0x20, 0x77, 0x69, 0x74, 0x68, 0x20, 0x74,
+                0x68, 0x65, 0x20, 0x65, 0x78, 0x70, 0x65, 0x72, 0x69, 0x65,
+                0x6e, 0x63, 0x65, 0x73, 0x20, 0x65, 0x61, 0x72, 0x6e, 0x65,
+                0x64, 0x20, 0x66, 0x72, 0x6f, 0x6d, 0x20,
 
-            // copy of "the "
-            0x01, 0x1c, 0x58,
+                // copy of "the "
+                0x01, 0x1c, 0x58,
 
-            // Next literal
-            0x69, 0x6d, 0x70, 0x6c, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x61,
-            0x74, 0x69, 0x6f, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x61, 0x20,
-            0x6c, 0x6f, 0x74,
+                // Next literal
+                0x69, 0x6d, 0x70, 0x6c, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x61,
+                0x74, 0x69, 0x6f, 0x6e, 0x20, 0x6f, 0x66, 0x20, 0x61, 0x20,
+                0x6c, 0x6f, 0x74,
 
-            // copy of " of "
-            0x01, 0x09, 0x60,
+                // copy of " of "
+                0x01, 0x09, 0x60,
 
-            // literal
-            0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x73, 0x20,
-            0x73, 0x75, 0x63, 0x68, 0x20, 0x61, 0x73, 0x20, 0x46, 0x54,
-            0x50, 0x2c, 0x20, 0x53, 0x4d,
+                // literal
+                0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x73, 0x20,
+                0x73, 0x75, 0x63, 0x68, 0x20, 0x61, 0x73, 0x20, 0x46, 0x54,
+                0x50, 0x2c, 0x20, 0x53, 0x4d,
 
-            // copy of " TP, "
-            0x01, 0x06, 0x04,
+                // copy of " TP, "
+                0x01, 0x06, 0x04,
 
-            // literal
-            0x48, 0x54,
+                // literal
+                0x48, 0x54,
 
-            // copy of " TP, "
-            0x01, 0x06, 0x44,
+                // copy of " TP, "
+                0x01, 0x06, 0x44,
 
-            // literal
-            0x61, 0x6e, 0x64, 0x20, 0x76, 0x61, 0x72, 0x69, 0x6f, 0x75,
-            0x73, 0x20, 0x62, 0x69, 0x6e, 0x61, 0x72, 0x79,
+                // literal
+                0x61, 0x6e, 0x64, 0x20, 0x76, 0x61, 0x72, 0x69, 0x6f, 0x75,
+                0x73, 0x20, 0x62, 0x69, 0x6e, 0x61, 0x72, 0x79,
 
-            // copy of "and "
-            0x05, 0x13, 0x48,
+                // copy of "and "
+                0x05, 0x13, 0x48,
 
-            // literal
-            0x74, 0x65, 0x78, 0x74, 0x2d, 0x62, 0x61, 0x73, 0x65,
-            0x64, 0x20, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x20, 0x70,
+                // literal
+                0x74, 0x65, 0x78, 0x74, 0x2d, 0x62, 0x61, 0x73, 0x65,
+                0x64, 0x20, 0x6c, 0x65, 0x67, 0x61, 0x63, 0x79, 0x20, 0x70,
 
-            // copy of "rotocols"
-            0x11, 0x4c,
-        });
+                // copy of "rotocols"
+                0x11, 0x4c,
+        };
+        try (Buffer in = BufferAllocator.onHeapUnpooled().copyOf(srcStr.getBytes(StandardCharsets.US_ASCII));
+            Buffer out = BufferAllocator.onHeapUnpooled().allocate(180);
+            Buffer outDecoded = BufferAllocator.onHeapUnpooled().allocate(256);
+            Buffer expected = BufferAllocator.onHeapUnpooled().copyOf(expectedBytes);
+            Buffer expectedDecoded = BufferAllocator.onHeapUnpooled().copyOf(
+                    srcStr.getBytes(StandardCharsets.US_ASCII))) {
+            snappy.encode(in, out, in.readableBytes());
 
-        assertEquals(expected, out, "Encoded result was incorrect");
+            assertEquals(expected, out, "Encoded result was incorrect");
 
-        // Decode
-        ByteBuf outDecoded = Unpooled.buffer();
-        snappy.decode(out, outDecoded);
-        assertEquals(CharBuffer.wrap(srcStr),
-            CharBuffer.wrap(outDecoded.getCharSequence(0, outDecoded.writerIndex(), CharsetUtil.US_ASCII)));
-
-        in.release();
-        out.release();
-        outDecoded.release();
-    }
-
-    @Test
-    public void testCalculateChecksum() {
-        ByteBuf input = Unpooled.wrappedBuffer(new byte[] {
-                'n', 'e', 't', 't', 'y'
-        });
-
-        assertEquals(maskChecksum(0xd6cb8b55L), calculateChecksum(input));
-        input.release();
-    }
-
-    @Test
-    public void testMaskChecksum() {
-        ByteBuf input = Unpooled.wrappedBuffer(new byte[] {
-                0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x00,
-                0x5f, 0x68, 0x65, 0x61, 0x72, 0x74, 0x62, 0x65,
-                0x61, 0x74, 0x5f,
-        });
-        assertEquals(0x44a4301f, calculateChecksum(input));
-        input.release();
-    }
-
-    @Test
-    public void testValidateChecksumMatches() {
-        ByteBuf input = Unpooled.wrappedBuffer(new byte[] {
-                'y', 't', 't', 'e', 'n'
-        });
-
-        validateChecksum(maskChecksum(0x2d4d3535), input);
-        input.release();
-    }
-
-    @Test
-    public void testValidateChecksumFails() {
-        ByteBuf input = Unpooled.wrappedBuffer(new byte[] {
-                'y', 't', 't', 'e', 'n'
-        });
-        try {
-            assertThrows(DecompressionException.class, () -> validateChecksum(maskChecksum(0xd6cb8b55), input));
-        } finally {
-            input.release();
+            // Decode
+            snappy.decode(out, outDecoded);
+            assertEquals(expectedDecoded, outDecoded);
         }
     }
 
     @Test
-    public void testEncodeLiteralAndDecodeLiteral() {
-        int[] lengths = {
+    public void testCalculateChecksum() {
+        try (Buffer input = BufferAllocator.onHeapUnpooled().copyOf(new byte[] {
+                'n', 'e', 't', 't', 'y'
+        })) {
+            assertEquals(maskChecksum(0xd6cb8b55L), calculateChecksum(input));
+        }
+    }
+
+    @Test
+    public void testMaskChecksum() {
+        try (Buffer input = BufferAllocator.onHeapUnpooled().copyOf(new byte[] {
+                0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x00,
+                0x5f, 0x68, 0x65, 0x61, 0x72, 0x74, 0x62, 0x65,
+                0x61, 0x74, 0x5f,
+        })) {
+            assertEquals(0x44a4301f, calculateChecksum(input));
+        }
+    }
+
+    @Test
+    public void testValidateChecksumMatches() {
+        try (Buffer input = BufferAllocator.onHeapUnpooled().copyOf(new byte[] {
+                'y', 't', 't', 'e', 'n'
+        })) {
+            validateChecksum(maskChecksum(0x2d4d3535), input);
+        }
+    }
+
+    @Test
+    public void testValidateChecksumFails() {
+        try (Buffer input = BufferAllocator.onHeapUnpooled().copyOf(new byte[] {
+                'y', 't', 't', 'e', 'n'
+        })) {
+            assertThrows(DecompressionException.class, () -> validateChecksum(maskChecksum(0xd6cb8b55), input));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {
             0x11, // default
             0x100, // case 60
             0x1000, // case 61
             0x100000, // case 62
             0x1000001 // case 63
-        };
-        for (int len : lengths) {
-            ByteBuf in = Unpooled.wrappedBuffer(new byte[len]);
-            ByteBuf encoded = Unpooled.buffer(10);
-            ByteBuf decoded = Unpooled.buffer(10);
-            ByteBuf expected = Unpooled.wrappedBuffer(new byte[len]);
-            try {
-                encodeLiteral(in, encoded, len);
-                byte tag = encoded.readByte();
-                decodeLiteral(tag, encoded, decoded);
-                assertEquals(expected, decoded, "Encoded or decoded literal was incorrect");
-            } finally {
-                in.release();
-                encoded.release();
-                decoded.release();
-                expected.release();
-            }
+    })
+    public void testEncodeLiteralAndDecodeLiteral(int len) {
+        try (Buffer in = BufferAllocator.onHeapUnpooled().copyOf(new byte[len]);
+            Buffer encoded = BufferAllocator.onHeapUnpooled().allocate(10);
+            Buffer decoded = BufferAllocator.onHeapUnpooled().allocate(10);
+            Buffer expected = BufferAllocator.onHeapUnpooled().copyOf(new byte[len])) {
+            encodeLiteral(in, encoded, len);
+            byte tag = encoded.readByte();
+            decodeLiteral(tag, encoded, decoded);
+            assertEquals(expected, decoded, "Encoded or decoded literal was incorrect");
         }
     }
 
     @Test
     public void testLarge2ByteLiteralLengthAndCopyOffset() {
-        ByteBuf compressed = Unpooled.buffer();
-        ByteBuf actualDecompressed = Unpooled.buffer();
-        ByteBuf expectedDecompressed = Unpooled.buffer().writeByte(0x01).writeZero(0x8000).writeByte(0x01);
-        try {
+        try (Buffer compressed = BufferAllocator.onHeapUnpooled().allocate(256);
+            Buffer actualDecompressed = BufferAllocator.onHeapUnpooled().allocate(256);
+             Buffer expectedDecompressed = BufferAllocator.onHeapUnpooled().allocate(256)) {
+            expectedDecompressed.writeByte((byte) 0x01);
+            for (int i = 0; i < 0x8000; i++) {
+                expectedDecompressed.writeByte((byte) 0);
+            }
+            expectedDecompressed.writeByte((byte) 0x01);
             // Generate a Snappy-encoded buffer that can only be decompressed correctly if
             // the decoder treats 2-byte literal lengths and 2-byte copy offsets as unsigned values.
 
             // Write preamble, uncompressed content length (0x8002) encoded as varint.
-            compressed.writeByte(0x82).writeByte(0x80).writeByte(0x02);
+            compressed.writeByte((byte) 0x82).writeByte((byte) 0x80).writeByte((byte) 0x02);
 
             // Write a literal consisting of 0x01 followed by 0x8000 zeroes.
             // The total length of this literal is 0x8001, which gets encoded as 0x8000 (length - 1).
             // This length was selected because the encoded form is one larger than the maximum value
             // representable using a signed 16-bit integer, and we want to assert the decoder is reading
             // the length as an unsigned value.
-            compressed.writeByte(61 << 2); // tag for LITERAL with a 2-byte length
-            compressed.writeShortLE(0x8000); // length - 1
-            compressed.writeByte(0x01).writeZero(0x8000); // literal content
+            compressed.writeByte((byte) (61 << 2)); // tag for LITERAL with a 2-byte length
+            compressed.writeShort(Short.reverseBytes((short) 0x8000)); // length - 1
+            compressed.writeByte((byte) 0x01);
 
+            for (int i = 0; i < 0x8000; i++) {
+                compressed.writeByte((byte) 0); // literal content
+            }
             // Similarly, for a 2-byte copy operation we want to ensure the offset is treated as unsigned.
             // Copy the initial 0x01 which was written 0x8001 bytes back in the stream.
-            compressed.writeByte(0x02); // tag for COPY with 2-byte offset, length = 1
-            compressed.writeShortLE(0x8001); // offset
+            compressed.writeByte((byte) 0x02); // tag for COPY with 2-byte offset, length = 1
+            compressed.writeShort(Short.reverseBytes((short) 0x8001)); // offset
 
             snappy.decode(compressed, actualDecompressed);
             assertEquals(expectedDecompressed, actualDecompressed);
-        } finally {
-            compressed.release();
-            actualDecompressed.release();
-            expectedDecompressed.release();
         }
     }
 }

--- a/codec/src/test/java/io/netty5/handler/codec/compression/SnappyTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/SnappyTest.java
@@ -194,12 +194,12 @@ public class SnappyTest {
                 // copy of "rotocols"
                 0x11, 0x4c,
         };
-        try (Buffer in = BufferAllocator.onHeapUnpooled().copyOf(srcStr.getBytes(StandardCharsets.US_ASCII));
+        try (Buffer in = BufferAllocator.onHeapUnpooled().copyOf(srcStr, StandardCharsets.US_ASCII);
             Buffer out = BufferAllocator.onHeapUnpooled().allocate(180);
             Buffer outDecoded = BufferAllocator.onHeapUnpooled().allocate(256);
             Buffer expected = BufferAllocator.onHeapUnpooled().copyOf(expectedBytes);
             Buffer expectedDecoded = BufferAllocator.onHeapUnpooled().copyOf(
-                    srcStr.getBytes(StandardCharsets.US_ASCII))) {
+                    srcStr, StandardCharsets.US_ASCII)) {
             snappy.encode(in, out, in.readableBytes());
 
             assertEquals(expected, out, "Encoded result was incorrect");

--- a/codec/src/test/java/io/netty5/handler/codec/compression/SnappyTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/SnappyTest.java
@@ -272,7 +272,7 @@ public class SnappyTest {
     public void testLarge2ByteLiteralLengthAndCopyOffset() {
         try (Buffer compressed = BufferAllocator.onHeapUnpooled().allocate(256);
             Buffer actualDecompressed = BufferAllocator.onHeapUnpooled().allocate(256);
-             Buffer expectedDecompressed = BufferAllocator.onHeapUnpooled().allocate(256)) {
+            Buffer expectedDecompressed = BufferAllocator.onHeapUnpooled().allocate(256)) {
             expectedDecompressed.writeByte((byte) 0x01);
             for (int i = 0; i < 0x8000; i++) {
                 expectedDecompressed.writeByte((byte) 0);

--- a/codec/src/test/java/io/netty5/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/ZstdEncoderTest.java
@@ -54,12 +54,8 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
     public void testCompressionOfLargeBatchedFlow(final Buffer data) throws Exception {
         final int dataLength = data.readableBytes();
         try (Buffer expected = data.copy()) {
-            Buffer in = data.readSplit(65535);
-            assertTrue(channel.writeOutbound(in));
-
-            Buffer in2 = data.readSplit(dataLength - 65535);
-            assertTrue(channel.writeOutbound(in2));
-
+            assertTrue(channel.writeOutbound(data.readSplit(data.readableBytes() / 2)));
+            assertTrue(channel.writeOutbound(data.split()));
             assertTrue(channel.finish());
 
             try (Buffer decompressed = readDecompressed(dataLength)) {

--- a/codec/src/test/java/io/netty5/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/ZstdEncoderTest.java
@@ -16,10 +16,9 @@
 package io.netty5.handler.codec.compression;
 
 import com.github.luben.zstd.ZstdInputStream;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.ByteBufInputStream;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.BufferInputStream;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,7 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
+        when(ctx.bufferAllocator()).thenReturn(BufferAllocator.onHeapUnpooled());
     }
 
     @Override
@@ -52,34 +51,32 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
 
     @ParameterizedTest
     @MethodSource("largeData")
-    public void testCompressionOfLargeBatchedFlow(final ByteBuf data) throws Exception {
+    public void testCompressionOfLargeBatchedFlow(final Buffer data) throws Exception {
         final int dataLength = data.readableBytes();
-        int written = 0;
+        try (Buffer expected = data.copy()) {
+            Buffer in = data.readSplit(65535);
+            assertTrue(channel.writeOutbound(in));
 
-        ByteBuf in = data.retainedSlice(written, 65535);
-        assertTrue(channel.writeOutbound(in));
+            Buffer in2 = data.readSplit(dataLength - 65535);
+            assertTrue(channel.writeOutbound(in2));
 
-        ByteBuf in2 = data.retainedSlice(65535, dataLength - 65535);
-        assertTrue(channel.writeOutbound(in2));
+            assertTrue(channel.finish());
 
-        assertTrue(channel.finish());
-
-        ByteBuf decompressed = readDecompressed(dataLength);
-        assertEquals(data, decompressed);
-
-        decompressed.release();
-        data.release();
+            try (Buffer decompressed = readDecompressed(dataLength)) {
+                assertEquals(expected, decompressed);
+            }
+        }
     }
 
     @ParameterizedTest
     @MethodSource("smallData")
-    public void testCompressionOfSmallBatchedFlow(final ByteBuf data) throws Exception {
+    public void testCompressionOfSmallBatchedFlow(final Buffer data) throws Exception {
         testCompressionOfBatchedFlow(data);
     }
 
     @Override
-    protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
-        InputStream is = new ByteBufInputStream(compressed, true);
+    protected Buffer decompress(Buffer compressed, int originalLength) throws Exception {
+        InputStream is = new BufferInputStream(compressed.send());
         ZstdInputStream zstdIs = null;
         byte[] decompressed = new byte[originalLength];
         try {
@@ -102,6 +99,6 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
             }
         }
 
-        return Unpooled.wrappedBuffer(decompressed);
+        return BufferAllocator.onHeapUnpooled().copyOf(decompressed);
     }
 }


### PR DESCRIPTION
Motivation:

We introduced a new Buffer API in netty 5 but didnt migrate the Compression
to use it yet

Modifications:

- Port Compression API and implementations to use new Buffer API
- Adjust tests

Result:

Use new Buffer API in compression implementations