### PR TITLE
Replace ReferenceCountUtil with Resource

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/BufferInputStream.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferInputStream.java
@@ -16,7 +16,7 @@
 package io.netty5.buffer;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.util.internal.StringUtil;
 
 import java.io.DataInput;

--- a/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Buffer.java
@@ -17,6 +17,7 @@ package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.ComponentIterator.Next;
 import io.netty5.buffer.api.internal.Statics;
+import io.netty5.util.Resource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferAllocator.java
@@ -18,6 +18,7 @@ package io.netty5.buffer.api;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.buffer.api.pool.PooledBufferAllocator;
 import io.netty5.util.SafeCloseable;
+import io.netty5.util.Send;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferHolder.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferHolder.java
@@ -17,6 +17,8 @@ package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.buffer.api.internal.Statics;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 
 import java.lang.invoke.VarHandle;
 import java.util.Objects;

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferRef.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferRef.java
@@ -15,6 +15,8 @@
  */
 package io.netty5.buffer.api;
 
+import io.netty5.util.Send;
+
 import java.lang.invoke.VarHandle;
 
 /**

--- a/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/BufferStub.java
@@ -16,6 +16,7 @@
 package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.ComponentIterator.Next;
+import io.netty5.util.Send;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/CompositeBuffer.java
@@ -15,6 +15,9 @@
  */
 package io.netty5.buffer.api;
 
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 

--- a/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/DefaultCompositeBuffer.java
@@ -19,6 +19,7 @@ import io.netty5.buffer.api.ComponentIterator.Next;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.util.SafeCloseable;
+import io.netty5.util.Send;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/buffer/src/main/java/io/netty5/buffer/api/Drop.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Drop.java
@@ -15,6 +15,8 @@
  */
 package io.netty5.buffer.api;
 
+import io.netty5.util.Resource;
+
 /**
  * An interface used by {@link Resource} instances to implement their resource disposal mechanics.
  * The {@link #drop(Object)} method will be called by the resource when they are closed.

--- a/buffer/src/main/java/io/netty5/buffer/api/LeakInfo.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/LeakInfo.java
@@ -16,6 +16,7 @@
 package io.netty5.buffer.api;
 
 import io.netty5.buffer.api.LeakInfo.TracePoint;
+import io.netty5.util.Resource;
 import io.netty5.util.internal.UnstableApi;
 
 import java.util.function.Consumer;

--- a/buffer/src/main/java/io/netty5/buffer/api/MemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/MemoryManager.java
@@ -20,6 +20,7 @@ import io.netty5.buffer.api.internal.LeakDetection;
 import io.netty5.buffer.api.internal.MemoryManagerLoader;
 import io.netty5.buffer.api.internal.MemoryManagerOverride;
 import io.netty5.buffer.api.internal.WrappingAllocation;
+import io.netty5.util.Resource;
 import io.netty5.util.SafeCloseable;
 import io.netty5.util.internal.UnstableApi;
 import io.netty5.util.internal.logging.InternalLogger;

--- a/buffer/src/main/java/io/netty5/buffer/api/Owned.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/Owned.java
@@ -15,6 +15,9 @@
  */
 package io.netty5.buffer.api;
 
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
+
 /**
  * This interface encapsulates the ownership of a {@link Resource}, and exposes a method that may be used to transfer
  * this ownership to the specified recipient thread.

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/LifecycleTracer.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/LifecycleTracer.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.LeakInfo;
 import io.netty5.buffer.api.LeakInfo.TracePoint;
 import io.netty5.buffer.api.Owned;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.UnstableApi;
 

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/ResourceSupport.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/ResourceSupport.java
@@ -17,8 +17,8 @@ package io.netty5.buffer.api.internal;
 
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.Owned;
-import io.netty5.buffer.api.Resource;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 import io.netty5.util.internal.UnstableApi;
 
 import java.util.Objects;
@@ -104,8 +104,10 @@ public abstract class ResourceSupport<I extends Resource<I>, T extends ResourceS
         }
         int acq = acquires;
         acquires--;
-        tracer.close(acq);
-        if (acq == 0) {
+        if (acq != 0) {
+            // Only record a CLOSE if we're not going to record a DROP.
+            tracer.close(acq);
+        } else {
             // The 'acquires' was 0, now decremented to -1, which means we need to drop.
             tracer.drop(0);
             try {

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/SendFromOwned.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/SendFromOwned.java
@@ -17,8 +17,8 @@ package io.netty5.buffer.api.internal;
 
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.Owned;
-import io.netty5.buffer.api.Resource;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 
 import java.lang.invoke.VarHandle;
 

--- a/buffer/src/main/java/io/netty5/buffer/api/internal/SingleComponentIterator.java
+++ b/buffer/src/main/java/io/netty5/buffer/api/internal/SingleComponentIterator.java
@@ -17,7 +17,7 @@ package io.netty5.buffer.api.internal;
 
 import io.netty5.buffer.api.ComponentIterator;
 import io.netty5.buffer.api.ComponentIterator.Next;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 
 import java.lang.ref.Reference;
 

--- a/buffer/src/test/java/io/netty5/buffer/api/BufferHolderTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/BufferHolderTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty5.buffer.api;
 
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 
 import static io.netty5.buffer.api.BufferAllocator.offHeapUnpooled;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCompositionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferCompositionTest.java
@@ -21,7 +21,7 @@ import io.netty5.buffer.api.BufferClosedException;
 import io.netty5.buffer.api.BufferReadOnlyException;
 import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.Drop;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.buffer.api.internal.Statics;
 import org.junit.jupiter.api.Test;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLeakDetectionTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferLeakDetectionTest.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.LeakInfo;
 import io.netty5.buffer.api.MemoryManager;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.TestInfo;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferReadOnlyTest.java
@@ -18,7 +18,7 @@ package io.netty5.buffer.api.tests;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferReadOnlyException;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferRefTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferRefTest.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferClosedException;
 import io.netty5.buffer.api.BufferRef;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSendTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/BufferSendTest.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.BufferClosedException;
 import io.netty5.buffer.api.BufferRef;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
+++ b/buffer/src/test/java/io/netty5/buffer/api/tests/SensitiveBufferTest.java
@@ -20,7 +20,7 @@ import io.netty5.buffer.api.AllocatorControl;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.Drop;
 import io.netty5.buffer.api.MemoryManager;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsMessage.java
@@ -15,8 +15,8 @@
  */
 package io.netty5.handler.codec.dns;
 
+import io.netty5.util.Resource;
 import io.netty5.util.AbstractReferenceCounted;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.ResourceLeakDetector;
 import io.netty5.util.ResourceLeakDetectorFactory;
 import io.netty5.util.ResourceLeakTracker;
@@ -338,14 +338,14 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     private void clear(int section) {
         final Object recordOrList = sectionAt(section);
         setSection(section, null);
-        if (ReferenceCountUtil.isReferenceCounted(recordOrList)) {
-            ReferenceCountUtil.release(recordOrList);
+        if (Resource.isAccessible(recordOrList, false)) {
+            Resource.dispose(recordOrList);
         } else if (recordOrList instanceof List) {
             @SuppressWarnings("unchecked")
             List<DnsRecord> list = (List<DnsRecord>) recordOrList;
             if (!list.isEmpty()) {
                 for (Object r : list) {
-                    ReferenceCountUtil.release(r);
+                    Resource.dispose(r);
                 }
             }
         }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
@@ -61,11 +61,6 @@ public abstract class AbstractDnsOptPseudoRrRecord extends AbstractDnsRecord imp
         return toStringBuilder().toString();
     }
 
-    @Override
-    public AbstractDnsOptPseudoRrRecord copy() {
-        return this;
-    }
-
     final StringBuilder toStringBuilder() {
         return new StringBuilder(64)
                 .append(StringUtil.simpleClassName(this))

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
@@ -61,6 +61,11 @@ public abstract class AbstractDnsOptPseudoRrRecord extends AbstractDnsRecord imp
         return toStringBuilder().toString();
     }
 
+    @Override
+    public AbstractDnsOptPseudoRrRecord copy() {
+        return this;
+    }
+
     final StringBuilder toStringBuilder() {
         return new StringBuilder(64)
                 .append(StringUtil.simpleClassName(this))

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsRecord.java
@@ -114,11 +114,6 @@ public abstract class AbstractDnsRecord implements DnsRecord {
     }
 
     @Override
-    public DnsRecord copy() {
-        return this; // Most record objects are immutable.
-    }
-
-    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/AbstractDnsRecord.java
@@ -114,6 +114,11 @@ public abstract class AbstractDnsRecord implements DnsRecord {
     }
 
     @Override
+    public DnsRecord copy() {
+        return this; // Most record objects are immutable.
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsOptEcsRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsOptEcsRecord.java
@@ -90,6 +90,11 @@ public final class DefaultDnsOptEcsRecord extends AbstractDnsOptPseudoRrRecord i
     }
 
     @Override
+    public DefaultDnsOptEcsRecord copy() {
+        return this;
+    }
+
+    @Override
     public String toString() {
         StringBuilder sb = toStringBuilder();
         sb.setLength(sb.length() - 1);

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsPtrRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsPtrRecord.java
@@ -70,4 +70,9 @@ public class DefaultDnsPtrRecord extends AbstractDnsRecord implements DnsPtrReco
 
         return buf.toString();
     }
+
+    @Override
+    public DnsPtrRecord copy() {
+        return this;
+    }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsQuestion.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsQuestion.java
@@ -69,4 +69,9 @@ public class DefaultDnsQuestion extends AbstractDnsRecord implements DnsQuestion
 
         return buf.toString();
     }
+
+    @Override
+    public DnsQuestion copy() {
+        return this;
+    }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DefaultDnsRawRecord.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.UnstableApi;
 
@@ -60,13 +60,13 @@ public class DefaultDnsRawRecord extends AbstractDnsRecord implements DnsRawReco
     public DefaultDnsRawRecord(
             String name, DnsRecordType type, int dnsClass, long timeToLive, Buffer content) {
         super(name, type, dnsClass, timeToLive);
-        this.content = requireNonNull(content, "content");
+        this.content = requireNonNull(content, "content").makeReadOnly();
     }
 
     public DefaultDnsRawRecord(
             String name, DnsRecordType type, int dnsClass, long timeToLive, Send<Buffer> content) {
         super(name, type, dnsClass, timeToLive);
-        this.content = requireNonNull(content, "content").receive();
+        this.content = requireNonNull(content, "content").receive().makeReadOnly();
     }
 
     @Override
@@ -124,5 +124,11 @@ public class DefaultDnsRawRecord extends AbstractDnsRecord implements DnsRawReco
            .append("B)");
 
         return buf.toString();
+    }
+
+    @Override
+    public DnsRawRecord copy() {
+        // We're required to copy here, because we need independent life-time for 'content'.
+        return new DefaultDnsRawRecord(name(), type(), dnsClass(), timeToLive(), content.copy(true));
     }
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsOptEcsRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsOptEcsRecord.java
@@ -40,4 +40,7 @@ public interface DnsOptEcsRecord extends DnsOptPseudoRecord {
      * Returns the bytes of the {@link InetAddress} to use.
      */
     byte[] address();
+
+    @Override
+    DnsOptEcsRecord copy();
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsOptPseudoRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsOptPseudoRecord.java
@@ -41,4 +41,7 @@ public interface DnsOptPseudoRecord extends DnsRecord {
      * into {@link DnsOptPseudoRecord#timeToLive()}.
      */
     int flags();
+
+    @Override
+    DnsOptPseudoRecord copy();
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsPtrRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsPtrRecord.java
@@ -25,4 +25,6 @@ public interface DnsPtrRecord extends DnsRecord {
      */
     String hostname();
 
+    @Override
+    DnsPtrRecord copy();
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsQuestion.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsQuestion.java
@@ -27,4 +27,7 @@ public interface DnsQuestion extends DnsRecord {
      */
     @Override
     long timeToLive();
+
+    @Override
+    DnsQuestion copy();
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRawRecord.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.util.internal.UnstableApi;
 
 /**
@@ -35,4 +35,7 @@ public interface DnsRawRecord extends DnsRecord, Resource<DnsRawRecord> {
 
     @Override
     DnsRawRecord touch(Object hint);
+
+    @Override
+    DnsRawRecord copy();
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecord.java
@@ -82,4 +82,10 @@ public interface DnsRecord {
      * Returns the time to live after reading for this resource record.
      */
     long timeToLive();
+
+    /**
+     * Return a copy of this record object.
+     * Immutable record objects may return themselves.
+     */
+    DnsRecord copy();
 }

--- a/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecord.java
+++ b/codec-dns/src/main/java/io/netty5/handler/codec/dns/DnsRecord.java
@@ -84,7 +84,7 @@ public interface DnsRecord {
     long timeToLive();
 
     /**
-     * Return a copy of this record object.
+     * Returns a copy of this record object.
      * Immutable record objects may return themselves.
      */
     DnsRecord copy();

--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/AbstractDnsRecordTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/AbstractDnsRecordTest.java
@@ -25,40 +25,51 @@ public class AbstractDnsRecordTest {
     @Test
     public void testValidDomainName() {
         String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        AbstractDnsRecord record = new TestDnsRecord(name, DnsRecordType.A, 0);
         assertEquals(name + '.', record.name());
     }
 
     @Test
     public void testValidDomainNameUmlaut() {
         String name = "ä";
-        AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        AbstractDnsRecord record = new TestDnsRecord(name, DnsRecordType.A, 0);
         assertEquals("xn--4ca.", record.name());
     }
 
     @Test
     public void testValidDomainNameTrailingDot() {
         String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.";
-        AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        AbstractDnsRecord record = new TestDnsRecord(name, DnsRecordType.A, 0);
         assertEquals(name, record.name());
     }
 
     @Test
     public void testValidDomainNameUmlautTrailingDot() {
         String name = "ä.";
-        AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        AbstractDnsRecord record = new TestDnsRecord(name, DnsRecordType.A, 0);
         assertEquals("xn--4ca.", record.name());
     }
 
     @Test
     public void testValidDomainNameLength() {
         String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        assertThrows(IllegalArgumentException.class, () -> new AbstractDnsRecord(name, DnsRecordType.A, 0) { });
+        assertThrows(IllegalArgumentException.class, () -> new TestDnsRecord(name, DnsRecordType.A, 0));
     }
 
     @Test
     public void testValidDomainNameUmlautLength() {
         String name = "äaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        assertThrows(IllegalArgumentException.class, () -> new AbstractDnsRecord(name, DnsRecordType.A, 0) { });
+        assertThrows(IllegalArgumentException.class, () -> new TestDnsRecord(name, DnsRecordType.A, 0));
+    }
+
+    private static final class TestDnsRecord extends AbstractDnsRecord {
+        TestDnsRecord(String name, DnsRecordType type, long timeToLive) {
+            super(name, type, timeToLive);
+        }
+
+        @Override
+        public DnsRecord copy() {
+            return this; // This class is immutable.
+        }
     }
 }

--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/DefaultDnsRecordDecoderTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/DefaultDnsRecordDecoderTest.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.onHeapAllocator;

--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/DnsResponseTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/DnsResponseTest.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.channel.socket.DatagramPacket;

--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/TcpDnsTest.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.dns;
 
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
@@ -65,8 +65,8 @@ public class TcpDnsTest {
                 DnsRecordType.A, TTL, onHeapAllocator().copyOf(QUERY_RESULT));
         assertThat(readResponse.recordAt(DnsSection.ANSWER), is((DnsRecord) record));
         assertThat(readResponse.<DnsRawRecord>recordAt(DnsSection.ANSWER).content(), is(record.content()));
-        ReferenceCountUtil.release(readResponse);
-        ReferenceCountUtil.release(record);
+        Resource.dispose(readResponse);
+        Resource.dispose(record);
         query.release();
         assertFalse(channel.finish());
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpRequest.java
@@ -82,7 +82,7 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
     @Override
     public FullHttpRequest copy() {
         return new DefaultFullHttpRequest(
-                protocolVersion(), method(), uri(), payload.copy(), headers(), trailingHeader.copy());
+                protocolVersion(), method(), uri(), payload.copy(), headers().copy(), trailingHeader.copy());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpResponse.java
@@ -88,6 +88,12 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     }
 
     @Override
+    public DefaultFullHttpResponse copy() {
+        return new DefaultFullHttpResponse(
+                protocolVersion(), status(), payload.copy(), headers().copy(), trailingHeaders);
+    }
+
+    @Override
     public HttpHeaders trailingHeaders() {
         return trailingHeaders;
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpResponse.java
@@ -90,7 +90,7 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     @Override
     public DefaultFullHttpResponse copy() {
         return new DefaultFullHttpResponse(
-                protocolVersion(), status(), payload.copy(), headers().copy(), trailingHeaders);
+                protocolVersion(), status(), payload.copy(), headers().copy(), trailingHeaders.copy());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultFullHttpResponse.java
@@ -16,7 +16,8 @@
 package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.buffer.api.BufferClosedException;
+import io.netty5.util.Send;
 import io.netty5.util.IllegalReferenceCountException;
 
 import static java.util.Objects.requireNonNull;
@@ -30,7 +31,7 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     private final HttpHeaders trailingHeaders;
 
     /**
-     * Used to cache the value of the hash code and avoid {@link IllegalReferenceCountException}.
+     * Used to cache the value of the hash code and avoid {@link BufferClosedException}.
      */
     private int hash;
 
@@ -111,8 +112,8 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
             if (payload.isAccessible()) {
                 try {
                     hash = 31 + payload.hashCode();
-                } catch (IllegalReferenceCountException | io.netty.util.IllegalReferenceCountException ignored) {
-                    // Handle race condition between checking refCnt() == 0 and using the object.
+                } catch (BufferClosedException ignored) {
+                    // Handle race condition between liveness checking and using the object.
                     hash = 31;
                 }
             } else {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpContent.java
@@ -47,6 +47,11 @@ public class DefaultHttpContent extends DefaultHttpObject implements HttpContent
     }
 
     @Override
+    public DefaultHttpContent copy() {
+        return new DefaultHttpContent(payload.copy());
+    }
+
+    @Override
     public void close() {
         payload.close();
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultHttpContent.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.util.internal.StringUtil;
 
 import static java.util.Objects.requireNonNull;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultLastHttpContent.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.handler.codec.DefaultHeaders.NameValidator;
 import io.netty5.util.internal.StringUtil;
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultLastHttpContent.java
@@ -76,6 +76,11 @@ public class DefaultLastHttpContent extends DefaultHttpObject implements LastHtt
     }
 
     @Override
+    public DefaultLastHttpContent copy() {
+        return new DefaultLastHttpContent(payload.copy(), trailingHeaders);
+    }
+
+    @Override
     public void close() {
         payload.close();
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/DefaultLastHttpContent.java
@@ -77,7 +77,7 @@ public class DefaultLastHttpContent extends DefaultHttpObject implements LastHtt
 
     @Override
     public DefaultLastHttpContent copy() {
-        return new DefaultLastHttpContent(payload.copy(), trailingHeaders);
+        return new DefaultLastHttpContent(payload.copy(), trailingHeaders.copy());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/EmptyLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/EmptyLastHttpContent.java
@@ -16,7 +16,7 @@ package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.handler.codec.DecoderResult;
 
 import java.util.Objects;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/EmptyLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/EmptyLastHttpContent.java
@@ -36,6 +36,11 @@ public final class EmptyLastHttpContent implements LastHttpContent<EmptyLastHttp
     }
 
     @Override
+    public EmptyLastHttpContent copy() {
+        return new EmptyLastHttpContent(allocator);
+    }
+
+    @Override
     public Send<EmptyLastHttpContent> send() {
         return Send.sending(EmptyLastHttpContent.class, () -> new EmptyLastHttpContent(allocator));
     }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/FullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/FullHttpRequest.java
@@ -28,6 +28,4 @@ public interface FullHttpRequest extends HttpRequest, FullHttpMessage<FullHttpRe
 
     @Override
     FullHttpRequest setUri(String uri);
-
-    FullHttpRequest copy();
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/FullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/FullHttpRequest.java
@@ -28,4 +28,6 @@ public interface FullHttpRequest extends HttpRequest, FullHttpMessage<FullHttpRe
 
     @Override
     FullHttpRequest setUri(String uri);
+
+    FullHttpRequest copy();
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientCodec.java
@@ -172,11 +172,11 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
         boolean upgraded;
 
         @Override
-        protected void encode(
+        protected void encodeAndClose(
                 ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
 
             if (upgraded) {
-                out.add(ReferenceCountUtil.retain(msg));
+                out.add(msg);
                 return;
             }
 
@@ -184,7 +184,7 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
                 queue.offer(((HttpRequest) msg).method());
             }
 
-            super.encode(ctx, msg, out);
+            super.encodeAndClose(ctx, msg, out);
 
             if (failOnMissingResponse && !done) {
                 // check if the request is chunked if so do not increment

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpClientUpgradeHandler.java
@@ -14,7 +14,7 @@
  */
 package io.netty5.handler.codec.http;
 
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.AsciiString;
 import io.netty5.util.concurrent.Future;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContent.java
@@ -35,4 +35,11 @@ public interface HttpContent<R extends HttpContent<R>> extends HttpObject, Resou
      * @return The {@link Buffer} representing the payload of the HTTP message.
      */
     Buffer payload();
+
+    /**
+     * Create a copy of this HTTP content instance, and return it.
+     *
+     * @return A copy of this HTTP content object.
+     */
+    R copy();
 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContent.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContent.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelPipeline;
 
 /**

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentCompressor.java
@@ -130,12 +130,12 @@ public class HttpContentCompressor extends HttpContentEncoder {
         this.windowBits = ObjectUtil.checkInRange(windowBits, 9, 15, "windowBits");
         this.memLevel = ObjectUtil.checkInRange(memLevel, 1, 9, "memLevel");
         this.contentSizeThreshold = ObjectUtil.checkPositiveOrZero(contentSizeThreshold, "contentSizeThreshold");
-        this.brotliOptions = null;
-        this.gzipOptions = null;
-        this.deflateOptions = null;
-        this.zstdOptions = null;
-        this.factories = null;
-        this.supportsCompressionOptions = false;
+        brotliOptions = null;
+        gzipOptions = null;
+        deflateOptions = null;
+        zstdOptions = null;
+        factories = null;
+        supportsCompressionOptions = false;
     }
 
     /**
@@ -200,34 +200,34 @@ public class HttpContentCompressor extends HttpContentEncoder {
         this.brotliOptions = brotliOptions;
         this.zstdOptions = zstdOptions;
 
-        this.factories = new HashMap<>();
+        factories = new HashMap<>();
 
         if (this.gzipOptions != null) {
-            this.factories.put("gzip", ZlibCompressor.newFactory(
+            factories.put("gzip", ZlibCompressor.newFactory(
                     ZlibWrapper.GZIP, gzipOptions.compressionLevel()));
         }
         if (this.deflateOptions != null) {
-            this.factories.put("deflate", ZlibCompressor.newFactory(
+            factories.put("deflate", ZlibCompressor.newFactory(
                     ZlibWrapper.ZLIB, deflateOptions.compressionLevel()));
         }
 
         if (Brotli.isAvailable() && this.brotliOptions != null) {
-            this.factories.put("br", BrotliCompressor.newFactory(brotliOptions.parameters()));
+            factories.put("br", BrotliCompressor.newFactory(brotliOptions.parameters()));
         }
         if (this.zstdOptions != null) {
-            this.factories.put("zstd", ZstdCompressor.newFactory(zstdOptions.compressionLevel(),
+            factories.put("zstd", ZstdCompressor.newFactory(zstdOptions.compressionLevel(),
                     zstdOptions.blockSize(), zstdOptions.maxEncodeSize()));
         }
 
-        this.compressionLevel = -1;
-        this.windowBits = -1;
-        this.memLevel = -1;
+        compressionLevel = -1;
+        windowBits = -1;
+        memLevel = -1;
         supportsCompressionOptions = true;
     }
 
     @Override
     protected Result beginEncode(HttpResponse httpResponse, String acceptEncoding) {
-        if (this.contentSizeThreshold > 0) {
+        if (contentSizeThreshold > 0) {
             if (httpResponse instanceof HttpContent &&
                     ((HttpContent<?>) httpResponse).payload().readableBytes() < contentSizeThreshold) {
                 return null;
@@ -308,27 +308,27 @@ public class HttpContentCompressor extends HttpContentEncoder {
             }
         }
         if (brQ > 0.0f || zstdQ > 0.0f || gzipQ > 0.0f || deflateQ > 0.0f) {
-            if (brQ != -1.0f && brQ >= zstdQ && this.brotliOptions != null) {
+            if (brQ != -1.0f && brQ >= zstdQ && brotliOptions != null) {
                 return "br";
-            } else if (zstdQ != -1.0f && zstdQ >= gzipQ && this.zstdOptions != null) {
+            } else if (zstdQ != -1.0f && zstdQ >= gzipQ && zstdOptions != null) {
                 return "zstd";
-            } else if (gzipQ != -1.0f && gzipQ >= deflateQ && this.gzipOptions != null) {
+            } else if (gzipQ != -1.0f && gzipQ >= deflateQ && gzipOptions != null) {
                 return "gzip";
-            } else if (deflateQ != -1.0f && this.deflateOptions != null) {
+            } else if (deflateQ != -1.0f && deflateOptions != null) {
                 return "deflate";
             }
         }
         if (starQ > 0.0f) {
-            if (brQ == -1.0f && this.brotliOptions != null) {
+            if (brQ == -1.0f && brotliOptions != null) {
                 return "br";
             }
-            if (zstdQ == -1.0f && this.zstdOptions != null) {
+            if (zstdQ == -1.0f && zstdOptions != null) {
                 return "zstd";
             }
-            if (gzipQ == -1.0f && this.gzipOptions != null) {
+            if (gzipQ == -1.0f && gzipOptions != null) {
                 return "gzip";
             }
-            if (deflateQ == -1.0f && this.deflateOptions != null) {
+            if (deflateQ == -1.0f && deflateOptions != null) {
                 return "deflate";
             }
         }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentEncoder.java
@@ -22,6 +22,7 @@ import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.MessageToMessageCodec;
 import io.netty5.handler.codec.compression.Compressor;
 import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.ArrayDeque;
@@ -76,6 +77,11 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
 
     @Override
     protected void decode(ChannelHandlerContext ctx, HttpRequest msg) throws Exception {
+        throw new UnsupportedOperationException("HttpContentEncoder use decodeAndClose().");
+    }
+
+    @Override
+    protected void decodeAndClose(ChannelHandlerContext ctx, HttpRequest msg) throws Exception {
         CharSequence acceptEncoding;
         List<String> acceptEncodingHeaders = msg.headers().getAll(ACCEPT_ENCODING);
         switch (acceptEncodingHeaders.size()) {
@@ -99,12 +105,18 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
         }
 
         acceptEncodingQueue.add(acceptEncoding);
-        ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
+        ctx.fireChannelRead(msg);
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
+    protected final void encode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
+        throw new UnsupportedOperationException("HttpContentEncoder uses encodeAndClose().");
+    }
+
+    @Override
+    protected void encodeAndClose(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
         final boolean isFull = msg instanceof HttpResponse && msg instanceof LastHttpContent;
+        boolean dispose = true;
         switch (state) {
             case AWAIT_HEADERS: {
                 ensureHeaders(msg);
@@ -141,6 +153,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
                  */
                 if (isPassthru(res.protocolVersion(), code, acceptEncoding)) {
                     out.add(res);
+                    dispose = false;
                     if (!isFull) {
                         // Pass through all following contents.
                         state = State.PASS_THROUGH;
@@ -151,6 +164,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
                 // Pass through the full response with empty content and continue waiting for the next resp.
                 if (isFull && ((LastHttpContent<?>) res).payload().readableBytes() == 0) {
                     out.add(res);
+                    dispose = false;
                     break;
                 }
 
@@ -161,6 +175,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
                 // If unable to encode, pass through.
                 if (result == null) {
                     out.add(res);
+                    dispose = false;
                     if (!isFull) {
                         // Pass through all following contents.
                         state = State.PASS_THROUGH;
@@ -190,6 +205,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
                     res.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
 
                     out.add(res);
+                    dispose = false;
                     state = State.AWAIT_CONTENT;
                     if (!(msg instanceof HttpContent)) {
                         // only break out the switch statement if we have not content to process
@@ -209,12 +225,16 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
             case PASS_THROUGH: {
                 ensureContent(msg);
                 out.add(msg);
+                dispose = false;
                 // Passed through all following contents of the current response.
                 if (msg instanceof LastHttpContent) {
                     state = State.AWAIT_HEADERS;
                 }
                 break;
             }
+        }
+        if (dispose) {
+            Resource.dispose(msg);
         }
     }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpContentEncoder.java
@@ -21,7 +21,6 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.MessageToMessageCodec;
 import io.netty5.handler.codec.compression.Compressor;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.Resource;
 import io.netty5.util.internal.StringUtil;
 
@@ -106,11 +105,6 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
 
         acceptEncodingQueue.add(acceptEncoding);
         ctx.fireChannelRead(msg);
-    }
-
-    @Override
-    protected final void encode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
-        throw new UnsupportedOperationException("HttpContentEncoder uses encodeAndClose().");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
@@ -392,7 +392,7 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
         }
 
         @Override
-        public FullHttpRequest copy() {
+        public AggregatedFullHttpRequest copy() {
             return new AggregatedFullHttpRequest(this, payload().copy(), trailingHeaders().copy());
         }
 
@@ -447,6 +447,11 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
         public Send<FullHttpResponse> send() {
             return payload().send().map(FullHttpResponse.class,
                     p -> new AggregatedFullHttpResponse(this, p, trailingHeaders()));
+        }
+
+        @Override
+        public AggregatedFullHttpResponse copy() {
+            return new AggregatedFullHttpResponse(this, payload().copy(), trailingHeaders());
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
@@ -18,7 +18,7 @@ package io.netty5.handler.codec.http;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
@@ -389,6 +389,11 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
         public Send<FullHttpRequest> send() {
             return payload().send().map(FullHttpRequest.class,
                     p -> new AggregatedFullHttpRequest(this, p, trailingHeaders()));
+        }
+
+        @Override
+        public FullHttpRequest copy() {
+            return new AggregatedFullHttpRequest(this, payload().copy(), trailingHeaders().copy());
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpObjectAggregator.java
@@ -451,7 +451,7 @@ public class HttpObjectAggregator<C extends HttpContent<C>>
 
         @Override
         public AggregatedFullHttpResponse copy() {
-            return new AggregatedFullHttpResponse(this, payload().copy(), trailingHeaders());
+            return new AggregatedFullHttpResponse(this, payload().copy(), trailingHeaders().copy());
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/HttpServerExpectContinueHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/HttpServerExpectContinueHandler.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelFutureListeners;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 
 import static io.netty5.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty5.handler.codec.http.HttpResponseStatus.CONTINUE;
@@ -78,7 +78,7 @@ public class HttpServerExpectContinueHandler implements ChannelHandler {
                 if (accept == null) {
                     // the expectation failed so we refuse the request.
                     HttpResponse rejection = rejectResponse(ctx.bufferAllocator(), req);
-                    ReferenceCountUtil.release(msg);
+                    Resource.dispose(msg);
                     ctx.writeAndFlush(rejection).addListener(ctx.channel(), ChannelFutureListeners.CLOSE_ON_FAILURE);
                     return;
                 }

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/PongWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/PongWebSocketFrame.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 
 /**
  * Web Socket frame containing binary data.

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocket13FrameEncoder.java
@@ -98,7 +98,7 @@ public class WebSocket13FrameEncoder extends MessageToMessageEncoder<WebSocketFr
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
+    protected void encodeAndClose(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
         final Buffer data = msg.binaryData();
         byte[] mask;
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -19,6 +19,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.http.HttpHeaders;
+import io.netty5.util.Resource;
 
 import java.net.URI;
 import java.util.Objects;
@@ -361,12 +362,13 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
+    protected void decodeAndClose(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
         if (clientConfig.handleCloseFrames() && frame instanceof CloseWebSocketFrame) {
+            Resource.dispose(frame);
             ctx.close();
             return;
         }
-        super.decode(ctx, frame);
+        super.decodeAndClose(ctx, frame);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketFrame.java
@@ -17,8 +17,8 @@ package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferHolder;
-import io.netty5.buffer.api.Resource;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 import io.netty5.util.internal.StringUtil;
 
 import static java.nio.charset.Charset.defaultCharset;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -18,7 +18,7 @@ package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToMessageDecoder;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 
@@ -59,7 +59,12 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
+    protected void decode(ChannelHandlerContext ctx, WebSocketFrame msg) throws Exception {
+        throw new UnsupportedOperationException("WebSocketProtocolHandler use decodeAndClose().");
+    }
+
+    @Override
+    protected void decodeAndClose(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
         if (frame instanceof PingWebSocketFrame) {
             // We need to `send` the binary data to the pong frame, because the MessageToMessageDecoder
             // is going to close the ping frame, which would otherwise cause the data to be freed.
@@ -101,7 +106,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
     @Override
     public Future<Void> write(final ChannelHandlerContext ctx, Object msg) {
         if (closeSent != null) {
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
             return ctx.newFailedFuture(new ClosedChannelException());
         }
         if (msg instanceof CloseWebSocketFrame) {

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -223,7 +223,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
+    protected void decodeAndClose(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
         if (serverConfig.handleCloseFrames() && frame instanceof CloseWebSocketFrame) {
             WebSocketServerHandshaker handshaker = getHandshaker(ctx.channel());
             if (handshaker != null) {
@@ -236,7 +236,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
             }
             return;
         }
-        super.decode(ctx, frame);
+        super.decodeAndClose(ctx, frame);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
@@ -31,6 +31,7 @@ import io.netty5.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty5.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionDecoder;
 import io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter;
+import io.netty5.util.internal.SilentDispose;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,9 +96,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
         } else if (msg instanceof ContinuationWebSocketFrame) {
             outMsg = new ContinuationWebSocketFrame(msg.isFinalFragment(), newRsv(msg), decompressedContent);
         } else {
-            if (Resource.isAccessible(msg, false)) {
-                Resource.dispose(msg);
-            }
+            SilentDispose.tryPropagatingDispose(msg);
             throw new CodecException("unexpected frame type: " + msg.getClass().getName());
         }
 

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.http.websocketx.extensions.compression;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.CodecException;
@@ -93,7 +93,7 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
     protected abstract boolean removeFrameTail(WebSocketFrame msg);
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
+    protected void encodeAndClose(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
         final Buffer compressedContent;
         if (msg.binaryData().readableBytes() > 0) {
             compressedContent = compressContent(ctx, msg);

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoder.java
@@ -80,9 +80,9 @@ class PerMessageDeflateDecoder extends DeflateDecoder {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, WebSocketFrame msg) throws Exception {
+    protected void decodeAndClose(ChannelHandlerContext ctx, WebSocketFrame msg) throws Exception {
         boolean isFinal = msg.isFinalFragment();
-        super.decode(ctx, msg);
+        super.decodeAndClose(ctx, msg);
 
         if (isFinal) {
             compressing = false;

--- a/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoder.java
@@ -87,9 +87,9 @@ class PerMessageDeflateEncoder extends DeflateEncoder {
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, WebSocketFrame msg,
+    protected void encodeAndClose(ChannelHandlerContext ctx, WebSocketFrame msg,
                           List<Object> out) throws Exception {
-        super.encode(ctx, msg, out);
+        super.encodeAndClose(ctx, msg, out);
 
         if (msg.isFinalFragment()) {
             compressing = false;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientCodecTest.java
@@ -18,7 +18,7 @@ package io.netty5.handler.codec.http;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Test;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 
-import static io.netty5.util.ReferenceCountUtil.release;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -252,7 +251,7 @@ public class HttpClientCodecTest {
             if (msg == null) {
                 break;
             }
-            release(msg);
+            Resource.dispose(msg);
         }
         for (;;) {
             Object msg = ch.readInbound();
@@ -260,7 +259,7 @@ public class HttpClientCodecTest {
                 break;
             }
             responseConsumer.onResponse(msg);
-            release(msg);
+            Resource.dispose(msg);
         }
     }
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.codec.http;
 
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentCompressorTest.java
@@ -710,6 +710,11 @@ public class HttpContentCompressorTest {
         }
 
         @Override
+        public AssembledHttpResponse copy() {
+            return new AssembledHttpResponse(protocolVersion(), status(), headers().copy(), payload.copy());
+        }
+
+        @Override
         public void close() {
             payload.close();
         }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentCompressorTest.java
@@ -17,12 +17,12 @@ package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.DecoderResult;
 import io.netty5.handler.codec.EncoderException;
 import io.netty5.handler.codec.compression.ZlibWrapper;
-import io.netty5.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -522,14 +522,14 @@ public class HttpContentCompressorTest {
             if (message == null) {
                 break;
             }
-            ReferenceCountUtil.release(message);
+            Resource.dispose(message);
         }
         for (;;) {
             Object message = ch.readInbound();
             if (message == null) {
                 break;
             }
-            ReferenceCountUtil.release(message);
+            Resource.dispose(message);
         }
     }
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpContentEncoderTest.java
@@ -436,11 +436,9 @@ public class HttpContentEncoderTest {
             @Override
             protected Result beginEncode(HttpResponse httpResponse, String acceptEncoding) {
                 return new Result("myencoding", new Compressor() {
-                    private Buffer input;
 
                     @Override
                     public Buffer compress(Buffer input, BufferAllocator allocator) throws CompressionException {
-                        this.input = input;
                         return input.copy();
                     }
 
@@ -461,9 +459,6 @@ public class HttpContentEncoderTest {
 
                     @Override
                     public void close() {
-                        if (input != null) {
-                            input.close();
-                        }
                         throw new EncoderException();
                     }
                 });
@@ -483,7 +478,7 @@ public class HttpContentEncoderTest {
         assertTrue(channel.writeOutbound(new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.OK)));
         HttpContent<?> content = new DefaultHttpContent(preferredAllocator().copyOf(new byte[10]));
         assertTrue(channel.writeOutbound(content));
-        assertTrue(content.isAccessible());
+        assertFalse(content.isAccessible());
         assertThrows(CodecException.class, channel::finishAndReleaseAll);
 
         assertTrue(channelInactiveCalled.get());

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpObjectAggregatorTest.java
@@ -20,7 +20,7 @@ import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.DecoderResultProvider;
 import io.netty5.util.AsciiString;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
@@ -165,7 +165,7 @@ public class HttpObjectAggregatorTest {
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
         assertThat(response, instanceOf(LastHttpContent.class));
-        ReferenceCountUtil.release(response);
+        Resource.dispose(response);
 
         assertTrue(embedder.isOpen());
 
@@ -213,7 +213,7 @@ public class HttpObjectAggregatorTest {
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
         assertThat(response, instanceOf(LastHttpContent.class));
-        ReferenceCountUtil.release(response);
+        Resource.dispose(response);
 
         if (serverShouldCloseConnection(message, response)) {
             assertFalse(embedder.isOpen());
@@ -581,7 +581,7 @@ public class HttpObjectAggregatorTest {
             try {
                 assertTrue(msg1 instanceof FullHttpRequest);
             } finally {
-                ReferenceCountUtil.release(msg1);
+                Resource.dispose(msg1);
             }
 
             // Don't aggregate: non-POST
@@ -598,8 +598,8 @@ public class HttpObjectAggregatorTest {
                 assertSame(content2, channel.readInbound());
                 assertEquals(new EmptyLastHttpContent(preferredAllocator()), channel.readInbound());
             } finally {
-              ReferenceCountUtil.release(request2);
-              ReferenceCountUtil.release(content2);
+              Resource.dispose(request2);
+              Resource.dispose(content2);
             }
 
             assertFalse(channel.finish());
@@ -644,7 +644,7 @@ public class HttpObjectAggregatorTest {
             try {
                 assertTrue(msg1 instanceof FullHttpResponse);
             } finally {
-                ReferenceCountUtil.release(msg1);
+                Resource.dispose(msg1);
             }
 
             // Don't aggregate: application/json
@@ -662,8 +662,8 @@ public class HttpObjectAggregatorTest {
                 assertSame(content2, channel.readInbound());
                 assertEquals(new EmptyLastHttpContent(preferredAllocator()), channel.readInbound());
             } finally {
-                ReferenceCountUtil.release(response2);
-                ReferenceCountUtil.release(content2);
+                Resource.dispose(response2);
+                Resource.dispose(content2);
             }
 
             assertFalse(channel.finish());

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpResponseDecoderTest.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.PrematureChannelClosureException;
 import io.netty5.util.CharsetUtil;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerExpectContinueHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerExpectContinueHandlerTest.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.http;
 
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
@@ -48,11 +48,11 @@ public class HttpServerExpectContinueHandlerTest {
 
         assertThat(response.status(), is(HttpResponseStatus.CONTINUE));
         assertThat(response.headers().get("foo"), is("bar"));
-        ReferenceCountUtil.release(response);
+        Resource.dispose(response);
 
         HttpRequest processedRequest = channel.readInbound();
         assertFalse(processedRequest.headers().contains(HttpHeaderNames.EXPECT));
-        ReferenceCountUtil.release(processedRequest);
+        Resource.dispose(processedRequest);
         assertFalse(channel.finishAndReleaseAll());
     }
 
@@ -81,7 +81,7 @@ public class HttpServerExpectContinueHandlerTest {
         HttpResponse response = channel.readOutbound();
 
         assertThat(response.status(), is(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE));
-        ReferenceCountUtil.release(response);
+        Resource.dispose(response);
 
         // request was swallowed
         assertTrue(channel.inboundMessages().isEmpty());

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerKeepAliveHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerKeepAliveHandlerTest.java
@@ -17,7 +17,7 @@ package io.netty5.handler.codec.http;
 
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.AsciiString;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -93,13 +93,13 @@ public class HttpServerKeepAliveHandlerTest {
         assertTrue(channel.writeInbound(request));
         Object requestForwarded = channel.readInbound();
         assertEquals(request, requestForwarded);
-        ReferenceCountUtil.release(requestForwarded);
+        Resource.dispose(requestForwarded);
         channel.writeAndFlush(response);
         HttpResponse writtenResponse = channel.readOutbound();
 
         assertEquals(isKeepAliveResponseExpected, channel.isOpen(), "channel.isOpen");
         assertEquals(isKeepAliveResponseExpected, isKeepAlive(writtenResponse), "response keep-alive");
-        ReferenceCountUtil.release(writtenResponse);
+        Resource.dispose(writtenResponse);
         assertFalse(channel.finishAndReleaseAll());
     }
 
@@ -130,7 +130,7 @@ public class HttpServerKeepAliveHandlerTest {
         HttpResponse writtenResponse = channel.readOutbound();
 
         assertFalse(channel.isOpen());
-        ReferenceCountUtil.release(writtenResponse);
+        Resource.dispose(writtenResponse);
         assertFalse(channel.finishAndReleaseAll());
     }
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -22,7 +22,7 @@ import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodec;
 import io.netty5.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodecFactory;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
@@ -200,7 +200,7 @@ public class HttpServerUpgradeHandlerTest {
         assertEquals(HttpVersion.HTTP_1_1, req.protocolVersion());
         assertTrue(req.headers().contains(HttpHeaderNames.UPGRADE, "h2c", false));
         assertFalse(req.headers().contains(HttpHeaderNames.CONNECTION));
-        ReferenceCountUtil.release(req);
+        Resource.dispose(req);
         assertNull(channel.readInbound());
 
         // No response should be written because we're just passing through.

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/HttpUtilTest.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.http;
 
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -303,7 +303,7 @@ public class HttpUtilTest {
 
     private static void run100ContinueTest(final HttpMessage message, final boolean expected) {
         assertEquals(expected, HttpUtil.is100ContinueExpected(message));
-        ReferenceCountUtil.release(message);
+        Resource.dispose(message);
     }
 
     @Test
@@ -333,7 +333,7 @@ public class HttpUtilTest {
 
     private static void runUnsupportedExpectationTest(final HttpMessage message, final boolean expected) {
         assertEquals(expected, HttpUtil.isUnsupportedExpectation(message));
-        ReferenceCountUtil.release(message);
+        Resource.dispose(message);
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/cors/CorsHandlerTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.codec.http.cors;
 
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.TooLongFrameException;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -143,7 +143,7 @@ public class WebSocketFrameAggregatorTest {
             if (msg == null) {
                 break;
             }
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
         }
         channel.finish();
     }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -26,6 +26,7 @@ import io.netty5.handler.codec.http.HttpClientCodec;
 import io.netty5.handler.codec.http.HttpObjectAggregator;
 import io.netty5.handler.codec.http.HttpServerCodec;
 import io.netty5.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -60,12 +61,13 @@ public class WebSocketHandshakeHandOverTest {
         }
 
         @Override
-        protected void decode(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
+        protected void decodeAndClose(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
             if (frame instanceof CloseWebSocketFrame) {
                 serverReceivedCloseHandshake = true;
+                Resource.dispose(frame);
                 return;
             }
-            super.decode(ctx, frame);
+            super.decodeAndClose(ctx, frame);
         }
     }
 

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
@@ -21,7 +21,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.flow.FlowControlHandler;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -160,7 +160,7 @@ public class WebSocketProtocolHandlerTest {
             public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
                 Future<Void> future = ctx.newPromise().asFuture();
                 ref.set(future);
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
                 return future;
             }
         }, handler);

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.codec.http.websocketx;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.http.DefaultFullHttpRequest;

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakerFactoryTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerHandshakerFactoryTest.java
@@ -21,7 +21,7 @@ import io.netty5.handler.codec.http.FullHttpResponse;
 import io.netty5.handler.codec.http.HttpHeaderNames;
 import io.netty5.handler.codec.http.HttpResponseStatus;
 import io.netty5.handler.codec.http.HttpUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,7 +49,7 @@ public class WebSocketServerHandshakerFactoryTest {
         assertTrue(HttpUtil.isContentLengthSet(response));
         assertEquals(0, HttpUtil.getContentLength(response));
 
-        ReferenceCountUtil.release(response);
+        Resource.dispose(response);
         assertFalse(ch.finish());
     }
 }

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -34,7 +34,7 @@ import io.netty5.handler.codec.http.HttpRequestDecoder;
 import io.netty5.handler.codec.http.HttpResponseEncoder;
 import io.netty5.handler.codec.http.HttpServerCodec;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -299,7 +299,9 @@ public class WebSocketServerProtocolHandlerTest {
         closeMessage.close();
 
         client.close();
-        assertTrue(ReferenceCountUtil.release(client.readOutbound()));
+        Object obj = client.readOutbound();
+        Resource.dispose(obj);
+        assertFalse(Resource.isAccessible(obj, true));
         assertFalse(client.finishAndReleaseAll());
         assertFalse(server.finishAndReleaseAll());
     }
@@ -324,7 +326,9 @@ public class WebSocketServerProtocolHandlerTest {
         closeMessage.close();
 
         client.close();
-        assertTrue(ReferenceCountUtil.release(client.readOutbound()));
+        Object obj = client.readOutbound();
+        Resource.dispose(obj);
+        assertFalse(Resource.isAccessible(obj, true));
         assertFalse(client.finishAndReleaseAll());
         assertFalse(server.finishAndReleaseAll());
     }
@@ -490,7 +494,7 @@ public class WebSocketServerProtocolHandlerTest {
         public void channelRead(ChannelHandlerContext ctx, Object msg) {
             assertNull(content);
             content = "processed: " + ((TextWebSocketFrame) msg).text();
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
         }
 
         String getContent() {

--- a/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty5/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -35,6 +35,7 @@ import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtens
 import static io.netty5.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.ALWAYS_SKIP;
 import static io.netty5.handler.codec.http.websocketx.extensions.compression.DeflateEncoder.EMPTY_DEFLATE_BLOCK;
 import static io.netty5.util.CharsetUtil.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -374,7 +375,7 @@ public class PerMessageDeflateDecoderTest {
         ContinuationWebSocketFrame uncompressedFrame2 = decoderChannel.readInbound();
         ContinuationWebSocketFrame uncompressedFrame3 = decoderChannel.readInbound();
         ContinuationWebSocketFrame uncompressedExtraData = decoderChannel.readInbound();
-        assertFalse(uncompressedExtraData.binaryData().readableBytes() > 0);
+        assertThat(uncompressedExtraData.binaryData().readableBytes()).isZero();
 
         Buffer uncompressedPayload = encoderChannel.bufferAllocator()
                 .allocate(uncompressedFrame1.binaryData().readableBytes() +

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2ClientUpgradeCodec.java
@@ -15,7 +15,7 @@
 package io.netty5.handler.codec.http2;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.base64.Base64;

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2FrameCodec.java
@@ -254,7 +254,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
             ctx.executor().execute(() -> ctx.fireUserEventTriggered(evt));
         } else if (evt instanceof UpgradeEvent) {
             try (UpgradeEvent upgrade = (UpgradeEvent) evt) {
-                ctx.fireUserEventTriggered(upgrade.copy());
+                ctx.fireUserEventTriggered(upgrade.copy()); // TODO try to avoid full copy (maybe make it read-only?)
                 Http2Stream stream = connection().stream(HTTP_UPGRADE_STREAM_ID);
                 if (stream.getProperty(streamKey) == null) {
                     // TODO: improve handler/stream lifecycle so that stream isn't active before handler added.

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -85,7 +85,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, Http2StreamFrame frame) throws Exception {
+    protected void decodeAndClose(ChannelHandlerContext ctx, Http2StreamFrame frame) throws Exception {
         if (frame instanceof Http2HeadersFrame) {
             Http2HeadersFrame headersFrame = (Http2HeadersFrame) frame;
             Http2Headers headers = headersFrame.headers();
@@ -157,7 +157,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
      * @throws Exception    is thrown if an error occurs
      */
     @Override
-    protected void encode(ChannelHandlerContext ctx, HttpObject obj, List<Object> out) throws Exception {
+    protected void encodeAndClose(ChannelHandlerContext ctx, HttpObject obj, List<Object> out) throws Exception {
         // 100-continue is typically a FullHttpResponse, but the decoded
         // Http2HeadersFrame should not be marked as endStream=true
         if (obj instanceof HttpResponse) {

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -27,7 +27,7 @@ import io.netty5.handler.codec.http.HttpMessage;
 import io.netty5.handler.codec.http.HttpScheme;
 import io.netty5.handler.codec.http.LastHttpContent;
 import io.netty5.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregator;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.UnstableApi;
@@ -152,7 +152,7 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
             promiseAggregator.setFailure(t);
         } finally {
             if (release) {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
             }
             promiseAggregator.doneAllocatingPromises();
         }

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/StreamBufferingEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/StreamBufferingEncoder.java
@@ -17,10 +17,10 @@ package io.netty5.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.UnstableApi;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
@@ -220,7 +220,7 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
             pendingStream.frames.add(new DataFrame(data, padding, endOfStream, promise));
             return promise.asFuture();
         } else {
-            Resource.dispose(data, logger);
+            SilentDispose.dispose(data, logger);
             return ctx.newFailedFuture(connectionError(PROTOCOL_ERROR, "Stream does not exist %d", streamId));
         }
     }
@@ -376,7 +376,7 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
         @Override
         void release(Throwable t) {
             super.release(t);
-            Resource.dispose(data, logger);
+            SilentDispose.dispose(data, logger);
         }
 
         @Override

--- a/codec-http2/src/main/java/io/netty5/handler/codec/http2/StreamBufferingEncoder.java
+++ b/codec-http2/src/main/java/io/netty5/handler/codec/http2/StreamBufferingEncoder.java
@@ -17,11 +17,13 @@ package io.netty5.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.UnstableApi;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.Iterator;
@@ -57,6 +59,7 @@ import static io.netty5.handler.codec.http2.Http2Exception.connectionError;
  */
 @UnstableApi
 public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(StreamBufferingEncoder.class);
 
     /**
      * Thrown if buffered streams are terminated due to this encoder being closed.
@@ -217,7 +220,7 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
             pendingStream.frames.add(new DataFrame(data, padding, endOfStream, promise));
             return promise.asFuture();
         } else {
-            ReferenceCountUtil.safeRelease(data);
+            Resource.dispose(data, logger);
             return ctx.newFailedFuture(connectionError(PROTOCOL_ERROR, "Stream does not exist %d", streamId));
         }
     }
@@ -373,7 +376,7 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
         @Override
         void release(Throwable t) {
             super.release(t);
-            ReferenceCountUtil.safeRelease(data);
+            Resource.dispose(data, logger);
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -16,6 +16,7 @@
 package io.netty5.handler.codec.http2;
 
 import io.netty5.buffer.api.Buffer;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -34,7 +35,6 @@ import io.netty5.handler.codec.http.LastHttpContent;
 import io.netty5.handler.codec.http2.CleartextHttp2ServerUpgradeHandler.PriorKnowledgeUpgradeEvent;
 import io.netty5.handler.codec.http2.Http2Stream.State;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -254,7 +254,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
         Object userEvent = userEvents.get(0);
         assertTrue(userEvent instanceof UpgradeEvent);
         assertEquals("h2c", ((UpgradeEvent) userEvent).protocol());
-        ReferenceCountUtil.release(userEvent);
+        Resource.dispose(userEvent);
 
         assertEquals(100, http2ConnectionHandler.connection().local().maxActiveStreams());
         assertEquals(65535, http2ConnectionHandler.connection().local().flowController().initialWindowSize());

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -19,7 +19,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import org.junit.jupiter.api.AfterEach;
@@ -77,7 +77,7 @@ public class DefaultHttp2FrameWriterTest {
             if (msg instanceof ByteBuf) {
                 outbound.writeBytes((ByteBuf) msg);
             }
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
             return future;
         };
         when(ctx.write(any())).then(answer);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
@@ -18,6 +18,7 @@ package io.netty5.handler.codec.http2;
 import io.netty.buffer.Unpooled;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
@@ -29,7 +30,6 @@ import io.netty5.channel.socket.SocketChannel;
 import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -224,7 +224,7 @@ public class DefaultHttp2PushPromiseFrameTest {
                         ctx.writeAndFlush(new DefaultHttp2GoAwayFrame(Http2Error.REFUSED_STREAM));
                     }
                 } finally {
-                    ReferenceCountUtil.release(dataFrame);
+                    Resource.dispose(dataFrame);
                 }
             }
         }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -25,7 +25,7 @@ import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.DefaultChannelConfig;
 import io.netty5.handler.codec.http.HttpResponseStatus;
 import io.netty5.handler.codec.http2.Http2Exception.ShutdownHint;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
@@ -200,7 +200,7 @@ public class Http2ConnectionHandlerTest {
         when(ctx.executor()).thenReturn(executor);
         doAnswer(in -> {
             Object msg = in.getArgument(0);
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
             return null;
         }).when(ctx).fireChannelRead(any());
         doAnswer((Answer<Future<Void>>) in ->

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -33,7 +34,6 @@ import io.netty5.channel.local.LocalServerChannel;
 import io.netty5.handler.codec.http2.Http2TestUtil.FrameCountDown;
 import io.netty5.util.AsciiString;
 import io.netty5.util.IllegalReferenceCountException;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
@@ -642,7 +642,7 @@ public class Http2ConnectionRoundtripTest {
             clientChannel.pipeline().addFirst(new ChannelHandler() {
                 @Override
                 public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
-                    ReferenceCountUtil.release(msg);
+                    Resource.dispose(msg);
 
                     try {
                         // Ensure we update the window size so we will try to write the rest of the frame while

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
@@ -17,12 +17,12 @@ package io.netty5.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.DefaultMessageSizeEstimator;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
@@ -112,7 +112,7 @@ public class Http2ControlFrameLimitEncoderTest {
                 });
         when(writer.writeGoAway(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class)))
                 .thenAnswer((Answer<Future<Void>>) invocationOnMock -> {
-                    ReferenceCountUtil.release(invocationOnMock.getArgument(3));
+                    Resource.dispose(invocationOnMock.getArgument(3));
                     Promise<Void> promise =  ImmediateEventExecutor.INSTANCE.newPromise();
                     goAwayPromises.offer(promise);
                     return promise.asFuture();

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2FrameCodecTest.java
@@ -33,8 +33,8 @@ import io.netty5.handler.codec.http2.Http2Stream.State;
 import io.netty5.handler.logging.LogLevel;
 import io.netty5.util.AbstractReferenceCounted;
 import io.netty5.util.AsciiString;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.ReferenceCounted;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 import io.netty5.util.concurrent.Promise;
@@ -898,7 +898,7 @@ public class Http2FrameCodecTest {
                         }
                     });
                 }
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
             }
         });
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTest.java
@@ -16,6 +16,7 @@ package io.netty5.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -53,7 +54,6 @@ import java.util.function.Consumer;
 import static io.netty5.handler.codec.http2.Http2TestUtil.anyHttp2Settings;
 import static io.netty5.handler.codec.http2.Http2TestUtil.assertEqualsAndRelease;
 import static io.netty5.handler.codec.http2.Http2TestUtil.bb;
-import static io.netty5.util.ReferenceCountUtil.release;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -416,7 +416,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("hello world"), 0, false);
         Http2DataFrame dataFrame0 = inboundHandler.readInbound();
         assertNotNull(dataFrame0);
-        release(dataFrame0);
+        Resource.dispose(dataFrame0);
 
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("foo"), 0, false);
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("bar"), 0, false);
@@ -450,7 +450,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("hello world"), 0, false);
         Http2DataFrame dataFrame0 = inboundHandler.readInbound();
         assertNotNull(dataFrame0);
-        release(dataFrame0);
+        Resource.dispose(dataFrame0);
 
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("foo"), 0, false);
         frameInboundWriter.writeInboundData(childChannel.stream().id(), bb("bar"), 0, false);
@@ -1329,7 +1329,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             Http2StreamFrame frame = inboundHandler.readInbound();
             assertNotNull(frame, i + " out of " + numFrames + " received");
             assertEquals(streamChannel.stream(), frame.stream());
-            release(frame);
+            Resource.dispose(frame);
         }
         assertNull(inboundHandler.readInbound());
     }

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -18,7 +18,7 @@ package io.netty5.handler.codec.http2;
 import io.netty.buffer.Unpooled;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerAdapter;
@@ -44,7 +44,6 @@ import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -160,7 +159,7 @@ public class Http2MultiplexTransportTest {
                             serverAckOneLatch.countDown();
                             serverAckAllLatch.countDown();
                         }
-                        ReferenceCountUtil.release(msg);
+                        Resource.dispose(msg);
                     }
                 });
             }
@@ -181,7 +180,7 @@ public class Http2MultiplexTransportTest {
                         if (msg instanceof Http2SettingsFrame) {
                             clientSettingsLatch.countDown();
                         }
-                        ReferenceCountUtil.release(msg);
+                        Resource.dispose(msg);
                     }
                 });
             }
@@ -234,7 +233,7 @@ public class Http2MultiplexTransportTest {
                                     });
                                 }, 500, MILLISECONDS);
                             }
-                            ReferenceCountUtil.release(msg);
+                            Resource.dispose(msg);
                         }
                     }));
                 }
@@ -260,7 +259,7 @@ public class Http2MultiplexTransportTest {
                     if (msg instanceof Http2DataFrame && ((Http2DataFrame) msg).isEndStream()) {
                         latch.countDown();
                     }
-                    ReferenceCountUtil.release(msg);
+                    Resource.dispose(msg);
                 }
             });
             Http2StreamChannel streamChannel = h2Bootstrap.open().syncUninterruptibly().getNow();
@@ -511,7 +510,7 @@ public class Http2MultiplexTransportTest {
                                                            true));
                                            });
                                     }
-                                    ReferenceCountUtil.release(msg);
+                                    Resource.dispose(msg);
                                 }
                             }));
                         }
@@ -558,7 +557,7 @@ public class Http2MultiplexTransportTest {
                                             if (msg instanceof Http2DataFrame && ((Http2DataFrame) msg).isEndStream()) {
                                                 latch.countDown();
                                             }
-                                            ReferenceCountUtil.release(msg);
+                                            Resource.dispose(msg);
                                         }
                                     });
                                     h2Bootstrap.open().addListener(future -> {

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/Http2TestUtil.java
@@ -22,6 +22,7 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.util.AsciiString;
 import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
 import org.mockito.Mockito;
@@ -32,9 +33,9 @@ import java.util.concurrent.CountDownLatch;
 
 import static io.netty5.handler.codec.http2.Http2CodecUtil.MAX_HEADER_LIST_SIZE;
 import static io.netty5.handler.codec.http2.Http2CodecUtil.MAX_HEADER_TABLE_SIZE;
-import static io.netty5.util.ReferenceCountUtil.release;
 import static java.lang.Math.min;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -422,11 +423,11 @@ public final class Http2TestUtil {
         try {
             assertEquals(expected, actual);
         } finally {
-            release(expected);
-            release(actual);
-            // Will return -1 when not implements ReferenceCounted.
-            assertTrue(ReferenceCountUtil.refCnt(expected) <= 0);
-            assertTrue(ReferenceCountUtil.refCnt(actual) <= 0);
+            Resource.dispose(expected);
+            Resource.dispose(actual);
+            // Will return 'false' when not implements Resource or ReferenceCounted.
+            assertFalse(Resource.isAccessible(expected, false));
+            assertFalse(Resource.isAccessible(actual, false));
         }
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/LastInboundHandler.java
@@ -20,7 +20,7 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.internal.PlatformDependent;
 
 import java.util.ArrayList;
@@ -195,7 +195,7 @@ public class LastInboundHandler implements ChannelHandler {
         checkException();
         Object o;
         while ((o = readInboundMessageOrUserEvent()) != null) {
-            ReferenceCountUtil.release(o);
+            Resource.dispose(o);
         }
     }
 

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -18,17 +18,19 @@ package io.netty5.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelMetadata;
 import io.netty5.channel.DefaultMessageSizeEstimator;
 import io.netty5.handler.codec.http2.StreamBufferingEncoder.Http2GoAwayException;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -71,6 +73,7 @@ import static org.mockito.Mockito.when;
  */
 @SuppressWarnings("unchecked")
 public class StreamBufferingEncoderTest {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(StreamBufferingEncoderTest.class);
 
     private StreamBufferingEncoder encoder;
 
@@ -544,7 +547,7 @@ public class StreamBufferingEncoderTest {
     private static Answer<Future<Void>> successAnswer() {
         return invocation -> {
             for (Object a : invocation.getArguments()) {
-                ReferenceCountUtil.safeRelease(a);
+                Resource.dispose(a, logger);
             }
 
             return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);

--- a/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty5/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -18,7 +18,6 @@ package io.netty5.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandlerContext;
@@ -29,6 +28,7 @@ import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -547,7 +547,7 @@ public class StreamBufferingEncoderTest {
     private static Answer<Future<Void>> successAnswer() {
         return invocation -> {
             for (Object a : invocation.getArguments()) {
-                Resource.dispose(a, logger);
+                SilentDispose.dispose(a, logger);
             }
 
             return ImmediateEventExecutor.INSTANCE.newSucceededFuture(null);

--- a/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageAggregator.java
@@ -22,7 +22,7 @@ import io.netty5.channel.ChannelFutureListeners;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureContextListener;
 
@@ -398,7 +398,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
             handleOversizedMessage(ctx, oversized);
         } finally {
             // Release the message in case it is a full one.
-            ReferenceCountUtil.release(oversized);
+            Resource.dispose(oversized);
         }
     }
 

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToByteEncoder.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToByteEncoder.java
@@ -21,7 +21,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.TypeParameterMatcher;
 
@@ -106,7 +106,7 @@ public abstract class MessageToByteEncoder<I> extends ChannelHandlerAdapter {
                 try {
                     encode(ctx, cast, buf);
                 } finally {
-                    ReferenceCountUtil.release(cast);
+                    Resource.dispose(cast);
                 }
 
                 if (buf.isReadable()) {

--- a/codec/src/main/java/io/netty5/handler/codec/MessageToByteEncoderForBuffer.java
+++ b/codec/src/main/java/io/netty5/handler/codec/MessageToByteEncoderForBuffer.java
@@ -16,11 +16,11 @@
 package io.netty5.handler.codec;
 
 import io.netty5.buffer.api.Buffer;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerAdapter;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.TypeParameterMatcher;
 
@@ -80,7 +80,7 @@ public abstract class MessageToByteEncoderForBuffer<I> extends ChannelHandlerAda
                 try {
                     encode(ctx, cast, buf);
                 } finally {
-                    ReferenceCountUtil.release(cast);
+                    Resource.dispose(cast);
                 }
 
                 if (buf.readableBytes() > 0) {

--- a/codec/src/test/java/io/netty5/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/AbstractIntegrationTest.java
@@ -21,7 +21,7 @@ import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.internal.EmptyArrays;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -84,7 +84,8 @@ public abstract class AbstractIntegrationTest {
     }
 
     @Test
-    @Ignore("Fails due extending a composite with a composite while the reader index is not 0 of the underlying buffer")
+    @Disabled("Fails due extending a composite with a composite while the reader index is not 0 of the underlying " +
+              "buffer")
     public void testLargeRandom() throws Exception {
         final byte[] data = new byte[1024 * 1024];
         rand.nextBytes(data);

--- a/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
+++ b/codec/src/test/java/io/netty5/handler/codec/compression/CompressionTestUtils.java
@@ -18,7 +18,7 @@ package io.netty5.handler.codec.compression;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.channel.embedded.EmbeddedChannel;
 
 import java.util.ArrayList;

--- a/common/src/main/java/io/netty5/util/Resource.java
+++ b/common/src/main/java/io/netty5/util/Resource.java
@@ -15,9 +15,6 @@
  */
 package io.netty5.util;
 
-import io.netty5.util.internal.logging.InternalLogger;
-import org.jetbrains.annotations.Nullable;
-
 /**
  * A resource that has a life-time, and can be {@linkplain #close() closed}.
  * Resources are initially {@linkplain #isAccessible() accessible}, but closing them makes them inaccessible.
@@ -93,31 +90,6 @@ public interface Resource<T extends Resource<T>> extends AutoCloseable {
             }
         } else if (ReferenceCountUtil.isReferenceCounted(obj)) {
             ReferenceCountUtil.release(obj);
-        }
-    }
-
-    /**
-     * Attempt to dispose of whatever the given object is.
-     * <p>
-     * If the object is {@link AutoCloseable}, such as anything that implements {@link Resource},
-     * then it will be closed.
-     * If the object is {@link ReferenceCounted}, then it will be released once.
-     * <p>
-     * Any exceptions caused by this will be logged using the given logger.
-     * The exception will be logged at log-level {@link io.netty5.util.internal.logging.InternalLogLevel#WARN WARN}.
-     *
-     * @param obj The object to dispose of.
-     * @param logger The logger to use for recording any exceptions thrown by the disposal.
-     */
-    static void dispose(Object obj, InternalLogger logger) {
-        try {
-            if (obj instanceof AutoCloseable) {
-                ((AutoCloseable) obj).close();
-            } else if (ReferenceCountUtil.isReferenceCounted(obj)) {
-                ReferenceCountUtil.release(obj);
-            }
-        } catch (Throwable throwable) {
-            logger.warn("Failed to dispose object: {}.", obj, throwable);
         }
     }
 

--- a/common/src/main/java/io/netty5/util/Send.java
+++ b/common/src/main/java/io/netty5/util/Send.java
@@ -13,10 +13,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty5.buffer.api;
+package io.netty5.util;
 
-import io.netty5.buffer.api.internal.SendFromSupplier;
-import io.netty5.util.SafeCloseable;
+import io.netty5.util.internal.SendFromSupplier;
 
 import java.util.function.Function;
 import java.util.function.Supplier;

--- a/common/src/main/java/io/netty5/util/internal/PendingWrite.java
+++ b/common/src/main/java/io/netty5/util/internal/PendingWrite.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.util.internal;
 
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.ObjectPool.Handle;
 
@@ -57,7 +57,7 @@ public final class PendingWrite {
      * Fails the underlying {@link Promise} with the given cause and recycle this instance.
      */
     public boolean failAndRecycle(Throwable cause) {
-        ReferenceCountUtil.release(msg);
+        Resource.dispose(msg);
         if (promise != null) {
             promise.setFailure(cause);
         }

--- a/common/src/main/java/io/netty5/util/internal/SendFromSupplier.java
+++ b/common/src/main/java/io/netty5/util/internal/SendFromSupplier.java
@@ -13,20 +13,27 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty5.buffer.api.internal;
+package io.netty5.util.internal;
 
-import io.netty5.buffer.api.Resource;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 
 import java.lang.invoke.VarHandle;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import static io.netty5.buffer.api.internal.Statics.findVarHandle;
 import static java.lang.invoke.MethodHandles.lookup;
 
 public class SendFromSupplier<T extends Resource<T>> implements Send<T> {
-    private static final VarHandle GATE = findVarHandle(lookup(), SendFromSupplier.class, "gate", boolean.class);
+    private static final VarHandle GATE;
+    static {
+        try {
+            GATE = lookup().findVarHandle(SendFromSupplier.class, "gate", boolean.class);
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
     private final Class<T> concreteObjectType;
     private final Supplier<? extends T> supplier;
 

--- a/common/src/main/java/io/netty5/util/internal/SilentDispose.java
+++ b/common/src/main/java/io/netty5/util/internal/SilentDispose.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty5.util.internal;
+
+import io.netty5.util.ReferenceCounted;
+import io.netty5.util.Resource;
+import io.netty5.util.internal.logging.InternalLogger;
+
+/**
+ * Utility class for disposing of {@linkplain Resource resources} without propagating any exception that
+ * {@link Resource#close()} might throw.
+ */
+public final class SilentDispose {
+    /**
+     * Attempt to dispose of whatever the given object is.
+     * <p>
+     * This method works similarly to {@link Resource#dispose(Object)}, except any exception thrown will be logged
+     * instead of propagated.
+     * <p>
+     * If the object is {@link AutoCloseable}, such as anything that implements {@link Resource},
+     * then it will be closed.
+     * If the object is {@link ReferenceCounted}, then it will be released once.
+     * <p>
+     * Any exceptions caused by this will be logged using the given logger.
+     * The exception will be logged at log-level {@link io.netty5.util.internal.logging.InternalLogLevel#WARN WARN}.
+     *
+     * @param obj The object to dispose of.
+     * @param logger The logger to use for recording any exceptions thrown by the disposal.
+     */
+    public static void dispose(Object obj, InternalLogger logger) {
+        try {
+            Resource.dispose(obj);
+        } catch (Throwable throwable) {
+            logger.warn("Failed to dispose object: {}.", obj, throwable);
+        }
+    }
+
+    private SilentDispose() {
+    }
+}

--- a/common/src/main/java/io/netty5/util/internal/SilentDispose.java
+++ b/common/src/main/java/io/netty5/util/internal/SilentDispose.java
@@ -48,6 +48,41 @@ public final class SilentDispose {
         }
     }
 
+    /**
+     * Attempt to dispose of whatever the given object is, but only if it is disposable.
+     * <p>
+     * This method works similarly to {@link #dispose(Object, InternalLogger)}, except the object is only disposed of
+     * if it is {@linkplain Resource#isAccessible(Object, boolean) accessible}.
+     * <p>
+     * Any exceptions caused by the disposal of the object will be logged using the given logger.
+     * The exception will be logged at log-level {@link io.netty5.util.internal.logging.InternalLogLevel#WARN WARN}.
+     *
+     * @param obj The object to dispose of.
+     * @param logger The logger to use for recording any exceptions thrown by the disposal.
+     */
+    public static void trySilentDispose(Object obj, InternalLogger logger) {
+        if (Resource.isAccessible(obj, false)) {
+            dispose(obj, logger);
+        }
+    }
+
+    /**
+     * Attempt to dispose of whatever the given object is, but only if it is disposable.
+     * <p>
+     * This method works similarly to {@link Resource#dispose(Object)}, except the object is only disposed of if it is
+     * {@linkplain Resource#isAccessible(Object, boolean) accessible}.
+     * <p>
+     * Any exceptions caused the disposal will be allowed to propagate from this method, which is in contrast to how
+     * {@link #dispose(Object, InternalLogger)} and {@link #trySilentDispose(Object, InternalLogger)} works.
+     *
+     * @param obj The object to dispose of.
+     */
+    public static void tryPropagatingDispose(Object obj) {
+        if (Resource.isAccessible(obj, false)) {
+            Resource.dispose(obj);
+        }
+    }
+
     private SilentDispose() {
     }
 }

--- a/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
+++ b/example/src/main/java/io/netty5/example/ocsp/OcspClientExample.java
@@ -43,7 +43,7 @@ import io.netty5.handler.ssl.SslContextBuilder;
 import io.netty5.handler.ssl.SslHandler;
 import io.netty5.handler.ssl.SslProvider;
 import io.netty5.handler.ssl.ocsp.OcspClientHandler;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Promise;
 import org.bouncycastle.asn1.ocsp.OCSPResponseStatus;
 import org.bouncycastle.cert.ocsp.BasicOCSPResp;
@@ -100,7 +100,7 @@ public class OcspClientExample {
 
                 try {
                     FullHttpResponse response = promise.asFuture().get();
-                    ReferenceCountUtil.release(response);
+                    Resource.dispose(response);
                 } finally {
                     channel.close();
                 }
@@ -183,7 +183,7 @@ public class OcspClientExample {
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             if (msg instanceof FullHttpResponse) {
                 if (!promise.trySuccess((FullHttpResponse) msg)) {
-                    ReferenceCountUtil.release(msg);
+                    Resource.dispose(msg);
                 }
                 return;
             }

--- a/handler/src/main/java/io/netty5/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty5/handler/flow/FlowControlHandler.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.handler.flow;
 
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkSslContext.java
@@ -16,7 +16,7 @@
 package io.netty5.handler.ssl;
 
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
@@ -296,7 +296,7 @@ public class JdkSslContext extends SslContext {
                     }
                 }
             } finally {
-                ReferenceCountUtil.release(engine);
+                Resource.dispose(engine);
             }
         }
 

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
@@ -26,6 +26,7 @@ import io.netty5.util.CharsetUtil;
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.NativeLibraryLoader;
 import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
@@ -681,7 +682,7 @@ public final class OpenSsl {
 
     static void releaseIfNeeded(Object obj) {
         if (Resource.isAccessible(obj, false)) {
-            Resource.dispose(obj, logger);
+            SilentDispose.dispose(obj, logger);
         }
     }
 

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
@@ -21,9 +21,8 @@ import io.netty.internal.tcnative.Library;
 import io.netty.internal.tcnative.SSL;
 import io.netty.internal.tcnative.SSLContext;
 import io.netty5.buffer.api.DefaultBufferAllocators;
+import io.netty5.util.Resource;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
-import io.netty5.util.ReferenceCounted;
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.NativeLibraryLoader;
 import io.netty5.util.internal.PlatformDependent;
@@ -680,9 +679,9 @@ public final class OpenSsl {
         return Library.initialize("provided", engine);
     }
 
-    static void releaseIfNeeded(ReferenceCounted counted) {
-        if (counted.refCnt() > 0) {
-            ReferenceCountUtil.safeRelease(counted);
+    static void releaseIfNeeded(Object obj) {
+        if (Resource.isAccessible(obj, false)) {
+            Resource.dispose(obj, logger);
         }
     }
 

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
@@ -681,9 +681,7 @@ public final class OpenSsl {
     }
 
     static void releaseIfNeeded(Object obj) {
-        if (Resource.isAccessible(obj, false)) {
-            SilentDispose.dispose(obj, logger);
-        }
+        SilentDispose.trySilentDispose(obj, logger);
     }
 
     static boolean isTlsv13Supported() {

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSslX509KeyManagerFactory.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSslX509KeyManagerFactory.java
@@ -18,7 +18,7 @@ package io.netty5.handler.ssl;
 import io.netty.internal.tcnative.SSL;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -225,7 +225,7 @@ public final class OpenSslX509KeyManagerFactory extends KeyManagerFactory {
                 @Override
                 void destroy() {
                     for (Object material: materialMap.values()) {
-                        ReferenceCountUtil.release(material);
+                        Resource.dispose(material);
                     }
                     materialMap.clear();
                 }

--- a/handler/src/main/java/io/netty5/handler/ssl/OptionalSslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OptionalSslHandler.java
@@ -17,10 +17,10 @@ package io.netty5.handler.ssl;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -64,7 +64,7 @@ public class OptionalSslHandler extends ByteToMessageDecoderForBuffer {
             // Since the SslHandler was not inserted into the pipeline the ownership of the SSLEngine was not
             // transferred to the SslHandler.
             if (sslHandler != null) {
-                Resource.dispose(sslHandler.engine(), logger);
+                SilentDispose.dispose(sslHandler.engine(), logger);
             }
         }
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/OptionalSslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OptionalSslHandler.java
@@ -17,10 +17,12 @@ package io.netty5.handler.ssl;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
@@ -32,6 +34,7 @@ import static java.util.Objects.requireNonNull;
  * based on the first message received.
  */
 public class OptionalSslHandler extends ByteToMessageDecoderForBuffer {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(OptionalSslHandler.class);
 
     private final SslContext sslContext;
 
@@ -61,7 +64,7 @@ public class OptionalSslHandler extends ByteToMessageDecoderForBuffer {
             // Since the SslHandler was not inserted into the pipeline the ownership of the SSLEngine was not
             // transferred to the SslHandler.
             if (sslHandler != null) {
-                ReferenceCountUtil.safeRelease(sslHandler.engine());
+                Resource.dispose(sslHandler.engine(), logger);
             }
         }
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/PemX509Certificate.java
@@ -17,8 +17,8 @@ package io.netty5.handler.ssl;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.util.CharsetUtil;

--- a/handler/src/main/java/io/netty5/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SniHandler.java
@@ -16,14 +16,16 @@
 package io.netty5.handler.ssl;
 
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.util.AsyncMapping;
 import io.netty5.util.DomainNameMapping;
 import io.netty5.util.Mapping;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 
 import static java.util.Objects.requireNonNull;
 
@@ -35,6 +37,7 @@ import static java.util.Objects.requireNonNull;
  * which certificate to choose for the host name.</p>
  */
 public class SniHandler extends AbstractSniHandler<SslContext> {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(SniHandler.class);
     private static final Selection EMPTY_SELECTION = new Selection(null, null);
 
     protected final AsyncMapping<String, SslContext> mapping;
@@ -138,7 +141,7 @@ public class SniHandler extends AbstractSniHandler<SslContext> {
             // transferred to the SslHandler.
             // See https://github.com/netty/netty/issues/5678
             if (sslHandler != null) {
-                ReferenceCountUtil.safeRelease(sslHandler.engine());
+                Resource.dispose(sslHandler.engine(), logger);
             }
         }
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SniHandler.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.ssl;
 
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.util.AsyncMapping;
@@ -24,6 +23,7 @@ import io.netty5.util.DomainNameMapping;
 import io.netty5.util.Mapping;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 
@@ -141,7 +141,7 @@ public class SniHandler extends AbstractSniHandler<SslContext> {
             // transferred to the SslHandler.
             // See https://github.com/netty/netty/issues/5678
             if (sslHandler != null) {
-                Resource.dispose(sslHandler.engine(), logger);
+                SilentDispose.dispose(sslHandler.engine(), logger);
             }
         }
     }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslClientHelloHandler.java
@@ -17,7 +17,7 @@ package io.netty5.handler.ssl;
 
 import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -41,6 +41,7 @@ import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.ImmediateExecutor;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.UnstableApi;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
@@ -625,7 +626,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
         if (!(msg instanceof Buffer)) {
             UnsupportedMessageTypeException exception = new UnsupportedMessageTypeException(msg, Buffer.class);
             logger.warn(exception);
-            Resource.dispose(msg, logger);
+            SilentDispose.dispose(msg, logger);
             return ctx.newFailedFuture(exception);
         }
         if (pendingUnencryptedWrites == null) {

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -20,7 +20,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.buffer.api.StandardAllocationTypes;
 import io.netty5.channel.AbstractCoalescingBufferQueue;
 import io.netty5.channel.Channel;
@@ -34,7 +34,6 @@ import io.netty5.channel.ChannelPipeline;
 import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.codec.DecoderException;
 import io.netty5.handler.codec.UnsupportedMessageTypeException;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.DefaultPromise;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
@@ -594,7 +593,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
                 notifyClosePromise(cause);
             }
         } finally {
-            ReferenceCountUtil.release(engine);
+            Resource.dispose(engine);
         }
     }
 
@@ -626,7 +625,7 @@ public class SslHandler extends ByteToMessageDecoderForBuffer {
         if (!(msg instanceof Buffer)) {
             UnsupportedMessageTypeException exception = new UnsupportedMessageTypeException(msg, Buffer.class);
             logger.warn(exception);
-            ReferenceCountUtil.safeRelease(msg);
+            Resource.dispose(msg, logger);
             return ctx.newFailedFuture(exception);
         }
         if (pendingUnencryptedWrites == null) {

--- a/handler/src/main/java/io/netty5/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty5/handler/stream/ChunkedWriteHandler.java
@@ -17,11 +17,11 @@ package io.netty5.handler.stream;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.logging.InternalLogger;
@@ -230,7 +230,7 @@ public class ChunkedWriteHandler implements ChannelHandler {
                     queue.remove();
 
                     if (message != null) {
-                        ReferenceCountUtil.release(message);
+                        Resource.dispose(message);
                     }
 
                     closeInput(chunks);
@@ -337,7 +337,7 @@ public class ChunkedWriteHandler implements ChannelHandler {
         }
 
         void fail(Throwable cause) {
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
             promise.tryFailure(cause);
         }
 

--- a/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/adaptor/BufferConversionHandlerTest.java
@@ -22,7 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;

--- a/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/flow/FlowControlHandlerTest.java
@@ -20,7 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandler;
@@ -37,7 +37,6 @@ import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.timeout.IdleStateEvent;
 import io.netty5.handler.timeout.IdleStateHandler;
-import io.netty5.util.ReferenceCountUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -129,7 +128,7 @@ public class FlowControlHandlerTest {
         ChannelHandler handler = new ChannelHandler() {
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
                 // We're turning off auto reading in the hope that no
                 // new messages are being sent but that is not true.
                 ctx.channel().config().setAutoRead(false);
@@ -262,7 +261,7 @@ public class FlowControlHandlerTest {
 
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws InterruptedException {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
 
                 // Disable auto reading after each message
                 ctx.channel().config().setAutoRead(false);
@@ -521,7 +520,7 @@ public class FlowControlHandlerTest {
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                 //consume this msg
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
             }
         };
 

--- a/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/CipherSuiteCanaryTest.java
@@ -19,6 +19,7 @@ package io.netty5.handler.ssl;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -33,7 +34,6 @@ import io.netty5.channel.local.LocalHandler;
 import io.netty5.channel.local.LocalServerChannel;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterAll;
@@ -229,10 +229,10 @@ public class CipherSuiteCanaryTest {
                     server.close().sync();
                 }
             } finally {
-                ReferenceCountUtil.release(sslClientContext);
+                Resource.dispose(sslClientContext);
             }
         } finally {
-            ReferenceCountUtil.release(sslServerContext);
+            Resource.dispose(sslServerContext);
 
             if (executorService != null) {
                 executorService.shutdown();

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -32,7 +32,7 @@ import io.netty5.channel.local.LocalHandler;
 import io.netty5.channel.local.LocalServerChannel;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
@@ -316,10 +316,10 @@ public class OpenSslPrivateKeyMethodTest {
                     server.close().sync();
                 }
             } finally {
-                ReferenceCountUtil.release(sslClientContext);
+                Resource.dispose(sslClientContext);
             }
         } finally {
-            ReferenceCountUtil.release(sslServerContext);
+            Resource.dispose(sslServerContext);
         }
     }
 
@@ -378,10 +378,10 @@ public class OpenSslPrivateKeyMethodTest {
                     server.close().sync();
                 }
             } finally {
-                ReferenceCountUtil.release(sslClientContext);
+                Resource.dispose(sslClientContext);
             }
         } finally {
-            ReferenceCountUtil.release(sslServerContext);
+            Resource.dispose(sslServerContext);
         }
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ParameterizedSslHandlerTest.java
@@ -19,8 +19,8 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.Resource;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
@@ -41,7 +41,6 @@ import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.ResourcesUtil;
@@ -269,8 +268,8 @@ public class ParameterizedSslHandlerTest {
             }
             group.shutdownGracefully();
 
-            ReferenceCountUtil.release(sslServerCtx);
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslServerCtx);
+            Resource.dispose(sslClientCtx);
             ssc.delete();
         }
     }
@@ -370,8 +369,8 @@ public class ParameterizedSslHandlerTest {
             }
             group.shutdownGracefully();
 
-            ReferenceCountUtil.release(sslServerCtx);
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslServerCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -460,7 +459,7 @@ public class ParameterizedSslHandlerTest {
                                         if (closeSent.get()) {
                                             // Drop data on the floor so we will get a timeout while waiting for the
                                             // close_notify.
-                                            ReferenceCountUtil.release(msg);
+                                            Resource.dispose(msg);
                                         } else {
                                             ctx.fireChannelRead(msg);
                                         }
@@ -505,8 +504,8 @@ public class ParameterizedSslHandlerTest {
             }
             group.shutdownGracefully();
 
-            ReferenceCountUtil.release(sslServerCtx);
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslServerCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -620,8 +619,8 @@ public class ParameterizedSslHandlerTest {
                 sc.close().syncUninterruptibly();
             }
 
-            ReferenceCountUtil.release(sslServerCtx);
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslServerCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/PemEncodedTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/PemEncodedTest.java
@@ -16,9 +16,8 @@
 
 package io.netty5.handler.ssl;
 
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
-import io.netty5.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -68,7 +67,7 @@ public class PemEncodedTest {
         try {
             assertTrue(context instanceof ReferenceCountedOpenSslContext);
         } finally {
-            ReferenceCountUtil.release(context);
+            Resource.dispose(context);
             assertRelease(pemKey);
             assertRelease(pemCert);
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ReferenceCountedOpenSslEngineTest.java
@@ -18,6 +18,7 @@ package io.netty5.handler.ssl;
 import io.netty5.buffer.api.DefaultBufferAllocators;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,22 +42,22 @@ public class ReferenceCountedOpenSslEngineTest extends OpenSslEngineTest {
 
     @Override
     protected void cleanupClientSslContext(SslContext ctx) {
-        ReferenceCountUtil.release(ctx);
+        Resource.dispose(ctx);
     }
 
     @Override
     protected void cleanupClientSslEngine(SSLEngine engine) {
-        ReferenceCountUtil.release(unwrapEngine(engine));
+        Resource.dispose(unwrapEngine(engine));
     }
 
     @Override
     protected void cleanupServerSslContext(SslContext ctx) {
-        ReferenceCountUtil.release(ctx);
+        Resource.dispose(ctx);
     }
 
     @Override
     protected void cleanupServerSslEngine(SSLEngine engine) {
-        ReferenceCountUtil.release(unwrapEngine(engine));
+        Resource.dispose(unwrapEngine(engine));
     }
 
     @MethodSource("newTestParams")

--- a/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/RenegotiateTest.java
@@ -29,7 +29,7 @@ import io.netty5.channel.local.LocalHandler;
 import io.netty5.channel.local.LocalServerChannel;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.FutureListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -67,7 +67,7 @@ public abstract class RenegotiateTest {
 
                                 @Override
                                 public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                                    ReferenceCountUtil.release(msg);
+                                    Resource.dispose(msg);
                                 }
 
                                 @Override

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -37,7 +37,7 @@ import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
@@ -1382,7 +1382,7 @@ public abstract class SSLEngineTest {
 
                             @Override
                             public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-                                ReferenceCountUtil.release(msg);
+                                Resource.dispose(msg);
                                 // The server then attempts to trigger a flush operation once the application data is
                                 // received from the client. The flush will encrypt all data and should not result in
                                 // deadlock.
@@ -1449,7 +1449,7 @@ public abstract class SSLEngineTest {
 
                             @Override
                             public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                                ReferenceCountUtil.release(msg);
+                                Resource.dispose(msg);
                                 // Simulate a request that the server's application logic will think is invalid.
                                 ctx.writeAndFlush(ctx.bufferAllocator().copyOf(new byte[] { 102 }));
                                 ctx.pipeline().get(SslHandler.class).renegotiate();

--- a/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniClientTest.java
@@ -30,7 +30,7 @@ import io.netty5.channel.local.LocalServerChannel;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.EmptyArrays;
 import io.netty5.util.internal.ThrowableUtil;
@@ -206,8 +206,8 @@ public class SniClientTest {
                 sc.close().syncUninterruptibly();
             }
 
-            ReferenceCountUtil.release(sslServerContext);
-            ReferenceCountUtil.release(sslClientContext);
+            Resource.dispose(sslServerContext);
+            Resource.dispose(sslClientContext);
 
             cert.delete();
 
@@ -455,8 +455,8 @@ public class SniClientTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            ReferenceCountUtil.release(sslServerContext);
-            ReferenceCountUtil.release(sslClientContext);
+            Resource.dispose(sslServerContext);
+            Resource.dispose(sslClientContext);
 
             cert.delete();
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -45,6 +45,7 @@ import io.netty5.util.ReferenceCounted;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.ResourcesUtil;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
@@ -526,12 +527,12 @@ public class SniHandlerTest {
                                     success = true;
                                 } finally {
                                     if (!success) {
-                                        Resource.dispose(sslEngine, logger);
+                                        SilentDispose.dispose(sslEngine, logger);
                                     }
                                 }
                             } finally {
                                 if (!success) {
-                                    Resource.dispose(sslContext, logger);
+                                    SilentDispose.dispose(sslContext, logger);
                                     releasePromise.cancel();
                                 }
                             }

--- a/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslErrorTest.java
@@ -31,7 +31,7 @@ import io.netty5.handler.logging.LoggingHandler;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.handler.ssl.util.SimpleTrustManagerFactory;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Timeout;
@@ -195,8 +195,8 @@ public class SslErrorTest {
             }
             group.shutdownGracefully();
 
-            ReferenceCountUtil.release(sslServerCtx);
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslServerCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SslHandlerTest.java
@@ -44,8 +44,8 @@ import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.AbstractReferenceCounted;
 import io.netty5.util.IllegalReferenceCountException;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.ReferenceCounted;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.ImmediateExecutor;
@@ -414,7 +414,7 @@ public class SslHandlerTest {
                 assertEquals(1, ((ReferenceCounted) sslContext).refCnt());
                 assertEquals(0, ((ReferenceCounted) sslEngine).refCnt());
             } finally {
-                ReferenceCountUtil.release(sslContext);
+                Resource.dispose(sslContext);
             }
         } finally {
             cert.delete();
@@ -765,8 +765,8 @@ public class SslHandlerTest {
             }
             group.shutdownGracefully();
 
-            ReferenceCountUtil.release(sslServerCtx);
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslServerCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -827,8 +827,8 @@ public class SslHandlerTest {
             }
             group.shutdownGracefully();
 
-            ReferenceCountUtil.release(sslServerCtx);
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslServerCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -912,7 +912,7 @@ public class SslHandlerTest {
             }
             group.shutdownGracefully();
 
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -983,7 +983,7 @@ public class SslHandlerTest {
                 sc.close().syncUninterruptibly();
             }
             group.shutdownGracefully();
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -1175,7 +1175,7 @@ public class SslHandlerTest {
                 sc.close().syncUninterruptibly();
             }
             group.shutdownGracefully();
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -1254,7 +1254,7 @@ public class SslHandlerTest {
                 sc.close().syncUninterruptibly();
             }
             group.shutdownGracefully();
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -1368,7 +1368,7 @@ public class SslHandlerTest {
                 sc.close().syncUninterruptibly();
             }
             group.shutdownGracefully();
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -1665,7 +1665,7 @@ public class SslHandlerTest {
                     not(instanceOf(ClosedChannelException.class)));
         } finally {
             group.shutdownGracefully();
-            ReferenceCountUtil.release(sslClientCtx);
+            Resource.dispose(sslClientCtx);
         }
     }
 
@@ -1758,8 +1758,8 @@ public class SslHandlerTest {
             assertEquals(0, serverCompletionEvents.size());
         } finally {
             group.shutdownGracefully();
-            ReferenceCountUtil.release(sslClientCtx);
-            ReferenceCountUtil.release(sslServerCtx);
+            Resource.dispose(sslClientCtx);
+            Resource.dispose(sslServerCtx);
         }
     }
 

--- a/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/ocsp/OcspTest.java
@@ -38,7 +38,7 @@ import io.netty5.handler.ssl.SslProvider;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.handler.ssl.util.SelfSignedCertificate;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -130,7 +130,7 @@ public class OcspTest {
                 engine.release();
             }
         } finally {
-            ReferenceCountUtil.release(context);
+            Resource.dispose(context);
         }
     }
 
@@ -164,7 +164,7 @@ public class OcspTest {
                     engine.release();
                 }
             } finally {
-                ReferenceCountUtil.release(context);
+                Resource.dispose(context);
             }
         } finally {
             ssc.delete();
@@ -200,7 +200,7 @@ public class OcspTest {
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                 try {
-                    ReferenceCountUtil.release(msg);
+                    Resource.dispose(msg);
                 } finally {
                     latch.countDown();
                 }
@@ -293,7 +293,7 @@ public class OcspTest {
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                 try {
-                    ReferenceCountUtil.release(msg);
+                    Resource.dispose(msg);
                 } finally {
                     latch.countDown();
                 }
@@ -387,10 +387,10 @@ public class OcspTest {
                         group.shutdownGracefully(1L, 1L, TimeUnit.SECONDS);
                     }
                 } finally {
-                    ReferenceCountUtil.release(clientSslContext);
+                    Resource.dispose(clientSslContext);
                 }
             } finally {
-                ReferenceCountUtil.release(serverSslContext);
+                Resource.dispose(serverSslContext);
             }
         } finally {
             ssc.delete();

--- a/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/stream/ChunkedWriteHandlerTest.java
@@ -18,11 +18,11 @@ package io.netty5.handler.stream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.internal.PlatformDependent;
@@ -326,10 +326,10 @@ public class ChunkedWriteHandlerTest {
 
             @Override
             public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
-                if (++this.passedWrites < 4) {
+                if (++passedWrites < 4) {
                     return ctx.write(msg);
                 }
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
                 return ctx.newFailedFuture(new RuntimeException());
             }
         };
@@ -459,7 +459,7 @@ public class ChunkedWriteHandlerTest {
         ChannelHandler noOpWrites = new ChannelHandler() {
             @Override
             public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
                 return ctx.newFailedFuture(new RuntimeException());
             }
         };
@@ -615,7 +615,7 @@ public class ChunkedWriteHandlerTest {
         EmbeddedChannel ch = new EmbeddedChannel(new ChannelHandler() {
             @Override
             public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
                 // Calling close so we will drop all queued messages in the ChunkedWriteHandler.
                 ctx.close();
                 return ctx.newSucceededFuture();
@@ -682,7 +682,7 @@ public class ChunkedWriteHandlerTest {
         ChannelHandler noOpWrites = new ChannelHandler() {
             @Override
             public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
                 return ctx.newFailedFuture(new RuntimeException());
             }
         };
@@ -704,8 +704,8 @@ public class ChunkedWriteHandlerTest {
                 if (alreadyFailed) {
                     return ctx.write(msg);
                 }
-                this.alreadyFailed = true;
-                ReferenceCountUtil.release(msg);
+                alreadyFailed = true;
+                Resource.dispose(msg);
                 return ctx.newFailedFuture(new RuntimeException());
             }
         };

--- a/handler/src/test/java/io/netty5/handler/timeout/AbstractIdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/timeout/AbstractIdleStateHandlerTest.java
@@ -16,6 +16,7 @@
 package io.netty5.handler.timeout;
 
 import io.netty5.buffer.api.Buffer;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOutboundBuffer;
@@ -307,7 +308,7 @@ public abstract class AbstractIdleStateHandlerTest {
 
     private static void assertNotNullAndRelease(Object msg) {
         assertNotNull(msg);
-        ReferenceCountUtil.release(msg);
+        Resource.dispose(msg);
     }
 
     private interface Action {

--- a/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -24,7 +24,7 @@ import io.netty5.channel.EventLoop;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.Attribute;
 import io.netty5.util.AttributeKey;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -128,13 +128,13 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
 
     @Override
     public final ChannelHandlerContext fireUserEventTriggered(Object event) {
-        ReferenceCountUtil.release(event);
+        Resource.dispose(event);
         return this;
     }
 
     @Override
     public final ChannelHandlerContext fireChannelRead(Object msg) {
-        ReferenceCountUtil.release(msg);
+        Resource.dispose(msg);
         return this;
     }
 

--- a/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
+++ b/microbench/src/main/java/io/netty5/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
@@ -18,7 +18,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 
 public abstract class EmbeddedChannelWriteReleaseHandlerContext extends EmbeddedChannelHandlerContext {
@@ -45,8 +45,8 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext extends Embedded
     @Override
     public final Future<Void> write(Object msg) {
         try {
-            if (ReferenceCountUtil.isReferenceCounted(msg)) {
-                ReferenceCountUtil.release(msg);
+            if (Resource.isAccessible(msg, false)) {
+                Resource.dispose(msg);
                 return channel().newSucceededFuture();
             }
             return channel().write(msg);
@@ -59,8 +59,8 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext extends Embedded
     @Override
     public final Future<Void> writeAndFlush(Object msg) {
         try {
-            if (ReferenceCountUtil.isReferenceCounted(msg)) {
-                ReferenceCountUtil.release(msg);
+            if (Resource.isAccessible(msg, false)) {
+                Resource.dispose(msg);
                 return channel().newSucceededFuture();
             }
             return channel().writeAndFlush(msg);

--- a/microbench/src/main/java/io/netty5/microbench/handler/ssl/AbstractSslEngineBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/handler/ssl/AbstractSslEngineBenchmark.java
@@ -16,12 +16,12 @@
 package io.netty5.microbench.handler.ssl;
 
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.Resource;
 import io.netty5.handler.ssl.SslContext;
 import io.netty5.handler.ssl.SslContextBuilder;
 import io.netty5.handler.ssl.SslProvider;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.internal.PlatformDependent;
 import org.openjdk.jmh.annotations.Param;
 
@@ -148,8 +148,8 @@ public class AbstractSslEngineBenchmark extends AbstractMicrobenchmark {
     }
 
     protected final void destroyEngines() {
-        ReferenceCountUtil.release(clientEngine);
-        ReferenceCountUtil.release(serverEngine);
+        Resource.dispose(clientEngine);
+        Resource.dispose(serverEngine);
     }
 
     protected final void initHandshakeBuffers() {

--- a/microbench/src/main/java/io/netty5/microbench/handler/ssl/AbstractSslHandlerBenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/handler/ssl/AbstractSslHandlerBenchmark.java
@@ -17,6 +17,7 @@ package io.netty5.microbench.handler.ssl;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
 import io.netty5.handler.ssl.SslContext;
@@ -26,7 +27,6 @@ import io.netty5.handler.ssl.SslProvider;
 import io.netty5.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty5.microbench.channel.EmbeddedChannelWriteAccumulatingHandlerContext;
 import io.netty5.microbench.util.AbstractMicrobenchmark;
-import io.netty5.util.ReferenceCountUtil;
 import org.openjdk.jmh.annotations.Param;
 
 import javax.net.ssl.SSLEngine;
@@ -127,11 +127,11 @@ public class AbstractSslHandlerBenchmark extends AbstractMicrobenchmark {
     protected final void destroySslHandlers() {
         try {
             if (clientSslHandler != null) {
-                ReferenceCountUtil.release(clientSslHandler.engine());
+                Resource.dispose(clientSslHandler.engine());
             }
         } finally {
             if (serverSslHandler != null) {
-                ReferenceCountUtil.release(serverSslHandler.engine());
+                Resource.dispose(serverSslHandler.engine());
             }
         }
     }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
@@ -24,7 +24,7 @@ import io.netty5.handler.codec.dns.DnsRecord;
 import io.netty5.handler.codec.dns.DnsRecordType;
 import io.netty5.handler.codec.dns.DnsResponse;
 import io.netty5.handler.codec.dns.DnsSection;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;
@@ -156,7 +156,7 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
             promise.tryFailure(cause);
             writePromise.setFailure(cause);
         } finally {
-            ReferenceCountUtil.release(query);
+            Resource.dispose(query);
         }
     }
 
@@ -205,7 +205,7 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
         } else if (trySuccess(envelope)) {
             return; // Ownership transferred, don't release
         }
-        ReferenceCountUtil.release(envelope);
+        Resource.dispose(envelope);
     }
 
     @SuppressWarnings("unchecked")

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsQueryContext.java
@@ -18,6 +18,7 @@ package io.netty5.resolver.dns;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.Channel;
 import io.netty5.handler.codec.dns.AbstractDnsOptPseudoRrRecord;
+import io.netty5.handler.codec.dns.DnsOptPseudoRecord;
 import io.netty5.handler.codec.dns.DnsQuery;
 import io.netty5.handler.codec.dns.DnsQuestion;
 import io.netty5.handler.codec.dns.DnsRecord;
@@ -75,6 +76,10 @@ abstract class DnsQueryContext implements FutureListener<AddressedEnvelope<DnsRe
                 !hasOptRecord(additionals)) {
             optResource = new AbstractDnsOptPseudoRrRecord(parent.maxPayloadSize(), 0, 0) {
                 // We may want to remove this in the future and let the user just specify the opt record in the query.
+                @Override
+                public DnsOptPseudoRecord copy() {
+                    return this; // This instance is immutable.
+                }
             };
         } else {
             optResource = null;

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsRecordResolveContext.java
@@ -19,7 +19,6 @@ import io.netty5.channel.EventLoop;
 import io.netty5.handler.codec.dns.DnsQuestion;
 import io.netty5.handler.codec.dns.DnsRecord;
 import io.netty5.handler.codec.dns.DnsRecordType;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Promise;
 
 import java.net.UnknownHostException;
@@ -55,7 +54,8 @@ final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
 
     @Override
     DnsRecord convertRecord(DnsRecord record, String hostname, DnsRecord[] additionals, EventLoop eventLoop) {
-        return ReferenceCountUtil.retain(record);
+        // The given record is a shared object, but we need to give back a record that has its own life time.
+        return record.copy();
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
@@ -35,6 +35,7 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.PlatformDependent;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.ThrowableUtil;
 import io.netty5.util.internal.logging.InternalLogger;
@@ -213,7 +214,7 @@ abstract class DnsResolveContext<T> {
                         final List<T> result = future.getNow();
                         if (!promise.trySuccess(result)) {
                             for (T item : result) {
-                                Resource.dispose(item, logger);
+                                SilentDispose.dispose(item, logger);
                             }
                         }
                     } else {
@@ -609,7 +610,7 @@ abstract class DnsResolveContext<T> {
                 }
             }
         } finally {
-            Resource.dispose(envelope, logger);
+            SilentDispose.dispose(envelope, logger);
         }
     }
 
@@ -998,7 +999,7 @@ abstract class DnsResolveContext<T> {
                 final List<T> result = filterResults(finalResult);
                 if (!DnsNameResolver.trySuccess(promise, result)) {
                     for (T item : result) {
-                        Resource.dispose(item, logger);
+                        SilentDispose.dispose(item, logger);
                     }
                 }
             }

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DnsResolveContext.java
@@ -17,6 +17,7 @@
 package io.netty5.resolver.dns;
 
 import io.netty5.buffer.api.Buffer;
+import io.netty5.util.Resource;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.EventLoop;
 import io.netty5.handler.codec.CorruptedFrameException;
@@ -30,7 +31,6 @@ import io.netty5.handler.codec.dns.DnsResponse;
 import io.netty5.handler.codec.dns.DnsResponseCode;
 import io.netty5.handler.codec.dns.DnsSection;
 import io.netty5.util.NetUtil;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;
@@ -213,7 +213,7 @@ abstract class DnsResolveContext<T> {
                         final List<T> result = future.getNow();
                         if (!promise.trySuccess(result)) {
                             for (T item : result) {
-                                ReferenceCountUtil.safeRelease(item);
+                                Resource.dispose(item, logger);
                             }
                         }
                     } else {
@@ -434,7 +434,7 @@ abstract class DnsResolveContext<T> {
                 // return null as well as the Future will be failed with a CancellationException.
                 AddressedEnvelope<DnsResponse, InetSocketAddress> result = future.getNow();
                 if (result != null) {
-                    ReferenceCountUtil.release(result);
+                    Resource.dispose(result);
                 }
                 return;
             }
@@ -609,7 +609,7 @@ abstract class DnsResolveContext<T> {
                 }
             }
         } finally {
-            ReferenceCountUtil.safeRelease(envelope);
+            Resource.dispose(envelope, logger);
         }
     }
 
@@ -837,7 +837,7 @@ abstract class DnsResolveContext<T> {
             found = true;
 
             if (shouldRelease) {
-                ReferenceCountUtil.release(converted);
+                Resource.dispose(converted);
             }
             // Note that we do not break from the loop here, so we decode/cache all A/AAAA records.
         }
@@ -998,7 +998,7 @@ abstract class DnsResolveContext<T> {
                 final List<T> result = filterResults(finalResult);
                 if (!DnsNameResolver.trySuccess(promise, result)) {
                     for (T item : result) {
-                        ReferenceCountUtil.safeRelease(item);
+                        Resource.dispose(item, logger);
                     }
                 }
             }

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
@@ -44,7 +44,7 @@ import io.netty5.resolver.ResolvedAddressTypes;
 import io.netty5.resolver.dns.TestDnsServer.TestResourceRecord;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.PlatformDependent;
@@ -1119,7 +1119,7 @@ public class DnsNameResolverTest {
                     buf.append(' ');
                     buf.append(DnsResolveContext.decodeDomainName(recordContent));
 
-                    ReferenceCountUtil.release(r);
+                    Resource.dispose(r);
                 }
 
                 logger.info("{} has the following MX records:{}", hostname, buf);
@@ -2774,7 +2774,7 @@ public class DnsNameResolverTest {
             }
             assertTrue(txts.contains(txt1));
             assertTrue(txts.contains(txt2));
-            ReferenceCountUtil.release(envelope);
+            Resource.dispose(envelope);
         } finally {
             resolver.close();
             server.stop();
@@ -2867,7 +2867,7 @@ public class DnsNameResolverTest {
                     .syncUninterruptibly().getNow();
             assertEquals(2, resolvedAddresses.size());
             for (DnsRecord record: resolvedAddresses) {
-                ReferenceCountUtil.release(record);
+                Resource.dispose(record);
             }
         } finally {
             dnsServer2.stop();
@@ -3127,7 +3127,8 @@ public class DnsNameResolverTest {
             } else {
                 assertTrue(envelope.content().isTruncated());
             }
-            assertTrue(ReferenceCountUtil.release(envelope));
+            Resource.dispose(envelope);
+            assertFalse(Resource.isAccessible(envelope, true));
         } finally {
             dnsServer2.stop();
             if (resolver != null) {
@@ -3470,7 +3471,7 @@ public class DnsNameResolverTest {
         List<DnsRecord> records = recordsFuture.get();
         assertFalse(records.isEmpty());
         for (DnsRecord record : records) {
-            ReferenceCountUtil.release(record);
+            Resource.dispose(record);
         }
     }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketAutoReadTest.java
@@ -20,7 +20,7 @@ import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandler;
@@ -28,7 +28,6 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.RecvBufferAllocator;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.UncheckedBooleanSupplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -135,7 +134,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
             if (msg instanceof Resource<?>) {
                 ((Resource<?>) msg).close();
             } else {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
             }
             if (count.incrementAndGet() == 1) {
                 ctx.channel().config().setAutoRead(false);

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -18,7 +18,7 @@ package io.netty5.testsuite.transport.socket;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.SimpleChannelInboundHandler;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConditionalWritabilityTest.java
@@ -18,7 +18,7 @@ package io.netty5.testsuite.transport.socket;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -18,14 +18,13 @@ package io.netty5.testsuite.transport.socket;
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOption;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -91,7 +90,7 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
             if (msg instanceof Resource<?>) {
                 ((Resource<?>) msg).close();
             } else {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
             }
             throw new NullPointerException("I am a bug!");
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -21,7 +21,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
 import io.netty5.buffer.api.MemoryManager;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -19,7 +19,7 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelFutureListeners;

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketReadPendingTest.java
@@ -19,7 +19,7 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelHandler;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollChannel.java
@@ -18,7 +18,7 @@ package io.netty5.channel.epoll;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/AbstractEpollStreamChannel.java
@@ -17,7 +17,7 @@ package io.netty5.channel.epoll;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelMetadata;

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/EpollDomainDatagramChannel.java
@@ -33,7 +33,7 @@ import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.PeerCredentials;
 import io.netty5.channel.unix.RecvFromAddressDomainSocket;
 import io.netty5.channel.unix.UnixChannelUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.UncheckedBooleanSupplier;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.UnstableApi;
@@ -237,9 +237,9 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
                     Buffer buf = (Buffer) e.content();
                     if (UnixChannelUtil.isBufferCopyNeededForWrite(buf)) {
                         try {
-                            return new DefaultBufferAddressedEnvelope<>(newDirectBuffer(buf), domainRecipient);
+                            return new DefaultBufferAddressedEnvelope<>(newDirectBuffer(null, buf), domainRecipient);
                         } finally {
-                            ReferenceCountUtil.release(e);
+                            Resource.dispose(e);
                         }
                     }
                     return e;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueChannel.java
@@ -18,7 +18,7 @@ package io.netty5.channel.kqueue;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -17,7 +17,7 @@ package io.netty5.channel.kqueue;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelMetadata;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDatagramChannel.java
@@ -29,7 +29,7 @@ import io.netty5.channel.unix.DatagramSocketAddress;
 import io.netty5.channel.unix.Errors;
 import io.netty5.channel.unix.IovArray;
 import io.netty5.channel.unix.UnixChannelUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.UncheckedBooleanSupplier;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
@@ -318,9 +318,9 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
                     Buffer buf = (Buffer) e.content();
                     if (UnixChannelUtil.isBufferCopyNeededForWrite(buf)) {
                         try {
-                            return new DefaultBufferAddressedEnvelope<>(newDirectBuffer(buf), inetRecipient);
+                            return new DefaultBufferAddressedEnvelope<>(newDirectBuffer(null, buf), inetRecipient);
                         } finally {
-                            ReferenceCountUtil.release(e);
+                            Resource.dispose(e);
                         }
                     }
                     return e;

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -18,7 +18,7 @@ package io.netty5.channel.kqueue;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.AddressedEnvelope;
 import io.netty5.channel.ChannelPipeline;
 import io.netty5.channel.DefaultBufferAddressedEnvelope;

--- a/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty5/channel/epoll/EpollReuseAddrTest.java
@@ -25,7 +25,7 @@ import io.netty5.channel.unix.UnixChannelOption;
 import io.netty5.handler.logging.LogLevel;
 import io.netty5.handler.logging.LoggingHandler;
 import io.netty5.util.NetUtil;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.ResourceLeakDetector;
 import io.netty5.util.internal.logging.InternalLogLevel;
 import io.netty5.util.internal.logging.InternalLogger;
@@ -248,7 +248,7 @@ public class EpollReuseAddrTest {
 
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
             received.set(true);
         }
     }

--- a/transport-native-unix-common/src/main/java/io/netty5/channel/unix/SocketWritableByteChannel.java
+++ b/transport-native-unix-common/src/main/java/io/netty5/channel/unix/SocketWritableByteChannel.java
@@ -19,7 +19,7 @@ import io.netty5.buffer.BufferUtil;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/transport-native-unix-common/src/test/java/io/netty5/channel/unix/UnixChannelUtilTest.java
+++ b/transport-native-unix-common/src/test/java/io/netty5/channel/unix/UnixChannelUtilTest.java
@@ -18,7 +18,7 @@ package io.netty5.channel.unix;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/transport/src/main/java/io/netty5/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractChannel.java
@@ -15,10 +15,10 @@
  */
 package io.netty5.channel;
 
+import io.netty5.util.Resource;
 import io.netty5.channel.socket.ChannelOutputShutdownEvent;
 import io.netty5.channel.socket.ChannelOutputShutdownException;
 import io.netty5.util.DefaultAttributeMap;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.DefaultPromise;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
@@ -673,7 +673,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             if (outboundBuffer == null) {
                 try {
                     // release message now to prevent resource-leak
-                    ReferenceCountUtil.release(msg);
+                    Resource.dispose(msg);
                 } finally {
                     // If the outboundBuffer is null we know the channel was closed and so
                     // need to fail the future right away. If it is not null the handling of the rest
@@ -697,7 +697,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 }
             } catch (Throwable t) {
                 try {
-                    ReferenceCountUtil.release(msg);
+                    Resource.dispose(msg);
                 } catch (Throwable inner) {
                     t.addSuppressed(inner);
                 } finally {

--- a/transport/src/main/java/io/netty5/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty5/channel/AbstractCoalescingBufferQueue.java
@@ -17,7 +17,7 @@ package io.netty5.channel;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.CompositeBuffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;

--- a/transport/src/main/java/io/netty5/channel/AddressedEnvelope.java
+++ b/transport/src/main/java/io/netty5/channel/AddressedEnvelope.java
@@ -17,6 +17,7 @@
 package io.netty5.channel;
 
 import io.netty5.util.ReferenceCounted;
+import io.netty5.util.Resource;
 
 import java.net.SocketAddress;
 
@@ -24,7 +25,7 @@ import java.net.SocketAddress;
  * A message that wraps another message with a sender address and a recipient address.
  *
  * @implNote AddressedEnvelope implementors likely also implement either {@link ReferenceCounted}
- * or {@link io.netty5.buffer.api.Resource}. Users should be mindful to release or close any address envelopes if
+ * or {@link Resource}. Users should be mindful to release or close any address envelopes if
  * that's the case.
  *
  * @param <M> the type of the wrapped message

--- a/transport/src/main/java/io/netty5/channel/BufferAddressedEnvelope.java
+++ b/transport/src/main/java/io/netty5/channel/BufferAddressedEnvelope.java
@@ -16,8 +16,8 @@
 package io.netty5.channel;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 
 import java.net.SocketAddress;
 import java.util.function.Supplier;

--- a/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty5/channel/ChannelOutboundBuffer.java
@@ -269,9 +269,7 @@ public final class ChannelOutboundBuffer {
 
         if (!e.cancelled) {
             // only release message, notify and decrement if it was not canceled before.
-            if (Resource.isAccessible(msg, false)) {
-                SilentDispose.dispose(msg, logger);
-            }
+            SilentDispose.trySilentDispose(msg, logger);
             safeSuccess(promise);
             decrementPendingOutboundBytes(size, false, true);
         }
@@ -306,9 +304,7 @@ public final class ChannelOutboundBuffer {
 
         if (!e.cancelled) {
             // only release message, fail and decrement if it was not canceled before.
-            if (Resource.isAccessible(msg, false)) {
-                SilentDispose.dispose(msg, logger);
-            }
+            SilentDispose.trySilentDispose(msg, logger);
 
             safeFail(promise, cause);
             decrementPendingOutboundBytes(size, false, notifyWritability);

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelHandlerContext.java
@@ -17,7 +17,7 @@ package io.netty5.channel;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.util.Attribute;
 import io.netty5.util.AttributeKey;
 import io.netty5.util.ResourceLeakHint;

--- a/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty5/channel/DefaultChannelPipeline.java
@@ -15,8 +15,7 @@
  */
 package io.netty5.channel;
 
-import io.netty5.buffer.api.Resource;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.ResourceLeakDetector;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.FastThreadLocal;
@@ -102,10 +101,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     final Object touch(Object msg, DefaultChannelHandlerContext next) {
         if (touch) {
-            if (msg instanceof Resource<?>) {
-                return ((Resource<?>) msg).touch(next);
-            }
-            return ReferenceCountUtil.touch(msg, next);
+            Resource.touch(msg, next);
         }
         return msg;
     }
@@ -920,7 +916,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
                             "It usually means the last handler in the pipeline did not handle the exception.",
                     cause);
         } finally {
-            ReferenceCountUtil.release(cause);
+            Resource.dispose(cause);
         }
     }
 
@@ -941,7 +937,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     /**
      * Called once a message hit the end of the {@link ChannelPipeline} without been handled by the user
      * in {@link ChannelHandler#channelRead(ChannelHandlerContext, Object)}. This method is responsible
-     * to call {@link ReferenceCountUtil#release(Object)} on the given msg at some point.
+     * to call {@link Resource#dispose(Object)} on the given msg at some point.
      */
     protected void onUnhandledInboundMessage(ChannelHandlerContext ctx, Object msg) {
         try {
@@ -950,7 +946,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
                             "Please check your pipeline configuration. Discarded message pipeline : {}. Channel : {}.",
                     msg, ctx.pipeline().names(), ctx.channel());
         } finally {
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
         }
     }
 
@@ -964,12 +960,12 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     /**
      * Called once an user event hit the end of the {@link ChannelPipeline} without been handled by the user
      * in {@link ChannelHandler#userEventTriggered(ChannelHandlerContext, Object)}. This method is responsible
-     * to call {@link ReferenceCountUtil#release(Object)} on the given event at some point.
+     * to call {@link Resource#dispose(Object)} on the given event at some point.
      */
     protected void onUnhandledInboundUserEventTriggered(Object evt) {
         // This may not be a configuration error and so don't log anything.
         // The event may be superfluous for the current pipeline configuration.
-        ReferenceCountUtil.release(evt);
+        Resource.dispose(evt);
     }
 
     /**

--- a/transport/src/main/java/io/netty5/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty5/channel/PendingWriteQueue.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.channel;
 
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.concurrent.PromiseCombiner;
@@ -157,7 +157,7 @@ public final class PendingWriteQueue {
 
     /**
      * Remove all pending write operation and fail them with the given {@link Throwable}. The message will be released
-     * via {@link ReferenceCountUtil#safeRelease(Object)}.
+     * via {@link Resource#dispose(Object, InternalLogger)}.
      */
     public void removeAndFailAll(Throwable cause) {
         assert ctx.executor().inEventLoop();
@@ -170,7 +170,7 @@ public final class PendingWriteQueue {
             bytes = 0;
             while (write != null) {
                 PendingWrite next = write.next;
-                ReferenceCountUtil.safeRelease(write.msg);
+                Resource.dispose(write.msg, logger);
                 Promise<Void> promise = write.promise;
                 recycle(write, false);
                 safeFail(promise, cause);
@@ -182,7 +182,7 @@ public final class PendingWriteQueue {
 
     /**
      * Remove a pending write operation and fail it with the given {@link Throwable}. The message will be released via
-     * {@link ReferenceCountUtil#safeRelease(Object)}.
+     * {@link Resource#dispose(Object, InternalLogger)}.
      */
     public void removeAndFail(Throwable cause) {
         assert ctx.executor().inEventLoop();
@@ -192,7 +192,7 @@ public final class PendingWriteQueue {
         if (write == null) {
             return;
         }
-        ReferenceCountUtil.safeRelease(write.msg);
+        Resource.dispose(write.msg, logger);
         Promise<Void> promise = write.promise;
         safeFail(promise, cause);
         recycle(write, true);
@@ -225,7 +225,7 @@ public final class PendingWriteQueue {
     }
 
     /**
-     * Removes a pending write operation and release it's message via {@link ReferenceCountUtil#safeRelease(Object)}.
+     * Removes a pending write operation and release it's message via {@link Resource#dispose(Object, InternalLogger)}.
      *
      * @return  {@link Promise} of the pending write or {@code null} if the queue is empty.
      *
@@ -237,7 +237,7 @@ public final class PendingWriteQueue {
             return null;
         }
         Promise<Void> promise = write.promise;
-        ReferenceCountUtil.safeRelease(write.msg);
+        Resource.dispose(write.msg, logger);
         recycle(write, true);
         return promise;
     }

--- a/transport/src/main/java/io/netty5/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty5/channel/PendingWriteQueue.java
@@ -20,6 +20,7 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.concurrent.PromiseCombiner;
 import io.netty5.util.internal.ObjectPool;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
@@ -157,7 +158,7 @@ public final class PendingWriteQueue {
 
     /**
      * Remove all pending write operation and fail them with the given {@link Throwable}. The message will be released
-     * via {@link Resource#dispose(Object, InternalLogger)}.
+     * via {@link Resource#dispose(Object)}.
      */
     public void removeAndFailAll(Throwable cause) {
         assert ctx.executor().inEventLoop();
@@ -170,7 +171,7 @@ public final class PendingWriteQueue {
             bytes = 0;
             while (write != null) {
                 PendingWrite next = write.next;
-                Resource.dispose(write.msg, logger);
+                SilentDispose.dispose(write.msg, logger);
                 Promise<Void> promise = write.promise;
                 recycle(write, false);
                 safeFail(promise, cause);
@@ -182,7 +183,7 @@ public final class PendingWriteQueue {
 
     /**
      * Remove a pending write operation and fail it with the given {@link Throwable}. The message will be released via
-     * {@link Resource#dispose(Object, InternalLogger)}.
+     * {@link Resource#dispose(Object)}.
      */
     public void removeAndFail(Throwable cause) {
         assert ctx.executor().inEventLoop();
@@ -192,7 +193,7 @@ public final class PendingWriteQueue {
         if (write == null) {
             return;
         }
-        Resource.dispose(write.msg, logger);
+        SilentDispose.dispose(write.msg, logger);
         Promise<Void> promise = write.promise;
         safeFail(promise, cause);
         recycle(write, true);
@@ -225,7 +226,7 @@ public final class PendingWriteQueue {
     }
 
     /**
-     * Removes a pending write operation and release it's message via {@link Resource#dispose(Object, InternalLogger)}.
+     * Removes a pending write operation and release it's message via {@link Resource#dispose(Object)}.
      *
      * @return  {@link Promise} of the pending write or {@code null} if the queue is empty.
      *
@@ -237,7 +238,7 @@ public final class PendingWriteQueue {
             return null;
         }
         Promise<Void> promise = write.promise;
-        Resource.dispose(write.msg, logger);
+        SilentDispose.dispose(write.msg, logger);
         recycle(write, true);
         return promise;
     }

--- a/transport/src/main/java/io/netty5/channel/SimpleChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty5/channel/SimpleChannelInboundHandler.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.channel;
 
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.internal.TypeParameterMatcher;
 
 /**
@@ -36,8 +36,7 @@ import io.netty5.util.internal.TypeParameterMatcher;
  * </pre>
  *
  * Be aware that depending of the constructor parameters it will release all handled messages by passing them to
- * {@link ReferenceCountUtil#release(Object)}. In this case you may need to use
- * {@link ReferenceCountUtil#retain(Object)} if you pass the object to the next handler in the {@link ChannelPipeline}.
+ * {@link Resource#dispose(Object)}.
  */
 public abstract class SimpleChannelInboundHandler<I> implements ChannelHandler {
 
@@ -55,7 +54,7 @@ public abstract class SimpleChannelInboundHandler<I> implements ChannelHandler {
      * Create a new instance which will try to detect the types to match out of the type parameter of the class.
      *
      * @param autoRelease   {@code true} if handled messages should be released automatically by passing them to
-     *                      {@link ReferenceCountUtil#release(Object)}.
+     *                      {@link Resource#dispose(Object)}.
      */
     protected SimpleChannelInboundHandler(boolean autoRelease) {
         matcher = TypeParameterMatcher.find(this, SimpleChannelInboundHandler.class, "I");
@@ -74,7 +73,7 @@ public abstract class SimpleChannelInboundHandler<I> implements ChannelHandler {
      *
      * @param inboundMessageType    The type of messages to match
      * @param autoRelease           {@code true} if handled messages should be released automatically by passing them to
-     *                              {@link ReferenceCountUtil#release(Object)}.
+     *                              {@link Resource#dispose(Object)}.
      */
     protected SimpleChannelInboundHandler(Class<? extends I> inboundMessageType, boolean autoRelease) {
         matcher = TypeParameterMatcher.get(inboundMessageType);
@@ -103,7 +102,7 @@ public abstract class SimpleChannelInboundHandler<I> implements ChannelHandler {
             }
         } finally {
             if (autoRelease && release) {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
             }
         }
     }

--- a/transport/src/main/java/io/netty5/channel/SimpleUserEventChannelHandler.java
+++ b/transport/src/main/java/io/netty5/channel/SimpleUserEventChannelHandler.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.channel;
 
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.internal.TypeParameterMatcher;
 
 /**
@@ -36,8 +36,7 @@ import io.netty5.util.internal.TypeParameterMatcher;
  * </pre>
  *
  * Be aware that depending of the constructor parameters it will release all handled events by passing them to
- * {@link ReferenceCountUtil#release(Object)}. In this case you may need to use
- * {@link ReferenceCountUtil#retain(Object)} if you pass the object to the next handler in the {@link ChannelPipeline}.
+ * {@link Resource#dispose(Object)}.
  */
 public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler {
 
@@ -55,7 +54,7 @@ public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler
      * Create a new instance which will try to detect the types to match out of the type parameter of the class.
      *
      * @param autoRelease   {@code true} if handled events should be released automatically by passing them to
-     *                      {@link ReferenceCountUtil#release(Object)}.
+     *                      {@link Resource#dispose(Object)}.
      */
     protected SimpleUserEventChannelHandler(boolean autoRelease) {
         matcher = TypeParameterMatcher.find(this, SimpleUserEventChannelHandler.class, "I");
@@ -74,7 +73,7 @@ public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler
      *
      * @param eventType      The type of events to match
      * @param autoRelease    {@code true} if handled events should be released automatically by passing them to
-     *                       {@link ReferenceCountUtil#release(Object)}.
+     *                       {@link Resource#dispose(Object)}.
      */
     protected SimpleUserEventChannelHandler(Class<? extends I> eventType, boolean autoRelease) {
         matcher = TypeParameterMatcher.get(eventType);
@@ -103,7 +102,7 @@ public abstract class SimpleUserEventChannelHandler<I> implements ChannelHandler
             }
         } finally {
             if (autoRelease && release) {
-                ReferenceCountUtil.release(evt);
+                Resource.dispose(evt);
             }
         }
     }

--- a/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty5/channel/embedded/EmbeddedChannel.java
@@ -15,7 +15,7 @@
  */
 package io.netty5.channel.embedded;
 
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
@@ -303,7 +303,7 @@ public class EmbeddedChannel extends AbstractChannel {
     public <T> T readInbound() {
         T message = (T) poll(inboundMessages);
         if (message != null) {
-            ReferenceCountUtil.touch(message, "Caller of readInbound() will handle the message from this point");
+            Resource.touch(message, "Caller of readInbound() will handle the message from this point");
         }
         return message;
     }
@@ -315,7 +315,7 @@ public class EmbeddedChannel extends AbstractChannel {
     public <T> T readOutbound() {
         T message =  (T) poll(outboundMessages);
         if (message != null) {
-            ReferenceCountUtil.touch(message, "Caller of readOutbound() will handle the message from this point.");
+            Resource.touch(message, "Caller of readOutbound() will handle the message from this point.");
         }
         return message;
     }
@@ -511,15 +511,13 @@ public class EmbeddedChannel extends AbstractChannel {
                 if (msg == null) {
                     break;
                 }
-                if (!ReferenceCountUtil.release(msg) && msg instanceof AutoCloseable) {
-                    try {
-                        ((AutoCloseable) msg).close();
-                    } catch (Exception e) {
-                        if (closeFailed == null) {
-                            closeFailed = e;
-                        } else {
-                            closeFailed.addSuppressed(e);
-                        }
+                try {
+                    Resource.dispose(msg);
+                } catch (Exception e) {
+                    if (closeFailed == null) {
+                        closeFailed = e;
+                    } else {
+                        closeFailed.addSuppressed(e);
                     }
                 }
             }

--- a/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty5/channel/group/DefaultChannelGroup.java
@@ -17,6 +17,7 @@ package io.netty5.channel.group;
 
 import io.netty.buffer.ByteBufConvertible;
 import io.netty.buffer.ByteBufHolder;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelId;
 import io.netty5.channel.ServerChannel;
@@ -250,7 +251,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
             }
         }
         ChannelGroupFuture future = new DefaultChannelGroupFuture(this, futures, executor);
-        ReferenceCountUtil.release(message);
+        Resource.dispose(message);
         return future;
     }
 
@@ -368,7 +369,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
             }
         }
         final ChannelGroupFuture future = new DefaultChannelGroupFuture(this, futures, executor);
-        ReferenceCountUtil.release(message);
+        Resource.dispose(message);
         return future;
     }
 

--- a/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty5/channel/local/LocalChannel.java
@@ -16,7 +16,7 @@
 package io.netty5.channel.local;
 
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.buffer.api.internal.ResourceSupport;
 import io.netty5.buffer.api.internal.Statics;
 import io.netty5.channel.AbstractChannel;
@@ -393,7 +393,7 @@ public class LocalChannel extends AbstractChannel {
         Queue<Object> inboundBuffer = this.inboundBuffer;
         Object msg;
         while ((msg = inboundBuffer.poll()) != null) {
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
         }
     }
 

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioByteChannel.java
@@ -17,7 +17,7 @@ package io.netty5.channel.nio;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelConfig;
 import io.netty5.channel.ChannelMetadata;

--- a/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty5/channel/nio/AbstractNioChannel.java
@@ -18,7 +18,7 @@ package io.netty5.channel.nio;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
 import io.netty5.buffer.api.DefaultBufferAllocators;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelException;

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -18,7 +18,7 @@ package io.netty5.channel.socket.nio;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufConvertible;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
+import io.netty5.util.Resource;
 import io.netty5.buffer.api.WritableComponent;
 import io.netty5.buffer.api.WritableComponentProcessor;
 import io.netty5.channel.AddressedEnvelope;
@@ -235,14 +235,12 @@ public final class NioDatagramChannel
 
     @Override
     protected int doReadMessages(List<Object> buf) throws Exception {
-        DatagramChannelConfig config = config();
         RecvBufferAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
 
         return doReadBufferMessages(allocHandle, buf);
     }
 
     private int doReadBufferMessages(Handle allocHandle, List<Object> buf) throws IOException {
-        DatagramChannel ch = javaChannel();
         Buffer data = allocHandle.allocate(config.getBufferAllocator());
         allocHandle.attemptedBytesRead(data.writableBytes());
         boolean free = true;

--- a/transport/src/test/java/io/netty5/channel/AbstractCoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty5/channel/AbstractCoalescingBufferQueueTest.java
@@ -17,8 +17,8 @@ package io.netty5.channel;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +46,7 @@ public class AbstractCoalescingBufferQueueTest {
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() {
             @Override
             public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
                 return ctx.newSucceededFuture();
             }
         }, new ChannelHandlerAdapter() { });

--- a/transport/src/test/java/io/netty5/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty5/channel/CoalescingBufferQueueTest.java
@@ -16,11 +16,11 @@ package io.netty5.channel;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.Resource;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -278,7 +278,7 @@ public class CoalescingBufferQueueTest {
     private String dequeue(int numBytes, Promise<Void> aggregatePromise) {
         Buffer removed = writeQueue.remove(numBytes, aggregatePromise);
         String result = removed.toString(US_ASCII);
-        Resource.dispose(removed, logger);
+        SilentDispose.dispose(removed, logger);
         return result;
     }
 }

--- a/transport/src/test/java/io/netty5/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty5/channel/CoalescingBufferQueueTest.java
@@ -16,15 +16,18 @@ package io.netty5.channel;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.CharsetUtil;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;
+import io.netty5.util.internal.logging.InternalLogger;
+import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -34,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for {@link CoalescingBufferQueue}.
  */
 public class CoalescingBufferQueueTest {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(CoalescingBufferQueueTest.class);
 
     private Buffer cat;
     private Buffer mouse;
@@ -273,8 +277,8 @@ public class CoalescingBufferQueueTest {
 
     private String dequeue(int numBytes, Promise<Void> aggregatePromise) {
         Buffer removed = writeQueue.remove(numBytes, aggregatePromise);
-        String result = removed.toString(CharsetUtil.US_ASCII);
-        ReferenceCountUtil.safeRelease(removed);
+        String result = removed.toString(US_ASCII);
+        Resource.dispose(removed, logger);
         return result;
     }
 }

--- a/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty5/channel/DefaultChannelPipelineTest.java
@@ -28,8 +28,8 @@ import io.netty5.channel.local.LocalServerChannel;
 import io.netty5.channel.nio.NioHandler;
 import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty5.util.AbstractReferenceCounted;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.ReferenceCounted;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
@@ -87,7 +87,7 @@ public class DefaultChannelPipelineTest {
 
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
             }
         });
 
@@ -1342,7 +1342,7 @@ public class DefaultChannelPipelineTest {
             @Override
             public Future<Void> write(ChannelHandlerContext ctx, Object msg) {
                 executionMask |= MASK_WRITE;
-                ReferenceCountUtil.release(msg);
+                Resource.dispose(msg);
                 return ctx.newSucceededFuture();
             }
 

--- a/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/embedded/EmbeddedChannelTest.java
@@ -24,7 +24,7 @@ import io.netty5.channel.ChannelId;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.ChannelOutboundInvoker;
 import io.netty5.channel.ChannelPipeline;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
@@ -401,7 +401,7 @@ public class EmbeddedChannelTest {
       EmbeddedChannel channel = new EmbeddedChannel(new ChannelHandler() {
           @Override
           public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-              ReferenceCountUtil.release(msg);
+              Resource.dispose(msg);
               latch.countDown();
           }
 

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -19,7 +19,6 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
-import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
@@ -36,6 +35,7 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.concurrent.RejectedExecutionHandler;
+import io.netty5.util.internal.SilentDispose;
 import io.netty5.util.internal.logging.InternalLogger;
 import io.netty5.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -875,7 +875,7 @@ public class LocalChannelTest {
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             logger.info(String.format("Received message: %s", msg));
-            Resource.dispose(msg, logger);
+            SilentDispose.dispose(msg, logger);
         }
     }
 

--- a/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalChannelTest.java
@@ -19,6 +19,7 @@ import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.buffer.api.BufferAllocator;
+import io.netty5.util.Resource;
 import io.netty5.channel.AbstractChannel;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
@@ -31,7 +32,6 @@ import io.netty5.channel.IoHandler;
 import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.SimpleChannelInboundHandler;
 import io.netty5.channel.SingleThreadEventLoop;
-import io.netty5.util.ReferenceCountUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.FutureListener;
 import io.netty5.util.concurrent.Promise;
@@ -875,7 +875,7 @@ public class LocalChannelTest {
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             logger.info(String.format("Received message: %s", msg));
-            ReferenceCountUtil.safeRelease(msg);
+            Resource.dispose(msg, logger);
         }
     }
 

--- a/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty5/channel/local/LocalTransportThreadModelTest2.java
@@ -22,7 +22,7 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.MultithreadEventLoopGroup;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -115,7 +115,7 @@ public class LocalTransportThreadModelTest2 {
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             count.incrementAndGet();
-            ReferenceCountUtil.release(msg);
+            Resource.dispose(msg);
         }
     }
 }

--- a/transport/src/test/java/io/netty5/channel/socket/nio/NioDatagramChannelTest.java
+++ b/transport/src/test/java/io/netty5/channel/socket/nio/NioDatagramChannelTest.java
@@ -24,7 +24,7 @@ import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.group.DefaultChannelGroup;
 import io.netty5.channel.nio.NioHandler;
 import io.netty5.channel.socket.DatagramChannel;
-import io.netty5.util.ReferenceCountUtil;
+import io.netty5.util.Resource;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +53,7 @@ public class NioDatagramChannelTest extends AbstractNioChannelTest<NioDatagramCh
                             @Override
                             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                                 // Discard
-                                ReferenceCountUtil.release(msg);
+                                Resource.dispose(msg);
                             }
                         });
                 DatagramChannel datagramChannel = (DatagramChannel) udpBootstrap


### PR DESCRIPTION
Motivation:
The static methods on Resource work on both Resource and ReferenceCounted types, while the ReferenceCountUtil methods only work on ReferenceCounted types.
We should switch to use the Resource methods, because not all Resource objects are ReferenceCounted, or vice versa, but the Resource methods work on both.

Modification:
- Move Resource and Send to the netty-common module where they are more widely accessible.
- This also changed the package of these classes from io.netty5.buffer.api to io.netty5.util.
- Add isAccessible and touch as static methods on Resource.
- Replace nearly all calls to ReferenceCountUtil.release with calls to Resource.dispose.
- Add a DnsRecord.copy method, which mostly just return this, except on DnsRawRecord where we need to copy the contained buffer to give it a separate lifetime. Prior code was trying to call retain here, but both retain and release was broken for these types.
- MessageToMessageEncoder and MessageToMessageDecoder subclasses can now choose to control the message lifetimes directly. By default, the messages are still automatically released, but by extending a different method, subclasses can bypass this. We have to make this change because retain is no longer a thing, and non-buffer resource usually don't have something like split that solve this issue naturally.
- MessageToByteEncoder has not been updated with this behavioural change, though. Perhaps it should.

Result:
Less use of reference counting.
This also uncovered some suspicious reference counting practices in HTTP/1 and DNS, which might have been bugs, but at any rate are now fixed.
