### PR TITLE
Allow blocking calls in JdkSslContext class initializer

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Hidden.java
+++ b/common/src/main/java/io/netty/util/internal/Hidden.java
@@ -108,6 +108,10 @@ class Hidden {
                     "io.netty.handler.ssl.ReferenceCountedOpenSslClientContext$ExtendedTrustManagerVerifyCallback",
                     "verify");
 
+            builder.allowBlockingCallsInside(
+                    "io.netty.handler.ssl.JdkSslContext$Defaults",
+                    "init");
+
             // Let's whitelist SSLEngineImpl.unwrap(...) for now as it may fail otherwise for TLS 1.3.
             // See https://mail.openjdk.java.net/pipermail/security-dev/2020-August/022271.html
             builder.allowBlockingCallsInside(

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -110,11 +110,11 @@ public class JdkSslContext extends SslContext {
             supportedCiphers = Collections.unmodifiableSet(supportedCiphers(engine));
             defaultCiphers = Collections.unmodifiableList(defaultCiphers(engine, supportedCiphers));
 
-            List<String> ciphersNonTLSv13 = new ArrayList<String>(DEFAULT_CIPHERS);
+            List<String> ciphersNonTLSv13 = new ArrayList<String>(defaultCiphers);
             ciphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
             defaultCiphersNonTLSv13 = Collections.unmodifiableList(ciphersNonTLSv13);
 
-            Set<String> suppertedCiphersNonTLSv13 = new LinkedHashSet<String>(SUPPORTED_CIPHERS);
+            Set<String> suppertedCiphersNonTLSv13 = new LinkedHashSet<String>(supportedCiphers);
             suppertedCiphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
             supportedCiphersNonTLSv13 = Collections.unmodifiableSet(suppertedCiphersNonTLSv13);
         }

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -69,33 +69,54 @@ public class JdkSslContext extends SslContext {
     private static final Provider DEFAULT_PROVIDER;
 
     static {
-        SSLContext context;
-        try {
-            context = SSLContext.getInstance(PROTOCOL);
-            context.init(null, null, null);
-        } catch (Exception e) {
-            throw new Error("failed to initialize the default SSL context", e);
-        }
+        Defaults defaults = new Defaults();
+        defaults.init();
 
-        DEFAULT_PROVIDER = context.getProvider();
-
-        SSLEngine engine = context.createSSLEngine();
-        DEFAULT_PROTOCOLS = defaultProtocols(context, engine);
-
-        SUPPORTED_CIPHERS = Collections.unmodifiableSet(supportedCiphers(engine));
-        DEFAULT_CIPHERS = Collections.unmodifiableList(defaultCiphers(engine, SUPPORTED_CIPHERS));
-
-        List<String> ciphersNonTLSv13 = new ArrayList<String>(DEFAULT_CIPHERS);
-        ciphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
-        DEFAULT_CIPHERS_NON_TLSV13 = Collections.unmodifiableList(ciphersNonTLSv13);
-
-        Set<String> suppertedCiphersNonTLSv13 = new LinkedHashSet<String>(SUPPORTED_CIPHERS);
-        suppertedCiphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
-        SUPPORTED_CIPHERS_NON_TLSV13 = Collections.unmodifiableSet(suppertedCiphersNonTLSv13);
+        DEFAULT_PROVIDER = defaults.defaultProvider;
+        DEFAULT_PROTOCOLS = defaults.defaultProtocols;
+        SUPPORTED_CIPHERS = defaults.supportedCiphers;
+        DEFAULT_CIPHERS = defaults.defaultCiphers;
+        DEFAULT_CIPHERS_NON_TLSV13 = defaults.defaultCiphersNonTLSv13;
+        SUPPORTED_CIPHERS_NON_TLSV13 = defaults.supportedCiphersNonTLSv13;
 
         if (logger.isDebugEnabled()) {
             logger.debug("Default protocols (JDK): {} ", Arrays.asList(DEFAULT_PROTOCOLS));
             logger.debug("Default cipher suites (JDK): {}", DEFAULT_CIPHERS);
+        }
+    }
+
+    private static final class Defaults {
+        String[] defaultProtocols;
+        List<String> defaultCiphers;
+        List<String> defaultCiphersNonTLSv13;
+        Set<String> supportedCiphers;
+        Set<String> supportedCiphersNonTLSv13;
+        Provider defaultProvider;
+
+        void init() {
+            SSLContext context;
+            try {
+                context = SSLContext.getInstance(PROTOCOL);
+                context.init(null, null, null);
+            } catch (Exception e) {
+                throw new Error("failed to initialize the default SSL context", e);
+            }
+
+            defaultProvider = context.getProvider();
+
+            SSLEngine engine = context.createSSLEngine();
+            defaultProtocols = defaultProtocols(context, engine);
+
+            supportedCiphers = Collections.unmodifiableSet(supportedCiphers(engine));
+            defaultCiphers = Collections.unmodifiableList(defaultCiphers(engine, supportedCiphers));
+
+            List<String> ciphersNonTLSv13 = new ArrayList<String>(DEFAULT_CIPHERS);
+            ciphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
+            defaultCiphersNonTLSv13 = Collections.unmodifiableList(ciphersNonTLSv13);
+
+            Set<String> suppertedCiphersNonTLSv13 = new LinkedHashSet<String>(SUPPORTED_CIPHERS);
+            suppertedCiphersNonTLSv13.removeAll(Arrays.asList(SslUtils.DEFAULT_TLSV13_CIPHER_SUITES));
+            supportedCiphersNonTLSv13 = Collections.unmodifiableSet(suppertedCiphersNonTLSv13);
         }
     }
 


### PR DESCRIPTION
Motivation:
Classes might be initialized inside the event loop where blocking calls are otherwise forbidden.
The JdkSslContext has a blocking call in its class initializer through initializing the Java SSLContext which does IO to deserialize its key store.

Modification:
Collect the class initialization code in a method, and allow it to have blocking calls in blockhound.

Result:
No more blockhound warnings about blocking calls in JdkSslContext class initializer.

Fixes #12425 