### PR TITLE
Check and skip if post body parameter name and value are empty

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -561,7 +561,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         // In that case, key would be "", will get exception:
                         // java.lang.IllegalArgumentException: Param 'name' must not be empty;
                         // Just check and skip empty key.
-                        if (key.length() > 0) {
+                        if (!key.isEmpty()) {
                             currentAttribute = factory.createAttribute(request, key);
                             currentAttribute.setValue(""); // empty
                             addHttpData(currentAttribute);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -435,7 +435,7 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         // In that case, key would be "", will get exception:
                         // java.lang.IllegalArgumentException: Param 'name' must not be empty;
                         // Just check and skip empty key.
-                        if (key.length() > 0) {
+                        if (!key.isEmpty()) {
                             currentAttribute = factory.createAttribute(request, key);
                             currentAttribute.setValue(""); // empty
                             addHttpData(currentAttribute);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -431,9 +431,15 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
-                        currentAttribute = factory.createAttribute(request, key);
-                        currentAttribute.setValue(""); // empty
-                        addHttpData(currentAttribute);
+                        // Some weird request bodies start with an '&' character, eg: &name=J&age=17.
+                        // In that case, key would be "", will get exception:
+                        // java.lang.IllegalArgumentException: Param 'name' must not be empty;
+                        // Just check and skip empty key.
+                        if (key.length() > 0) {
+                            currentAttribute = factory.createAttribute(request, key);
+                            currentAttribute.setValue(""); // empty
+                            addHttpData(currentAttribute);
+                        }
                         currentAttribute = null;
                         firstpos = currentpos;
                         contRead = true;
@@ -551,9 +557,15 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                         ampersandpos = currentpos - 1;
                         String key = decodeAttribute(
                                 undecodedChunk.toString(firstpos, ampersandpos - firstpos, charset), charset);
-                        currentAttribute = factory.createAttribute(request, key);
-                        currentAttribute.setValue(""); // empty
-                        addHttpData(currentAttribute);
+                        // Some weird request bodies start with an '&' char, eg: &name=J&age=17.
+                        // In that case, key would be "", will get exception:
+                        // java.lang.IllegalArgumentException: Param 'name' must not be empty;
+                        // Just check and skip empty key.
+                        if (key.length() > 0) {
+                            currentAttribute = factory.createAttribute(request, key);
+                            currentAttribute.setValue(""); // empty
+                            addHttpData(currentAttribute);
+                        }
                         currentAttribute = null;
                         firstpos = currentpos;
                         contRead = true;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -546,7 +546,7 @@ public class HttpPostRequestDecoderTest {
     @Test
     public void testFormEncodeIncorrect() throws Exception {
         LastHttpContent content = new DefaultLastHttpContent(
-                Unpooled.copiedBuffer("project=netty&&project=netty", CharsetUtil.US_ASCII));
+                Unpooled.copiedBuffer("project=netty&=netty&project=netty", CharsetUtil.US_ASCII));
         DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
         HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(req);
         try {
@@ -768,7 +768,7 @@ public class HttpPostRequestDecoderTest {
     @Test
     public void testNotLeak() {
         final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/",
-                Unpooled.copiedBuffer("a=1&&b=2", CharsetUtil.US_ASCII));
+                Unpooled.copiedBuffer("a=1&=2&b=3", CharsetUtil.US_ASCII));
         try {
             assertThrows(HttpPostRequestDecoder.ErrorDataDecoderException.class, new Executable() {
                 @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -60,6 +60,7 @@ class HttpPostStandardRequestDecoderTest {
 
         assertEquals(1, decoder.getBodyHttpDatas().size());
         assertMemoryAttribute(decoder.getBodyHttpData("key1"), "value1");
+        decoder.destroy();
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.multipart;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpPostStandardRequestDecoderTest {
+
+    @Test
+    void testDecodeAttributes() {
+        String requestBody = "key1=value1&key2=value2";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
+        decoder.offer(httpContent);
+
+        assertEquals(2, decoder.getBodyHttpDatas().size());
+        assertMemoryAttribute(decoder.getBodyHttpData("key1"), "value1");
+        assertMemoryAttribute(decoder.getBodyHttpData("key2"), "value2");
+    }
+
+    @Test
+    void testDecodeAttributesWithAmpersandPrefixSkipsNullAttribute() {
+        String requestBody = "&key1=value1";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
+        decoder.offer(httpContent);
+
+        assertEquals(1, decoder.getBodyHttpDatas().size());
+        assertMemoryAttribute(decoder.getBodyHttpData("key1"), "value1");
+    }
+
+    @Test
+    void testDecodeZeroAttributesWithAmpersandPrefix() {
+        String requestBody = "&";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+
+        HttpPostStandardRequestDecoder decoder = new HttpPostStandardRequestDecoder(httpDiskDataFactory(), request);
+        ByteBuf buf = Unpooled.wrappedBuffer(requestBody.getBytes(CharsetUtil.UTF_8));
+        DefaultHttpContent httpContent = new DefaultLastHttpContent(buf);
+        decoder.offer(httpContent);
+
+        assertEquals(0, decoder.getBodyHttpDatas().size());
+    }
+
+    private DefaultHttpDataFactory httpDiskDataFactory() {
+        return new DefaultHttpDataFactory(false);
+    }
+
+    private void assertMemoryAttribute(InterfaceHttpData data, String expectedValue) {
+        assertEquals(InterfaceHttpData.HttpDataType.Attribute, data.getHttpDataType());
+        assertEquals(((MemoryAttribute) data).getValue(), expectedValue);
+    }
+
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -77,7 +77,7 @@ class HttpPostStandardRequestDecoderTest {
         assertEquals(0, decoder.getBodyHttpDatas().size());
     }
 
-    private DefaultHttpDataFactory httpDiskDataFactory() {
+    private static DefaultHttpDataFactory httpDiskDataFactory() {
         return new DefaultHttpDataFactory(false);
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -44,6 +44,7 @@ class HttpPostStandardRequestDecoderTest {
         assertEquals(2, decoder.getBodyHttpDatas().size());
         assertMemoryAttribute(decoder.getBodyHttpData("key1"), "value1");
         assertMemoryAttribute(decoder.getBodyHttpData("key2"), "value2");
+        decoder.destroy();
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -81,7 +81,7 @@ class HttpPostStandardRequestDecoderTest {
         return new DefaultHttpDataFactory(false);
     }
 
-    private void assertMemoryAttribute(InterfaceHttpData data, String expectedValue) {
+    private static void assertMemoryAttribute(InterfaceHttpData data, String expectedValue) {
         assertEquals(InterfaceHttpData.HttpDataType.Attribute, data.getHttpDataType());
         assertEquals(((MemoryAttribute) data).getValue(), expectedValue);
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -75,6 +75,7 @@ class HttpPostStandardRequestDecoderTest {
         decoder.offer(httpContent);
 
         assertEquals(0, decoder.getBodyHttpDatas().size());
+        decoder.destroy();
     }
 
     private static DefaultHttpDataFactory httpDiskDataFactory() {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2022 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance


### PR DESCRIPTION
Motivation:

HTTP form bodies sometimes have RFC illegal extra ampersands in them; this has become accepted by lots of frameworks and so it makes it difficult to migrate to Netty.

This builds on top of https://github.com/netty/netty/pull/12016

Contextual information:
A POST body with the following was not accepted by Netty:
`&foo=bar&baz=bang`
Now it will be.

Modification:

Skips name and valueless attributes silently

Result:

Library now compatible with the broken internets
