### PR TITLE
Allow PcapWriteHandler instances to write to the same OutputStream

### DIFF
--- a/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapHeaders.java
@@ -31,7 +31,7 @@ final class PcapHeaders {
      *      <li> network </li>
      * </ol>
      */
-    private static final byte[] GLOBAL_HEADER = new byte[]{-95, -78, -61, -44, 0, 2, 0, 4, 0, 0,
+    static final byte[] GLOBAL_HEADER = new byte[]{-95, -78, -61, -44, 0, 2, 0, 4, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, -1, -1, 0, 0, 0, 1};
 
     private PcapHeaders() {

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
@@ -108,8 +108,12 @@ final class PcapWriter implements Closeable {
             logger.debug("PcapWriter is already closed");
         } else {
             isClosed = true;
-            outputStream.flush();
-            if (!sharedOutputStream) {
+            if (sharedOutputStream) {
+                synchronized(outputStream) {
+                    outputStream.flush();
+                }
+            } else {
+                outputStream.flush();
                 outputStream.close();
             }
             logger.debug("PcapWriter is now closed");

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
@@ -67,7 +67,7 @@ final class PcapWriter implements Closeable {
 
         PcapHeaders.writeGlobalHeader(byteBuf);
         if (sharedOutputStream) {
-            synchronized(outputStream) {
+            synchronized (outputStream) {
                 byteBuf.readBytes(outputStream, byteBuf.readableBytes());
             }
         } else {

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriter.java
@@ -66,7 +66,13 @@ final class PcapWriter implements Closeable {
         this.sharedOutputStream = sharedOutputStream;
 
         PcapHeaders.writeGlobalHeader(byteBuf);
-        byteBuf.readBytes(outputStream, byteBuf.readableBytes());
+        if (sharedOutputStream) {
+            synchronized(outputStream) {
+                byteBuf.readBytes(outputStream, byteBuf.readableBytes());
+            }
+        } else {
+            byteBuf.readBytes(outputStream, byteBuf.readableBytes());
+        }
     }
 
     /**
@@ -109,7 +115,7 @@ final class PcapWriter implements Closeable {
         } else {
             isClosed = true;
             if (sharedOutputStream) {
-                synchronized(outputStream) {
+                synchronized (outputStream) {
                     outputStream.flush();
                 }
             } else {


### PR DESCRIPTION
Motivation:

Currently, PcapWriteHandler expects a dedicated OutputStream, and cannot support multiple streams written to a single pcap file. These modifications are intended to support sharing the OutputStream between multiple concurrent PcapWriteHandler instances.

Modification:

Added a "shareOutputStream" flag to PcapWriteHandler (and PcapWriter) to enable synchronization on the OutputStream in order to prevent interleaved writes. Also provide a method to write the pcap Global Header to the OutputStream.

Result:

Allows multiple channels to write to the same pcap file. 
