### PR TITLE
Fix data race in `Http2ConnectionRoundtripTest`

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -454,7 +454,7 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void priorityUsingHigherValuedStreamIdDoesNotPreventUsingLowerStreamId() throws Exception {
-        bootstrapEnv(1, 1, 2, 0);
+        bootstrapEnv(1, 1, 3, 0);
 
         final Http2Headers headers = dummyHeaders();
         runInChannel(clientChannel, new Http2Runnable() {


### PR DESCRIPTION
Motivation:
With HTTP/2 preface flushing from #12420, we need to wait for an additional message before we can be sure that we've received the headers frame.

Modification:
Increment the request count down latch by one in `Http2ConnectionRoundtripTest.priorityUsingHigherValuedStreamIdDoesNotPreventUsingLowerStreamId`.
This increment was already done in multiple other tests in #12420, but not in this one.
Usually that was "fine", but it left the headers check in the test racing with the headers frame.
This made the test flaky.

Result:
Now the test is always passing.

This is a pack port of #12428